### PR TITLE
ci(docker): add workflow_dispatch to build a SHA-tagged preview image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,19 @@ on:
       - "master"
     tags:
       - "v*"
+  # Manual builds so an unmerged ref can be previewed before it lands. This
+  # publishes a SHA-tagged image and no `latest`/`v*` (release) tag — it is a
+  # review image, not a release — and the deploy tooling accepts the resulting
+  # `sha-<short>` tag as an ordinary app ref, so nothing downstream changes.
+  # Deliberately not the release workflow: that one publishes a stable `v*`
+  # release, a far bigger act than building a preview image.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to build. Defaults to the ref this run was dispatched on."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -26,9 +39,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # push/tag builds resolve to github.sha — the checkout default, so
+          # their behaviour is unchanged. A manual run may override it with the
+          # `ref` input to build an unmerged branch, tag, or commit.
+          ref: ${{ inputs.ref || github.sha }}
           # Full history and tags so `git describe` below can compute the
           # release version to stamp into the image.
           fetch-depth: 0
+
+      # Pin every downstream reference to the exact commit that was checked
+      # out. On push/tag builds this equals github.sha; on a manual run it is
+      # the head of the `ref` input, which can differ from github.sha (the ref
+      # the dispatch ran on). The SHA image tag and the commit stamped into the
+      # image are both derived from this, so a manual build always tags the
+      # commit it actually built.
+      - name: Resolve build ref
+        id: resolve-ref
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Building ${GITHUB_REF} at ${sha}"
 
       # `.git` is dockerignored, so a running image cannot derive its own
       # version and otherwise reports the source package.json placeholder in
@@ -140,7 +172,11 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            # push/tag builds keep the stock sha tag (sha-<short> of github.sha).
+            # A manual run may build a ref other than github.sha, so it tags the
+            # resolved commit instead — same sha-<short> format, correct commit.
+            type=sha,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value=sha-${{ steps.resolve-ref.outputs.short_sha }},enable=${{ github.event_name == 'workflow_dispatch' }}
           labels: |
             io.github.paperclipai.schema.last-migration=${{ steps.schema.outputs.last }}
             io.github.paperclipai.schema.migration-count=${{ steps.schema.outputs.count }}
@@ -155,7 +191,7 @@ jobs:
           target: production
           build-args: |
             PAPERCLIP_BUILD_VERSION=${{ steps.build-version.outputs.version }}
-            PAPERCLIP_BUILD_COMMIT=${{ github.sha }}
+            PAPERCLIP_BUILD_COMMIT=${{ steps.resolve-ref.outputs.sha }}
             CLI_TOOLS_CACHE_EPOCH=${{ steps.tools-epoch.outputs.epoch }}
           platforms: linux/amd64,linux/arm64
           push: true
@@ -183,9 +219,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # push/tag builds resolve to github.sha — the checkout default, so
+          # their behaviour is unchanged. A manual run may override it with the
+          # `ref` input to build an unmerged branch, tag, or commit.
+          ref: ${{ inputs.ref || github.sha }}
           # Full history and tags so `git describe` below can compute the
           # release version to stamp into the image.
           fetch-depth: 0
+
+      # Pin every downstream reference to the exact commit that was checked
+      # out. On push/tag builds this equals github.sha; on a manual run it is
+      # the head of the `ref` input, which can differ from github.sha (the ref
+      # the dispatch ran on). The SHA image tag and the commit stamped into the
+      # image are both derived from this, so a manual build always tags the
+      # commit it actually built.
+      - name: Resolve build ref
+        id: resolve-ref
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Building ${GITHUB_REF} at ${sha}"
 
       # `.git` is dockerignored, so a running image cannot derive its own
       # version and otherwise reports the source package.json placeholder in
@@ -301,7 +356,11 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            # push/tag builds keep the stock sha tag (sha-<short> of github.sha).
+            # A manual run may build a ref other than github.sha, so it tags the
+            # resolved commit instead — same sha-<short> format, correct commit.
+            type=sha,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value=sha-${{ steps.resolve-ref.outputs.short_sha }},enable=${{ github.event_name == 'workflow_dispatch' }}
           labels: |
             io.github.paperclipai.schema.last-migration=${{ steps.schema.outputs.last }}
             io.github.paperclipai.schema.migration-count=${{ steps.schema.outputs.count }}
@@ -316,7 +375,7 @@ jobs:
           build-args: |
             CLOUD_BUNDLED_PLUGINS=daytona
             PAPERCLIP_BUILD_VERSION=${{ steps.build-version.outputs.version }}
-            PAPERCLIP_BUILD_COMMIT=${{ github.sha }}
+            PAPERCLIP_BUILD_COMMIT=${{ steps.resolve-ref.outputs.sha }}
             CLI_TOOLS_CACHE_EPOCH=${{ steps.tools-epoch.outputs.epoch }}
           # amd64 only, unlike the self-hosted image above: the cloud variant
           # is consumed exclusively by managed-deployment hosts, which run

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -169,9 +169,15 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            # `latest` and `v*` are release pointers. Gate them off for manual
+            # (workflow_dispatch) runs — even one dispatched from master — so a
+            # preview build can never move `latest` or mint a release tag. The
+            # explicit default-branch check replaces `{{is_default_branch}}`,
+            # which is also true on a dispatch from master and would otherwise
+            # leak `latest` onto a preview image.
+            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch && github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'workflow_dispatch' }}
             # push/tag builds keep the stock sha tag (sha-<short> of github.sha).
             # A manual run may build a ref other than github.sha, so it tags the
             # resolved commit instead — same sha-<short> format, correct commit.
@@ -353,9 +359,15 @@ jobs:
           flavor: |
             suffix=-cloud,onlatest=true
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            # `latest` and `v*` are release pointers. Gate them off for manual
+            # (workflow_dispatch) runs — even one dispatched from master — so a
+            # preview build can never move `latest` or mint a release tag. The
+            # explicit default-branch check replaces `{{is_default_branch}}`,
+            # which is also true on a dispatch from master and would otherwise
+            # leak `latest` onto a preview image.
+            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch && github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'workflow_dispatch' }}
             # push/tag builds keep the stock sha tag (sha-<short> of github.sha).
             # A manual run may build a ref other than github.sha, so it tags the
             # resolved commit instead — same sha-<short> format, correct commit.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The `docker.yml` workflow builds and pushes the server image to ghcr.
> - Today it triggers only on `push` to `master` and on `v*` tags. It has no branch build.
> - Because of this, you cannot build an image from an unmerged branch. You cannot preview a change end to end before you merge it.
> - The concurrency group is `docker-${{ github.ref }}` with `cancel-in-progress: false`. A newer push still supersedes a *pending* run, so a given `master` commit is not guaranteed to have an image either.
> - This pull request adds a manual `workflow_dispatch` trigger with an optional `ref` input. The manual run builds a SHA-tagged image and does not publish a release tag.
> - The benefit is a reliable preview image for any ref. The deploy tooling accepts the resulting `sha-<short>` tag as an ordinary app ref, so nothing downstream changes.

## Linked Issues or Issue Description

No public GitHub issue exists. The problem is described below.

**Current behavior**

`docker.yml` triggers only on `push` to `master` and on `v*` tags. There is no way to build an image from an unmerged branch. A preview of a change before merge has no image to deploy. In addition, the per-ref concurrency group supersedes a pending `master` run when the next push arrives, so an arbitrary `master` commit can have no image.

**Proposed behavior**

Add a `workflow_dispatch` trigger with an optional `ref` input. The manual run checks out that ref, builds it, and pushes an image tagged `sha-<short>` for the built commit. The manual run does not publish `latest` or a `v*`/semver release tag. The push and tag paths do not change.

**Reason and benefit**

An operator can build a preview image for any unmerged branch, tag, or commit. This is the reliable way to be sure a ref has an image before you pin it as an app ref. This uses a dedicated preview build. It does not use the release workflow, because the release workflow publishes a stable `v*` tag, which is a much bigger action than a review image.

## What Changed

- Added a `workflow_dispatch` trigger to `docker.yml` with an optional `ref` input (default: the dispatched ref).
- Both build jobs now check out `${{ inputs.ref || github.sha }}`. On push and tag events this resolves to `github.sha`, the checkout default.
- Added a `Resolve build ref` step that reads the exact checked-out commit (`git rev-parse HEAD`) and its short SHA.
- Kept `type=sha` unchanged for push and tag events. For a manual run it is disabled, and a raw `sha-<short>` tag of the resolved commit is used instead. This keeps the SHA tag correct even when the built ref differs from `github.sha`.
- Set `PAPERCLIP_BUILD_COMMIT` from the resolved commit. On push and tag events this value equals `github.sha`, so those images do not change.

## Verification

- `actionlint` reports no issues on `.github/workflows/docker.yml`.
- The workflow YAML parses.
- The push and tag paths stay behaviorally identical. `inputs.ref` is empty on those events, so the checkout ref and `PAPERCLIP_BUILD_COMMIT` both resolve to `github.sha`. `type=sha` is enabled only when `github.event_name != 'workflow_dispatch'`, so it is unchanged on push and tag events.
- Manual test after merge: run the workflow against an unmerged branch and confirm the image gets a `sha-<short>` tag and no `v*` tag.

## Risks

Low risk. The change adds a new trigger and does not alter the push or tag build behavior. A `workflow_dispatch` run never publishes a release pointer: `latest`, `type=semver`, and the stock `type=sha` tag are all gated `enable=${{ github.event_name != 'workflow_dispatch' }}`, and `latest` additionally replaces `{{is_default_branch}}` with an explicit `github.ref_name == default_branch && github.event_name != 'workflow_dispatch'` check. So even a manual run dispatched **from `master`** leaves `latest` and every `v*`/semver tag untouched and publishes only `sha-<short>`. Push and tag builds are byte-for-byte unchanged because `inputs.ref` is empty and `github.event_name` is `push`/`tag` on those events.

## Model Used

- Provider and model: Anthropic Claude (Opus 4.8).
- Exact model ID: `claude-opus-4-8`.
- Reasoning mode: extended thinking.
- Capabilities: tool use, code execution (repo edits, `actionlint`, git).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

