### PR TITLE
feat(cursor-local): inject adapterConfig.mcpServers into agent-scoped Cursor HOME

### DIFF
--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -93,6 +93,7 @@ Core fields:
 - command (string, optional): defaults to "agent"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables
+- mcpServers (object, optional): Cursor MCP server map (stdio command/args or url/headers). Materialized into an agent-scoped HOME/.cursor/mcp.json for local runs so binds stay per-agent (not shared host ~/.cursor/mcp.json).
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
@@ -103,6 +104,7 @@ Notes:
 - Prompts are piped to Cursor via stdin.
 - Sessions are resumed with --resume when stored session cwd matches current cwd.
 - Paperclip auto-injects local skills into "~/.cursor/skills" when missing, so Cursor can discover "$paperclip" and related skills on local runs.
+- When mcpServers (or runtime MCP gateways) are present on local runs, Paperclip sets HOME to an agent-scoped cursor-runtime home containing only that agent's mcp.json, then auto-adds --approve-mcps.
 - Paperclip auto-adds --yolo unless one of --trust/--yolo/-f is already present in extraArgs.
 - Remote sandbox runs prepend "~/.cursor/bin" and "~/.local/bin" to PATH and prefer the installed absolute entrypoint from one of those directories when the default Cursor command is requested, so installer-managed sandbox leases do not need hardcoded command paths.
 `;

--- a/packages/adapters/cursor-local/src/server/cursor-mcp.test.ts
+++ b/packages/adapters/cursor-local/src/server/cursor-mcp.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mergeCursorMcpServers,
+  parseAdapterCursorMcpServers,
+  prepareCursorMcpHome,
+} from "./cursor-mcp.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("parseAdapterCursorMcpServers", () => {
+  it("keeps stdio and url servers and drops incomplete entries", () => {
+    const parsed = parseAdapterCursorMcpServers({
+      scout: {
+        command: "/opt/workspace/Scout/.venv/bin/python",
+        args: ["/opt/workspace/Scout/mcp_server.py"],
+      },
+      remote: { url: "https://example.test/mcp", headers: { Authorization: "Bearer x" } },
+      broken: { args: ["nope"] },
+      "": { command: "/bin/true" },
+    });
+    expect(Object.keys(parsed).sort()).toEqual(["remote", "scout"]);
+    expect(parsed.scout).toMatchObject({
+      command: "/opt/workspace/Scout/.venv/bin/python",
+      args: ["/opt/workspace/Scout/mcp_server.py"],
+    });
+    expect(parsed.remote).toMatchObject({ url: "https://example.test/mcp" });
+  });
+});
+
+describe("mergeCursorMcpServers", () => {
+  it("lets adapter binds win and renames overlapping runtime gateways", () => {
+    const merged = mergeCursorMcpServers({
+      adapterServers: {
+        scout: { command: "/bin/scout" },
+      },
+      runtimeServers: [
+        {
+          name: "scout",
+          url: "https://gateway.test/mcp",
+          token: "tok",
+          connectionId: "abcd1234-efgh",
+        },
+      ],
+    });
+    expect(merged.scout).toEqual({ command: "/bin/scout" });
+    expect(merged["scout-abcd1234"]).toEqual({
+      url: "https://gateway.test/mcp",
+      headers: { Authorization: "Bearer tok" },
+    });
+  });
+});
+
+describe("prepareCursorMcpHome", () => {
+  it("returns null when no servers are configured", async () => {
+    const prepared = await prepareCursorMcpHome({
+      companyId: "co",
+      agentId: "ag",
+      mcpServers: {},
+    });
+    expect(prepared).toBeNull();
+  });
+
+  it("writes agent-scoped mcp.json and links host cursor assets", async () => {
+    const root = await makeTempDir("paperclip-cursor-mcp-");
+    const hostHome = path.join(root, "host-home");
+    const paperclipHome = path.join(root, "paperclip-home");
+    const hostCursor = path.join(hostHome, ".cursor");
+    await fs.mkdir(path.join(hostCursor, "skills"), { recursive: true });
+    await fs.writeFile(path.join(hostCursor, "cli-config.json"), '{"auth":true}\n');
+
+    const prepared = await prepareCursorMcpHome({
+      companyId: "company-1",
+      agentId: "agent-1",
+      hostHome,
+      env: {
+        PAPERCLIP_HOME: paperclipHome,
+        PAPERCLIP_INSTANCE_ID: "default",
+      },
+      mcpServers: {
+        scout: {
+          command: "/opt/workspace/Scout/.venv/bin/python",
+          args: ["/opt/workspace/Scout/mcp_server.py"],
+        },
+      },
+    });
+
+    expect(prepared).not.toBeNull();
+    expect(prepared!.homeDir).toBe(
+      path.join(paperclipHome, "instances", "default", "companies", "company-1", "agents", "agent-1", "cursor-runtime", "home"),
+    );
+
+    const written = JSON.parse(await fs.readFile(prepared!.mcpConfigPath, "utf8"));
+    expect(written).toEqual({
+      mcpServers: {
+        scout: {
+          command: "/opt/workspace/Scout/.venv/bin/python",
+          args: ["/opt/workspace/Scout/mcp_server.py"],
+        },
+      },
+    });
+
+    const linkedConfig = path.join(prepared!.homeDir, ".cursor", "cli-config.json");
+    expect(await fs.readlink(linkedConfig)).toBe(path.join(hostCursor, "cli-config.json"));
+    expect(await fs.readlink(path.join(prepared!.homeDir, ".cursor", "skills"))).toBe(
+      path.join(hostCursor, "skills"),
+    );
+  });
+});

--- a/packages/adapters/cursor-local/src/server/cursor-mcp.ts
+++ b/packages/adapters/cursor-local/src/server/cursor-mcp.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-utils/server-utils";
+
+const CURSOR_HOME_LINK_ENTRIES = [
+  "cli-config.json",
+  "agent-cli-state.json",
+  "skills",
+  "skills-cursor",
+  "plugins",
+  "ai-tracking",
+] as const;
+
+function nonEmpty(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export type CursorMcpServerConfig = Record<string, unknown>;
+
+export function resolveManagedCursorRuntimeStateDir(
+  env: NodeJS.ProcessEnv,
+  companyId: string,
+  agentId: string,
+): string {
+  const instanceRoot = resolvePaperclipInstanceRootForAdapter({
+    homeDir: nonEmpty(env.PAPERCLIP_HOME) ?? undefined,
+    instanceId: nonEmpty(env.PAPERCLIP_INSTANCE_ID) ?? undefined,
+    env,
+  });
+  return path.join(instanceRoot, "companies", companyId, "agents", agentId, "cursor-runtime");
+}
+
+/**
+ * Parse adapterConfig.mcpServers into a Cursor mcp.json map.
+ * Supports stdio ({command,args,env}) and remote ({url,headers}) shapes.
+ */
+export function parseAdapterCursorMcpServers(raw: unknown): Record<string, CursorMcpServerConfig> {
+  if (!isPlainRecord(raw)) return {};
+  const out: Record<string, CursorMcpServerConfig> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    const key = name.trim();
+    if (!key || !isPlainRecord(value)) continue;
+    const command = nonEmpty(value.command);
+    const url = nonEmpty(value.url);
+    if (!command && !url) continue;
+    const server: CursorMcpServerConfig = { ...value };
+    out[key] = server;
+  }
+  return out;
+}
+
+export function mergeCursorMcpServers(input: {
+  adapterServers: Record<string, CursorMcpServerConfig>;
+  runtimeServers?: Array<{ name: string; url: string; token: string; connectionId: string }>;
+}): Record<string, CursorMcpServerConfig> {
+  const mcpServers: Record<string, CursorMcpServerConfig> = { ...input.adapterServers };
+  const usedNames = new Set(Object.keys(mcpServers));
+  for (const server of input.runtimeServers ?? []) {
+    let name = server.name.trim() || `gateway-${server.connectionId.slice(0, 8)}`;
+    if (usedNames.has(name)) name = `${name}-${server.connectionId.slice(0, 8)}`;
+    let suffix = 2;
+    while (usedNames.has(name)) {
+      name = `${server.name}-${server.connectionId.slice(0, 8)}-${suffix}`;
+      suffix += 1;
+    }
+    usedNames.add(name);
+    mcpServers[name] = {
+      url: server.url,
+      headers: { Authorization: `Bearer ${server.token}` },
+    };
+  }
+  return mcpServers;
+}
+
+async function ensureSymlink(target: string, source: string): Promise<void> {
+  const existing = await fs.lstat(target).catch(() => null);
+  if (existing) {
+    if (existing.isSymbolicLink()) {
+      const current = await fs.readlink(target).catch(() => null);
+      if (current === source) return;
+      await fs.unlink(target);
+    } else {
+      return;
+    }
+  }
+  await fs.symlink(source, target);
+}
+
+/**
+ * Materialize adapter/runtime MCP servers into an agent-scoped Cursor HOME.
+ * Cursor discovers user MCP from `$HOME/.cursor/mcp.json` (not CURSOR_CONFIG_DIR),
+ * so when servers are present we isolate HOME for the agent process instead of
+ * writing into the shared host ~/.cursor/mcp.json.
+ */
+export async function prepareCursorMcpHome(input: {
+  companyId: string;
+  agentId: string;
+  mcpServers: Record<string, CursorMcpServerConfig>;
+  hostHome?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ homeDir: string; mcpConfigPath: string; serverNames: string[] } | null> {
+  const serverNames = Object.keys(input.mcpServers);
+  if (serverNames.length === 0) return null;
+
+  const hostHome = path.resolve(input.hostHome ?? os.homedir());
+  const stateDir = resolveManagedCursorRuntimeStateDir(
+    input.env ?? process.env,
+    input.companyId,
+    input.agentId,
+  );
+  const homeDir = path.join(stateDir, "home");
+  const cursorDir = path.join(homeDir, ".cursor");
+  await fs.mkdir(cursorDir, { recursive: true });
+
+  const hostCursorDir = path.join(hostHome, ".cursor");
+  for (const entry of CURSOR_HOME_LINK_ENTRIES) {
+    const source = path.join(hostCursorDir, entry);
+    const target = path.join(cursorDir, entry);
+    const sourceExists = await fs.access(source).then(() => true).catch(() => false);
+    if (!sourceExists) continue;
+    await ensureSymlink(target, source);
+  }
+
+  const mcpConfigPath = path.join(cursorDir, "mcp.json");
+  await fs.writeFile(mcpConfigPath, `${JSON.stringify({ mcpServers: input.mcpServers }, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await fs.chmod(mcpConfigPath, 0o600).catch(() => undefined);
+
+  // Also mirror into agent workspace home when present so operators can inspect
+  // the bound config without reading the managed runtime tree.
+  return { homeDir, mcpConfigPath, serverNames };
+}

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -50,6 +50,11 @@ import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
 import { prepareCursorSandboxCommand } from "./remote-command.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
+import {
+  mergeCursorMcpServers,
+  parseAdapterCursorMcpServers,
+  prepareCursorMcpHome,
+} from "./cursor-mcp.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -230,11 +235,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const cursorSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredCursorSkillNames = resolvePaperclipDesiredSkillNames(config, cursorSkillEntries);
-  if (!executionTargetIsRemote) {
-    await ensureCursorSkillsInjected(onLog, {
-      skillsEntries: cursorSkillEntries.filter((entry) => desiredCursorSkillNames.includes(entry.key)),
-    });
-  }
+  const adapterMcpServers = parseAdapterCursorMcpServers(config.mcpServers);
+  const runtimeMcpServers = ctx.runtimeMcp?.getServers() ?? [];
+  const cursorMcpServers = mergeCursorMcpServers({
+    adapterServers: adapterMcpServers,
+    runtimeServers: runtimeMcpServers,
+  });
+  const injectCursorMcp = Object.keys(cursorMcpServers).length > 0;
 
   const envConfig = parseObject(config.env);
   let env: Record<string, string> = { ...buildPaperclipEnv(agent) };
@@ -304,6 +311,50 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }
+
+  let cursorMcpHome: Awaited<ReturnType<typeof prepareCursorMcpHome>> = null;
+  if (!executionTargetIsRemote && injectCursorMcp) {
+    cursorMcpHome = await prepareCursorMcpHome({
+      companyId: agent.companyId,
+      agentId: agent.id,
+      mcpServers: cursorMcpServers,
+      hostHome: os.homedir(),
+    });
+    if (cursorMcpHome) {
+      env.HOME = cursorMcpHome.homeDir;
+      await onLog(
+        "stdout",
+        `[paperclip] Injected Cursor MCP servers (${cursorMcpHome.serverNames.join(", ")}) via agent-scoped HOME ${cursorMcpHome.homeDir} → ${cursorMcpHome.mcpConfigPath}\n`,
+      );
+    }
+  }
+
+  if (!executionTargetIsRemote) {
+    const skillsHome = cursorMcpHome
+      ? path.join(cursorMcpHome.homeDir, ".cursor", "skills")
+      : undefined;
+    await ensureCursorSkillsInjected(onLog, {
+      skillsEntries: cursorSkillEntries.filter((entry) => desiredCursorSkillNames.includes(entry.key)),
+      ...(skillsHome ? { skillsHome } : {}),
+    });
+  }
+
+  // Mirror bind into PAPERCLIP agent home for operator inspection (not used by Cursor discovery).
+  if (injectCursorMcp && agentHome) {
+    try {
+      const mirrorDir = path.join(agentHome, ".cursor");
+      await fs.mkdir(mirrorDir, { recursive: true });
+      await fs.writeFile(
+        path.join(mirrorDir, "mcp.json"),
+        `${JSON.stringify({ mcpServers: cursorMcpServers }, null, 2)}\n`,
+        { mode: 0o600 },
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog("stderr", `[paperclip] Warning: could not mirror Cursor mcp.json into agent home: ${reason}\n`);
+    }
+  }
+
   const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
     executionTarget,
     asNumber(config.timeoutSec, 0),
@@ -518,6 +569,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (autoTrustEnabled) {
       notes.push("Auto-added --yolo to bypass interactive prompts.");
     }
+    if (injectCursorMcp) {
+      notes.push("Auto-added --approve-mcps for Paperclip-materialized adapter/runtime MCP servers.");
+      if (cursorMcpHome) {
+        notes.push(
+          `Materialized agent-scoped Cursor MCP config at ${cursorMcpHome.mcpConfigPath} (HOME=${cursorMcpHome.homeDir}).`,
+        );
+      }
+    }
     notes.push("Prompt is piped to Cursor via stdin.");
     const sandboxCommand = finalSandboxCommand ?? initialSandboxCommand;
     if (sandboxCommand?.addedPathEntry) {
@@ -587,6 +646,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (model) args.push("--model", model);
     if (mode) args.push("--mode", mode);
     if (autoTrustEnabled) args.push("--yolo");
+    // Cursor prompts for MCP approval unless servers are already trusted; auto-approve
+    // when Paperclip materialized adapterConfig/runtime MCP for this run.
+    if (injectCursorMcp && !extraArgs.includes("--approve-mcps")) {
+      args.push("--approve-mcps");
+    }
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/packages/adapters/cursor-local/src/server/index.ts
+++ b/packages/adapters/cursor-local/src/server/index.ts
@@ -2,6 +2,12 @@ export { execute, ensureCursorSkillsInjected } from "./execute.js";
 export { listCursorSkills, syncCursorSkills } from "./skills.js";
 export { testEnvironment } from "./test.js";
 export { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
+export {
+  mergeCursorMcpServers,
+  parseAdapterCursorMcpServers,
+  prepareCursorMcpHome,
+  resolveManagedCursorRuntimeStateDir,
+} from "./cursor-mcp.js";
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
 
 function readNonEmptyString(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- Materialize `adapterConfig.mcpServers` (plus runtime MCP gateways) into an agent-scoped `cursor-runtime/home/.cursor/mcp.json` for local Cursor runs
- Set that run's `HOME` to the managed home so Cursor discovers the bind without writing the shared host `~/.cursor/mcp.json`
- Auto-add `--approve-mcps` when Paperclip materializes MCP for the run; mirror config into `$AGENT_HOME/.cursor/mcp.json` for operators

## Why
Cursor CLI loads user MCP from `$HOME/.cursor/mcp.json` (not `CURSOR_CONFIG_DIR`). Without this, Paperclip `adapterConfig.mcpServers` stamps never appear in-session (`GetMcpTools` / `agent mcp list`), which blocked sole-target Scout binds for Growth agents.

## Test plan
- [x] Unit tests for parse/merge/prepare helpers
- [x] Smoke: managed Growth HOME → `agent mcp list` shows `scout: ready`; host HOME without scout does not
- [ ] CI on this PR
- [ ] After merge/release: Growth heartbeat `GetMcpTools` shows Scout without shared-host mcp.json


Made with [Cursor](https://cursor.com)