### PR TITLE
fix(adapter-utils): skip usrmerge symlink mounts

### DIFF
--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -94,6 +94,14 @@ describe("local process sandbox", () => {
     expect(target.args).toContain(workspace);
     expect(target.args).toContain(managedHome);
     expect(target.args.slice(-3)).toEqual([process.execPath, "-e", "console.log('ok')"]);
+    const readOnlyBinds = target.args.flatMap((argument, index) =>
+      argument === "--ro-bind" ? [[target.args[index + 1], target.args[index + 2]]] : []
+    );
+    for (const systemPath of ["/bin", "/sbin", "/lib", "/lib64"]) {
+      const stats = await fs.lstat(systemPath).catch(() => null);
+      if (!stats?.isSymbolicLink()) continue;
+      expect(readOnlyBinds).not.toContainEqual([systemPath, systemPath]);
+    }
   });
 
   it("binds a confined absolute alias to the synchronized workspace", async () => {

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -402,7 +402,11 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
       mounted.add(normalized);
       created.add(normalized);
     };
-    for (const systemPath of SYSTEM_READ_PATHS) await mount(systemPath, "ro");
+    for (const systemPath of SYSTEM_READ_PATHS) {
+      const stats = await fs.lstat(systemPath).catch(() => null);
+      if (stats?.isSymbolicLink()) continue;
+      await mount(systemPath, "ro");
+    }
     for (const executablePath of await executableReadPaths(input.executable)) await mount(executablePath, "ro");
     if (networkScope === "allowlist") {
       for (const nodePath of await executableReadPaths(process.execPath)) await mount(nodePath, "ro");


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and runs local adapters.
> - The adapter-utils package builds Bubblewrap commands for confined process execution.
> - Fresh-root mounts create standard compatibility links such as `/bin` and `/lib`.
> - On usrmerge hosts, these source paths can also be symbolic links.
> - Bubblewrap cannot use the same path as both a created symlink destination and a read-only bind mount.
> - This pull request skips only symbolic-link system read paths.
> - The result keeps required real system paths mounted without conflicting usrmerge mounts.

## Linked Issues or Issue Description

**What happened?**

On a usrmerge host, a fresh-root Bubblewrap command can include a read-only bind for a system path that is already created as a symlink in the sandbox. This creates a mount conflict.

**Expected behavior**

The fresh-root command does not bind a system read path when that path is a symbolic link. It continues to bind real system paths.

**Steps to reproduce**

1. Use the workspace filesystem scope on a host where `/bin`, `/sbin`, `/lib`, or `/lib64` is a symbolic link.
2. Build a local-process sandbox target.
3. Inspect the Bubblewrap arguments.

**Paperclip version or commit**

Current `master` at PR creation.

**Deployment mode**

Other — local adapter sandbox construction.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

## What Changed

- Skip symbolic-link entries in the fixed system read-path list before creating Bubblewrap read-only mounts.
- Add a regression assertion for usrmerge compatibility links.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/local-process-sandbox.test.ts`
- `pnpm --filter @paperclipai/adapter-utils typecheck`

## Risks

Low risk. The change skips only host paths that are symbolic links. Required target directories remain available through the sandbox compatibility links and mounted real paths.

## Model Used

OpenAI Codex, `gpt-5.6-terra`, with tool use and local code execution. Context window size was not provided.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge