### PR TITLE
fix(adapters): scope Hermes MOA selection per profile

### DIFF
--- a/packages/adapters/hermes/src/index.ts
+++ b/packages/adapters/hermes/src/index.ts
@@ -84,6 +84,8 @@ tools, persistent memory, session persistence, skills, and MCP support.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| profile | string | default | Authoritative Hermes profile. Safe identifiers only; passed before \`chat\` for every run. |
+| moaProfileBindings | object | (none) | Optional profile-to-preset map, for example \`{ "planner": "LagunaS-Qwen" }\`. Only the exact bound profile selects Hermes' virtual \`moa:<preset>\` model; unbound profiles keep their configured single model. |
 | model | string | (Hermes configured default) | Optional explicit model in provider/model format. Leave blank to use Hermes's configured default model. |
 | provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
 | timeoutSec | number | 300 | Execution timeout in seconds |

--- a/packages/adapters/hermes/src/server/config-schema.test.ts
+++ b/packages/adapters/hermes/src/server/config-schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getConfigSchema } from "./config-schema.js";
+
+describe("Hermes adapter config schema", () => {
+  it("exposes profile-scoped MOA bindings as JSON configuration", () => {
+    const field = getConfigSchema().fields.find(
+      (candidate) => candidate.key === "moaProfileBindings",
+    );
+
+    expect(field).toMatchObject({
+      key: "moaProfileBindings",
+      type: "textarea",
+    });
+  });
+});

--- a/packages/adapters/hermes/src/server/config-schema.ts
+++ b/packages/adapters/hermes/src/server/config-schema.ts
@@ -21,6 +21,20 @@ export function getConfigSchema(): AdapterConfigSchema {
   return {
     fields: [
       {
+        key: "profile",
+        label: "Hermes profile",
+        type: "text",
+        default: "default",
+        meta: { pattern: "^[a-z0-9][a-z0-9_-]{0,63}$", maxLength: 64 },
+        hint: "Authoritative Hermes profile. Extra args cannot override it.",
+      },
+      {
+        key: "moaProfileBindings",
+        label: "Profile-scoped MOA bindings",
+        type: "textarea",
+        hint: 'Optional JSON object mapping exact Hermes profiles to existing presets, for example { "planner": "LagunaS-Qwen" }. Unbound profiles stay on their configured single model.',
+      },
+      {
         key: "provider",
         label: "Provider",
         type: "select",

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -104,6 +104,38 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(opts.onSpawn).toBe(onSpawn);
   });
 
+  it("binds MOA to Planner without changing the Executor route", async () => {
+    const binding = { planner: "LagunaS-Qwen" };
+
+    const { ctx: plannerCtx } = makeCtx({
+      profile: "planner",
+      model: "qwen3.6:27b",
+      provider: "ollama-launch",
+      moaProfileBindings: binding,
+    });
+    await execute(plannerCtx as any);
+
+    const plannerArgs = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)?.[2] as string[];
+    expect(plannerArgs[plannerArgs.indexOf("-m") + 1]).toBe("moa:LagunaS-Qwen");
+    expect(plannerArgs[plannerArgs.indexOf("--provider") + 1]).toBe("moa");
+
+    const { ctx: executorCtx } = makeCtx({
+      profile: "executor",
+      model: "qwen3.6:27b",
+      provider: "ollama-launch",
+      moaProfileBindings: binding,
+      extraArgs: ["--profile", "planner"],
+    });
+    await execute(executorCtx as any);
+
+    const executorArgs = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)?.[2] as string[];
+    expect(executorArgs.slice(0, 3)).toEqual(["--profile", "executor", "chat"]);
+    expect(executorArgs[executorArgs.indexOf("-m") + 1]).toBe("qwen3.6:27b");
+    expect(executorArgs[executorArgs.indexOf("--provider") + 1]).toBe("ollama-launch");
+    expect(executorArgs).not.toContain("moa:LagunaS-Qwen");
+    expect(executorArgs).not.toContain("planner");
+  });
+
   it("runChildProcess opts type includes onSpawn", () => {
     // Type-level assertion: if onSpawn were removed from the type,
     // this file would fail to compile. The runtime test above catches

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -136,6 +136,58 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(executorArgs).not.toContain("planner");
   });
 
+  it("keeps Planner MOA and Executor single-model routing authoritative over conflicting passthrough flags", async () => {
+    const conflictingExtraArgs = [
+      "-m", "wrong-short-model",
+      "-m=wrong-equals-model",
+      "--model", "wrong-model",
+      "--model=wrong-equals-model",
+      "--provider", "openrouter",
+      "--provider=wrong-provider",
+      "--keep", "value",
+    ];
+    const binding = { planner: "LagunaS-Qwen" };
+
+    const { ctx: plannerCtx } = makeCtx({
+      profile: "planner",
+      model: "qwen3.6:27b",
+      provider: "auto",
+      moaProfileBindings: binding,
+      extraArgs: conflictingExtraArgs,
+    });
+    await execute(plannerCtx as any);
+
+    const plannerArgs = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)?.[2] as string[];
+    expect(plannerArgs[plannerArgs.indexOf("-m") + 1]).toBe("moa:LagunaS-Qwen");
+    expect(plannerArgs[plannerArgs.indexOf("--provider") + 1]).toBe("moa");
+    expect(plannerArgs).toContain("--keep");
+    expect(plannerArgs).toContain("value");
+    expect(plannerArgs).not.toContain("wrong-short-model");
+    expect(plannerArgs).not.toContain("wrong-equals-model");
+    expect(plannerArgs).not.toContain("wrong-model");
+    expect(plannerArgs).not.toContain("openrouter");
+    expect(plannerArgs).not.toContain("wrong-provider");
+
+    const { ctx: executorCtx } = makeCtx({
+      profile: "executor",
+      model: "qwen3.6:27b",
+      provider: "auto",
+      moaProfileBindings: binding,
+      extraArgs: conflictingExtraArgs,
+    });
+    await execute(executorCtx as any);
+
+    const executorArgs = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)?.[2] as string[];
+    expect(executorArgs[executorArgs.indexOf("-m") + 1]).toBe("qwen3.6:27b");
+    expect(executorArgs).not.toContain("--provider");
+    expect(executorArgs).not.toContain("moa:LagunaS-Qwen");
+    expect(executorArgs).not.toContain("wrong-short-model");
+    expect(executorArgs).not.toContain("wrong-equals-model");
+    expect(executorArgs).not.toContain("wrong-model");
+    expect(executorArgs).not.toContain("openrouter");
+    expect(executorArgs).not.toContain("wrong-provider");
+  });
+
   it("runChildProcess opts type includes onSpawn", () => {
     // Type-level assertion: if onSpawn were removed from the type,
     // this file would fail to compile. The runtime test above catches

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -52,6 +52,11 @@ import {
   detectModel,
   resolveProvider,
 } from "./detect-model.js";
+import {
+  HERMES_PROFILE_INVALID_MESSAGE,
+  resolveHermesProfile,
+} from "./profile.js";
+import { resolveHermesModelSelection } from "./moa-profile.js";
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -70,6 +75,25 @@ function cfgStringArray(v: unknown): string[] | undefined {
   return Array.isArray(v) && v.every((i) => typeof i === "string")
     ? (v as string[])
     : undefined;
+}
+
+const RESERVED_HERMES_PASSTHROUGH_FLAGS = new Set(["--profile", "-p"]);
+
+function sanitizeHermesExtraArgs(extraArgs: string[] | undefined): string[] {
+  if (!extraArgs?.length) return [];
+
+  const sanitized: string[] = [];
+  for (let index = 0; index < extraArgs.length; index += 1) {
+    const arg = extraArgs[index]!;
+    const equalsIndex = arg.indexOf("=");
+    const flag = equalsIndex >= 0 ? arg.slice(0, equalsIndex) : arg;
+    if (RESERVED_HERMES_PASSTHROUGH_FLAGS.has(flag)) {
+      if (equalsIndex < 0) index += 1;
+      continue;
+    }
+    sanitized.push(arg);
+  }
+  return sanitized;
 }
 
 export function resolveHermesCommand(config: Record<string, unknown>): string {
@@ -337,12 +361,26 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = resolveHermesCommand(config);
-  const model = cfgString(config.model) || DEFAULT_MODEL;
+  const profile = resolveHermesProfile(config);
+  if (!profile) {
+    const model = cfgString(config.model) || DEFAULT_MODEL;
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "hermes_local_profile_invalid",
+      errorMessage: HERMES_PROFILE_INVALID_MESSAGE,
+      model,
+    };
+  }
+  const modelSelection = resolveHermesModelSelection(config, profile);
+  const model = modelSelection.model;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
   const extraArgs = cfgStringArray(config.extraArgs);
+  const sanitizedExtraArgs = sanitizeHermesExtraArgs(extraArgs);
   const persistSession = cfgBoolean(config.persistSession) !== false;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
@@ -363,7 +401,7 @@ export async function execute(
   let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
   const explicitProvider = cfgString(config.provider);
 
-  if (!explicitProvider) {
+  if (!explicitProvider && !modelSelection.moaPreset) {
     try {
       detectedConfig = await detectModel();
     } catch {
@@ -371,15 +409,17 @@ export async function execute(
     }
   }
 
-  const { provider: resolvedProvider, resolvedFrom } = resolveProvider({
-    explicitProvider,
-    detectedProvider: detectedConfig?.provider,
-    detectedModel: detectedConfig?.model,
-    detectedBaseUrl: detectedConfig?.baseUrl,
-    detectedHasApiKey: detectedConfig?.hasApiKey,
-    detectedApiMode: detectedConfig?.apiMode,
-    model,
-  });
+  const { provider: resolvedProvider, resolvedFrom } = modelSelection.moaPreset
+    ? { provider: "moa", resolvedFrom: "profileMoaBinding" }
+    : resolveProvider({
+        explicitProvider,
+        detectedProvider: detectedConfig?.provider,
+        detectedModel: detectedConfig?.model,
+        detectedBaseUrl: detectedConfig?.baseUrl,
+        detectedHasApiKey: detectedConfig?.hasApiKey,
+        detectedApiMode: detectedConfig?.apiMode,
+        model,
+      });
 
   // ── Load agent instructions file (Paperclip instruction bundles) ──────
   // Paperclip can materialize managed instructions into instructionsFilePath;
@@ -417,7 +457,7 @@ export async function execute(
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
   const useQuiet = cfgBoolean(config.quiet) === true; // default false
-  const args: string[] = ["chat", "-q", prompt];
+  const args: string[] = ["--profile", profile, "chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 
   if (model) {
@@ -457,8 +497,8 @@ export async function execute(
     args.push("--resume", prevSessionId);
   }
 
-  if (extraArgs?.length) {
-    args.push(...extraArgs);
+  if (sanitizedExtraArgs.length) {
+    args.push(...sanitizedExtraArgs);
   }
 
   // ── Build environment ──────────────────────────────────────────────────

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -77,7 +77,7 @@ function cfgStringArray(v: unknown): string[] | undefined {
     : undefined;
 }
 
-const RESERVED_HERMES_PASSTHROUGH_FLAGS = new Set(["--profile", "-p"]);
+const RESERVED_HERMES_PASSTHROUGH_FLAGS = new Set(["--profile", "-p", "--model", "-m", "--provider"]);
 
 function sanitizeHermesExtraArgs(extraArgs: string[] | undefined): string[] {
   if (!extraArgs?.length) return [];

--- a/packages/adapters/hermes/src/server/index.ts
+++ b/packages/adapters/hermes/src/server/index.ts
@@ -5,6 +5,7 @@
 export { execute } from "./execute.js";
 export { testEnvironment } from "./test.js";
 export { detectModel, parseModelFromConfig, resolveProvider, inferProviderFromModel } from "./detect-model.js";
+export { resolveHermesModelSelection, resolveHermesMoaPreset } from "./moa-profile.js";
 export { getConfigSchema } from "./config-schema.js";
 export {
   listHermesSkills as listSkills,

--- a/packages/adapters/hermes/src/server/moa-profile.test.ts
+++ b/packages/adapters/hermes/src/server/moa-profile.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveHermesModelSelection } from "./moa-profile.js";
+
+describe("Hermes profile-scoped MoA selection", () => {
+  it("selects the named LagunaS-Qwen preset only for the bound Planner profile", () => {
+    const config = {
+      model: "qwen3.6:27b",
+      provider: "ollama-launch",
+      moaProfileBindings: {
+        planner: "LagunaS-Qwen",
+      },
+    };
+
+    expect(resolveHermesModelSelection(config, "planner")).toEqual({
+      model: "moa:LagunaS-Qwen",
+      provider: "moa",
+      moaPreset: "LagunaS-Qwen",
+    });
+  });
+
+  it("keeps an unbound Executor on its configured single-model Qwen route", () => {
+    const config = {
+      model: "qwen3.6:27b",
+      provider: "ollama-launch",
+      moaProfileBindings: {
+        planner: "LagunaS-Qwen",
+      },
+    };
+
+    expect(resolveHermesModelSelection(config, "executor")).toEqual({
+      model: "qwen3.6:27b",
+      provider: "ollama-launch",
+    });
+  });
+
+  it("ignores malformed bindings instead of creating an implicit global MOA route", () => {
+    expect(resolveHermesModelSelection({
+      model: "qwen3.6:27b",
+      moaProfileBindings: {
+        planner: "LagunaS-Qwen/Node-B",
+      },
+    }, "planner")).toEqual({
+      model: "qwen3.6:27b",
+    });
+  });
+});

--- a/packages/adapters/hermes/src/server/moa-profile.ts
+++ b/packages/adapters/hermes/src/server/moa-profile.ts
@@ -1,0 +1,75 @@
+import { DEFAULT_MODEL } from "../shared/constants.js";
+
+const HERMES_MOA_PRESET_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+const MOA_PROFILE_BINDINGS_KEY = "moaProfileBindings";
+
+export interface HermesModelSelection {
+  model: string;
+  provider?: string;
+  moaPreset?: string;
+}
+
+function configuredModel(config: Record<string, unknown>): string {
+  return typeof config.model === "string" && config.model.length > 0
+    ? config.model
+    : DEFAULT_MODEL;
+}
+
+function configuredProvider(config: Record<string, unknown>): string | undefined {
+  return typeof config.provider === "string" && config.provider.trim().length > 0
+    ? config.provider
+    : undefined;
+}
+
+function readProfileBindings(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export function resolveHermesMoaPreset(
+  config: Record<string, unknown>,
+  profile: string,
+): string | null {
+  const bindings = readProfileBindings(config[MOA_PROFILE_BINDINGS_KEY]);
+  if (!bindings || !Object.prototype.hasOwnProperty.call(bindings, profile)) {
+    return null;
+  }
+
+  const preset = bindings[profile];
+  return typeof preset === "string" && HERMES_MOA_PRESET_PATTERN.test(preset)
+    ? preset
+    : null;
+}
+
+/** The adapter's profile-to-model selection point. */
+export function resolveHermesModelSelection(
+  config: Record<string, unknown>,
+  profile: string,
+): HermesModelSelection {
+  const moaPreset = resolveHermesMoaPreset(config, profile);
+  if (moaPreset) {
+    return {
+      model: `moa:${moaPreset}`,
+      provider: "moa",
+      moaPreset,
+    };
+  }
+
+  const selection: HermesModelSelection = {
+    model: configuredModel(config),
+  };
+  const provider = configuredProvider(config);
+  if (provider) selection.provider = provider;
+  return selection;
+}

--- a/packages/adapters/hermes/src/server/profile.ts
+++ b/packages/adapters/hermes/src/server/profile.ts
@@ -1,0 +1,18 @@
+const HERMES_PROFILE_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export const DEFAULT_HERMES_PROFILE = "default";
+
+export function validateHermesProfile(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return HERMES_PROFILE_PATTERN.test(value) ? value : null;
+}
+
+export function resolveHermesProfile(config: Record<string, unknown>): string | null {
+  if (!Object.prototype.hasOwnProperty.call(config, "profile")) {
+    return DEFAULT_HERMES_PROFILE;
+  }
+  return validateHermesProfile(config.profile);
+}
+
+export const HERMES_PROFILE_INVALID_MESSAGE =
+  "Invalid Hermes profile. Use 1-64 lowercase letters, numbers, hyphens, or underscores.";

--- a/packages/adapters/hermes/src/shared/constants.ts
+++ b/packages/adapters/hermes/src/shared/constants.ts
@@ -45,6 +45,7 @@ export const VALID_PROVIDERS = [
   "minimax",
   "minimax-cn",
   "kilocode",
+  "ollama-launch",
 ] as const;
 
 /**

--- a/packages/adapters/hermes/src/ui/build-config.test.ts
+++ b/packages/adapters/hermes/src/ui/build-config.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+import { buildHermesConfig } from "./build-config.js";
+
+test("buildHermesConfig preserves schema-configured MOA bindings", () => {
+  const config = buildHermesConfig({
+    model: "qwen3.6:27b",
+    maxTurnsPerRun: 0,
+    adapterSchemaValues: {
+      profile: "planner",
+      moaProfileBindings: '{ "planner": "LagunaS-Qwen" }',
+    },
+  } as unknown as CreateConfigValues);
+
+  expect(config.profile).toBe("planner");
+  expect(config.moaProfileBindings).toBe('{ "planner": "LagunaS-Qwen" }');
+});

--- a/packages/adapters/hermes/src/ui/build-config.ts
+++ b/packages/adapters/hermes/src/ui/build-config.ts
@@ -81,6 +81,10 @@ export function buildHermesConfig(
     ac.promptTemplate = v.promptTemplate;
   }
 
+  if (v.adapterSchemaValues) {
+    Object.assign(ac, v.adapterSchemaValues);
+  }
+
   // Heartbeat config is handled by Paperclip itself
 
   return ac;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Hermes local adapter converts an agent profile into Hermes CLI arguments
> - Passthrough model and provider flags could override the adapter's profile-scoped route
> - Such an override could move Planner away from LagunaS-Qwen or move Executor onto MOA
> - This pull request reserves the route-defining flags and adds direct precedence tests
> - The benefit is deterministic profile isolation for the distributed MOA pilot

## Linked Issues or Issue Description

No public GitHub issue was found for this focused adapter repair.

**What existing behavior does this improve?**

The Hermes adapter now keeps its profile-selected model and provider authoritative when extra CLI arguments contain conflicting route flags.

**Subsystem affected**

`packages/adapters/hermes` local execution and argv regression tests.

**Current behavior**

Profile selection can be bypassed if passthrough arguments include `-m`, `--model`, or `--provider`.

**Proposed behavior**

The adapter removes those reserved flags from passthrough arguments, including equals-form arguments, before spawning Hermes.

**Reason and benefit**

Planner MOA and Executor single-model routing remain isolated under conflicting configuration.

**Breaking changes**

Users can no longer override the adapter-owned model or provider through `extraArgs`. This is required for profile routing safety.

## What Changed

- Reserved `-m`, `--model`, and `--provider` in Hermes passthrough sanitization.
- Added Planner and Executor precedence coverage for separated and equals-form conflicting flags.
- Preserved unrelated passthrough arguments.

## Verification

- TDD red: removing the three reserved flags caused the two precedence tests to fail.
- TDD green: `pnpm --filter @paperclipai/hermes-paperclip-adapter test -- src/server/execute.onspawn.test.ts src/server/moa-profile.test.ts src/server/config-schema.test.ts` — 3 files, 25 tests passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` — passed.
- `git diff --check` for `c65f160c...4ce9c249` — passed.
- PR #11132 `review` / Greptile gate — passed on exact head `4ce9c24944e69b6fe1a082d5f25c3d86cca99037`; no inline findings were reported.
- The local full adapter suite was attempted. Twelve files passed, but the bridge suite failed because the sandbox denied `listen(127.0.0.1)` with `EPERM`. No live service was started.

## Risks

- `extraArgs` can no longer change the adapter-owned route flags. This is intentional.
- Unbound profiles keep their configured single-model route.
- No live Hermes, Ollama, or Laguna execution was performed.

## Model Used

OpenAI Codex — GPT-5.6-luna. Used for repository inspection, TDD, code execution, and verification. Context-window value was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge