### PR TITLE
fix(heartbeat): don't reopen a done issue on self-authored close comment

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1327,6 +1327,176 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
+  it("does not reopen a finished issue when the closing comment is authored by the local-board sentinel", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Local CLI Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Local-board self-close must not reopen",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      // The MCP bridge closes the issue AND posts the closing comment without a
+      // run id, attributing it to the `local-board` non-human sentinel under user
+      // auth (createdByRunId is null). This is the exact TABA-202 shape: keying
+      // self-authorship on run id alone misses it, so without the sentinel guard
+      // the close comment reopens the just-closed issue in a loop.
+      const selfComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorType: "user",
+          authorUserId: "local-board",
+          createdByRunId: null,
+          body: "GATE fechado. Analisador confirmou.",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: selfComment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: selfComment.id,
+          wakeCommentId: selfComment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "local-board",
+      });
+
+      expect(deferredRun).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      // The deferred wake still promotes, but the issue must remain `done`: the
+      // only referenced comment is authored by the local-board sentinel, not a
+      // genuine human follow-up.
+      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId));
+        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+      }, 90_000);
+
+      const issueAfterPromotion = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(issueAfterPromotion).toMatchObject({
+        status: "done",
+      });
+      expect(issueAfterPromotion?.completedAt).not.toBeNull();
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("still reopens a finished issue when a deferred batch mixes self-authored and human comments", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -149,7 +149,7 @@ import {
   readManagedWorktreeInstanceOwnership,
   WORKTREE_INSTANCE_ROOT_METADATA_KEY,
 } from "./workspace-instance-cleanup.js";
-import { issueService } from "./issues.js";
+import { issueService, NON_HUMAN_SENTINEL_AUTHOR_USER_IDS } from "./issues.js";
 import { projectService } from "./projects.js";
 import { authorizationService, type AuthorizationActor } from "./authorization.js";
 import { createToolGatewayService } from "./tool-gateway.js";
@@ -16598,12 +16598,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.
-        // Suppress reopen only when every referenced comment came from this run;
+        // The MCP bridge closes+comments without a run id, attributing the
+        // comment to the `local-board` non-human sentinel (or directly to the
+        // issue's own agent) — so keying self-authorship on run id alone misses
+        // it and the close comment reopens the just-closed issue in a loop.
+        // Treat a comment as self-authored when it came from this run, from the
+        // issue's own agent, or from a non-human sentinel user; only a genuine
+        // third-party (real human or a different agent) follow-up should reopen.
+        // Suppress reopen only when EVERY referenced comment is self-authored;
         // mixed batches must still reopen because they contain a real follow-up.
         let deferredCommentWakeIsSelfAuthored = false;
         if (deferredCommentIds.length > 0) {
           const deferredComments = await tx
-            .select({ createdByRunId: issueComments.createdByRunId })
+            .select({
+              createdByRunId: issueComments.createdByRunId,
+              authorType: issueComments.authorType,
+              authorUserId: issueComments.authorUserId,
+              authorAgentId: issueComments.authorAgentId,
+            })
             .from(issueComments)
             .where(
               and(
@@ -16613,9 +16625,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ),
             )
             .then((rows) => rows);
+          const isSelfAuthoredComment = (comment: {
+            createdByRunId: string | null;
+            authorType: string | null;
+            authorUserId: string | null;
+            authorAgentId: string | null;
+          }) =>
+            comment.createdByRunId === run.id ||
+            (comment.authorAgentId != null && comment.authorAgentId === deferred.agentId) ||
+            (comment.authorType === "user" &&
+              comment.authorUserId != null &&
+              NON_HUMAN_SENTINEL_AUTHOR_USER_IDS.has(comment.authorUserId));
           deferredCommentWakeIsSelfAuthored =
-            deferredComments.length > 0 &&
-            deferredComments.every((comment) => comment.createdByRunId === run.id);
+            deferredComments.length > 0 && deferredComments.every(isSelfAuthoredComment);
         }
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -151,7 +151,7 @@ const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
 // agent-attribution derivation even though `local-board` is also materialized
 // as a row in the `user` table (it is the implicit board admin). Genuine human
 // users — real signups with their own ids — are never reattributed.
-const NON_HUMAN_SENTINEL_AUTHOR_USER_IDS = new Set<string>(["local-board"]);
+export const NON_HUMAN_SENTINEL_AUTHOR_USER_IDS = new Set<string>(["local-board"]);
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_MAX_LOG_BYTES = 2_000_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_CHUNK_BYTES = 256_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS = 60_000;


### PR DESCRIPTION
## Problem
An agent operating via the MCP bridge closes an issue **and** posts the closing comment under the `local-board` non-human sentinel with a null `createdByRunId`. The `deferred_comment_wake` reopen guard only treated a comment as self-authored when `createdByRunId === run.id`, so it misclassified the close comment as a genuine human follow-up and reopened the just-closed issue (`done -> todo`). The agent then redid the work, re-closed + re-commented, and looped for ~14 min until recovery — observed on a real run (36 comments, ~2 min of work + ~14 min of reopen loop).

## Fix
Treat a comment as self-authored when it also comes from the issue's own agent (`authorAgentId === deferred.agentId`) or from a non-human sentinel user (`NON_HUMAN_SENTINEL_AUTHOR_USER_IDS`, e.g. `local-board`). Only a genuine third-party follow-up (real human or a different agent) reopens a finished issue.

## Test
Adds a red→green regression test (`heartbeat-comment-wake-batching.test.ts`) reproducing the exact `local-board` close-comment loop: without the fix the issue reopens (`in_progress`); with it, it stays `done`. Full file 12/12 green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)