### PR TITLE
feat(plugin-sdk): binary-safe http.fetch via opt-in base64 body encoding

### DIFF
--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -1250,8 +1250,25 @@ export interface WorkerToHostMethods {
 
   // HTTP
   "http.fetch": [
-    params: { url: string; init?: Record<string, unknown> },
-    result: { status: number; statusText: string; headers: Record<string, string>; body: string },
+    params: {
+      url: string;
+      init?: Record<string, unknown>;
+      /**
+       * How the worker wants the response body encoded on the wire. "base64"
+       * preserves binary bodies (the JSON-RPC transport cannot carry raw
+       * bytes); hosts that predate this option ignore it and reply with utf8
+       * text and no `bodyEncoding` marker.
+       */
+      responseEncoding?: "utf8" | "base64";
+    },
+    result: {
+      status: number;
+      statusText: string;
+      headers: Record<string, string>;
+      body: string;
+      /** Encoding of `body`. Absent means utf8 text (legacy hosts). */
+      bodyEncoding?: "utf8" | "base64";
+    },
   ];
 
   // Secrets

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -593,10 +593,18 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
           const result = await callHost("http.fetch", {
             url,
             init: Object.keys(serializedInit).length > 0 ? serializedInit : undefined,
+            // Ask for base64 so binary bodies (.docx, images, archives)
+            // survive the JSON-RPC wire; a host that predates the option
+            // ignores it and replies with utf8 text and no bodyEncoding
+            // marker, which decodes below exactly as before.
+            responseEncoding: "base64",
           });
 
           // Reconstruct a Response-like object from the serialized result
-          return new Response(result.body, {
+          const body = result.bodyEncoding === "base64"
+            ? Buffer.from(result.body, "base64")
+            : result.body;
+          return new Response(body, {
             status: result.status,
             statusText: result.statusText,
             headers: result.headers,

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -755,3 +755,108 @@ describe("worker execute.log emitter", () => {
     ]);
   });
 });
+
+describe("worker http.fetch body encoding", () => {
+  // Drive a data handler that fetches through ctx.http and echoes the bytes it
+  // received, with the test standing in for the host end of the RPC pipe.
+  async function runFetchProbe(hostReply: Record<string, unknown>) {
+    const hostToWorker = new PassThrough();
+    const workerToHost = new PassThrough();
+    const hostReadline = createInterface({ input: workerToHost });
+    const pending = new Map<string, (response: JsonRpcResponse) => void>();
+    const fetchRequests: unknown[] = [];
+    let nextRequestId = 1;
+
+    const plugin = definePlugin({
+      async setup(ctx) {
+        ctx.data.register("probe", async () => {
+          const res = await ctx.http.fetch("https://files.example/report.docx");
+          return { bytes: Array.from(new Uint8Array(await res.arrayBuffer())) };
+        });
+      },
+    });
+
+    const worker = startWorkerRpcHost({ plugin, stdin: hostToWorker, stdout: workerToHost });
+
+    function callWorker(method: string, params: unknown) {
+      const id = `host-${nextRequestId++}`;
+      const result = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, (response) => {
+          if ("error" in response && response.error) {
+            reject(new Error(response.error.message));
+            return;
+          }
+          resolve((response as { result?: unknown }).result);
+        });
+      });
+      hostToWorker.write(serializeMessage(createRequest(method, params, id)));
+      return result;
+    }
+
+    hostReadline.on("line", (line) => {
+      const message = parseMessage(line);
+      if (isJsonRpcResponse(message)) {
+        pending.get(String(message.id))?.(message);
+        pending.delete(String(message.id));
+        return;
+      }
+      if (!isJsonRpcRequest(message)) return;
+      if (message.method === "http.fetch") {
+        fetchRequests.push(message.params);
+        hostToWorker.write(serializeMessage(createSuccessResponse(message.id, hostReply)));
+      }
+    });
+
+    try {
+      await callWorker("initialize", {
+        manifest: {
+          id: "paperclip.fetch-encoding-test",
+          apiVersion: 1,
+          version: "1.0.0",
+          displayName: "Fetch encoding test",
+          description: "Fetch encoding test",
+          author: "Paperclip",
+          categories: ["automation"],
+          capabilities: ["http.outbound"],
+          entrypoints: { worker: "dist/worker.js" },
+        },
+        config: {},
+        instanceInfo: { instanceId: "test", hostVersion: "0.0.0" },
+        apiVersion: 1,
+      });
+      const result = await callWorker("getData", { key: "probe", companyId: "company-a", params: {} });
+      return { fetchRequests, result: result as { bytes: number[] } };
+    } finally {
+      worker.stop();
+      hostReadline.close();
+      hostToWorker.destroy();
+      workerToHost.destroy();
+    }
+  }
+
+  it("requests base64 and decodes a marked body back to the original bytes", async () => {
+    // ZIP magic plus bytes that are NOT valid utf8 — the exact shape a .docx
+    // body has, and exactly what a utf8 round-trip destroys (U+FFFD).
+    const bytes = [0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0x9c, 0x01];
+    const { fetchRequests, result } = await runFetchProbe({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+      body: Buffer.from(bytes).toString("base64"),
+      bodyEncoding: "base64",
+    });
+    expect(fetchRequests).toHaveLength(1);
+    expect(fetchRequests[0]).toMatchObject({ responseEncoding: "base64" });
+    expect(result.bytes).toEqual(bytes);
+  });
+
+  it("still treats an unmarked body as utf8 text (host predates the option)", async () => {
+    const { result } = await runFetchProbe({
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/plain" },
+      body: "plain text body",
+    });
+    expect(Buffer.from(Uint8Array.from(result.bytes)).toString("utf8")).toBe("plain text body");
+  });
+});

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -269,7 +269,14 @@ async function executePinnedHttpRequest(
   target: ValidatedFetchTarget,
   init: RequestInit | undefined,
   signal: AbortSignal,
-): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: string }> {
+  responseEncoding: "utf8" | "base64",
+): Promise<{
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  bodyEncoding?: "base64";
+}> {
   const { options, body } = buildPinnedRequestOptions(target, init);
 
   const response = await new Promise<IncomingMessage>((resolve, reject) => {
@@ -311,11 +318,16 @@ async function executePinnedHttpRequest(
     }
   }
 
+  // utf8 is the legacy default and is LOSSY for binary bodies (invalid byte
+  // sequences become U+FFFD). Workers that need fidelity ask for base64; the
+  // marker in the result tells them the request was honored.
+  const raw = Buffer.concat(chunks);
   return {
     status: response.statusCode ?? 500,
     statusText: response.statusMessage ?? "",
     headers,
-    body: Buffer.concat(chunks).toString("utf8"),
+    body: raw.toString(responseEncoding),
+    ...(responseEncoding === "base64" ? { bodyEncoding: "base64" as const } : {}),
   };
 }
 
@@ -1574,7 +1586,8 @@ export function buildHostServices(
 
         try {
           const init = params.init as RequestInit | undefined;
-          return await executePinnedHttpRequest(target, init, controller.signal);
+          const responseEncoding = params.responseEncoding === "base64" ? "base64" : "utf8";
+          return await executePinnedHttpRequest(target, init, controller.signal, responseEncoding);
         } finally {
           clearTimeout(timeout);
         }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins extend it, and they reach the network through the sandboxed `ctx.http.fetch`, which crosses a JSON-RPC pipe between the worker and the host
> - The host serializes every response body with `toString("utf8")`, which is lossy for binary content: invalid byte sequences collapse to U+FFFD
> - Any plugin that fetches a binary artifact (a `.docx` report, an image, an archive) receives destroyed bytes, with no workaround inside the sandbox
> - This pull request lets the worker ask for a base64-encoded body on the wire and decodes it back to raw bytes before the `Response` is built
> - The benefit is that `response.arrayBuffer()` returns the original octets, so plugins can process binary files, with no change to the plugin-facing API and full compatibility in both upgrade directions

## Linked Issues or Issue Description

No existing issue found (searched: fetch binary, base64, docx). In-PR description:

**Describe the bug**
A plugin worker calls `await ctx.http.fetch(url)` for a binary file and reads it with `response.arrayBuffer()`. The bytes do not match the origin bytes.

**Expected behavior**
`response.arrayBuffer()` returns the exact bytes the remote server sent.

**Actual behavior**
The host serializes the body as utf8 text for the JSON-RPC transport. Bytes that are not valid utf8 are replaced with U+FFFD. ZIP-based formats such as `.docx` become unreadable.

**Environment**
Reproduced on the current `main` and on release 2026.722.0. The coercion is in `server/src/services/plugin-host-services.ts` (`executePinnedHttpRequest`, `Buffer.concat(chunks).toString("utf8")`).

## What Changed

- `packages/plugins/sdk/src/protocol.ts` — `http.fetch` params accept `responseEncoding?: "utf8" | "base64"`; the result carries an optional `bodyEncoding` marker.
- `packages/plugins/sdk/src/worker-rpc-host.ts` — the worker always requests `responseEncoding: "base64"` and decodes the body with `Buffer.from(body, "base64")` when the result is marked. An unmarked result is treated as utf8 text, exactly as before.
- `server/src/services/plugin-host-services.ts` — `executePinnedHttpRequest` encodes the body as requested and sets the `bodyEncoding` marker only for base64.
- `packages/plugins/sdk/tests/worker-rpc-host.test.ts` — two new round-trip tests: a base64-marked binary body decodes to the original bytes (including bytes that are not valid utf8), and an unmarked body still reads as text.

Compatibility: a new SDK against an old host gets utf8 text with no marker and behaves as before. An old SDK against a new host never sends the option, so the host replies utf8. The SDK is vendored into each plugin bundle, so the two sides of each request always agree.

## Verification

- `packages/plugins/sdk`: `vitest run tests/worker-rpc-host.test.ts` — 15/15 pass (13 existing + 2 new).
- `pnpm --filter @paperclipai/plugin-sdk typecheck` — clean.
- `pnpm --filter @paperclipai/server typecheck` — clean.
- Manual: a SharePoint connector plugin on a private fork fetches `.docx` files through `ctx.http.fetch`; with this change the ZIP central directory parses and text extraction succeeds. Without it, the same bytes fail with a ZIP signature mismatch.

## Risks

- Low. The default wire format is unchanged; base64 is opt-in per request and marked in the result.
- Base64 inflates the wire size of large binary bodies by ~33%. The existing 200 MB response cap still applies to the raw bytes.
- No migrations, no schema changes, no plugin-facing API changes.

## Model Used

Claude (Anthropic) — claude-fable-5, extended thinking, agentic tool use via Claude Code CLI. Human-reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge