### PR TITLE
fix: propagate adapter cancellation to Hermes runs

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -173,6 +173,12 @@ export interface AdapterExecutionContext {
   runtime: AdapterRuntime;
   config: Record<string, unknown>;
   context: Record<string, unknown>;
+  /**
+   * Aborted when the control plane cancels this execution. Remote adapters
+   * must translate this into their runtime's stop primitive rather than only
+   * returning from the local adapter promise.
+   */
+  signal?: AbortSignal;
   runtimeCommandSpec?: AdapterRuntimeCommandSpec | null;
   executionTarget?: AdapterExecutionTarget | null;
   /**

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -486,6 +486,40 @@ describe("execute", () => {
     expect(result.errorMessage).not.toContain("paperclip:company:company-1:agent:agent-1:issue:issue-1");
   });
 
+  it("calls stop when the control plane cancels the run", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/runs")) {
+        queueMicrotask(() => controller.abort());
+        return new Response(JSON.stringify({ run_id: "run-cancelled", status: "started" }), { status: 200 });
+      }
+      if (url.endsWith("/events")) {
+        return new Promise<Response>(() => {});
+      }
+      if (url.endsWith("/stop")) {
+        return new Response(JSON.stringify({ status: "stopping" }), { status: 200 });
+      }
+      if (init?.method === "GET") {
+        return new Response(JSON.stringify({ status: "cancelled", last_event: "run.cancelled" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ status: "running" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = makeCtx({
+      apiBaseUrl: "http://127.0.0.1:8642",
+      apiKey: "test-value",
+      timeoutSec: 5,
+    });
+    ctx.signal = controller.signal;
+
+    const result = await execute(ctx);
+
+    expect(result.errorCode).toBe("hermes_gateway_cancelled");
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith("/stop"))).toBe(true);
+  });
+
   it("calls stop on timeout", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -920,10 +920,46 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (timeoutMs <= 0) return;
     timeoutTimer = setTimeout(() => resolve("timeout"), timeoutMs);
   });
+  let removeCancellationListener: () => void = () => undefined;
+  const cancellationPromise = new Promise<"cancelled">((resolve) => {
+    if (!ctx.signal) return;
+    if (ctx.signal.aborted) {
+      resolve("cancelled");
+      return;
+    }
+    const onAbort = () => resolve("cancelled");
+    ctx.signal.addEventListener("abort", onAbort, { once: true });
+    removeCancellationListener = () => ctx.signal?.removeEventListener("abort", onAbort);
+  });
 
-  const outcome = await Promise.race([state.terminalPromise, timeoutPromise]);
+  const outcome = await Promise.race([state.terminalPromise, timeoutPromise, cancellationPromise]);
   if (timeoutTimer) clearTimeout(timeoutTimer);
+  removeCancellationListener();
   controller.abort();
+
+  if (outcome === "cancelled") {
+    await stopRun({ ctx, baseUrl, headers: eventHeaders, runId, redactText });
+    const finalStatus = await fetchFinalStatus({ baseUrl, headers: eventHeaders, runId, deadlineMs: STOP_GRACE_MS });
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "hermes_gateway_cancelled",
+      errorMessage: "Hermes gateway run was cancelled by the control plane.",
+      provider: "hermes_gateway",
+      resultJson: {
+        run_id: runId,
+        status: extractStatus(finalStatus) ?? "cancelled",
+        last_event: state.lastEventName,
+        final_status: redactForLog(finalStatus, [], 0, redactText),
+      },
+      sessionParams: {
+        hermesRunId: runId,
+        strategy,
+      },
+      sessionDisplayId: sessionKey ? redactText(sessionKey) : null,
+    };
+  }
 
   if (outcome === "timeout") {
     await stopRun({ ctx, baseUrl, headers: eventHeaders, runId, redactText });

--- a/server/src/__tests__/heartbeat-runtime-state.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-state.test.ts
@@ -3,10 +3,15 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import { eq } from "drizzle-orm";
 import {
   agents,
+  activityLog,
   agentRuntimeState,
   agentWakeupRequests,
   companies,
+  companySkills,
   createDb,
+  environmentLeases,
+  environments,
+  executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
 } from "@paperclipai/db";
@@ -20,15 +25,21 @@ import {
   getHeartbeatRunRuntimeStatus,
 } from "../services/heartbeat-run-runtime-status.ts";
 
-vi.doMock("../adapters/index.js", () => ({
-  getServerAdapter: vi.fn(() => ({
+const mockAdapterExecute = vi.hoisted(() => vi.fn());
+
+vi.doMock("../adapters/index.js", () => {
+  const adapter = {
     type: "process",
-    execute: vi.fn(),
+    execute: mockAdapterExecute,
     testEnvironment: vi.fn(),
-  })),
-  listAdapterModelProfiles: vi.fn(() => []),
-  runningProcesses: new Map(),
-}));
+  };
+  return {
+    getServerAdapter: vi.fn(() => adapter),
+    findActiveServerAdapter: vi.fn(() => adapter),
+    listAdapterModelProfiles: vi.fn(() => []),
+    runningProcesses: new Map(),
+  };
+});
 
 const { heartbeatService } = await import("../services/heartbeat.ts");
 
@@ -51,12 +62,18 @@ describeEmbeddedPostgres("heartbeat runtime state deduplication", () => {
   }, 20_000);
 
   afterEach(async () => {
+    mockAdapterExecute.mockReset();
     clearAllHeartbeatRunRuntimeStatuses();
+    await db.delete(activityLog);
+    await db.delete(environmentLeases);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(environments);
+    await db.delete(executionWorkspaces);
+    await db.delete(companySkills);
     await db.delete(companies);
   });
 
@@ -101,6 +118,54 @@ describeEmbeddedPostgres("heartbeat runtime state deduplication", () => {
       adapterType: "codex_local",
       stateJson: {},
     });
+  });
+
+  it("aborts the active adapter execution when a run is cancelled", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    let releaseExecution!: () => void;
+    let observedSignal: AbortSignal | undefined;
+
+    mockAdapterExecute.mockImplementation(async (ctx: { signal?: AbortSignal }) => {
+      observedSignal = ctx.signal;
+      await new Promise<void>((resolve) => {
+        releaseExecution = resolve;
+        ctx.signal?.addEventListener("abort", resolve, { once: true });
+      });
+      return { exitCode: 1, signal: null, timedOut: false, errorCode: "cancelled" };
+    });
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "RemoteAgent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "hermes_gateway",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.invoke(agentId);
+
+    try {
+      await vi.waitFor(() => expect(mockAdapterExecute).toHaveBeenCalledOnce(), { timeout: 10_000 });
+      await heartbeat.cancelRun(run.id, "Cancelled by board");
+      expect(observedSignal?.aborted).toBe(true);
+    } finally {
+      releaseExecution?.();
+      await heartbeat.waitForRunExecutionDrain(run.id, { timeoutMs: 10_000 });
+    }
   });
 
   it("publishes runtime progress without persisting heartbeat run events", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -690,6 +690,10 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
 // Routes and the scheduler construct separate heartbeatService instances, but
 // they must agree on in-process adapter executions when reaping stale runs.
 const activeRunExecutions = new Set<string>();
+// Adapter executions need an in-process cancellation primitive in addition to
+// local PID termination. Remote adapters use this signal to call their own
+// stop endpoint before returning from execute().
+const activeRunCancellationControllers = new Map<string, AbortController>();
 // Background heartbeat executions are dispatched fire-and-forget (see
 // startNextQueuedRunForAgent), so the promise that resolves once a run's DB
 // writes are fully flushed is otherwise unobservable. Track those promises here
@@ -13573,6 +13577,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     activeRunExecutions.add(run.id);
+    const cancellationController = new AbortController();
+    activeRunCancellationControllers.set(run.id, cancellationController);
     let runScratch: HeartbeatRunScratch | null = null;
 
     try {
@@ -15567,6 +15573,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           runtime: runtimeForAdapter,
           config: runtimeConfig,
           context: adapterContext,
+          signal: cancellationController.signal,
           runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
           executionTarget,
           executionTransport: remoteExecution
@@ -16356,6 +16363,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               });
             }
           }
+          activeRunCancellationControllers.delete(run.id);
           activeRunExecutions.delete(run.id);
           await startNextQueuedRunForAgent(run.agentId);
         }
@@ -18505,6 +18513,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
       : options.resultJson;
 
+    activeRunCancellationControllers.get(run.id)?.abort();
     const running = runningProcesses.get(run.id);
     try {
       if (running) {
@@ -18562,6 +18571,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES])));
 
     for (const run of runs) {
+      activeRunCancellationControllers.get(run.id)?.abort();
       await setRunStatus(run.id, "cancelled", {
         finishedAt: new Date(),
         error: reason,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service starts and controls adapter executions.
> - A board cancel changes the Paperclip run state.
> - A remote adapter does not receive that cancel event today.
> - A Hermes Gateway run can therefore continue after the board reports that it is cancelled.
> - This pull request adds a control-plane abort signal and maps it to the Hermes stop endpoint.
> - The benefit is that the stop action stops both the Paperclip run and the remote Hermes run.

## Linked Issues or Issue Description

Refs #2224

## What Changed

- Add an optional `AbortSignal` to `AdapterExecutionContext`.
- Create one abort controller for each active heartbeat adapter execution.
- Abort the controller when the board cancels a run, pauses an agent, or applies a budget stop.
- Make the Hermes Gateway adapter call `/v1/runs/{id}/stop` after it receives the signal.
- Read the final Hermes state before the adapter returns a cancelled result.
- Add regression tests for the heartbeat service and the Hermes Gateway adapter.

## Verification

- `vitest run src/gateway/server/execute.test.ts` in `packages/adapters/hermes`: 23 tests passed.
- `vitest run server/src/__tests__/heartbeat-runtime-state.test.ts`: 4 tests passed.
- `tsc --noEmit` in `packages/adapter-utils`: passed.
- `tsc --noEmit` in `packages/adapters/hermes`: passed.
- `NODE_OPTIONS=--max-old-space-size=4096 tsc --noEmit` in `server`: passed.

## Risks

- The abort controller is in process memory. A Paperclip process restart cannot stop a remote run that started before the restart.
- The shared signal is optional. Other remote adapters do not change until they implement their own stop mapping.
- The Hermes stop request can fail if the gateway is unavailable. The adapter then returns the stop failure through the existing error path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, exact model ID `gpt-5.6-sol`, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
