### PR TITLE
feat(db): add an opt-in connection circuit breaker

### DIFF
--- a/doc/DATABASE.md
+++ b/doc/DATABASE.md
@@ -126,6 +126,29 @@ DATABASE_IDLE_TIMEOUT_SECONDS=60     # close idle pooled connections; default: k
 DATABASE_CONNECT_TIMEOUT_SECONDS=10  # default: 30
 ```
 
+### Connection circuit breaker (optional)
+
+When the database becomes unreachable, the driver parks every query until
+`connect_timeout` elapses. Under load that means request handlers accumulate
+faster than they drain, and a multi-minute connectivity blip can exhaust the
+process memory limit before the connection error ever surfaces.
+
+Turning the breaker on makes those queries reject immediately instead. After
+`DATABASE_CIRCUIT_BREAKER_FAILURE_THRESHOLD` consecutive *connection* failures
+(a server that answers with a constraint or syntax error is reachable and does
+not count), the breaker opens and every query fails fast with
+`DATABASE_CIRCUIT_OPEN`. After the reset timeout it admits one probe query,
+which closes the breaker on success and restarts the cooldown on failure.
+
+```sh
+DATABASE_CIRCUIT_BREAKER=true                     # off unless set
+DATABASE_CIRCUIT_BREAKER_FAILURE_THRESHOLD=5      # consecutive connection failures; default: 5
+DATABASE_CIRCUIT_BREAKER_RESET_TIMEOUT_SECONDS=5  # cooldown before the probe; default: 5
+```
+
+Setting either tuning variable turns the breaker on by itself. Set
+`DATABASE_CIRCUIT_BREAKER=false` to keep it off regardless.
+
 ### Push the schema
 
 ```sh

--- a/docs/deploy/database.md
+++ b/docs/deploy/database.md
@@ -64,6 +64,8 @@ DATABASE_PREPARED_STATEMENTS=false
 
 Related optional client tuning (driver defaults apply when unset): `DATABASE_POOL_MAX`, `DATABASE_IDLE_TIMEOUT_SECONDS`, `DATABASE_CONNECT_TIMEOUT_SECONDS`.
 
+Set `DATABASE_CIRCUIT_BREAKER=true` to fail queries fast while the database is unreachable, instead of parking each one until `connect_timeout` elapses — during an outage that pile-up is what exhausts process memory. Tune with `DATABASE_CIRCUIT_BREAKER_FAILURE_THRESHOLD` and `DATABASE_CIRCUIT_BREAKER_RESET_TIMEOUT_SECONDS`; see `doc/DATABASE.md` for the full description.
+
 ## Switching Between Modes
 
 | `DATABASE_URL` | Mode |

--- a/packages/db/src/circuit-breaker-sql.test.ts
+++ b/packages/db/src/circuit-breaker-sql.test.ts
@@ -1,0 +1,224 @@
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import { withConnectionCircuitBreaker } from "./circuit-breaker-sql.js";
+import { ConnectionCircuitBreaker, DatabaseUnavailableError } from "./connection-circuit-breaker.js";
+
+type Outcome = { ok: true; value: unknown } | { ok: false; error: unknown };
+
+function connectionError(code = "CONNECT_TIMEOUT"): Error {
+  return Object.assign(new Error(`write ${code} db:5432`), { code, errno: code });
+}
+
+/**
+ * A stand-in for postgres.js with the two properties that matter here: queries
+ * are lazy (nothing runs until the caller subscribes) and the configuration
+ * methods return the query itself.
+ */
+function createFakeSql(outcomes: Outcome[]) {
+  const dialled: string[] = [];
+  const created: string[] = [];
+
+  const makeQuery = (label: string) => {
+    let run: Promise<unknown> | undefined;
+    const start = () => {
+      run ??= (() => {
+        dialled.push(label);
+        const outcome = outcomes.shift() ?? { ok: true, value: [] };
+        return outcome.ok ? Promise.resolve(outcome.value) : Promise.reject(outcome.error);
+      })();
+      return run;
+    };
+    const query: Record<string, unknown> = {
+      label,
+      then: (...args: unknown[]) => (start().then as (...a: unknown[]) => unknown)(...args),
+      catch: (...args: unknown[]) => (start().catch as (...a: unknown[]) => unknown)(...args),
+      finally: (...args: unknown[]) => (start().finally as (...a: unknown[]) => unknown)(...args),
+      execute: () => {
+        void start();
+        return query;
+      },
+    };
+    for (const method of ["values", "raw", "simple", "describe", "cursor", "forEach"]) {
+      query[method] = () => query;
+    }
+    return query;
+  };
+
+  const sql = ((...args: unknown[]) => {
+    const strings = args[0] as { raw?: unknown } | undefined;
+    if (!Array.isArray(strings?.raw)) return { fragment: args[0] };
+    created.push("tagged");
+    return makeQuery("tagged");
+  }) as unknown as Record<string, unknown> & ((...args: unknown[]) => unknown);
+
+  sql.unsafe = (text: string) => {
+    created.push(`unsafe:${text}`);
+    return makeQuery(`unsafe:${text}`);
+  };
+  sql.begin = (_fn: unknown) => {
+    created.push("begin");
+    return makeQuery("begin");
+  };
+  let ended = 0;
+  sql.end = () => {
+    ended += 1;
+    return Promise.resolve();
+  };
+  sql.options = { parsers: {}, serializers: {} };
+
+  return { sql, dialled, created, endCount: () => ended };
+}
+
+function wrap(outcomes: Outcome[], failureThreshold = 2, resetTimeoutMs = 5_000) {
+  const clock = { now: 0 };
+  const fake = createFakeSql(outcomes);
+  const breaker = new ConnectionCircuitBreaker({ failureThreshold, resetTimeoutMs, now: () => clock.now });
+  const sql = withConnectionCircuitBreaker(fake.sql as any, breaker) as any;
+  return { ...fake, breaker, clock, sql };
+}
+
+describe("withConnectionCircuitBreaker", () => {
+  it("returns the client untouched when no breaker is configured", () => {
+    const fake = createFakeSql([]);
+    expect(withConnectionCircuitBreaker(fake.sql as any, null)).toBe(fake.sql);
+  });
+
+  it("passes results through while the breaker is closed", async () => {
+    const { sql } = wrap([{ ok: true, value: [{ one: 1 }] }]);
+    await expect(sql`select 1`).resolves.toEqual([{ one: 1 }]);
+  });
+
+  it("keeps queries lazy — nothing dials until the caller subscribes", async () => {
+    const { sql, dialled } = wrap([{ ok: true, value: [] }]);
+    const pending = sql.unsafe("select 1");
+    expect(dialled).toEqual([]);
+    await pending;
+    expect(dialled).toEqual(["unsafe:select 1"]);
+  });
+
+  it("preserves the self-returning configuration chain", async () => {
+    const { sql } = wrap([{ ok: true, value: [[1]] }]);
+    // drizzle's own call shape: `client.unsafe(query, params).values()`.
+    await expect(sql.unsafe("select 1", []).values()).resolves.toEqual([[1]]);
+  });
+
+  it("opens after consecutive connection failures and then rejects without dialling", async () => {
+    const { sql, breaker, dialled } = wrap(
+      [
+        { ok: false, error: connectionError() },
+        { ok: false, error: connectionError() },
+      ],
+      2,
+    );
+
+    await expect(sql.unsafe("a")).rejects.toThrow(/CONNECT_TIMEOUT/);
+    await expect(sql.unsafe("b")).rejects.toThrow(/CONNECT_TIMEOUT/);
+    expect(breaker.state).toBe("open");
+
+    const before = dialled.length;
+    await expect(sql.unsafe("c")).rejects.toBeInstanceOf(DatabaseUnavailableError);
+    await expect(sql`select 1`).rejects.toBeInstanceOf(DatabaseUnavailableError);
+    expect(dialled.length).toBe(before);
+  });
+
+  it("rejects the whole configuration chain while open", async () => {
+    const { sql } = wrap(
+      [
+        { ok: false, error: connectionError() },
+        { ok: false, error: connectionError() },
+      ],
+      2,
+    );
+    await expect(sql.unsafe("a")).rejects.toThrow();
+    await expect(sql.unsafe("b")).rejects.toThrow();
+
+    await expect(sql.unsafe("c", []).values()).rejects.toBeInstanceOf(DatabaseUnavailableError);
+  });
+
+  it("does not open on errors the server itself returned", async () => {
+    const failures: Outcome[] = Array.from({ length: 5 }, () => ({
+      ok: false as const,
+      error: connectionError("23505"),
+    }));
+    const { sql, breaker } = wrap(failures, 2);
+    for (let i = 0; i < 5; i += 1) {
+      await expect(sql.unsafe(`q${i}`)).rejects.toThrow();
+    }
+    expect(breaker.state).toBe("closed");
+  });
+
+  it("recovers through a half-open probe", async () => {
+    const { sql, breaker, clock } = wrap(
+      [
+        { ok: false, error: connectionError() },
+        { ok: false, error: connectionError() },
+        { ok: true, value: [{ ok: true }] },
+        { ok: true, value: [{ ok: true }] },
+      ],
+      2,
+      5_000,
+    );
+    await expect(sql.unsafe("a")).rejects.toThrow();
+    await expect(sql.unsafe("b")).rejects.toThrow();
+    expect(breaker.state).toBe("open");
+
+    clock.now = 5_000;
+    await expect(sql.unsafe("probe")).resolves.toEqual([{ ok: true }]);
+    expect(breaker.state).toBe("closed");
+    await expect(sql.unsafe("after")).resolves.toEqual([{ ok: true }]);
+  });
+
+  it("lets non-query surfaces through even while open", async () => {
+    const { sql, breaker, endCount } = wrap(
+      [
+        { ok: false, error: connectionError() },
+        { ok: false, error: connectionError() },
+      ],
+      2,
+    );
+    await expect(sql.unsafe("a")).rejects.toThrow();
+    await expect(sql.unsafe("b")).rejects.toThrow();
+    expect(breaker.state).toBe("open");
+
+    // Shutting the pool down, and building SQL fragments, must not depend on
+    // the database being reachable.
+    await sql.end();
+    expect(endCount()).toBe(1);
+    expect(sql({ id: 1 })).toEqual({ fragment: { id: 1 } });
+    // drizzle mutates these during driver setup.
+    expect(sql.options.parsers).toEqual({});
+  });
+
+  it("exposes the breaker for health reporting", () => {
+    const { sql, breaker } = wrap([]);
+    expect(sql.circuitBreaker).toBe(breaker);
+  });
+});
+
+describe("withConnectionCircuitBreaker against the real driver", () => {
+  it("classifies a genuinely unreachable server and stops dialling it", async () => {
+    // Port 1 on loopback is closed, so the driver fails at connect time — the
+    // same class of failure as a database that has gone away.
+    const client = postgres("postgres://nobody:nobody@127.0.0.1:1/nothing", {
+      max: 1,
+      connect_timeout: 1,
+      onnotice: () => {},
+    });
+    const breaker = new ConnectionCircuitBreaker({ failureThreshold: 2, resetTimeoutMs: 60_000 });
+    const sql = withConnectionCircuitBreaker(client, breaker);
+
+    try {
+      await expect(sql`select 1`).rejects.toThrow();
+      await expect(sql`select 1`).rejects.toThrow();
+      expect(breaker.state).toBe("open");
+
+      const started = Date.now();
+      await expect(sql`select 1`).rejects.toBeInstanceOf(DatabaseUnavailableError);
+      // Fail-fast means "no connect attempt", which is what bounds the
+      // in-flight handler count during an outage.
+      expect(Date.now() - started).toBeLessThan(200);
+    } finally {
+      await client.end({ timeout: 1 });
+    }
+  }, 20_000);
+});

--- a/packages/db/src/circuit-breaker-sql.ts
+++ b/packages/db/src/circuit-breaker-sql.ts
@@ -1,0 +1,156 @@
+/**
+ * Wraps a postgres.js client so every query passes through a
+ * {@link ConnectionCircuitBreaker}.
+ *
+ * The wrapper is deliberately thin. It guards the three ways a query enters
+ * the driver — the tagged template, `unsafe()`, and `begin()` — and observes
+ * how each one settles so the breaker learns whether the database is
+ * reachable. Everything else (`end`, `listen`, `notify`, the `sql(value)`
+ * fragment helpers, `options`) is passed through untouched, including while
+ * the breaker is open: shutting a pool down must not depend on the database
+ * being up.
+ *
+ * postgres.js queries are lazy — the driver only dials out when the query is
+ * awaited — so the wrapper preserves that laziness. It never subscribes on the
+ * caller's behalf; it only decorates the caller's own `then`/`catch`/`finally`.
+ */
+
+import type postgres from "postgres";
+import { ConnectionCircuitBreaker, DatabaseUnavailableError } from "./connection-circuit-breaker.js";
+
+type Sql = ReturnType<typeof postgres>;
+
+/** Query methods that configure the pending query and return it unchanged. */
+const SELF_RETURNING_QUERY_METHODS = new Set([
+  "cursor",
+  "describe",
+  "execute",
+  "forEach",
+  "raw",
+  "simple",
+  "values",
+]);
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+/**
+ * A stand-in for a pending query that rejects immediately. Returned instead of
+ * throwing synchronously so that callers who never expected `sql.unsafe(...)`
+ * to throw — drizzle among them — keep seeing a rejected thenable.
+ */
+function rejectedQuery(error: DatabaseUnavailableError): unknown {
+  const rejection = Promise.reject(error);
+  // Nobody is guaranteed to await the stub (a caller may build a query and
+  // drop it), so pre-handle the rejection to keep it off the unhandled path.
+  // The chained promise below is what callers actually subscribe to.
+  rejection.catch(() => {});
+
+  const stub: Record<string, unknown> = {
+    then: (...args: unknown[]) => (rejection.then as (...a: unknown[]) => unknown)(...args),
+    catch: (...args: unknown[]) => (rejection.catch as (...a: unknown[]) => unknown)(...args),
+    finally: (...args: unknown[]) => (rejection.finally as (...a: unknown[]) => unknown)(...args),
+    cancel: () => undefined,
+  };
+  for (const method of SELF_RETURNING_QUERY_METHODS) {
+    stub[method] = () => stub;
+  }
+  return stub;
+}
+
+/**
+ * Wraps a pending query so the breaker sees how it settles, without forcing it
+ * to run. `values()`/`raw()`/... return the query itself, so those come back as
+ * the wrapper to keep the chain observed.
+ */
+function observePendingQuery(query: object, breaker: ConnectionCircuitBreaker): unknown {
+  let settled: Promise<unknown> | undefined;
+  const settle = (): Promise<unknown> => {
+    settled ??= (query as PromiseLike<unknown>).then(
+      (value) => {
+        breaker.recordSuccess();
+        return value;
+      },
+      (error: unknown) => {
+        breaker.recordFailure(error);
+        throw error;
+      },
+    ) as Promise<unknown>;
+    return settled;
+  };
+
+  const wrapper: ProxyHandler<object> = {
+    get(target, property, receiver) {
+      if (property === "then" || property === "catch" || property === "finally") {
+        return (...args: unknown[]) => {
+          const promise = settle() as unknown as Record<string, (...a: unknown[]) => unknown>;
+          return promise[property as string](...args);
+        };
+      }
+
+      const value = Reflect.get(target, property, target);
+      if (typeof value === "function" && SELF_RETURNING_QUERY_METHODS.has(property as string)) {
+        return (...args: unknown[]) => {
+          const result = (value as (...a: unknown[]) => unknown).apply(target, args);
+          return result === target ? receiver : result;
+        };
+      }
+      return value;
+    },
+  };
+
+  return new Proxy(query, wrapper);
+}
+
+function guard<T>(
+  breaker: ConnectionCircuitBreaker,
+  run: () => T,
+): T | unknown {
+  try {
+    breaker.assertAvailable();
+  } catch (error) {
+    if (error instanceof DatabaseUnavailableError) return rejectedQuery(error);
+    throw error;
+  }
+
+  const result = run();
+  return isThenable(result) ? observePendingQuery(result as object, breaker) : result;
+}
+
+/**
+ * Returns `sql` wrapped in a breaker, or `sql` itself when no breaker is
+ * configured.
+ */
+export function withConnectionCircuitBreaker(sql: Sql, breaker: ConnectionCircuitBreaker | null): Sql {
+  if (breaker === null) return sql;
+
+  return new Proxy(sql, {
+    apply(target, thisArg, args: unknown[]) {
+      // Only a tagged-template call is a query. `sql(identifier)` and
+      // `sql(rows)` build fragments that must keep flowing through untouched,
+      // breaker open or not.
+      const isTaggedTemplate = Array.isArray((args[0] as { raw?: unknown } | undefined)?.raw);
+      if (!isTaggedTemplate) return Reflect.apply(target as never, thisArg, args);
+      return guard(breaker, () => Reflect.apply(target as never, target, args));
+    },
+
+    get(target, property) {
+      if (property === "unsafe" || property === "file" || property === "begin") {
+        const method = Reflect.get(target, property, target) as
+          | ((...args: unknown[]) => unknown)
+          | undefined;
+        if (typeof method !== "function") return method;
+        return (...args: unknown[]) => guard(breaker, () => method.apply(target, args));
+      }
+      // `circuitBreaker` is not part of the postgres.js surface; it is exposed
+      // so callers (health endpoints, tests) can read the breaker's state.
+      if (property === "circuitBreaker") return breaker;
+      return Reflect.get(target, property, target);
+    },
+  }) as Sql;
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -5,6 +5,12 @@ import { readFile, readdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 import * as schema from "./schema/index.js";
+import { withConnectionCircuitBreaker } from "./circuit-breaker-sql.js";
+import {
+  ConnectionCircuitBreaker,
+  DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT_MS,
+} from "./connection-circuit-breaker.js";
 
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
@@ -60,6 +66,19 @@ export interface DatabaseClientOptions {
   idleTimeoutSeconds?: number;
   /** postgres.js `connect_timeout` in seconds (driver default: 30). */
   connectTimeoutSeconds?: number;
+  /**
+   * Fail fast while the database is unreachable instead of parking every
+   * query until `connect_timeout` elapses. Omit to disable (the default),
+   * which keeps behavior identical to a bare `postgres(url)`.
+   */
+  circuitBreaker?: CircuitBreakerSettings;
+}
+
+export interface CircuitBreakerSettings {
+  /** Consecutive connection failures that trip the breaker open. */
+  failureThreshold: number;
+  /** How long the breaker stays open before admitting one probe query. */
+  resetTimeoutMs: number;
 }
 
 function envBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
@@ -96,7 +115,33 @@ export function databaseClientOptionsFromEnv(env: NodeJS.ProcessEnv = process.en
   if (idleTimeoutSeconds !== undefined) options.idleTimeoutSeconds = idleTimeoutSeconds;
   const connectTimeoutSeconds = envPositiveInteger(env, "DATABASE_CONNECT_TIMEOUT_SECONDS");
   if (connectTimeoutSeconds !== undefined) options.connectTimeoutSeconds = connectTimeoutSeconds;
+  const circuitBreaker = circuitBreakerSettingsFromEnv(env);
+  if (circuitBreaker !== undefined) options.circuitBreaker = circuitBreaker;
   return options;
+}
+
+/**
+ * The breaker is off unless `DATABASE_CIRCUIT_BREAKER` is true. Setting either
+ * tuning variable also turns it on, so an operator who reaches for a threshold
+ * does not have to remember the enable flag as well.
+ */
+function circuitBreakerSettingsFromEnv(env: NodeJS.ProcessEnv): CircuitBreakerSettings | undefined {
+  const enabled = envBoolean(env, "DATABASE_CIRCUIT_BREAKER");
+  const failureThreshold = envPositiveInteger(env, "DATABASE_CIRCUIT_BREAKER_FAILURE_THRESHOLD");
+  const resetTimeoutSeconds = envPositiveInteger(env, "DATABASE_CIRCUIT_BREAKER_RESET_TIMEOUT_SECONDS");
+
+  if (enabled === false) return undefined;
+  if (enabled === undefined && failureThreshold === undefined && resetTimeoutSeconds === undefined) {
+    return undefined;
+  }
+
+  return {
+    failureThreshold: failureThreshold ?? DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+    resetTimeoutMs:
+      resetTimeoutSeconds === undefined
+        ? DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT_MS
+        : resetTimeoutSeconds * 1000,
+  };
 }
 
 export function postgresJsOptions(options: DatabaseClientOptions): Record<string, unknown> {
@@ -110,7 +155,8 @@ export function postgresJsOptions(options: DatabaseClientOptions): Record<string
 
 export function createDb(url: string, options?: DatabaseClientOptions) {
   const resolved = options ?? databaseClientOptionsFromEnv();
-  const sql = postgres(url, postgresJsOptions(resolved));
+  const breaker = resolved.circuitBreaker ? new ConnectionCircuitBreaker(resolved.circuitBreaker) : null;
+  const sql = withConnectionCircuitBreaker(postgres(url, postgresJsOptions(resolved)), breaker);
   return drizzlePg(sql, { schema });
 }
 

--- a/packages/db/src/connection-circuit-breaker.test.ts
+++ b/packages/db/src/connection-circuit-breaker.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  ConnectionCircuitBreaker,
+  DatabaseUnavailableError,
+  isConnectionFailure,
+} from "./connection-circuit-breaker.js";
+
+function connectionError(code: string): Error {
+  return Object.assign(new Error(`write ${code} db:5432`), { code, errno: code });
+}
+
+/** A breaker on a clock the test controls, so no test waits out a timeout. */
+function breakerAt(clock: { now: number }, failureThreshold = 3, resetTimeoutMs = 5_000) {
+  return new ConnectionCircuitBreaker({ failureThreshold, resetTimeoutMs, now: () => clock.now });
+}
+
+describe("isConnectionFailure", () => {
+  it("recognizes the postgres.js connection codes", () => {
+    for (const code of [
+      "CONNECT_TIMEOUT",
+      "CONNECTION_CLOSED",
+      "CONNECTION_DESTROYED",
+      "CONNECTION_ENDED",
+      "CONNECTION_REFUSED",
+    ]) {
+      expect(isConnectionFailure(connectionError(code))).toBe(true);
+    }
+  });
+
+  it("recognizes the underlying socket codes", () => {
+    expect(isConnectionFailure(connectionError("ECONNREFUSED"))).toBe(true);
+    expect(isConnectionFailure(connectionError("ETIMEDOUT"))).toBe(true);
+    expect(isConnectionFailure(connectionError("ENOTFOUND"))).toBe(true);
+  });
+
+  it("does not treat a server-side error as unreachable", () => {
+    // A unique-violation means the server answered — it is up.
+    expect(isConnectionFailure(connectionError("23505"))).toBe(false);
+    expect(isConnectionFailure(new Error("syntax error at or near \"slect\""))).toBe(false);
+    expect(isConnectionFailure(undefined)).toBe(false);
+    expect(isConnectionFailure(null)).toBe(false);
+    expect(isConnectionFailure("CONNECT_TIMEOUT")).toBe(false);
+  });
+
+  it("unwraps a wrapped connection failure", () => {
+    const wrapped = new Error("query failed", { cause: connectionError("CONNECT_TIMEOUT") });
+    expect(isConnectionFailure(wrapped)).toBe(true);
+  });
+});
+
+describe("ConnectionCircuitBreaker", () => {
+  it("stays closed while the database answers", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock);
+    for (let i = 0; i < 10; i += 1) {
+      expect(() => breaker.assertAvailable()).not.toThrow();
+      breaker.recordSuccess();
+    }
+    expect(breaker.state).toBe("closed");
+  });
+
+  it("stays closed below the failure threshold", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 3);
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    expect(breaker.state).toBe("closed");
+    expect(() => breaker.assertAvailable()).not.toThrow();
+  });
+
+  it("opens on the nth consecutive connection failure and then fails fast", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 3, 5_000);
+    for (let i = 0; i < 3; i += 1) breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+
+    expect(breaker.state).toBe("open");
+    expect(() => breaker.assertAvailable()).toThrow(DatabaseUnavailableError);
+    expect(breaker.snapshot()).toEqual({ state: "open", consecutiveFailures: 3, retryAfterMs: 5_000 });
+
+    // The whole point: rejection is immediate and repeatable, so handlers do
+    // not accumulate waiting on a connection that is not coming.
+    clock.now = 4_999;
+    let thrown: unknown;
+    try {
+      breaker.assertAvailable();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(DatabaseUnavailableError);
+    expect((thrown as DatabaseUnavailableError).retryAfterMs).toBe(1);
+    expect((thrown as DatabaseUnavailableError).code).toBe("DATABASE_CIRCUIT_OPEN");
+  });
+
+  it("resets the failure count when the server answers, even with an error", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 3);
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("23505"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    expect(breaker.state).toBe("closed");
+  });
+
+  it("admits exactly one probe once the reset timeout elapses", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 2, 5_000);
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+
+    clock.now = 5_000;
+    expect(breaker.state).toBe("halfOpen");
+    expect(() => breaker.assertAvailable()).not.toThrow();
+    // Second caller in the same window is still rejected.
+    expect(() => breaker.assertAvailable()).toThrow(DatabaseUnavailableError);
+  });
+
+  it("closes when the probe succeeds", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 2, 5_000);
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+
+    clock.now = 5_000;
+    breaker.assertAvailable();
+    breaker.recordSuccess();
+
+    expect(breaker.state).toBe("closed");
+    expect(() => breaker.assertAvailable()).not.toThrow();
+    expect(breaker.snapshot()).toEqual({ state: "closed", consecutiveFailures: 0, retryAfterMs: 0 });
+  });
+
+  it("restarts the cooldown when the probe fails", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 2, 5_000);
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+
+    clock.now = 5_000;
+    breaker.assertAvailable();
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+
+    expect(breaker.state).toBe("open");
+    expect(breaker.snapshot().retryAfterMs).toBe(5_000);
+    clock.now = 9_999;
+    expect(() => breaker.assertAvailable()).toThrow(DatabaseUnavailableError);
+    clock.now = 10_000;
+    expect(() => breaker.assertAvailable()).not.toThrow();
+  });
+
+  it("releases a probe slot that was claimed but never settled", () => {
+    const clock = { now: 0 };
+    const breaker = breakerAt(clock, 2, 5_000);
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+    breaker.recordFailure(connectionError("CONNECT_TIMEOUT"));
+
+    clock.now = 5_000;
+    breaker.assertAvailable(); // claimed, and the caller never reports back
+
+    clock.now = 9_999;
+    expect(() => breaker.assertAvailable()).toThrow(DatabaseUnavailableError);
+    clock.now = 10_000;
+    expect(() => breaker.assertAvailable()).not.toThrow();
+  });
+
+  it("rejects nonsensical settings instead of silently misbehaving", () => {
+    expect(() => new ConnectionCircuitBreaker({ failureThreshold: 0 })).toThrow(/failureThreshold/);
+    expect(() => new ConnectionCircuitBreaker({ failureThreshold: 1.5 })).toThrow(/failureThreshold/);
+    expect(() => new ConnectionCircuitBreaker({ resetTimeoutMs: -1 })).toThrow(/resetTimeoutMs/);
+  });
+});

--- a/packages/db/src/connection-circuit-breaker.ts
+++ b/packages/db/src/connection-circuit-breaker.ts
@@ -1,0 +1,178 @@
+/**
+ * Fail-fast circuit breaker for the Postgres connection.
+ *
+ * When the database becomes unreachable, postgres.js keeps accepting queries
+ * and parks each one in its pending queue until `connect_timeout` elapses.
+ * Under sustained inbound traffic every request handler stays alive for the
+ * whole timeout window, so handlers (and their request/response graphs)
+ * accumulate faster than they drain. A multi-minute connectivity blip is
+ * therefore enough to exhaust the process memory limit — the failure mode is
+ * an out-of-memory kill, not the connection error the operator expected.
+ *
+ * The breaker converts that pile-up into immediate rejections: after
+ * `failureThreshold` consecutive connection-level failures it opens, and every
+ * subsequent query rejects right away with {@link DatabaseUnavailableError}
+ * instead of waiting on a connection that is not coming. After
+ * `resetTimeoutMs` it admits a single probe query; the probe closes the
+ * breaker on success and re-opens it on failure.
+ *
+ * Only connection-level failures count. A query that fails because of a
+ * constraint violation or a syntax error says nothing about reachability and
+ * leaves the breaker closed — it also resets the consecutive-failure counter,
+ * because a server that answers is a server that is up.
+ */
+
+/** postgres.js driver codes plus the Node socket codes it passes through. */
+const CONNECTION_ERROR_CODES = new Set([
+  "CONNECTION_CLOSED",
+  "CONNECTION_DESTROYED",
+  "CONNECTION_ENDED",
+  "CONNECTION_REFUSED",
+  "CONNECT_TIMEOUT",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+]);
+
+export const DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD = 5;
+export const DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT_MS = 5_000;
+
+export type CircuitBreakerState = "closed" | "open" | "halfOpen";
+
+export interface CircuitBreakerOptions {
+  /** Consecutive connection failures that trip the breaker open. */
+  failureThreshold?: number;
+  /** How long the breaker stays open before admitting one probe query. */
+  resetTimeoutMs?: number;
+  /** Injectable clock, so tests do not have to wait out the reset timeout. */
+  now?: () => number;
+}
+
+export class DatabaseUnavailableError extends Error {
+  readonly code = "DATABASE_CIRCUIT_OPEN";
+  /** Milliseconds until the breaker will admit its next probe query. */
+  readonly retryAfterMs: number;
+
+  constructor(retryAfterMs: number, options?: { cause?: unknown }) {
+    super(
+      `Database is unavailable: the connection circuit breaker is open. Retry in ${retryAfterMs}ms.`,
+      options,
+    );
+    this.name = "DatabaseUnavailableError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * True when `error` says the database could not be reached, as opposed to the
+ * database answering with an error.
+ */
+export function isConnectionFailure(error: unknown): boolean {
+  if (error === null || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string" && CONNECTION_ERROR_CODES.has(code)) return true;
+  const cause = (error as { cause?: unknown }).cause;
+  return cause !== undefined && cause !== error ? isConnectionFailure(cause) : false;
+}
+
+export interface CircuitBreakerSnapshot {
+  state: CircuitBreakerState;
+  consecutiveFailures: number;
+  /** Milliseconds until the next probe is admitted; 0 unless the state is `open`. */
+  retryAfterMs: number;
+}
+
+export class ConnectionCircuitBreaker {
+  readonly #failureThreshold: number;
+  readonly #resetTimeoutMs: number;
+  readonly #now: () => number;
+
+  #consecutiveFailures = 0;
+  #openedAt: number | null = null;
+  #probeStartedAt: number | null = null;
+  #lastFailure: unknown = undefined;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.#failureThreshold = options.failureThreshold ?? DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD;
+    this.#resetTimeoutMs = options.resetTimeoutMs ?? DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT_MS;
+    this.#now = options.now ?? Date.now;
+    if (!Number.isInteger(this.#failureThreshold) || this.#failureThreshold < 1) {
+      throw new Error(`Circuit breaker failureThreshold must be a positive integer, got: ${this.#failureThreshold}`);
+    }
+    if (!Number.isFinite(this.#resetTimeoutMs) || this.#resetTimeoutMs < 0) {
+      throw new Error(`Circuit breaker resetTimeoutMs must be a non-negative number, got: ${this.#resetTimeoutMs}`);
+    }
+  }
+
+  get state(): CircuitBreakerState {
+    if (this.#openedAt === null) return "closed";
+    return this.#retryAfterMs() === 0 ? "halfOpen" : "open";
+  }
+
+  snapshot(): CircuitBreakerSnapshot {
+    return {
+      state: this.state,
+      consecutiveFailures: this.#consecutiveFailures,
+      retryAfterMs: this.#retryAfterMs(),
+    };
+  }
+
+  /**
+   * Throws {@link DatabaseUnavailableError} when the query must not be
+   * attempted. Returns normally when the breaker is closed, and for the single
+   * probe query admitted once the reset timeout has elapsed.
+   */
+  assertAvailable(): void {
+    if (this.#openedAt === null) return;
+
+    const retryAfterMs = this.#retryAfterMs();
+    if (retryAfterMs > 0) throw new DatabaseUnavailableError(retryAfterMs, { cause: this.#lastFailure });
+
+    // Half-open: exactly one probe may run at a time. Everything else keeps
+    // failing fast, otherwise the pile-up the breaker exists to prevent simply
+    // resumes the moment the timeout elapses. The probe slot expires after one
+    // reset window so a query that is created but never awaited cannot wedge
+    // the breaker half-open forever.
+    const now = this.#now();
+    if (this.#probeStartedAt !== null && now - this.#probeStartedAt < this.#resetTimeoutMs) {
+      throw new DatabaseUnavailableError(this.#resetTimeoutMs, { cause: this.#lastFailure });
+    }
+    this.#probeStartedAt = now;
+  }
+
+  recordSuccess(): void {
+    this.#consecutiveFailures = 0;
+    this.#openedAt = null;
+    this.#probeStartedAt = null;
+    this.#lastFailure = undefined;
+  }
+
+  recordFailure(error: unknown): void {
+    if (!isConnectionFailure(error)) {
+      // The server answered, so it is reachable. Treat that as a success for
+      // reachability purposes even though the query itself failed.
+      this.recordSuccess();
+      return;
+    }
+
+    this.#lastFailure = error;
+    this.#consecutiveFailures += 1;
+    this.#probeStartedAt = null;
+    if (this.#consecutiveFailures >= this.#failureThreshold) {
+      // A failed probe restarts the cooldown rather than leaving the breaker
+      // permanently half-open.
+      this.#openedAt = this.#now();
+    }
+  }
+
+  #retryAfterMs(): number {
+    if (this.#openedAt === null) return 0;
+    const elapsed = this.#now() - this.#openedAt;
+    return elapsed >= this.#resetTimeoutMs ? 0 : this.#resetTimeoutMs - elapsed;
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -11,7 +11,20 @@ export {
   migratePostgresIfEmpty,
   type MigrationBootstrapResult,
   type Db,
+  type CircuitBreakerSettings,
+  type DatabaseClientOptions,
 } from "./client.js";
+export {
+  ConnectionCircuitBreaker,
+  DatabaseUnavailableError,
+  isConnectionFailure,
+  DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT_MS,
+  type CircuitBreakerOptions,
+  type CircuitBreakerSnapshot,
+  type CircuitBreakerState,
+} from "./connection-circuit-breaker.js";
+export { withConnectionCircuitBreaker } from "./circuit-breaker-sql.js";
 export {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The control plane keeps one postgres.js pool, created in `packages/db/src/client.ts`
> - When the database becomes unreachable, postgres.js does not refuse work. It parks each query in its pending queue until `connect_timeout` elapses
> - Under normal inbound traffic the parked handlers accumulate faster than they drain, so a short connectivity loss turns into unbounded memory growth
> - On our deployment this ended as an out-of-memory kill of the server process, not as the connection error the operator expected. The database recovered on its own; the server did not
> - This pull request adds an opt-in circuit breaker in front of the driver. It rejects queries immediately while the database is unreachable
> - The benefit is that an outage stays an outage. It does not become a memory-exhaustion crash, and the process is still alive to recover when the database returns

## Linked Issues or Issue Description

No existing issue covers this. A GitHub search for "circuit breaker" returns only breakers on other subsystems — heartbeat loops, recovery, and LLM budget walls (for example #10695, #9968, #4845). None of them touches the database connection, so this does not duplicate them.

The problem, in bug-report form:

**What happened?**
The database became unreachable for about two minutes. During that window every inbound request created a query that postgres.js parked until `connect_timeout`. Request handlers accumulated. The server process reached its memory limit and the kernel killed it. The database recovered before the server did.

**Expected behavior**
While the database is unreachable, queries must fail fast. The server must stay alive with bounded memory, return errors to clients, and resume when the database returns.

**Steps to reproduce**
1. Start the server against a reachable Postgres.
2. Make the database unreachable (drop the packets, or stop the instance). Do not close the port, so connects hang instead of being refused.
3. Send steady request traffic.
4. Watch the resident memory of the server process. It grows for as long as the database is away, because every handler waits out `connect_timeout`.

**Paperclip version or commit**
Reproduced on `master`.

**Deployment mode**
Self-hosted, single node.

**Database mode**
External managed Postgres over the network. This is the mode that can lose the database while the process keeps running.

## What Changed

- Add `packages/db/src/connection-circuit-breaker.ts`: the breaker state machine (`closed` / `open` / `halfOpen`), the `DatabaseUnavailableError` it throws, and `isConnectionFailure()`, which separates "the server did not answer" from "the server answered with an error".
- Add `packages/db/src/circuit-breaker-sql.ts`: a thin wrapper around the postgres.js client. It guards the three query entry points (the tagged template, `unsafe()`, `begin()`) and observes how each query settles. Queries stay lazy. `end()`, `listen()`, the `sql(value)` fragment helpers, and `options` pass through untouched, so a pool can still be shut down while the breaker is open.
- Wire the breaker into `createDb()` in `packages/db/src/client.ts`, behind the new `circuitBreaker` client option.
- Read the option from the environment: `DATABASE_CIRCUIT_BREAKER`, `DATABASE_CIRCUIT_BREAKER_FAILURE_THRESHOLD`, `DATABASE_CIRCUIT_BREAKER_RESET_TIMEOUT_SECONDS`.
- Export the new symbols from `packages/db/src/index.ts`.
- Document the breaker in `doc/DATABASE.md` and `docs/deploy/database.md`.

Behavior of the breaker:

- It counts only connection-level failures. A constraint violation or a syntax error proves the server is reachable, so it resets the counter and leaves the breaker closed.
- It opens after `failureThreshold` consecutive connection failures (default 5).
- While open, every query rejects at once with `DatabaseUnavailableError` (`code: "DATABASE_CIRCUIT_OPEN"`) and carries `retryAfterMs`.
- After `resetTimeoutMs` (default 5s) it admits exactly one probe query. Success closes the breaker. Failure restarts the cooldown.
- A probe slot that is claimed but never settled expires after one reset window, so a query that is built and dropped cannot wedge the breaker.

## Verification

```sh
pnpm --filter @paperclipai/db exec vitest run src/connection-circuit-breaker.test.ts src/circuit-breaker-sql.test.ts src/client-options.test.ts
pnpm --filter @paperclipai/db typecheck
```

30 tests pass. They cover:

- The state machine: threshold, fail-fast while open, single half-open probe, close on probe success, cooldown restart on probe failure, probe-slot expiry, and rejection of invalid settings. A injected clock keeps the tests instant.
- Error classification: the postgres.js codes (`CONNECT_TIMEOUT`, `CONNECTION_CLOSED`, `CONNECTION_DESTROYED`, `CONNECTION_ENDED`, `CONNECTION_REFUSED`), the Node socket codes, wrapped causes, and the negative cases.
- The wrapper: queries stay lazy, `unsafe(...).values()` still works, the breaker opens and then stops dialling, non-query surfaces still work while open, and `null` breaker returns the client itself.
- One test drives the real driver against a closed port. It confirms the driver's own error codes match the classifier, and that the third query rejects in under 200ms with no connect attempt.

## Risks

Low.

- The breaker is off unless the operator turns it on. With it off, `createDb()` returns the unwrapped client, so the default path is byte-for-byte the previous behavior.
- With it on, the wrapper is a `Proxy` over the postgres.js client. It intercepts only the three query entry points and passes everything else through. The `sql(value)` fragment form is detected and left alone, so fragment building is unaffected.
- Callers see a new error type during an outage. They already had to handle connection errors there, and the new error arrives sooner.
- No schema change and no migration.

## Model Used

Claude Opus 5 (`claude-opus-5`) by Anthropic, extended thinking, with tool use and shell execution, running in Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
