### PR TITLE
fix(issues): release a blocked issue when its last blocker edge is removed

### DIFF
--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -101,18 +101,28 @@ vi.mock("../services/issue-dependency-wakeups.js", async () => {
   };
 });
 
-async function createApp() {
+// Drizzle stamps the SQL table name on this symbol; the route module is re-imported per test
+// via vi.resetModules(), so table objects cannot be matched by identity — match by name.
+const drizzleTableName = (table: unknown): string | undefined =>
+  (table as Record<symbol, unknown> | null)?.[Symbol.for("drizzle:Name")] as string | undefined;
+
+async function createApp(rowsByTable?: Record<string, unknown[]>) {
   const emptyRows: unknown[] = [];
-  const whereResult = {
-    limit: vi.fn(async () => emptyRows),
-    then: async (resolve: (rows: unknown[]) => unknown) => resolve(emptyRows),
+  const buildQuery = (table: unknown) => {
+    const tableName = drizzleTableName(table);
+    const rows = (tableName ? rowsByTable?.[tableName] : undefined) ?? emptyRows;
+    const whereResult = {
+      limit: vi.fn(async () => rows),
+      then: async (resolve: (queried: unknown[]) => unknown) => resolve(rows),
+    };
+    const query: Record<string, unknown> = {};
+    query.innerJoin = vi.fn(() => query);
+    query.where = vi.fn(() => whereResult);
+    return query;
   };
-  const query: Record<string, unknown> = {};
-  query.innerJoin = vi.fn(() => query);
-  query.where = vi.fn(() => whereResult);
   const routeDb = {
     select: vi.fn(() => ({
-      from: vi.fn(() => query),
+      from: vi.fn((table: unknown) => buildQuery(table)),
     })),
   };
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
@@ -384,6 +394,178 @@ describe("issue dependency wakeups in issue routes", () => {
             ]),
           }),
         }),
+      );
+    });
+  });
+
+  describe("clearing the last blocker on an already-blocked issue", () => {
+    const blockedIssueId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const blockerIssueId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+    const blockedIssue = (overrides: Record<string, unknown> = {}) => ({
+      id: blockedIssueId,
+      companyId: "company-1",
+      identifier: "PAP-300",
+      title: "Waiting on nothing",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-7",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      unblockDescriptor: null,
+      labels: [],
+      labelIds: [],
+      ...overrides,
+    });
+
+    const blockerRelation = {
+      id: blockerIssueId,
+      identifier: "PAP-301",
+      title: "The blocker",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    };
+
+    const statusSentToUpdate = () =>
+      (mockIssueService.update.mock.calls[0]?.[1] as { status?: string } | undefined)?.status;
+
+    // Wakes are emitted from a fire-and-forget post-commit IIFE, so asserting that NO wake was
+    // emitted needs the event loop drained first — otherwise the assertion passes vacuously.
+    const drainPostCommitWakeups = async () => {
+      for (let turn = 0; turn < 5; turn += 1) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    };
+
+    it("releases the issue to todo and wakes the assignee when the last blocker edge is removed", async () => {
+      mockIssueService.getById.mockResolvedValue(blockedIssue());
+      mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [blockerRelation], blocks: [] });
+      mockIssueService.update.mockResolvedValue(blockedIssue({ status: "todo" }));
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ blockedByIssueIds: [] });
+
+      expect(res.status).toBe(200);
+      expect(statusSentToUpdate()).toBe("todo");
+      await vi.waitFor(() => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-7",
+          expect.objectContaining({
+            reason: "issue_blockers_resolved",
+            payload: expect.objectContaining({
+              issueId: blockedIssueId,
+              resolvedBlockerIssueId: blockerIssueId,
+              blockerIssueIds: [blockerIssueId],
+              mutation: "blockers_cleared",
+            }),
+            contextSnapshot: expect.objectContaining({
+              source: "issue.blockers_cleared",
+            }),
+          }),
+        );
+      });
+    });
+
+    it("releases an already naked-blocked issue to todo without emitting a wake", async () => {
+      mockIssueService.getById.mockResolvedValue(blockedIssue());
+      // Already naked-blocked: status "blocked" with zero blocker edges, no interaction,
+      // no approval, no unblockDescriptor.
+      mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+      mockIssueService.update.mockResolvedValue(blockedIssue({ status: "todo" }));
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ blockedByIssueIds: [] });
+
+      expect(res.status).toBe(200);
+      expect(statusSentToUpdate()).toBe("todo");
+
+      await drainPostCommitWakeups();
+      expect(mockFindExistingIssueBlockersResolvedWake).not.toHaveBeenCalled();
+      expect(mockWakeup).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ reason: "issue_blockers_resolved" }),
+      );
+      expect(mockWakeup).not.toHaveBeenCalled();
+    });
+
+    it("keeps the issue blocked when a pending thread interaction remains", async () => {
+      mockIssueService.getById.mockResolvedValue(blockedIssue());
+      mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [blockerRelation], blocks: [] });
+      mockIssueService.update.mockResolvedValue(blockedIssue());
+
+      const res = await request(
+        await createApp({ issue_thread_interactions: [{ id: "interaction-1" }] }),
+      )
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ blockedByIssueIds: [] });
+
+      expect(res.status).toBe(200);
+      expect(statusSentToUpdate()).toBeUndefined();
+    });
+
+    it("keeps the issue blocked when a pending linked approval remains", async () => {
+      mockIssueService.getById.mockResolvedValue(blockedIssue());
+      mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [blockerRelation], blocks: [] });
+      mockIssueService.update.mockResolvedValue(blockedIssue());
+
+      const res = await request(await createApp({ issue_approvals: [{ id: "approval-1" }] }))
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ blockedByIssueIds: [] });
+
+      expect(res.status).toBe(200);
+      expect(statusSentToUpdate()).toBeUndefined();
+    });
+
+    it("keeps the issue blocked when an unblockDescriptor remains", async () => {
+      mockIssueService.getById.mockResolvedValue(
+        blockedIssue({ unblockDescriptor: { owner: "board", action: "Decide on the vendor" } }),
+      );
+      mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [blockerRelation], blocks: [] });
+      mockIssueService.update.mockResolvedValue(
+        blockedIssue({ unblockDescriptor: { owner: "board", action: "Decide on the vendor" } }),
+      );
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ blockedByIssueIds: [] });
+
+      expect(res.status).toBe(200);
+      expect(statusSentToUpdate()).toBeUndefined();
+    });
+
+    it("keeps the issue blocked when blockers are replaced with a still-open blocker", async () => {
+      mockIssueService.getById.mockResolvedValue(blockedIssue());
+      mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+      mockIssueService.update.mockResolvedValue(blockedIssue());
+
+      const res = await request(await createApp({ issues: [{ id: blockerIssueId }] }))
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ blockedByIssueIds: [blockerIssueId] });
+
+      expect(res.status).toBe(200);
+      expect(statusSentToUpdate()).toBeUndefined();
+    });
+
+    it("still rejects entering blocked without any wait surface", async () => {
+      mockIssueService.getById.mockResolvedValue(blockedIssue({ status: "todo" }));
+      mockIssueService.update.mockResolvedValue(blockedIssue());
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${blockedIssueId}`)
+        .send({ status: "blocked" });
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toBe(
+        "Entering blocked requires unresolved blockers, a pending interaction/approval, or unblockDescriptor",
       );
     });
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8760,15 +8760,14 @@ export function issueRoutes(
         if (!member) throw unprocessable("Unblock owner user must be an active company member");
       }
     }
-    const enteringBlocked = existing.status !== "blocked" && updateFields.status === "blocked";
-    if (enteringBlocked) {
-      const requestedBlockerIds = Array.isArray(req.body.blockedByIssueIds)
-        ? [...new Set(req.body.blockedByIssueIds as string[])]
-        : null;
-      const hasUnresolvedBlocker = requestedBlockerIds
-        ? requestedBlockerIds.length > 0 && await db.select({ id: issueRows.id }).from(issueRows).where(and(
+    const requestedBlockerIds = Array.isArray(req.body.blockedByIssueIds)
+      ? [...new Set(req.body.blockedByIssueIds as string[])]
+      : null;
+    const hasLiveBlockedWaitSurface = async (blockerIds: string[] | null) => {
+      const hasUnresolvedBlocker = blockerIds
+        ? blockerIds.length > 0 && await db.select({ id: issueRows.id }).from(issueRows).where(and(
           eq(issueRows.companyId, existing.companyId),
-          inArray(issueRows.id, requestedBlockerIds),
+          inArray(issueRows.id, blockerIds),
           notInArray(issueRows.status, ["done", "cancelled"]),
         )).limit(1).then((rows) => rows.length > 0)
         : (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0;
@@ -8784,9 +8783,32 @@ export function issueRoutes(
           eq(approvals.status, "pending"),
         )).limit(1).then((rows) => rows[0] ?? null),
       ]);
-      if (!hasUnresolvedBlocker && !pendingInteraction && !pendingApproval && !descriptor) {
+      return Boolean(hasUnresolvedBlocker || pendingInteraction || pendingApproval);
+    };
+    const enteringBlocked = existing.status !== "blocked" && updateFields.status === "blocked";
+    if (enteringBlocked) {
+      if (!(await hasLiveBlockedWaitSurface(requestedBlockerIds)) && !descriptor) {
         res.status(422).json({ error: "Entering blocked requires unresolved blockers, a pending interaction/approval, or unblockDescriptor" });
         return;
+      }
+    }
+    // `blocked` only means something while a wait surface is live. Removing the last blocker
+    // edge from an already-blocked issue used to be accepted silently, leaving it parked with
+    // nothing left to wake it ("naked blocked"). Release it to `todo` instead — but only when
+    // no pending interaction, pending approval, or unblockDescriptor is still holding it.
+    const clearingBlockersWhileBlocked =
+      !enteringBlocked &&
+      existing.status === "blocked" &&
+      requestedBlockerIds !== null &&
+      (updateFields.status === undefined || updateFields.status === "blocked");
+    let releasedFromBlocked = false;
+    if (clearingBlockersWhileBlocked) {
+      const effectiveDescriptor = updateFields.unblockDescriptor !== undefined
+        ? updateFields.unblockDescriptor
+        : existing.unblockDescriptor;
+      if (!(await hasLiveBlockedWaitSurface(requestedBlockerIds)) && !effectiveDescriptor) {
+        updateFields.status = "todo";
+        releasedFromBlocked = true;
       }
     }
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
@@ -9761,6 +9783,23 @@ export function issueRoutes(
             blockerIssueIds: readiness.blockerIssueIds,
             source: "issue.blockers_restored",
             mutation: "blocked_dependency_restored",
+          });
+        }
+      }
+
+      // The issue was auto-released from `blocked` because its last blocker edge was removed;
+      // wake the assignee the same way a blocker completing would have.
+      if (releasedFromBlocked && issue.assigneeAgentId) {
+        const clearedBlockerIssueIds = (existingRelations?.blockedBy ?? []).map((relation) => relation.id);
+        const resolvedBlockerIssueId = clearedBlockerIssueIds[0] ?? null;
+        if (resolvedBlockerIssueId) {
+          await addDependencyResolvedWakeup({
+            agentId: issue.assigneeAgentId,
+            dependentIssueId: issue.id,
+            resolvedBlockerIssueId,
+            blockerIssueIds: clearedBlockerIssueIds,
+            source: "issue.blockers_cleared",
+            mutation: "blockers_cleared",
           });
         }
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues coordinate that work, and first-class blockers (`blockedByIssueIds`) are how dependent work auto-resumes when its prerequisites finish
> - An issue that is already `blocked` can have its last blocker edge removed by a PATCH that says nothing about `status`
> - The route accepted that write verbatim. The issue kept `status='blocked'` with zero edges, and nothing was left to wake it
> - This state is worse than a stale blocker. A stale blocker still shows an edge in the dependency graph. An issue in this state looks like it waits for something, and it waits for nothing
> - The existing `enteringBlocked` guard does not catch this. It is gated on `existing.status !== "blocked"`, so it fires only on the transition into blocked
> - This pull request releases the issue to `todo` and wakes the assignee, but only when no wait surface is left
> - The benefit is that a blocker-hygiene sweep that removes edges no longer creates dead issues

## Linked Issues or Issue Description

Refs #10404 — Liveness classifier has no invariant for `status=blocked` with zero blocker relations
Refs #8062 — feat: auto-flip to `todo` when reassigning a `blocked` ticket with no active `blockedByIssueIds`
Refs #9201 — run-recovery parks `routine_execution` issues in `blocked` with empty `blockedByIssueIds`
Refs #6523 — Recovery wake loop, parent issue stuck in `blocked` with empty `blockedByIssueIds`

**Related pull requests (searched before opening this one):**

- #7850 `recovery: never write status='blocked' with empty blockedBy[]` — the closest prior attempt. It rejects the write with `400 blocked_requires_blocker` for agent actors. It was opened on 2026-06-09, before #10112 landed the `enteringBlocked` gate. That gate made a pending interaction, a pending approval, and an `unblockDescriptor` legitimate reasons to stay `blocked` with zero edges. A blanket reject now refuses those valid states. This pull request keys on the same wait-surface predicate instead, and releases rather than rejects, so no caller has to change.
- #6587 `feat: warn when issue set to blocked without blockedByIssueIds` — the soft variant. It adds a `warnings` array and does not change the outcome, so the issue still strands.
- #10269 `don't implicitly reopen a blocked issue when the same PATCH wires blockers` — the mirror case. That one stops an unwanted flip to `todo` when blockers are *added*. This one performs a wanted flip when the last blocker is *removed*. Both touch the PATCH status path, so they will need a trivial rebase against each other.
- #10807 — also touches `blockerAttention` rendering for a blocked row with no live blocker. Complementary, not overlapping. That one fixes how the state is displayed; this one stops the state from being created.

**Bug report fields**

**What happened:** `PATCH /api/issues/:id` with `{"blockedByIssueIds": []}` on an issue already at `status="blocked"` returns `200`. The issue keeps `status="blocked"` and has zero blocker edges. No wake is emitted, and no error is returned.

**Expected behavior:** The write must not leave the issue parked with nothing to wake it. Either the issue moves out of `blocked`, or the request fails.

**Steps to reproduce:**
1. Create issue A. Create issue B with `status="blocked"` and `blockedByIssueIds: [A]`. `GET` B and confirm `blockedBy` has one entry.
2. `PATCH` B with `{"blockedByIssueIds": []}`. The response is `200`.
3. `GET` B. `status` is still `"blocked"`, `blockedBy` is `[]`, and `blockerAttention.unresolvedBlockerCount` is `0`. Nothing wakes the assignee.

**Deployment mode:** local, self-hosted. Reproduced against a running control plane, then confirmed by reading `master` at `19be4cf92`.

## What Changed

- Extracted the wait-surface test in the `PATCH /api/issues/:id` handler into a local `hasLiveBlockedWaitSurface(blockerIds)` helper. It returns true when an unresolved blocker, a pending thread interaction, or a pending linked approval exists. This is a pure refactor of the `enteringBlocked` check, and that check keeps its behavior and its `422` message.
- Added a `clearingBlockersWhileBlocked` branch. When the issue is already `blocked`, the PATCH supplies `blockedByIssueIds`, the PATCH does not itself set a different status, and no wait surface and no `unblockDescriptor` are left, the route sets `status` to `todo`.
- Added a post-commit wake for that case. It reuses the existing `addDependencyResolvedWakeup` closure with `source: "issue.blockers_cleared"` and `mutation: "blockers_cleared"`. The first previously-present blocker id is the `resolvedBlockerIssueId`, which keeps the wake idempotency key stable.
- No wake is emitted when the issue had no edges before the PATCH. There is nothing to report as resolved. The move to `todo` is the whole remedy.
- Added 7 tests.

## Verification

`cd server && npx vitest run --testTimeout=20000 src/__tests__/issue-dependency-wakeups-routes.test.ts` → **10 passed**.

The two new regression tests were confirmed to fail before the production change. With `server/src/routes/issues.ts` stashed and the tests kept: **2 failed, 8 passed**. The two failures are `releases the issue to todo and wakes the assignee when the last blocker edge is removed` and `releases an already naked-blocked issue to todo without emitting a wake`. The five anti-regression tests pass in both states, which is what they are for.

New tests:
1. Last blocker edge removed → status becomes `todo`, assignee is woken.
2. Already zero edges → status becomes `todo`, no wake emitted. This is the repair path for issues already in the bad state.
3. Pending thread interaction remains → stays `blocked`.
4. Pending linked approval remains → stays `blocked`.
5. `unblockDescriptor` remains → stays `blocked`.
6. Blockers replaced with a still-open blocker → stays `blocked`.
7. Entering blocked with no wait surface → still `422`, message unchanged.

Regression sweep, all passing: `issue-activity-events-routes`, `issue-agent-mutation-ownership-routes`, `low-trust-red-team-routes` (97 passed); `issue-blocker-diagnostics-routes`, `issue-scheduled-retry-routes`, `issue-stale-execution-lock-routes`, `issue-wake-diagnostics-routes`, `issue-execution-policy-routes`, `issue-subtree-diagnostics-routes`, `issue-assigned-backlog-contract-routes`, `issue-list-assignee-filter-routes` (75 passed).

`pnpm --filter @paperclipai/server typecheck` → clean.

Note for reviewers: `wakes dependents when the final blocker transitions to done` in this file times out at the default 5s on a slow machine. That is pre-existing. It fails the same way on a clean tree at the same commit, and it passes at `--testTimeout=20000`.

## Risks

- **Behavioral shift, intended.** A PATCH that clears the last blocker on a blocked issue now also moves that issue to `todo`. A caller that expected the issue to stay `blocked` sees a different status. That combination previously produced an issue nothing could wake, so no caller should depend on it.
- **The guarded case is the risky one, and it is tested.** `blocked` with zero edges is valid when a pending interaction, a pending approval, or an `unblockDescriptor` holds the issue. Releasing those would create a new liveness bug in place of the old one. Four of the seven tests exist to pin that down.
- **Authorization surface, please review.** `agentStatusTransitionRequiresResumeAuthority` is computed earlier in the handler, from `updateFields.status` as the caller supplied it. The release sets `status` after that point, so an agent that clears its own last blocker gets `blocked` → `todo` without passing `resume: true`. This looks correct to me, because the release is system-initiated rather than an agent asserting resume intent, and because the platform already auto-wakes dependents when a blocker closes without asking anyone for resume intent. `assertRecoveryActionAuthority` still runs, since it already keys on `blockedByIssueIds` being present. I am flagging it rather than hiding it, because it is a real change to when that gate applies.
- **Merge order.** #10269 touches the same status path. Whichever lands second needs a small rebase.
- No migration. No schema change. No API shape change.

## Model Used

Claude Opus 4.5 (`claude-opus-4-5`), extended thinking, with tool use and code execution. The design and the review were mine; a subagent on the same model wrote the tests and applied the edit to my specification. I verified the diff, ran the suite myself, and confirmed the before-state failures myself.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing documentation covers this route behavior
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending first CI run
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending first review
- [x] I will address all Greptile and reviewer comments before requesting merge
