### PR TITLE
fix(heartbeat): honor operator run cancellation

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1880,4 +1880,40 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.error).toBe("Heartbeat run not found");
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
+
+  it("suppresses automatic continuation after a board operator cancels a run", async () => {
+    const run = {
+      id: "run-1",
+      companyId,
+      agentId,
+      status: "running",
+    };
+    mockHeartbeatService.getRun.mockResolvedValue(run);
+    mockHeartbeatService.cancelRun.mockResolvedValue({ ...run, status: "cancelled" });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post("/api/heartbeat-runs/run-1/cancel").send({}),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith(
+      "run-1",
+      "Cancelled by a board operator",
+      expect.objectContaining({
+        suppressImmediateRecovery: true,
+        resultJson: expect.objectContaining({
+          cancelledByActorType: "user",
+          cancelledByUserId: "board-user",
+        }),
+      }),
+    );
+  });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4060,6 +4060,38 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("does not immediately restart an issue after an operator cancellation", async () => {
+    const { companyId, issueId, runId } = await seedRunFixture({
+      agentStatus: "idle",
+      includeIssue: true,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const cancelled = await heartbeat.cancelRun(runId, "Cancelled by a board operator", {
+      suppressImmediateRecovery: true,
+      resultJson: {
+        cancelledByActorType: "user",
+        cancelledByUserId: "board-user",
+      },
+    });
+
+    expect(cancelled?.status).toBe("cancelled");
+
+    const companyRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.companyId, companyId));
+    expect(companyRuns).toHaveLength(1);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.executionRunId).toBeNull();
+  });
+
   it("records operator interrupt cancellation metadata without changing terminal status", async () => {
     const { runId, issueId } = await seedRunFixture({
       agentStatus: "running",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3890,6 +3890,7 @@ export function agentRoutes(
     // Recovery reads this to stand down instead of classifying the cancelled
     // run as agent stranding and re-waking the agent the operator just stopped.
     const run = await heartbeat.cancelRun(runId, "Cancelled by a board operator", {
+      suppressImmediateRecovery: true,
       resultJson: {
         cancelledByActorType: "user",
         cancelledByUserId: req.actor.userId ?? null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18486,6 +18486,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     resultJson?: Record<string, unknown>;
     eventMessage?: string;
     eventPayload?: Record<string, unknown>;
+    suppressImmediateRecovery?: boolean;
   };
 
   async function cancelRunInternal(runId: string, reason = "Cancelled by control plane", options: CancelRunOptions = {}) {
@@ -18544,7 +18545,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         message: options.eventMessage ?? "run cancelled",
         ...(options.eventPayload ? { payload: options.eventPayload } : {}),
       });
-      await releaseIssueExecutionAndPromote(cancelled);
+      await releaseIssueExecutionAndPromote(cancelled, {
+        suppressImmediateRecovery: options.suppressImmediateRecovery === true,
+      });
     }
 
     await finalizeAgentStatus(run.agentId, "cancelled", undefined, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent work and its execution lifecycle
> - Board operators can stop one active heartbeat run
> - The cancel route records that the operator initiated the stop
> - The recovery scanner respects that record and stands down
> - The synchronous lock-release path did not respect it
> - That path started a continuation before the scanner could stand down
> - This pull request suppresses only that immediate continuation
> - The benefit is that a board cancel stops the selected run as requested

## Linked Issues or Issue Description

Refs #10656

**What happened?**

POST /api/heartbeat-runs/{runId}/cancel marked the run as operator-cancelled. The same request then released the issue execution lock and immediately created a continuation run for an assigned in_progress issue. The later recovery scanner correctly ignored the operator-cancelled run, but the replacement run already existed.

**Expected behavior**

A board operator cancellation must terminate the selected run, release its issue lock, and leave recovery stopped. A later explicit wake or issue mutation may resume the work.

**Steps to reproduce**

1. Assign an in_progress issue to an active agent.
2. Start a heartbeat run for the issue.
3. Call the board-only run cancel endpoint.
4. Observe that Paperclip creates and starts an issue_continuation_needed run immediately.

**Paperclip version or commit**

Reproduced on 6a4e2e1b8, which was master at implementation time.

**Deployment mode**

Self-hosted server with external Postgres. The defect is in the core heartbeat service and does not depend on an adapter.

## What Changed

- Add suppressImmediateRecovery to the internal run cancellation options.
- Pass the option to issue execution release and promotion.
- Set the option on the board-only run cancel route.
- Add a service test that proves no replacement run is created.
- Add a route test that proves the board endpoint requests suppression.

## Verification

- pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts -t "suppresses automatic continuation after a board operator cancels a run"
- pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "does not immediately restart an issue after an operator cancellation"
- pnpm --filter @paperclipai/server typecheck
- git diff --check

All checks passed locally.

## Risks

Low risk. The change affects only the board-only per-run cancel route. System cancellation, timeouts, failures, budget handling, agent pause, and normal automatic recovery retain their existing behavior. The issue remains open and can be resumed with an explicit wake.

## Model Used

- OpenAI Codex
- Model: GPT-5.6
- Reasoning mode: high
- Tool use: repository inspection, code changes, test execution, and live reproduction analysis

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked a related public PR and described the issue with the bug report fields
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added tests
- [x] No documentation change is required for this internal lifecycle correction
- [x] I have considered and documented the risk
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all reviewer comments before requesting merge