### PR TITLE
Add GET /api/issues/:id/interactions/:interactionId endpoint

### DIFF
--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -487,6 +487,49 @@ describe.sequential("issue thread interaction routes", () => {
     );
   });
 
+  it("gets a single interaction by id for a board actor", async () => {
+    mockInteractionService.getForIssue.mockResolvedValueOnce({
+      id: "interaction-1",
+      kind: "ask_user_questions",
+      status: "pending",
+      payload: { version: 1, questions: [{ id: "q1", prompt: "What?", selectionMode: "single", options: [{ id: "o1", label: "One" }] }], selectionMode: "single" },
+    });
+    const app = await createApp();
+    const res = await request(app).get("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-1");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: "interaction-1",
+      kind: "ask_user_questions",
+      status: "pending",
+    });
+    expect(res.body.payload.questions).toHaveLength(1);
+    expect(res.body.payload.selectionMode).toBe("single");
+  });
+
+  it("gets a single interaction by id for an agent actor", async () => {
+    mockInteractionService.getForIssue.mockResolvedValueOnce({
+      id: "interaction-1",
+      kind: "request_confirmation",
+      status: "pending",
+      payload: { version: 1, prompt: "Deploy?" },
+      result: null,
+    });
+    const app = await createApp({
+      type: "agent",
+      agentId: ASSIGNEE_AGENT_ID,
+      companyId: "company-1",
+      runId: "run-1",
+    });
+    const res = await request(app).get("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-1");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: "interaction-1",
+      kind: "request_confirmation",
+      status: "pending",
+    });
+    expect(res.body.payload.prompt).toBe("Deploy?");
+  });
+
   it("queues one bounded recovery when historical-comment catch-up expires the final review interactions", async () => {
     mockIssueService.getById.mockResolvedValue(createIssue({
       status: "in_review",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10181,6 +10181,16 @@ export function issueRoutes(
     res.json(interactions);
   });
 
+  router.get("/issues/:id/interactions/:interactionId", async (req, res) => {
+    const id = req.params.id as string;
+    const interactionId = req.params.interactionId as string;
+    const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+    if (!issue) return;
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+    const interaction = await issueThreadInteractionsSvc.getForIssue(issue, interactionId);
+    res.json(interaction);
+  });
+
   router.post("/issues/:id/interactions", validate(createIssueThreadInteractionSchema), async (req, res) => {
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -4424,6 +4424,15 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/api/issues/{id}/interactions/{interactionId}",
+  tags: ["issues"],
+  summary: "Get an issue thread interaction by ID",
+  request: { params: z.object({ id: z.string(), interactionId: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 404: r.notFound },
+});
+
+registry.registerPath({
   method: "post",
   path: "/api/issues/{id}/interactions",
   tags: ["issues"],


### PR DESCRIPTION
## Summary
- Adds `GET /api/issues/{id}/interactions/{interactionId}` — returns a single interaction by ID
- Uses the same auth pattern (`getAccessibleResource` + `assertIssueReadAllowed`) as the existing list endpoint, which already allows agent tokens for `issue:read`
- Agent tokens can now read structured ask payloads (questions, options, selectionMode, results) without a browser

## Why
Drain agents enumerating the Decisions queue could list interactions but had no way to read individual interaction payloads — they could see a card had an `ask_user_questions` interaction but not *what* it was asking. This forced them to either guess from titles (banned by rule 4) or escalate every card as unreadable.

## What changed
- New route handler in `server/src/routes/issues.ts` (3 lines of business logic + auth)
- OpenAPI spec registration in `server/src/routes/openapi.ts`
- Two tests: board actor and agent actor both get 200 with full payload

Refs SPA-2955

🤖 Generated with [Claude Code](https://claude.com/claude-code)