### PR TITLE
fix(heartbeat): replay child completion after active parent run

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -419,7 +419,10 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     expect(noActiveRuns).toBe(true);
   });
 
-  it("defers issue_blockers_resolved as a follow-up when the same issue is already running", async () => {
+  it.each([
+    "issue_blockers_resolved",
+    "issue_children_completed",
+  ])("defers %s as a follow-up when the same issue is already running", async (wakeReason) => {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const blockerId = randomUUID();
@@ -490,11 +493,11 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       processGroupId: null,
     });
 
-    const idempotencyKey = `issue_blockers_resolved:${blockedIssueId}:${blockerId}`;
+    const idempotencyKey = `${wakeReason}:${blockedIssueId}:${blockerId}`;
     const wake = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",
-      reason: "issue_blockers_resolved",
+      reason: wakeReason,
       payload: {
         issueId: blockedIssueId,
         resolvedBlockerIssueId: blockerId,
@@ -502,7 +505,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       idempotencyKey,
       contextSnapshot: {
         issueId: blockedIssueId,
-        wakeReason: "issue_blockers_resolved",
+        wakeReason,
         resolvedBlockerIssueId: blockerId,
       },
     });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -660,6 +660,7 @@ function mergeAdapterRecoveryMetadata(input: {
 const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
   "approval_approved",
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
+  "issue_children_completed",
   "issue_recovery_action_restored",
 ]);
 const ISSUE_RESPONSIBLE_USER_WAKE_REASONS = new Set([


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their work.
> - The heartbeat service starts and continues issue work.
> - An issue wake can arrive while the same issue already has a running agent.
> - Paperclip can merge a wake into the stored context of that running run.
> - The adapter already received its prompt, so it cannot see the merged context.
> - A final child completion can therefore be lost after Paperclip records it as coalesced.
> - This pull request defers that wake and starts one follow-up run after the active run ends.
> - The benefit is that a parent agent sees the final state of its children without duplicate concurrent work.

## Linked Issues or Issue Description

**What happened?**

A parent issue had an active agent run when its final child changed to `done`. Paperclip marked the `issue_children_completed` wake as `coalesced` into the active run. The running adapter had already received its context. It did not see the child completion. Paperclip did not start a later run after the active run ended. The parent stayed open without a live execution path.

**Expected behavior**

Paperclip must preserve a child completion that arrives after the parent run starts. It must start exactly one follow-up run after the active run ends. The follow-up run must read the latest child state.

**Steps to reproduce**

1. Create a parent issue and assign it to an agent.
2. Start a run for the parent issue.
3. Complete the final direct child while the parent run is still running.
4. Let the parent run end without reading the new child state.
5. Observe that the old behavior records a coalesced wake and creates no follow-up run.

**Paperclip version or commit**

`6a4e2e1b8c7129f6f913ae458ab0be9cba50bd6a`

**Deployment mode**

Self-hosted server with external PostgreSQL. The bug is in the core heartbeat service and is not adapter-specific.

## What Changed

- Added `issue_children_completed` to the set of running-issue events that require a follow-up run.
- Reused the existing durable `deferred_issue_execution` queue and promotion path.
- Extended the dependency scheduling integration test to cover blocker resolution and child completion.

## Verification

- Ran `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts`.
- Result: 7 tests passed.
- Ran `pnpm --filter @paperclipai/server typecheck`.
- Result: passed.
- The full GitHub build, server, workspace, serialized server, end-to-end, policy, and security checks passed on this pull request.

## Risks

Low risk. The change affects one wake reason. It can create one additional sequential run when the final child completes during an active parent run. Existing coalescing still applies when the wake targets a queued run. The database schema does not change.

> I checked `ROADMAP.md`. This bug fix does not duplicate planned core work.

## Model Used

OpenAI Codex with GPT-5.6-sol. The run used max reasoning, tool use, shell execution, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
