### PR TITLE
fix(server): DB-backed grace-verify for expired run JWTs (RENA-56180)

### DIFF
--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
+import { agentJwtGraceWindowSeconds, createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 
 describe("agent local JWT", () => {
   const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
@@ -251,6 +251,60 @@ describe("agent local JWT", () => {
     // instance-agnostic; disabling it closes that residual cross-instance hole.
     const legacyToken = craftLegacyMasterSecretToken(process.env[secretEnv]!, "company-1");
     expect(verifyLocalAgentJwt(legacyToken)).toBeNull();
+  });
+
+  // --- allowExpired grace-verify (RENA-56176/RENA-56180) --------------------
+
+  it("returns claims with expired: true for an expired-but-validly-signed token when allowExpired is set", () => {
+    process.env[ttlEnv] = "1";
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1", "user-1");
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+    const claims = verifyLocalAgentJwt(token!, { allowExpired: true });
+    expect(claims).toMatchObject({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "run-1",
+      expired: true,
+    });
+  });
+
+  it("still rejects an expired token when allowExpired is unset or false (unchanged default behavior)", () => {
+    process.env[ttlEnv] = "1";
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+    expect(verifyLocalAgentJwt(token!)).toBeNull();
+    expect(verifyLocalAgentJwt(token!, {})).toBeNull();
+    expect(verifyLocalAgentJwt(token!, { allowExpired: false })).toBeNull();
+  });
+
+  it("never skips signature verification for an expired token, even with allowExpired set", () => {
+    process.env[ttlEnv] = "1";
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+
+    // Tamper the signature of an otherwise-expired token.
+    const [headerB64, claimsB64, signature] = token!.split(".");
+    const tamperedSignature = signature.slice(0, -1) + (signature.at(-1) === "A" ? "B" : "A");
+    const tampered = `${headerB64}.${claimsB64}.${tamperedSignature}`;
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+    expect(verifyLocalAgentJwt(tampered, { allowExpired: true })).toBeNull();
+  });
+
+  it("returns claims with expired: false via allowExpired for a token that is not actually expired", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+    const claims = verifyLocalAgentJwt(token!, { allowExpired: true });
+    expect(claims).toMatchObject({ sub: "agent-1", expired: false });
+  });
+
+  it("defaults the grace window to 24h when PAPERCLIP_AGENT_JWT_GRACE_SECONDS is unset", () => {
+    delete process.env.PAPERCLIP_AGENT_JWT_GRACE_SECONDS;
+    expect(agentJwtGraceWindowSeconds()).toBe(24 * 60 * 60);
   });
 
   it("defaults TTL to 1h when PAPERCLIP_AGENT_JWT_TTL_SECONDS is unset", () => {

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -1,7 +1,7 @@
 import { createHash, createHmac, randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agentApiKeys,
@@ -33,7 +33,7 @@ function createSelectChain(rowsForTable: (table: unknown) => unknown[]) {
 function createDbState(input: {
   agent: { id: string; companyId: string; status?: string };
   agentKey?: { id: string; agentId: string; companyId: string; keyHash: string; responsibleUserId?: string | null };
-  run?: { id: string; companyId: string; agentId: string; responsibleUserId?: string | null };
+  run?: { id: string; companyId: string; agentId: string; responsibleUserId?: string | null; status?: string };
 }) {
   const activity: Array<Record<string, unknown>> = [];
   const agentRow = {
@@ -58,6 +58,7 @@ function createDbState(input: {
         companyId: input.run.companyId,
         agentId: input.run.agentId,
         responsibleUserId: input.run.responsibleUserId ?? null,
+        status: input.run.status ?? "running",
       }
     : null;
 
@@ -376,6 +377,132 @@ describe("agent auth middleware", () => {
       entityType: "agent_api_key",
       entityId: keyId,
       details: { method: "GET", url: `/companies/${companyId}/protected` },
+    });
+  });
+
+  // --- Run-JWT grace-verify (RENA-56176/RENA-56180) -------------------------
+  // Adapter processes hold a single, non-refreshing JWT for the whole run.
+  // Once `exp` passes mid-run, standard verification always rejects the token
+  // even though the run may still be genuinely active. These tests pin the
+  // bounded, DB-backed grace path: an expired-but-validly-signed token is
+  // accepted only if `heartbeat_runs` still has a matching status='running'
+  // row for the exact (run, agent, company) the token claims, and only within
+  // PAPERCLIP_AGENT_JWT_GRACE_SECONDS of `exp`.
+  describe("grace path for expired-but-validly-signed run JWTs", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      delete process.env.PAPERCLIP_AGENT_JWT_GRACE_SECONDS;
+    });
+
+    it("accepts an expired token when the claimed heartbeat run is still status='running'", async () => {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const runId = randomUUID();
+      const { db, activity } = createDbState({
+        agent: { id: agentId, companyId },
+        run: { id: runId, companyId, agentId, responsibleUserId: "user-claim", status: "running" },
+      });
+      const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+      // exp = mint time + 3600s TTL. Jump 5 minutes past it, well within the
+      // default 24h grace window.
+      vi.setSystemTime(new Date("2026-01-01T01:05:00.000Z"));
+
+      const res = await request(createApp(db))
+        .get("/actor")
+        .set("Authorization", `Bearer ${token}`)
+        .set("X-Paperclip-Run-Id", runId);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        type: "agent",
+        agentId,
+        companyId,
+        runId,
+        onBehalfOfUserId: "user-claim",
+        source: "agent_jwt",
+      });
+      expect(activity).toHaveLength(1);
+      expect(activity[0]).toMatchObject({
+        companyId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "auth.agent_jwt_grace_expiry_accepted",
+        entityType: "heartbeat_run",
+        entityId: runId,
+        runId,
+      });
+    });
+
+    it("rejects an expired token once the run is no longer status='running'", async () => {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const runId = randomUUID();
+      const issueId = randomUUID();
+      const { db } = createDbState({
+        agent: { id: agentId, companyId },
+        run: { id: runId, companyId, agentId, responsibleUserId: "user-claim", status: "succeeded" },
+      });
+      const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+      vi.setSystemTime(new Date("2026-01-01T01:05:00.000Z"));
+
+      const res = await request(createApp(db))
+        .get(`/companies/${companyId}/issues/${issueId}`)
+        .set("Authorization", `Bearer ${token}`)
+        .set("X-Paperclip-Run-Id", runId);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects an expired token when the run_id belongs to a different agent", async () => {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const otherAgentId = randomUUID();
+      const runId = randomUUID();
+      const issueId = randomUUID();
+      const { db } = createDbState({
+        agent: { id: agentId, companyId },
+        run: { id: runId, companyId, agentId: otherAgentId, responsibleUserId: "user-claim", status: "running" },
+      });
+      const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+      vi.setSystemTime(new Date("2026-01-01T01:05:00.000Z"));
+
+      const res = await request(createApp(db))
+        .get(`/companies/${companyId}/issues/${issueId}`)
+        .set("Authorization", `Bearer ${token}`)
+        .set("X-Paperclip-Run-Id", runId);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects an expired token once the bounded grace window has elapsed, even if the run is still status='running'", async () => {
+      process.env.PAPERCLIP_AGENT_JWT_GRACE_SECONDS = "60";
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const runId = randomUUID();
+      const issueId = randomUUID();
+      const { db } = createDbState({
+        agent: { id: agentId, companyId },
+        run: { id: runId, companyId, agentId, responsibleUserId: "user-claim", status: "running" },
+      });
+      const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+      // 120s past exp exceeds the 60s grace window configured above.
+      vi.setSystemTime(new Date("2026-01-01T01:02:00.000Z"));
+
+      const res = await request(createApp(db))
+        .get(`/companies/${companyId}/issues/${issueId}`)
+        .set("Authorization", `Bearer ${token}`)
+        .set("X-Paperclip-Run-Id", runId);
+
+      expect(res.status).toBe(401);
     });
   });
 });

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -36,6 +36,19 @@ function parseBooleanEnv(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+/**
+ * Bounded window (seconds) during which an expired-but-validly-signed run JWT
+ * may still authenticate, provided the DB confirms the claimed heartbeat run
+ * is still `status='running'` (see verifyLocalAgentJwt's `allowExpired` option
+ * and actorMiddleware's grace path). This is defense-in-depth: it caps how
+ * long a run stuck on `status='running'` by an unrelated liveness/recovery bug
+ * could keep authenticating past its token's `exp`, independent of whatever
+ * that other bug's root cause turns out to be. See RENA-56176/RENA-56180.
+ */
+export function agentJwtGraceWindowSeconds(): number {
+  return parseNumber(process.env.PAPERCLIP_AGENT_JWT_GRACE_SECONDS, 24 * 60 * 60);
+}
+
 function jwtConfig() {
   const secret = process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
   if (!secret) return null;
@@ -154,7 +167,22 @@ export function createLocalAgentJwt(
   return `${signingInput}.${signature}`;
 }
 
-export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
+export interface VerifyLocalAgentJwtOptions {
+  /**
+   * When true, an otherwise-valid token whose `exp` has passed is not
+   * rejected outright — it is returned with `expired: true` so the caller
+   * (actorMiddleware's grace path) can decide whether to accept it based on
+   * independent, DB-backed evidence that the run is still live. Signature,
+   * issuer/audience, and instance checks are never skipped, regardless of
+   * this flag.
+   */
+  allowExpired?: boolean;
+}
+
+export function verifyLocalAgentJwt(
+  token: string,
+  options?: VerifyLocalAgentJwtOptions,
+): (LocalAgentJwtClaims & { expired: boolean }) | null {
   if (!token) return null;
   const config = jwtConfig();
   if (!config) return null;
@@ -216,7 +244,8 @@ export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
   const companyId = claimedCompanyId;
 
   const now = Math.floor(Date.now() / 1000);
-  if (exp < now) return null;
+  const expired = exp < now;
+  if (expired && !options?.allowExpired) return null;
 
   const issuer = typeof claims.iss === "string" ? claims.iss : undefined;
   const audience = typeof claims.aud === "string" ? claims.aud : undefined;
@@ -245,5 +274,6 @@ export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
     ...(audience ? { aud: audience } : {}),
     ...(instanceClaim ? { instance_id: instanceClaim } : {}),
     jti: typeof claims.jti === "string" ? claims.jti : undefined,
+    expired,
   };
 }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -12,7 +12,7 @@ import {
   heartbeatRuns,
   instanceUserRoles,
 } from "@paperclipai/db";
-import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
+import { agentJwtGraceWindowSeconds, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import { isUuidLike, normalizeAgentApiKeyScope, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
@@ -48,6 +48,33 @@ async function resolveLegacyRunResponsibleUserId(
     )
     .then((rows) => rows[0] ?? null);
   return normalizeOptionalString(run?.responsibleUserId);
+}
+
+/**
+ * DB-backed liveness check for the grace path: an expired-but-validly-signed
+ * run JWT is only accepted if `heartbeat_runs` still has a matching row with
+ * status='running' for the exact (run, agent, company) the token claims.
+ * Company/agent/status are re-checked here in JS (not just relied on via the
+ * SQL WHERE) so this stays correct even against a query layer that doesn't
+ * enforce the WHERE clause itself, mirroring the belt-and-braces checks
+ * already used elsewhere in this file (e.g. the agentRecord.companyId check).
+ */
+async function isHeartbeatRunLiveForGrace(
+  db: Db,
+  input: { companyId: string; agentId: string; runId: string },
+) {
+  if (!isUuidLike(input.runId)) return false;
+  const run = await db
+    .select({
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+      status: heartbeatRuns.status,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, input.runId))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return false;
+  return run.companyId === input.companyId && run.agentId === input.agentId && run.status === "running";
 }
 
 async function loadResponsibleUserMemberships(
@@ -127,6 +154,34 @@ async function auditAgentJwtRunHeaderMismatch(
     logger.warn(
       { err, companyId: input.companyId, agentId: input.agentId, claimRunId: input.claimRunId },
       "Failed to audit rejected agent JWT run header mismatch",
+    );
+  }
+}
+
+async function auditAgentJwtGraceExpiryAccepted(
+  db: Db,
+  input: { companyId: string; agentId: string; runId: string; method: string; url: string },
+) {
+  try {
+    await db.insert(activityLog).values({
+      companyId: input.companyId,
+      actorType: "agent",
+      actorId: input.agentId,
+      action: "auth.agent_jwt_grace_expiry_accepted",
+      entityType: "heartbeat_run",
+      entityId: input.runId,
+      ...(isUuidLike(input.agentId) ? { agentId: input.agentId } : {}),
+      ...(isUuidLike(input.runId) ? { runId: input.runId } : {}),
+      details: {
+        runId: input.runId,
+        method: input.method,
+        url: input.url,
+      },
+    });
+  } catch (err) {
+    logger.warn(
+      { err, companyId: input.companyId, agentId: input.agentId, runId: input.runId },
+      "Failed to audit accepted agent JWT grace-expiry authentication",
     );
   }
 }
@@ -268,7 +323,37 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       .then((rows) => rows[0] ?? null);
 
     if (!key) {
-      const claims = verifyLocalAgentJwt(token);
+      let claims = verifyLocalAgentJwt(token);
+      if (!claims) {
+        // Standard verification failed. If the only reason is that `exp` has
+        // passed on an otherwise validly-signed token (adapter processes hold
+        // a single, non-refreshing JWT for the full run — RENA-56176), fall
+        // back to a bounded, DB-backed grace check instead of failing the
+        // request outright: an agent whose heartbeat run is still genuinely
+        // `status='running'` should not be locked out of commenting/PATCHing
+        // its own issue just because the token clock ran out mid-run.
+        const graceClaims = verifyLocalAgentJwt(token, { allowExpired: true });
+        if (graceClaims?.expired) {
+          const withinGraceWindow = Math.floor(Date.now() / 1000) - graceClaims.exp <= agentJwtGraceWindowSeconds();
+          const runIsLive =
+            withinGraceWindow &&
+            (await isHeartbeatRunLiveForGrace(db, {
+              companyId: graceClaims.company_id,
+              agentId: graceClaims.sub,
+              runId: graceClaims.run_id,
+            }));
+          if (runIsLive) {
+            await auditAgentJwtGraceExpiryAccepted(db, {
+              companyId: graceClaims.company_id,
+              agentId: graceClaims.sub,
+              runId: graceClaims.run_id,
+              method: req.method,
+              url: req.originalUrl,
+            });
+            claims = graceClaims;
+          }
+        }
+      }
       if (!claims) {
         next();
         return;


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent adapter processes authenticate every API call with a signed run JWT issued once at the start of a heartbeat run.
> - Long heartbeat runs can outlive that token's TTL; once it expires mid-run, `verifyLocalAgentJwt` always returns `null` and every later authenticated call from that same run gets a 401, even while the run is still genuinely active.
> - Raising the global TTL only delays the symptom and needs a fleet-wide control-plane restart, so it does not fix the underlying gap.
> - This pull request adds a narrow, DB-backed grace path: an expired-but-validly-signed token is accepted only when a live `heartbeat_runs` row still shows `status='running'` for the exact run/agent/company the token claims, and only inside a bounded grace window.
> - The benefit is that long heartbeat runs stop failing purely on token expiry, while signature, issuer, audience, and per-tenant key checks stay fully enforced.

## Linked Issues or Issue Description

**What happened**
Agent adapter processes hold a single, non-refreshing run JWT for the whole heartbeat run. Once the configured JWT TTL (default 1 hour, `PAPERCLIP_AGENT_JWT_TTL_SECONDS`) elapses mid-run, `verifyLocalAgentJwt` starts returning `null` for that token and `actorMiddleware` leaves `req.actor` unauthenticated. Every subsequent authenticated route the agent calls (posting a comment, patching issue status, checking out an issue) then returns 401, even though the run is still genuinely active.

**Expected behavior**
A long-running but still-active heartbeat run should keep making authenticated API calls for its full duration, without being cut off purely because a fixed-TTL token expired while the run itself is healthy.

**Steps to reproduce**
1. Start a heartbeat run whose adapter process issues a single run JWT at start.
2. Let the run continue past the JWT TTL (default 1h) while `heartbeat_runs.status` stays `running`.
3. Have the agent call any authenticated route (for example, PATCH issue status) after the TTL has elapsed.
4. Observe a 401 response even though the run is still active in the database.

**Deployment mode**
Self-hosted, or any instance that uses the local agent JWT auth path.

## What Changed
- `server/src/agent-auth-jwt.ts`
  - `verifyLocalAgentJwt(token, { allowExpired? })` — new optional second parameter. When `allowExpired` is true, a token that fails only the expiry check is returned instead of `null`, with a new `expired: boolean` field on the claims.
  - New `agentJwtGraceWindowSeconds()` reading `PAPERCLIP_AGENT_JWT_GRACE_SECONDS` (default 24h) — bounds how long an expired token can be accepted at all, independent of whatever separately causes a `heartbeat_runs` row to stay stuck on `status='running'`.
- `server/src/middleware/auth.ts`
  - `actorMiddleware`: on normal JWT verification failure, retries with `allowExpired: true`. If that succeeds with `expired: true` and the claim is within the grace window, queries `heartbeat_runs` for a matching `status='running'` row (company/agent/status re-checked in JS, not just relied on via the SQL `WHERE`) before accepting. On acceptance, falls through to the existing success path unchanged (run-id header check, responsible-user resolution, `req.actor` construction).
  - New `isHeartbeatRunLiveForGrace` helper (query pattern modeled on the existing `resolveLegacyRunResponsibleUserId`).
  - New `auditAgentJwtGraceExpiryAccepted` — writes an `activity_log` row with `action: "auth.agent_jwt_grace_expiry_accepted"` whenever the grace path is used, so this can be monitored and used to decide whether a real token-refresh mechanism is needed later.
- Tests (`server/src/__tests__/agent-auth-jwt.test.ts`, `agent-auth-middleware.test.ts`): cover `allowExpired` returning `expired: true`/`false`, unchanged default-rejection behavior when the flag is unset, signature tampering never bypassed even with `allowExpired`, grace acceptance when the run is `status='running'`, grace rejection when the run is no longer running / belongs to a different agent / the grace window has elapsed.

## Verification
- `pnpm exec vitest run src/__tests__/agent-auth-jwt.test.ts src/__tests__/agent-auth-middleware.test.ts` — 33/33 passing, covering `allowExpired` semantics, signature tampering still rejected, and grace acceptance/rejection across run-status, agent, company, and grace-window-elapsed cases.
- `tsc --noEmit` on `server/` — clean.
- Manual smoke test after deploy: replay a signed-but-expired run JWT against a request whose `heartbeat_runs.status='running'` matches the token's run/agent/company — expect `200` and an `auth.agent_jwt_grace_expiry_accepted` row in `activity_log`. Replay the same token for a non-running run, a different agent/company, or after the grace window has elapsed — expect it to keep returning `401`.

## Risks
- This touches authentication code. The grace path is opt-in only on expiry failure (all other checks — signature, issuer/audience, per-instance/per-company key derivation — are unaffected), bounded by `PAPERCLIP_AGENT_JWT_GRACE_SECONDS` (default 24h), and requires a live DB `heartbeat_runs.status='running'` match on the exact run/agent/company, so it cannot be used to forge access to an unrelated run or company.
- If a separate bug leaves a `heartbeat_runs` row stuck on `status='running'` indefinitely, the grace window is the only remaining bound on how long an expired token stays acceptable — tracked as a follow-up watchdog/recovery concern, out of scope here.

## Model Used
Claude Opus 4.7 (claude-opus-4-7), Claude Code CLI agent.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list (open + recently closed) for similar PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
