### PR TITLE
fix(routines): preserve todo issue when wakeup fails due to agent not invokable

### DIFF
--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -56,7 +56,7 @@ import {
   syncRoutineVariablesWithTemplate,
 } from "@paperclipai/shared";
 import { trackRoutineRun } from "@paperclipai/shared/telemetry";
-import { conflict, forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
+import { HttpError, conflict, forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { getTelemetryClient } from "../telemetry.js";
 import { getConfiguredSecretProvider } from "../secrets/configured-provider.js";
@@ -1875,6 +1875,57 @@ export function routineService(
         }, txDb);
         return updated ?? createdRun;
       } catch (error) {
+        // If the wakeup failed because the assignee agent is not currently invokable
+        // (paused, terminated, pending-approval, or invalid org-chain), preserve the
+        // issue as a visible `todo` so operators can see the pending work and it can
+        // be executed when the agent resumes or is reassigned.  Without this guard
+        // the issue is deleted and the run is marked `failed`, leaving zero board
+        // artifact and no way for the platform to retry without operator intervention.
+        const isAgentNotInvokable =
+          error instanceof HttpError &&
+          error.status === 409 &&
+          error.details != null &&
+          typeof error.details === "object" &&
+          "reason" in error.details &&
+          [
+            "paused",
+            "terminated",
+            "pending_approval",
+            "unknown_status",
+            "manager_terminated",
+            "manager_missing",
+            "reporting_cycle",
+          ].includes((error.details as Record<string, unknown>).reason as string);
+
+        if (createdIssue && isAgentNotInvokable) {
+          // Issue survives as `todo`; link the run to it so the audit trail is intact.
+          // The agent's resume / next heartbeat timer will pick up the open issue.
+          const preserved = await finalizeRun(createdRun.id, {
+            status: "issue_created",
+            linkedIssueId: createdIssue.id,
+          }, txDb);
+          await updateRoutineTouchedState({
+            routineId: input.routine.id,
+            triggerId: input.trigger?.id ?? null,
+            triggeredAt,
+            status: "issue_created",
+            issueId: createdIssue.id,
+            nextRunAt,
+          }, txDb);
+          logger.warn(
+            {
+              error,
+              routineId: input.routine.id,
+              runId: createdRun.id,
+              issueId: createdIssue.id,
+              assigneeAgentId,
+            },
+            "routine dispatch: wakeup failed because assignee agent is not invokable; " +
+              "issue preserved as todo — will be picked up on agent resume",
+          );
+          return preserved ?? createdRun;
+        }
+
         if (createdIssue) {
           await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
         }


### PR DESCRIPTION
## Problem

When a scheduled routine fires and the assignee agent is paused (or terminated / pending-approval / has an invalid org-chain), the issue created by `dispatchRoutineRun` is **silently deleted** and the run is marked `failed`.  The board shows nothing — there is zero artifact that the work was ever scheduled.

### Exact failure path

```
tickScheduledTriggers
  └─ dispatchRoutineRun (source="schedule")
       ├─ assertAssignableAgent  →  passes  (paused is still "assignable")
       ├─ db.transaction opens
       │   ├─ INSERT routineRuns   → run created (status="received")
       │   ├─ issueSvc.create      → issue created (status="todo")
       │   └─ queueIssueAssignmentWakeup(rethrowOnError: true)
       │        └─ enqueueWakeup
       │             └─ getAgentInvokability → agent is paused
       │                throws HttpError(409, "Agent is not invokable", {reason:"paused"})
       └─ catch(error)
            ├─ txDb.delete(issues)       ← ISSUE DELETED
            └─ finalizeRun → status="failed"  ← RUN MARKED FAILED
```

Net result: run = `failed`, issue = **gone**, board = empty.  Only a server-log line records the failure.

Observed during W32 Weekly Performance Review (routine `6a1e1956`): Performance Reviewer was paused, the issue was deleted, and the missed execution sat undetected (reported as HER-2349 in the HERMES system).

### Why `assertAssignableAgent` doesn't catch it

`ASSIGNABLE_AGENT_STATUSES` includes `"paused"` (an operator can still assign future work to a paused agent).  The invokability gate is separate and lives inside `enqueueWakeup` — after the issue has already been created.

### Relationship to #4949 / PR #4995

Issue #4949 tracks the symptom visible in 2026.403.0: the failed run's reason not being surfaced in the UI.  PR #4995 addresses that UI gap.

This PR targets the deeper data-loss: **the issue should not be deleted at all**.  Once the issue exists on the board, the agent's resume / next heartbeat timer picks it up automatically — no operator intervention required and no work is lost.

## Fix

In the `catch` block inside `dispatchRoutineRun`, detect `HttpError(409)` with an agent-invokability reason and preserve the issue as `todo` instead of deleting it.  The run is linked to the issue (`status: "issue_created"`) so the audit trail is intact.  All other errors continue through the existing delete-and-fail path.

The full set of guarded reasons: `paused`, `terminated`, `pending_approval`, `unknown_status`, `manager_terminated`, `manager_missing`, `reporting_cycle`.

## Testing

1. Assign a scheduled routine to an agent and pause the agent.
2. Wait for or manually trigger the routine's next tick.
3. **Before this fix**: board shows nothing; run tab shows `failed`.
4. **After this fix**: board shows the issue as `todo`; run is linked to it; unpausing the agent picks up the issue in the next heartbeat.

## Notes

- No schema changes.
- No change to the happy-path (invokable agent) — only the catch branch is affected.
- The `rethrowOnError: true` on `queueIssueAssignmentWakeup` is preserved so budget errors and other non-invokability failures still propagate correctly.