### PR TITLE
fix(acpx): keep sessions stable across run scratch paths

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -979,6 +979,90 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(fp(sameEnvNewWake)).toBe(fp(first));
   });
 
+  it("keeps the session fingerprint stable across server-owned run scratch directories", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const baseConfig = { agentCommand: "node ./fake-acp.js", stateDir };
+    const runWithScratch = async (scratchDir: string) =>
+      runExecutor(
+        {
+          ...baseConfig,
+          env: {
+            PAPERCLIP_RUN_SCRATCH_DIR: scratchDir,
+            PAPERCLIP_TASK_SCRATCH_DIR: scratchDir,
+            PAPERCLIP_SCRATCH_DIR: scratchDir,
+            PAPERCLIP_TMPDIR: scratchDir,
+            TMPDIR: scratchDir,
+            TEMP: scratchDir,
+            TMP: scratchDir,
+          },
+        },
+        {
+          context: {
+            taskId: "issue-1",
+            wakeReason: "execution_review_requested",
+            paperclipScratch: {
+              dir: scratchDir,
+              tempKeysApplied: ["TMPDIR", "TEMP", "TMP"],
+            },
+          },
+        },
+      );
+
+    const first = await runWithScratch(path.join(root, "paperclip-run-a"));
+    const second = await runWithScratch(path.join(root, "paperclip-run-b"));
+    const fp = (r: { result: { sessionParams?: unknown } }) =>
+      (r.result.sessionParams as { configFingerprint?: string } | undefined)?.configFingerprint;
+
+    expect(fp(first)).toBeDefined();
+    expect(fp(second)).toBe(fp(first));
+    const secondEnv = (
+      second.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }
+    ).env;
+    expect(secondEnv.PAPERCLIP_RUN_SCRATCH_DIR).toBe(path.join(root, "paperclip-run-b"));
+    expect(secondEnv.TMPDIR).toBe(path.join(root, "paperclip-run-b"));
+  });
+
+  it("still fingerprints a user-configured temp directory", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const baseConfig = { agentCommand: "node ./fake-acp.js", stateDir };
+    const runWithTemp = async (scratchDir: string, tmpDir: string) =>
+      runExecutor(
+        {
+          ...baseConfig,
+          env: {
+            PAPERCLIP_RUN_SCRATCH_DIR: scratchDir,
+            PAPERCLIP_TASK_SCRATCH_DIR: scratchDir,
+            PAPERCLIP_SCRATCH_DIR: scratchDir,
+            PAPERCLIP_TMPDIR: scratchDir,
+            TMPDIR: tmpDir,
+          },
+        },
+        {
+          context: {
+            taskId: "issue-1",
+            wakeReason: "execution_review_requested",
+            paperclipScratch: { dir: scratchDir, tempKeysApplied: [] },
+          },
+        },
+      );
+
+    const first = await runWithTemp(
+      path.join(root, "paperclip-run-a"),
+      path.join(root, "user-tmp-a"),
+    );
+    const second = await runWithTemp(
+      path.join(root, "paperclip-run-b"),
+      path.join(root, "user-tmp-b"),
+    );
+    const fp = (r: { result: { sessionParams?: unknown } }) =>
+      (r.result.sessionParams as { configFingerprint?: string } | undefined)?.configFingerprint;
+
+    expect(fp(first)).toBeDefined();
+    expect(fp(second)).not.toBe(fp(first));
+  });
+
   it("busts the session fingerprint when a stable configured PAPERCLIP_* value rotates", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1524,6 +1524,22 @@ async function buildRuntime(input: {
   await fs.mkdir(stateDir, { recursive: true });
 
   const envConfig = parseObject(config.env);
+  const scratchContext = parseObject(context.paperclipScratch);
+  const runScratchDir = asString(scratchContext.dir, "");
+  const runScratchTempKeys = new Set(
+    Array.isArray(scratchContext.tempKeysApplied)
+      ? scratchContext.tempKeysApplied.filter(
+          (value): value is string => typeof value === "string" && value.trim().length > 0,
+        )
+      : [],
+  );
+  const runScratchEnvKeys = new Set([
+    "PAPERCLIP_RUN_SCRATCH_DIR",
+    "PAPERCLIP_TASK_SCRATCH_DIR",
+    "PAPERCLIP_SCRATCH_DIR",
+    "PAPERCLIP_TMPDIR",
+    ...runScratchTempKeys,
+  ]);
   const env: Record<string, string> = { ...buildPaperclipEnv(agent), PAPERCLIP_RUN_ID: runId };
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim()) ||
@@ -1569,11 +1585,12 @@ async function buildRuntime(input: {
   // Resolved adapter env (plain + server-resolved secret_ref values) that we
   // forward to the spawned agent process. Captured so a stable hash of it can be
   // folded into the session fingerprint below — a change here must invalidate a
-  // warm/resumable session so the next launch picks up the latest env. Only
-  // user/adapter-configured env flows through this loop; per-wake PAPERCLIP_*
-  // runtime vars (PAPERCLIP_RUN_ID, wake/approval ids, ...) were assigned to
-  // `env` above and are never present in shapedEnvConfig, so they inherently
-  // stay out of the hash and don't reset the session every heartbeat.
+  // warm/resumable session so the next launch picks up the latest env. The server
+  // also merges its per-run scratch directory into config.env. Those entries must
+  // still reach the child process, but must not enter this stable-config hash:
+  // every heartbeat gets a newly-created path. `paperclipScratch` identifies the
+  // exact server-owned value and the optional TEMP/TMP/TMPDIR keys it supplied,
+  // so user-configured temp directories remain fingerprinted normally.
   const resolvedAdapterEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(shapedEnvConfig)) {
     if (typeof value !== "string") continue;
@@ -1585,7 +1602,9 @@ async function buildRuntime(input: {
     if (isForbiddenConfigEnvKey(key)) continue;
     if (isPaperclipRuntimeEnvKey(key) && key in env) continue;
     env[key] = value;
-    resolvedAdapterEnv[key] = value;
+    const isRunScratchEnv =
+      runScratchDir.length > 0 && value === runScratchDir && runScratchEnvKeys.has(key);
+    if (!isRunScratchEnv) resolvedAdapterEnv[key] = value;
   }
   if (authToken) env.PAPERCLIP_API_KEY = authToken;
   // For the claude agent, set model via ANTHROPIC_MODEL at startup rather than


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and keeps their work state across heartbeat runs.
> - The ACPX engine uses a configuration fingerprint to decide whether it can resume a saved session.
> - Paperclip also creates a new server-owned scratch directory for each heartbeat.
> - The server forwards that directory through the adapter environment.
> - ACPX incorrectly included those changing paths in the stable configuration fingerprint.
> - This pull request removes only verified server-owned scratch entries from that fingerprint.
> - The child process still receives the current scratch paths.
> - The benefit is reliable session resume without hiding user configuration changes.

## Linked Issues or Issue Description

Fixes: #11180

Refs: #8246

Refs: #9976

## What Changed

- Read the server-owned scratch metadata from the heartbeat context.
- Keep all scratch environment entries in the spawned child environment.
- Exclude an entry from `adapterEnvHash` only when its key is server-owned and its value exactly matches the current run scratch directory.
- Keep user-configured temporary-directory entries in the fingerprint.
- Add regression tests for scratch rotation and user-owned temp changes.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts` — 111 tests passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `pnpm check:tokens` — passed.
- The ACPX runtime comment now documents why verified server-owned scratch entries stay out of the stable configuration hash.
- The repo-wide stable test runner was also attempted. Unrelated macOS path and workspace suites failed before completion. GitHub CI is the source of truth for the full Linux matrix.
- The complete GitHub CI matrix passed, including build, typecheck, canary dry run, all server and workspace shards, all serialized suites, and all E2E shards.

## Risks

- Low risk. The filter requires both a server-declared scratch key and an exact value match with the current run scratch directory.
- Missing or invalid scratch metadata keeps the previous conservative fingerprint behavior.
- User-owned environment changes still invalidate resumable sessions.
- This change has no database or migration impact.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 family. The runtime did not expose a more specific deployment ID. The model used reasoning, repository tools, local code execution, Git, and GitHub CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
