### PR TITLE
fix(recovery): keep returned todo work live

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -523,6 +523,8 @@ Recovery hand-back is covered by the same liveness guarantee:
 
 - an `issue_recovery_action_restored` wake requested while the resolving recovery run is still active is persisted as a follow-up and dispatched only after that run exits, so it cannot be coalesced into the run that requested it
 - if that follow-up is nevertheless lost, the stranded-work backstop treats an assigned `todo` issue with a resolved `handed_back` recovery action from during or after its latest successful run as stranded and queues the bounded assignment recovery wake; the successful resolving run is not, by itself, evidence that the handed-back source work is live
+- the same backstop applies when a successful run explicitly transitions its source issue from an active status back to `todo`; `todo` means ready work, so that durable transition receives one bounded assignment recovery if no wake or run survives
+- if that assignment recovery terminates and the issue remains stranded in `todo`, Paperclip surfaces the failed execution path instead of recursively dispatching assignment recovery
 
 ### 9.2 Stranded assigned `in_progress`
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4364,6 +4364,72 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("re-enqueues todo work when its latest successful run explicitly returned it to ready work", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "succeeded",
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        identifier: "TEST-READY-HANDOFF",
+        status: "todo",
+        _previous: { status: "in_progress" },
+      },
+      createdAt: new Date("2026-03-19T00:04:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.contextSnapshot).toMatchObject({
+      issueId,
+      taskId: issueId,
+      wakeReason: "issue_assignment_recovery",
+      retryReason: "assignment_recovery",
+      source: "issue.assignment_recovery",
+      retryOfRunId: runId,
+    });
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  it("escalates instead of looping when a successful assignment recovery leaves work in todo", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "succeeded",
+      retryReason: "assignment_recovery",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
   it("re-enqueues an already stranded execution-review participant during reconciliation", async () => {
     const { agentId, issueId, runId, wakeupRequestId, stageId } = await seedInReviewParticipantRunFixture();
     const finishedAt = new Date("2026-03-19T00:05:00.000Z");

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -319,7 +319,7 @@ function summarizeRunFailureForIssueComment(run: LatestIssueRun) {
 }
 
 
-function didAutomaticRecoveryFail(
+function isAutomaticRecoveryRun(
   latestRun: LatestIssueRun,
   expectedRetryReason: "assignment_recovery" | "issue_continuation_needed" | typeof EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON,
 ) {
@@ -327,10 +327,17 @@ function didAutomaticRecoveryFail(
 
   const latestContext = parseObject(latestRun.contextSnapshot);
   const latestRetryReason = readNonEmptyString(latestContext.retryReason);
-  return latestRetryReason === expectedRetryReason &&
-    UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
-      latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
-    );
+  return latestRetryReason === expectedRetryReason;
+}
+
+function didAutomaticRecoveryFail(
+  latestRun: LatestIssueRun,
+  expectedRetryReason: "assignment_recovery" | "issue_continuation_needed" | typeof EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON,
+) {
+  if (!latestRun || !isAutomaticRecoveryRun(latestRun, expectedRetryReason)) return false;
+  return UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
+    latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+  );
 }
 
 function isTerminalIssueRun(latestRun: LatestIssueRun) {
@@ -962,27 +969,49 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
-  async function wasTodoHandedBackDuringOrAfterLatestRun(
+  async function wasTodoReturnedToReadyWorkDuringOrAfterLatestRun(
     issue: typeof issues.$inferSelect,
     latestRun: LatestIssueRun,
   ) {
     if (issue.status !== "todo" || latestRun?.status !== "succeeded") return false;
     const runBeganAt = latestRun.startedAt ?? latestRun.createdAt;
 
-    return db
-      .select({ id: issueRecoveryActions.id })
-      .from(issueRecoveryActions)
-      .where(
-        and(
-          eq(issueRecoveryActions.companyId, issue.companyId),
-          eq(issueRecoveryActions.sourceIssueId, issue.id),
-          eq(issueRecoveryActions.status, "resolved"),
-          eq(issueRecoveryActions.outcome, "handed_back"),
-          gte(issueRecoveryActions.resolvedAt, runBeganAt),
-        ),
-      )
-      .limit(1)
-      .then((rows) => Boolean(rows[0]));
+    const [recoveryHandBack, explicitTodoTransition] = await Promise.all([
+      db
+        .select({ id: issueRecoveryActions.id })
+        .from(issueRecoveryActions)
+        .where(
+          and(
+            eq(issueRecoveryActions.companyId, issue.companyId),
+            eq(issueRecoveryActions.sourceIssueId, issue.id),
+            eq(issueRecoveryActions.status, "resolved"),
+            eq(issueRecoveryActions.outcome, "handed_back"),
+            gte(issueRecoveryActions.resolvedAt, runBeganAt),
+          ),
+        )
+        .limit(1)
+        .then((rows) => Boolean(rows[0])),
+      db
+        .select({ id: activityLog.id })
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.companyId, issue.companyId),
+            eq(activityLog.runId, latestRun.id),
+            eq(activityLog.action, "issue.updated"),
+            eq(activityLog.entityType, "issue"),
+            eq(activityLog.entityId, issue.id),
+            sql`${activityLog.details} ->> 'status' = 'todo'`,
+            sql`${activityLog.details} -> '_previous' ->> 'status' IS NOT NULL`,
+            sql`${activityLog.details} -> '_previous' ->> 'status' <> 'todo'`,
+            gte(activityLog.createdAt, runBeganAt),
+          ),
+        )
+        .limit(1)
+        .then((rows) => Boolean(rows[0])),
+    ]);
+
+    return recoveryHandBack || explicitTodoTransition;
   }
 
   async function hasQueuedIssueWake(companyId: string, issueId: string, agentId?: string | null) {
@@ -4057,22 +4086,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
-        if (
-          latestRun.status === "succeeded" &&
-          !(await wasTodoHandedBackDuringOrAfterLatestRun(issue, latestRun))
-        ) {
-          result.skipped += 1;
-          continue;
-        }
-
-        if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
+        // A bounded assignment recovery is the one retry. If it terminates and
+        // the issue is still ready but has no live path, surface the strand
+        // instead of allowing successful no-op retries to loop forever.
+        if (isAutomaticRecoveryRun(latestRun, "assignment_recovery") && isTerminalIssueRun(latestRun)) {
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "todo",
             latestRun,
             notice: {
               body:
-                "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
+                "Paperclip automatically retried dispatch for this assigned `todo` issue, " +
                 "but it still has no live execution path. " +
                 "Moving it to `blocked` so it is visible for intervention.",
               title: "No live execution path",
@@ -4085,6 +4109,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           } else {
             result.skipped += 1;
           }
+          continue;
+        }
+
+        if (
+          latestRun.status === "succeeded" &&
+          !(await wasTodoReturnedToReadyWorkDuringOrAfterLatestRun(issue, latestRun))
+        ) {
+          result.skipped += 1;
           continue;
         }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages assigned work and keeps each active issue on a live execution path.
> - The recovery service repairs assigned `todo` issues when their wake or run disappears.
> - A successful run can explicitly move its source issue from `in_progress` back to `todo` for more work.
> - The reconciler treated that successful run as proof that the issue was complete enough to ignore.
> - The assigned issue then stayed in `todo` with no wake, run, blocker, monitor, or recovery action.
> - This pull request detects the durable status transition and dispatches one bounded assignment recovery.
> - The benefit is that ready work cannot become permanently inert after a successful handoff.

## Linked Issues or Issue Description

Refs #10562 and #4459.

**What happened?**

An agent run changed its assigned issue from `in_progress` to `todo` and then succeeded. The issue had no queued wake or active run. The periodic stranded-work pass skipped it because its latest run succeeded. The issue remained ready but never ran again.

**Expected behavior**

An explicit transition from an active status to `todo` means that work is ready. Paperclip must dispatch one bounded assignment recovery when no live path remains. If that recovery also terminates without a live path, Paperclip must surface the strand instead of creating an infinite retry loop.

**Steps to reproduce**

1. Create an issue that is assigned to an invokable agent.
2. Start a run and move the issue to `in_progress`.
3. In the same run, update the issue to `todo` and let the run succeed.
4. Remove or lose the expected follow-up wake.
5. Run `reconcileStrandedAssignedIssues()`.
6. Observe that the current code skips the issue and queues no run.

**Paperclip version or commit**

Reproduced on `6a4e2e1b8c7129f6f913ae458ab0be9cba50bd6a`.

**Deployment mode**

Self-hosted server with external PostgreSQL. The regression test uses the embedded PostgreSQL test harness.

## What Changed

- Detect an `issue.updated` activity record that moves the source issue from a non-`todo` status to `todo` during its latest successful run.
- Treat that transition like an explicit recovery hand-back when no execution path survives.
- Treat a terminal assignment-recovery run as the one allowed retry, including when the run reports success.
- Add focused tests for lost ready-work dispatch and successful no-op retry exhaustion.
- Document the assigned-`todo` liveness rule.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — 102 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/server build` — passed.

## Risks

Low risk. The new query uses the existing `activity_log.run_id` index and requires an explicit status change to `todo`. A no-op update does not qualify. The existing live-path checks still prevent duplicate dispatch. The automatic retry remains bounded to one attempt.

This change overlaps with #4459 only in retry exhaustion. That pull request states that its change does not affect the `todo` branch. This pull request closes that separate branch gap and adds the missing explicit-ready transition.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, maximum reasoning, with repository, shell, test, Kubernetes, and GitHub tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
