### PR TITLE
fix(routines): assign real responsible users to built-ins

### DIFF
--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -20,6 +20,7 @@ import {
   issues,
   principalPermissionGrants,
   routines,
+  routineRevisions,
   routineTriggers,
 } from "@paperclipai/db";
 import { readPaperclipSkillSyncPreference } from "@paperclipai/adapter-utils/server-utils";
@@ -641,6 +642,7 @@ describeEmbeddedPostgres("built-in agents", () => {
       title: "Review recent agent trajectories for coaching proposals",
       status: "paused",
       assigneeAgentId: state.agentId,
+      responsibleUserId: "responsible-user",
     });
     const [trigger] = await db.select().from(routineTriggers).where(eq(routineTriggers.routineId, routine!.id));
     expect(trigger).toMatchObject({
@@ -653,6 +655,42 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(coachGrantKeys).toEqual(expect.arrayContaining(["agents:suggest-changes", "skills:suggest-changes"]));
     expect(coachGrantKeys).not.toContain("agents:configure");
     expect(coachGrantKeys).not.toContain("skills:create");
+  });
+
+  it("repairs the legacy system actor stored as a built-in routine responsible user", async () => {
+    const companyId = await seedCompany({ requireApproval: false });
+    await agentService(db).create(companyId, {
+      name: "CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: { model: "gpt-5.4" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const builtIns = builtInAgentService(db);
+    await builtIns.ensure(companyId, "reflection-coach");
+
+    const [legacyRoutine] = await db.select().from(routines).where(eq(routines.companyId, companyId));
+    await db
+      .update(routines)
+      .set({ responsibleUserId: "built-in-bundles" })
+      .where(eq(routines.id, legacyRoutine!.id));
+    await db
+      .update(routineRevisions)
+      .set({ responsibleUserId: "built-in-bundles" })
+      .where(eq(routineRevisions.id, legacyRoutine!.latestRevisionId!));
+
+    await builtIns.ensure(companyId, "reflection-coach");
+
+    const [repairedRoutine] = await db.select().from(routines).where(eq(routines.id, legacyRoutine!.id));
+    const [repairedRevision] = await db
+      .select()
+      .from(routineRevisions)
+      .where(eq(routineRevisions.id, repairedRoutine!.latestRevisionId!));
+    expect(repairedRoutine?.responsibleUserId).toBe("responsible-user");
+    expect(repairedRevision?.responsibleUserId).toBe("responsible-user");
+    expect(repairedRevision?.createdByUserId).toBeNull();
   });
 
   it("recreates missing managed resource bindings idempotently during concurrent reconcile", async () => {
@@ -1141,6 +1179,7 @@ describeEmbeddedPostgres("built-in agents", () => {
       assigneeAgentId: state.agentId,
       originKind: "built_in_agent_bundle",
       originId: "reflection-coach:recent-agent-reflection",
+      responsibleUserId: "responsible-user",
     });
     const [trigger] = await db.select().from(routineTriggers).where(eq(routineTriggers.routineId, routine!.id));
     expect(trigger).toMatchObject({
@@ -1217,6 +1256,7 @@ describeEmbeddedPostgres("built-in agents", () => {
       assigneeAgentId: state.agentId,
       originKind: "built_in_agent_bundle",
       originId: "summarizer:refresh-stale-summaries",
+      responsibleUserId: "responsible-user",
     });
     const [trigger] = await db.select().from(routineTriggers).where(eq(routineTriggers.routineId, routine!.id));
     expect(trigger).toMatchObject({

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -143,6 +143,7 @@ export interface RequiredBuiltInAgent {
 }
 
 const BUILT_IN_AGENT_KEY_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const LEGACY_BUILT_IN_BUNDLE_USER_ID = "built-in-bundles";
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -1278,7 +1279,10 @@ export function builtInAgentService(db: Db) {
 
   async function createOrResetRoutine(agent: Agent, definition: BuiltInAgentDefinition, existing: Routine | null, mode: "reconcile" | "reset") {
     const routine = definition.bundle!.routine;
-    const actor = { agentId: null, userId: "built-in-bundles" };
+    // Bundle reconciliation is a system mutation. Leaving userId null makes the
+    // routine service resolve the company's real responsible user instead of
+    // persisting the audit actor label as an on-behalf-of user.
+    const actor = { agentId: null, userId: null };
     const nextRoutine = existing
       ? await routineSvc.update(existing.id, {
         title: routine.title,
@@ -1289,7 +1293,9 @@ export function builtInAgentService(db: Db) {
         concurrencyPolicy: routine.concurrencyPolicy,
         catchUpPolicy: routine.catchUpPolicy,
         variables: routine.variables,
-      }, actor)
+      }, actor, {
+        replaceResponsibleUser: existing.responsibleUserId === LEGACY_BUILT_IN_BUNDLE_USER_ID,
+      })
       : await routineSvc.create(agent.companyId, {
         title: routine.title,
         description: routine.description,
@@ -1373,7 +1379,8 @@ export function builtInAgentService(db: Db) {
     const shouldWrite =
       mode === "reset"
       || currentState.stockStatus === "missing"
-      || currentState.stockStatus === "stock_update_available";
+      || currentState.stockStatus === "stock_update_available"
+      || routine?.responsibleUserId === LEGACY_BUILT_IN_BUNDLE_USER_ID;
     const nextRoutine = shouldWrite
       ? await createOrResetRoutine(agent, definition, routine, mode)
       : routine!;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -2140,7 +2140,12 @@ export function routineService(
       return createdRoutine;
     },
 
-    update: async (id: string, patch: UpdateRoutine, actor: Actor): Promise<Routine | null> => {
+    update: async (
+      id: string,
+      patch: UpdateRoutine,
+      actor: Actor,
+      options: { replaceResponsibleUser?: boolean } = {},
+    ): Promise<Routine | null> => {
       const existing = await getRoutineById(id);
       if (!existing) return null;
       const nextProjectId = patch.projectId === undefined ? existing.projectId : patch.projectId;
@@ -2232,7 +2237,9 @@ export function routineService(
           activityGateScope: patch.activityGateScope ?? locked.activityGateScope,
           variables: nextVariables,
           env: nextEnv,
-          responsibleUserId: locked.responsibleUserId ?? responsibleUserId,
+          responsibleUserId: options.replaceResponsibleUser
+            ? responsibleUserId
+            : locked.responsibleUserId ?? responsibleUserId,
           updatedByAgentId: actor.agentId ?? null,
           updatedByUserId: actor.userId ?? null,
         };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for AI-agent companies.
> - Built-in agents can own scheduled routines that create issues and heartbeat runs.
> - A system audit label was stored as the routine's responsible user.
> - The label does not identify a real user or an active company member.
> - Authorization therefore rejected built-in routine API calls.
> - This pull request assigns the company default user and repairs existing affected routines.
> - The benefit is that built-in routine runs use valid on-behalf-of credentials.

## Linked Issues or Issue Description

**What happened?**

Built-in Summarizer and Reflection Coach routines stored `built-in-bundles` as their responsible user. Runs then received `RESPONSIBLE_USER_UNAVAILABLE` from company-scoped API calls.

**Expected behavior**

Built-in routines must resolve a real company user. Existing stock routines with the legacy value must repair themselves during reconciliation.

**Steps to reproduce**

1. Provision the Summarizer or Reflection Coach built-in agent.
2. Enable and run its managed routine.
3. Observe that the routine revision and run use `built-in-bundles` as the responsible user.
4. Observe HTTP 403 responses from company-scoped API calls.

**Paperclip version or commit**

Reproduced on `6b826602f` plus the current master branch history.

**Deployment mode**

Docker with external PostgreSQL.

## What Changed

- Treat built-in bundle reconciliation as a system mutation with no user actor.
- Add an internal routine update option that replaces a legacy responsible user while creating a synchronized revision.
- Force reconciliation when a managed routine contains the legacy `built-in-bundles` user value.
- Add assertions for valid built-in routine ownership and a regression test for self-repair.
- No user documentation changed because this corrects internal authorization behavior without changing a public contract.

## Verification

- `pnpm exec vitest run --config vitest.config.ts src/__tests__/built-in-agents.test.ts --reporter=dot` in the server package: 35 tests passed.
- `pnpm --filter @paperclipai/server typecheck`: passed.
- `docker compose build paperclip`: passed, including the UI and server production builds.
- Live data repair: both affected routines and their latest revisions now reference an active company owner. No legacy rows remain.
- `pnpm test:run` did not complete in the isolated Node 24 production image. Two unrelated `workspace-runtime.test.ts` auto-port process-adoption tests failed, and the full command later reached the 600-second execution limit. The focused suite is green.

## Risks

- Low risk. The replacement path runs only for the known legacy pseudo-user value.
- The routine service keeps its existing responsible user behavior unless an internal caller explicitly requests replacement.
- Reconciliation appends a routine revision when it repairs an affected routine.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, exact model ID `gpt-5.6-sol`, with reasoning, repository tools, shell execution, and live-system verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
