### PR TITLE
fix(activity-log): tolerate runId with no matching heartbeat_runs row (RENA-56155)

### DIFF
--- a/server/src/__tests__/activity-log-responsible-user.test.ts
+++ b/server/src/__tests__/activity-log-responsible-user.test.ts
@@ -243,4 +243,60 @@ describeEmbeddedPostgres("logActivity responsible-user stamping", () => {
 
     expect(row?.responsibleUserId).toBe("key-user");
   });
+
+  it("does not crash on a syntactically valid runId that has no heartbeat_runs row (RENA-56155)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const agentApiKeyId = randomUUID();
+    const nonExistentRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "default-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(agentApiKeys).values({
+      id: agentApiKeyId,
+      companyId,
+      agentId,
+      name: "test",
+      keyHash: `hash-${agentApiKeyId}`,
+      responsibleUserId: "key-user",
+    });
+
+    const postCommitPublications: ActivityPublication[] = [];
+    await expect(logActivity(db, activityInput({
+      companyId,
+      actorId: agentId,
+      agentId,
+      entityType: "agent",
+      entityId: agentId,
+      agentApiKeyId,
+      runId: nonExistentRunId,
+    }), postCommitPublications)).resolves.toBeDefined();
+
+    expect(postCommitPublications[0]?.payload.runId).toBeNull();
+
+    const row = await db
+      .select({ runId: activityLog.runId, responsibleUserId: activityLog.responsibleUserId })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId))
+      .then((rows) => rows[0]);
+
+    expect(row?.runId).toBeNull();
+    expect(row?.responsibleUserId).toBe("key-user");
+  });
 });

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -157,9 +157,38 @@ export function publishActivity(publication: ActivityPublication) {
   if (publication.pluginEvent) publishPluginDomainEvent(publication.pluginEvent);
 }
 
+/**
+ * The activity_log.run_id column has a FK constraint on heartbeat_runs. A syntactically
+ * valid but never-persisted run id (e.g. a freshly minted bridge JWT claim) would otherwise
+ * make the whole logActivity() insert fail even though the primary write already committed
+ * (see RENA-56155). Falling back to null keeps the audit row instead of crashing the caller.
+ */
+async function resolveExistingRunId(db: Db, companyId: string, runId: string | null) {
+  if (!runId || !isUuidLike(runId)) return null;
+  const run = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.id, runId)))
+    .then((rows) => rows[0] ?? null);
+  return run ? runId : null;
+}
+
 export async function persistActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = await redactActivityDetails(db, input.details ?? null);
   const responsibleUserId = await resolveResponsibleUserIdForActivity(db, input);
+  const runId = await resolveExistingRunId(db, input.companyId, input.runId ?? null);
+  if (input.runId && !runId) {
+    logger.warn(
+      {
+        companyId: input.companyId,
+        runId: input.runId,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+      },
+      "logActivity: runId does not reference an existing heartbeat run; persisting activity_log row without runId",
+    );
+  }
   const [activity] = await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -168,7 +197,7 @@ export async function persistActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId,
     responsibleUserId,
     details: redactedDetails,
   }).returning({ id: activityLog.id });
@@ -180,7 +209,7 @@ export async function persistActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId,
     responsibleUserId,
     details: redactedDetails,
   };


### PR DESCRIPTION
## Summary
- `logActivity()` / `persistActivity()` inserted `input.runId` into `activity_log` unconditionally. A syntactically valid UUID that doesn't reference an existing `heartbeat_runs` row (e.g. a freshly minted bridge JWT claim never used for a real heartbeat) violated the `activity_log_run_id_heartbeat_runs_id_fk` FK constraint and crashed the whole request handler with a 500 — even though the primary write (e.g. the `agents` row update in the PATCH handler) had already committed.
- `persistActivity()` now checks whether `runId` references an existing `heartbeat_runs` row (scoped by `companyId`) before using it in the insert; if not, it falls back to `runId = null` and logs a warning instead of crashing.

Fixes RENA-56155.

## Test plan
- [x] Added a regression test (`activity-log-responsible-user.test.ts`) that calls `logActivity()` with a syntactically valid but non-existent `runId` against an embedded Postgres instance and asserts it resolves instead of throwing, persists `runId = null`, and still resolves `responsibleUserId` correctly.
- [x] `pnpm exec vitest run src/__tests__/activity-log-responsible-user.test.ts` — 10/10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
