### PR TITLE
fix(api): reject unsupported issue dates and routine triggers

### DIFF
--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -66,6 +66,8 @@ The optional `comment` field adds a comment in the same call. For execution-poli
 
 Updatable fields: `title`, `description`, `status`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`.
 
+Unsupported fields, including `dueDate`, are rejected with `400`; issue deadlines must use a routine trigger.
+
 For `PATCH /api/issues/{issueId}`, `assigneeAgentId` may be either the agent UUID or the agent shortname/urlKey within the same company.
 
 ### Update Response

--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -65,6 +65,8 @@ Fields:
 
 **Catch-up policies:**
 
+Create routine triggers separately with the endpoint below; inline `triggers` in a create request are rejected with `400`.
+
 | Value | Behaviour |
 |-------|-----------|
 | `skip_missed` (default) | Missed scheduled runs are dropped |

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -149,22 +149,22 @@ describe("issue validators", () => {
     });
   });
 
-  it("keeps issue attribution fields create-only", () => {
+  it("accepts issue attribution only on create", () => {
     const created = createIssueSchema.parse({
       title: "Preserve attribution input for route checks",
       createdByUserId: "spoofed-creator",
       responsibleUserId: "spoofed-responsible",
     });
-    const updated = updateIssueSchema.parse({
-      title: "Do not update attribution",
-      createdByUserId: "spoofed-creator",
-      responsibleUserId: "spoofed-responsible",
-    });
+    expect(() =>
+      updateIssueSchema.parse({
+        title: "Do not update attribution",
+        createdByUserId: "spoofed-creator",
+        responsibleUserId: "spoofed-responsible",
+      }),
+    ).toThrow("Unrecognized key(s)");
 
     expect(created.createdByUserId).toBe("spoofed-creator");
     expect(created.responsibleUserId).toBe("spoofed-responsible");
-    expect(updated).not.toHaveProperty("createdByUserId");
-    expect(updated).not.toHaveProperty("responsibleUserId");
   });
 
   it("allows false-positive recovery resolutions to atomically restore the source issue status", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -551,7 +551,7 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),
   hiddenAt: z.string().datetime().nullable().optional(),
-});
+}).strict();
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
 export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorkspaceSettingsSchema>;

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -77,7 +77,7 @@ export const createRoutineSchema = z.object({
   activityGateScope: z.enum(ROUTINE_ACTIVITY_GATE_SCOPES).optional(),
   variables: z.array(routineVariableSchema).optional().default([]),
   env: envConfigSchema.optional().nullable(),
-});
+}).strict();
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;
 

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -187,6 +187,14 @@ describe("issue telemetry routes", () => {
     }));
   });
 
+  it('rejects unsupported dueDate before issue lookup or update', async () => {
+    const app = await createApp({ type: 'board', userId: 'local-board', companyIds: ['company-1'], source: 'local_implicit', isInstanceAdmin: false });
+    const res = await request(app).patch('/api/issues/11111111-1111-4111-8111-111111111111').send({ dueDate: '2026-11-30' });
+    expect(res.status).toBe(400);
+    expect(mockIssueService.getById).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("emits task-completed telemetry with the agent role, adapter type, and model", async () => {
     mockAgentService.getById.mockResolvedValue({
       id: "agent-1",

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -308,6 +308,13 @@ describe("routine routes", () => {
     mockAnnotationService.remapOpenThreadsForRoutineDocument.mockResolvedValue([]);
   });
 
+  it('rejects inline triggers before routine creation', async () => {
+    const app = await createApp({ type: 'board', userId: 'board-user', source: 'session', isInstanceAdmin: true, companyIds: [companyId] });
+    const res = await request(app).post(`/api/companies/${companyId}/routines`).send({ title: 'Daily routine', triggers: [{ kind: 'schedule', cronExpression: '0 9 * * *', timezone: 'America/New_York' }] });
+    expect(res.status).toBe(400);
+    expect(mockRoutineService.create).not.toHaveBeenCalled();
+  });
+
   it("passes project filters to the routine list service", async () => {
     const app = await createApp({
       type: "board",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The API validates issue updates and routine creation requests.
> - Two validators accepted unsupported fields and removed them.
> - The API then returned success without applying the requested behavior.
> - This pull request makes both request contracts strict.
> - It also adds route tests and documents the supported paths.
> - The benefit is a clear 400 response before any service method runs.

## Linked Issues or Issue Description

Refs #3458

Supersedes #10475

**What happened?**

`PATCH /api/issues/{issueId}` accepted `dueDate` and removed it. `POST /api/companies/{companyId}/routines` accepted inline `triggers` and removed them. Both endpoints returned success.

**Expected behavior**

The API must reject unsupported fields with `400`. It must not report success after it removes requested behavior.

**Steps to reproduce**

1. Send an issue update with `dueDate`.
2. Read the issue and observe that the date is absent.
3. Create a routine with inline `triggers`.
4. Read the routine and observe that it has no triggers.

**Paperclip version or commit**

`19be4cf9278b70bc151063778a94bf38bfd5c903`

**Deployment mode**

Local dev from `master`.

## What Changed

- Made the issue update schema reject unknown fields.
- Made the routine create schema reject unknown fields.
- Added route tests that verify `400` responses before service calls.
- Documented that issue deadlines use routines and routine triggers use the trigger endpoint.

## Verification

- Passed: `pnpm --filter @paperclipai/shared typecheck`
- Passed: `pnpm --filter @paperclipai/server typecheck`
- Passed: a direct schema smoke check. It returned `unrecognized_keys` for `dueDate` and `triggers`.
- Passed: all 28 GitHub check runs completed with no failure at commit `29894f92a2ee154682e83ecfe974ed474789b77b`.
- Added focused Vitest route regressions.
- Local Vitest startup was blocked by Node 24.13.1 with `ERR_PACKAGE_IMPORT_NOT_DEFINED` inside Vitest 4.1.10. CI must run the focused tests on its supported runtime.

## Risks

- Low data risk. There is no migration and no persistence change.
- This is a deliberate API behavior change. Requests with unknown fields now receive `400` instead of success with removed fields.
- The strict routine create schema also makes the derived routine update schema strict.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex `gpt-5.6-sol` produced and reviewed this change with local shell and code execution tools. A gated xAI Grok delegation returned no output and did not contribute code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge