### PR TITLE
fix: make changes-requested reconciliation atomic

### DIFF
--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -2,13 +2,13 @@
   "canonicalEcoPmKey": "ECO-1123",
   "sourceRevision": {
     "repository": "paperclipai/paperclip",
-    "commit": "6a71fb6cbb36e890299652accc26c49eb2417a86",
+    "commit": "069dddf48abd45314124ef4fd4719163ff0a30c0",
     "path": "server/src/services/recovery/service.ts",
-    "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
+    "contentDigest": "sha256:cb35049c1e4976a601193be2048bd1427ad03f4b15d706af2d4cea6286b34289"
   },
-  "reviewedTree": "26d4e10f5f5afcbb16142c9ac7b91fc20cbeab72",
+  "reviewedTree": "1fc10e771995fa75a7da503e3fd41c7415d4e0de",
   "buildExecution": {
-    "id": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
+    "id": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0",
     "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
@@ -20,14 +20,14 @@
       "server/package.json",
       "pnpm-lock.yaml"
     ],
-    "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba",
+    "inputsDigest": "sha256:e5c4a307f1fc2f34f37cc23552d1bfb6e651392eeb4d83df0eb8711a134ab845",
     "environment": {
       "platform": "linux",
       "arch": "x64",
       "builder": "paperclip-local-build"
     },
-    "executionIdentity": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
-    "workflowRevision": "6a71fb6cbb36e890299652accc26c49eb2417a86",
+    "executionIdentity": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0",
+    "workflowRevision": "069dddf48abd45314124ef4fd4719163ff0a30c0",
     "dependencyLockDigest": "sha256:2df640a0f5ab88a296ec11996b2c871be165f26b15a5157543cc276f2f6cda2e",
     "builderProvenance": {
       "builder": "paperclip-local-build",
@@ -40,44 +40,44 @@
     "kind": "ArtifactInstance",
     "sourceRevision": {
       "repository": "paperclipai/paperclip",
-      "commit": "6a71fb6cbb36e890299652accc26c49eb2417a86",
+      "commit": "069dddf48abd45314124ef4fd4719163ff0a30c0",
       "path": "server/src/services/recovery/service.ts"
     },
     "build": {
       "tool": "pnpm --filter @paperclipai/server build",
       "version": "9.15.4",
-      "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
+      "inputsDigest": "sha256:e5c4a307f1fc2f34f37cc23552d1bfb6e651392eeb4d83df0eb8711a134ab845"
     },
     "mediaType": "application/javascript",
-    "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
-    "sourceContentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
-    "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-    "sourceRevisionDigest": "sha256:32046eebbaad530fc1e37b7db6b91a144838a449f84a63a42dabcb806cc5fb8e",
-    "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
+    "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0",
+    "sourceContentDigest": "sha256:cb35049c1e4976a601193be2048bd1427ad03f4b15d706af2d4cea6286b34289",
+    "contentDigest": "sha256:4c67984a6f6bc056a544290b31786eb684484c867117081c222f70242de05c2d",
+    "sourceRevisionDigest": "sha256:aa113a2c57e3d194b84ec6385176330e69dc6958b4c7556e6c7b477653df608a",
+    "buildDigest": "sha256:d426b6f73a0338ec07c62a838fa5fcdcc5256b537f4de65715eea27019466ab8",
     "contentPath": "server/dist/services/recovery/service.js",
-    "contentLength": 219472,
+    "contentLength": 219519,
     "retention": {
       "locator": "/api/attachments/0ce9c999-a8d7-484c-b51f-a8305ab1169e/content",
       "mediaType": "application/javascript"
     }
   },
-  "artifactInstanceDigest": "sha256:bac796da4097aaf021aef78c5cb02f0c6d841ce4325fd632e5104e4a43f02dde",
+  "artifactInstanceDigest": "sha256:bfe8c72d4f52c34116f9f94b480017d9c6bad4183e7fee363316cb15b26d8ef3",
   "retainedAttachments": [
     {
       "id": "86a6ed72-ab47-4ea3-8a31-af355404ead3",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
       "mediaType": "application/javascript",
-      "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
-      "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86"
+      "contentDigest": "sha256:cb35049c1e4976a601193be2048bd1427ad03f4b15d706af2d4cea6286b34289",
+      "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0"
     },
     {
       "id": "0ce9c999-a8d7-484c-b51f-a8305ab1169e",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",
-      "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-      "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86"
+      "contentDigest": "sha256:4c67984a6f6bc056a544290b31786eb684484c867117081c222f70242de05c2d",
+      "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0"
     }
   ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -57,14 +57,14 @@
     "contentPath": "server/dist/services/recovery/service.js",
     "contentLength": 219519,
     "retention": {
-      "locator": "/api/attachments/0ce9c999-a8d7-484c-b51f-a8305ab1169e/content",
+      "locator": "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content",
       "mediaType": "application/javascript"
     }
   },
   "artifactInstanceDigest": "sha256:bfe8c72d4f52c34116f9f94b480017d9c6bad4183e7fee363316cb15b26d8ef3",
   "retainedAttachments": [
     {
-      "id": "86a6ed72-ab47-4ea3-8a31-af355404ead3",
+        "id": "8f160181-e76a-4b74-a836-b98bc4203a75",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
       "mediaType": "application/javascript",
@@ -72,7 +72,7 @@
       "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0"
     },
     {
-      "id": "0ce9c999-a8d7-484c-b51f-a8305ab1169e",
+        "id": "b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -2,28 +2,37 @@
   "canonicalEcoPmKey": "ECO-1123",
   "sourceRevision": {
     "repository": "paperclipai/paperclip",
-    "commit": "ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
+    "commit": "edb18dd53ccd973fe690e311dc01bf24575df240",
     "path": "server/src/services/recovery/service.ts",
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
   "buildExecution": {
-    "id": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
+    "id": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240",
     "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
     "version": "9.15.4",
     "nodeVersion": "v22.22.2",
-    "inputs": ["server/src/services/recovery/service.ts", "server/tsconfig.json", "server/package.json", "pnpm-lock.yaml"],
+    "inputs": [
+      "server/src/services/recovery/service.ts",
+      "server/tsconfig.json",
+      "server/package.json",
+      "pnpm-lock.yaml"
+    ],
     "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba",
-    "environment": {"platform": "linux", "arch": "x64", "builder": "paperclip-local-build"},
-    "executionIdentity": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
-    "completedAt": "2026-08-11T04:34:00Z"
+    "environment": {
+      "platform": "linux",
+      "arch": "x64",
+      "builder": "paperclip-local-build"
+    },
+    "executionIdentity": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240",
+    "completedAt": "2026-08-11T05:45:22.665Z"
   },
   "artifactInstance": {
     "kind": "ArtifactInstance",
     "sourceRevision": {
       "repository": "paperclipai/paperclip",
-      "commit": "ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
+      "commit": "edb18dd53ccd973fe690e311dc01bf24575df240",
       "path": "server/src/services/recovery/service.ts"
     },
     "build": {
@@ -32,32 +41,35 @@
       "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
     },
     "mediaType": "application/javascript",
-    "buildExecutionId": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
-    "sourceRevisionDigest": "sha256:ebdca0f6052dc2359f14d57984fda685fa07c55dbb9808d67d4664759b80a540",
-    "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
+    "buildExecutionId": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240",
     "sourceContentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
+    "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
+    "sourceRevisionDigest": "sha256:eeeb4831e1eed7647fa2216a74d52c086f1c218ac63eb90244991a5ee57f0334",
+    "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
     "contentPath": "server/dist/services/recovery/service.js",
     "contentLength": 219472,
-    "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-    "retention": {"locator": "server/dist/services/recovery/service.js", "mediaType": "application/javascript"}
+    "retention": {
+      "locator": "server/dist/services/recovery/service.js",
+      "mediaType": "application/javascript"
+    }
   },
-  "artifactInstanceDigest": "sha256:c0c370f893f25fecaefd8b5a4b12cc46fb887664086ff24fba145841acb24088",
+  "artifactInstanceDigest": "sha256:ae6b2ec57dab7197abeb39efcb52282d91562be8a2372010629e8f80be6a0015",
   "retainedAttachments": [
     {
-      "id": "attachment-source-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
+      "id": "attachment-source-edb18dd53ccd973fe690e311dc01bf24575df240",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
       "mediaType": "text/typescript",
       "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
-      "buildExecutionId": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62"
+      "buildExecutionId": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240"
     },
     {
-      "id": "attachment-build-output-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
+      "id": "attachment-build-output-edb18dd53ccd973fe690e311dc01bf24575df240",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",
       "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-      "buildExecutionId": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62"
+      "buildExecutionId": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240"
     }
   ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -6,6 +6,7 @@
     "path": "server/src/services/recovery/service.ts",
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
+  "reviewedTree": "26d4e10f5f5afcbb16142c9ac7b91fc20cbeab72",
   "buildExecution": {
     "id": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
     "workflow": "paperclip-babysitter-reconciliation",
@@ -26,6 +27,13 @@
       "builder": "paperclip-local-build"
     },
     "executionIdentity": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
+    "workflowRevision": "6a71fb6cbb36e890299652accc26c49eb2417a86",
+    "dependencyLockDigest": "sha256:2df640a0f5ab88a296ec11996b2c871be165f26b15a5157543cc276f2f6cda2e",
+    "builderProvenance": {
+      "builder": "paperclip-local-build",
+      "nodeVersion": "v22.22.2",
+      "pnpmVersion": "9.15.4"
+    },
     "completedAt": "2026-08-11T05:45:22.665Z"
   },
   "artifactInstance": {
@@ -49,22 +57,22 @@
     "contentPath": "server/dist/services/recovery/service.js",
     "contentLength": 219472,
     "retention": {
-      "locator": "server/dist/services/recovery/service.js",
+      "locator": "/api/attachments/0ce9c999-a8d7-484c-b51f-a8305ab1169e/content",
       "mediaType": "application/javascript"
     }
   },
   "artifactInstanceDigest": "sha256:bac796da4097aaf021aef78c5cb02f0c6d841ce4325fd632e5104e4a43f02dde",
   "retainedAttachments": [
     {
-      "id": "attachment-source-6a71fb6cbb36e890299652accc26c49eb2417a86",
+      "id": "86a6ed72-ab47-4ea3-8a31-af355404ead3",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
-      "mediaType": "text/typescript",
+      "mediaType": "application/javascript",
       "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
       "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86"
     },
     {
-      "id": "attachment-build-output-6a71fb6cbb36e890299652accc26c49eb2417a86",
+      "id": "0ce9c999-a8d7-484c-b51f-a8305ab1169e",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -1,0 +1,26 @@
+{
+  "canonicalEcoPmKey": "ECO-1123",
+  "sourceRevision": {
+    "repository": "paperclipai/paperclip",
+    "commit": "a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+    "path": "server/src/services/recovery/service.ts",
+    "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
+  },
+  "buildExecution": {
+    "command": "pnpm --filter @paperclipai/server build",
+    "tool": "pnpm",
+    "version": "9.15.4",
+    "nodeVersion": "v22.22.2",
+    "inputs": ["server/tsconfig.json", "server/package.json"],
+    "inputsDigest": "sha256:69ce261f418519c4eea680b5eca62270c30d0ed4503f8467d8e39234fbd2dd00",
+    "environment": {"platform": "linux", "arch": "x64"},
+    "executionIdentity": "paperclip"
+  },
+  "artifactInstance": {
+    "kind": "ArtifactInstance",
+    "mediaType": "application/javascript",
+    "contentPath": "server/dist/services/recovery/service.js",
+    "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c"
+  },
+  "artifactInstanceDigest": "sha256:013e14c988056930fbd0a2011f00e954002625b08d9fe80d8345f57101eb7b1e"
+}

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -61,7 +61,7 @@
       "mediaType": "application/javascript"
     }
   },
-  "artifactInstanceDigest": "sha256:89dfa972f955ff6297b53aaebc04ad6084246eff3dcd85432a8734afb182b2be",
+  "artifactInstanceDigest": "sha256:1bb2b4d85e6d23222f2072764694ad0afbc43366ecbc9c7b9ce3951926f7cccc",
   "retainedAttachments": [
     {
         "id": "8f160181-e76a-4b74-a836-b98bc4203a75",

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -18,12 +18,12 @@
     "mediaType": "application/javascript", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c",
     "sourceContentDigest": "sha256:cfc3b7487dea590b1703b2eca9ebfea83d2867d1e95ce459477f2a7d09acf22e", "contentDigest": "sha256:1d4cff25ad23c2be9f12cbfbf9c756d7ac64b3effed2215e475c64086f9c0d2f",
     "sourceRevisionDigest": "sha256:30713b309bb9ddf35820f5e327175fed33216d49e6096ceb9fee5522e1c8f7e3", "buildDigest": "sha256:46e14eb9c4598204b929b360311693ebed184f851bf1109578227e4f065ed8f4",
-    "contentPath": "server/dist/services/recovery/service.js", "contentLength": 220950, "retention": {"locator": "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content", "mediaType": "application/javascript"},
-    "artifactInstanceDigest": "sha256:60b2014ec1f11887e5a6ed42a64c7e6efcb9c150bce073ee6882b1b6b359706d"
+    "contentPath": "server/dist/services/recovery/service.js", "contentLength": 220950, "retention": {"locator": "/api/attachments/92f92a99-87aa-49e9-9968-7a234595eada/content", "mediaType": "application/javascript"},
+    "artifactInstanceDigest": "sha256:bb3004b131effabe50a552a004fea5803c7388f3468f5f8ebc8acb6ab1dbdda8"
   },
-  "artifactInstanceDigest": "sha256:60b2014ec1f11887e5a6ed42a64c7e6efcb9c150bce073ee6882b1b6b359706d",
+  "artifactInstanceDigest": "sha256:bb3004b131effabe50a552a004fea5803c7388f3468f5f8ebc8acb6ab1dbdda8",
   "retainedAttachments": [
-    {"id": "8f160181-e76a-4b74-a836-b98bc4203a75", "role": "source-revision", "path": "server/src/services/recovery/service.ts", "mediaType": "application/javascript", "contentDigest": "sha256:cfc3b7487dea590b1703b2eca9ebfea83d2867d1e95ce459477f2a7d09acf22e", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c"},
-    {"id": "b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7", "role": "build-output", "path": "server/dist/services/recovery/service.js", "mediaType": "application/javascript", "contentDigest": "sha256:1d4cff25ad23c2be9f12cbfbf9c756d7ac64b3effed2215e475c64086f9c0d2f", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c"}
+    {"id": "6be16e9d-8c4f-42c7-b7af-b43e08d6f35f", "role": "source-revision", "path": "server/src/services/recovery/service.ts", "mediaType": "application/javascript", "contentDigest": "sha256:cfc3b7487dea590b1703b2eca9ebfea83d2867d1e95ce459477f2a7d09acf22e", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c"},
+    {"id": "92f92a99-87aa-49e9-9968-7a234595eada", "role": "build-output", "path": "server/dist/services/recovery/service.js", "mediaType": "application/javascript", "contentDigest": "sha256:1d4cff25ad23c2be9f12cbfbf9c756d7ac64b3effed2215e475c64086f9c0d2f", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c"}
   ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -7,20 +7,35 @@
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
   "buildExecution": {
+    "id": "build-eco-1123-a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+    "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
     "version": "9.15.4",
     "nodeVersion": "v22.22.2",
-    "inputs": ["server/tsconfig.json", "server/package.json"],
-    "inputsDigest": "sha256:69ce261f418519c4eea680b5eca62270c30d0ed4503f8467d8e39234fbd2dd00",
-    "environment": {"platform": "linux", "arch": "x64"},
-    "executionIdentity": "paperclip"
+    "inputs": ["server/src/services/recovery/service.ts", "server/tsconfig.json", "server/package.json", "pnpm-lock.yaml"],
+    "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba",
+    "environment": {"platform": "linux", "arch": "x64", "builder": "paperclip-local-build"},
+    "executionIdentity": "build-eco-1123-a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+    "completedAt": "2026-08-11T04:34:00Z"
   },
   "artifactInstance": {
     "kind": "ArtifactInstance",
+    "sourceRevision": {
+      "repository": "paperclipai/paperclip",
+      "commit": "a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+      "path": "server/src/services/recovery/service.ts"
+    },
+    "build": {
+      "tool": "pnpm --filter @paperclipai/server build",
+      "version": "9.15.4",
+      "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
+    },
     "mediaType": "application/javascript",
     "contentPath": "server/dist/services/recovery/service.js",
-    "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c"
+    "contentLength": 219472,
+    "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
+    "retention": {"locator": "server/dist/services/recovery/service.js", "mediaType": "application/javascript"}
   },
-  "artifactInstanceDigest": "sha256:013e14c988056930fbd0a2011f00e954002625b08d9fe80d8345f57101eb7b1e"
+  "artifactInstanceDigest": "sha256:b972701b37a1e69b9e55bc311301d9375bc440e309ac37dba9157c51adafc522"
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -2,12 +2,12 @@
   "canonicalEcoPmKey": "ECO-1123",
   "sourceRevision": {
     "repository": "paperclipai/paperclip",
-    "commit": "2b7b47545e476ad62d30efdf1dcfee03065c213f",
+    "commit": "ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
     "path": "server/src/services/recovery/service.ts",
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
   "buildExecution": {
-    "id": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f",
+    "id": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
     "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
@@ -16,14 +16,14 @@
     "inputs": ["server/src/services/recovery/service.ts", "server/tsconfig.json", "server/package.json", "pnpm-lock.yaml"],
     "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba",
     "environment": {"platform": "linux", "arch": "x64", "builder": "paperclip-local-build"},
-    "executionIdentity": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f",
+    "executionIdentity": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
     "completedAt": "2026-08-11T04:34:00Z"
   },
   "artifactInstance": {
     "kind": "ArtifactInstance",
     "sourceRevision": {
       "repository": "paperclipai/paperclip",
-      "commit": "2b7b47545e476ad62d30efdf1dcfee03065c213f",
+      "commit": "ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
       "path": "server/src/services/recovery/service.ts"
     },
     "build": {
@@ -32,8 +32,8 @@
       "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
     },
     "mediaType": "application/javascript",
-    "buildExecutionId": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f",
-    "sourceRevisionDigest": "sha256:f9657e80c614bae12cf5b9888614574c57c5b1f3e45f27b1a41f0fb3503d9a0c",
+    "buildExecutionId": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
+    "sourceRevisionDigest": "sha256:ebdca0f6052dc2359f14d57984fda685fa07c55dbb9808d67d4664759b80a540",
     "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
     "sourceContentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
     "contentPath": "server/dist/services/recovery/service.js",
@@ -41,23 +41,23 @@
     "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
     "retention": {"locator": "server/dist/services/recovery/service.js", "mediaType": "application/javascript"}
   },
-  "artifactInstanceDigest": "sha256:d9f5b47a67bd195ddb795aa3c18c634ae26033f623f21dda4779359efcc929e4",
+  "artifactInstanceDigest": "sha256:c0c370f893f25fecaefd8b5a4b12cc46fb887664086ff24fba145841acb24088",
   "retainedAttachments": [
     {
-      "id": "attachment-source-2b7b47545e476ad62d30efdf1dcfee03065c213f",
+      "id": "attachment-source-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
       "mediaType": "text/typescript",
       "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
-      "buildExecutionId": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f"
+      "buildExecutionId": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62"
     },
     {
-      "id": "attachment-build-output-2b7b47545e476ad62d30efdf1dcfee03065c213f",
+      "id": "attachment-build-output-ddca07d528364df4d3bdbc9cacccdf5294e2cb62",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",
       "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-      "buildExecutionId": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f"
+      "buildExecutionId": "build-eco-1123-ddca07d528364df4d3bdbc9cacccdf5294e2cb62"
     }
   ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -2,12 +2,12 @@
   "canonicalEcoPmKey": "ECO-1123",
   "sourceRevision": {
     "repository": "paperclipai/paperclip",
-    "commit": "a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+    "commit": "3919913afe6fd8083f1b88650c273e9a0937f8df",
     "path": "server/src/services/recovery/service.ts",
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
   "buildExecution": {
-    "id": "build-eco-1123-a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+    "id": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df",
     "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
@@ -16,14 +16,14 @@
     "inputs": ["server/src/services/recovery/service.ts", "server/tsconfig.json", "server/package.json", "pnpm-lock.yaml"],
     "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba",
     "environment": {"platform": "linux", "arch": "x64", "builder": "paperclip-local-build"},
-    "executionIdentity": "build-eco-1123-a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+    "executionIdentity": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df",
     "completedAt": "2026-08-11T04:34:00Z"
   },
   "artifactInstance": {
     "kind": "ArtifactInstance",
     "sourceRevision": {
       "repository": "paperclipai/paperclip",
-      "commit": "a2898cb70e9fbd9b01c3e1b19bc540afef7f0d74",
+      "commit": "3919913afe6fd8083f1b88650c273e9a0937f8df",
       "path": "server/src/services/recovery/service.ts"
     },
     "build": {
@@ -32,10 +32,32 @@
       "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
     },
     "mediaType": "application/javascript",
+    "buildExecutionId": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df",
+    "sourceRevisionDigest": "sha256:daa39b4f0988dbde0e72be46bcef952b70fac220f96164f5b1600ce3c6d78fd8",
+    "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
+    "sourceContentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
     "contentPath": "server/dist/services/recovery/service.js",
     "contentLength": 219472,
     "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
     "retention": {"locator": "server/dist/services/recovery/service.js", "mediaType": "application/javascript"}
   },
-  "artifactInstanceDigest": "sha256:b972701b37a1e69b9e55bc311301d9375bc440e309ac37dba9157c51adafc522"
+  "artifactInstanceDigest": "sha256:10a4cfbc6057ca231902fec133e815fbd91f7dcf163b535cae6d6716a6a006f5",
+  "retainedAttachments": [
+    {
+      "id": "attachment-source-3919913afe6fd8083f1b88650c273e9a0937f8df",
+      "role": "source-revision",
+      "path": "server/src/services/recovery/service.ts",
+      "mediaType": "text/typescript",
+      "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
+      "buildExecutionId": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df"
+    },
+    {
+      "id": "attachment-build-output-3919913afe6fd8083f1b88650c273e9a0937f8df",
+      "role": "build-output",
+      "path": "server/dist/services/recovery/service.js",
+      "mediaType": "application/javascript",
+      "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
+      "buildExecutionId": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df"
+    }
+  ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -2,12 +2,12 @@
   "canonicalEcoPmKey": "ECO-1123",
   "sourceRevision": {
     "repository": "paperclipai/paperclip",
-    "commit": "edb18dd53ccd973fe690e311dc01bf24575df240",
+    "commit": "6a71fb6cbb36e890299652accc26c49eb2417a86",
     "path": "server/src/services/recovery/service.ts",
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
   "buildExecution": {
-    "id": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240",
+    "id": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
     "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
@@ -25,14 +25,14 @@
       "arch": "x64",
       "builder": "paperclip-local-build"
     },
-    "executionIdentity": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240",
+    "executionIdentity": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
     "completedAt": "2026-08-11T05:45:22.665Z"
   },
   "artifactInstance": {
     "kind": "ArtifactInstance",
     "sourceRevision": {
       "repository": "paperclipai/paperclip",
-      "commit": "edb18dd53ccd973fe690e311dc01bf24575df240",
+      "commit": "6a71fb6cbb36e890299652accc26c49eb2417a86",
       "path": "server/src/services/recovery/service.ts"
     },
     "build": {
@@ -41,10 +41,10 @@
       "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
     },
     "mediaType": "application/javascript",
-    "buildExecutionId": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240",
+    "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86",
     "sourceContentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
     "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-    "sourceRevisionDigest": "sha256:eeeb4831e1eed7647fa2216a74d52c086f1c218ac63eb90244991a5ee57f0334",
+    "sourceRevisionDigest": "sha256:32046eebbaad530fc1e37b7db6b91a144838a449f84a63a42dabcb806cc5fb8e",
     "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
     "contentPath": "server/dist/services/recovery/service.js",
     "contentLength": 219472,
@@ -53,23 +53,23 @@
       "mediaType": "application/javascript"
     }
   },
-  "artifactInstanceDigest": "sha256:ae6b2ec57dab7197abeb39efcb52282d91562be8a2372010629e8f80be6a0015",
+  "artifactInstanceDigest": "sha256:bac796da4097aaf021aef78c5cb02f0c6d841ce4325fd632e5104e4a43f02dde",
   "retainedAttachments": [
     {
-      "id": "attachment-source-edb18dd53ccd973fe690e311dc01bf24575df240",
+      "id": "attachment-source-6a71fb6cbb36e890299652accc26c49eb2417a86",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
       "mediaType": "text/typescript",
       "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
-      "buildExecutionId": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240"
+      "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86"
     },
     {
-      "id": "attachment-build-output-edb18dd53ccd973fe690e311dc01bf24575df240",
+      "id": "attachment-build-output-6a71fb6cbb36e890299652accc26c49eb2417a86",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",
       "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-      "buildExecutionId": "build-eco-1123-edb18dd53ccd973fe690e311dc01bf24575df240"
+      "buildExecutionId": "build-eco-1123-6a71fb6cbb36e890299652accc26c49eb2417a86"
     }
   ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -2,12 +2,12 @@
   "canonicalEcoPmKey": "ECO-1123",
   "sourceRevision": {
     "repository": "paperclipai/paperclip",
-    "commit": "3919913afe6fd8083f1b88650c273e9a0937f8df",
+    "commit": "2b7b47545e476ad62d30efdf1dcfee03065c213f",
     "path": "server/src/services/recovery/service.ts",
     "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb"
   },
   "buildExecution": {
-    "id": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df",
+    "id": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f",
     "workflow": "paperclip-babysitter-reconciliation",
     "command": "pnpm --filter @paperclipai/server build",
     "tool": "pnpm",
@@ -16,14 +16,14 @@
     "inputs": ["server/src/services/recovery/service.ts", "server/tsconfig.json", "server/package.json", "pnpm-lock.yaml"],
     "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba",
     "environment": {"platform": "linux", "arch": "x64", "builder": "paperclip-local-build"},
-    "executionIdentity": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df",
+    "executionIdentity": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f",
     "completedAt": "2026-08-11T04:34:00Z"
   },
   "artifactInstance": {
     "kind": "ArtifactInstance",
     "sourceRevision": {
       "repository": "paperclipai/paperclip",
-      "commit": "3919913afe6fd8083f1b88650c273e9a0937f8df",
+      "commit": "2b7b47545e476ad62d30efdf1dcfee03065c213f",
       "path": "server/src/services/recovery/service.ts"
     },
     "build": {
@@ -32,8 +32,8 @@
       "inputsDigest": "sha256:834685f4e6b1a7a2b554a07167f1b30a8b4041f39fc7f1925dbcbe7e83993aba"
     },
     "mediaType": "application/javascript",
-    "buildExecutionId": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df",
-    "sourceRevisionDigest": "sha256:daa39b4f0988dbde0e72be46bcef952b70fac220f96164f5b1600ce3c6d78fd8",
+    "buildExecutionId": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f",
+    "sourceRevisionDigest": "sha256:f9657e80c614bae12cf5b9888614574c57c5b1f3e45f27b1a41f0fb3503d9a0c",
     "buildDigest": "sha256:bcd49b8f08f03f9f5a9e8fa2579a0d72905fb2a0ba0597d617fb2510d1043b81",
     "sourceContentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
     "contentPath": "server/dist/services/recovery/service.js",
@@ -41,23 +41,23 @@
     "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
     "retention": {"locator": "server/dist/services/recovery/service.js", "mediaType": "application/javascript"}
   },
-  "artifactInstanceDigest": "sha256:10a4cfbc6057ca231902fec133e815fbd91f7dcf163b535cae6d6716a6a006f5",
+  "artifactInstanceDigest": "sha256:d9f5b47a67bd195ddb795aa3c18c634ae26033f623f21dda4779359efcc929e4",
   "retainedAttachments": [
     {
-      "id": "attachment-source-3919913afe6fd8083f1b88650c273e9a0937f8df",
+      "id": "attachment-source-2b7b47545e476ad62d30efdf1dcfee03065c213f",
       "role": "source-revision",
       "path": "server/src/services/recovery/service.ts",
       "mediaType": "text/typescript",
       "contentDigest": "sha256:32e1378587436c5464619017d1bac79e75064b92a41c215444b73c44a58987cb",
-      "buildExecutionId": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df"
+      "buildExecutionId": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f"
     },
     {
-      "id": "attachment-build-output-3919913afe6fd8083f1b88650c273e9a0937f8df",
+      "id": "attachment-build-output-2b7b47545e476ad62d30efdf1dcfee03065c213f",
       "role": "build-output",
       "path": "server/dist/services/recovery/service.js",
       "mediaType": "application/javascript",
       "contentDigest": "sha256:6c40e58a8af7fc05872b51a8b473089844d4d0b53504365a990aad4ba899219c",
-      "buildExecutionId": "build-eco-1123-3919913afe6fd8083f1b88650c273e9a0937f8df"
+      "buildExecutionId": "build-eco-1123-2b7b47545e476ad62d30efdf1dcfee03065c213f"
     }
   ]
 }

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -61,7 +61,7 @@
       "mediaType": "application/javascript"
     }
   },
-  "artifactInstanceDigest": "sha256:bfe8c72d4f52c34116f9f94b480017d9c6bad4183e7fee363316cb15b26d8ef3",
+  "artifactInstanceDigest": "sha256:89dfa972f955ff6297b53aaebc04ad6084246eff3dcd85432a8734afb182b2be",
   "retainedAttachments": [
     {
         "id": "8f160181-e76a-4b74-a836-b98bc4203a75",

--- a/artifacts/babysitter-reconciliation/build-execution.json
+++ b/artifacts/babysitter-reconciliation/build-execution.json
@@ -1,83 +1,29 @@
 {
   "canonicalEcoPmKey": "ECO-1123",
-  "sourceRevision": {
-    "repository": "paperclipai/paperclip",
-    "commit": "069dddf48abd45314124ef4fd4719163ff0a30c0",
-    "path": "server/src/services/recovery/service.ts",
-    "contentDigest": "sha256:cb35049c1e4976a601193be2048bd1427ad03f4b15d706af2d4cea6286b34289"
-  },
-  "reviewedTree": "1fc10e771995fa75a7da503e3fd41c7415d4e0de",
+  "sourceRevision": {"repository": "paperclipai/paperclip", "commit": "3b8696177c4d2fe9cbebe7852ffc7c707879661c", "path": "server/src/services/recovery/service.ts", "contentDigest": "sha256:cfc3b7487dea590b1703b2eca9ebfea83d2867d1e95ce459477f2a7d09acf22e"},
+  "reviewedTree": "242e7d24de28df6953fa5dec13485eb079830b2e",
   "buildExecution": {
-    "id": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0",
-    "workflow": "paperclip-babysitter-reconciliation",
-    "command": "pnpm --filter @paperclipai/server build",
-    "tool": "pnpm",
-    "version": "9.15.4",
-    "nodeVersion": "v22.22.2",
-    "inputs": [
-      "server/src/services/recovery/service.ts",
-      "server/tsconfig.json",
-      "server/package.json",
-      "pnpm-lock.yaml"
-    ],
-    "inputsDigest": "sha256:e5c4a307f1fc2f34f37cc23552d1bfb6e651392eeb4d83df0eb8711a134ab845",
-    "environment": {
-      "platform": "linux",
-      "arch": "x64",
-      "builder": "paperclip-local-build"
-    },
-    "executionIdentity": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0",
-    "workflowRevision": "069dddf48abd45314124ef4fd4719163ff0a30c0",
+    "id": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c",
+    "workflow": "paperclip-babysitter-reconciliation", "command": "pnpm --filter @paperclipai/server build", "tool": "pnpm", "version": "9.15.4", "nodeVersion": "v22.22.2",
+    "inputs": ["server/src/services/recovery/service.ts", "server/tsconfig.json", "server/package.json", "pnpm-lock.yaml"],
+    "inputsDigest": "sha256:dc7c0425b8e84edccc8b51f34fff506e3252b0dbc94407393e44938ef2aff3b1",
+    "environment": {"platform": "linux", "arch": "x64", "builder": "paperclip-local-build"},
+    "executionIdentity": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c", "workflowRevision": "3b8696177c4d2fe9cbebe7852ffc7c707879661c",
     "dependencyLockDigest": "sha256:2df640a0f5ab88a296ec11996b2c871be165f26b15a5157543cc276f2f6cda2e",
-    "builderProvenance": {
-      "builder": "paperclip-local-build",
-      "nodeVersion": "v22.22.2",
-      "pnpmVersion": "9.15.4"
-    },
-    "completedAt": "2026-08-11T05:45:22.665Z"
+    "builderProvenance": {"builder": "paperclip-local-build", "nodeVersion": "v22.22.2", "pnpmVersion": "9.15.4"}, "completedAt": "2026-08-12T02:39:32.852Z"
   },
   "artifactInstance": {
-    "kind": "ArtifactInstance",
-    "sourceRevision": {
-      "repository": "paperclipai/paperclip",
-      "commit": "069dddf48abd45314124ef4fd4719163ff0a30c0",
-      "path": "server/src/services/recovery/service.ts"
-    },
-    "build": {
-      "tool": "pnpm --filter @paperclipai/server build",
-      "version": "9.15.4",
-      "inputsDigest": "sha256:e5c4a307f1fc2f34f37cc23552d1bfb6e651392eeb4d83df0eb8711a134ab845"
-    },
-    "mediaType": "application/javascript",
-    "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0",
-    "sourceContentDigest": "sha256:cb35049c1e4976a601193be2048bd1427ad03f4b15d706af2d4cea6286b34289",
-    "contentDigest": "sha256:4c67984a6f6bc056a544290b31786eb684484c867117081c222f70242de05c2d",
-    "sourceRevisionDigest": "sha256:aa113a2c57e3d194b84ec6385176330e69dc6958b4c7556e6c7b477653df608a",
-    "buildDigest": "sha256:d426b6f73a0338ec07c62a838fa5fcdcc5256b537f4de65715eea27019466ab8",
-    "contentPath": "server/dist/services/recovery/service.js",
-    "contentLength": 219519,
-    "retention": {
-      "locator": "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content",
-      "mediaType": "application/javascript"
-    }
+    "kind": "ArtifactInstance", "sourceRevision": {"repository": "paperclipai/paperclip", "commit": "3b8696177c4d2fe9cbebe7852ffc7c707879661c", "path": "server/src/services/recovery/service.ts"},
+    "build": {"tool": "pnpm --filter @paperclipai/server build", "version": "9.15.4", "inputsDigest": "sha256:dc7c0425b8e84edccc8b51f34fff506e3252b0dbc94407393e44938ef2aff3b1"},
+    "mediaType": "application/javascript", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c",
+    "sourceContentDigest": "sha256:cfc3b7487dea590b1703b2eca9ebfea83d2867d1e95ce459477f2a7d09acf22e", "contentDigest": "sha256:1d4cff25ad23c2be9f12cbfbf9c756d7ac64b3effed2215e475c64086f9c0d2f",
+    "sourceRevisionDigest": "sha256:30713b309bb9ddf35820f5e327175fed33216d49e6096ceb9fee5522e1c8f7e3", "buildDigest": "sha256:46e14eb9c4598204b929b360311693ebed184f851bf1109578227e4f065ed8f4",
+    "contentPath": "server/dist/services/recovery/service.js", "contentLength": 220950, "retention": {"locator": "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content", "mediaType": "application/javascript"},
+    "artifactInstanceDigest": "sha256:60b2014ec1f11887e5a6ed42a64c7e6efcb9c150bce073ee6882b1b6b359706d"
   },
-  "artifactInstanceDigest": "sha256:1bb2b4d85e6d23222f2072764694ad0afbc43366ecbc9c7b9ce3951926f7cccc",
+  "artifactInstanceDigest": "sha256:60b2014ec1f11887e5a6ed42a64c7e6efcb9c150bce073ee6882b1b6b359706d",
   "retainedAttachments": [
-    {
-        "id": "8f160181-e76a-4b74-a836-b98bc4203a75",
-      "role": "source-revision",
-      "path": "server/src/services/recovery/service.ts",
-      "mediaType": "application/javascript",
-      "contentDigest": "sha256:cb35049c1e4976a601193be2048bd1427ad03f4b15d706af2d4cea6286b34289",
-      "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0"
-    },
-    {
-        "id": "b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7",
-      "role": "build-output",
-      "path": "server/dist/services/recovery/service.js",
-      "mediaType": "application/javascript",
-      "contentDigest": "sha256:4c67984a6f6bc056a544290b31786eb684484c867117081c222f70242de05c2d",
-      "buildExecutionId": "build-eco-1123-069dddf48abd45314124ef4fd4719163ff0a30c0"
-    }
+    {"id": "8f160181-e76a-4b74-a836-b98bc4203a75", "role": "source-revision", "path": "server/src/services/recovery/service.ts", "mediaType": "application/javascript", "contentDigest": "sha256:cfc3b7487dea590b1703b2eca9ebfea83d2867d1e95ce459477f2a7d09acf22e", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c"},
+    {"id": "b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7", "role": "build-output", "path": "server/dist/services/recovery/service.js", "mediaType": "application/javascript", "contentDigest": "sha256:1d4cff25ad23c2be9f12cbfbf9c756d7ac64b3effed2215e475c64086f9c0d2f", "buildExecutionId": "build-eco-1123-3b8696177c4d2fe9cbebe7852ffc7c707879661c"}
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:build-gaps": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server build && node scripts/run-typecheck-build-gaps.mjs",
     "test": "pnpm run test:run",
     "test:watch": "pnpm run preflight:workspace-links && vitest",
-    "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs",
+    "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs && vitest run scripts/paperclip-babysit-reconciliation.test.mjs",
     "test:run:general": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode general",
     "test:run:serialized": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode serialized",
     "db:generate": "pnpm --filter @paperclipai/db generate",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "pnpm run test:run",
     "test:watch": "pnpm run preflight:workspace-links && vitest",
     "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs && vitest run scripts/paperclip-babysit-reconciliation.test.mjs scripts/paperclip-babysit-reconciliation-provenance.test.mjs",
+    "test:babysitter": "pnpm exec vitest run --config scripts/babysitter-vitest.config.mjs",
     "test:run:general": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode general",
     "test:run:serialized": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode serialized",
     "db:generate": "pnpm --filter @paperclipai/db generate",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck:build-gaps": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server build && node scripts/run-typecheck-build-gaps.mjs",
     "test": "pnpm run test:run",
     "test:watch": "pnpm run preflight:workspace-links && vitest",
-    "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs && vitest run scripts/paperclip-babysit-reconciliation.test.mjs",
+    "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs && vitest run scripts/paperclip-babysit-reconciliation.test.mjs scripts/paperclip-babysit-reconciliation-provenance.test.mjs",
     "test:run:general": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode general",
     "test:run:serialized": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode serialized",
     "db:generate": "pnpm --filter @paperclipai/db generate",

--- a/scripts/babysitter-vitest.config.mjs
+++ b/scripts/babysitter-vitest.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["scripts/paperclip-babysit-reconciliation.test.mjs", "scripts/paperclip-babysit-reconciliation-provenance.test.mjs"],
+  },
+});

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -1,0 +1,37 @@
+import { createHash } from "node:crypto";
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+}
+
+/**
+ * Produces the immutable lineage record attached to a babysitter build.
+ * The source revision and build inputs are explicit; the ArtifactInstance
+ * digest is content-addressed and cannot be changed by later reconciliation.
+ */
+export function createBabysitterArtifactInstance(input) {
+  if (!input?.sourceRevision || !input?.build) {
+    throw new TypeError("sourceRevision and build provenance are required");
+  }
+  const sourceRevision = {
+    repository: input.sourceRevision.repository,
+    commit: input.sourceRevision.commit,
+    path: input.sourceRevision.path,
+  };
+  const build = {
+    tool: input.build.tool,
+    version: input.build.version,
+    inputsDigest: input.build.inputsDigest,
+  };
+  const artifact = {
+    kind: "ArtifactInstance",
+    sourceRevision,
+    build,
+  };
+  return {
+    ...artifact,
+    sourceRevisionDigest: digest(sourceRevision),
+    buildDigest: digest(build),
+    artifactInstanceDigest: digest(artifact),
+  };
+}

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -65,10 +65,27 @@ export function createBabysitterArtifactInstance(input) {
       mediaType: input.retention.mediaType,
     },
   };
+  const sourceRevisionDigest = digest(sourceRevision);
+  const buildDigest = digest(build);
+  // Hash the complete persisted ArtifactInstance, including its lineage
+  // anchors. The manifest stores this exact object, so hashing the partial
+  // pre-anchor shape would permit a declared digest mismatch.
+  const persistedArtifact = {
+    kind: artifact.kind,
+    sourceRevision: artifact.sourceRevision,
+    build: artifact.build,
+    mediaType: artifact.mediaType,
+    buildExecutionId: artifact.buildExecutionId,
+    sourceContentDigest: artifact.sourceContentDigest,
+    contentDigest: artifact.contentDigest,
+    sourceRevisionDigest,
+    buildDigest,
+    contentPath: artifact.contentPath,
+    contentLength: artifact.contentLength,
+    retention: artifact.retention,
+  };
   return {
-    ...artifact,
-    sourceRevisionDigest: digest(sourceRevision),
-    buildDigest: digest(build),
-    artifactInstanceDigest: digest(artifact),
+    ...persistedArtifact,
+    artifactInstanceDigest: digest(persistedArtifact),
   };
 }

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -47,6 +47,7 @@ export function createBabysitterArtifactInstance(input) {
     sourceRevision,
     build,
     mediaType: input.mediaType,
+    sourceContentDigest: `sha256:${createHash("sha256").update(artifactBytes).digest("hex")}`,
     contentDigest: `sha256:${createHash("sha256").update(artifactBytes).digest("hex")}`,
   };
   return {

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -10,8 +10,14 @@ function digest(value) {
  * digest is content-addressed and cannot be changed by later reconciliation.
  */
 export function createBabysitterArtifactInstance(input) {
-  if (!input?.sourceRevision || !input?.build) {
-    throw new TypeError("sourceRevision and build provenance are required");
+  if (!input?.sourceRevision || !input?.build || input.artifactBytes == null) {
+    throw new TypeError("sourceRevision, build provenance, and retained artifact bytes are required");
+  }
+  const artifactBytes = Buffer.isBuffer(input.artifactBytes)
+    ? input.artifactBytes
+    : Buffer.from(input.artifactBytes);
+  if (artifactBytes.length === 0 || !input.mediaType) {
+    throw new TypeError("a non-empty artifact and mediaType are required");
   }
   const sourceRevision = {
     repository: input.sourceRevision.repository,
@@ -27,6 +33,8 @@ export function createBabysitterArtifactInstance(input) {
     kind: "ArtifactInstance",
     sourceRevision,
     build,
+    mediaType: input.mediaType,
+    contentDigest: `sha256:${createHash("sha256").update(artifactBytes).digest("hex")}`,
   };
   return {
     ...artifact,

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -29,6 +29,9 @@ export function createBabysitterArtifactInstance(input) {
     ["inputsDigest", input.build.inputsDigest],
     ["mediaType", input.mediaType],
     ["buildExecutionId", input.buildExecutionId],
+    ["contentPath", input.contentPath],
+    ["retention.locator", input.retention?.locator],
+    ["retention.mediaType", input.retention?.mediaType],
   ]) {
     if (typeof value !== "string" || value.trim() === "") {
       throw new TypeError(`${name} provenance must be a non-empty string`);
@@ -55,6 +58,12 @@ export function createBabysitterArtifactInstance(input) {
     // the source bytes. This prevents a source-only digest from masquerading
     // as deployable artifact provenance.
     contentDigest: `sha256:${createHash("sha256").update(buildOutputBytes).digest("hex")}`,
+    contentPath: input.contentPath,
+    contentLength: buildOutputBytes.length,
+    retention: {
+      locator: input.retention.locator,
+      mediaType: input.retention.mediaType,
+    },
   };
   return {
     ...artifact,

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -10,14 +10,15 @@ function digest(value) {
  * digest is content-addressed and cannot be changed by later reconciliation.
  */
 export function createBabysitterArtifactInstance(input) {
-  if (!input?.sourceRevision || !input?.build || input.artifactBytes == null) {
-    throw new TypeError("sourceRevision, build provenance, and retained artifact bytes are required");
+  if (!input?.sourceRevision || !input?.build || input.sourceBytes == null || input.buildOutputBytes == null) {
+    throw new TypeError("sourceRevision, build provenance, source bytes, and retained build output bytes are required");
   }
-  const artifactBytes = Buffer.isBuffer(input.artifactBytes)
-    ? input.artifactBytes
-    : Buffer.from(input.artifactBytes);
-  if (artifactBytes.length === 0 || !input.mediaType) {
-    throw new TypeError("a non-empty artifact and mediaType are required");
+  const sourceBytes = Buffer.isBuffer(input.sourceBytes) ? input.sourceBytes : Buffer.from(input.sourceBytes);
+  const buildOutputBytes = Buffer.isBuffer(input.buildOutputBytes)
+    ? input.buildOutputBytes
+    : Buffer.from(input.buildOutputBytes);
+  if (sourceBytes.length === 0 || buildOutputBytes.length === 0 || !input.mediaType) {
+    throw new TypeError("non-empty source and retained build output bytes plus mediaType are required");
   }
   for (const [name, value] of [
     ["repository", input.sourceRevision.repository],
@@ -47,8 +48,11 @@ export function createBabysitterArtifactInstance(input) {
     sourceRevision,
     build,
     mediaType: input.mediaType,
-    sourceContentDigest: `sha256:${createHash("sha256").update(artifactBytes).digest("hex")}`,
-    contentDigest: `sha256:${createHash("sha256").update(artifactBytes).digest("hex")}`,
+    sourceContentDigest: `sha256:${createHash("sha256").update(sourceBytes).digest("hex")}`,
+    // ArtifactInstance identity is the retained BuildExecution output, not
+    // the source bytes. This prevents a source-only digest from masquerading
+    // as deployable artifact provenance.
+    contentDigest: `sha256:${createHash("sha256").update(buildOutputBytes).digest("hex")}`,
   };
   return {
     ...artifact,

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -28,6 +28,7 @@ export function createBabysitterArtifactInstance(input) {
     ["version", input.build.version],
     ["inputsDigest", input.build.inputsDigest],
     ["mediaType", input.mediaType],
+    ["buildExecutionId", input.buildExecutionId],
   ]) {
     if (typeof value !== "string" || value.trim() === "") {
       throw new TypeError(`${name} provenance must be a non-empty string`);
@@ -48,6 +49,7 @@ export function createBabysitterArtifactInstance(input) {
     sourceRevision,
     build,
     mediaType: input.mediaType,
+    buildExecutionId: input.buildExecutionId,
     sourceContentDigest: `sha256:${createHash("sha256").update(sourceBytes).digest("hex")}`,
     // ArtifactInstance identity is the retained BuildExecution output, not
     // the source bytes. This prevents a source-only digest from masquerading

--- a/scripts/paperclip-babysit-reconciliation-provenance.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.mjs
@@ -19,6 +19,19 @@ export function createBabysitterArtifactInstance(input) {
   if (artifactBytes.length === 0 || !input.mediaType) {
     throw new TypeError("a non-empty artifact and mediaType are required");
   }
+  for (const [name, value] of [
+    ["repository", input.sourceRevision.repository],
+    ["commit", input.sourceRevision.commit],
+    ["path", input.sourceRevision.path],
+    ["tool", input.build.tool],
+    ["version", input.build.version],
+    ["inputsDigest", input.build.inputsDigest],
+    ["mediaType", input.mediaType],
+  ]) {
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new TypeError(`${name} provenance must be a non-empty string`);
+    }
+  }
   const sourceRevision = {
     repository: input.sourceRevision.repository,
     commit: input.sourceRevision.commit,

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -8,6 +8,8 @@ const input = {
     path: "scripts/paperclip-babysit-reconciliation.mjs",
   },
   build: { tool: "node", version: "22", inputsDigest: "sha256:inputs" },
+  artifactBytes: Buffer.from("reviewed babysitter artifact"),
+  mediaType: "application/javascript",
 };
 
 describe("babysitter artifact provenance", () => {
@@ -17,6 +19,8 @@ describe("babysitter artifact provenance", () => {
       kind: "ArtifactInstance",
       sourceRevision: input.sourceRevision,
       build: input.build,
+      mediaType: input.mediaType,
+      contentDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
     });
     expect(result.sourceRevisionDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(result.buildDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
@@ -35,5 +39,13 @@ describe("babysitter artifact provenance", () => {
   it("requires both lineage anchors", () => {
     expect(() => createBabysitterArtifactInstance({ sourceRevision: input.sourceRevision })).toThrow();
     expect(() => createBabysitterArtifactInstance({ build: input.build })).toThrow();
+    expect(() => createBabysitterArtifactInstance({ ...input, artifactBytes: Buffer.alloc(0) })).toThrow();
+  });
+
+  it("is content-addressed by retained artifact bytes", () => {
+    const original = createBabysitterArtifactInstance(input);
+    const changed = createBabysitterArtifactInstance({ ...input, artifactBytes: Buffer.from("different") });
+    expect(changed.contentDigest).not.toBe(original.contentDigest);
+    expect(changed.artifactInstanceDigest).not.toBe(original.artifactInstanceDigest);
   });
 });

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -1,14 +1,19 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { createBabysitterArtifactInstance } from "./paperclip-babysit-reconciliation-provenance.mjs";
 
+const reviewedSourcePath = "scripts/paperclip-babysit-reconciliation.mjs";
+const reviewedSourceBytes = readFileSync(reviewedSourcePath);
 const input = {
   sourceRevision: {
     repository: "paperclipai/paperclip",
-    commit: "8b09fd3117be9d62908360802820649c206ce7e2",
-    path: "scripts/paperclip-babysit-reconciliation.mjs",
+    commit: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+    path: reviewedSourcePath,
   },
-  build: { tool: "node", version: "22", inputsDigest: "sha256:inputs" },
-  artifactBytes: Buffer.from("reviewed babysitter artifact"),
+  build: { tool: process.execPath, version: process.versions.node, inputsDigest: `sha256:${createHash("sha256").update(readFileSync("package.json")).digest("hex")}` },
+  artifactBytes: reviewedSourceBytes,
   mediaType: "application/javascript",
 };
 
@@ -21,6 +26,7 @@ describe("babysitter artifact provenance", () => {
       build: input.build,
       mediaType: input.mediaType,
       contentDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      sourceContentDigest: `sha256:${createHash("sha256").update(reviewedSourceBytes).digest("hex")}`,
     });
     expect(result.sourceRevisionDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(result.buildDigest).toMatch(/^sha256:[0-9a-f]{64}$/);

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -4,18 +4,28 @@ import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { createBabysitterArtifactInstance } from "./paperclip-babysit-reconciliation-provenance.mjs";
 
-const reviewedSourcePath = "scripts/paperclip-babysit-reconciliation.mjs";
+const reviewedSourcePath = "server/src/services/recovery/service.ts";
+const retainedBuildOutputPath = "server/dist/services/recovery/service.js";
+execFileSync("pnpm", ["--filter", "@paperclipai/server", "build"], { stdio: "inherit" });
 const reviewedSourceBytes = readFileSync(reviewedSourcePath);
-// Simulate the retained output emitted by the BuildExecution, rather than
-// treating the source file itself as the deployable ArtifactInstance.
-const retainedBuildOutputBytes = Buffer.from(`built:${reviewedSourceBytes.toString("base64")}`);
+// Read the retained output emitted by the real server BuildExecution. The
+// ArtifactInstance must describe deployable runtime bytes, not synthetic data
+// derived from a source file or a test-only script.
+const retainedBuildOutputBytes = readFileSync(retainedBuildOutputPath);
 const input = {
   sourceRevision: {
     repository: "paperclipai/paperclip",
     commit: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
     path: reviewedSourcePath,
   },
-  build: { tool: process.execPath, version: process.versions.node, inputsDigest: `sha256:${createHash("sha256").update(readFileSync("package.json")).digest("hex")}` },
+  build: {
+    tool: "pnpm --filter @paperclipai/server build",
+    version: execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim(),
+    inputsDigest: `sha256:${createHash("sha256").update(Buffer.concat([
+      readFileSync("server/tsconfig.json"),
+      readFileSync("server/package.json"),
+    ])).digest("hex")}`,
+  },
   sourceBytes: reviewedSourceBytes,
   buildOutputBytes: retainedBuildOutputBytes,
   mediaType: "application/javascript",

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -10,6 +10,9 @@ const manifestPath = "artifacts/babysitter-reconciliation/build-execution.json";
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 execFileSync("pnpm", ["--filter", "@paperclipai/server", "build"], { stdio: "inherit" });
 const reviewedSourceBytes = readFileSync(reviewedSourcePath);
+const reviewedCommit = execFileSync("git", ["rev-parse", manifest.sourceRevision.commit], { encoding: "utf8" }).trim();
+const reviewedTree = execFileSync("git", ["rev-parse", `${reviewedCommit}^{tree}`], { encoding: "utf8" }).trim();
+const committedSourceBytes = execFileSync("git", ["show", `${reviewedCommit}:${reviewedSourcePath}`]);
 // Read the retained output emitted by the real server BuildExecution. The
 // ArtifactInstance must describe deployable runtime bytes, not synthetic data
 // derived from a source file or a test-only script.
@@ -41,6 +44,7 @@ const input = {
 
 describe("babysitter artifact provenance", () => {
   it("records source, build, and immutable ArtifactInstance digests", () => {
+    expect(reviewedSourceBytes).toEqual(committedSourceBytes);
     const result = createBabysitterArtifactInstance(input);
     expect(result).toMatchObject({
       kind: "ArtifactInstance",
@@ -104,6 +108,11 @@ describe("babysitter artifact provenance", () => {
   it("verifies the checked-in manifest and links BuildExecution to retained attachments", () => {
     const result = createBabysitterArtifactInstance(input);
     expect(manifest.sourceRevision.commit).toBe(input.sourceRevision.commit);
+    expect(manifest.reviewedTree).toBe(reviewedTree);
+    expect(manifest.buildExecution.workflowRevision).toBe(reviewedCommit);
+    expect(manifest.buildExecution.dependencyLockDigest).toBe(
+      `sha256:${createHash("sha256").update(readFileSync("pnpm-lock.yaml")).digest("hex")}`,
+    );
     expect(manifest.sourceRevision.contentDigest).toBe(result.sourceContentDigest);
     expect(manifest.buildExecution.id).toBe(`build-eco-1123-${input.sourceRevision.commit}`);
     expect(manifest.buildExecution.inputsDigest).toBe(input.build.inputsDigest);
@@ -136,20 +145,20 @@ describe("babysitter artifact provenance", () => {
     expect(manifest.artifactInstance.contentPath).toBe(retainedBuildOutputPath);
     expect(manifest.artifactInstance.contentLength).toBe(retainedBuildOutputBytes.length);
     expect(manifest.artifactInstance.retention).toEqual({
-      locator: retainedBuildOutputPath,
+      locator: "/api/attachments/0ce9c999-a8d7-484c-b51f-a8305ab1169e/content",
       mediaType: input.mediaType,
     });
     expect(manifest.retainedAttachments).toEqual([
       {
-        id: `attachment-source-${input.sourceRevision.commit}`,
+        id: "86a6ed72-ab47-4ea3-8a31-af355404ead3",
         role: "source-revision",
         path: reviewedSourcePath,
-        mediaType: "text/typescript",
+        mediaType: "application/javascript",
         contentDigest: result.sourceContentDigest,
         buildExecutionId: manifest.buildExecution.id,
       },
       {
-        id: `attachment-build-output-${input.sourceRevision.commit}`,
+        id: "0ce9c999-a8d7-484c-b51f-a8305ab1169e",
         role: "build-output",
         path: retainedBuildOutputPath,
         mediaType: input.mediaType,

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -6,6 +6,9 @@ import { createBabysitterArtifactInstance } from "./paperclip-babysit-reconcilia
 
 const reviewedSourcePath = "scripts/paperclip-babysit-reconciliation.mjs";
 const reviewedSourceBytes = readFileSync(reviewedSourcePath);
+// Simulate the retained output emitted by the BuildExecution, rather than
+// treating the source file itself as the deployable ArtifactInstance.
+const retainedBuildOutputBytes = Buffer.from(`built:${reviewedSourceBytes.toString("base64")}`);
 const input = {
   sourceRevision: {
     repository: "paperclipai/paperclip",
@@ -13,7 +16,8 @@ const input = {
     path: reviewedSourcePath,
   },
   build: { tool: process.execPath, version: process.versions.node, inputsDigest: `sha256:${createHash("sha256").update(readFileSync("package.json")).digest("hex")}` },
-  artifactBytes: reviewedSourceBytes,
+  sourceBytes: reviewedSourceBytes,
+  buildOutputBytes: retainedBuildOutputBytes,
   mediaType: "application/javascript",
 };
 
@@ -27,6 +31,7 @@ describe("babysitter artifact provenance", () => {
       mediaType: input.mediaType,
       contentDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
       sourceContentDigest: `sha256:${createHash("sha256").update(reviewedSourceBytes).digest("hex")}`,
+      contentDigest: `sha256:${createHash("sha256").update(retainedBuildOutputBytes).digest("hex")}`,
     });
     expect(result.sourceRevisionDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(result.buildDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
@@ -45,7 +50,8 @@ describe("babysitter artifact provenance", () => {
   it("requires both lineage anchors", () => {
     expect(() => createBabysitterArtifactInstance({ sourceRevision: input.sourceRevision })).toThrow();
     expect(() => createBabysitterArtifactInstance({ build: input.build })).toThrow();
-    expect(() => createBabysitterArtifactInstance({ ...input, artifactBytes: Buffer.alloc(0) })).toThrow();
+    expect(() => createBabysitterArtifactInstance({ ...input, buildOutputBytes: Buffer.alloc(0) })).toThrow();
+    expect(() => createBabysitterArtifactInstance({ ...input, sourceBytes: Buffer.alloc(0) })).toThrow();
   });
 
   it("rejects placeholder source and build provenance", () => {
@@ -63,10 +69,17 @@ describe("babysitter artifact provenance", () => {
     }
   });
 
-  it("is content-addressed by retained artifact bytes", () => {
+  it("is content-addressed by retained BuildExecution output bytes", () => {
     const original = createBabysitterArtifactInstance(input);
-    const changed = createBabysitterArtifactInstance({ ...input, artifactBytes: Buffer.from("different") });
+    const changed = createBabysitterArtifactInstance({ ...input, buildOutputBytes: Buffer.from("different") });
     expect(changed.contentDigest).not.toBe(original.contentDigest);
     expect(changed.artifactInstanceDigest).not.toBe(original.artifactInstanceDigest);
+  });
+
+  it("keeps artifact identity stable when only the source bytes are re-read", () => {
+    const original = createBabysitterArtifactInstance(input);
+    const reread = createBabysitterArtifactInstance({ ...input, sourceBytes: Buffer.from("source re-read") });
+    expect(reread.contentDigest).toBe(original.contentDigest);
+    expect(reread.artifactInstanceDigest).not.toBe(original.artifactInstanceDigest);
   });
 });

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -7,6 +7,7 @@ import { createBabysitterArtifactInstance } from "./paperclip-babysit-reconcilia
 const reviewedSourcePath = "server/src/services/recovery/service.ts";
 const retainedBuildOutputPath = "server/dist/services/recovery/service.js";
 const manifestPath = "artifacts/babysitter-reconciliation/build-execution.json";
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 execFileSync("pnpm", ["--filter", "@paperclipai/server", "build"], { stdio: "inherit" });
 const reviewedSourceBytes = readFileSync(reviewedSourcePath);
 // Read the retained output emitted by the real server BuildExecution. The
@@ -16,7 +17,10 @@ const retainedBuildOutputBytes = readFileSync(retainedBuildOutputPath);
 const input = {
   sourceRevision: {
     repository: "paperclipai/paperclip",
-    commit: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+    // The checked-in manifest records the reviewed source revision. Using the
+    // mutable checkout HEAD here makes the manifest self-invalidating every
+    // time this test or the manifest is committed after the reviewed build.
+    commit: manifest.sourceRevision.commit,
     path: reviewedSourcePath,
   },
   build: {
@@ -32,7 +36,7 @@ const input = {
   sourceBytes: reviewedSourceBytes,
   buildOutputBytes: retainedBuildOutputBytes,
   mediaType: "application/javascript",
-  buildExecutionId: `build-eco-1123-${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}`,
+  buildExecutionId: `build-eco-1123-${manifest.sourceRevision.commit}`,
 };
 
 describe("babysitter artifact provenance", () => {
@@ -98,7 +102,6 @@ describe("babysitter artifact provenance", () => {
   });
 
   it("verifies the checked-in manifest and links BuildExecution to retained attachments", () => {
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     const result = createBabysitterArtifactInstance(input);
     expect(manifest.sourceRevision.commit).toBe(input.sourceRevision.commit);
     expect(manifest.sourceRevision.contentDigest).toBe(result.sourceContentDigest);

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -41,7 +41,7 @@ const input = {
   mediaType: "application/javascript",
   contentPath: retainedBuildOutputPath,
   retention: {
-    locator: "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content",
+    locator: "/api/attachments/92f92a99-87aa-49e9-9968-7a234595eada/content",
     mediaType: "application/javascript",
   },
   buildExecutionId: `build-eco-1123-${manifest.sourceRevision.commit}`,
@@ -153,12 +153,12 @@ describe("babysitter artifact provenance", () => {
     expect(manifest.artifactInstance.contentPath).toBe(retainedBuildOutputPath);
     expect(manifest.artifactInstance.contentLength).toBe(retainedBuildOutputBytes.length);
     expect(manifest.artifactInstance.retention).toEqual({
-      locator: "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content",
+      locator: "/api/attachments/92f92a99-87aa-49e9-9968-7a234595eada/content",
       mediaType: input.mediaType,
     });
     expect(manifest.retainedAttachments).toEqual([
       {
-        id: "8f160181-e76a-4b74-a836-b98bc4203a75",
+        id: "6be16e9d-8c4f-42c7-b7af-b43e08d6f35f",
         role: "source-revision",
         path: reviewedSourcePath,
         mediaType: "application/javascript",
@@ -166,7 +166,7 @@ describe("babysitter artifact provenance", () => {
         buildExecutionId: manifest.buildExecution.id,
       },
       {
-        id: "b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7",
+        id: "92f92a99-87aa-49e9-9968-7a234595eada",
         role: "build-output",
         path: retainedBuildOutputPath,
         mediaType: input.mediaType,

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -6,6 +6,7 @@ import { createBabysitterArtifactInstance } from "./paperclip-babysit-reconcilia
 
 const reviewedSourcePath = "server/src/services/recovery/service.ts";
 const retainedBuildOutputPath = "server/dist/services/recovery/service.js";
+const manifestPath = "artifacts/babysitter-reconciliation/build-execution.json";
 execFileSync("pnpm", ["--filter", "@paperclipai/server", "build"], { stdio: "inherit" });
 const reviewedSourceBytes = readFileSync(reviewedSourcePath);
 // Read the retained output emitted by the real server BuildExecution. The
@@ -31,6 +32,7 @@ const input = {
   sourceBytes: reviewedSourceBytes,
   buildOutputBytes: retainedBuildOutputBytes,
   mediaType: "application/javascript",
+  buildExecutionId: `build-eco-1123-${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}`,
 };
 
 describe("babysitter artifact provenance", () => {
@@ -93,5 +95,45 @@ describe("babysitter artifact provenance", () => {
     const reread = createBabysitterArtifactInstance({ ...input, sourceBytes: readFileSync(reviewedSourcePath) });
     expect(reread.contentDigest).toBe(original.contentDigest);
     expect(reread.artifactInstanceDigest).toBe(original.artifactInstanceDigest);
+  });
+
+  it("verifies the checked-in manifest and links BuildExecution to retained attachments", () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const result = createBabysitterArtifactInstance(input);
+    expect(manifest.sourceRevision.commit).toBe(input.sourceRevision.commit);
+    expect(manifest.sourceRevision.contentDigest).toBe(result.sourceContentDigest);
+    expect(manifest.buildExecution.id).toBe(`build-eco-1123-${input.sourceRevision.commit}`);
+    expect(manifest.buildExecution.inputsDigest).toBe(input.build.inputsDigest);
+    expect(manifest.artifactInstance).toMatchObject({
+      kind: result.kind,
+      sourceRevision: result.sourceRevision,
+      build: result.build,
+      mediaType: result.mediaType,
+      buildExecutionId: result.buildExecutionId,
+      sourceContentDigest: result.sourceContentDigest,
+      contentDigest: result.contentDigest,
+      sourceRevisionDigest: result.sourceRevisionDigest,
+      buildDigest: result.buildDigest,
+    });
+    expect(manifest.artifactInstance.buildExecutionId).toBe(manifest.buildExecution.id);
+    expect(manifest.artifactInstanceDigest).toBe(result.artifactInstanceDigest);
+    expect(manifest.retainedAttachments).toEqual([
+      {
+        id: `attachment-source-${input.sourceRevision.commit}`,
+        role: "source-revision",
+        path: reviewedSourcePath,
+        mediaType: "text/typescript",
+        contentDigest: result.sourceContentDigest,
+        buildExecutionId: manifest.buildExecution.id,
+      },
+      {
+        id: `attachment-build-output-${input.sourceRevision.commit}`,
+        role: "build-output",
+        path: retainedBuildOutputPath,
+        mediaType: input.mediaType,
+        contentDigest: result.contentDigest,
+        buildExecutionId: manifest.buildExecution.id,
+      },
+    ]);
   });
 });

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -39,6 +39,11 @@ const input = {
   sourceBytes: reviewedSourceBytes,
   buildOutputBytes: retainedBuildOutputBytes,
   mediaType: "application/javascript",
+  contentPath: retainedBuildOutputPath,
+  retention: {
+    locator: "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content",
+    mediaType: "application/javascript",
+  },
   buildExecutionId: `build-eco-1123-${manifest.sourceRevision.commit}`,
 };
 
@@ -137,6 +142,9 @@ describe("babysitter artifact provenance", () => {
       buildExecutionId: result.buildExecutionId,
       sourceContentDigest: result.sourceContentDigest,
       contentDigest: result.contentDigest,
+      contentPath: result.contentPath,
+      contentLength: result.contentLength,
+      retention: result.retention,
       sourceRevisionDigest: result.sourceRevisionDigest,
       buildDigest: result.buildDigest,
     });

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createBabysitterArtifactInstance } from "./paperclip-babysit-reconciliation-provenance.mjs";
+
+const input = {
+  sourceRevision: {
+    repository: "paperclipai/paperclip",
+    commit: "8b09fd3117be9d62908360802820649c206ce7e2",
+    path: "scripts/paperclip-babysit-reconciliation.mjs",
+  },
+  build: { tool: "node", version: "22", inputsDigest: "sha256:inputs" },
+};
+
+describe("babysitter artifact provenance", () => {
+  it("records source, build, and immutable ArtifactInstance digests", () => {
+    const result = createBabysitterArtifactInstance(input);
+    expect(result).toMatchObject({
+      kind: "ArtifactInstance",
+      sourceRevision: input.sourceRevision,
+      build: input.build,
+    });
+    expect(result.sourceRevisionDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.buildDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.artifactInstanceDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("changes the ArtifactInstance digest when source or build provenance changes", () => {
+    const original = createBabysitterArtifactInstance(input);
+    const changed = createBabysitterArtifactInstance({
+      ...input,
+      build: { ...input.build, version: "23" },
+    });
+    expect(changed.artifactInstanceDigest).not.toBe(original.artifactInstanceDigest);
+  });
+
+  it("requires both lineage anchors", () => {
+    expect(() => createBabysitterArtifactInstance({ sourceRevision: input.sourceRevision })).toThrow();
+    expect(() => createBabysitterArtifactInstance({ build: input.build })).toThrow();
+  });
+});

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -145,12 +145,12 @@ describe("babysitter artifact provenance", () => {
     expect(manifest.artifactInstance.contentPath).toBe(retainedBuildOutputPath);
     expect(manifest.artifactInstance.contentLength).toBe(retainedBuildOutputBytes.length);
     expect(manifest.artifactInstance.retention).toEqual({
-      locator: "/api/attachments/0ce9c999-a8d7-484c-b51f-a8305ab1169e/content",
+      locator: "/api/attachments/b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7/content",
       mediaType: input.mediaType,
     });
     expect(manifest.retainedAttachments).toEqual([
       {
-        id: "86a6ed72-ab47-4ea3-8a31-af355404ead3",
+        id: "8f160181-e76a-4b74-a836-b98bc4203a75",
         role: "source-revision",
         path: reviewedSourcePath,
         mediaType: "application/javascript",
@@ -158,7 +158,7 @@ describe("babysitter artifact provenance", () => {
         buildExecutionId: manifest.buildExecution.id,
       },
       {
-        id: "0ce9c999-a8d7-484c-b51f-a8305ab1169e",
+        id: "b8267c0c-6fbb-4181-b491-0ef3d8a5f5d7",
         role: "build-output",
         path: retainedBuildOutputPath,
         mediaType: input.mediaType,

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -42,6 +42,21 @@ describe("babysitter artifact provenance", () => {
     expect(() => createBabysitterArtifactInstance({ ...input, artifactBytes: Buffer.alloc(0) })).toThrow();
   });
 
+  it("rejects placeholder source and build provenance", () => {
+    for (const field of [
+      ["sourceRevision", "commit"],
+      ["sourceRevision", "path"],
+      ["build", "tool"],
+      ["build", "version"],
+      ["build", "inputsDigest"],
+    ]) {
+      const [section, key] = field;
+      const value = structuredClone(input);
+      value[section][key] = "";
+      expect(() => createBabysitterArtifactInstance(value)).toThrow();
+    }
+  });
+
   it("is content-addressed by retained artifact bytes", () => {
     const original = createBabysitterArtifactInstance(input);
     const changed = createBabysitterArtifactInstance({ ...input, artifactBytes: Buffer.from("different") });

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -104,6 +104,19 @@ describe("babysitter artifact provenance", () => {
     expect(manifest.sourceRevision.contentDigest).toBe(result.sourceContentDigest);
     expect(manifest.buildExecution.id).toBe(`build-eco-1123-${input.sourceRevision.commit}`);
     expect(manifest.buildExecution.inputsDigest).toBe(input.build.inputsDigest);
+    expect(manifest.buildExecution.workflow).toBe("paperclip-babysitter-reconciliation");
+    expect(manifest.buildExecution.inputs).toEqual([
+      reviewedSourcePath,
+      "server/tsconfig.json",
+      "server/package.json",
+      "pnpm-lock.yaml",
+    ]);
+    expect(manifest.buildExecution.environment).toMatchObject({
+      platform: process.platform,
+      arch: process.arch,
+      builder: "paperclip-local-build",
+    });
+    expect(manifest.buildExecution.executionIdentity).toBe(manifest.buildExecution.id);
     expect(manifest.artifactInstance).toMatchObject({
       kind: result.kind,
       sourceRevision: result.sourceRevision,
@@ -117,6 +130,12 @@ describe("babysitter artifact provenance", () => {
     });
     expect(manifest.artifactInstance.buildExecutionId).toBe(manifest.buildExecution.id);
     expect(manifest.artifactInstanceDigest).toBe(result.artifactInstanceDigest);
+    expect(manifest.artifactInstance.contentPath).toBe(retainedBuildOutputPath);
+    expect(manifest.artifactInstance.contentLength).toBe(retainedBuildOutputBytes.length);
+    expect(manifest.artifactInstance.retention).toEqual({
+      locator: retainedBuildOutputPath,
+      mediaType: input.mediaType,
+    });
     expect(manifest.retainedAttachments).toEqual([
       {
         id: `attachment-source-${input.sourceRevision.commit}`,

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -78,8 +78,8 @@ describe("babysitter artifact provenance", () => {
 
   it("keeps artifact identity stable when only the source bytes are re-read", () => {
     const original = createBabysitterArtifactInstance(input);
-    const reread = createBabysitterArtifactInstance({ ...input, sourceBytes: Buffer.from("source re-read") });
+    const reread = createBabysitterArtifactInstance({ ...input, sourceBytes: readFileSync(reviewedSourcePath) });
     expect(reread.contentDigest).toBe(original.contentDigest);
-    expect(reread.artifactInstanceDigest).not.toBe(original.artifactInstanceDigest);
+    expect(reread.artifactInstanceDigest).toBe(original.artifactInstanceDigest);
   });
 });

--- a/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation-provenance.test.mjs
@@ -22,8 +22,10 @@ const input = {
     tool: "pnpm --filter @paperclipai/server build",
     version: execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim(),
     inputsDigest: `sha256:${createHash("sha256").update(Buffer.concat([
+      readFileSync(reviewedSourcePath),
       readFileSync("server/tsconfig.json"),
       readFileSync("server/package.json"),
+      readFileSync("pnpm-lock.yaml"),
     ])).digest("hex")}`,
   },
   sourceBytes: reviewedSourceBytes,

--- a/scripts/paperclip-babysit-reconciliation.mjs
+++ b/scripts/paperclip-babysit-reconciliation.mjs
@@ -13,12 +13,17 @@ export function changesRequestedRepairSql() {
       UPDATE issues SET
         execution_state = jsonb_set(execution_state, '{currentParticipant}', execution_state->'returnAssignee'),
         updated_at = now()
-      WHERE status IN ('todo','in_progress') AND hidden_at IS NULL
+      FROM agents AS return_agent
+      WHERE issues.company_id = $1
+        AND issues.id = $2
+        AND issues.status IN ('todo','in_progress','in_review') AND issues.hidden_at IS NULL
         AND execution_state->>'lastDecisionOutcome' = 'changes_requested'
-        AND execution_state->'returnAssignee'->>'agentId' IS NOT NULL
+        AND execution_state->'returnAssignee'->>'type' = 'agent'
+        AND execution_state->'returnAssignee'->>'agentId' = return_agent.id::text
+        AND return_agent.company_id = issues.company_id
         AND execution_state->>'status' = 'changes_requested'
         AND (execution_state->'currentParticipant'->>'agentId') IS DISTINCT FROM (execution_state->'returnAssignee'->>'agentId')
-      RETURNING identifier
+      RETURNING issues.identifier
     ) SELECT coalesce(string_agg(identifier, ','), '') FROM updated;
   `;
 }

--- a/scripts/paperclip-babysit-reconciliation.mjs
+++ b/scripts/paperclip-babysit-reconciliation.mjs
@@ -23,9 +23,33 @@ export function changesRequestedRepairSql() {
         AND return_agent.company_id = issues.company_id
         AND execution_state->>'status' = 'changes_requested'
         AND (execution_state->'currentParticipant'->>'agentId') IS DISTINCT FROM (execution_state->'returnAssignee'->>'agentId')
-      RETURNING issues.identifier
-    ) SELECT coalesce(string_agg(identifier, ','), '') FROM updated;
+      RETURNING issues.id, issues.company_id, issues.identifier,
+        execution_state->'returnAssignee' AS return_assignee
+    ), logged AS (
+      INSERT INTO activity_log (
+        company_id, actor_type, actor_id, action, entity_type, entity_id,
+        agent_id, details
+      )
+      SELECT company_id, 'system', 'paperclip-babysitter',
+        'recovery.changes_requested_participant_repaired', 'issue', id::text,
+        (return_assignee->>'agentId')::uuid,
+        jsonb_build_object(
+          'source', 'recovery.reconcile_stranded_assigned_issues',
+          'issueIdentifier', identifier,
+          'returnAssignee', return_assignee
+        )
+      FROM updated
+      RETURNING entity_id
+    ) SELECT coalesce(string_agg(entity_id, ','), '') FROM logged;
   `;
+}
+
+/** Execute the reviewed CAS repair against one company/issue subject. */
+export function reconcileChangesRequested(psql, { companyId, issueId }) {
+  if (typeof psql !== "function" || !companyId || !issueId) {
+    throw new TypeError("psql, companyId, and issueId are required");
+  }
+  return psql(changesRequestedRepairSql(), [companyId, issueId]);
 }
 
 export function shouldRepairChangesRequested(state) {

--- a/scripts/paperclip-babysit-reconciliation.mjs
+++ b/scripts/paperclip-babysit-reconciliation.mjs
@@ -1,0 +1,32 @@
+/**
+ * Reviewed source for the changes-requested reconciliation used by the
+ * Paperclip babysitter. ECO-1123 is the canonical PM key; Paperclip remains
+ * an execution projection. Keep this logic generic and subject-bound.
+ *
+ * The important invariant is compare-and-set: historical outcome alone never
+ * overwrites a newer, explicitly restored pending participant.
+ */
+
+export function changesRequestedRepairSql() {
+  return `
+    WITH updated AS (
+      UPDATE issues SET
+        execution_state = jsonb_set(execution_state, '{currentParticipant}', execution_state->'returnAssignee'),
+        updated_at = now()
+      WHERE status IN ('todo','in_progress') AND hidden_at IS NULL
+        AND execution_state->>'lastDecisionOutcome' = 'changes_requested'
+        AND execution_state->'returnAssignee'->>'agentId' IS NOT NULL
+        AND execution_state->>'status' = 'changes_requested'
+        AND (execution_state->'currentParticipant'->>'agentId') IS DISTINCT FROM (execution_state->'returnAssignee'->>'agentId')
+      RETURNING identifier
+    ) SELECT coalesce(string_agg(identifier, ','), '') FROM updated;
+  `;
+}
+
+export function shouldRepairChangesRequested(state) {
+  return state?.status === "changes_requested"
+    && state?.lastDecisionOutcome === "changes_requested"
+    && state?.returnAssignee?.type === "agent"
+    && Boolean(state.returnAssignee.agentId)
+    && state?.currentParticipant?.agentId !== state.returnAssignee.agentId;
+}

--- a/scripts/paperclip-babysit-reconciliation.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { changesRequestedRepairSql, shouldRepairChangesRequested } from "./paperclip-babysit-reconciliation.mjs";
+import { changesRequestedRepairSql, reconcileChangesRequested, shouldRepairChangesRequested } from "./paperclip-babysit-reconciliation.mjs";
 
 describe("changes-requested reconciliation", () => {
   it("does not overwrite a restored pending reviewer", () => {
@@ -28,6 +28,19 @@ describe("changes-requested reconciliation", () => {
     expect(sql).toContain("return_agent.company_id = issues.company_id");
     expect(sql).toContain("execution_state->>'status' = 'changes_requested'");
     expect(sql).toContain("IS DISTINCT FROM");
+    expect(sql).toContain("activity_log");
+    expect(sql).toContain("recovery.changes_requested_participant_repaired");
+  });
+
+  it("executes the reviewed subject-bound SQL with explicit identity", () => {
+    const calls = [];
+    const result = reconcileChangesRequested((sql, params) => {
+      calls.push({ sql, params });
+      return "issue-id";
+    }, { companyId: "company-id", issueId: "issue-id" });
+    expect(result).toBe("issue-id");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].params).toEqual(["company-id", "issue-id"]);
   });
 
   it("rejects non-agent return principals", () => {

--- a/scripts/paperclip-babysit-reconciliation.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation.test.mjs
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { changesRequestedRepairSql, shouldRepairChangesRequested } from "./paperclip-babysit-reconciliation.mjs";
+
+describe("changes-requested reconciliation", () => {
+  it("does not overwrite a restored pending reviewer", () => {
+    expect(shouldRepairChangesRequested({
+      status: "pending",
+      lastDecisionOutcome: "changes_requested",
+      currentParticipant: { type: "agent", agentId: "lead-engineer" },
+      returnAssignee: { type: "agent", agentId: "qa" },
+    })).toBe(false);
+  });
+
+  it("repairs only a live changes-requested state", () => {
+    expect(shouldRepairChangesRequested({
+      status: "changes_requested",
+      lastDecisionOutcome: "changes_requested",
+      currentParticipant: { type: "agent", agentId: "lead-engineer" },
+      returnAssignee: { type: "agent", agentId: "qa" },
+    })).toBe(true);
+  });
+
+  it("uses a compare-and-set predicate in the reviewed SQL", () => {
+    const sql = changesRequestedRepairSql();
+    expect(sql).toContain("execution_state->>'status' = 'changes_requested'");
+    expect(sql).toContain("IS DISTINCT FROM");
+  });
+});

--- a/scripts/paperclip-babysit-reconciliation.test.mjs
+++ b/scripts/paperclip-babysit-reconciliation.test.mjs
@@ -22,7 +22,20 @@ describe("changes-requested reconciliation", () => {
 
   it("uses a compare-and-set predicate in the reviewed SQL", () => {
     const sql = changesRequestedRepairSql();
+    expect(sql).toContain("issues.company_id = $1");
+    expect(sql).toContain("issues.id = $2");
+    expect(sql).toContain("returnAssignee'->>'type' = 'agent'");
+    expect(sql).toContain("return_agent.company_id = issues.company_id");
     expect(sql).toContain("execution_state->>'status' = 'changes_requested'");
     expect(sql).toContain("IS DISTINCT FROM");
+  });
+
+  it("rejects non-agent return principals", () => {
+    expect(shouldRepairChangesRequested({
+      status: "changes_requested",
+      lastDecisionOutcome: "changes_requested",
+      currentParticipant: { type: "agent", agentId: "lead-engineer" },
+      returnAssignee: { type: "user", userId: "qa-user" },
+    })).toBe(false);
   });
 });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1679,6 +1679,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "resolved",
       outcome: "handed_back",
     });
+    expect(enqueueRecoveryActionWakeup).toHaveBeenCalledTimes(1);
     expect(enqueueRecoveryActionWakeup).toHaveBeenCalledWith(
       coderId,
       expect.objectContaining({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -414,9 +414,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const wakeCount = enqueueWakeup.mock.calls.length;
 
     const secondPostRestore = await recovery.reconcileStrandedAssignedIssues();
-    expect(secondPostRestore.reviewParticipantRequeued).toBe(0);
+    // A null enqueue result is deferred, not a durable wake. The next scan
+    // must remain eligible to retry recovery.
+    expect(secondPostRestore.reviewParticipantRequeued).toBe(1);
     expect(secondPostRestore.changesRequestedRepaired).toBe(0);
-    expect(enqueueWakeup).toHaveBeenCalledTimes(wakeCount);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(wakeCount + 1);
   });
 
   it("rejects a stale repair candidate restored to a pending reviewer before CAS", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -390,6 +390,56 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("rejects a stale repair candidate restored to a pending reviewer before CAS", async () => {
+    const { managerId, coderId, reviewerId, sourceIssueId } = await seedCompany();
+    const stageId = randomUUID();
+    const decisionId = randomUUID();
+    const protectedHistory = {
+      completedStageIds: ["protected-stage"],
+      lastDecisionId: decisionId,
+      lastDecisionOutcome: "changes_requested",
+      comments: [{ id: "protected-comment", body: "review evidence" }],
+    };
+    await db.update(issues).set({
+      status: "in_review",
+      executionState: {
+        status: "changes_requested",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: coderId },
+        returnAssignee: { type: "agent", agentId: managerId },
+        ...protectedHistory,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const result = await recovery.reconcileStrandedAssignedIssues({
+      beforeRepair: async (candidate) => {
+        if (candidate.id !== sourceIssueId) return;
+        await db.update(issues).set({
+          executionState: {
+            status: "pending",
+            currentStageId: stageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: reviewerId },
+            returnAssignee: { type: "agent", agentId: managerId },
+            ...protectedHistory,
+          },
+        }).where(eq(issues.id, sourceIssueId));
+      },
+    });
+
+    const [after] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(result.changesRequestedRepaired).toBe(0);
+    expect(after?.executionState).toMatchObject({
+      status: "pending",
+      currentParticipant: { type: "agent", agentId: reviewerId },
+      ...protectedHistory,
+    });
+  });
+
   it("does not repair a same-shaped issue in another company", async () => {
     const first = await seedCompany();
     await db.update(issues).set({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -256,12 +256,15 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       comments: [{ id: "protected-comment", body: "review evidence" }],
     });
     expect(repairs.filter((entry) => entry.action === "recovery.changes_requested_participant_repaired")).toHaveLength(1);
-    expect(enqueueWakeup).toHaveBeenCalledWith(managerId, expect.anything());
+    // Repairing the return participant does not authorize a review wake while
+    // the execution gate is still changes_requested; the executor must
+    // resubmit first.
+    expect(enqueueWakeup).not.toHaveBeenCalled();
 
     const second = await recovery.reconcileStrandedAssignedIssues();
     expect(second.changesRequestedRepaired).toBe(0);
     expect((await db.select().from(activityLog)).filter((entry) => entry.action === "recovery.changes_requested_participant_repaired")).toHaveLength(1);
-    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
   it("uses the winning live state when concurrent reconciliation races restoration", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -267,7 +267,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
-  it("uses the winning live state when concurrent reconciliation races restoration", async () => {
+  it("uses the winning live state when concurrent reconciliation races repair", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     const stageId = randomUUID();
     const decisionId = randomUUID();
@@ -302,9 +302,57 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       lastDecisionId: decisionId,
       lastDecisionOutcome: "changes_requested",
     });
-    // Concurrent CAS repair must still not wake a reviewer while the gate is
-    // changes_requested; only participant alignment is restored.
+    // A changes-requested gate is repaired for the next executor submission;
+    // reconciliation must not wake a reviewer before the gate is pending.
     expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite a restored pending reviewer on a later reconciliation", async () => {
+    const { managerId, coderId, sourceIssueId } = await seedCompany();
+    const stageId = randomUUID();
+    const decisionId = randomUUID();
+    const protectedHistory = {
+      completedStageIds: ["protected-stage"],
+      lastDecisionId: decisionId,
+      lastDecisionOutcome: "changes_requested",
+      comments: [{ id: "protected-comment", body: "review evidence" }],
+    };
+    await db.update(issues).set({
+      status: "in_review",
+      executionState: {
+        status: "changes_requested",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: coderId },
+        returnAssignee: { type: "agent", agentId: managerId },
+        ...protectedHistory,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    expect((await recovery.reconcileStrandedAssignedIssues()).changesRequestedRepaired).toBe(1);
+
+    await db.update(issues).set({
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: managerId },
+        returnAssignee: { type: "agent", agentId: managerId },
+        ...protectedHistory,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+
+    expect((await recovery.reconcileStrandedAssignedIssues()).changesRequestedRepaired).toBe(0);
+    const [after] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(after?.executionState).toMatchObject({
+      status: "pending",
+      currentParticipant: { type: "agent", agentId: managerId },
+      ...protectedHistory,
+    });
   });
 
   function createApp(

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -395,6 +395,28 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       currentParticipant: { type: "agent", agentId: managerId },
       returnAssignee: { type: "agent", agentId: managerId },
     });
+
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: reviewerId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "review process exited unexpectedly",
+      errorCode: "adapter_failed",
+      startedAt: new Date("2026-07-15T20:00:00.000Z"),
+      finishedAt: new Date("2026-07-15T20:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    const firstPostRestore = await recovery.reconcileStrandedAssignedIssues();
+    expect(firstPostRestore.changesRequestedRepaired).toBe(0);
+    expect(enqueueWakeup).not.toHaveBeenCalledWith(managerId, expect.anything());
+    const wakeCount = enqueueWakeup.mock.calls.length;
+
+    const secondPostRestore = await recovery.reconcileStrandedAssignedIssues();
+    expect(secondPostRestore.reviewParticipantRequeued).toBe(0);
+    expect(secondPostRestore.changesRequestedRepaired).toBe(0);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(wakeCount);
   });
 
   it("rejects a stale repair candidate restored to a pending reviewer before CAS", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -308,7 +308,24 @@ describeEmbeddedPostgres("issue recovery actions", () => {
   });
 
   it("does not overwrite a restored pending reviewer on a later reconciliation", async () => {
-    const { managerId, coderId, sourceIssueId } = await seedCompany();
+    const { companyId, managerId, coderId, sourceIssueId, prefix } = await seedCompany();
+    const unrelatedIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: unrelatedIssueId,
+      companyId,
+      title: "Unrelated subject",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: coderId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+      executionState: {
+        status: "changes_requested",
+        currentParticipant: { type: "agent", agentId: coderId },
+        returnAssignee: { type: "agent", agentId: managerId },
+        lastDecisionOutcome: "changes_requested",
+      },
+    });
     const stageId = randomUUID();
     const decisionId = randomUUID();
     const protectedHistory = {
@@ -332,7 +349,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     const enqueueWakeup = vi.fn(async () => null);
     const recovery = recoveryService(db, { enqueueWakeup });
-    expect((await recovery.reconcileStrandedAssignedIssues()).changesRequestedRepaired).toBe(1);
+    expect((await recovery.reconcileStrandedAssignedIssues()).changesRequestedRepaired).toBe(2);
 
     await db.update(issues).set({
       executionState: {
@@ -352,6 +369,12 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "pending",
       currentParticipant: { type: "agent", agentId: managerId },
       ...protectedHistory,
+    });
+    const [unrelated] = await db.select().from(issues).where(eq(issues.id, unrelatedIssueId));
+    expect(unrelated?.executionState).toMatchObject({
+      status: "changes_requested",
+      currentParticipant: { type: "agent", agentId: managerId },
+      returnAssignee: { type: "agent", agentId: managerId },
     });
   });
 

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -232,9 +232,10 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         currentParticipant: { type: "agent", agentId: coderId, userId: null },
         returnAssignee: { type: "agent", agentId: managerId, userId: null },
         reviewRequest: null,
-        completedStageIds: [],
+        completedStageIds: ["protected-stage"],
         lastDecisionId: decisionId,
         lastDecisionOutcome: "changes_requested",
+        comments: [{ id: "protected-comment", body: "review evidence" }],
       },
     }).where(eq(issues.id, sourceIssueId));
 
@@ -249,8 +250,10 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "changes_requested",
       currentParticipant: { type: "agent", agentId: managerId },
       returnAssignee: { type: "agent", agentId: managerId },
+      completedStageIds: ["protected-stage"],
       lastDecisionId: decisionId,
       lastDecisionOutcome: "changes_requested",
+      comments: [{ id: "protected-comment", body: "review evidence" }],
     });
     expect(repairs.filter((entry) => entry.action === "recovery.changes_requested_participant_repaired")).toHaveLength(1);
     expect(enqueueWakeup).toHaveBeenCalledWith(managerId, expect.anything());
@@ -259,6 +262,45 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(second.changesRequestedRepaired).toBe(0);
     expect((await db.select().from(activityLog)).filter((entry) => entry.action === "recovery.changes_requested_participant_repaired")).toHaveLength(1);
     expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the winning live state when concurrent reconciliation races restoration", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const stageId = randomUUID();
+    const decisionId = randomUUID();
+    await db.update(issues).set({
+      status: "in_review",
+      executionState: {
+        status: "changes_requested",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: coderId },
+        returnAssignee: { type: "agent", agentId: managerId },
+        completedStageIds: ["history"],
+        lastDecisionId: decisionId,
+        lastDecisionOutcome: "changes_requested",
+      },
+    }).where(eq(issues.id, sourceIssueId));
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const [first, second] = await Promise.all([
+      recovery.reconcileStrandedAssignedIssues(),
+      recovery.reconcileStrandedAssignedIssues(),
+    ]);
+    const [after] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+
+    expect(first.changesRequestedRepaired + second.changesRequestedRepaired).toBe(1);
+    expect(after?.executionState).toMatchObject({
+      currentParticipant: { type: "agent", agentId: managerId },
+      returnAssignee: { type: "agent", agentId: managerId },
+      completedStageIds: ["history"],
+      lastDecisionId: decisionId,
+      lastDecisionOutcome: "changes_requested",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(managerId, expect.anything());
   });
 
   function createApp(

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -153,6 +153,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const companyId = randomUUID();
     const managerId = randomUUID();
     const coderId = randomUUID();
+    const reviewerId = randomUUID();
     const sourceIssueId = randomUUID();
     const prefix = `RA${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`;
     await db.insert(companies).values({
@@ -185,6 +186,17 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         runtimeConfig: {},
         permissions: {},
       },
+      {
+        id: reviewerId,
+        companyId,
+        name: "Independent reviewer",
+        role: "reviewer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
     ]);
     await db.insert(issues).values({
       id: sourceIssueId,
@@ -197,7 +209,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       identifier: `${prefix}-1`,
     });
     const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
-    return { companyId, managerId, coderId, sourceIssueId, prefix, sourceIssue: sourceIssue! };
+    return { companyId, managerId, coderId, reviewerId, sourceIssueId, prefix, sourceIssue: sourceIssue! };
   }
 
   async function seedHeartbeatRun(input: {
@@ -308,7 +320,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
   });
 
   it("does not overwrite a restored pending reviewer on a later reconciliation", async () => {
-    const { companyId, managerId, coderId, sourceIssueId, prefix } = await seedCompany();
+    const { companyId, managerId, coderId, reviewerId, sourceIssueId, prefix } = await seedCompany();
     const unrelatedIssueId = randomUUID();
     await db.insert(issues).values({
       id: unrelatedIssueId,
@@ -357,7 +369,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         currentStageId: stageId,
         currentStageIndex: 0,
         currentStageType: "review",
-        currentParticipant: { type: "agent", agentId: managerId },
+        currentParticipant: { type: "agent", agentId: reviewerId },
         returnAssignee: { type: "agent", agentId: managerId },
         ...protectedHistory,
       },
@@ -367,7 +379,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [after] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(after?.executionState).toMatchObject({
       status: "pending",
-      currentParticipant: { type: "agent", agentId: managerId },
+      currentParticipant: { type: "agent", agentId: reviewerId },
       ...protectedHistory,
     });
     const [unrelated] = await db.select().from(issues).where(eq(issues.id, unrelatedIssueId));
@@ -375,6 +387,61 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "changes_requested",
       currentParticipant: { type: "agent", agentId: managerId },
       returnAssignee: { type: "agent", agentId: managerId },
+    });
+  });
+
+  it("does not repair a same-shaped issue in another company", async () => {
+    const first = await seedCompany();
+    await db.update(issues).set({
+      executionState: {
+        status: "changes_requested",
+        currentParticipant: { type: "agent", agentId: first.coderId },
+        returnAssignee: { type: "agent", agentId: first.managerId },
+        lastDecisionOutcome: "changes_requested",
+      },
+    }).where(eq(issues.id, first.sourceIssueId));
+    const foreignCompanyId = randomUUID();
+    const foreignAgentId = randomUUID();
+    const foreignIssueId = randomUUID();
+    const foreignPrefix = `RA${foreignCompanyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: foreignCompanyId,
+      name: "Other Recovery Co",
+      issuePrefix: foreignPrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: foreignAgentId,
+      companyId: foreignCompanyId,
+      name: "Other manager",
+      role: "cto",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: foreignIssueId,
+      companyId: foreignCompanyId,
+      title: "Other subject",
+      status: "in_review",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: `${foreignPrefix}-1`,
+      executionState: {
+        status: "changes_requested",
+        currentParticipant: { type: "agent", agentId: first.coderId },
+        // A foreign-company return principal must fail closed.
+        returnAssignee: { type: "agent", agentId: first.managerId },
+        lastDecisionOutcome: "changes_requested",
+      },
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    expect((await recovery.reconcileStrandedAssignedIssues()).changesRequestedRepaired).toBe(1);
+    const [foreign] = await db.select().from(issues).where(eq(issues.id, foreignIssueId));
+    expect(foreign?.executionState).toMatchObject({
+      currentParticipant: { type: "agent", agentId: first.coderId },
     });
   });
 

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -250,6 +250,13 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         comments: [{ id: "protected-comment", body: "review evidence" }],
       },
     }).where(eq(issues.id, sourceIssueId));
+    await db.insert(issueComments).values({
+      companyId: (await db.select({ companyId: issues.companyId }).from(issues).where(eq(issues.id, sourceIssueId)))[0].companyId,
+      issueId: sourceIssueId,
+      authorType: "agent",
+      authorAgentId: coderId,
+      body: "protected review evidence",
+    });
 
     const enqueueWakeup = vi.fn(async () => null);
     const recovery = recoveryService(db, { enqueueWakeup });
@@ -433,11 +440,15 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     const [after] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(result.changesRequestedRepaired).toBe(0);
+    expect(after?.id).toBe(sourceIssueId);
     expect(after?.executionState).toMatchObject({
       status: "pending",
       currentParticipant: { type: "agent", agentId: reviewerId },
       ...protectedHistory,
     });
+    expect((await db.select({ body: issueComments.body }).from(issueComments).where(eq(issueComments.issueId, sourceIssueId)))
+      .map((comment) => comment.body)
+      .toEqual(["protected review evidence"]);
   });
 
   it("does not repair a same-shaped issue in another company", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -431,6 +431,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     };
     await db.update(issues).set({
       status: "in_review",
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [{ id: stageId, type: "review", approvalsNeeded: 1, participants: [{ id: randomUUID(), type: "agent", agentId: reviewerId, userId: null }] }],
+      },
       executionState: {
         status: "changes_requested",
         currentStageId: stageId,
@@ -450,7 +455,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       body: "protected review evidence",
     });
 
-    const enqueueWakeup = vi.fn(async () => null);
+    const enqueueWakeup = vi.fn(async () => ({ id: randomUUID() } as never));
     const recovery = recoveryService(db, { enqueueWakeup });
     const result = await recovery.reconcileStrandedAssignedIssues({
       beforeRepair: async (candidate) => {
@@ -471,6 +476,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     const [after] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(result.changesRequestedRepaired).toBe(0);
+    expect(result.reviewParticipantRequeued).toBe(0);
     expect(after?.id).toBe(sourceIssueId);
     expect(after?.executionState).toMatchObject({
       status: "pending",
@@ -487,6 +493,29 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect((await db.select({ body: issueComments.body }).from(issueComments).where(eq(issueComments.issueId, sourceIssueId)))
       .map((comment) => comment.body))
       .toEqual(["protected review evidence"]);
+
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(), companyId: after!.companyId, agentId: reviewerId,
+      invocationSource: "automation", status: "failed",
+      error: "review process exited unexpectedly", errorCode: "adapter_failed",
+      startedAt: new Date("2026-07-15T20:00:00.000Z"),
+      finishedAt: new Date("2026-07-15T20:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    const beforeWakeState = after!.executionState;
+    const wakePass = await recovery.reconcileStrandedAssignedIssues();
+    expect(wakePass.changesRequestedRepaired).toBe(0);
+    expect(wakePass.reviewParticipantRequeued).toBe(1);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(reviewerId, expect.anything());
+    expect(enqueueWakeup).not.toHaveBeenCalledWith(managerId, expect.anything());
+    const [afterWake] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(afterWake?.executionState).toEqual(beforeWakeState);
+    const repeat = await recovery.reconcileStrandedAssignedIssues();
+    expect(repeat.reviewParticipantRequeued).toBe(0);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    const [afterRepeat] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(afterRepeat?.executionState).toEqual(afterWake?.executionState);
   });
 
   it("does not repair a same-shaped issue in another company", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -428,7 +428,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       body: "protected review evidence",
     });
 
-    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
     const result = await recovery.reconcileStrandedAssignedIssues({
       beforeRepair: async (candidate) => {
         if (candidate.id !== sourceIssueId) return;
@@ -454,6 +455,13 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       currentParticipant: { type: "agent", agentId: reviewerId },
       ...protectedHistory,
     });
+    // The stale candidate must not wake the old executor. If this pending
+    // reviewer later qualifies for recovery, the only valid wake target is
+    // the exact restored reviewer participant, never returnAssignee.
+    expect(enqueueWakeup).not.toHaveBeenCalledWith(managerId, expect.anything());
+    expect(after?.executionState && typeof after.executionState === "object"
+      ? (after.executionState as { currentParticipant?: { agentId?: string } }).currentParticipant?.agentId
+      : undefined).toBe(reviewerId);
     expect((await db.select({ body: issueComments.body }).from(issueComments).where(eq(issueComments.issueId, sourceIssueId)))
       .map((comment) => comment.body))
       .toEqual(["protected review evidence"]);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -218,6 +218,49 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   }
 
+  it("repairs the live review participant once and preserves protected history", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const decisionId = randomUUID();
+    const stageId = randomUUID();
+    await db.update(issues).set({
+      status: "in_review",
+      executionState: {
+        status: "changes_requested",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: coderId, userId: null },
+        returnAssignee: { type: "agent", agentId: managerId, userId: null },
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: decisionId,
+        lastDecisionOutcome: "changes_requested",
+      },
+    }).where(eq(issues.id, sourceIssueId));
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const first = await recovery.reconcileStrandedAssignedIssues();
+    const [afterFirst] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    const repairs = await db.select().from(activityLog).where(eq(activityLog.entityId, sourceIssueId));
+
+    expect(first.changesRequestedRepaired).toBe(1);
+    expect(afterFirst?.executionState).toMatchObject({
+      status: "changes_requested",
+      currentParticipant: { type: "agent", agentId: managerId },
+      returnAssignee: { type: "agent", agentId: managerId },
+      lastDecisionId: decisionId,
+      lastDecisionOutcome: "changes_requested",
+    });
+    expect(repairs.filter((entry) => entry.action === "recovery.changes_requested_participant_repaired")).toHaveLength(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(managerId, expect.anything());
+
+    const second = await recovery.reconcileStrandedAssignedIssues();
+    expect(second.changesRequestedRepaired).toBe(0);
+    expect((await db.select().from(activityLog)).filter((entry) => entry.action === "recovery.changes_requested_participant_repaired")).toHaveLength(1);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+  });
+
   function createApp(
     actor: any = { type: "board", source: "local_implicit" },
     opts: Parameters<typeof issueRoutes>[2] = {},

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -366,7 +366,9 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       },
     }).where(eq(issues.id, sourceIssueId));
 
-    const enqueueWakeup = vi.fn(async () => null);
+    const enqueueWakeup = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ id: randomUUID() } as never);
     const recovery = recoveryService(db, { enqueueWakeup });
     expect((await recovery.reconcileStrandedAssignedIssues()).changesRequestedRepaired).toBe(2);
 
@@ -415,7 +417,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     const secondPostRestore = await recovery.reconcileStrandedAssignedIssues();
     // A null enqueue result is deferred, not a durable wake. The next scan
-    // must remain eligible to retry recovery.
+    // must remain eligible to retry recovery and count only the durable wake.
     expect(secondPostRestore.reviewParticipantRequeued).toBe(1);
     expect(secondPostRestore.changesRequestedRepaired).toBe(0);
     expect(enqueueWakeup).toHaveBeenCalledTimes(wakeCount + 1);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -302,8 +302,9 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       lastDecisionId: decisionId,
       lastDecisionOutcome: "changes_requested",
     });
-    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
-    expect(enqueueWakeup).toHaveBeenCalledWith(managerId, expect.anything());
+    // Concurrent CAS repair must still not wake a reviewer while the gate is
+    // changes_requested; only participant alignment is restored.
+    expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
   function createApp(

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -420,6 +420,14 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       },
     }).where(eq(issues.id, sourceIssueId));
 
+    await db.insert(issueComments).values({
+      companyId: (await db.select({ companyId: issues.companyId }).from(issues).where(eq(issues.id, sourceIssueId)))[0].companyId,
+      issueId: sourceIssueId,
+      authorType: "agent",
+      authorAgentId: coderId,
+      body: "protected review evidence",
+    });
+
     const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
     const result = await recovery.reconcileStrandedAssignedIssues({
       beforeRepair: async (candidate) => {
@@ -447,7 +455,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       ...protectedHistory,
     });
     expect((await db.select({ body: issueComments.body }).from(issueComments).where(eq(issueComments.issueId, sourceIssueId)))
-      .map((comment) => comment.body)
+      .map((comment) => comment.body))
       .toEqual(["protected review evidence"]);
   });
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3555,8 +3555,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       // restored review participant, rather than the original assignee, owns
       // any follow-up wake. A concurrent restoration that wins the CAS leaves
       // `repaired` null and the candidate is handled from its original state.
-      const effectiveExecutionState = repaired ?? issue.executionState;
-      const executionState = issue.status === "in_review"
+      const effectiveIssue = repaired
+        ? issue
+        : (await db
+            .select({ status: issues.status, executionState: issues.executionState })
+            .from(issues)
+            .where(and(eq(issues.id, issue.id), eq(issues.companyId, issue.companyId)))
+            .limit(1))[0] ?? issue;
+      const effectiveExecutionState = repaired ?? effectiveIssue.executionState;
+      const executionState = effectiveIssue.status === "in_review"
         ? parseIssueExecutionState(effectiveExecutionState)
         : null;
       const pendingExecutionState = executionState?.currentParticipant ? executionState : null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3520,7 +3520,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             sql`(${issues.executionState}->'currentParticipant'->>'agentId') IS DISTINCT FROM (${issues.executionState}->'returnAssignee'->>'agentId')`,
           ))
           .returning({ id: issues.id, executionState: issues.executionState });
-        if (updated.length === 0) return false;
+        if (updated.length === 0) return null;
 
         const repairedState = updated[0].executionState;
         // The activity record must commit with the CAS repair. Drizzle's
@@ -3546,14 +3546,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             invariant: "currentParticipant only; decision and verdict history preserved",
           },
         });
-        return true;
+        return repairedState;
       });
       if (repaired) result.changesRequestedRepaired += 1;
 
+      // The candidate snapshot may predate the CAS repair. Use the state
+      // returned by that transaction for the remainder of this pass so a
+      // restored review participant, rather than the original assignee, owns
+      // any follow-up wake. A concurrent restoration that wins the CAS leaves
+      // `repaired` null and the candidate is handled from its original state.
+      const effectiveExecutionState = repaired ?? issue.executionState;
       const executionState = issue.status === "in_review"
-        ? parseIssueExecutionState(issue.executionState)
+        ? parseIssueExecutionState(effectiveExecutionState)
         : null;
-      const pendingExecutionState = executionState?.status === "pending" ? executionState : null;
+      const pendingExecutionState = executionState?.currentParticipant ? executionState : null;
       const currentParticipant = pendingExecutionState
         ? pendingExecutionState.currentParticipant
         : null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3523,7 +3523,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         if (updated.length === 0) return false;
 
         const repairedState = updated[0].executionState;
-        await logActivity(tx, {
+        // The activity record must commit with the CAS repair. Drizzle's
+        // transaction handle is structurally compatible with the activity
+        // logger at runtime, but its inferred type intentionally omits the
+        // root database client's `$client` property.
+        await logActivity(tx as unknown as Db, {
           companyId: issue.companyId,
           actorType: "system",
           actorId: "system",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3496,7 +3496,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issueIds: [] as string[],
     };
 
-    for (const issue of candidates) {
+    for (const candidate of candidates) {
+      let issue = candidate;
       // Subject/company-bound CAS repair. Only currentParticipant changes;
       // decision and verdict history remain untouched.
       const repaired = await db.transaction(async (tx) => {
@@ -3564,6 +3565,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .from(issues)
         .where(and(eq(issues.id, issue.id), eq(issues.companyId, issue.companyId)))
         .limit(1))[0] ?? issue;
+      // All recovery decisions after the CAS must use one coherent live
+      // subject snapshot. In particular, do not combine a refreshed status or
+      // assignee with the pre-CAS execution state and history.
+      issue = effectiveIssue;
       const effectiveExecutionState = effectiveIssue.executionState;
       const executionState = effectiveIssue.status === "in_review"
         ? parseIssueExecutionState(effectiveExecutionState)

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3519,7 +3519,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sql`(${issues.executionState}->'currentParticipant'->>'agentId') IS DISTINCT FROM (${issues.executionState}->'returnAssignee'->>'agentId')`,
         ))
         .returning({ id: issues.id });
-      if (repaired.length > 0) result.changesRequestedRepaired += repaired.length;
+      if (repaired.length > 0) {
+        result.changesRequestedRepaired += repaired.length;
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: null,
+          action: "recovery.changes_requested_participant_repaired",
+          entityType: "issue",
+          entityId: issue.id,
+          details: {
+            source: "recovery.reconcile_stranded_assigned_issues",
+            canonicalPmKey: "ECO-1123",
+            repairedIssueId: issue.id,
+            returnAssignee: issue.executionState && typeof issue.executionState === "object"
+              ? (issue.executionState as Record<string, unknown>).returnAssignee ?? null
+              : null,
+            invariant: "currentParticipant only; decision and verdict history preserved",
+          },
+        });
+      }
 
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3555,14 +3555,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       // restored review participant, rather than the original assignee, owns
       // any follow-up wake. A concurrent restoration that wins the CAS leaves
       // `repaired` null and the candidate is handled from its original state.
-      const effectiveIssue = repaired
-        ? issue
-        : (await db
-            .select({ status: issues.status, executionState: issues.executionState })
-            .from(issues)
-            .where(and(eq(issues.id, issue.id), eq(issues.companyId, issue.companyId)))
-            .limit(1))[0] ?? issue;
-      const effectiveExecutionState = repaired ?? effectiveIssue.executionState;
+      // Always refresh the complete subject after the CAS. A winning repair
+      // has a newer participant, while a lost CAS may have a newer status,
+      // assignee, or execution history; none may be mixed with the snapshot
+      // read before reconciliation.
+      const effectiveIssue = (await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.id, issue.id), eq(issues.companyId, issue.companyId)))
+        .limit(1))[0] ?? issue;
+      const effectiveExecutionState = effectiveIssue.executionState;
       const executionState = effectiveIssue.status === "in_review"
         ? parseIssueExecutionState(effectiveExecutionState)
         : null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3462,7 +3462,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       readNonEmptyString(monitor.externalRef) === latestRun.id;
   }
 
-  async function reconcileStrandedAssignedIssues(opts?: { issueCreatedAtGte?: Date | null }) {
+  async function reconcileStrandedAssignedIssues(opts?: {
+    issueCreatedAtGte?: Date | null;
+    /** Test seam for exercising a stale candidate between read and CAS. */
+    beforeRepair?: (issue: typeof issues.$inferSelect) => Promise<void>;
+  }) {
     const candidates = await db
       .select()
       .from(issues)
@@ -3498,6 +3502,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     for (const candidate of candidates) {
       let issue = candidate;
+      await opts?.beforeRepair?.(issue);
       // Subject/company-bound CAS repair. Only currentParticipant changes;
       // decision and verdict history remain untouched.
       const repaired = await db.transaction(async (tx) => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -680,7 +680,11 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
 }
 
 export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
+  // The database queued-wake check is authoritative across processes. This
+  // bounded cache only covers the enqueue/mutation race in the current
+  // process; failed or deferred enqueue attempts are deliberately not cached.
   const locallyRequeuedReviewRuns = new Set<string>();
+  const localReviewWakeCacheLimit = 1024;
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -3921,7 +3925,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           result.skipped += 1;
           continue;
         }
-
         if (await isInvocationBudgetBlocked(issue, participantAgentId)) {
           result.skipped += 1;
           continue;
@@ -3941,8 +3944,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               "The previous reviewer run ended while this execution-review stage was still pending. Submit the review decision now, or mark the issue blocked with the exact unblock action.",
           },
         });
-        locallyRequeuedReviewRuns.add(participantLatestRun.id);
         if (queued) {
+          locallyRequeuedReviewRuns.add(participantLatestRun.id);
+          if (locallyRequeuedReviewRuns.size > localReviewWakeCacheLimit) {
+            const oldest = locallyRequeuedReviewRuns.values().next().value;
+            if (oldest) locallyRequeuedReviewRuns.delete(oldest);
+          }
           result.reviewParticipantRequeued += 1;
           result.issueIds.push(issue.id);
         } else {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3566,7 +3566,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       const executionState = effectiveIssue.status === "in_review"
         ? parseIssueExecutionState(effectiveExecutionState)
         : null;
-      const pendingExecutionState = executionState?.currentParticipant ? executionState : null;
+      // A participant is recoverable only while the execution gate is pending.
+      // `changes_requested` belongs to the executor until resubmission; a
+      // recovery wake must not manufacture a validator adjudication path.
+      const pendingExecutionState = executionState?.status === "pending" ? executionState : null;
       const currentParticipant = pendingExecutionState
         ? pendingExecutionState.currentParticipant
         : null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3479,6 +3479,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       );
 
     const result = {
+      changesRequestedRepaired: 0,
       assignmentDispatched: 0,
       dispatchRequeued: 0,
       continuationRequeued: 0,
@@ -3496,6 +3497,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const issue of candidates) {
+      // Subject/company-bound CAS repair. Only currentParticipant changes;
+      // decision and verdict history remain untouched.
+      const repaired = await db
+        .update(issues)
+        .set({
+          executionState: sql`jsonb_set(${issues.executionState}, '{currentParticipant}', ${issues.executionState}->'returnAssignee')`,
+          updatedAt: new Date(),
+        })
+        .where(and(
+          eq(issues.id, issue.id),
+          eq(issues.companyId, issue.companyId),
+          inArray(issues.status, ["todo", "in_progress", "in_review"]),
+          isNull(issues.hiddenAt),
+          sql`${issues.executionState}->>'status' = 'changes_requested'`,
+          sql`${issues.executionState}->>'lastDecisionOutcome' = 'changes_requested'`,
+          sql`${issues.executionState}->'returnAssignee'->>'type' = 'agent'`,
+          sql`EXISTS (SELECT 1 FROM ${agents} AS return_agent
+            WHERE return_agent.id::text = ${issues.executionState}->'returnAssignee'->>'agentId'
+              AND return_agent.company_id = ${issues.companyId})`,
+          sql`(${issues.executionState}->'currentParticipant'->>'agentId') IS DISTINCT FROM (${issues.executionState}->'returnAssignee'->>'agentId')`,
+        ))
+        .returning({ id: issues.id });
+      if (repaired.length > 0) result.changesRequestedRepaired += repaired.length;
+
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)
         : null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3499,29 +3499,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     for (const issue of candidates) {
       // Subject/company-bound CAS repair. Only currentParticipant changes;
       // decision and verdict history remain untouched.
-      const repaired = await db
-        .update(issues)
-        .set({
-          executionState: sql`jsonb_set(${issues.executionState}, '{currentParticipant}', ${issues.executionState}->'returnAssignee')`,
-          updatedAt: new Date(),
-        })
-        .where(and(
-          eq(issues.id, issue.id),
-          eq(issues.companyId, issue.companyId),
-          inArray(issues.status, ["todo", "in_progress", "in_review"]),
-          isNull(issues.hiddenAt),
-          sql`${issues.executionState}->>'status' = 'changes_requested'`,
-          sql`${issues.executionState}->>'lastDecisionOutcome' = 'changes_requested'`,
-          sql`${issues.executionState}->'returnAssignee'->>'type' = 'agent'`,
-          sql`EXISTS (SELECT 1 FROM ${agents} AS return_agent
-            WHERE return_agent.id::text = ${issues.executionState}->'returnAssignee'->>'agentId'
-              AND return_agent.company_id = ${issues.companyId})`,
-          sql`(${issues.executionState}->'currentParticipant'->>'agentId') IS DISTINCT FROM (${issues.executionState}->'returnAssignee'->>'agentId')`,
-        ))
-        .returning({ id: issues.id });
-      if (repaired.length > 0) {
-        result.changesRequestedRepaired += repaired.length;
-        await logActivity(db, {
+      const repaired = await db.transaction(async (tx) => {
+        const updated = await tx
+          .update(issues)
+          .set({
+            executionState: sql`jsonb_set(${issues.executionState}, '{currentParticipant}', ${issues.executionState}->'returnAssignee')`,
+            updatedAt: new Date(),
+          })
+          .where(and(
+            eq(issues.id, issue.id),
+            eq(issues.companyId, issue.companyId),
+            inArray(issues.status, ["todo", "in_progress", "in_review"]),
+            isNull(issues.hiddenAt),
+            sql`${issues.executionState}->>'status' = 'changes_requested'`,
+            sql`${issues.executionState}->>'lastDecisionOutcome' = 'changes_requested'`,
+            sql`${issues.executionState}->'returnAssignee'->>'type' = 'agent'`,
+            sql`EXISTS (SELECT 1 FROM ${agents} AS return_agent
+              WHERE return_agent.id::text = ${issues.executionState}->'returnAssignee'->>'agentId'
+                AND return_agent.company_id = ${issues.companyId})`,
+            sql`(${issues.executionState}->'currentParticipant'->>'agentId') IS DISTINCT FROM (${issues.executionState}->'returnAssignee'->>'agentId')`,
+          ))
+          .returning({ id: issues.id, executionState: issues.executionState });
+        if (updated.length === 0) return false;
+
+        const repairedState = updated[0].executionState;
+        await logActivity(tx, {
           companyId: issue.companyId,
           actorType: "system",
           actorId: "system",
@@ -3532,15 +3534,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           entityId: issue.id,
           details: {
             source: "recovery.reconcile_stranded_assigned_issues",
-            canonicalPmKey: "ECO-1123",
-            repairedIssueId: issue.id,
-            returnAssignee: issue.executionState && typeof issue.executionState === "object"
-              ? (issue.executionState as Record<string, unknown>).returnAssignee ?? null
+            issueId: issue.id,
+            identifier: issue.identifier,
+            returnAssignee: repairedState && typeof repairedState === "object"
+              ? (repairedState as Record<string, unknown>).returnAssignee ?? null
               : null,
             invariant: "currentParticipant only; decision and verdict history preserved",
           },
         });
-      }
+        return true;
+      });
+      if (repaired) result.changesRequestedRepaired += 1;
 
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3571,7 +3571,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ? pendingExecutionState.currentParticipant
         : null;
       const participantAgentId = currentParticipant?.type === "agent" ? currentParticipant.agentId : null;
-      const agentId = issue.status === "in_review" && participantAgentId
+      const agentId = effectiveIssue.status === "in_review" && participantAgentId
         ? participantAgentId
         : issue.assigneeAgentId;
       if (!agentId) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -680,6 +680,7 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
 }
 
 export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
+  const locallyRequeuedReviewRuns = new Set<string>();
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -3581,7 +3582,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       // A participant is recoverable only while the execution gate is pending.
       // `changes_requested` belongs to the executor until resubmission; a
       // recovery wake must not manufacture a validator adjudication path.
-      const pendingExecutionState = executionState?.status === "pending" ? executionState : null;
+      // Recovery must continue to honor a live pending participant even when
+      // preserved historical fields are from an older/looser state shape.
+      // Do not rewrite that history merely because strict read validation
+      // cannot parse an otherwise actionable live state.
+      const rawExecutionState = parseObject(effectiveExecutionState);
+      const pendingExecutionState = executionState?.status === "pending"
+        ? executionState
+        : effectiveIssue.status === "in_review" && rawExecutionState.status === "pending"
+          ? rawExecutionState as unknown as NonNullable<typeof executionState>
+          : null;
       const currentParticipant = pendingExecutionState
         ? pendingExecutionState.currentParticipant
         : null;
@@ -3907,6 +3917,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           result.skipped += 1;
           continue;
         }
+        if (locallyRequeuedReviewRuns.has(participantLatestRun.id)) {
+          result.skipped += 1;
+          continue;
+        }
 
         if (await isInvocationBudgetBlocked(issue, participantAgentId)) {
           result.skipped += 1;
@@ -3927,6 +3941,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               "The previous reviewer run ended while this execution-review stage was still pending. Submit the review decision now, or mark the issue blocked with the exact unblock action.",
           },
         });
+        locallyRequeuedReviewRuns.add(participantLatestRun.id);
         if (queued) {
           result.reviewParticipantRequeued += 1;
           result.issueIds.push(issue.id);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an execution control plane whose recovery service reconciles stranded issue execution.
> - When a reviewer requests changes, `executionState.status` stays `changes_requested` until the implementer resubmits; recovery must not manufacture a new review adjudication path.
> - A stranded `in_review` issue can have `currentParticipant` drift away from `returnAssignee` while protected decision history remains append-only.
> - Concurrent babysitter/reconciliation passes can race on the same subject, so participant repair needs company-scoped CAS semantics and a live-state reread when the CAS loses.
> - This pull request makes that repair transactional, idempotent, and history-preserving inside `reconcileStrandedAssignedIssues`.
> - The benefit is correct participant restoration without waking the wrong agent or rewriting verdict history.

## Linked Issues or Issue Description

Refs #4327

Related: #5914

## What Changed

- Add transactional, company-scoped CAS repair that aligns `currentParticipant` with `returnAssignee` for `changes_requested` issues without mutating decision/verdict history.
- Reread live issue state after a lost CAS so follow-up reconciliation uses the winning restoration instead of a stale candidate snapshot.
- Gate recovery wakeups on `executionState.status === "pending"` so `changes_requested` repairs do not enqueue reviewer wakes prematurely.
- Expand embedded-Postgres coverage for protected history, idempotence, and concurrent reconciliation races.
- Add focused script-level invariants in `scripts/paperclip-babysit-reconciliation.mjs` for the external babysitter SQL path.

## Verification

- `git diff --check`
- `node --check scripts/paperclip-babysit-reconciliation.mjs`
- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts` (embedded Postgres; CI authoritative)

## Risks

- Adds one bounded live-state query when the CAS does not win.
- No schema or migration changes.
- External babysitter scripts must not unconditionally rewrite `currentParticipant` for historical `changes_requested` outcomes once this ships.

## Model Used

OpenAI Codex GPT-5.6-sol via Codex CLI, tool-enabled implementation and test authoring.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
