### PR TITLE
fix(server): reject unsupported monitor-scheduling fields on PATCH /issues/:id (RBR-1101)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1691,6 +1691,7 @@ export {
   issueBlockedInboxSeveritySchema,
   issueBlockedInboxStateSchema,
   updateIssueSchema,
+  findUnsupportedMonitorSchedulingFields,
   stalledReviewDecisionSchema,
   issueExecutionPolicySchema,
   issueExecutionStateSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -410,6 +410,7 @@ export {
   issueBlockedInboxSeveritySchema,
   issueBlockedInboxStateSchema,
   updateIssueSchema,
+  findUnsupportedMonitorSchedulingFields,
   stalledReviewDecisionSchema,
   issueExecutionPolicySchema,
   issueExecutionStateSchema,

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -3,6 +3,7 @@ import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
 import {
   addIssueCommentSchema,
   createIssueSchema,
+  findUnsupportedMonitorSchedulingFields,
   issueBlockedInboxAttentionSchema,
   resolveIssueRecoveryActionSchema,
   respondIssueThreadInteractionSchema,
@@ -37,6 +38,46 @@ describe("issue validators", () => {
     });
 
     expect(parsed.description).toBe("Line 1\n\nLine 2");
+  });
+
+  describe("findUnsupportedMonitorSchedulingFields (RBR-1101)", () => {
+    it("detects each flat monitor-scheduling field individually", () => {
+      expect(findUnsupportedMonitorSchedulingFields({ monitorNextCheckAt: new Date().toISOString() }))
+        .toEqual(["monitorNextCheckAt"]);
+      expect(findUnsupportedMonitorSchedulingFields({ monitorNotes: "note" })).toEqual(["monitorNotes"]);
+      expect(findUnsupportedMonitorSchedulingFields({ monitorScheduledBy: "assignee" }))
+        .toEqual(["monitorScheduledBy"]);
+    });
+
+    it("detects all flat fields together, in declared order", () => {
+      expect(findUnsupportedMonitorSchedulingFields({
+        status: "todo",
+        monitorNextCheckAt: new Date().toISOString(),
+        monitorNotes: "note",
+        monitorScheduledBy: "assignee",
+      })).toEqual(["monitorNextCheckAt", "monitorNotes", "monitorScheduledBy"]);
+    });
+
+    it("detects the nested executionState.monitor key without inspecting its shape", () => {
+      expect(findUnsupportedMonitorSchedulingFields({ executionState: { monitor: {} } }))
+        .toEqual(["executionState.monitor"]);
+      expect(findUnsupportedMonitorSchedulingFields({ executionState: { monitor: null } }))
+        .toEqual(["executionState.monitor"]);
+    });
+
+    it("does not flag legitimate payloads without monitor-scheduling keys", () => {
+      expect(findUnsupportedMonitorSchedulingFields({ status: "todo" })).toEqual([]);
+      expect(findUnsupportedMonitorSchedulingFields({ executionState: { workspace: {} } })).toEqual([]);
+      expect(findUnsupportedMonitorSchedulingFields({})).toEqual([]);
+    });
+
+    it("tolerates non-object or malformed input without throwing", () => {
+      expect(findUnsupportedMonitorSchedulingFields(null)).toEqual([]);
+      expect(findUnsupportedMonitorSchedulingFields(undefined)).toEqual([]);
+      expect(findUnsupportedMonitorSchedulingFields("string")).toEqual([]);
+      expect(findUnsupportedMonitorSchedulingFields([1, 2, 3])).toEqual([]);
+      expect(findUnsupportedMonitorSchedulingFields({ executionState: "not-an-object" })).toEqual([]);
+    });
   });
 
   it("accepts null and omitted optional multiline issue fields", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -556,6 +556,48 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
 export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorkspaceSettingsSchema>;
 
+/**
+ * PATCH /issues/:id has no write path for monitor-scheduling: these fields are
+ * not in `createIssueBaseSchema`, and `services/issues.ts` `svc.update()` never
+ * persists them. Because `updateIssueSchema` isn't `.strict()`'d, Zod's default
+ * `.parse()` silently drops unrecognized keys, so a caller sending these fields
+ * previously got an HTTP 200 with a silent no-op (RBR-1094).
+ *
+ * This inspects the *raw* request body (before Zod strips unknown keys) for
+ * monitor-scheduling keys and returns their names so a route guard can reject
+ * the request outright, naming exactly what was rejected. Scoped narrowly to
+ * monitor-scheduling per RBR-1101; this intentionally does not flip
+ * `updateIssueSchema` to global `.strict()`, which would newly reject any
+ * other silently-ignored extra key across every PATCH caller company-wide.
+ */
+export const UNSUPPORTED_MONITOR_SCHEDULING_FLAT_FIELDS = [
+  "monitorNextCheckAt",
+  "monitorNotes",
+  "monitorScheduledBy",
+] as const;
+
+function isPlainObjectForMonitorFieldCheck(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function findUnsupportedMonitorSchedulingFields(raw: unknown): string[] {
+  if (!isPlainObjectForMonitorFieldCheck(raw)) return [];
+  const found: string[] = [];
+  for (const field of UNSUPPORTED_MONITOR_SCHEDULING_FLAT_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(raw, field)) {
+      found.push(field);
+    }
+  }
+  const executionState = raw.executionState;
+  if (
+    isPlainObjectForMonitorFieldCheck(executionState)
+    && Object.prototype.hasOwnProperty.call(executionState, "monitor")
+  ) {
+    found.push("executionState.monitor");
+  }
+  return found;
+}
+
 export const stalledReviewDecisionSchema = z.object({
   action: z.enum(["approve", "request_changes", "send_back"]),
   note: multilineTextSchema.pipe(z.string().min(1)).optional(),

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1606,6 +1606,54 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("rejects unsupported monitor-scheduling fields on PATCH /issues/:id with a 4xx naming them (RBR-1101)", async () => {
+    const { sourceIssueId, sourceIssue } = await seedCompany();
+    const app = createApp();
+
+    const flatFields = await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({
+        status: "todo",
+        monitorNextCheckAt: new Date().toISOString(),
+        monitorNotes: "retry the assignee at the provider reset time",
+        monitorScheduledBy: "assignee",
+      })
+      .expect(400);
+    expect(flatFields.body.code).toBe("unsupported_monitor_scheduling_fields");
+    expect(flatFields.body.error).toContain("monitorNextCheckAt");
+    expect(flatFields.body.error).toContain("monitorNotes");
+    expect(flatFields.body.error).toContain("monitorScheduledBy");
+    expect(flatFields.body.details).toMatchObject({
+      code: "unsupported_monitor_scheduling_fields",
+      fields: expect.arrayContaining(["monitorNextCheckAt", "monitorNotes", "monitorScheduledBy"]),
+    });
+
+    const nestedField = await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({
+        executionState: { monitor: { nextCheckAt: new Date().toISOString() } },
+      })
+      .expect(400);
+    expect(nestedField.body.code).toBe("unsupported_monitor_scheduling_fields");
+    expect(nestedField.body.error).toContain("executionState.monitor");
+    expect(nestedField.body.details).toMatchObject({
+      code: "unsupported_monitor_scheduling_fields",
+      fields: ["executionState.monitor"],
+    });
+
+    // The request must be rejected outright: no partial write of the legitimate
+    // `status` field alongside the rejected monitor-scheduling fields.
+    const [unchangedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(unchangedIssue?.status).toBe(sourceIssue.status);
+
+    // AC-b: existing legitimate PATCH payloads without these fields are unaffected.
+    const legitimate = await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({ status: "todo" })
+      .expect(200);
+    expect(legitimate.body).toMatchObject({ id: sourceIssueId, status: "todo" });
+  });
+
   it("folds stale recovery during read projection after the source issue reaches done", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { Router, type Request, type Response } from "express";
+import { Router, type Request, type Response, type NextFunction } from "express";
 import multer from "multer";
 import { z } from "zod";
 import { and, asc, desc, eq, inArray, isNull, notInArray } from "drizzle-orm";
@@ -65,6 +65,7 @@ import {
   updateDocumentAnnotationThreadSchema,
   upsertIssueDocumentSchema,
   updateIssueSchema,
+  findUnsupportedMonitorSchedulingFields,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
   isUuidLike,
@@ -230,6 +231,25 @@ const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
+
+/**
+ * RBR-1101: monitor-scheduling fields have no write path on PATCH /issues/:id
+ * (see `findUnsupportedMonitorSchedulingFields` for the full rationale). Zod's
+ * default `.parse()` in `validate()` silently strips these unknown keys before
+ * the handler ever sees them, so this must inspect the *raw* body ahead of
+ * that validation to catch and name them, instead of relying on the schema.
+ */
+function rejectUnsupportedMonitorSchedulingFields(req: Request, res: Response, next: NextFunction) {
+  const unsupportedFields = findUnsupportedMonitorSchedulingFields(req.body);
+  if (unsupportedFields.length > 0) {
+    next(badRequest(
+      `Unsupported field(s): ${unsupportedFields.join(", ")}. Monitor-scheduling is not settable via PATCH /issues/:id.`,
+      { code: "unsupported_monitor_scheduling_fields", fields: unsupportedFields },
+    ));
+    return;
+  }
+  next();
+}
 
 function prefersMinimalIssueUpdateResponse(req: Request) {
   return (req.get("Prefer") ?? "")
@@ -8417,7 +8437,11 @@ export function issueRoutes(
     },
   );
 
-  router.patch("/issues/:id", validate(updateIssueRouteSchema), async (req, res) => {
+  router.patch(
+    "/issues/:id",
+    rejectUnsupportedMonitorSchedulingFields,
+    validate(updateIssueRouteSchema),
+    async (req, res) => {
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
@@ -9902,7 +9926,8 @@ export function issueRoutes(
       return;
     }
     res.json({ ...issueResponse, changes, comment });
-  });
+    },
+  );
 
   router.delete("/issues/:id", async (req, res) => {
     const id = req.params.id as string;


### PR DESCRIPTION
## Summary
RBR-1094 diagnosed that `PATCH /issues/:id` silently accepts and drops `monitorNextCheckAt` / `monitorNotes` / `monitorScheduledBy` (flat) and `executionState.monitor.*` (nested) — HTTP 200, no error, zero persistence. `updateIssueSchema` isn't `.strict()`'d, so Zod's default `.parse()` silently strips these unrecognized keys before the handler ever sees them.

Per the CEO-approved scope in RBR-1101, this ships a narrow fix rather than flipping `updateIssueSchema` to global `.strict()` (which would newly reject any other currently-silently-ignored key across every PATCH caller company-wide).

## Changes
- `packages/shared/src/validators/issue.ts`: add `findUnsupportedMonitorSchedulingFields()`, which inspects the *raw* request body (ahead of Zod stripping) for the flat monitor-scheduling keys and the nested `executionState.monitor` key, returning the names of any present.
- `server/src/routes/issues.ts`: add `rejectUnsupportedMonitorSchedulingFields` middleware ahead of `validate(updateIssueRouteSchema)` on `PATCH /issues/:id`; returns a 400 (`badRequest`) naming the unsupported field(s) with `code: "unsupported_monitor_scheduling_fields"` instead of silently no-opping.
- Test coverage:
  - `packages/shared/src/validators/issue.test.ts`: unit tests for `findUnsupportedMonitorSchedulingFields` covering each flat field, all together, the nested key, legitimate payloads, and malformed input.
  - `server/src/__tests__/issue-recovery-actions.test.ts`: integration test against the real `PATCH /issues/:id` route asserting 400 + field names for both flat and nested shapes, that the request is rejected outright (no partial write), and that a legitimate payload without these fields still returns 200 (no regression).

## Acceptance criteria (RBR-1101)
- AC-a: PATCH `/issues/:id` with any of these fields now returns a 4xx naming the unsupported field(s) — verified via new tests.
- AC-b: existing legitimate PATCH payloads are unaffected — full `issue-recovery-actions.test.ts` suite (45/45) passes with no regressions.
- AC-c: new/updated test coverage proving AC-a — see tests above.
- AC-d: parent RBR-1094 comment + RBR-954 verification to follow as a separate step once this merges.

## Testing
- `packages/shared`: `npx vitest run src/validators/issue.test.ts` → 37/37 pass
- `server`: `npx vitest run src/__tests__/issue-recovery-actions.test.ts` → 45/45 pass (full suite)
- `packages/shared`: `npx tsc --noEmit` → clean
- `server`: `npx tsc --noEmit` → no new errors on `routes/issues.ts` or `validators/issue.ts` (remaining errors are pre-existing `@paperclipai/plugin-sdk` build-dependency issues unrelated to this change)

Closes RBR-1101.