### PR TITLE
feat(cost,budgets): impute token cost for subscription runs and enforce it

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -808,7 +808,10 @@ export type FinanceUnit = (typeof FINANCE_UNITS)[number];
 export const BUDGET_SCOPE_TYPES = ["company", "agent", "project"] as const;
 export type BudgetScopeType = (typeof BUDGET_SCOPE_TYPES)[number];
 
-export const BUDGET_METRICS = ["billed_cents"] as const;
+// billed_cents = real invoiced cost only (0 for subscription runs).
+// effective_cents = billed cost, or imputed token cost when nothing was billed,
+// so subscription (e.g. Claude Max) usage is governed instead of reading zero.
+export const BUDGET_METRICS = ["billed_cents", "effective_cents"] as const;
 export type BudgetMetric = (typeof BUDGET_METRICS)[number];
 
 export const BUDGET_WINDOW_KINDS = ["calendar_month_utc", "lifetime"] as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,12 @@
 export { agentAdapterTypeSchema, optionalAgentAdapterTypeSchema } from "./adapter-type.js";
+
+export {
+  MODEL_PRICING,
+  resolveModelPricing,
+  imputeCostCents,
+  effectiveCostCents,
+} from "./model-pricing.js";
+export type { ModelPrice, TokenUsage, CostEventLike } from "./model-pricing.js";
 export {
   decisionEffectStalenessSchema,
   decisionOptionStyleSchema,

--- a/packages/shared/src/model-pricing.test.ts
+++ b/packages/shared/src/model-pricing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  effectiveCostCents,
+  imputeCostCents,
+  resolveModelPricing,
+} from "./model-pricing.js";
+
+describe("model-pricing", () => {
+  it("imputes non-zero cents for subscription token usage", () => {
+    // 1M uncached input on opus = $15.00 = 1500 cents.
+    expect(
+      imputeCostCents({ model: "claude-opus-4-8", inputTokens: 1_000_000 }),
+    ).toBe(1500);
+  });
+
+  it("prices cached input far below uncached input", () => {
+    const uncached = imputeCostCents({ model: "claude-sonnet-4", inputTokens: 1_000_000 });
+    const cached = imputeCostCents({ model: "claude-sonnet-4", cachedInputTokens: 1_000_000 });
+    expect(uncached).toBe(300);
+    expect(cached).toBe(30);
+    expect(cached).toBeLessThan(uncached);
+  });
+
+  it("distinguishes model families and falls back for unknown models", () => {
+    expect(resolveModelPricing("claude-3-5-haiku-20241022").outputPer1M).toBe(400);
+    expect(resolveModelPricing("claude-opus-4-8").outputPer1M).toBe(7500);
+    expect(resolveModelPricing("some-unknown-model").inputPer1M).toBe(300);
+  });
+
+  it("effectiveCostCents prefers a real billed cost and imputes only when zero", () => {
+    // Metered run with a real billed cost is returned as-is.
+    expect(
+      effectiveCostCents({ costCents: 250, model: "claude-opus-4-8", inputTokens: 1_000_000 }),
+    ).toBe(250);
+    // Subscription run (costCents=0) falls back to imputed token cost.
+    expect(
+      effectiveCostCents({ costCents: 0, model: "claude-opus-4-8", outputTokens: 1_000_000 }),
+    ).toBe(7500);
+  });
+
+  it("sums all three token classes and rounds to whole cents", () => {
+    // opus: 500k input (750) + 2M cached (300) + 100k output (750) = 1800 cents.
+    expect(
+      imputeCostCents({
+        model: "claude-opus-4-8",
+        inputTokens: 500_000,
+        cachedInputTokens: 2_000_000,
+        outputTokens: 100_000,
+      }),
+    ).toBe(1800);
+  });
+
+  it("returns zero for no usage", () => {
+    expect(imputeCostCents({ model: "claude-opus-4-8" })).toBe(0);
+  });
+});

--- a/packages/shared/src/model-pricing.ts
+++ b/packages/shared/src/model-pricing.ts
@@ -1,0 +1,81 @@
+// Static, calibratable model -> price map used to impute an economic cost for
+// runs that carry no billed cost. Subscription runs (e.g. Claude Max) report
+// costCents=0, so without imputation every budget/finance metric reads zero even
+// while millions of tokens are consumed. Rates are US cents per 1,000,000 tokens
+// and are DEFAULTS meant to be tuned by an operator as provider pricing changes
+// — they are a knob, not ground truth. Cached input reads are priced far below
+// uncached input.
+//
+// Matching is by lowercase substring against the model id, first match wins, so
+// order entries most-specific first. The final entry (match: "") is the
+// fallback used for unknown models.
+
+export interface ModelPrice {
+  /** lowercase substring matched against the model id; "" matches anything (fallback). */
+  readonly match: string;
+  /** US cents per 1M uncached input tokens. */
+  readonly inputPer1M: number;
+  /** US cents per 1M cached input (read) tokens. */
+  readonly cachedInputPer1M: number;
+  /** US cents per 1M output tokens. */
+  readonly outputPer1M: number;
+}
+
+// Ordered most-specific first. Values approximate public Anthropic list prices
+// (USD/1M x 100 = cents/1M) as of 2026-08; edit these as pricing changes.
+// ponytail: static default table; swap for a provider-fed source only if pricing
+// churn makes hand-editing painful.
+export const MODEL_PRICING: readonly ModelPrice[] = [
+  { match: "opus", inputPer1M: 1500, cachedInputPer1M: 150, outputPer1M: 7500 },
+  { match: "haiku", inputPer1M: 80, cachedInputPer1M: 8, outputPer1M: 400 },
+  { match: "sonnet", inputPer1M: 300, cachedInputPer1M: 30, outputPer1M: 1500 },
+  // Fallback for unknown models: neutral mid-tier (sonnet-like).
+  { match: "", inputPer1M: 300, cachedInputPer1M: 30, outputPer1M: 1500 },
+];
+
+const FALLBACK_PRICE: ModelPrice =
+  MODEL_PRICING.find((price) => price.match === "") ?? MODEL_PRICING[MODEL_PRICING.length - 1];
+
+export function resolveModelPricing(model: string | null | undefined): ModelPrice {
+  const id = (model ?? "").toLowerCase();
+  for (const price of MODEL_PRICING) {
+    if (price.match === "" || id.includes(price.match)) return price;
+  }
+  return FALLBACK_PRICE;
+}
+
+export interface TokenUsage {
+  model?: string | null;
+  inputTokens?: number | null;
+  cachedInputTokens?: number | null;
+  outputTokens?: number | null;
+}
+
+/** Imputed cost in integer US cents for the given token usage. */
+export function imputeCostCents(usage: TokenUsage): number {
+  const price = resolveModelPricing(usage.model);
+  const input = Math.max(0, usage.inputTokens ?? 0);
+  const cached = Math.max(0, usage.cachedInputTokens ?? 0);
+  const output = Math.max(0, usage.outputTokens ?? 0);
+  const cents =
+    (input / 1_000_000) * price.inputPer1M +
+    (cached / 1_000_000) * price.cachedInputPer1M +
+    (output / 1_000_000) * price.outputPer1M;
+  return Math.round(cents);
+}
+
+export interface CostEventLike extends TokenUsage {
+  costCents?: number | null;
+}
+
+/**
+ * The economic "truth" for a cost event: the real billed cost when one was
+ * reported (metered API runs), otherwise the imputed token cost (subscription
+ * runs report costCents=0). Reused by cost views and budget enforcement so both
+ * see a non-zero number for subscription usage.
+ */
+export function effectiveCostCents(event: CostEventLike): number {
+  const billed = event.costCents ?? 0;
+  if (billed > 0) return billed;
+  return imputeCostCents(event);
+}

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -412,6 +412,58 @@ describeEmbeddedPostgres("budgetService release gate enforcement", () => {
     return event!;
   }
 
+  it("enforces an effective_cents budget on a $0 subscription run via imputed token cost", async () => {
+    const { companyId, agentId } = await createBudgetFixture();
+    const service = budgetService(db);
+
+    // Agent hard-stop of 500 cents on the effective_cents metric.
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "effective_cents",
+      windowKind: "calendar_month_utc",
+      amount: 500,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: true,
+      isActive: true,
+    });
+
+    // Subscription run: $0 billed, but 1M output opus tokens => 7500 imputed cents.
+    const [event] = await db
+      .insert(costEvents)
+      .values({
+        companyId,
+        agentId,
+        provider: "anthropic",
+        biller: "claude-max",
+        billingType: "subscription_included",
+        costStatus: "unpriced",
+        model: "claude-opus-4-8",
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 1_000_000,
+        costCents: 0,
+        occurredAt: new Date(),
+      })
+      .returning();
+
+    await service.evaluateCostEvent(event!);
+
+    const [agentAfter] = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents);
+    expect(agentAfter).toEqual({ status: "paused", pauseReason: "budget" });
+
+    const incidents = await db.select().from(budgetIncidents);
+    expect(incidents.some((incident) => incident.thresholdType === "hard")).toBe(true);
+
+    // New work is refused while the effective-cost hard-stop is exceeded.
+    const block = await service.getInvocationBlock(companyId, agentId);
+    expect(block?.scopeType).toBe("agent");
+  });
+
   it("raises one soft incident per window before hard-stopping and safely logging agent telemetry", async () => {
     const { companyId, agentId } = await createBudgetFixture();
     const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -476,6 +476,54 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(agent?.spentMonthlyCents).toBe(0);
   });
 
+  it("imputes an effective cost for subscription runs that report zero billed cost", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      budgetMonthlyCents: 2500,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Subscription Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // opus: 1M input (1500) + 1M cached (150) + 1M output (7500) = 9150 cents,
+    // all imputed because the subscription run reports costCents=0.
+    await costs.createEvent(companyId, {
+      agentId,
+      provider: "anthropic",
+      biller: "claude-max",
+      billingType: "subscription_included",
+      costStatus: "unpriced",
+      model: "claude-opus-4-8",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      costCents: 0,
+      occurredAt: new Date("2026-07-13T14:22:54.000Z"),
+    });
+
+    const [byAgentRow] = await costs.byAgent(companyId);
+    expect(byAgentRow?.costCents).toBe(0);
+    expect(byAgentRow?.effectiveCostCents).toBe(9150);
+
+    const summary = await costs.summary(companyId);
+    expect(summary.spendCents).toBe(0);
+    expect(summary.effectiveSpendCents).toBe(9150);
+  });
+
   it("aggregates cost event sums above int32 without raising Postgres integer overflow", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -24,6 +24,11 @@ import type {
 } from "@paperclipai/shared";
 import { notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
+import { effectiveCostCentsSum } from "./cost-imputation-sql.js";
+
+// Metrics whose policies are enforced. effective_cents lets subscription
+// (imputed) token usage trip the same soft/hard gates as real billed spend.
+const ENFORCED_BUDGET_METRICS = ["billed_cents", "effective_cents"] as const;
 
 type ScopeRecord = {
   companyId: string;
@@ -144,7 +149,7 @@ async function computeObservedAmount(
   db: Db,
   policy: Pick<PolicyRow, "companyId" | "scopeType" | "scopeId" | "windowKind" | "metric">,
 ) {
-  if (policy.metric !== "billed_cents") return 0;
+  if (policy.metric !== "billed_cents" && policy.metric !== "effective_cents") return 0;
 
   const conditions = [eq(costEvents.companyId, policy.companyId)];
   if (policy.scopeType === "agent") conditions.push(eq(costEvents.agentId, policy.scopeId));
@@ -155,14 +160,47 @@ async function computeObservedAmount(
     conditions.push(lt(costEvents.occurredAt, end));
   }
 
+  // effective_cents adds imputed token cost for $0 subscription runs; billed_cents
+  // sums only real invoiced cost.
+  const totalExpr =
+    policy.metric === "effective_cents"
+      ? effectiveCostCentsSum()
+      : sql<number>`coalesce(sum(${costEvents.costCents}), 0)::double precision`;
+
   const [row] = await db
-    .select({
-      total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::double precision`,
-    })
+    .select({ total: totalExpr })
     .from(costEvents)
     .where(and(...conditions));
 
   return Number(row?.total ?? 0);
+}
+
+// The first active hard-stop policy for a scope whose observed amount has reached
+// its limit, or null. Considers every enforced metric so an effective_cents
+// policy pauses work even when billed_cents is zero.
+async function firstExceededHardStopPolicy(
+  db: Db,
+  scope: { companyId: string; scopeType: BudgetScopeType; scopeId: string },
+): Promise<PolicyRow | null> {
+  const policies = await db
+    .select()
+    .from(budgetPolicies)
+    .where(
+      and(
+        eq(budgetPolicies.companyId, scope.companyId),
+        eq(budgetPolicies.scopeType, scope.scopeType),
+        eq(budgetPolicies.scopeId, scope.scopeId),
+        eq(budgetPolicies.isActive, true),
+        inArray(budgetPolicies.metric, [...ENFORCED_BUDGET_METRICS]),
+      ),
+    );
+  for (const policy of policies) {
+    if (policy.hardStopEnabled && policy.amount > 0) {
+      const observed = await computeObservedAmount(db, policy);
+      if (observed >= policy.amount) return policy;
+    }
+  }
+  return null;
 }
 
 function buildApprovalPayload(input: {
@@ -666,7 +704,11 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
       });
 
       for (const policy of relevantPolicies) {
-        if (policy.metric !== "billed_cents" || policy.amount <= 0) continue;
+        if (
+          (policy.metric !== "billed_cents" && policy.metric !== "effective_cents") ||
+          policy.amount <= 0
+        )
+          continue;
         const observedAmount = await computeObservedAmount(db, policy);
         const softThreshold = Math.ceil((policy.amount * policy.warnPercent) / 100);
 
@@ -754,29 +796,13 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         };
       }
 
-      const companyPolicy = await db
-        .select()
-        .from(budgetPolicies)
-        .where(
-          and(
-            eq(budgetPolicies.companyId, companyId),
-            eq(budgetPolicies.scopeType, "company"),
-            eq(budgetPolicies.scopeId, companyId),
-            eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
-          ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (companyPolicy && companyPolicy.hardStopEnabled && companyPolicy.amount > 0) {
-        const observed = await computeObservedAmount(db, companyPolicy);
-        if (observed >= companyPolicy.amount) {
-          return {
-            scopeType: "company" as const,
-            scopeId: companyId,
-            scopeName: company.name,
-            reason: "Company cannot start new work because its budget hard-stop is exceeded.",
-          };
-        }
+      if (await firstExceededHardStopPolicy(db, { companyId, scopeType: "company", scopeId: companyId })) {
+        return {
+          scopeType: "company" as const,
+          scopeId: companyId,
+          scopeName: company.name,
+          reason: "Company cannot start new work because its budget hard-stop is exceeded.",
+        };
       }
 
       if (agent.status === "paused" && agent.pauseReason === "budget") {
@@ -788,29 +814,13 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         };
       }
 
-      const agentPolicy = await db
-        .select()
-        .from(budgetPolicies)
-        .where(
-          and(
-            eq(budgetPolicies.companyId, companyId),
-            eq(budgetPolicies.scopeType, "agent"),
-            eq(budgetPolicies.scopeId, agentId),
-            eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
-          ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (agentPolicy && agentPolicy.hardStopEnabled && agentPolicy.amount > 0) {
-        const observed = await computeObservedAmount(db, agentPolicy);
-        if (observed >= agentPolicy.amount) {
-          return {
-            scopeType: "agent" as const,
-            scopeId: agentId,
-            scopeName: agent.name,
-            reason: "Agent cannot start because its budget hard-stop is still exceeded.",
-          };
-        }
+      if (await firstExceededHardStopPolicy(db, { companyId, scopeType: "agent", scopeId: agentId })) {
+        return {
+          scopeType: "agent" as const,
+          scopeId: agentId,
+          scopeName: agent.name,
+          reason: "Agent cannot start because its budget hard-stop is still exceeded.",
+        };
       }
 
       const candidateProjectId = context?.projectId ?? null;
@@ -829,29 +839,13 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         .then((rows) => rows[0] ?? null);
 
       if (!project || project.companyId !== companyId) return null;
-      const projectPolicy = await db
-        .select()
-        .from(budgetPolicies)
-        .where(
-          and(
-            eq(budgetPolicies.companyId, companyId),
-            eq(budgetPolicies.scopeType, "project"),
-            eq(budgetPolicies.scopeId, project.id),
-            eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
-          ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (projectPolicy && projectPolicy.hardStopEnabled && projectPolicy.amount > 0) {
-        const observed = await computeObservedAmount(db, projectPolicy);
-        if (observed >= projectPolicy.amount) {
-          return {
-            scopeType: "project" as const,
-            scopeId: project.id,
-            scopeName: project.name,
-            reason: "Project cannot start work because its budget hard-stop is still exceeded.",
-          };
-        }
+      if (await firstExceededHardStopPolicy(db, { companyId, scopeType: "project", scopeId: project.id })) {
+        return {
+          scopeType: "project" as const,
+          scopeId: project.id,
+          scopeName: project.name,
+          reason: "Project cannot start work because its budget hard-stop is still exceeded.",
+        };
       }
 
       if (!project.pausedAt || project.pauseReason !== "budget") return null;

--- a/server/src/services/cost-imputation-sql.ts
+++ b/server/src/services/cost-imputation-sql.ts
@@ -1,0 +1,35 @@
+import { sql } from "drizzle-orm";
+import { costEvents } from "@paperclipai/db";
+import { MODEL_PRICING } from "@paperclipai/shared";
+
+// Per-token rate (cents/token) selected by model, generated from the shared
+// MODEL_PRICING map so SQL imputation and the TS imputeCostCents() helper stay
+// in sync from a single source. First matching substring wins (CASE order).
+function modelRateCase(field: "inputPer1M" | "cachedInputPer1M" | "outputPer1M") {
+  const specific = MODEL_PRICING.filter((price) => price.match !== "");
+  const fallback =
+    (MODEL_PRICING.find((price) => price.match === "") ?? MODEL_PRICING[MODEL_PRICING.length - 1])[field] /
+    1_000_000;
+  const whens = specific.map(
+    (price) => sql`when lower(${costEvents.model}) like ${`%${price.match}%`} then ${price[field] / 1_000_000}::numeric`,
+  );
+  return sql`case ${sql.join(whens, sql` `)} else ${fallback}::numeric end`;
+}
+
+/**
+ * SUM of the economic "truth" per cost_events row: the real billed cost when
+ * reported (metered API), otherwise the imputed token cost (subscription runs
+ * report cost_cents=0). Mirrors effectiveCostCents() from @paperclipai/shared.
+ * Shared by the cost views and by budget enforcement so both govern the same
+ * number for subscription usage.
+ */
+export function effectiveCostCentsSum() {
+  return sql<number>`coalesce(sum(
+    case when ${costEvents.costCents} > 0 then ${costEvents.costCents}
+    else round(
+      ${costEvents.inputTokens} * (${modelRateCase("inputPer1M")})
+      + ${costEvents.cachedInputTokens} * (${modelRateCase("cachedInputPer1M")})
+      + ${costEvents.outputTokens} * (${modelRateCase("outputPer1M")})
+    ) end
+  ), 0)::double precision`;
+}

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from "drizzle-orm
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
+import { effectiveCostCentsSum } from "./cost-imputation-sql.js";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
@@ -115,24 +116,33 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
       if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
 
-      const [{ total }] = await db
+      const [{ total, effectiveTotal }] = await db
         .select({
           total: sumAsNumber(costEvents.costCents),
+          effectiveTotal: effectiveCostCentsSum(),
         })
         .from(costEvents)
         .where(and(...conditions));
 
       const spendCents = Number(total);
+      const effectiveSpendCents = Number(effectiveTotal);
       const utilization =
         company.budgetMonthlyCents > 0
           ? (spendCents / company.budgetMonthlyCents) * 100
+          : 0;
+      const effectiveUtilization =
+        company.budgetMonthlyCents > 0
+          ? (effectiveSpendCents / company.budgetMonthlyCents) * 100
           : 0;
 
       return {
         companyId,
         spendCents,
+        // Includes imputed cost for subscription runs that report a $0 billed cost.
+        effectiveSpendCents,
         budgetCents: company.budgetMonthlyCents,
         utilizationPercent: Number(utilization.toFixed(2)),
+        effectiveUtilizationPercent: Number(effectiveUtilization.toFixed(2)),
       };
     },
 
@@ -288,6 +298,8 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           agentName: agents.name,
           agentStatus: agents.status,
           costCents: sumAsNumber(costEvents.costCents),
+          // Billed cost plus imputed token cost for $0 subscription runs.
+          effectiveCostCents: effectiveCostCentsSum(),
           inputTokens: sumAsNumber(costEvents.inputTokens),
           cachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
           outputTokens: sumAsNumber(costEvents.outputTokens),
@@ -440,6 +452,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           billingType: costEvents.billingType,
           model: costEvents.model,
           costCents: sumAsNumber(costEvents.costCents),
+          effectiveCostCents: effectiveCostCentsSum(),
           inputTokens: sumAsNumber(costEvents.inputTokens),
           cachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
           outputTokens: sumAsNumber(costEvents.outputTokens),
@@ -496,6 +509,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           projectId: effectiveProjectId,
           projectName: projects.name,
           costCents: costCentsExpr,
+          effectiveCostCents: effectiveCostCentsSum(),
           inputTokens: sumAsNumber(costEvents.inputTokens),
           cachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
           outputTokens: sumAsNumber(costEvents.outputTokens),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane that people use to run companies of AI agents.
> - Cost and budgets are the control plane's safety layer. Runs write `cost_events`, and `budget_policies` enforce spend limits.
> - Many agents run on subscription plans, for example Claude Max. These runs report `cost_cents = 0`.
> - So cost views and budget metrics read zero even when the runs use millions of tokens. Hard-stops never fire for this usage.
> - This means the "safe autonomy, no hidden token burn" promise is not enforced for subscription runs.
> - This pull request imputes a token cost from a calibratable per-model price map, shows it in the cost views, and adds a budget metric that enforces on it.
> - The benefit is that subscription usage becomes visible and can trip the same soft and hard budget gates as billed spend.

## Linked Issues or Issue Description

No public GitHub issue exists. The change is described below with the feature template fields.

**Related pull requests**
I searched the PR list and found related work. Refs #3330 (open) and #4430 (closed) — both impute an API-equivalent cost for subscription-included runs; the imputation approach overlaps. Refs #10871 (open) — reports token usage where subscription billing zeroes spend; complementary. This PR's distinct piece is the `effective_cents` **budget metric that enforces** on the imputed cost, so soft and hard budget gates pause a scope on subscription usage — which the above PRs do not do. Maintainers may prefer to consolidate the imputation half with #3330.

**Subsystem affected**
Cost accounting and budgets (`server/src/services/costs.ts`, `server/src/services/budgets.ts`, `@paperclipai/shared`).

**Problem or motivation**
Subscription runs report `cost_cents = 0`. Every cost view and budget metric reads zero even while the runs consume many tokens. A billed-cents hard-stop can never pause a subscription workload, so spend is ungoverned.

**Proposed solution**
Add a calibratable per-model price map with `imputeCostCents` and `effectiveCostCents` helpers. Surface `effectiveCostCents` in the cost views. Add an `effective_cents` budget metric and enforce it in `computeObservedAmount`, `evaluateCostEvent`, and `getInvocationBlock`.

**Alternatives considered**
Store an imputed cost column at write time. This was rejected because it needs a migration and freezes prices in old rows. Imputing at query time keeps prices editable and avoids schema churn.

**Additional context**
`billed_cents` behavior is unchanged and stays the default metric. The price table holds documented default rates that an operator can tune as provider pricing changes.

## What Changed

- Add `packages/shared/src/model-pricing.ts`: a per-model price map plus `imputeCostCents()` and `effectiveCostCents()` (one source of truth for imputation). Exported from the package index.
- Add `server/src/services/cost-imputation-sql.ts`: a SQL sum expression generated from the same price map, so the views and budgets share one definition.
- Update `server/src/services/costs.ts`: report `effectiveCostCents` in `summary`, `byAgent`, `byAgentModel`, and `byProject`. No schema change.
- Add an `effective_cents` value to `BUDGET_METRICS`. Update `computeObservedAmount`, `evaluateCostEvent`, and all three `getInvocationBlock` scopes to enforce it. The three per-scope lookups now route through one `firstExceededHardStopPolicy` helper.
- Add tests: price math, a real-SQL subscription imputation test, and an `effective_cents` hard-stop that pauses an agent and blocks new work.

## Verification

- `pnpm --filter @paperclipai/shared build` — passes.
- `pnpm --filter @paperclipai/server typecheck` — passes.
- `npx vitest run packages/shared/src/model-pricing.test.ts server/src/__tests__/costs-service.test.ts server/src/__tests__/budgets-service.test.ts` — 32 tests pass.
- End-to-end (embedded Postgres): a subscription run of 1M input + 1M cached + 1M output opus tokens at `cost_cents = 0` returns `effectiveCostCents = 9150` from `byAgent` and `summary`, and trips a 500-cent `effective_cents` agent hard-stop (agent paused, hard incident raised, new work blocked).

## Risks

- Low risk. `billed_cents` is unchanged and remains the default, so existing policies behave exactly as before.
- `effective_cents` is opt-in per policy. No migration runs.
- The price table holds default rates. If a rate is stale, imputed cost drifts from the true rate. The table is a single, commented file that an operator edits.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), Anthropic. Extended thinking, tool use, and code execution, run through an agentic CLI harness. The model read the code, wrote the change, and ran the tests and typecheck locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
