### PR TITLE
feat(issues): opt-in evidence predicate on terminal stage approval

### DIFF
--- a/packages/db/src/migrations/0212_issue_execution_decision_evidence.sql
+++ b/packages/db/src/migrations/0212_issue_execution_decision_evidence.sql
@@ -1,0 +1,11 @@
+-- Persist the structured delivery evidence a terminal approval can carry.
+--
+-- The execution-policy service can now require {pr, mergedSha, checkRun?} when an
+-- issue's policy sets `evidenceRequired`. Validating that claim and then dropping
+-- it would leave downstream auditors with nothing to confront against the
+-- repository — the whole point of asking for data instead of prose is that it
+-- survives on the decision record.
+--
+-- Nullable by design: every decision made without evidence (the default path,
+-- and all historical rows) stays untouched. No backfill, no rewrite.
+ALTER TABLE "issue_execution_decisions" ADD COLUMN IF NOT EXISTS "evidence" jsonb;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1471,6 +1471,13 @@
       "when": 1786129601533,
       "tag": "0211_bright_morg",
       "breakpoints": true
+    },
+    {
+      "idx": 212,
+      "version": "7",
+      "when": 1786129601534,
+      "tag": "0212_issue_execution_decision_evidence",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue_execution_decisions.ts
+++ b/packages/db/src/schema/issue_execution_decisions.ts
@@ -1,4 +1,4 @@
-import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { issues } from "./issues.js";
 import { agents } from "./agents.js";
@@ -16,6 +16,12 @@ export const issueExecutionDecisions = pgTable(
     actorUserId: text("actor_user_id"),
     outcome: text("outcome").notNull(),
     body: text("body").notNull(),
+    // Structured delivery evidence carried by a terminal approval when the issue's
+    // policy sets `evidenceRequired` — {pr, mergedSha, checkRun?, note?}. Null for
+    // every decision made without it. This is what downstream auditors confront
+    // with the repository; without persistence the predicate validates a claim
+    // and then loses it.
+    evidence: jsonb("evidence"),
     createdByRunId: uuid("created_by_run_id").references(() => heartbeatRuns.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -679,6 +679,12 @@ export interface IssueExecutionPolicy {
    * default. Human decisions reset the round counter.
    */
   maxReviewRounds?: number | null;
+  /**
+   * When true, the transition that closes the final stage must carry structured
+   * delivery evidence ({ pr, mergedSha, checkRun? }) instead of prose asserting
+   * it. Opt-in; absent or false keeps the existing behavior unchanged.
+   */
+  evidenceRequired?: boolean;
 }
 
 export interface IssueExecutionMonitorState {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -567,6 +567,8 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
   onBehalfOfUserId: z.string().trim().min(1).optional().nullable(),
   reviewInteractionId: z.string().uuid().optional(),
   reviewRequest: issueReviewRequestSchema.optional().nullable(),
+  /** Delivery evidence for a terminal approval — required when the policy sets `evidenceRequired`. */
+  evidence: issueExecutionEvidenceSchema.optional().nullable(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),
@@ -689,6 +691,12 @@ export type IssueCommentMetadata = z.infer<typeof issueCommentMetadataSchema>;
 export const addIssueCommentSchema = z.object({
   body: multilineTextSchema.pipe(z.string().min(1)),
   onBehalfOfUserId: z.string().trim().min(1).optional().nullable(),
+  /**
+   * Delivery evidence for the auto-approval path: a reviewer's approving comment can
+   * close the final stage, so it must be able to carry the same structured proof as
+   * a direct status update. Ignored when the policy does not require it.
+   */
+  evidence: issueExecutionEvidenceSchema.optional().nullable(),
   authorType: issueCommentAuthorTypeSchema.optional(),
   presentation: issueCommentPresentationSchema.nullable().optional(),
   metadata: issueCommentMetadataSchema.nullable().optional(),

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -246,9 +246,29 @@ export const issueExecutionMonitorPolicySchema = z.object({
   recoveryPolicy: z.enum(ISSUE_EXECUTION_MONITOR_RECOVERY_POLICIES).optional().nullable().default(null),
 });
 
+/**
+ * Evidence a terminal approval must carry when `evidenceRequired` is enabled.
+ *
+ * Deliberately narrow: a pull request number, the SHA that actually landed, and the
+ * identifier of the check run that validated it. These are the three facts a reviewer
+ * already looks up by hand today — asking for them as data rather than prose is what
+ * makes them auditable.
+ */
+export const issueExecutionEvidenceSchema = z.object({
+  pr: z.union([z.number().int().positive(), z.string().trim().min(1)]),
+  mergedSha: z.string().trim().regex(/^[0-9a-f]{7,40}$/i, "mergedSha must be a git SHA"),
+  checkRun: z.union([z.number().int().positive(), z.string().trim().min(1)]).optional().nullable(),
+  note: z.string().trim().max(500).optional().nullable(),
+});
+
 export const issueExecutionPolicySchema = z.object({
   mode: z.enum(ISSUE_EXECUTION_POLICY_MODES).optional().default("normal"),
   commentRequired: z.boolean().optional().default(true),
+  /**
+   * Opt-in. When true, closing the final stage requires structured evidence instead of
+   * a free-text comment. Defaults to false so existing policies are untouched.
+   */
+  evidenceRequired: z.boolean().optional().default(false),
   stages: z.array(issueExecutionStageSchema).default([]),
   monitor: issueExecutionMonitorPolicySchema.optional().nullable(),
   reviewPreset: lowTrustReviewPresetPolicySchema.optional(),

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -2175,4 +2175,60 @@ describe("evidenceRequired on the terminal transition", () => {
     const result = closeTerminalStage(terminalApprovalPolicy(true), { pr: "34", mergedSha: "c6d3a6f" });
     expect(result.decision?.outcome).toBe("approved");
   });
+
+  // The review on the first version of this change found two real defects: evidence
+  // could not flow through the production API, and accepted evidence was discarded
+  // before persistence. These tests pin the fixes.
+
+  it("carries validated evidence on the decision, normalized — persistence has something to store", () => {
+    const result = closeTerminalStage(terminalApprovalPolicy(true), EVIDENCE_OK);
+    expect(result.decision?.evidence).toEqual({
+      pr: "34",
+      mergedSha: EVIDENCE_OK.mergedSha,
+      checkRun: "31359056766",
+      note: null,
+    });
+  });
+
+  it("keeps well-formed evidence even when the policy does not require it — worth persisting, never worth failing over", () => {
+    const result = closeTerminalStage(terminalApprovalPolicy(false), EVIDENCE_OK);
+    expect(result.decision?.outcome).toBe("approved");
+    expect(result.decision?.evidence?.mergedSha).toBe(EVIDENCE_OK.mergedSha);
+  });
+
+  it("malformed optional evidence never blocks an approval on a policy that does not require it", () => {
+    const result = closeTerminalStage(terminalApprovalPolicy(false), { mergedSha: "not-a-sha" });
+    expect(result.decision?.outcome).toBe("approved");
+    expect(result.decision?.evidence).toBeNull();
+  });
+});
+
+describe("evidence flows through the request contracts", () => {
+  it("updateIssueSchema accepts evidence — the production issue-update path can carry it", async () => {
+    const { updateIssueSchema } = await import("@paperclipai/shared");
+    const parsed = updateIssueSchema.safeParse({
+      status: "done",
+      comment: "Approved",
+      evidence: { pr: 34, mergedSha: "c6d3a6fa2e" },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("addIssueCommentSchema accepts evidence — the auto-approval comment path can carry it", async () => {
+    const { addIssueCommentSchema } = await import("@paperclipai/shared");
+    const parsed = addIssueCommentSchema.safeParse({
+      body: "kind: review\ndecision: approved",
+      evidence: { pr: "34", mergedSha: "c6d3a6fa2e" },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("the schema rejects a malformed SHA at the API boundary, before the service", async () => {
+    const { updateIssueSchema } = await import("@paperclipai/shared");
+    const parsed = updateIssueSchema.safeParse({
+      status: "done",
+      evidence: { pr: 34, mergedSha: "will be published" },
+    });
+    expect(parsed.success).toBe(false);
+  });
 });

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -2085,3 +2085,94 @@ describe("review round circuit breaker", () => {
     });
   });
 });
+
+// ── evidenceRequired: proof at the terminal transition ────────────────────────
+//
+// Motivation, from a real deployment: an issue reached `done` while its pull request was
+// still open, on an approval that read "the workflow will publish the served version" —
+// future tense. Six such closures happened on one instance in a single day, each with a
+// green review. Nothing in the platform refused them, because a status is a declaration
+// and no predicate confronts it with the repository.
+//
+// The flag is opt-in and defaults to false: every test above this line exercises the
+// unchanged path, and none of them pass `evidence`.
+
+const EVIDENCE_OK = { pr: 34, mergedSha: "c6d3a6fa2e1b4f7890abcdef1234567890abcdef", checkRun: 31359056766 };
+
+function terminalApprovalPolicy(evidenceRequired: boolean) {
+  const base = normalizeIssueExecutionPolicy({
+    stages: [{ type: "approval", participants: [{ type: "user", userId: ctoUserId }] }],
+  })!;
+  return { ...base, evidenceRequired } as IssueExecutionPolicy;
+}
+
+function closeTerminalStage(policy: IssueExecutionPolicy, evidence?: unknown) {
+  return applyIssueExecutionPolicyTransition({
+    issue: {
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: ctoUserId,
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0]!.id!,
+        currentStageIndex: 0,
+        currentStageType: "approval",
+        currentParticipant: { type: "user", userId: ctoUserId, agentId: null },
+        returnAssignee: { type: "agent", agentId: coderAgentId, userId: null },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        reviewRequest: null,
+        monitor: null,
+      } as unknown as IssueExecutionState,
+    },
+    policy,
+    requestedStatus: "done",
+    requestedAssigneePatch: {},
+    actor: { userId: ctoUserId },
+    commentBody: "Approved",
+    ...(evidence !== undefined ? { evidence: evidence as never } : {}),
+  });
+}
+
+describe("evidenceRequired on the terminal transition", () => {
+  it("is off by default: an existing policy closes exactly as before", () => {
+    const result = closeTerminalStage(terminalApprovalPolicy(false));
+    expect(result.decision?.outcome).toBe("approved");
+  });
+
+  it("off by default even when evidence is absent AND the policy omits the field", () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [{ type: "approval", participants: [{ type: "user", userId: ctoUserId }] }],
+    })!;
+    expect(() => closeTerminalStage(policy)).not.toThrow();
+  });
+
+  it("enabled: refuses a closure with no evidence at all", () => {
+    expect(() => closeTerminalStage(terminalApprovalPolicy(true)))
+      .toThrowError(/evidenceRequired/);
+  });
+
+  it("enabled: names what is missing rather than just refusing", () => {
+    expect(() => closeTerminalStage(terminalApprovalPolicy(true), { mergedSha: EVIDENCE_OK.mergedSha }))
+      .toThrowError(/missing pr/);
+    expect(() => closeTerminalStage(terminalApprovalPolicy(true), { pr: 34 }))
+      .toThrowError(/missing mergedSha/);
+  });
+
+  it("enabled: rejects a SHA that is not a SHA — 'will be published' is not a commit", () => {
+    expect(() => closeTerminalStage(terminalApprovalPolicy(true), { pr: 34, mergedSha: "pending" }))
+      .toThrowError(/must be a git SHA/);
+  });
+
+  it("enabled: accepts complete evidence and closes the issue", () => {
+    const result = closeTerminalStage(terminalApprovalPolicy(true), EVIDENCE_OK);
+    expect(result.decision?.outcome).toBe("approved");
+  });
+
+  it("enabled: checkRun is optional — not every project runs checks", () => {
+    const result = closeTerminalStage(terminalApprovalPolicy(true), { pr: "34", mergedSha: "c6d3a6f" });
+    expect(result.decision?.outcome).toBe("approved");
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8716,6 +8716,7 @@ export function issueRoutes(
       },
       allowBoardOverride: req.actor.type === "board",
       commentBody,
+      evidence: req.body.evidence === undefined ? undefined : req.body.evidence,
       reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
       monitorExplicitlyUpdated: req.body.executionPolicy !== undefined && monitorChanged,
     });
@@ -8942,6 +8943,7 @@ export function issueRoutes(
             actorUserId: actor.actorType === "user" ? actor.actorId : null,
             outcome: decision.outcome,
             body: decision.body,
+            evidence: decision.evidence ?? null,
             createdByRunId: actor.runId ?? null,
           });
 
@@ -11196,6 +11198,7 @@ export function issueRoutes(
           userId: actor.actorType === "user" ? actor.actorId : null,
         },
         commentBody: req.body.body,
+        evidence: req.body.evidence === undefined ? undefined : req.body.evidence,
       });
       const decisionId = transition.decision ? randomUUID() : null;
       if (decisionId) {
@@ -11258,6 +11261,7 @@ export function issueRoutes(
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
               outcome: transition.decision.outcome,
               body: transition.decision.body,
+              evidence: transition.decision.evidence ?? null,
               createdByRunId: actor.runId ?? null,
             });
           }

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -57,9 +57,14 @@ type TransitionInput = {
   monitorExplicitlyUpdated?: boolean;
 };
 
+type NormalizedEvidence = { pr: string; mergedSha: string; checkRun: string | null; note: string | null };
+
 type TransitionResult = {
   patch: Record<string, unknown>;
-  decision?: Pick<IssueExecutionDecision, "stageId" | "stageType" | "outcome" | "body">;
+  decision?: Pick<IssueExecutionDecision, "stageId" | "stageType" | "outcome" | "body"> & {
+    /** Structured delivery proof — persisted with the decision, null when not provided. */
+    evidence?: NormalizedEvidence | null;
+  };
   workflowControlledAssignment?: boolean;
 };
 
@@ -495,7 +500,7 @@ function nextPendingStageAfter(
  * Errors say what is missing, never just "rejected": an approver who is refused at 3am must
  * be able to act on the message without reading this file.
  */
-function assertTerminalEvidence(evidence: TransitionInput["evidence"]): void {
+function assertTerminalEvidence(evidence: TransitionInput["evidence"]): NormalizedEvidence {
   if (!evidence || typeof evidence !== "object") {
     throw unprocessable(
       "This issue's policy sets evidenceRequired: closing the final stage needs `evidence` "
@@ -518,6 +523,28 @@ function assertTerminalEvidence(evidence: TransitionInput["evidence"]): void {
       `evidence is missing ${missing.join(" and ")}. A terminal approval must name the pull request `
       + "and the SHA that actually landed.",
     );
+  }
+  const checkRun = (evidence as { checkRun?: unknown }).checkRun;
+  const note = (evidence as { note?: unknown }).note;
+  return {
+    pr: String(pr).trim(),
+    mergedSha: shaText,
+    checkRun: checkRun == null || String(checkRun).trim() === "" ? null : String(checkRun).trim(),
+    note: typeof note === "string" && note.trim() !== "" ? note.trim().slice(0, 500) : null,
+  };
+}
+
+/**
+ * Best-effort normalization for the OPTIONAL path: when the policy does not require
+ * evidence but the caller supplies a well-formed one anyway, it is still worth
+ * persisting — never worth failing over.
+ */
+function normalizeOptionalEvidence(evidence: TransitionInput["evidence"]): NormalizedEvidence | null {
+  if (!evidence || typeof evidence !== "object") return null;
+  try {
+    return assertTerminalEvidence(evidence);
+  } catch {
+    return null;
   }
 }
 
@@ -848,9 +875,9 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
           // served version" is accepted today, and the issue closes on an event that has
           // not happened. Six such closures were observed on a single instance in one day,
           // each with a green review and an open pull request.
-          if (input.policy?.evidenceRequired) {
-            assertTerminalEvidence(input.evidence);
-          }
+          const evidence = input.policy?.evidenceRequired
+            ? assertTerminalEvidence(input.evidence)
+            : normalizeOptionalEvidence(input.evidence);
           patch.executionState = approvedState;
           return {
             patch,
@@ -859,6 +886,7 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
               stageType: activeStage.type,
               outcome: "approved",
               body: input.commentBody.trim(),
+              evidence,
             },
           };
         }

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -51,6 +51,8 @@ type TransitionInput = {
   actor: ActorLike;
   allowBoardOverride?: boolean;
   commentBody?: string | null;
+  /** Structured proof of delivery, required when `policy.evidenceRequired` is set. */
+  evidence?: { pr?: unknown; mergedSha?: unknown; checkRun?: unknown; note?: unknown } | null;
   reviewRequest?: IssueExecutionState["reviewRequest"] | null;
   monitorExplicitlyUpdated?: boolean;
 };
@@ -481,6 +483,44 @@ function nextPendingStageAfter(
   return policy.stages.find((stage, index) => index > completedIndex && !completed.has(stage.id)) ?? null;
 }
 
+/**
+ * Enforces the delivery evidence a terminal approval must carry.
+ *
+ * The server cannot reach GitHub, so it does not attempt to verify that the SHA was really
+ * merged — it enforces that the claim is *typed and complete* rather than narrative. That is
+ * already the difference between a statement an auditor can check and one they cannot: the
+ * fields end up on the decision record, where a downstream checker can confront them with
+ * the repository.
+ *
+ * Errors say what is missing, never just "rejected": an approver who is refused at 3am must
+ * be able to act on the message without reading this file.
+ */
+function assertTerminalEvidence(evidence: TransitionInput["evidence"]): void {
+  if (!evidence || typeof evidence !== "object") {
+    throw unprocessable(
+      "This issue's policy sets evidenceRequired: closing the final stage needs `evidence` "
+      + "with `pr` and `mergedSha` (and optionally `checkRun`).",
+    );
+  }
+  const missing: string[] = [];
+  const pr = (evidence as { pr?: unknown }).pr;
+  if (pr == null || (typeof pr !== "number" && String(pr).trim() === "")) missing.push("pr");
+
+  const sha = (evidence as { mergedSha?: unknown }).mergedSha;
+  const shaText = typeof sha === "string" ? sha.trim() : "";
+  if (!shaText) missing.push("mergedSha");
+  else if (!/^[0-9a-f]{7,40}$/i.test(shaText)) {
+    throw unprocessable(`evidence.mergedSha must be a git SHA (7-40 hex chars), received "${shaText}".`);
+  }
+
+  if (missing.length > 0) {
+    throw unprocessable(
+      `evidence is missing ${missing.join(" and ")}. A terminal approval must name the pull request `
+      + "and the SHA that actually landed.",
+    );
+  }
+}
+
 function selectStageParticipant(
   stage: IssueExecutionStage,
   opts?: {
@@ -797,6 +837,20 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
         const nextStage = nextPendingStageAfter(input.policy, activeStage, approvedState);
 
         if (!nextStage) {
+          // Terminal approval: this is the transition that makes an issue `done`.
+          //
+          // Without `evidenceRequired`, behaviour is unchanged — the comment alone closes
+          // the issue, exactly as before. With it, the approver must hand over facts the
+          // platform can record and an external checker can verify, instead of prose that
+          // asserts them.
+          //
+          // Why this predicate exists: an approval reading "the workflow will publish the
+          // served version" is accepted today, and the issue closes on an event that has
+          // not happened. Six such closures were observed on a single instance in one day,
+          // each with a green review and an open pull request.
+          if (input.policy?.evidenceRequired) {
+            assertTerminalEvidence(input.evidence);
+          }
           patch.executionState = approvedState;
           return {
             patch,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its execution policies (`review`/`approval` stages) are the governance layer: they decide when an issue may reach `done`
> - A stage approval is free-text prose — nothing links the verdict to what actually happened in the repository
> - In practice issues reach `done` with their pull request still open; we observed six such closures in one day on our instance, one approved in the future tense ("the workflow *will* publish the served version")
> - Agents produce plausible prose at scale, so declaration-based status degrades faster with agent workers than with humans
> - This PR adds an opt-in policy flag that makes the final approval carry structured, typed delivery evidence instead of prose
> - The benefit is that a closure claim becomes data on the decision record — auditable downstream against the repository, instead of an assertion nobody can check

## Linked Issues or Issue Description

Fixes: #11145

Related (same closure-integrity family, different angles, no overlap):
- Refs #3525 — prevents parents closing over open children; this PR addresses the sibling gap (closing over an unmerged PR)
- Refs #9418 — reopens `done` blockers pending finalize; complementary, post-hoc repair vs. this PR's pre-condition

- [x] I have searched the GitHub PR list for similar PRs (searches: "evidence", "done open pull request", "enforced outcome", "terminal approval" — no duplicate found; the two closest are linked above)

## What Changed

- `packages/shared/src/validators/issue.ts` — new `issueExecutionEvidenceSchema` (`pr`, `mergedSha`, optional `checkRun`/`note`); new opt-in `evidenceRequired` flag on `issueExecutionPolicySchema` (defaults to `false`); `evidence` accepted by **both** production request contracts: `updateIssueSchema` and `addIssueCommentSchema` (the reviewer auto-approval path can also close a final stage)
- `server/src/services/issue-execution-policy.ts` — terminal-stage approval enforces evidence when the policy requires it; the returned decision **carries the normalized evidence**; well-formed evidence is kept even when not required (worth persisting, never worth failing over); malformed optional evidence never blocks an approval; error messages name what is missing
- `server/src/routes/issues.ts` — both `applyIssueExecutionPolicyTransition` call sites pass `req.body.evidence` through; both `issue_execution_decisions` inserts persist `decision.evidence`
- `packages/db` — nullable `evidence` jsonb column on `issue_execution_decisions` + migration `0196` (no backfill, historical rows untouched)
- `server/src/__tests__/issue-execution-policy.test.ts` — 13 new tests (see Verification)

## Verification

```bash
pnpm --filter @paperclipai/db run check:migrations   # numbering + safety: pass
npx vitest run server/src/__tests__/issue-execution-policy.test.ts
# 67 passed — 54 pre-existing unmodified (compatibility), 13 new
```

New coverage, all shapes taken from the real incident, not invented:
- no evidence at all → refused; `mergedSha: "will be published"` → refused (*must be a git SHA*); PR without SHA / SHA without PR → refused naming the missing field; prose-only comment → refused
- complete evidence → accepted **and present, normalized, on the returned decision** (what persistence stores)
- schema-level: both request contracts accept `evidence`; a malformed SHA is rejected **at the API boundary**, before the service — this negative test also proves the field is actually wired (an unknown key would be silently stripped and the test would fail)
- optional path: well-formed evidence kept, malformed evidence ignored without blocking

Manual review note: in our workshop, repo-wide `tsc` on `server/` reports pre-existing errors about `@paperclipai/plugin-sdk` in files this PR does not touch (unbuilt workspace package); the test suite and the two touched packages typecheck clean.

## Risks

- **Default-off**: `evidenceRequired` defaults to `false`; the 54 pre-existing policy tests pass unmodified, none of them passing `evidence`. Existing policies and API callers are untouched.
- **Migration safety**: single nullable `jsonb` column, `ADD COLUMN IF NOT EXISTS`, no backfill, no rewrite; passes the repo's own `check-migration-safety`.
- **Deliberate limitation**: the server does **not** verify the merge against GitHub — it enforces that the claim is typed and complete, and persists it where a downstream checker can confront it with the repository. A follow-up could add real verification behind a provider hook; this PR does not presume that design.
- Behavioral edge: on a policy *without* the flag, a well-formed `evidence` payload is now persisted with the decision (previously impossible since the field did not exist). This is additive.

## Model Used

Claude Opus 5 (`claude-opus-5`, Anthropic) — extended thinking, tool use (shell, file edits), driven interactively through Claude Code. The failure analysis comes from a live deployment where the six false closures were observed and documented before this change was written.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md — **this PR overlaps the "Enforced Outcomes" milestone** (*"stricter about what counts as finished work… merged code… instead of vague status updates"*). I did not coordinate in `#dev` before writing it, which CONTRIBUTING.md asks for on roadmap-level work — my mistake, stated rather than hidden. Offering this as a tightly scoped, opt-in first step toward that milestone (built from six documented real-world failures); happy to redirect, split, or close in favor of the planned design if the maintainers prefer.
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked existing issues with `Fixes:` / `Refs`
- [x] I have not referenced internal/instance-local Paperclip issues or links

