### PR TITLE
fix(issues): dedupe rephrased siblings that share a leading work-item code

### DIFF
--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -425,4 +425,31 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
     expect(children).toHaveLength(2);
   });
+
+  it("keeps unrelated siblings that merely share a leading product or version token", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+
+    // Review case: a coincidental product token is not a batch code.
+    // None of these pairs may collapse — a false positive here silently drops real work.
+    const pairs = [
+      ["GPT-4 pricing update for the billing page", "GPT-4 rate limit fix for the ingest worker"],
+      ["ISO-8601 parsing in the importer", "ISO-8601 output in the export job"],
+      ["SEC-02 handles the prod keys", "SEC-02 handles the lab keys"],
+    ];
+    for (const [first, second] of pairs) {
+      await request(app)
+        .post(`/api/companies/${companyId}/issues`)
+        .send({ parentId: parent.id, title: first })
+        .expect(201);
+      await request(app)
+        .post(`/api/companies/${companyId}/issues`)
+        .send({ parentId: parent.id, title: second })
+        .expect(201);
+    }
+
+    const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
+    expect(children).toHaveLength(6);
+  });
 });

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
-import { eq } from "drizzle-orm";
+import { eq, isNull } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
@@ -451,5 +451,42 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
 
     const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
     expect(children).toHaveLength(6);
+  });
+
+  it("keeps unrelated root issues that share a leading batch code", async () => {
+    const companyId = await seedCompany();
+    const app = createApp();
+
+    // Root issues share one company-wide bucket, so a shared leading code there is
+    // not evidence of a single batch. Collapsing them would silently drop real work.
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "ROT-01 — rotate the staging keys" })
+      .expect(201);
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "ROT-01 — rotate the vendor webhook secret" })
+      .expect(201);
+
+    const roots = await db.select().from(issues).where(isNull(issues.parentId));
+    expect(roots).toHaveLength(2);
+  });
+
+  it("still collapses rephrased siblings under the same parent", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "ROT-02 — rotate the staging keys" })
+      .expect(201);
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "ROT-02 — rotate keys in staging" })
+      .expect(200); // replayed, not created
+
+    const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
+    expect(children).toHaveLength(1);
   });
 });

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -322,4 +322,107 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     expect(created.originKind).toBe("manual");
     expect(created.originRunId).toBe(runId);
   });
+
+  it("deduplicates a rephrased sibling that carries the same leading work-item code", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+
+    // Taken from a real incident: two runs re-planned the same parent and restated
+    // every title, so exact-title dedup matched none of the five pairs.
+    const firstPass = [
+      "ROT-01 — Rotate every exposed secret (8 tickets absorbed)",
+      "SEC-02 — AWS privileges of the prod app + root keys (4 tickets absorbed) — lab first",
+      "SEC-02b — Purge the excess IAM grants on the agent identities (5 tickets absorbed)",
+      "SEC-03 — Close the 2 controls that fail open (3 tickets absorbed)",
+      "SEC-05 — Forced HTTPS + HSTS + security headers actually shipped (~1h30)",
+    ];
+    const secondPass = [
+      "ROT-01 — Rotate every exposed secret (prod + lab)",
+      "SEC-02 — Remove AdministratorAccess from the prod app + neutralise the root keys",
+      "SEC-02b — Purge the excess IAM grants on the agent identities",
+      "SEC-03 — Close the 2 security controls that fail open",
+      "SEC-05 — Forced HTTPS + HSTS + security headers actually shipped",
+    ];
+
+    const originals: string[] = [];
+    for (const title of firstPass) {
+      const created = await request(app)
+        .post(`/api/companies/${companyId}/issues`)
+        .send({ parentId: parent.id, title })
+        .expect(201);
+      originals.push(created.body.id);
+    }
+    for (const [index, title] of secondPass.entries()) {
+      const replay = await request(app)
+        .post(`/api/companies/${companyId}/issues`)
+        .send({ parentId: parent.id, title })
+        .expect(200);
+      expect(replay.body).toMatchObject({
+        id: originals[index],
+        deduplicated: true,
+        deduplicationReason: "recent_open_sibling_code",
+      });
+    }
+
+    const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
+    expect(children).toHaveLength(5);
+  });
+
+  it("keeps distinct codes, closed siblings and explicit duplicates out of the code guard", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+
+    const first = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "SEC-05 — HTTPS force" })
+      .expect(201);
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "SEC-06 — HTTPS force elsewhere" })
+      .expect(201);
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "SEC-07 — deliberate second pass", allowDuplicate: true })
+      .expect(201);
+
+    // A closed sibling no longer shadows its code.
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, first.body.id));
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "SEC-05 — reopened work" })
+      .expect(201);
+
+    const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
+    expect(children).toHaveLength(4);
+  });
+
+  it("treats a leading existing issue identifier as a reference, not a work-item code", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+
+    // An issue whose identifier IS the leading token: "ROT-01 — …" then reads as a
+    // reference to that issue, so two siblings citing it stay distinct.
+    await db.insert(issues).values({
+      companyId,
+      title: "Referenced issue",
+      status: "todo",
+      priority: "medium",
+      identifier: "ROT-01",
+    });
+
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "ROT-01 — write the migration" })
+      .expect(201);
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "ROT-01 — write the tests" })
+      .expect(201);
+
+    const children = await db.select().from(issues).where(eq(issues.parentId, parent.id));
+    expect(children).toHaveLength(2);
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -190,6 +190,7 @@ import {
   ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS,
   readAcceptedPlanConfirmationTarget,
 } from "../services/issues.js";
+import type { IssueCreateDeduplicationReason } from "../services/issues.js";
 import { authorizationDeniedDetails } from "../services/authorization.js";
 import { stalledReviewDecisionService } from "../services/stalled-review-decisions.js";
 import { environmentService } from "../services/environments.js";
@@ -7814,7 +7815,7 @@ export function issueRoutes(
       projectId: createBody.projectId ?? null,
       executionPolicy,
     }, actor);
-    let deduplicationReason: "idempotency_key" | "recent_open_title" | null = null;
+    let deduplicationReason: IssueCreateDeduplicationReason | null = null;
     const createInput = {
       ...createBody,
       ...(taskBridgeOriginForActor(req) ?? {}),
@@ -7828,7 +7829,7 @@ export function issueRoutes(
       actorResponsibleUserId: authenticatedActorResponsibleUserId(req),
       trustExplicitResponsibleUserId: actor.actorType === "user",
       watchdogActorRunId: actor.runId,
-      onDeduplicated: (reason: "idempotency_key" | "recent_open_title") => {
+      onDeduplicated: (reason: IssueCreateDeduplicationReason) => {
         deduplicationReason = reason;
       },
     };

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4354,13 +4354,21 @@ export function issueService(db: Db) {
     return title.trim().replace(/\s+/g, " ").toLowerCase();
   }
 
-  // A leading "ROT-01 — ", "SEC-02b: ", "AUTH-3 - " style token is a work-item code the
-  // author already treats as an identifier, so two open siblings carrying the same code
-  // are the same item even when the rest of the title was rephrased. Exact-title dedup
-  // misses that case: a second run re-planning the same parent restates each title
-  // slightly differently and every duplicate slips through.
+  // A leading "ROT-01 — ", "SEC-02b: " style token is a batch code the author already
+  // treats as an identifier, so two open siblings carrying the same code are the same
+  // item even when the rest of the title was rephrased. Exact-title dedup misses that
+  // case: a second run re-planning the same parent restates each title slightly
+  // differently and every duplicate slips through.
+  //
+  // The shape is deliberately narrow, because a false positive here silently drops a
+  // real task. Both signals must be present: the ordinal is zero-padded ("SEC-02", not
+  // "GPT-4"), and the code is followed by a separator rather than a plain word
+  // ("SEC-02 — fix", not "GPT-04 pricing"). A product/version token that happens to be
+  // shared by two unrelated sibling titles therefore never collapses them. The cost of
+  // being too narrow is only a duplicate that the caller can still avoid with
+  // idempotencyKey — the pre-existing behaviour.
   function extractCreateIssueTitleCode(title: string) {
-    const match = /^\s*([A-Za-z]{2,8}-\d{1,4}[A-Za-z]?)\s*(?:[—–\-:.)\]]|\s)/.exec(title);
+    const match = /^\s*([A-Za-z]{2,8}-0\d{1,4}[A-Za-z]?)\s*(?:[—–:.)\]-]\s|$)/.exec(title);
     return match ? match[1].toLowerCase() : null;
   }
 
@@ -7002,7 +7010,7 @@ export function issueService(db: Db) {
                 isNull(issues.hiddenAt),
                 notInArray(issues.status, ["done", "cancelled"]),
                 gte(issues.createdAt, new Date(Date.now() - 48 * 60 * 60 * 1000)),
-                sql`lower(substring(btrim(${issues.title}) from '^[A-Za-z]{2,8}-[0-9]{1,4}[A-Za-z]?(?=[[:space:]]|[—–:.)\\]-])')) = ${titleCode}`,
+                sql`lower(substring(btrim(${issues.title}) from '^[A-Za-z]{2,8}-0[0-9]{1,4}[A-Za-z]?(?=[[:space:]]*([—–:.)\\]-][[:space:]]|$))')) = ${titleCode}`,
               ))
               .orderBy(asc(issues.createdAt), asc(issues.id))
               .limit(1);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -664,8 +664,12 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   trustExplicitResponsibleUserId?: boolean;
   idempotencyKey?: string | null;
   allowDuplicate?: boolean;
-  onDeduplicated?: (reason: "idempotency_key" | "recent_open_title") => void;
+  onDeduplicated?: (reason: IssueCreateDeduplicationReason) => void;
 };
+export type IssueCreateDeduplicationReason =
+  | "idempotency_key"
+  | "recent_open_title"
+  | "recent_open_sibling_code";
 type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
   blockParentUntilDone?: boolean;
@@ -4350,6 +4354,16 @@ export function issueService(db: Db) {
     return title.trim().replace(/\s+/g, " ").toLowerCase();
   }
 
+  // A leading "ROT-01 — ", "SEC-02b: ", "AUTH-3 - " style token is a work-item code the
+  // author already treats as an identifier, so two open siblings carrying the same code
+  // are the same item even when the rest of the title was rephrased. Exact-title dedup
+  // misses that case: a second run re-planning the same parent restates each title
+  // slightly differently and every duplicate slips through.
+  function extractCreateIssueTitleCode(title: string) {
+    const match = /^\s*([A-Za-z]{2,8}-\d{1,4}[A-Za-z]?)\s*(?:[—–\-:.)\]]|\s)/.exec(title);
+    return match ? match[1].toLowerCase() : null;
+  }
+
   async function getIssueByUuid(id: string) {
     const row = await db
       .select()
@@ -6907,10 +6921,16 @@ export function issueService(db: Db) {
       return db.transaction(async (tx) => {
         const idempotencyKey = rawIdempotencyKey?.trim() || null;
         const normalizedTitle = normalizeCreateIssueTitle(issueData.title);
+        const titleCode = extractCreateIssueTitleCode(issueData.title);
         if (allowDuplicate === false) {
           const titleGuardKey =
             `issue-create:title:${companyId}:${issueData.parentId ?? "root"}:${normalizedTitle}`;
           await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${titleGuardKey}, 0))`);
+          if (titleCode) {
+            const codeGuardKey =
+              `issue-create:code:${companyId}:${issueData.parentId ?? "root"}:${titleCode}`;
+            await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${codeGuardKey}, 0))`);
+          }
         }
         if (idempotencyKey) {
           const idempotencyGuardKey = `issue-create:idempotency:${companyId}:${idempotencyKey}`;
@@ -6918,7 +6938,7 @@ export function issueService(db: Db) {
         }
 
         let existingIssue: typeof issues.$inferSelect | undefined;
-        let deduplicationReason: "idempotency_key" | "recent_open_title" | null = null;
+        let deduplicationReason: IssueCreateDeduplicationReason | null = null;
         if (idempotencyKey) {
           const idempotencyKeyRetentionCutoff = new Date(Date.now() - ISSUE_CREATE_IDEMPOTENCY_KEY_RETENTION_MS);
           await tx.execute(sql`
@@ -6960,6 +6980,34 @@ export function issueService(db: Db) {
             .orderBy(asc(issues.createdAt), asc(issues.id))
             .limit(1);
           if (existingIssue) deduplicationReason = "recent_open_title";
+        }
+        if (!existingIssue && allowDuplicate === false && titleCode) {
+          // A code that names an existing issue is a reference ("ENG-0042 follow-up"),
+          // not a work-item code, so it must not collapse unrelated siblings.
+          const [referencedIssue] = await tx
+            .select({ id: issues.id })
+            .from(issues)
+            .where(and(
+              eq(issues.companyId, companyId),
+              sql`lower(${issues.identifier}) = ${titleCode}`,
+            ))
+            .limit(1);
+          if (!referencedIssue) {
+            [existingIssue] = await tx
+              .select()
+              .from(issues)
+              .where(and(
+                eq(issues.companyId, companyId),
+                issueData.parentId ? eq(issues.parentId, issueData.parentId) : isNull(issues.parentId),
+                isNull(issues.hiddenAt),
+                notInArray(issues.status, ["done", "cancelled"]),
+                gte(issues.createdAt, new Date(Date.now() - 48 * 60 * 60 * 1000)),
+                sql`lower(substring(btrim(${issues.title}) from '^[A-Za-z]{2,8}-[0-9]{1,4}[A-Za-z]?(?=[[:space:]]|[—–:.)\\]-])')) = ${titleCode}`,
+              ))
+              .orderBy(asc(issues.createdAt), asc(issues.id))
+              .limit(1);
+            if (existingIssue) deduplicationReason = "recent_open_sibling_code";
+          }
         }
         if (existingIssue) {
           if (idempotencyKey) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6934,9 +6934,9 @@ export function issueService(db: Db) {
           const titleGuardKey =
             `issue-create:title:${companyId}:${issueData.parentId ?? "root"}:${normalizedTitle}`;
           await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${titleGuardKey}, 0))`);
-          if (titleCode) {
+          if (titleCode && issueData.parentId) {
             const codeGuardKey =
-              `issue-create:code:${companyId}:${issueData.parentId ?? "root"}:${titleCode}`;
+              `issue-create:code:${companyId}:${issueData.parentId}:${titleCode}`;
             await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${codeGuardKey}, 0))`);
           }
         }
@@ -6989,7 +6989,11 @@ export function issueService(db: Db) {
             .limit(1);
           if (existingIssue) deduplicationReason = "recent_open_title";
         }
-        if (!existingIssue && allowDuplicate === false && titleCode) {
+        // Scoped to real siblings on purpose. Root issues share a single company-wide
+        // bucket, so a leading code there is not evidence of one batch: two unrelated
+        // root issues opened days apart under the same code would collapse and the
+        // second one would be silently dropped. Under a parent the bucket is the batch.
+        if (!existingIssue && allowDuplicate === false && titleCode && issueData.parentId) {
           // A code that names an existing issue is a reference ("ENG-0042 follow-up"),
           // not a work-item code, so it must not collapse unrelated siblings.
           const [referencedIssue] = await tx
@@ -7006,7 +7010,7 @@ export function issueService(db: Db) {
               .from(issues)
               .where(and(
                 eq(issues.companyId, companyId),
-                issueData.parentId ? eq(issues.parentId, issueData.parentId) : isNull(issues.parentId),
+                eq(issues.parentId, issueData.parentId),
                 isNull(issues.hiddenAt),
                 notInArray(issues.status, ["done", "cancelled"]),
                 gte(issues.createdAt, new Date(Date.now() - 48 * 60 * 60 * 1000)),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents plan work by creating child issues under a parent issue, through `POST /api/companies/:companyId/issues`
> - That endpoint already has a duplicate guard: an idempotency key, and a recent-open-sibling match on the normalized title
> - The title match is byte-exact after normalization, so it only catches a verbatim restatement
> - When two runs of the same agent plan the same parent, the second run rephrases each child title. Every duplicate passes the guard, the parent gets two full sets of children, and two agents do the same work
> - Agents already number a planned batch (`ROT-01 — …`, `SEC-02b — …`). That leading code is an identifier the author chose, so it survives rephrasing when the prose does not
> - This pull request extends the existing sibling guard: an open sibling of the same parent, created in the last 48 hours, that carries the same leading batch code replays instead of creating
> - The benefit is that a re-plan of the same parent no longer doubles the work item set

## Linked Issues or Issue Description

Refs #4393 — "Double wakeup on assignee assignment creates parallel runs and duplicate downstream issues". This pull request does not stop the parallel runs. It stops the duplicate child issues they emit, so it is a mitigation, not the fix for that issue.

Related prior art: #7307 added the server-side duplicate-issue guard that this change extends.

**What happened**

A parent issue was planned twice by two runs of the same agent. Each run created 5 child issues. The titles carried the same batch codes (`ROT-01`, `SEC-02`, `SEC-02b`, `SEC-03`, `SEC-05`) but the prose after the code was rephrased, for example `ROT-01 — Rotate every exposed secret (8 tickets absorbed)` and `ROT-01 — Rotate every exposed secret (prod + lab)`. The normalized-title guard matched none of the 5 pairs. The parent ended with 10 children and two agents started the same work.

**Expected behavior**

The second plan pass replays the existing sibling for each batch code, so the parent keeps 5 children.

**Steps to reproduce**

1. Create a parent issue.
2. `POST /api/companies/:companyId/issues` with `parentId` set and title `ROT-01 — Rotate every exposed secret (8 tickets absorbed)`. This returns 201.
3. `POST` again with the same `parentId` and title `ROT-01 — Rotate every exposed secret (prod + lab)`.
4. Before this change, step 3 returns 201 and a second child. After this change, step 3 returns 200 with `deduplicated: true` and `deduplicationReason: "recent_open_sibling_code"`.

**Paperclip version**

2026.722.0

**Deployment mode**

Self-hosted, single host, `local_trusted`.

## What Changed

- `server/src/services/issues.ts`: added `extractCreateIssueTitleCode()`, which reads a leading batch code from a title. The shape is deliberately narrow. It needs a zero-padded ordinal (`SEC-02`, not `GPT-4`) and a separator after the code (`SEC-02 — fix`, not `GPT-04 pricing`).
- `server/src/services/issues.ts`: when `allowDuplicate` is false and a title carries a batch code, the create now also looks for an open sibling of the same parent, created in the last 48 hours, whose title carries the same code. On a match it replays that issue with `deduplicationReason: "recent_open_sibling_code"`.
- `server/src/services/issues.ts`: a code that is the identifier of an existing issue in the same company is treated as a reference, not a work-item code, and never collapses siblings. This keeps `ENG-0042 follow-up` style titles distinct.
- `server/src/services/issues.ts`: the create transaction takes a second advisory lock keyed on the batch code, so two concurrent creates of the same code serialize the same way two identical titles already do.
- `server/src/services/issues.ts` + `server/src/routes/issues.ts`: exported `IssueCreateDeduplicationReason` and used it in place of the inline union, so the new reason is added in one place.
- `server/src/__tests__/issue-create-deduplication-routes.test.ts`: added 4 route tests — the rephrased 5-pair replay, distinct/closed/`allowDuplicate` siblings staying out of the guard, a leading existing identifier read as a reference, and unrelated siblings that share a leading product or version token.

## Verification

- `cd server && npx vitest run src/__tests__/issue-create-deduplication-routes.test.ts` — 12 tests pass, including the 4 new ones. The suite runs against embedded Postgres, so the advisory locks and the SQL `substring(... from ...)` predicate are exercised for real, not mocked.
- Manual replay against a running self-hosted instance, patched dist, `POST /api/companies/:id/issues` four times:
  - `ZZT-01 - <text A>` then `ZZT-01 : <text B>` — 201 then **200**, same issue id, `deduplicated: true`.
  - `GPT-4 pricing update for the billing page` then `GPT-4 rate limit fix for the ingest worker` — 201 then **201**, two distinct ids. The negative control does not collapse.

## Risks

- A false positive in this guard silently drops a real task, so the code shape is the main risk. It is narrowed on two independent signals — the zero-padded ordinal and the trailing separator — and the negative-control test pins `GPT-4`, `ISO-8601`, and a code with no separator. The cost of being too narrow is only a duplicate, which a caller can still avoid with `idempotencyKey`. That is the pre-existing behaviour.
- The guard is scoped to open siblings of the same parent within 48 hours, so it cannot reach across unrelated parts of the board.
- `allowDuplicate: true` still bypasses it, unchanged.
- The extra advisory lock is taken inside the same transaction that already takes the title lock, and only when a title carries a code. Both keys are derived from `companyId` + `parentId`, so contention stays scoped to one parent.
- Behavioural shift for existing callers: a create that previously returned 201 can now return 200 with the existing issue. That is the same contract the title guard already uses, and the response carries `deduplicated` and `deduplicationReason` so callers can tell.
- No schema migration.

## Model Used

Claude (Anthropic), Opus 4.x family, extended thinking, with tool use and code execution — used for the implementation, the tests, and this pull request description. Commit trailers attribute `Co-Authored-By: Paperclip <noreply@paperclip.ing>` per project convention. Same disclosure as #8206.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no documentation names the deduplication reasons, so there was nothing to update; the new reason is documented in code comments and in the tests
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
