### PR TITLE
refactor(ci): split workspaces-a into two Vitest native shards

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -174,8 +174,20 @@ jobs:
             group_label: server (5/5)
             shard_index: 4
             shard_count: 5
+          # workspaces-a was the slowest check in the fully-green PR run
+          # 31371439296 (2026-08-10) at 319s, with the ui project's single
+          # vitest invocation accounting for ~224s and the paperclipai CLI
+          # ~37s. Two shards use Vitest's native --shard on each project's
+          # file list (ui: 439 files, cli: 54), bringing each job to roughly
+          # half the suite time (~130s + setup) without a duration manifest.
           - group: general-workspaces-a
-            group_label: workspaces-a
+            group_label: workspaces-a (1/2)
+            shard_index: 0
+            shard_count: 2
+          - group: general-workspaces-a
+            group_label: workspaces-a (2/2)
+            shard_index: 1
+            shard_count: 2
           - group: general-workspaces-b
             group_label: workspaces-b
 

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -64,8 +64,16 @@ jobs:
             group_label: server (3/3)
             shard_index: 2
             shard_count: 3
+          # Keep parity with pr.yml: workspaces-a is split with Vitest's
+          # native --shard because the ui project dominates the lane.
           - group: general-workspaces-a
-            group_label: workspaces-a
+            group_label: workspaces-a (1/2)
+            shard_index: 0
+            shard_count: 2
+          - group: general-workspaces-a
+            group_label: workspaces-a (2/2)
+            shard_index: 1
+            shard_count: 2
           - group: general-workspaces-b
             group_label: workspaces-b
 

--- a/scripts/__tests__/release-verify-workflow.test.mjs
+++ b/scripts/__tests__/release-verify-workflow.test.mjs
@@ -47,6 +47,15 @@ test("release verify workflow covers the same split test surface as stable PR ve
     assert.match(verifyWorkflow, new RegExp(`shard_index: ${shardIndex}[\\s\\S]*?shard_count: 5`));
   }
 
+  // workspaces-a splits with Vitest native --shard in pr.yml; release
+  // verification must keep the same two-shard coverage.
+  for (const shardIndex of [0, 1]) {
+    assert.match(
+      verifyWorkflow,
+      new RegExp(`group: general-workspaces-a[\\s\\S]*?shard_index: ${shardIndex}\\n\\s+shard_count: 2`),
+    );
+  }
+
   assert.match(verifyWorkflow, /pnpm test:run:general -- --group/);
   assert.match(verifyWorkflow, /pnpm test:run:serialized -- --shard-index/);
 });

--- a/scripts/__tests__/run-vitest-stable-shard.test.mjs
+++ b/scripts/__tests__/run-vitest-stable-shard.test.mjs
@@ -77,9 +77,37 @@ test("a route/authz suite never leaks into the general-server shards", () => {
   }
 });
 
-test("shard flags are rejected for the parallel workspace groups", () => {
-  const result = dryRun(["--mode", "general", "--group", "general-workspaces-a", "--shard-index", "0", "--shard-count", "3"]);
-  assert.notEqual(result.status, 0, "workspace groups must not accept shard flags");
+test("shard flags are rejected for the workspaces-b group", () => {
+  const result = dryRun(["--mode", "general", "--group", "general-workspaces-b", "--shard-index", "0", "--shard-count", "3"]);
+  assert.notEqual(result.status, 0, "workspaces-b must not accept shard flags");
+});
+
+test("workspaces-a shards map to Vitest native --shard slices over a stable project list", () => {
+  const shards = [0, 1].map((index) =>
+    dryRunJson([
+      "--mode", "general", "--group", "general-workspaces-a",
+      "--shard-index", String(index), "--shard-count", "2",
+    ]),
+  );
+
+  assert.deepEqual(
+    shards.map((shard) => shard.workspacesVitestShard),
+    ["1/2", "2/2"],
+    "each matrix job must pass its own --shard slice to vitest",
+  );
+  // Vitest's --shard partitions each project's file list deterministically, so
+  // an identical project list across jobs is what guarantees complete,
+  // non-overlapping coverage of the lane.
+  assert.deepEqual(shards[0].workspaceProjects, shards[1].workspaceProjects);
+  assert.ok(shards[0].workspaceProjects.length > 0, "workspaces-a must run at least one project");
+
+  const unsharded = dryRunJson(["--mode", "general", "--group", "general-workspaces-a"]);
+  assert.deepEqual(
+    unsharded.workspaceProjects,
+    shards[0].workspaceProjects,
+    "sharding must not change which projects the lane covers",
+  );
+  assert.equal(unsharded.workspacesVitestShard, null);
 });
 
 test("duration-aware partition balances skewed weights better than round-robin", () => {

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -208,10 +208,11 @@ function parseCliOptions(argv) {
 
   const shardAllowed =
     mode === serializedModeName ||
-    (mode === generalModeName && group === generalServerGroupName);
+    (mode === generalModeName &&
+      (group === generalServerGroupName || group === generalWorkspacesAGroupName));
   if (!shardAllowed && shardIndex !== null) {
     fail(
-      "--shard-index/--shard-count are only valid with --mode serialized or --mode general --group general-server.",
+      "--shard-index/--shard-count are only valid with --mode serialized, --mode general --group general-server, or --mode general --group general-workspaces-a.",
     );
   }
 
@@ -287,9 +288,16 @@ function runGeneralSuites(routeTests) {
   }
 }
 
-function runProjectGroup(projects, groupName) {
+function runProjectGroup(projects, groupName, shardIndex = null, shardCount = null) {
+  // With shard args, lean on Vitest's native --shard: each matrix job runs the
+  // same per-project invocations but only its slice of each project's test
+  // files. Vitest's sharding is deterministic for an identical file list, so
+  // the matrix jobs form a complete, non-overlapping cover of every project.
+  const shardArgs =
+    shardCount !== null && shardCount > 1 ? [`--shard=${shardIndex + 1}/${shardCount}`] : [];
+  const shardSuffix = shardArgs.length > 0 ? ` shard ${shardIndex + 1}/${shardCount}` : "";
   for (const project of projects) {
-    runVitest(["--project", project], `${groupName} project ${project}`);
+    runVitest(["--project", project, ...shardArgs], `${groupName} project ${project}${shardSuffix}`);
   }
 }
 
@@ -335,7 +343,11 @@ function runGeneralGroup(routeTests, groupName, shardIndex = null, shardCount = 
   }
 
   if (groupName === generalWorkspacesAGroupName) {
-    runProjectGroup(generalWorkspacesAProjects, groupName);
+    // The ui project dominates this lane (~224s of a 319s job in actions run
+    // 31371439296, 2026-08-10, where workspaces-a was the slowest PR check).
+    // Its 439 test files shard cleanly with Vitest's native --shard, so the
+    // lane splits across runners without a duration manifest.
+    runProjectGroup(generalWorkspacesAProjects, groupName, shardIndex, shardCount);
     return;
   }
 
@@ -415,6 +427,18 @@ if (options.dryRun) {
                 options.shardCount,
                 generalServerShardDurations,
               )
+            : null,
+        workspaceProjects:
+          options.group === generalWorkspacesAGroupName
+            ? generalWorkspacesAProjects
+            : options.group === generalWorkspacesBGroupName
+              ? generalWorkspacesBProjects
+              : null,
+        workspacesVitestShard:
+          options.group === generalWorkspacesAGroupName &&
+          options.shardCount !== null &&
+          options.shardCount > 1
+            ? `${options.shardIndex + 1}/${options.shardCount}`
             : null,
       },
       null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - CI health depends on fast PR feedback; the PR verification workflow runs test lanes as a matrix
> - In a recent fully-green PR run (actions run 31371439296), the `workspaces-a` lane was the slowest check at 319s; the ui project's single vitest invocation took ~224s of that
> - One long serial lane sets the floor for total PR wall-clock time
> - This pull request splits `workspaces-a` into two matrix jobs with Vitest's native `--shard`
> - The benefit is that the slowest lane drops to roughly half its test time, which shortens every PR's critical path

## Linked Issues or Issue Description

**What existing behavior does this improve?**

PR CI verification speed. The `workspaces-a` test lane runs all ui and CLI vitest suites in one serial job and is the slowest required check.

**Subsystem affected**

CI workflows (`.github/workflows/pr.yml`, `.github/workflows/release-verify.yml`) and the stable vitest runner script.

**Current behavior**

`workspaces-a` runs as a single matrix job. In a recent green PR run it took 319s and was the longest check.

**Proposed behavior**

`workspaces-a` runs as two matrix jobs. Each job passes `--shard=N/2` to Vitest for each project in the lane. Vitest partitions each project's file list deterministically, so the two jobs cover every test exactly once.

**Reason and benefit**

Shorter critical path for every PR. No duration manifest is needed because Vitest sharding is native and deterministic.

**Breaking changes**

None. The same tests run; they are only distributed across two jobs.

## What Changed

- `.github/workflows/pr.yml`: replace the single `workspaces-a` matrix entry with two sharded entries (`workspaces-a (1/2)` and `workspaces-a (2/2)`).
- `.github/workflows/release-verify.yml`: mirror the same two-shard split for release verification parity.
- `scripts/run-vitest-stable.mjs`: accept `--shard-index`/`--shard-count` for `general-workspaces-a` and pass Vitest's native `--shard=N/M` to each project invocation; expose the shard slice and project list in `--dry-run` output.
- `scripts/__tests__/run-vitest-stable-shard.test.mjs`: add a test that the two shards map to `--shard=1/2` and `--shard=2/2` over an identical project list, and that sharding does not change lane coverage; keep the rejection test for `workspaces-b`.
- `scripts/__tests__/release-verify-workflow.test.mjs`: assert release verification keeps the two-shard `workspaces-a` coverage.

## Verification

- Run `node --test scripts/__tests__/run-vitest-stable-shard.test.mjs scripts/__tests__/release-verify-workflow.test.mjs`. All 13 tests pass.
- CI on this PR runs the new sharded lanes directly; both `workspaces-a` shards must pass with the full suite covered.

## Risks

- Low risk. Vitest's `--shard` is deterministic for an identical file list, so the two jobs form a complete, non-overlapping partition. If a shard selected zero files Vitest would fail loudly, not silently skip; both projects in the lane have far more files than the shard count (439 and 54).
- Two jobs add one more runner slot per PR run; this trades a small amount of runner capacity for a shorter critical path.

## Model Used

- Claude (Anthropic), Claude Code CLI agent, model ID `claude-fable-5`, with extended thinking and tool use (file edits, shell, GitHub CLI).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge