### PR TITLE
Restore scoped agent secret controls

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -971,6 +971,7 @@ export const PERMISSION_KEYS = [
   "users:invite",
   "users:manage_permissions",
   "credentials:write",
+  "credentials:view_metadata",
   "tasks:assign",
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -750,6 +750,27 @@ export const CLASS3_STATIC_LEASE_ALLOWLIST = [
     configPath: "credentials.bot_token",
     envKey: "DISCORD_BOT_TOKEN",
   },
+  {
+    key: "aws.games_logging_preflight.access_key_id",
+    label: "AWS games logging preflight access key ID",
+    targetType: "agent",
+    configPath: "env.AWS_ACCESS_KEY_ID",
+    envKey: "AWS_ACCESS_KEY_ID",
+  },
+  {
+    key: "aws.games_logging_preflight.secret_access_key",
+    label: "AWS games logging preflight secret access key",
+    targetType: "agent",
+    configPath: "env.AWS_SECRET_ACCESS_KEY",
+    envKey: "AWS_SECRET_ACCESS_KEY",
+  },
+  {
+    key: "aws.games_logging_preflight.session_token",
+    label: "AWS games logging preflight session token",
+    targetType: "agent",
+    configPath: "env.AWS_SESSION_TOKEN",
+    envKey: "AWS_SESSION_TOKEN",
+  },
 ] as const;
 export type Class3StaticLeaseAllowlistKey = (typeof CLASS3_STATIC_LEASE_ALLOWLIST)[number]["key"];
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -970,6 +970,7 @@ export const PERMISSION_KEYS = [
   "inbox:manage",
   "users:invite",
   "users:manage_permissions",
+  "credentials:write",
   "tasks:assign",
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",

--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -162,6 +162,93 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     });
   });
 
+  it("persists and reads back the three exact AWS class-3 preflight refs without serializing their sentinels", async () => {
+    const companyId = await seedCompany();
+    const secrets = secretService(db);
+    const sentinels = [
+      `aws-access-${randomUUID()}`,
+      `aws-secret-${randomUUID()}`,
+      `aws-session-${randomUUID()}`,
+    ];
+    const [accessKey, secretAccessKey, sessionToken] = await Promise.all(
+      sentinels.map((value, index) => secrets.create(companyId, {
+        name: `aws-preflight-${index}-${randomUUID()}`,
+        provider: "local_encrypted",
+        value,
+      })),
+    );
+    const expectedEnv = {
+      AWS_ACCESS_KEY_ID: {
+        type: "secret_ref",
+        secretId: accessKey.id,
+        version: "latest",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.access_key_id",
+      },
+      AWS_SECRET_ACCESS_KEY: {
+        type: "secret_ref",
+        secretId: secretAccessKey.id,
+        version: "latest",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.secret_access_key",
+      },
+      AWS_SESSION_TOKEN: {
+        type: "secret_ref",
+        secretId: sessionToken.id,
+        version: "latest",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.session_token",
+      },
+    };
+
+    const created = await agentService(db).create(companyId, {
+      name: "AWS Games Logging Preflight",
+      role: "operator",
+      adapterType: "codex_local",
+      adapterConfig: { env: expectedEnv },
+      runtimeConfig: {},
+      spentMonthlyCents: 0,
+      lastHeartbeatAt: null,
+    });
+    const reloaded = await agentService(db).getById(created.id);
+    const bindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(and(
+        eq(companySecretBindings.companyId, companyId),
+        eq(companySecretBindings.targetType, "agent"),
+        eq(companySecretBindings.targetId, created.id),
+      ));
+
+    expect(reloaded?.adapterConfig).toMatchObject({ env: expectedEnv });
+    expect(bindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        secretId: accessKey.id,
+        configPath: "env.AWS_ACCESS_KEY_ID",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.access_key_id",
+      }),
+      expect.objectContaining({
+        secretId: secretAccessKey.id,
+        configPath: "env.AWS_SECRET_ACCESS_KEY",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.secret_access_key",
+      }),
+      expect.objectContaining({
+        secretId: sessionToken.id,
+        configPath: "env.AWS_SESSION_TOKEN",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.session_token",
+      }),
+    ]));
+    expect(bindings).toHaveLength(3);
+
+    const capturedOutput = JSON.stringify({ adapterConfig: reloaded?.adapterConfig, bindings });
+    for (const sentinel of sentinels) {
+      expect(capturedOutput).not.toContain(sentinel);
+    }
+  });
+
   it("rejects class-3 env lease bindings outside the enumerated allowlist", async () => {
     const companyId = await seedCompany();
     const secrets = secretService(db);
@@ -201,6 +288,78 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
       .from(agents)
       .where(eq(agents.companyId, companyId));
     expect(persistedAgents).toHaveLength(0);
+  });
+
+  it("rejects missing, swapped, and fourth AWS-looking class-3 env refs before binding", async () => {
+    const companyId = await seedCompany();
+    const secrets = secretService(db);
+    const secret = await secrets.create(companyId, {
+      name: `aws-rejection-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: `aws-sentinel-${randomUUID()}`,
+    });
+    const cases = [
+      {
+        env: {
+          AWS_ACCESS_KEY_ID: {
+            type: "secret_ref" as const,
+            secretId: secret.id,
+            version: "latest" as const,
+            projectionClass: "class_3_static_lease" as const,
+          },
+        },
+        code: "class_3_static_lease_allowlist_required",
+      },
+      {
+        env: {
+          AWS_ACCESS_KEY_ID: {
+            type: "secret_ref" as const,
+            secretId: secret.id,
+            version: "latest" as const,
+            projectionClass: "class_3_static_lease" as const,
+            projectionAllowlistKey: "aws.games_logging_preflight.secret_access_key",
+          },
+        },
+        code: "class_3_static_lease_not_allowed",
+      },
+      {
+        env: {
+          AWS_REGION: {
+            type: "secret_ref" as const,
+            secretId: secret.id,
+            version: "latest" as const,
+            projectionClass: "class_3_static_lease" as const,
+            projectionAllowlistKey: "aws.games_logging_preflight.access_key_id",
+          },
+        },
+        code: "class_3_static_lease_not_allowed",
+      },
+    ];
+
+    for (const candidate of cases) {
+      await expect(
+        agentService(db).create(companyId, {
+          name: "Rejected AWS Static Lease",
+          role: "operator",
+          adapterType: "codex_local",
+          adapterConfig: { env: candidate.env },
+          runtimeConfig: {},
+          spentMonthlyCents: 0,
+          lastHeartbeatAt: null,
+        }),
+      ).rejects.toMatchObject({ status: 422, details: { code: candidate.code } });
+    }
+
+    const persistedAgents = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.companyId, companyId));
+    const persistedBindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(eq(companySecretBindings.companyId, companyId));
+    expect(persistedAgents).toHaveLength(0);
+    expect(persistedBindings).toHaveLength(0);
   });
 
   it("converts Hermes gateway apiKey strings into persisted secret refs", async () => {

--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -23,6 +23,24 @@ import { secretService } from "../services/secrets.js";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function expectStillPending(promise: Promise<unknown>) {
+  const state = await Promise.race([
+    promise.then(() => "settled", () => "settled"),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 40)),
+  ]);
+  expect(state).toBe("pending");
+}
+
 if (!embeddedPostgresSupport.supported) {
   console.warn(
     `Skipping embedded Postgres agent secret binding tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
@@ -32,6 +50,7 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("agent service secret binding sync", () => {
   let stopDb: (() => Promise<void>) | null = null;
   let db!: ReturnType<typeof createDb>;
+  let contenderDb!: ReturnType<typeof createDb>;
   const previousKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
   const secretsTmpDir = path.join(os.tmpdir(), `paperclip-agent-secret-bindings-${randomUUID()}`);
 
@@ -41,6 +60,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     const started = await startEmbeddedPostgresTestDatabase("agent-secret-bindings");
     stopDb = started.cleanup;
     db = createDb(started.connectionString);
+    contenderDb = createDb(started.connectionString);
   }, 20_000);
 
   afterEach(async () => {
@@ -72,6 +92,125 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     });
     return companyId;
   }
+
+  async function seedAgentOwnedSecret() {
+    const companyId = await seedCompany();
+    const owner = await agentService(db).create(companyId, {
+      name: `Owner-${randomUUID()}`,
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: { env: {} },
+      runtimeConfig: {},
+      spentMonthlyCents: 0,
+      lastHeartbeatAt: null,
+    });
+    const secret = await secretService(db).create(
+      companyId,
+      {
+        name: `owner-race-${randomUUID()}`,
+        provider: "local_encrypted",
+        value: `race-value-${randomUUID()}`,
+      },
+      { userId: null, agentId: owner.id },
+    );
+    return { companyId, owner, secret };
+  }
+
+  it("serializes owner delete after a winning adapter binding so binding and config survive", async () => {
+    const { companyId, owner, secret } = await seedAgentOwnedSecret();
+    const bindingCommitted = deferred<void>();
+    const releaseBinding = deferred<void>();
+    const bindingPromise = db.transaction(async (tx) => {
+      const updated = await agentService(tx as unknown as ReturnType<typeof createDb>).update(owner.id, {
+        adapterConfig: {
+          env: {
+            RACE_SECRET: { type: "secret_ref", secretId: secret.id, version: "latest" },
+          },
+        },
+      });
+      bindingCommitted.resolve();
+      await releaseBinding.promise;
+      return updated;
+    });
+
+    await bindingCommitted.promise;
+    const deletePromise = secretService(contenderDb).removeOwnedUnboundCompanySecret({
+      secretId: secret.id,
+      companyId,
+      agentId: owner.id,
+    });
+    await expectStillPending(deletePromise);
+    releaseBinding.resolve();
+    await bindingPromise;
+    await expect(deletePromise).rejects.toMatchObject({
+      status: 403,
+      message: "Secret is still bound and cannot be deleted",
+    });
+
+    const [persistedSecret, persistedOwner, bindings] = await Promise.all([
+      secretService(db).getById(secret.id),
+      agentService(db).getById(owner.id),
+      db.select().from(companySecretBindings).where(and(
+        eq(companySecretBindings.companyId, companyId),
+        eq(companySecretBindings.targetType, "agent"),
+        eq(companySecretBindings.targetId, owner.id),
+      )),
+    ]);
+    expect(persistedSecret?.status).toBe("active");
+    expect(persistedOwner?.adapterConfig).toMatchObject({
+      env: { RACE_SECRET: { type: "secret_ref", secretId: secret.id, version: "latest" } },
+    });
+    expect(bindings).toEqual([expect.objectContaining({
+      secretId: secret.id,
+      configPath: "env.RACE_SECRET",
+    })]);
+  });
+
+  it("serializes a winning owner delete so a later adapter binding and config both roll back", async () => {
+    const { companyId, owner, secret } = await seedAgentOwnedSecret();
+    const deleteCommitted = deferred<void>();
+    const releaseDelete = deferred<void>();
+    const deletePromise = db.transaction(async (tx) => {
+      const removed = await secretService(tx as unknown as ReturnType<typeof createDb>)
+        .removeOwnedUnboundCompanySecret({
+          secretId: secret.id,
+          companyId,
+          agentId: owner.id,
+        });
+      deleteCommitted.resolve();
+      await releaseDelete.promise;
+      return removed;
+    });
+
+    await deleteCommitted.promise;
+    const bindingPromise = agentService(contenderDb).update(owner.id, {
+      adapterConfig: {
+        env: {
+          RACE_SECRET: { type: "secret_ref", secretId: secret.id, version: "latest" },
+        },
+      },
+    });
+    await expectStillPending(bindingPromise);
+    releaseDelete.resolve();
+    await expect(deletePromise).resolves.toMatchObject({ id: secret.id });
+    await expect(bindingPromise).rejects.toMatchObject({
+      status: 404,
+      message: "Secret not found",
+    });
+
+    const [persistedSecret, persistedOwner, bindings] = await Promise.all([
+      secretService(db).getById(secret.id),
+      agentService(db).getById(owner.id),
+      db.select().from(companySecretBindings).where(and(
+        eq(companySecretBindings.companyId, companyId),
+        eq(companySecretBindings.targetType, "agent"),
+        eq(companySecretBindings.targetId, owner.id),
+      )),
+    ]);
+    expect(persistedSecret).toBeNull();
+    expect(persistedOwner?.adapterConfig).toMatchObject({ env: {} });
+    expect(bindings).toHaveLength(0);
+  });
 
   it("creates agent secret bindings when a new agent persists secret_ref env", async () => {
     const companyId = await seedCompany();

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -594,6 +594,105 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("allows credential metadata grants for active responsible-user JWT and key actors", async () => {
+    const company = await createCompany(db, "ResponsibleUserCredentialMetadata");
+    const actorAgent = await createAgent(db, company.id);
+    const responsibleUserId = await createUser(db);
+    await grantAgentPermission(db, company.id, actorAgent.id, "credentials:view_metadata");
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: responsibleUserId,
+      status: "active",
+      membershipRole: "viewer",
+    });
+
+    const decideFor = (source: "agent_jwt" | "agent_key") => authorizationService(db).decide({
+      actor: {
+        type: "agent" as const,
+        agentId: actorAgent.id,
+        companyId: company.id,
+        onBehalfOfUserId: responsibleUserId,
+        source,
+      },
+      action: "credentials:view_metadata" as const,
+      resource: { type: "company" as const, companyId: company.id },
+    });
+
+    await expect(decideFor("agent_jwt")).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_explicit_grant",
+    });
+    await expect(decideFor("agent_key")).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_explicit_grant",
+    });
+  });
+
+  it("fails closed for credential metadata without an agent grant or active same-company responsible user", async () => {
+    const company = await createCompany(db, "ResponsibleUserCredentialMetadataDenied");
+    const otherCompany = await createCompany(db, "ResponsibleUserCredentialMetadataOther");
+    const actorAgent = await createAgent(db, company.id);
+    const activeUserId = await createUser(db);
+    const inactiveUserId = await createUser(db);
+    const crossCompanyUserId = await createUser(db);
+    await db.insert(companyMemberships).values([
+      {
+        companyId: company.id,
+        principalType: "user",
+        principalId: activeUserId,
+        status: "active",
+        membershipRole: "operator",
+      },
+      {
+        companyId: company.id,
+        principalType: "user",
+        principalId: inactiveUserId,
+        status: "inactive",
+        membershipRole: "operator",
+      },
+      {
+        companyId: otherCompany.id,
+        principalType: "user",
+        principalId: crossCompanyUserId,
+        status: "active",
+        membershipRole: "operator",
+      },
+    ]);
+
+    const decideFor = (onBehalfOfUserId: string, source: "agent_jwt" | "agent_key") => authorizationService(db).decide({
+      actor: {
+        type: "agent" as const,
+        agentId: actorAgent.id,
+        companyId: company.id,
+        onBehalfOfUserId,
+        source,
+      },
+      action: "credentials:view_metadata" as const,
+      resource: { type: "company" as const, companyId: company.id },
+    });
+
+    await expect(decideFor(activeUserId, "agent_jwt")).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+
+    await grantAgentPermission(db, company.id, actorAgent.id, "credentials:view_metadata");
+
+    await expect(decideFor(`missing-${randomUUID()}`, "agent_key")).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+    await expect(decideFor(inactiveUserId, "agent_jwt")).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+    await expect(decideFor(crossCompanyUserId, "agent_key")).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+  });
+
   it("denies cross-company agent decisions before grant evaluation", async () => {
     const sourceCompany = await createCompany(db, "Source");
     const targetCompany = await createCompany(db, "Target");

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -483,6 +483,117 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain(`Responsible user ${responsibleUserId} is not authorized`);
   });
 
+  it("allows an explicit credential-write agent grant for an active non-viewer responsible user without a duplicate user grant", async () => {
+    const company = await createCompany(db, "ResponsibleUserCredentialWrite");
+    const actorAgent = await createAgent(db, company.id);
+    const responsibleUserId = await createUser(db);
+    await grantAgentPermission(db, company.id, actorAgent.id, "credentials:write");
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: responsibleUserId,
+      status: "active",
+      membershipRole: "operator",
+    });
+
+    await expect(authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: actorAgent.id,
+        companyId: company.id,
+        onBehalfOfUserId: responsibleUserId,
+        source: "agent_jwt",
+      },
+      action: "credentials:write",
+      resource: { type: "company", companyId: company.id },
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_explicit_grant",
+      grant: { principalType: "agent", principalId: actorAgent.id, permissionKey: "credentials:write" },
+    });
+  });
+
+  it("fails closed for credential-write grants without an active same-company non-viewer responsible user", async () => {
+    const company = await createCompany(db, "ResponsibleUserCredentialWriteDenied");
+    const otherCompany = await createCompany(db, "ResponsibleUserCredentialWriteOther");
+    const actorAgent = await createAgent(db, company.id);
+    const activeUserId = await createUser(db);
+    const viewerUserId = await createUser(db);
+    const inactiveUserId = await createUser(db);
+    const crossCompanyUserId = await createUser(db);
+    await db.insert(companyMemberships).values([
+      { companyId: company.id, principalType: "user", principalId: activeUserId, status: "active", membershipRole: "operator" },
+      { companyId: company.id, principalType: "user", principalId: viewerUserId, status: "active", membershipRole: "viewer" },
+      { companyId: company.id, principalType: "user", principalId: inactiveUserId, status: "inactive", membershipRole: "operator" },
+      { companyId: otherCompany.id, principalType: "user", principalId: crossCompanyUserId, status: "active", membershipRole: "operator" },
+    ]);
+
+    const decideFor = (onBehalfOfUserId: string) => authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: actorAgent.id,
+        companyId: company.id,
+        onBehalfOfUserId,
+        source: "agent_jwt",
+      },
+      action: "credentials:write",
+      resource: { type: "company", companyId: company.id },
+    });
+
+    await expect(decideFor(activeUserId)).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    await grantAgentPermission(db, company.id, actorAgent.id, "credentials:write");
+
+    await expect(decideFor(viewerUserId)).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAUTHORIZED",
+    });
+    await expect(decideFor(inactiveUserId)).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+    await expect(decideFor("missing-" + randomUUID())).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+    await expect(decideFor(crossCompanyUserId)).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+
+    const priorMode = process.env.PAPERCLIP_RESPONSIBLE_USER_AUTHZ_MODE;
+    process.env.PAPERCLIP_RESPONSIBLE_USER_AUTHZ_MODE = "shadow";
+    try {
+      await expect(decideFor(viewerUserId)).resolves.toMatchObject({
+        allowed: false,
+        code: "RESPONSIBLE_USER_UNAUTHORIZED",
+      });
+    } finally {
+      if (priorMode === undefined) delete process.env.PAPERCLIP_RESPONSIBLE_USER_AUTHZ_MODE;
+      else process.env.PAPERCLIP_RESPONSIBLE_USER_AUTHZ_MODE = priorMode;
+    }
+  });
+
+  it("denies a credential-write grant when the agent has no responsible-user binding", async () => {
+    const company = await createCompany(db, "ResponsibleUserCredentialWriteMissingBinding");
+    const actorAgent = await createAgent(db, company.id);
+    await grantAgentPermission(db, company.id, actorAgent.id, "credentials:write");
+
+    await expect(authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: actorAgent.id,
+        companyId: company.id,
+        source: "agent_jwt",
+      },
+      action: "credentials:write",
+      resource: { type: "company", companyId: company.id },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_membership",
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+    });
+  });
+
   it("denies cross-company agent decisions before grant evaluation", async () => {
     const sourceCompany = await createCompany(db, "Source");
     const targetCompany = await createCompany(db, "Target");

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -41,9 +41,11 @@ const mockSecretService = vi.hoisted(() => ({
   resolveSecretValueForAgentAccess: vi.fn(),
 }));
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockAccessService = vi.hoisted(() => ({ decide: vi.fn() }));
 
 vi.mock("../services/index.js", () => ({
   secretService: () => mockSecretService,
+  accessService: () => mockAccessService,
   logActivity: mockLogActivity,
 }));
 
@@ -71,6 +73,8 @@ describe("secret routes", () => {
       mock.mockReset();
     }
     mockLogActivity.mockReset();
+    mockAccessService.decide.mockReset();
+    mockAccessService.decide.mockResolvedValue({ allowed: false, explanation: "Missing permission", reason: "deny_missing_grant" });
   });
 
   it("returns provider health checks for board callers with company access", async () => {
@@ -96,6 +100,147 @@ describe("secret routes", () => {
         },
       ],
     });
+  });
+
+  it("allows only a granted run-bound agent JWT to create a company secret without exposing its value", async () => {
+    const sentinel = "route-test-secret-sentinel";
+    const created = {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: sentinel,
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value: sentinel,
+      encryptedValue: sentinel,
+      externalRef: "should-not-leak",
+      providerMetadata: { secret: sentinel },
+    };
+    mockAccessService.decide.mockResolvedValue({ allowed: true, explanation: "Granted", reason: "allow_explicit_grant" });
+    mockSecretService.create.mockResolvedValue(created);
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+      source: "agent_jwt",
+      onBehalfOfUserId: "user-1",
+      onBehalfOfMemberships: [
+        { companyId: "company-1", status: "active", membershipRole: "operator" },
+      ],
+    })).post("/api/companies/company-1/secrets").send({
+      name: sentinel,
+      key: "agent_created_secret",
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value: sentinel,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: created.id });
+    expect(mockAccessService.decide).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ agentId: "agent-1", runId: "run-1", source: "agent_jwt" }),
+      action: "credentials:write",
+      resource: { type: "company", companyId: "company-1" },
+    });
+    expect(mockSecretService.create).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value: sentinel,
+    }), { userId: null, agentId: "agent-1" });
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "secret.created",
+      actorType: "agent",
+      actorId: "agent-1",
+      entityId: created.id,
+      details: {},
+    }));
+    expect(JSON.stringify({ response: res.body, activity: mockLogActivity.mock.calls })).not.toContain(sentinel);
+  });
+
+  it("denies an otherwise allowed run-bound agent JWT without a responsible-user binding", async () => {
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+      source: "agent_jwt",
+    })).post("/api/companies/company-1/secrets").send({
+      name: "Agent-created secret",
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value: "route-test-secret-sentinel",
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockAccessService.decide).not.toHaveBeenCalled();
+    expect(mockSecretService.create).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("denies ungranted, cross-company, agent-key, and runless agents before creating company secrets", async () => {
+    const body = {
+      name: "Agent-created secret",
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value: "route-test-secret-sentinel",
+    };
+    const actors = [
+      {
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-1",
+        runId: "run-1",
+        source: "agent_jwt",
+        onBehalfOfUserId: "user-1",
+        onBehalfOfMemberships: [
+          { companyId: "company-1", status: "active", membershipRole: "operator" },
+        ],
+      },
+      { type: "agent", agentId: "agent-1", companyId: "other-company", runId: "run-1", source: "agent_jwt" },
+      { type: "agent", agentId: "agent-1", companyId: "company-1", runId: "run-1", source: "agent_key" },
+      { type: "agent", agentId: "agent-1", companyId: "company-1", source: "agent_jwt" },
+    ];
+
+    for (const actor of actors) {
+      const res = await request(createApp(actor)).post("/api/companies/company-1/secrets").send(body);
+      expect(res.status).toBe(403);
+    }
+
+    expect(mockSecretService.create).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("keeps board company-secret creation response and attribution unchanged", async () => {
+    const created = {
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "Board-created secret",
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      createdByUserId: "user-1",
+    };
+    mockSecretService.create.mockResolvedValue(created);
+
+    const res = await request(createApp()).post("/api/companies/company-1/secrets").send({
+      name: "Board-created secret",
+      provider: "local_encrypted",
+      managedMode: "paperclip_managed",
+      value: "route-test-secret-sentinel",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(created);
+    expect(mockSecretService.create).toHaveBeenCalledWith("company-1", expect.anything(), { userId: "user-1", agentId: null });
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "secret.created",
+      actorType: "user",
+      actorId: "user-1",
+    }));
   });
 
   it("rejects managed secret creation when externalRef is supplied", async () => {

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -1230,4 +1230,174 @@ describe("secret routes", () => {
       }),
     );
   });
+
+  const agentActor = {
+    type: "agent",
+    agentId: "agent-1",
+    companyId: "company-1",
+    runId: "run-1",
+    source: "agent_jwt",
+    onBehalfOfUserId: "user-1",
+    onBehalfOfMemberships: [
+      { companyId: "company-1", status: "active", membershipRole: "operator" },
+    ],
+  };
+
+  it("allows an owning run-bound agent JWT to delete its own unbound paperclip_managed secret", async () => {
+    const secret = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: "company-1",
+      scope: "company",
+      status: "active",
+      managedMode: "paperclip_managed",
+      createdByAgentId: "agent-1",
+      name: "Agent-created",
+      key: "agent_created_key",
+    };
+    mockSecretService.getById.mockResolvedValue(secret);
+    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockSecretService.remove.mockResolvedValue(secret);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const res = await request(createApp(agentActor)).delete(
+      "/api/secrets/99999999-9999-4999-8999-999999999999",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(mockAccessService.decide).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ agentId: "agent-1", runId: "run-1", source: "agent_jwt" }),
+      action: "credentials:write",
+      resource: { type: "company", companyId: "company-1" },
+    });
+    expect(mockSecretService.listBindingReferences).toHaveBeenCalledWith("company-1", secret.id);
+    expect(mockSecretService.remove).toHaveBeenCalledWith(secret.id);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "secret.deleted",
+        actorType: "agent",
+        actorId: "agent-1",
+        entityId: secret.id,
+        details: {},
+      }),
+    );
+  });
+
+  it("denies an owning agent from deleting a bound paperclip_managed secret", async () => {
+    const secret = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: "company-1",
+      scope: "company",
+      status: "active",
+      managedMode: "paperclip_managed",
+      createdByAgentId: "agent-1",
+      name: "Agent-created",
+      key: "agent_created_key",
+    };
+    mockSecretService.getById.mockResolvedValue(secret);
+    mockSecretService.listBindingReferences.mockResolvedValue([{ id: "bind-1" }]);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const res = await request(createApp(agentActor)).delete(
+      "/api/secrets/99999999-9999-4999-8999-999999999999",
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("denies a non-owning agent from deleting another agent's secret", async () => {
+    const secret = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: "company-1",
+      scope: "company",
+      status: "active",
+      managedMode: "paperclip_managed",
+      createdByAgentId: "other-agent",
+      name: "Agent-created",
+      key: "agent_created_key",
+    };
+    mockSecretService.getById.mockResolvedValue(secret);
+    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const res = await request(createApp(agentActor)).delete(
+      "/api/secrets/99999999-9999-4999-8999-999999999999",
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("denies an owning agent from deleting a non-paperclip_managed secret", async () => {
+    const secret = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: "company-1",
+      scope: "company",
+      status: "active",
+      managedMode: "external_reference",
+      createdByAgentId: "agent-1",
+      name: "Imported",
+      key: "imported_key",
+    };
+    mockSecretService.getById.mockResolvedValue(secret);
+    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const res = await request(createApp(agentActor)).delete(
+      "/api/secrets/99999999-9999-4999-8999-999999999999",
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("denies a granted but unbound-agent-key owner from deleting (run-bound JWT required)", async () => {
+    const secret = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: "company-1",
+      scope: "company",
+      status: "active",
+      managedMode: "paperclip_managed",
+      createdByAgentId: "agent-1",
+      name: "Agent-created",
+      key: "agent_created_key",
+    };
+    mockSecretService.getById.mockResolvedValue(secret);
+    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const res = await request(createApp({
+      ...agentActor,
+      source: "agent_key",
+    })).delete("/api/secrets/99999999-9999-4999-8999-999999999999");
+
+    expect(res.status).toBe(403);
+    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -24,6 +24,7 @@ const mockSecretService = vi.hoisted(() => ({
   rotate: vi.fn(),
   update: vi.fn(),
   remove: vi.fn(),
+  removeOwnedUnboundCompanySecret: vi.fn(),
   listUserSecretDefinitions: vi.fn(),
   createUserSecretDefinition: vi.fn(),
   updateUserSecretDefinition: vi.fn(),
@@ -1267,8 +1268,7 @@ describe("secret routes", () => {
       key: "agent_created_key",
     };
     mockSecretService.getById.mockResolvedValue(secret);
-    mockSecretService.listBindingReferences.mockResolvedValue([]);
-    mockSecretService.remove.mockResolvedValue(secret);
+    mockSecretService.removeOwnedUnboundCompanySecret.mockResolvedValue(secret);
     mockAccessService.decide.mockResolvedValue({
       allowed: true,
       explanation: "Granted",
@@ -1286,8 +1286,11 @@ describe("secret routes", () => {
       action: "credentials:write",
       resource: { type: "company", companyId: "company-1" },
     });
-    expect(mockSecretService.listBindingReferences).toHaveBeenCalledWith("company-1", secret.id);
-    expect(mockSecretService.remove).toHaveBeenCalledWith(secret.id);
+    expect(mockSecretService.removeOwnedUnboundCompanySecret).toHaveBeenCalledWith({
+      secretId: secret.id,
+      companyId: "company-1",
+      agentId: "agent-1",
+    });
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -1312,7 +1315,9 @@ describe("secret routes", () => {
       key: "agent_created_key",
     };
     mockSecretService.getById.mockResolvedValue(secret);
-    mockSecretService.listBindingReferences.mockResolvedValue([{ id: "bind-1" }]);
+    mockSecretService.removeOwnedUnboundCompanySecret.mockRejectedValue(
+      new HttpError(403, "Secret is still bound and cannot be deleted"),
+    );
     mockAccessService.decide.mockResolvedValue({
       allowed: true,
       explanation: "Granted",
@@ -1324,7 +1329,7 @@ describe("secret routes", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockSecretService.removeOwnedUnboundCompanySecret).toHaveBeenCalledOnce();
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
@@ -1340,7 +1345,9 @@ describe("secret routes", () => {
       key: "agent_created_key",
     };
     mockSecretService.getById.mockResolvedValue(secret);
-    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockSecretService.removeOwnedUnboundCompanySecret.mockRejectedValue(
+      new HttpError(403, "Not an active agent-created paperclip_managed secret owned by this agent"),
+    );
     mockAccessService.decide.mockResolvedValue({
       allowed: true,
       explanation: "Granted",
@@ -1352,7 +1359,7 @@ describe("secret routes", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockSecretService.removeOwnedUnboundCompanySecret).toHaveBeenCalledOnce();
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
@@ -1368,7 +1375,9 @@ describe("secret routes", () => {
       key: "imported_key",
     };
     mockSecretService.getById.mockResolvedValue(secret);
-    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockSecretService.removeOwnedUnboundCompanySecret.mockRejectedValue(
+      new HttpError(403, "Not an active agent-created paperclip_managed secret owned by this agent"),
+    );
     mockAccessService.decide.mockResolvedValue({
       allowed: true,
       explanation: "Granted",
@@ -1380,7 +1389,7 @@ describe("secret routes", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockSecretService.removeOwnedUnboundCompanySecret).toHaveBeenCalledOnce();
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -19,6 +19,7 @@ const mockSecretService = vi.hoisted(() => ({
   checkProviderConfigHealth: vi.fn(),
   getById: vi.fn(),
   getByKey: vi.fn(),
+  list: vi.fn(),
   create: vi.fn(),
   rotate: vi.fn(),
   update: vi.fn(),
@@ -100,6 +101,109 @@ describe("secret routes", () => {
         },
       ],
     });
+  });
+
+  it("returns exactly approved credential metadata to an explicitly granted agent", async () => {
+    mockAccessService.decide.mockResolvedValue({ allowed: true, explanation: "Granted" });
+    mockSecretService.list.mockResolvedValue([{
+      id: "secret-1",
+      companyId: "company-1",
+      scope: "company",
+      name: "GitHub token",
+      provider: "aws_secrets_manager",
+      ownerUserId: null,
+      createdByUserId: "local-board",
+      createdByAgentId: "creator-agent",
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      lastResolvedAt: new Date("2026-04-12T00:00:00.000Z"),
+      externalRef: "should-not-leak",
+      providerMetadata: { token: "should-not-leak" },
+      providerConfigId: "should-not-leak",
+      latestVersion: 7,
+      encryptedValue: "should-not-leak",
+    }]);
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    })).get("/api/companies/company-1/secrets");
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.decide).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ agentId: "agent-1", runId: "run-1" }),
+      action: "credentials:view_metadata",
+      resource: { type: "company", companyId: "company-1" },
+    });
+    expect(Object.keys(res.body[0])).toEqual(["id", "name", "provider", "owner", "latestVersion", "createdAt", "lastUsedAt"]);
+    expect(res.body[0]).toEqual({
+      id: "secret-1",
+      name: "GitHub token",
+      provider: "aws_secrets_manager",
+      owner: "local-board",
+      latestVersion: 7,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      lastUsedAt: "2026-04-12T00:00:00.000Z",
+    });
+  });
+
+  it("keeps the board company-secret metadata shape unchanged", async () => {
+    const secret = {
+      id: "secret-1",
+      companyId: "company-1",
+      scope: "company",
+      ownerUserId: null,
+      userSecretDefinitionId: null,
+      key: "github_token",
+      name: "GitHub token",
+      provider: "local_encrypted",
+      status: "active",
+      managedMode: "paperclip_managed",
+      externalRef: "external-ref",
+      providerConfigId: "config-1",
+      providerMetadata: { region: "us-east-1" },
+      latestVersion: 1,
+      description: "Board-visible metadata",
+      lastResolvedAt: null,
+      lastRotatedAt: null,
+      deletedAt: null,
+      createdByAgentId: null,
+      createdByUserId: "local-board",
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+      referenceCount: 2,
+    };
+    mockSecretService.list.mockResolvedValue([secret]);
+
+    const res = await request(createApp()).get("/api/companies/company-1/secrets");
+
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toEqual({
+      ...secret,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-12T00:00:00.000Z",
+    });
+  });
+
+  it("denies ungranted and cross-company agent company-secret reads before listing", async () => {
+    const ungranted = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: "run-1",
+    })).get("/api/companies/company-1/secrets");
+    expect(ungranted.status).toBe(403);
+    expect(mockSecretService.list).not.toHaveBeenCalled();
+
+    const crossCompany = await request(createApp({
+      type: "agent",
+      agentId: "agent-2",
+      companyId: "company-2",
+      runId: "run-2",
+    })).get("/api/companies/company-1/secrets");
+    expect(crossCompany.status).toBe(403);
+    expect(mockSecretService.list).not.toHaveBeenCalled();
   });
 
   it("allows only a granted run-bound agent JWT to create a company secret without exposing its value", async () => {

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -194,6 +194,11 @@ describe("secret routes", () => {
       runId: "run-1",
     })).get("/api/companies/company-1/secrets");
     expect(ungranted.status).toBe(403);
+    expect(ungranted.body).toMatchObject({
+      error: "Missing permission",
+      details: { reason: "deny_missing_grant" },
+    });
+    expect(JSON.stringify(ungranted.body)).not.toContain("Board access required");
     expect(mockSecretService.list).not.toHaveBeenCalled();
 
     const crossCompany = await request(createApp({
@@ -311,11 +316,18 @@ describe("secret routes", () => {
       { type: "agent", agentId: "agent-1", companyId: "company-1", source: "agent_jwt" },
     ];
 
+    const responses = [];
     for (const actor of actors) {
       const res = await request(createApp(actor)).post("/api/companies/company-1/secrets").send(body);
       expect(res.status).toBe(403);
+      responses.push(res);
     }
 
+    expect(responses[0].body).toMatchObject({
+      error: "Missing permission",
+      details: { reason: "deny_missing_grant" },
+    });
+    expect(JSON.stringify(responses[0].body)).not.toContain("Board access required");
     expect(mockSecretService.create).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
@@ -1397,6 +1409,42 @@ describe("secret routes", () => {
     })).delete("/api/secrets/99999999-9999-4999-8999-999999999999");
 
     expect(res.status).toBe(403);
+    expect(mockSecretService.remove).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("denies an owning agent missing a run or responsible-user binding before delete mutation", async () => {
+    const secret = {
+      id: "99999999-9999-4999-8999-999999999999",
+      companyId: "company-1",
+      scope: "company",
+      status: "active",
+      managedMode: "paperclip_managed",
+      createdByAgentId: "agent-1",
+      name: "Agent-created",
+      key: "agent_created_key",
+    };
+    mockSecretService.getById.mockResolvedValue(secret);
+    mockSecretService.listBindingReferences.mockResolvedValue([]);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      explanation: "Granted",
+      reason: "allow_explicit_grant",
+    });
+
+    const actors = [
+      { ...agentActor, runId: undefined },
+      { ...agentActor, onBehalfOfUserId: "   " },
+    ];
+    for (const actor of actors) {
+      const res = await request(createApp(actor)).delete(
+        "/api/secrets/99999999-9999-4999-8999-999999999999",
+      );
+      expect(res.status).toBe(403);
+    }
+
+    expect(mockAccessService.decide).not.toHaveBeenCalled();
+    expect(mockSecretService.listBindingReferences).not.toHaveBeenCalled();
     expect(mockSecretService.remove).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();
   });

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -803,6 +803,39 @@ describeEmbeddedPostgres("secretService", () => {
     });
   });
 
+  it("rejects an AWS class-3 allowlist key for a non-agent target before binding", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+    const sentinel = `aws-wrong-target-${randomUUID()}`;
+    const secret = await svc.create(companyId, {
+      name: `aws-wrong-target-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: sentinel,
+    });
+
+    await expect(
+      svc.createBinding({
+        companyId,
+        secretId: secret.id,
+        targetType: "project",
+        targetId: randomUUID(),
+        configPath: "env.AWS_ACCESS_KEY_ID",
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "aws.games_logging_preflight.access_key_id",
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      details: { code: "class_3_static_lease_not_allowed" },
+    });
+
+    const bindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(eq(companySecretBindings.companyId, companyId));
+    expect(bindings).toHaveLength(0);
+    expect(JSON.stringify(bindings)).not.toContain(sentinel);
+  });
+
   it("denies user secret resolution outside the low-trust declaration allowlist", async () => {
     const companyId = await seedCompany();
     await seedCompanyMember(companyId, "user-1", "owner");

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -17,12 +17,11 @@ import {
 } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { assertBoard, assertCompanyAccess, getAccessibleResource } from "./authz.js";
-import { logActivity, secretService } from "../services/index.js";
+import { accessService, logActivity, secretService } from "../services/index.js";
 import { createSecretProposalsService } from "../services/secret-proposals.js";
 import { getConfiguredSecretProvider } from "../secrets/configured-provider.js";
 import { forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
 import { authorizationDeniedDetails } from "../services/authorization.js";
-import { accessService } from "../services/access.js";
 import { heartbeatService } from "../services/heartbeat.js";
 import { issueService } from "../services/issues.js";
 import {
@@ -152,6 +151,7 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
       provider: secret.provider,
       // Company rows may not have ownerUserId; audit exports use the creator as the accountable owner.
       owner: secret.ownerUserId ?? secret.createdByUserId ?? secret.createdByAgentId ?? null,
+      latestVersion: secret.latestVersion,
       createdAt: secret.createdAt,
       lastUsedAt: secret.lastResolvedAt,
     };

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -1195,7 +1195,38 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
   });
 
   router.delete("/secrets/:id", async (req, res) => {
-    assertBoard(req);
+    if (req.actor.type !== "agent") {
+      assertBoard(req);
+      const id = req.params.id as string;
+      const fetched = await svc.getById(id);
+      const existing = await getAccessibleResource(
+        req,
+        res,
+        fetched && isCompanyScopedSecret(fetched) ? fetched : null,
+        "Secret not found",
+      );
+      if (!existing) return;
+
+      const removed = await svc.remove(id);
+      if (!removed) {
+        res.status(404).json({ error: "Secret not found" });
+        return;
+      }
+
+      await logActivity(db, {
+        companyId: removed.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "secret.deleted",
+        entityType: "secret",
+        entityId: removed.id,
+        details: { name: removed.name },
+      });
+
+      res.json({ ok: true });
+      return;
+    }
+
     const id = req.params.id as string;
     const fetched = await svc.getById(id);
     const existing = await getAccessibleResource(
@@ -1206,6 +1237,22 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
     );
     if (!existing) return;
 
+    const agent = await assertCanCreateCompanySecret(req, existing.companyId);
+    if (!agent) {
+      throw forbidden("Run-bound agent JWT with responsible-user binding required");
+    }
+    if (
+      existing.status !== "active" ||
+      existing.managedMode !== "paperclip_managed" ||
+      existing.createdByAgentId !== agent.agentId
+    ) {
+      throw forbidden("Not an active agent-created paperclip_managed secret owned by this agent");
+    }
+    const bindings = await svc.listBindingReferences(existing.companyId, existing.id);
+    if (bindings.length !== 0) {
+      throw forbidden("Secret is still bound and cannot be deleted");
+    }
+
     const removed = await svc.remove(id);
     if (!removed) {
       res.status(404).json({ error: "Secret not found" });
@@ -1214,12 +1261,13 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
 
     await logActivity(db, {
       companyId: removed.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: "agent",
+      actorId: agent.agentId,
       action: "secret.deleted",
       entityType: "secret",
       entityId: removed.id,
-      details: { name: removed.name },
+      // Opaque activity so request-controlled metadata is never logged.
+      details: {},
     });
 
     res.json({ ok: true });

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -117,6 +117,60 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
   const heartbeat = deps.heartbeat ?? heartbeatService(db);
   const runRedactions = createRunSecretRedactionRegistry(db);
   const defaultProvider = getConfiguredSecretProvider();
+  function serializeSecretMetadata(secret: Awaited<ReturnType<typeof svc.list>>[number]) {
+    return {
+      id: secret.id,
+      companyId: secret.companyId,
+      scope: secret.scope,
+      ownerUserId: secret.ownerUserId,
+      userSecretDefinitionId: secret.userSecretDefinitionId,
+      key: secret.key,
+      name: secret.name,
+      provider: secret.provider,
+      status: secret.status,
+      managedMode: secret.managedMode,
+      externalRef: secret.externalRef,
+      providerConfigId: secret.providerConfigId,
+      providerMetadata: secret.providerMetadata,
+      latestVersion: secret.latestVersion,
+      description: secret.description,
+      lastResolvedAt: secret.lastResolvedAt,
+      lastRotatedAt: secret.lastRotatedAt,
+      deletedAt: secret.deletedAt,
+      createdByAgentId: secret.createdByAgentId,
+      createdByUserId: secret.createdByUserId,
+      createdAt: secret.createdAt,
+      updatedAt: secret.updatedAt,
+      referenceCount: secret.referenceCount,
+    };
+  }
+
+  function serializeGrantedSecretMetadata(secret: Awaited<ReturnType<typeof svc.list>>[number]) {
+    return {
+      id: secret.id,
+      name: secret.name,
+      provider: secret.provider,
+      // Company rows may not have ownerUserId; audit exports use the creator as the accountable owner.
+      owner: secret.ownerUserId ?? secret.createdByUserId ?? secret.createdByAgentId ?? null,
+      createdAt: secret.createdAt,
+      lastUsedAt: secret.lastResolvedAt,
+    };
+  }
+
+  async function assertCanReadCredentialMetadata(req: Parameters<typeof assertBoard>[0], companyId: string) {
+    assertCompanyAccess(req, companyId);
+    if (req.actor.type === "board") return;
+
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "credentials:view_metadata",
+      resource: { type: "company", companyId },
+    });
+    if (!decision.allowed) {
+      throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
+    }
+  }
+
 
   async function assertCanCreateCompanySecret(req: Parameters<typeof assertBoard>[0], companyId: string) {
     if (req.actor.type === "board") {
@@ -628,11 +682,12 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
   });
 
   router.get("/companies/:companyId/secrets", async (req, res) => {
-    assertBoard(req);
     const companyId = req.params.companyId as string;
-    assertCompanyAccess(req, companyId);
+    await assertCanReadCredentialMetadata(req, companyId);
     const secrets = await svc.list(companyId);
-    res.json(secrets);
+    res.json(req.actor.type === "board"
+      ? secrets.map(serializeSecretMetadata)
+      : secrets.map(serializeGrantedSecretMetadata));
   });
 
   router.get("/companies/:companyId/user-secret-definitions", async (req, res) => {

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -118,6 +118,35 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
   const runRedactions = createRunSecretRedactionRegistry(db);
   const defaultProvider = getConfiguredSecretProvider();
 
+  async function assertCanCreateCompanySecret(req: Parameters<typeof assertBoard>[0], companyId: string) {
+    if (req.actor.type === "board") {
+      assertBoard(req);
+      assertCompanyAccess(req, companyId);
+      return null;
+    }
+
+    assertCompanyAccess(req, companyId);
+    if (
+      req.actor.type !== "agent" ||
+      req.actor.source !== "agent_jwt" ||
+      !req.actor.agentId ||
+      !req.actor.runId ||
+      !req.actor.onBehalfOfUserId?.trim()
+    ) {
+      throw forbidden("Run-bound agent JWT with responsible-user binding required");
+    }
+
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "credentials:write",
+      resource: { type: "company", companyId },
+    });
+    if (!decision.allowed) {
+      throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
+    }
+    return { agentId: req.actor.agentId };
+  }
+
   function agentSecretContext(req: Parameters<typeof assertBoard>[0]) {
     if (req.actor.type !== "agent" || !req.actor.agentId || !req.actor.companyId || !req.actor.runId) {
       throw forbidden("Run-bound agent authentication required");
@@ -893,7 +922,7 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
 
   router.post("/companies/:companyId/secrets", validate(createSecretSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
-    assertCompanySecretWrite(req, companyId);
+    const agent = await assertCanCreateCompanySecret(req, companyId);
 
     const created = await svc.create(
       companyId,
@@ -909,20 +938,20 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
         providerVersionRef: req.body.providerVersionRef,
         providerMetadata: req.body.providerMetadata,
       },
-      { userId: req.actor.userId ?? "board", agentId: null },
+      agent ? { userId: null, agentId: agent.agentId } : { userId: req.actor.userId ?? "board", agentId: null },
     );
 
     await logActivity(db, {
       companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: agent ? "agent" : "user",
+      actorId: agent?.agentId ?? req.actor.userId ?? "board",
       action: "secret.created",
       entityType: "secret",
       entityId: created.id,
-      details: { name: created.name, provider: created.provider },
+      details: agent ? {} : { name: created.name, provider: created.provider },
     });
 
-    res.status(201).json(created);
+    res.status(201).json(agent ? { id: created.id } : created);
   });
 
   router.post(

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -1241,19 +1241,11 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
     if (!agent) {
       throw forbidden("Run-bound agent JWT with responsible-user binding required");
     }
-    if (
-      existing.status !== "active" ||
-      existing.managedMode !== "paperclip_managed" ||
-      existing.createdByAgentId !== agent.agentId
-    ) {
-      throw forbidden("Not an active agent-created paperclip_managed secret owned by this agent");
-    }
-    const bindings = await svc.listBindingReferences(existing.companyId, existing.id);
-    if (bindings.length !== 0) {
-      throw forbidden("Secret is still bound and cannot be deleted");
-    }
-
-    const removed = await svc.remove(id);
+    const removed = await svc.removeOwnedUnboundCompanySecret({
+      secretId: id,
+      companyId: existing.companyId,
+      agentId: agent.agentId,
+    });
     if (!removed) {
       res.status(404).json({ error: "Secret not found" });
       return;

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -543,6 +543,26 @@ function activeResponsibleUserCanAuthorizeAgentGrantedCredentialWrite(
   );
 }
 
+function activeResponsibleUserCanAuthorizeAgentGrantedCredentialMetadata(
+  action: AuthorizationAction,
+  membership: ResponsibleUserSnapshot["activeMembership"],
+  agentDecision: AuthorizationDecision,
+  actorAgentId: string | null | undefined,
+) {
+  // Credential metadata is a read-only, agent-scoped audit grant. The bound
+  // user remains an active same-company accountability check, but does not
+  // need an identical user grant.
+  return Boolean(
+    action === "credentials:view_metadata" &&
+    membership &&
+    membership.status === "active" &&
+    agentDecision.allowed &&
+    agentDecision.reason === "allow_explicit_grant" &&
+    agentDecision.grant?.principalType === "agent" &&
+    agentDecision.grant.principalId === actorAgentId &&
+    agentDecision.grant.permissionKey === "credentials:view_metadata",
+  );
+}
 function scopeBoolean(scope: Record<string, unknown> | null | undefined, key: string) {
   return scope?.[key] === true;
 }
@@ -2310,6 +2330,16 @@ export function authorizationService(db: Db) {
       return agentDecision;
     }
 
+    if (
+      activeResponsibleUserCanAuthorizeAgentGrantedCredentialMetadata(
+        input.action,
+        snapshot.activeMembership,
+        agentDecision,
+        input.actor.agentId,
+      )
+    ) {
+      return agentDecision;
+    }
     const userDecision = snapshot.userExists && snapshot.activeMembership
       ? await decideBase({
           ...input,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -524,6 +524,25 @@ function activeResponsibleUserCanAuthorizeAgentGrantedSkillChange(
   );
 }
 
+function activeResponsibleUserCanAuthorizeAgentGrantedCredentialWrite(
+  action: AuthorizationAction,
+  membership: ResponsibleUserSnapshot["activeMembership"],
+  agentDecision: AuthorizationDecision,
+  actorAgentId: string | null | undefined,
+) {
+  return Boolean(
+    action === "credentials:write" &&
+    membership &&
+    membership.status === "active" &&
+    membership.membershipRole !== "viewer" &&
+    agentDecision.allowed &&
+    agentDecision.reason === "allow_explicit_grant" &&
+    agentDecision.grant?.principalType === "agent" &&
+    agentDecision.grant.principalId === actorAgentId &&
+    agentDecision.grant.permissionKey === "credentials:write",
+  );
+}
+
 function scopeBoolean(scope: Record<string, unknown> | null | undefined, key: string) {
   return scope?.[key] === true;
 }
@@ -2222,6 +2241,30 @@ export function authorizationService(db: Db) {
   ): Promise<AuthorizationDecision> {
     const responsibleUserId = input.actor.onBehalfOfUserId?.trim();
     if (
+      input.actor.type === "agent" &&
+      input.action === "credentials:write" &&
+      !responsibleUserId &&
+      agentDecision.allowed
+    ) {
+      const denied = deny({
+        action: input.action,
+        reason: "deny_missing_membership",
+        code: "RESPONSIBLE_USER_UNAVAILABLE",
+        explanation: "A responsible user is required for credential writes.",
+      });
+      logger.warn({
+        authzMode: "enforce",
+        code: denied.code,
+        reason: denied.reason,
+        action: input.action,
+        resourceType: input.resource.type,
+        companyId: companyIdForResource(input.resource),
+        actorAgentId: input.actor.agentId ?? null,
+        responsibleUserId: null,
+      }, "responsible-user authorization intersection denied");
+      return denied;
+    }
+    if (
       input.actor.type !== "agent" ||
       input.action === "inbox:manage" ||
       !responsibleUserId ||
@@ -2253,6 +2296,17 @@ export function authorizationService(db: Db) {
       // grant. The responsible-user intersection still requires an active
       // non-viewer user, but does not require duplicating that grant on the
       // responsible user's board account for standard heartbeat JWTs.
+      return agentDecision;
+    }
+
+    if (
+      activeResponsibleUserCanAuthorizeAgentGrantedCredentialWrite(
+        input.action,
+        snapshot.activeMembership,
+        agentDecision,
+        input.actor.agentId,
+      )
+    ) {
       return agentDecision;
     }
 
@@ -2307,7 +2361,9 @@ export function authorizationService(db: Db) {
       responsibleUserId,
     }, "responsible-user authorization intersection denied");
 
-    return responsibleUserAuthzShadowMode() ? agentDecision : denied;
+    return input.action === "credentials:write" || !responsibleUserAuthzShadowMode()
+      ? denied
+      : agentDecision;
   }
 
   async function decide(input: {

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -710,11 +710,16 @@ export function secretService(db: Db) {
     actor?: { userId?: string | null; agentId?: string | null };
   };
 
-  async function getById(id: string, source: Pick<Db | DbTransaction, "select"> = db) {
-    return source
+  async function getById(
+    id: string,
+    source: Pick<Db | DbTransaction, "select"> = db,
+    options?: { lockForUpdate?: boolean },
+  ) {
+    const query = source
       .select()
       .from(companySecrets)
-      .where(eq(companySecrets.id, id))
+      .where(eq(companySecrets.id, id));
+    return (options?.lockForUpdate ? query.for("update") : query)
       .then((rows) => rows[0] ?? null);
   }
 
@@ -941,8 +946,9 @@ export function secretService(db: Db) {
     companyId: string,
     secretId: string,
     source: Pick<Db | DbTransaction, "select"> = db,
+    options?: { lockForUpdate?: boolean },
   ) {
-    const secret = await getById(secretId, source);
+    const secret = await getById(secretId, source, options);
     if (!secret) throw notFound("Secret not found");
     if (secret.status === "deleted") throw notFound("Secret not found");
     if (secret.companyId !== companyId) throw unprocessable("Secret must belong to same company");
@@ -2290,6 +2296,71 @@ export function secretService(db: Db) {
     }
     await db.delete(companySecrets).where(eq(companySecrets.id, secretId));
     return secret;
+  }
+
+  async function reserveOwnedUnboundCompanySecretDeletion(input: {
+    secretId: string;
+    companyId: string;
+    agentId: string;
+  }) {
+    type ReservationResult = typeof companySecrets.$inferSelect;
+    const reserve = async (txDb: Db): Promise<ReservationResult> => {
+      const secret = await getById(input.secretId, txDb, { lockForUpdate: true });
+      if (!secret || secret.companyId !== input.companyId || secret.scope !== "company") {
+        throw notFound("Secret not found");
+      }
+      if (
+        secret.status !== "active" ||
+        secret.managedMode !== "paperclip_managed" ||
+        secret.createdByAgentId !== input.agentId
+      ) {
+        throw forbidden("Not an active agent-created paperclip_managed secret owned by this agent");
+      }
+      const binding = await txDb
+        .select({ id: companySecretBindings.id })
+        .from(companySecretBindings)
+        .where(and(
+          eq(companySecretBindings.companyId, input.companyId),
+          eq(companySecretBindings.secretId, input.secretId),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (binding) {
+        throw forbidden("Secret is still bound and cannot be deleted");
+      }
+
+      const reserved = await txDb
+        .update(companySecrets)
+        .set({
+          key: `${secret.key}__deleted__${secret.id}`,
+          name: `${secret.name}__deleted__${secret.id}`,
+          status: "deleted",
+          deletedAt: secret.deletedAt ?? new Date(),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(companySecrets.id, secret.id), eq(companySecrets.status, "active")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!reserved) {
+        throw forbidden("Not an active agent-created paperclip_managed secret owned by this agent");
+      }
+      return secret;
+    };
+
+    const transaction = (db as unknown as {
+      transaction?: (callback: (tx: unknown) => Promise<ReservationResult>) => Promise<ReservationResult>;
+    }).transaction;
+    if (typeof transaction !== "function") return reserve(db);
+    return transaction.call(db, async (tx) => reserve(tx as Db));
+  }
+
+  async function removeOwnedUnboundCompanySecret(input: {
+    secretId: string;
+    companyId: string;
+    agentId: string;
+  }) {
+    await reserveOwnedUnboundCompanySecretDeletion(input);
+    return removeSecretInternal(input.secretId);
   }
 
   async function removeUserSecretDefinitionInternal(
@@ -3960,6 +4031,9 @@ export function secretService(db: Db) {
       const pathPrefixes = [...new Set(normalizedRefs.map((ref) => ref.configPath.split(".")[0]))];
 
       await db.transaction(async (tx) => {
+        for (const secretId of [...new Set(normalizedRefs.map((ref) => ref.secretId))].sort()) {
+          await assertSecretInCompany(companyId, secretId, tx, { lockForUpdate: true });
+        }
         if (options?.replaceAll) {
           await tx
             .delete(companySecretBindings)
@@ -4221,7 +4295,7 @@ export function secretService(db: Db) {
           continue;
         }
         if (binding.type !== "secret_ref") continue;
-        await assertSecretInCompany(companyId, binding.secretId, bindingDb);
+        await assertSecretInCompany(companyId, binding.secretId, bindingDb, { lockForUpdate: true });
         const configPath = `${pathPrefix}.${key}`;
         assertClass3StaticLeaseAllowed({
           targetType: target.targetType,
@@ -4310,6 +4384,8 @@ export function secretService(db: Db) {
     },
 
     remove: removeSecretInternal,
+
+    removeOwnedUnboundCompanySecret,
 
     normalizeAdapterConfigForPersistence: async (
       companyId: string,


### PR DESCRIPTION
Restores narrowly scoped secret operations for agents:

- permits scoped secret writes and separately scoped credential metadata reads;
- adds exactly three `aws.games_logging_preflight` allowlist bindings;
- permits deletion only when the requesting agent owns an active, unbound, managed secret, with deletion serialized to prevent concurrent ownership changes.

The six-commit series includes regression coverage for binding selection, authorization, routes, and service behavior.