### PR TITLE
fix(hermes): forward run-scoped agent credentials

### DIFF
--- a/packages/adapters/hermes/src/gateway/index.ts
+++ b/packages/adapters/hermes/src/gateway/index.ts
@@ -64,7 +64,9 @@ export function createServerAdapter(): ServerAdapterModule {
     sessionCodec,
     sessionManagement,
     models,
-    supportsLocalAgentJwt: false,
+    // The gateway forwards the run-scoped token through Hermes' trusted
+    // runtime environment, never through the model-visible prompt.
+    supportsLocalAgentJwt: true,
     supportsInstructionsBundle: false,
     requiresMaterializedRuntimeSkills: false,
     agentConfigurationDoc,

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -121,7 +121,7 @@ describe("execute", () => {
 
     const ctx = makeCtx({
       apiBaseUrl: "http://127.0.0.1:8642",
-      apiKey: ***
+      apiKey: "gateway-key",
       paperclipApiUrl: "https://paperclip.example/api",
       timeoutSec: 5,
     });

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -139,8 +139,9 @@ describe("execute", () => {
         PAPERCLIP_TASK_ID: "issue-1",
       },
     });
-    expect(String(createBody?.input)).not.toContain(scopedToken);
-    expect(String(createBody?.instructions)).not.toContain(scopedToken);
+    const submittedBody = createBody as unknown as Record<string, unknown>;
+    expect(String(submittedBody.input)).not.toContain(scopedToken);
+    expect(String(submittedBody.instructions)).not.toContain(scopedToken);
     expect(result.summary).not.toContain(scopedToken);
   });
 

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -94,6 +94,56 @@ describe("execute", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("injects the scoped Paperclip run credential into the remote Hermes runtime", async () => {
+    const scopedToken = "paperclip-run-jwt";
+    let createBody: Record<string, unknown> | null = null;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/runs")) {
+        createBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ run_id: "run-hermes-auth", status: "started" }), { status: 200 });
+      }
+      if (url.endsWith("/events")) {
+        return new Response(
+          sseStream(
+            [
+              "event: run.completed",
+              `data: ${JSON.stringify({ status: "completed", output: scopedToken })}`,
+              "",
+            ].join("\n"),
+          ),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(JSON.stringify({ status: "completed", output: "done" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = makeCtx({
+      apiBaseUrl: "http://127.0.0.1:8642",
+      apiKey: ***
+      paperclipApiUrl: "https://paperclip.example/api",
+      timeoutSec: 5,
+    });
+    ctx.authToken = scopedToken;
+
+    const result = await execute(ctx);
+
+    expect(createBody).toMatchObject({
+      runtime_env: {
+        PAPERCLIP_API_KEY: scopedToken,
+        PAPERCLIP_RUN_ID: "pc-run-1",
+        PAPERCLIP_AGENT_ID: "agent-1",
+        PAPERCLIP_COMPANY_ID: "company-1",
+        PAPERCLIP_API_URL: "https://paperclip.example/api",
+        PAPERCLIP_TASK_ID: "issue-1",
+      },
+    });
+    expect(String(createBody?.input)).not.toContain(scopedToken);
+    expect(String(createBody?.instructions)).not.toContain(scopedToken);
+    expect(result.summary).not.toContain(scopedToken);
+  });
+
   it("constructs POST /v1/runs with auth, idempotency, and Hermes session headers", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -327,10 +327,19 @@ function buildRunBody(ctx: AdapterExecutionContext, sessionKey: string | null): 
     nonEmpty(ctx.config.instructions) ??
     nonEmpty(payloadTemplate.instructions) ??
     "Follow the Paperclip wake instructions exactly. Do not expose secrets in logs, comments, or final output.";
+  const runtimeEnv = {
+    ...(nonEmpty(ctx.authToken) ? { PAPERCLIP_API_KEY: ctx.authToken } : {}),
+    PAPERCLIP_RUN_ID: ctx.runId,
+    PAPERCLIP_AGENT_ID: ctx.agent.id,
+    PAPERCLIP_COMPANY_ID: ctx.agent.companyId,
+    ...(paperclipApiUrl ? { PAPERCLIP_API_URL: paperclipApiUrl } : {}),
+    ...(issueIdFromContext(ctx) ? { PAPERCLIP_TASK_ID: issueIdFromContext(ctx) } : {}),
+  };
   return {
     ...payloadTemplate,
     input,
     instructions,
+    runtime_env: runtimeEnv,
     ...(sessionKey ? { session_id: sessionKey } : {}),
   };
 }
@@ -848,6 +857,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const redactText = createTextRedactor([
     apiKey,
+    ctx.authToken,
     sessionKey,
     runHeaders.Authorization,
     runHeaders["X-Hermes-Session-Key"],

--- a/packages/adapters/hermes/src/index.test.ts
+++ b/packages/adapters/hermes/src/index.test.ts
@@ -35,7 +35,7 @@ test("root package export keeps explicit local and gateway adapter factories", (
   expect(localAdapter.type).toBe("hermes_local");
   expect(gatewayAdapter.type).toBe("hermes_gateway");
   expect(hermesGatewayType).toBe("hermes_gateway");
-  expect(gatewayAdapter.supportsLocalAgentJwt).toBe(false);
+  expect(gatewayAdapter.supportsLocalAgentJwt).toBe(true);
   expect(gatewayAdapter.supportsInstructionsBundle).toBe(false);
 });
 

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -142,7 +142,7 @@ describe("server adapter registry", () => {
     expect(builtInLocal?.getConfigSchema).toBeTypeOf("function");
 
     expect(builtInGateway).not.toBeNull();
-    expect(builtInGateway?.supportsLocalAgentJwt).toBe(false);
+    expect(builtInGateway?.supportsLocalAgentJwt).toBe(true);
     expect(builtInGateway?.supportsInstructionsBundle).toBe(false);
     expect(builtInGateway?.requiresMaterializedRuntimeSkills).toBe(false);
     expect(builtInGateway?.getConfigSchema).toBeTypeOf("function");

--- a/server/src/__tests__/adapter-routes.test.ts
+++ b/server/src/__tests__/adapter-routes.test.ts
@@ -235,7 +235,7 @@ describe("adapter routes", () => {
     expect(hermesGateway.capabilities).toMatchObject({
       supportsInstructionsBundle: false,
       supportsSkills: false,
-      supportsLocalAgentJwt: false,
+      supportsLocalAgentJwt: true,
       requiresMaterializedRuntimeSkills: false,
       supportsAcp: false,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent work through heartbeat runs.
> - The `hermes_gateway` adapter starts those runs through the Hermes `/v1/runs` API.
> - The adapter declared that it did not support Paperclip run-scoped JWTs.
> - Paperclip therefore did not mint an agent bearer for Hermes gateway runs.
> - The adapter also had no runtime-only transport for a bearer.
> - This pull request enables the existing scoped JWT path and sends the value through the companion Hermes runtime environment contract.
> - The benefit is authenticated Paperclip API access without placing a bearer in model-visible prompts, logs, or durable result data.

## Linked Issues or Issue Description

**What happened?**

A `hermes_gateway` heartbeat did not receive the scoped agent bearer that Paperclip can mint for a run. Authenticated agent endpoints returned HTTP 401 from the awakened runtime.

**Expected behavior**

Paperclip must mint a run-scoped agent bearer for this adapter. Hermes tool subprocesses must receive it as runtime state. The model prompt and adapter logs must not contain the bearer.

**Steps to reproduce**

1. Configure an agent with the `hermes_gateway` adapter.
2. Start a heartbeat.
3. Call an authenticated Paperclip agent endpoint from the Hermes run.
4. Observe HTTP 401 because the run has no agent bearer.

**Paperclip version or commit**

`19be4cf9278b70bc151063778a94bf38bfd5c903`

**Agent adapter(s) involved**

Hermes

**Additional context**

Companion Hermes runtime contract: NousResearch/hermes-agent#81976

## What Changed

- Set `supportsLocalAgentJwt` for `hermes_gateway`.
- Give the freshly minted `ctx.authToken` strict precedence as `PAPERCLIP_API_KEY`.
- Send Paperclip run, agent, company, API, and task context in `/v1/runs.runtime_env`.
- Preserve `PAPERCLIP_RUN_ID` for `X-Paperclip-Run-Id` on mutations.
- Add the scoped bearer to the adapter redactor.
- Add regression tests for capability discovery, runtime transport, and prompt/result non-exposure.

## Verification

- `vitest run --config packages/adapters/hermes/vitest.config.ts packages/adapters/hermes/src/gateway/server/execute.test.ts packages/adapters/hermes/src/index.test.ts --testTimeout=30000`
- Result at commit `6639b79662306e1a0d6e0491b782cfe3bfc9d2f1`: 2 files passed, 27 tests passed.
- `git diff --check` passed.
- The full Paperclip CI suite passed, including typecheck, build, server suites, workspace suites, release checks, and all three end-to-end shards.

## Risks

- The change depends on Hermes support for the allowlisted `runtime_env` contract. The companion PR provides it.
- An older Hermes gateway ignores the extra JSON field, so the run remains unauthenticated until both halves deploy.
- The adapter never writes the bearer to its prompt or metadata. A tool subprocess can read it because authenticated control-plane calls require that access.

## Model Used

OpenAI Codex with model `gpt-5.6-sol`. The run used reasoning, repository tools, code execution, and independent source review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked the companion PR above
- [x] I have described the issue in-PR with the bug template labels
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused tests locally and they pass
- [x] I have added tests for my changes
- [x] Relevant behavior is documented in source comments and the companion API contract
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
