### PR TITLE
fix(recovery): keep quota retries on cooldown (SAG-1807)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5535,6 +5535,45 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     )).toBe(true);
   });
 
+  it("keeps assigned todo quota exhaustion quiet during recovery cooldown", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+      runErrorCode: "claude_transient_upstream",
+      runError: "You've hit your org's monthly usage limit",
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        finishedAt: new Date("2030-03-19T00:05:00.000Z"),
+        updatedAt: new Date("2030-03-19T00:05:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toEqual([runId]);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",
@@ -6003,6 +6042,120 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
     expect(runs).toHaveLength(2);
     const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
+      issueId,
+      retryReason: "issue_continuation_needed",
+      source: "issue.continuation_recovery",
+    });
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  it("keeps quota-exhausted continuation retries quiet during transient backoff", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "claude_transient_upstream",
+      runError: "You've hit your org's monthly usage limit",
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        finishedAt: new Date("2030-03-19T00:05:00.000Z"),
+        updatedAt: new Date("2030-03-19T00:05:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toEqual([runId]);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("keeps retrying quota-exhausted continuation after cooldown without escalating", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "claude_transient_upstream",
+      runError: "You've hit your org's monthly usage limit",
+    });
+    // Backfill enough consecutive quota failures to prove quota exhaustion does not
+    // use the normal transient cap to create a recovery action.
+    const olderTimestamps = [
+      new Date("2026-03-18T23:45:00.000Z"),
+      new Date("2026-03-18T23:50:00.000Z"),
+      new Date("2026-03-18T23:55:00.000Z"),
+    ];
+    for (const finishedAt of olderTimestamps) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+        },
+        errorCode: "claude_transient_upstream",
+        error: "You've hit your org's monthly usage limit",
+        startedAt: finishedAt,
+        finishedAt,
+        createdAt: finishedAt,
+        updatedAt: finishedAt,
+      });
+    }
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    const retryRun = runs.find((row) => {
+      const ctx = row.contextSnapshot as Record<string, unknown> | null;
+      return row.id !== runId &&
+        row.errorCode === null &&
+        ctx?.retryReason === "issue_continuation_needed" &&
+        ctx?.source === "issue.continuation_recovery";
+    });
     expect(retryRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
       issueId,
       retryReason: "issue_continuation_needed",

--- a/server/src/services/recovery/run-error-guards.ts
+++ b/server/src/services/recovery/run-error-guards.ts
@@ -1,0 +1,19 @@
+type RunWithErrorFields = {
+  errorCode: string | null;
+  error: string | null;
+};
+
+/**
+ * Returns true when the run failed because the org's Claude API quota was
+ * exhausted ("You've hit your org's monthly usage limit").  These failures
+ * are an external billing constraint, not an agent failure, so they must not
+ * trigger "Recover stalled issues" escalation tickets.
+ */
+export function isQuotaLimitExhaustionRun(run: RunWithErrorFields | null): boolean {
+  if (!run) return false;
+  return (
+    run.errorCode === "claude_transient_upstream" &&
+    typeof run.error === "string" &&
+    run.error.toLowerCase().includes("monthly usage limit")
+  );
+}

--- a/server/src/services/recovery/service.test.ts
+++ b/server/src/services/recovery/service.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { isQuotaLimitExhaustionRun } from "./run-error-guards.js";
+
+describe("isQuotaLimitExhaustionRun", () => {
+  const base = {
+    id: "run-1",
+    agentId: "agent-1",
+    status: "failed" as const,
+    error: null,
+    errorCode: null,
+    contextSnapshot: null,
+    livenessState: null,
+  };
+
+  it("returns false for null run", () => {
+    expect(isQuotaLimitExhaustionRun(null)).toBe(false);
+  });
+
+  it("returns true for claude_transient_upstream with monthly usage limit message", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "You've hit your org's monthly usage limit",
+      }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive on the error message", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "You've hit your org's Monthly Usage Limit",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when errorCode is not claude_transient_upstream", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "adapter_failed",
+        error: "monthly usage limit exceeded",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when error message does not contain monthly usage limit", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "Claude API rate limit exceeded, retry after 60s",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when error is null even with matching errorCode", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for genuine transient upstream without quota message", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "overloaded_error: The API is temporarily overloaded",
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -156,6 +156,7 @@ type LatestIssueRun = Pick<
   | "livenessState"
   | "startedAt"
   | "createdAt"
+  | "finishedAt"
 > & {
   resultJson?: unknown;
 } | null;
@@ -367,6 +368,7 @@ const INTERACTION_CONTINUATION_REQUEUE_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const QUOTA_LIMIT_RECOVERY_BASE_BACKOFF_MS = CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
 const PROVIDER_QUOTA_ERROR_RE =
@@ -797,6 +799,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
+        finishedAt: heartbeatRuns.finishedAt,
       })
       .from(heartbeatRuns)
       .where(
@@ -841,10 +844,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
-  async function summarizeRecentContinuationRetries(
+  async function summarizeRecentIssueRetries(
     companyId: string,
     issueId: string,
     agentId: string,
+    retryReasonToMatch: "assignment_recovery" | "issue_continuation_needed",
     errorCodeToMatch: string | null,
     since: Date | null = null,
   ) {
@@ -873,7 +877,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     for (const row of rows) {
       const ctx = parseObject(row.contextSnapshot);
       const retryReason = readNonEmptyString(ctx.retryReason);
-      if (retryReason !== "issue_continuation_needed") break;
+      if (retryReason !== retryReasonToMatch) break;
       if (
         !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
           row.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
@@ -891,6 +895,34 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (latestFinishedAt === null) latestFinishedAt = row.finishedAt ?? null;
     }
     return { consecutive, latestFinishedAt };
+  }
+
+  async function summarizeRecentContinuationRetries(
+    companyId: string,
+    issueId: string,
+    agentId: string,
+    errorCodeToMatch: string | null,
+    since: Date | null = null,
+  ) {
+    return summarizeRecentIssueRetries(
+      companyId,
+      issueId,
+      agentId,
+      "issue_continuation_needed",
+      errorCodeToMatch,
+      since,
+    );
+  }
+
+  function shouldDelayQuotaLimitRetry(input: {
+    latestFinishedAt: Date | null;
+    consecutive: number;
+  }) {
+    if (!input.latestFinishedAt) return false;
+    const elapsed = Date.now() - input.latestFinishedAt.getTime();
+    const requiredDelay = QUOTA_LIMIT_RECOVERY_BASE_BACKOFF_MS *
+      Math.pow(2, Math.max(0, input.consecutive - 1));
+    return elapsed < requiredDelay;
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
@@ -4067,7 +4099,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
-          if (!isQuotaLimitExhaustionRun(latestRun)) {
+          const isQuotaLimitExhaustion = isQuotaLimitExhaustionRun(latestRun);
+          if (!isQuotaLimitExhaustion) {
             const updated = await escalateStrandedAssignedIssue({
               issue,
               previousStatus: "todo",
@@ -4089,8 +4122,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             }
             continue;
           }
-          // Quota exhaustion: do not create a recovery ticket; fall through to re-enqueue
-          // so the issue retries on the next recovery cron cycle once quota is restored.
+
+          const retrySummary = await summarizeRecentIssueRetries(
+            issue.companyId,
+            issue.id,
+            agentId,
+            "assignment_recovery",
+            readNonEmptyString(latestRun.errorCode),
+          );
+          if (shouldDelayQuotaLimitRetry(retrySummary)) {
+            result.skipped += 1;
+            continue;
+          }
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
@@ -4202,7 +4245,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
         continue;
       }
-      if (isUnsuccessfulTerminalIssueRun(latestRun) && !isQuotaLimitExhaustionRun(latestRun)) {
+      if (isUnsuccessfulTerminalIssueRun(latestRun)) {
+        const isQuotaLimitExhaustion = isQuotaLimitExhaustionRun(latestRun);
         const classification = classifyContinuationFailure(latestRun);
 
         if (classification.errorCode === CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE) {
@@ -4214,7 +4258,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           }
         }
 
-        if (classification.kind === "non_retryable") {
+        if (!isQuotaLimitExhaustion && classification.kind === "non_retryable") {
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "in_progress",
@@ -4244,7 +4288,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             agentId,
             classification.errorCode,
           );
-          if (consecutive >= classification.maxAttempts) {
+          if (!isQuotaLimitExhaustion && consecutive >= classification.maxAttempts) {
             const attemptCopy = consecutive <= 1 ? "" : ` (${consecutive}× attempts)`;
             const updated = await escalateStrandedAssignedIssue({
               issue,
@@ -4268,9 +4312,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             continue;
           }
 
-          if (classification.baseBackoffMs > 0 && latestFinishedAt) {
+          const baseBackoffMs = isQuotaLimitExhaustion
+            ? QUOTA_LIMIT_RECOVERY_BASE_BACKOFF_MS
+            : classification.baseBackoffMs;
+          if (baseBackoffMs > 0 && latestFinishedAt) {
             const elapsed = Date.now() - latestFinishedAt.getTime();
-            const requiredDelay = classification.baseBackoffMs *
+            const requiredDelay = baseBackoffMs *
               Math.pow(2, Math.max(0, consecutive - 1));
             if (elapsed < requiredDelay) {
               result.skipped += 1;
@@ -4278,8 +4325,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             }
           }
         }
-        // Quota exhaustion: isQuotaLimitExhaustionRun guard above skips this block entirely;
-        // fall through to re-enqueue so the issue retries once quota is restored.
       }
 
       if (await isInvocationBudgetBlocked(issue, agentId)) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -82,6 +82,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { isQuotaLimitExhaustionRun } from "./run-error-guards.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -4066,26 +4067,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
-          const updated = await escalateStrandedAssignedIssue({
-            issue,
-            previousStatus: "todo",
-            latestRun,
-            notice: {
-              body:
-                "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
-                "but it still has no live execution path. " +
-                "Moving it to `blocked` so it is visible for intervention.",
-              title: "No live execution path",
-              tone: "danger",
-            },
-          });
-          if (updated) {
-            result.escalated += 1;
-            result.issueIds.push(issue.id);
-          } else {
-            result.skipped += 1;
+          if (!isQuotaLimitExhaustionRun(latestRun)) {
+            const updated = await escalateStrandedAssignedIssue({
+              issue,
+              previousStatus: "todo",
+              latestRun,
+              notice: {
+                body:
+                  "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
+                  "but it still has no live execution path. " +
+                  "Moving it to `blocked` so it is visible for intervention.",
+                title: "No live execution path",
+                tone: "danger",
+              },
+            });
+            if (updated) {
+              result.escalated += 1;
+              result.issueIds.push(issue.id);
+            } else {
+              result.skipped += 1;
+            }
+            continue;
           }
-          continue;
+          // Quota exhaustion: do not create a recovery ticket; fall through to re-enqueue
+          // so the issue retries on the next recovery cron cycle once quota is restored.
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
@@ -4197,7 +4202,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
         continue;
       }
-      if (isUnsuccessfulTerminalIssueRun(latestRun)) {
+      if (isUnsuccessfulTerminalIssueRun(latestRun) && !isQuotaLimitExhaustionRun(latestRun)) {
         const classification = classifyContinuationFailure(latestRun);
 
         if (classification.errorCode === CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE) {
@@ -4273,6 +4278,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             }
           }
         }
+        // Quota exhaustion: isQuotaLimitExhaustionRun guard above skips this block entirely;
+        // fall through to re-enqueue so the issue retries once quota is restored.
       }
 
       if (await isInvocationBudgetBlocked(issue, agentId)) {


### PR DESCRIPTION
Rebased reconciliation of #8303 onto current `master` (source head `089fc2cef`).

- preserves `isQuotaLimitExhaustionRun` and the quota cooldown behavior
- resolves the current lifecycle recovery-service overlap without lockfile or generated-artifact churn
- targeted guard unit tests: 7 passed

Ready — awaiting @local-board merge.