### PR TITLE
fix(codex): reconcile managed skills

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -107,6 +107,7 @@ import {
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const executeCodexAcp = createCodexAcpExecutor();
+const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
 const CODEX_ROLLOUT_NOISE_RE =
   /^\d{4}-\d{2}-\d{2}T[^\s]+\s+ERROR\s+codex_core::rollout::list:\s+state db missing rollout path for thread\s+[a-z0-9-]+$/i;
 
@@ -242,6 +243,65 @@ async function pruneBrokenUnavailablePaperclipSkillSymlinks(
 
 function resolveCodexSkillsDir(codexHome: string): string {
   return path.join(codexHome, "skills");
+}
+
+async function readManagedCodexSkillsManifest(skillsHome: string): Promise<Set<string>> {
+  try {
+    const raw = JSON.parse(
+      await fs.readFile(path.join(skillsHome, PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST), "utf8"),
+    ) as unknown;
+    const parsed = parseObject(raw);
+    return new Set(
+      Array.isArray(parsed.managedSkillNames)
+        ? parsed.managedSkillNames.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+        : [],
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+async function writeManagedCodexSkillsManifest(skillsHome: string, skillNames: Iterable<string>): Promise<void> {
+  await fs.writeFile(
+    path.join(skillsHome, PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST),
+    `${JSON.stringify({ version: 1, managedSkillNames: Array.from(new Set(skillNames)).sort() }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function isPaperclipManagedCodexSkillTarget(input: {
+  target: string;
+  source: string | undefined;
+  runtimeName: string;
+}): Promise<boolean> {
+  const existing = await fs.lstat(input.target).catch(() => null);
+  if (!existing?.isSymbolicLink()) return false;
+  const linkedPath = await fs.readlink(input.target).catch(() => null);
+  if (!linkedPath) return false;
+  const resolvedLinkedPath = path.resolve(path.dirname(input.target), linkedPath);
+  if (input.source && resolvedLinkedPath === path.resolve(input.source)) return true;
+  return isLikelyPaperclipRuntimeSkillPath(resolvedLinkedPath, input.runtimeName, {
+    requireSkillMarkdown: false,
+  });
+}
+
+async function reconcileManagedCodexSkills(input: {
+  skillsHome: string;
+  allSkillsEntries: Array<{ runtimeName: string; source: string }>;
+  desiredRuntimeNames: Set<string>;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  const managed = await readManagedCodexSkillsManifest(input.skillsHome);
+  const availableByRuntimeName = new Map(input.allSkillsEntries.map((entry) => [entry.runtimeName, entry]));
+
+  for (const name of managed) {
+    if (input.desiredRuntimeNames.has(name)) continue;
+    const target = path.join(input.skillsHome, name);
+    const source = availableByRuntimeName.get(name)?.source;
+    if (!(await isPaperclipManagedCodexSkillTarget({ target, source, runtimeName: name }))) continue;
+    await fs.rm(target, { recursive: true, force: true });
+    await input.onLog("stdout", `[paperclip] Revoked Codex skill "${name}" from ${input.skillsHome}\n`);
+  }
 }
 
 type EnsureCodexSkillsInjectedOptions = {
@@ -482,10 +542,14 @@ export async function ensureCodexSkillsInjected(
     options.desiredSkillNames ?? allSkillsEntries.map((entry) => entry.key);
   const desiredSet = new Set(desiredSkillNames);
   const skillsEntries = allSkillsEntries.filter((entry) => desiredSet.has(entry.key));
-  if (skillsEntries.length === 0) return;
-
   const skillsHome = options.skillsHome ?? resolveCodexSkillsDir(resolveSharedCodexHomeDir());
   await fs.mkdir(skillsHome, { recursive: true });
+  await reconcileManagedCodexSkills({
+    skillsHome,
+    allSkillsEntries,
+    desiredRuntimeNames: new Set(skillsEntries.map((entry) => entry.runtimeName)),
+    onLog,
+  });
   const linkSkill = options.linkSkill;
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.runtimeName);
@@ -530,6 +594,22 @@ export async function ensureCodexSkillsInjected(
       );
     }
   }
+
+  const managedSkillNames = await Promise.all(
+    skillsEntries.map(async (entry) =>
+      (await isPaperclipManagedCodexSkillTarget({
+        target: path.join(skillsHome, entry.runtimeName),
+        source: entry.source,
+        runtimeName: entry.runtimeName,
+      }))
+        ? entry.runtimeName
+        : null,
+    ),
+  );
+  await writeManagedCodexSkillsManifest(
+    skillsHome,
+    managedSkillNames.filter((name): name is string => name !== null),
+  );
 
   await pruneBrokenUnavailablePaperclipSkillSymlinks(
     skillsHome,

--- a/server/src/__tests__/codex-local-skill-injection.test.ts
+++ b/server/src/__tests__/codex-local-skill-injection.test.ts
@@ -121,6 +121,50 @@ describe("codex local adapter skill injection", () => {
     );
   });
 
+  it("revokes only Paperclip-managed skills that are no longer desired", async () => {
+    const currentRepo = await makeTempDir("paperclip-codex-current-");
+    const skillsHome = await makeTempDir("paperclip-codex-home-");
+    cleanupDirs.add(currentRepo);
+    cleanupDirs.add(skillsHome);
+
+    await createPaperclipRepoSkill(currentRepo, "keep");
+    await createPaperclipRepoSkill(currentRepo, "remove");
+    await fs.mkdir(path.join(skillsHome, "user-owned"), { recursive: true });
+    await fs.writeFile(path.join(skillsHome, "user-owned", "SKILL.md"), "# user-owned\n", "utf8");
+
+    const skillsEntries = [
+      {
+        key: "paperclipai/paperclip/keep",
+        runtimeName: "keep",
+        source: path.join(currentRepo, "skills", "keep"),
+      },
+      {
+        key: "paperclipai/paperclip/remove",
+        runtimeName: "remove",
+        source: path.join(currentRepo, "skills", "remove"),
+      },
+    ];
+
+    await ensureCodexSkillsInjected(async () => {}, {
+      skillsHome,
+      skillsEntries,
+      desiredSkillNames: skillsEntries.map((entry) => entry.key),
+    });
+    await ensureCodexSkillsInjected(async () => {}, {
+      skillsHome,
+      skillsEntries,
+      desiredSkillNames: [skillsEntries[0]!.key],
+    });
+
+    expect(await fs.realpath(path.join(skillsHome, "keep"))).toBe(
+      await fs.realpath(path.join(currentRepo, "skills", "keep")),
+    );
+    await expect(fs.lstat(path.join(skillsHome, "remove"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await fs.readFile(path.join(skillsHome, "user-owned", "SKILL.md"), "utf8")).toBe("# user-owned\n");
+  });
+
   it("prunes broken symlinks for unavailable Paperclip repo skills before Codex starts", async () => {
     const currentRepo = await makeTempDir("paperclip-codex-current-");
     const oldRepo = await makeTempDir("paperclip-codex-old-");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source control plane for AI agents at work.
> - The Codex local adapter prepares the Codex runtime before each run.
> - The adapter links selected Paperclip skills into the effective `CODEX_HOME`.
> - The adapter did not remove a prior Paperclip-managed skill when the desired skill set became smaller.
> - This pull request adds manifest-based reconciliation for those links.
> - The change keeps user-owned skills outside the managed manifest unchanged.
> - The benefit is that Codex loads only the selected Paperclip skills.

## Linked Issues or Issue Description

**What happened?**

A Codex local run kept a Paperclip-managed skill after that skill was removed from `desiredSkills`.

**Expected behavior**

A later run removes only Paperclip-managed skills that are no longer desired. User-owned skills remain.

**Steps to reproduce**

1. Run Codex local with two desired Paperclip skills.
2. Run it again with one of those skills removed from `desiredSkills`.
3. Observe that the removed Paperclip-managed skill remained before this change.

**Paperclip version or commit**

Current `master` at the time of this pull request.

**Deployment mode**

Built from source.

## What Changed

- Add a Codex local managed-skill manifest.
- Reconcile manifest entries before skill injection.
- Remove only manifest-tracked links that still resolve to Paperclip skills.
- Add a regression test for `[keep, remove]` followed by `[keep]`.
- Verify that a user-owned skill remains unchanged.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/execute.test.ts server/src/__tests__/codex-local-skill-injection.test.ts --reporter=dot`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

Low risk. The manifest records only targets that resolve to Paperclip skills. Reconciliation leaves regular directories and non-Paperclip symlinks unchanged.

## Model Used

OpenAI `gpt-5.6-terra` via `openai-codex`. Used tool calls and local code execution. Context window information was not provided.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and found no duplicate for this behavior
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge