### PR TITLE
fix(control-plane): gate stale issue wakes atomically

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -933,6 +933,26 @@ Optional auth flags (for authenticated mode):
 - `PAPERCLIP_AUTH_HEADER` (for example `Bearer ...`)
 - `PAPERCLIP_COOKIE` (session cookie header value)
 
+## Managed Codex Home Permission Repair
+
+New managed Codex homes use `0700` directories and `0600` Paperclip-owned
+files. Audit an existing company's managed Codex home with:
+
+```sh
+pnpm codex:remediate-home-permissions -- --company-id <company-id>
+```
+
+The command is dry-run by default. Stop and drain all Codex runs for that
+company before applying changes, then explicitly confirm the drain:
+
+```sh
+pnpm codex:remediate-home-permissions -- --company-id <company-id> --apply --post-drain-confirmed
+```
+
+The remediation only changes the Paperclip-managed company home. It does not
+follow symlinks, delete sessions, or touch an adapter-configured external
+`CODEX_HOME`.
+
 ## OpenClaw Docker UI One-Command Script
 
 To boot OpenClaw in Docker and print a host-browser dashboard URL in one command:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "issue-references:backfill": "pnpm run preflight:workspace-links && tsx scripts/backfill-issue-reference-mentions.ts",
     "secrets:migrate-inline-env": "tsx scripts/migrate-inline-env-secrets.ts",
+    "codex:remediate-home-permissions": "node cli/node_modules/tsx/dist/cli.mjs scripts/remediate-codex-home-permissions.ts",
     "db:backup": "./scripts/backup-db.sh",
     "paperclipai": "node cli/node_modules/tsx/dist/cli.mjs cli/src/index.ts",
     "build:npm": "./scripts/build-npm.sh",

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1515,6 +1515,7 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
   let socket: net.Socket | null = null;
   let stopping = false;
   let stdinSeq = 0;
+  let stdinWriteChain: Promise<void> = Promise.resolve();
   let pollTimer: NodeJS.Timeout | null = null;
   const pendingRemoteEvents: Array<{
     type?: string;
@@ -1557,6 +1558,27 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
       const event = pendingRemoteEvents.shift();
       if (event) writeRemoteEventToSocket(event);
     }
+  };
+
+  // Each stdin message is written through a separate remote execution. Those
+  // executions are asynchronous, so issuing them concurrently can let the
+  // stdinEnd marker land before the data file even though its sequence number
+  // is larger. Keep the bridge's filesystem queue ordered at the host boundary
+  // so the remote poller always observes stdin data before stdinEnd.
+  const queueStdinWrite = (stdinPayload: { type: string; data?: string }) => {
+    stdinSeq += 1;
+    const name = `${String(stdinSeq).padStart(12, "0")}.json`;
+    const write = stdinWriteChain
+      .catch(() => undefined)
+      .then(() =>
+        runRuntimeWork(AGENT_SESSION_SEND_INPUT_SPAN, () =>
+          client.writeTextFile(path.posix.join(stdinDir, name), jsonLine(stdinPayload)),
+        ),
+      );
+    // Keep the chain usable after one failed write; the caller still receives
+    // the rejection and reports the bridge error to the connected proxy.
+    stdinWriteChain = write.catch(() => undefined);
+    return write;
   };
 
   const liveSockets = new Set<net.Socket>();
@@ -1623,11 +1645,7 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
               ? { type: "stdinEnd" }
               : null;
         if (stdinPayload) {
-          stdinSeq += 1;
-          const name = `${String(stdinSeq).padStart(12, "0")}.json`;
-          void runRuntimeWork(AGENT_SESSION_SEND_INPUT_SPAN, () =>
-            client.writeTextFile(path.posix.join(stdinDir, name), jsonLine(stdinPayload)),
-          ).catch((error) => {
+          void queueStdinWrite(stdinPayload).catch((error) => {
             nextSocket.write(jsonLine({ type: "error", message: error instanceof Error ? error.message : String(error) }));
             nextSocket.destroy();
           });
@@ -1786,6 +1804,7 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
       if (pollTimer) clearTimeout(pollTimer);
       for (const liveSocket of liveSockets) liveSocket.destroy();
       await new Promise<void>((resolve) => server.close(() => resolve())).catch(() => undefined);
+      await stdinWriteChain;
       await client.writeTextFile(
         path.posix.join(stdinDir, `${String(stdinSeq + 1).padStart(12, "0")}.json`),
         jsonLine({ type: "stdinEnd" }),

--- a/packages/adapters/claude-local/src/server/acp.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.test.ts
@@ -85,7 +85,15 @@ afterEach(async () => {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
-  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  // A remote process-session wrapper can flush one trailing event file after
+  // the run has returned. Retry the recursive temp-root removal across that
+  // bounded window instead of turning an otherwise passing test into an
+  // ENOTEMPTY teardown failure under CI load.
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }),
+    ),
+  );
 });
 
 class FakeRuntime {

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -33,6 +33,16 @@ describe("detectClaudeLoginRequired", () => {
       }).requiresLogin,
     ).toBe(false);
   });
+
+  it("does not classify parsed-null assistant stdout as auth evidence", () => {
+    expect(
+      detectClaudeLoginRequired({
+        parsed: null,
+        stdout: "The assistant summarized that the source text says authentication required.",
+        stderr: "",
+      }),
+    ).toEqual({ requiresLogin: false, loginUrl: null });
+  });
 });
 
 describe("isClaudeModelNotFoundError", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -169,7 +169,7 @@ export function detectClaudeLoginRequired(input: {
   stderr: string;
 }): { requiresLogin: boolean; loginUrl: string | null } {
   const resultText = asString(input.parsed?.result, "").trim();
-  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())

--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -10,6 +10,7 @@ import {
   mergeManagedCodexMcpGateways,
   isManagedCodexHomePath,
   prepareManagedCodexHome,
+  remediateManagedCodexHomePermissions,
   reconcileManagedCodexHome,
   seedManagedCodexHome,
   stageCodexHomeForSync,
@@ -1124,6 +1125,61 @@ describe("stageCodexHomeForSync", () => {
       expect(stagedSkillEntries).not.toContain("up");
     } finally {
       if (staged) await fs.rm(staged, { recursive: true, force: true });
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("audits and repairs managed runtime directory permissions without following symlinks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-permissions-"));
+    try {
+      const paperclipHome = path.join(root, "paperclip-home");
+      const env = {
+        PAPERCLIP_HOME: paperclipHome,
+        PAPERCLIP_INSTANCE_ID: "default",
+      } satisfies NodeJS.ProcessEnv;
+      const companyId = "company-1";
+      const managedHome = path.join(
+        paperclipHome,
+        "instances",
+        "default",
+        "companies",
+        companyId,
+        "codex-home",
+      );
+      await fs.mkdir(path.join(managedHome, "sessions", "nested"), { recursive: true, mode: 0o755 });
+      await fs.mkdir(path.join(managedHome, "shell_snapshots"), { recursive: true, mode: 0o755 });
+      await fs.writeFile(path.join(managedHome, "sessions", "nested", "run.json"), "{}", { mode: 0o644 });
+      await fs.writeFile(path.join(managedHome, "config.toml"), "model = \"gpt-5\"\n", { mode: 0o644 });
+
+      const changes = await remediateManagedCodexHomePermissions(env, companyId);
+      expect(changes.map((change) => change.requiredMode)).toContain(0o700);
+      expect(changes.map((change) => change.requiredMode)).toContain(0o600);
+      expect((await fs.stat(path.join(managedHome, "sessions", "nested", "run.json"))).mode & 0o777).toBe(0o644);
+
+      await remediateManagedCodexHomePermissions(env, companyId, {
+        apply: true,
+        postDrainConfirmed: true,
+      });
+      expect((await fs.stat(managedHome)).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(path.join(managedHome, "sessions"))).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(path.join(managedHome, "sessions", "nested", "run.json"))).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(path.join(managedHome, "config.toml"))).mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requires post-drain confirmation before changing managed permissions", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-permissions-guard-"));
+    try {
+      const env = {
+        PAPERCLIP_HOME: root,
+        PAPERCLIP_INSTANCE_ID: "default",
+      } satisfies NodeJS.ProcessEnv;
+      await expect(
+        remediateManagedCodexHomePermissions(env, "company-1", { apply: true }),
+      ).rejects.toThrow("post-drain confirmation");
+    } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -9,6 +9,9 @@ const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const MANAGED_MCP_BLOCK_START = "# BEGIN PAPERCLIP MANAGED MCP";
 const MANAGED_MCP_BLOCK_END = "# END PAPERCLIP MANAGED MCP";
+const MANAGED_PRIVATE_DIRECTORIES = ["skills", "shell_snapshots", "sessions"] as const;
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
 
 /**
  * The allowlist of managed `CODEX_HOME` entries that the codex-local adapter
@@ -170,7 +173,7 @@ async function codexHomeHasMatchingApiKeyAuth(home: string, apiKey: string): Pro
 }
 
 async function ensureParentDir(target: string): Promise<void> {
-  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.mkdir(path.dirname(target), { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
 }
 
 async function isExpectedSymlink(target: string, source: string): Promise<boolean> {
@@ -226,9 +229,12 @@ export async function ensureSymlink(target: string, source: string): Promise<voi
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
-  if (existing) return;
-  await ensureParentDir(target);
-  await fs.copyFile(source, target);
+  if (!existing) {
+    await ensureParentDir(target);
+    await fs.copyFile(source, target);
+  }
+  const copied = await fs.lstat(target).catch(() => null);
+  if (copied?.isFile()) await fs.chmod(target, PRIVATE_FILE_MODE);
 }
 
 function tomlString(value: string): string {
@@ -331,10 +337,12 @@ export async function writeManagedCodexMcpConfig(input: {
  * environment variable and only reads credentials from `$CODEX_HOME/auth.json`.
  */
 export async function writeApiKeyAuthJson(home: string, apiKey: string): Promise<void> {
-  await fs.mkdir(home, { recursive: true });
+  await fs.mkdir(home, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  await fs.chmod(home, PRIVATE_DIRECTORY_MODE);
   const target = path.join(home, "auth.json");
   await fs.rm(target, { force: true });
-  await fs.writeFile(target, JSON.stringify({ OPENAI_API_KEY: apiKey }), { mode: 0o600 });
+  await fs.writeFile(target, JSON.stringify({ OPENAI_API_KEY: apiKey }), { mode: PRIVATE_FILE_MODE });
+  await fs.chmod(target, PRIVATE_FILE_MODE);
 }
 
 export interface StageCodexHomeForSyncOptions {
@@ -586,7 +594,8 @@ export async function seedManagedCodexHome(
   const sourceHome = resolveSharedCodexHomeDir(env);
   const seedFromShared = path.resolve(sourceHome) !== path.resolve(targetHome);
 
-  await fs.mkdir(targetHome, { recursive: true });
+  await fs.mkdir(targetHome, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  await fs.chmod(targetHome, PRIVATE_DIRECTORY_MODE);
 
   // If a previous run wrote an apikey-mode auth.json (regular file) and this
   // run has no apiKey, remove it so the chatgpt-mode symlink can be restored.
@@ -637,6 +646,85 @@ export async function prepareManagedCodexHome(
   const targetHome = resolveManagedCodexHomeDir(env, companyId);
   await seedManagedCodexHome(targetHome, env, onLog, options);
   return targetHome;
+}
+
+export type CodexHomePermissionChange = {
+  path: string;
+  currentMode: number;
+  requiredMode: number;
+};
+
+async function collectPermissionChanges(
+  target: string,
+  requiredMode: number,
+  options: { recurse: boolean },
+): Promise<CodexHomePermissionChange[]> {
+  const stat = await fs.lstat(target).catch(() => null);
+  if (!stat || stat.isSymbolicLink()) return [];
+
+  const currentMode = stat.mode & 0o777;
+  const changes: CodexHomePermissionChange[] = currentMode === requiredMode
+    ? []
+    : [{ path: target, currentMode, requiredMode }];
+  if (!options.recurse || !stat.isDirectory()) return changes;
+
+  const entries = await fs.readdir(target, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const child = path.join(target, entry.name);
+    changes.push(...await collectPermissionChanges(
+      child,
+      entry.isDirectory() ? PRIVATE_DIRECTORY_MODE : PRIVATE_FILE_MODE,
+      { recurse: entry.isDirectory() },
+    ));
+  }
+  return changes;
+}
+
+/**
+ * Audits or repairs permissions in the Paperclip-managed company Codex home.
+ * It never follows symlinks, never touches the shared/external CODEX_HOME, and
+ * requires an explicit post-drain confirmation before changing session files.
+ */
+export async function remediateManagedCodexHomePermissions(
+  env: NodeJS.ProcessEnv,
+  companyId: string,
+  options: { apply?: boolean; postDrainConfirmed?: boolean } = {},
+): Promise<CodexHomePermissionChange[]> {
+  if (!companyId.trim()) throw new Error("companyId is required");
+  if (options.apply && !options.postDrainConfirmed) {
+    throw new Error("Refusing to change Codex session permissions without post-drain confirmation");
+  }
+
+  const targetHome = resolveManagedCodexHomeDir(env, companyId);
+  const homeStat = await fs.lstat(targetHome).catch(() => null);
+  if (!homeStat) return [];
+  if (!homeStat.isDirectory() || homeStat.isSymbolicLink()) {
+    throw new Error(`Refusing to remediate an invalid managed Codex home: ${targetHome}`);
+  }
+
+  const changes = await collectPermissionChanges(targetHome, PRIVATE_DIRECTORY_MODE, { recurse: false });
+  for (const name of MANAGED_PRIVATE_DIRECTORIES) {
+    changes.push(...await collectPermissionChanges(
+      path.join(targetHome, name),
+      PRIVATE_DIRECTORY_MODE,
+      { recurse: name === "shell_snapshots" || name === "sessions" },
+    ));
+  }
+  for (const name of COPIED_SHARED_FILES) {
+    changes.push(...await collectPermissionChanges(
+      path.join(targetHome, name),
+      PRIVATE_FILE_MODE,
+      { recurse: false },
+    ));
+  }
+
+  if (options.apply) {
+    for (const change of changes) {
+      await fs.chmod(change.path, change.requiredMode);
+    }
+  }
+  return changes;
 }
 
 export type ReconcileManagedCodexHomeStatus =

--- a/packages/db/src/company-secret-proposals-migration.test.ts
+++ b/packages/db/src/company-secret-proposals-migration.test.ts
@@ -40,5 +40,5 @@ describeEmbeddedPostgres("company secret proposals migration", () => {
         (SELECT count(*)::int FROM pg_indexes WHERE tablename = 'company_secret_proposals') AS indexes
     `;
     expect(result).toEqual({ constraints: 13, indexes: 5 });
-  });
+  }, 30_000);
 });

--- a/scripts/remediate-codex-home-permissions.ts
+++ b/scripts/remediate-codex-home-permissions.ts
@@ -1,0 +1,29 @@
+import {
+  remediateManagedCodexHomePermissions,
+} from "../packages/adapters/codex-local/src/server/codex-home.js";
+
+function readFlagValue(args: string[], flag: string): string | null {
+  const index = args.indexOf(flag);
+  const value = index >= 0 ? args[index + 1] : null;
+  return value && !value.startsWith("--") ? value : null;
+}
+
+const args = process.argv.slice(2);
+const companyId = readFlagValue(args, "--company-id");
+if (!companyId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(companyId)) {
+  throw new Error("Usage: --company-id <id> [--apply --post-drain-confirmed]");
+}
+
+const apply = args.includes("--apply");
+const postDrainConfirmed = args.includes("--post-drain-confirmed");
+const changes = await remediateManagedCodexHomePermissions(process.env, companyId, {
+  apply,
+  postDrainConfirmed,
+});
+
+console.log(`${apply ? "Applied" : "Dry-run found"} ${changes.length} permission change(s) in the managed Codex home.`);
+for (const change of changes) {
+  console.log(
+    `${apply ? "changed" : "would change"} ${change.path}: ${change.currentMode.toString(8)} -> ${change.requiredMode.toString(8)}`,
+  );
+}

--- a/server/src/__tests__/agent-session-invalidation.test.ts
+++ b/server/src/__tests__/agent-session-invalidation.test.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentTaskSessions,
+  agents,
+  companies,
+  createDb,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("agent session invalidation", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-session-invalidation-");
+    db = createDb(tempDb.connectionString);
+  }, 60_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(agentTaskSessions);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  }, 60_000);
+
+  async function seed(adapterConfig: Record<string, unknown>) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `S${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Session Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig,
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(agentRuntimeState).values({
+      companyId,
+      agentId,
+      adapterType: "codex_local",
+      sessionId: "runtime-session",
+      stateJson: { sessionId: "runtime-session" },
+    });
+    await db.insert(agentTaskSessions).values({
+      companyId,
+      agentId,
+      adapterType: "codex_local",
+      taskKey: "issue-session-test",
+      sessionParamsJson: { sessionId: "task-session" },
+      sessionDisplayId: "task-session",
+    });
+    return { companyId, agentId };
+  }
+
+  it("clears persisted sessions and records evidence when the model changes", async () => {
+    const fixture = await seed({ model: "gpt-5.4", modelReasoningEffort: "high" });
+
+    await agentService(db).update(
+      fixture.agentId,
+      { adapterConfig: { model: "gpt-5.6-sol", modelReasoningEffort: "high" } },
+      { recordRevision: { createdByUserId: "local-board", source: "patch" } },
+    );
+
+    await expect(
+      db.select().from(agentTaskSessions).where(eq(agentTaskSessions.agentId, fixture.agentId)),
+    ).resolves.toHaveLength(0);
+    const [runtimeState] = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, fixture.agentId));
+    expect(runtimeState).toMatchObject({ sessionId: null, stateJson: {}, lastError: null });
+    const [audit] = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "agent.task_sessions_invalidated"));
+    expect(audit).toMatchObject({
+      actorType: "user",
+      actorId: "local-board",
+      entityType: "agent",
+      entityId: fixture.agentId,
+      details: {
+        changedFields: ["adapterConfig.model"],
+        taskSessionsCleared: 1,
+      },
+    });
+  });
+
+  it("keeps sessions when only a non-identity setting changes", async () => {
+    const fixture = await seed({ model: "gpt-5.6-sol", modelReasoningEffort: "high", timeoutSec: 1_800 });
+
+    await agentService(db).update(
+      fixture.agentId,
+      { adapterConfig: { model: "gpt-5.6-sol", modelReasoningEffort: "high", timeoutSec: 3_600 } },
+      { recordRevision: { createdByUserId: "local-board", source: "patch" } },
+    );
+
+    await expect(
+      db.select().from(agentTaskSessions).where(eq(agentTaskSessions.agentId, fixture.agentId)),
+    ).resolves.toHaveLength(1);
+    const invalidations = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "agent.task_sessions_invalidated"));
+    expect(invalidations).toHaveLength(0);
+  });
+
+  it("removes an adapter-specific issue model override during adapter migration", async () => {
+    const fixture = await seed({});
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: fixture.companyId,
+      title: "Provider override",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: fixture.agentId,
+      assigneeAdapterOverrides: {
+        adapterConfig: { model: "codex-model", timeoutSec: 1_800 },
+        useProjectWorkspace: false,
+      },
+    });
+
+    await agentService(db).update(
+      fixture.agentId,
+      { adapterType: "claude_local" },
+      { recordRevision: { createdByUserId: "local-board", source: "patch" } },
+    );
+
+    const [issue] = await db
+      .select({ overrides: issues.assigneeAdapterOverrides })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(issue?.overrides).toEqual({
+      adapterConfig: { timeoutSec: 1_800 },
+      useProjectWorkspace: false,
+    });
+    const [audit] = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.assignee_adapter_override_migrated"));
+    expect(audit).toMatchObject({ entityType: "issue", entityId: issueId });
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -609,6 +609,93 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { environmentId, leaseId };
   }
 
+  it("does not claim an executor wake while a concurrent review transition owns the issue lock", async () => {
+    const fixture = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      contextSnapshot: {
+        wakeReason: "issue_assigned",
+        executionStage: { wakeRole: "executor" },
+      },
+    });
+
+    await db
+      .update(agentWakeupRequests)
+      .set({ status: "queued", claimedAt: null, finishedAt: null, error: null })
+      .where(eq(agentWakeupRequests.id, fixture.wakeupRequestId));
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        executionState: null,
+      })
+      .where(eq(issues.id, fixture.issueId));
+
+    let reviewLockReady!: () => void;
+    const reviewLockAcquired = new Promise<void>((resolve) => {
+      reviewLockReady = resolve;
+    });
+    const reviewTransition = db.transaction(async (tx) => {
+      await tx
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.id, fixture.issueId))
+        .for("update");
+      await tx
+        .update(issues)
+        .set({
+          status: "in_review",
+          executionState: {
+            status: "pending",
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: randomUUID() },
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, fixture.issueId));
+      reviewLockReady();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+
+    await reviewLockAcquired;
+    const heartbeat = heartbeatService(db);
+    const resumePromise = heartbeat.resumeQueuedRuns();
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, fixture.runId))
+        .then((rows) => rows[0] ?? null);
+      expect(run?.status).toBe("queued");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    await reviewTransition;
+    await resumePromise;
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, fixture.runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_review_participant_changed");
+    expect(run?.error).toContain("entered in_review");
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const issue = await db
+      .select({ status: issues.status, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue).toEqual({ status: "in_review", executionRunId: null });
+  }, 20_000);
+
   it("does not reap active adapter executions started by another heartbeat service instance", async () => {
     let releaseAdapter: (() => void) | null = null;
     const adapterStarted = new Promise<void>((resolve) => {

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -97,6 +97,26 @@ function jsonEqual(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function normalizedConfigString(config: Record<string, unknown>, key: string): string | null {
+  const value = config[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function adapterSessionIdentity(config: unknown): {
+  model: string | null;
+  modelReasoningEffort: string | null;
+} {
+  const record = isPlainRecord(config) ? config : {};
+  return {
+    model: normalizedConfigString(record, "model"),
+    modelReasoningEffort:
+      normalizedConfigString(record, "modelReasoningEffort")
+      ?? normalizedConfigString(record, "reasoningEffort"),
+  };
+}
+
 function buildConfigSnapshot(
   row: Pick<typeof agents.$inferSelect, ConfigRevisionField>,
 ): AgentConfigSnapshot {
@@ -529,6 +549,25 @@ export function agentService(db: Db) {
 
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
     const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
+    const changingAdapterType =
+      typeof normalizedPatch.adapterType === "string"
+      && normalizedPatch.adapterType !== existing.adapterType;
+    const beforeSessionIdentity = adapterSessionIdentity(existing.adapterConfig);
+    const effectiveAdapterConfig = normalizedPatch.adapterConfig ?? existing.adapterConfig;
+    const afterSessionIdentity = adapterSessionIdentity(effectiveAdapterConfig);
+    const changingModel = beforeSessionIdentity.model !== afterSessionIdentity.model;
+    const changingModelReasoningEffort =
+      beforeSessionIdentity.modelReasoningEffort !== afterSessionIdentity.modelReasoningEffort;
+    const invalidatesSessions = changingAdapterType || changingModel || changingModelReasoningEffort;
+    const revisionActor = options?.recordRevision;
+    const actorType: "agent" | "user" | "system" = revisionActor?.createdByAgentId
+      ? "agent"
+      : revisionActor?.createdByUserId
+        ? "user"
+        : "system";
+    const actorId = revisionActor?.createdByAgentId
+      ?? revisionActor?.createdByUserId
+      ?? "system";
 
     type AgentUpdateResult = Awaited<ReturnType<typeof getById>>;
     const applyUpdate = async (txDb: Db): Promise<AgentUpdateResult> => {
@@ -547,6 +586,83 @@ export function agentService(db: Db) {
       const normalizedUpdated = await agentService(txDb).getById(updated.id);
       if (!normalizedUpdated) {
         throw notFound("Agent not found");
+      }
+
+      if (invalidatesSessions) {
+        const deletedTaskSessions = await txDb
+          .delete(agentTaskSessions)
+          .where(and(
+            eq(agentTaskSessions.companyId, existing.companyId),
+            eq(agentTaskSessions.agentId, id),
+          ))
+          .returning({ id: agentTaskSessions.id });
+        await txDb
+          .update(agentRuntimeState)
+          .set({
+            adapterType: normalizedUpdated.adapterType,
+            sessionId: null,
+            stateJson: {},
+            lastError: null,
+            updatedAt: new Date(),
+          })
+          .where(and(
+            eq(agentRuntimeState.companyId, existing.companyId),
+            eq(agentRuntimeState.agentId, id),
+          ));
+        await txDb.insert(activityLog).values({
+          companyId: existing.companyId,
+          actorType,
+          actorId,
+          agentId: revisionActor?.createdByAgentId ?? null,
+          action: "agent.task_sessions_invalidated",
+          entityType: "agent",
+          entityId: id,
+          details: {
+            changedFields: [
+              ...(changingAdapterType ? ["adapterType"] : []),
+              ...(changingModel ? ["adapterConfig.model"] : []),
+              ...(changingModelReasoningEffort ? ["adapterConfig.modelReasoningEffort"] : []),
+            ],
+            taskSessionsCleared: deletedTaskSessions.length,
+          },
+        });
+      }
+
+      if (changingAdapterType) {
+        const migratedIssues = await txDb
+          .update(issues)
+          .set({
+            assigneeAdapterOverrides: sql`
+              coalesce(${issues.assigneeAdapterOverrides}, '{}'::jsonb)
+              #- '{adapterConfig,model}'
+            `,
+            updatedAt: new Date(),
+          })
+          .where(and(
+            eq(issues.companyId, existing.companyId),
+            eq(issues.assigneeAgentId, id),
+            sql`${issues.assigneeAdapterOverrides} -> 'adapterConfig' ? 'model'`,
+          ))
+          .returning({ id: issues.id, identifier: issues.identifier });
+
+        if (migratedIssues.length > 0) {
+          await txDb.insert(activityLog).values(migratedIssues.map((issue) => ({
+            companyId: existing.companyId,
+            actorType,
+            actorId,
+            agentId: revisionActor?.createdByAgentId ?? null,
+            action: "issue.assignee_adapter_override_migrated",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              issueIdentifier: issue.identifier,
+              agentId: id,
+              fromAdapterType: existing.adapterType,
+              toAdapterType: normalizedUpdated.adapterType,
+              removedFields: ["adapterConfig.model"],
+            },
+          })));
+        }
       }
 
       if (shouldRecordRevision && beforeConfig) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3153,6 +3153,44 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+const STALE_EXECUTOR_REVIEW_WAKE_REASON =
+  "Dropped stale executor wake because the issue entered in_review before adapter spawn";
+const ISSUE_EXECUTION_LOCK_CONFLICT_REASON =
+  "Cancelled queued issue wake because the issue execution lock is owned by another run";
+
+function shouldDropExecutorWakeForReview(input: {
+  issueStatus: string | null | undefined;
+  issueAssigneeAgentId: string | null | undefined;
+  issueExecutionState: unknown;
+  wakeAgentId: string;
+  contextSnapshot: Record<string, unknown> | null | undefined;
+}) {
+  if (input.issueStatus !== "in_review") return false;
+
+  const executionStage = parseObject(input.contextSnapshot?.executionStage);
+  const wakeRole = readNonEmptyString(executionStage.wakeRole);
+  if (wakeRole === "reviewer" || wakeRole === "approver") return false;
+  if (wakeRole === "executor") return true;
+
+  const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason);
+  if (wakeReason !== "issue_assigned" && wakeReason !== "execution_changes_requested") return false;
+
+  const executionState = parseIssueExecutionState(input.issueExecutionState);
+  const currentParticipantAgentId =
+    executionState?.currentParticipant?.type === "agent"
+      ? executionState.currentParticipant.agentId
+      : null;
+  if (currentParticipantAgentId === input.wakeAgentId) return false;
+
+  const returnExecutorAgentId =
+    executionState?.returnAssignee?.type === "agent"
+      ? executionState.returnAssignee.agentId
+      : null;
+  if (returnExecutorAgentId === input.wakeAgentId) return true;
+
+  return input.issueAssigneeAgentId !== input.wakeAgentId;
+}
+
 function sanitizeAgentSessionMessageText(value: unknown): string | null {
   const text = readNonEmptyString(value);
   if (!text) return null;
@@ -12469,18 +12507,216 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueContext: issueId ? await getIssueExecutionContext(run.companyId, issueId) : null,
       routineEnvContext: { routineId: null, env: null, responsibleUserId: null },
     });
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        responsibleUserId,
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
-    if (!claimed) return null;
+
+    const claimedWakeReason = readNonEmptyString(context.wakeReason);
+    const claimOutcome = await db.transaction(async (tx) => {
+      // Serialize the review transition and queued-run claim on the same Issue row.
+      // The earlier staleness read is intentionally not trusted as the final gate.
+      const lockedIssue = issueId
+        ? await tx
+            .select({
+              id: issues.id,
+              status: issues.status,
+              assigneeAgentId: issues.assigneeAgentId,
+              executionRunId: issues.executionRunId,
+              executionState: issues.executionState,
+            })
+            .from(issues)
+            .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+            .for("update")
+            .then((rows) => rows[0] ?? null)
+        : null;
+
+      // Lock the run after the Issue so a second scheduler cannot clear an Issue
+      // lock that the first scheduler acquired for this same run.
+      const lockedRun = await tx
+        .select()
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.companyId, run.companyId)))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+
+      if (!lockedRun || lockedRun.status !== "queued") {
+        return { kind: "none" as const };
+      }
+
+      const cancelQueuedRunInTransaction = async (input: {
+        errorCode: string;
+        reason: string;
+        details: Record<string, unknown>;
+      }) => {
+        const now = new Date();
+        const cancelled = await tx
+          .update(heartbeatRuns)
+          .set({
+            status: "cancelled",
+            finishedAt: now,
+            updatedAt: now,
+            error: input.reason,
+            errorCode: input.errorCode,
+            resultJson: {
+              ...parseObject(lockedRun.resultJson),
+              stopReason: input.errorCode,
+              effectiveTimeoutSec: 0,
+              timeoutConfigured: false,
+              timeoutSource: "atomic_queued_run_gate",
+              timeoutFired: false,
+            },
+          })
+          .where(and(eq(heartbeatRuns.id, lockedRun.id), eq(heartbeatRuns.status, "queued")))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (!cancelled) return { kind: "none" as const };
+
+        if (cancelled.wakeupRequestId) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "skipped",
+              finishedAt: now,
+              error: input.reason,
+              updatedAt: now,
+            })
+            .where(eq(agentWakeupRequests.id, cancelled.wakeupRequestId));
+        }
+
+        if (issueId) {
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: now,
+            })
+            .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, lockedRun.id)));
+        }
+
+        return {
+          kind: "cancelled" as const,
+          run: cancelled,
+          errorCode: input.errorCode,
+          reason: input.reason,
+          details: input.details,
+        };
+      };
+
+      if (issueId && !lockedIssue) {
+        return cancelQueuedRunInTransaction({
+          errorCode: "issue_not_found",
+          reason: "Cancelled because the target issue no longer exists",
+          details: { issueId },
+        });
+      }
+
+      if (lockedIssue && shouldDropExecutorWakeForReview({
+        issueStatus: lockedIssue.status,
+        issueAssigneeAgentId: lockedIssue.assigneeAgentId,
+        issueExecutionState: lockedIssue.executionState,
+        wakeAgentId: lockedRun.agentId,
+        contextSnapshot: context,
+      })) {
+        return cancelQueuedRunInTransaction({
+          errorCode: "issue_review_participant_changed",
+          reason: STALE_EXECUTOR_REVIEW_WAKE_REASON,
+          details: {
+            issueId,
+            currentStatus: lockedIssue.status,
+            wakeRole: readNonEmptyString(parseObject(context.executionStage).wakeRole),
+          },
+        });
+      }
+
+      if (
+        lockedIssue
+        && issueId
+        && claimedWakeReason !== "source_scoped_recovery_action"
+        // Mention/context wakes are allowed to touch an Issue without owning
+        // its execution lock. Only the current assignee is required to claim
+        // that lock, so an assignee mismatch must remain dispatchable.
+        && lockedIssue.assigneeAgentId === lockedRun.agentId
+      ) {
+        const issueLock = await tx
+          .update(issues)
+          .set({
+            executionRunId: lockedRun.id,
+            executionAgentNameKey: normalizeAgentNameKey(agent.name),
+            executionLockedAt: claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(and(
+            eq(issues.id, issueId),
+            eq(issues.companyId, lockedRun.companyId),
+            // Mention/context runs can touch an issue, but only the current assignee
+            // owns the issue execution lock shown as the active run.
+            eq(issues.assigneeAgentId, lockedRun.agentId),
+            or(isNull(issues.executionRunId), eq(issues.executionRunId, lockedRun.id)),
+          ))
+          .returning({ id: issues.id });
+
+        if (issueLock.length === 0) {
+          return cancelQueuedRunInTransaction({
+            errorCode: "issue_execution_lock_conflict",
+            reason: ISSUE_EXECUTION_LOCK_CONFLICT_REASON,
+            details: {
+              issueId,
+              currentExecutionRunId: lockedIssue.executionRunId,
+              queuedRunId: lockedRun.id,
+            },
+          });
+        }
+      }
+
+      const claimed = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          responsibleUserId,
+          startedAt: lockedRun.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, lockedRun.id), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!claimed) return { kind: "none" as const };
+
+      if (claimed.wakeupRequestId) {
+        await tx
+          .update(agentWakeupRequests)
+          .set({ status: "claimed", claimedAt, updatedAt: claimedAt })
+          .where(eq(agentWakeupRequests.id, claimed.wakeupRequestId));
+      }
+
+      return { kind: "claimed" as const, run: claimed };
+    });
+
+    if (claimOutcome.kind === "none") return null;
+
+    if (claimOutcome.kind === "cancelled") {
+      const cancelled = await setRunStatus(claimOutcome.run.id, "cancelled", {
+        finishedAt: claimOutcome.run.finishedAt ?? new Date(),
+        error: claimOutcome.reason,
+        errorCode: claimOutcome.errorCode,
+        resultJson: claimOutcome.run.resultJson,
+      });
+      if (cancelled) {
+        await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: claimOutcome.reason,
+          payload: claimOutcome.details,
+        });
+      }
+      logger.info(
+        { runId: claimOutcome.run.id, issueId, errorCode: claimOutcome.errorCode },
+        "claimQueuedRun: cancelled atomically gated queued run",
+      );
+      return null;
+    }
+
+    const claimed = claimOutcome.run;
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -12498,35 +12734,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
     publishRunLifecyclePluginEvent(claimed);
-
-    await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
-
-    // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedContext = parseObject(claimed.contextSnapshot);
-    const claimedIssueId = readNonEmptyString(claimedContext.issueId);
-    const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
-    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
-      const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, claimedIssueId),
-            eq(issues.companyId, claimed.companyId),
-            // Mention/context runs can touch an issue, but only the current assignee
-            // owns the issue execution lock shown as the active run.
-            eq(issues.assigneeAgentId, claimed.agentId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
-        );
-    }
 
     return claimed;
   }


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100). -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip runs issue work through heartbeat queues and agent adapters
> - Managed adapter homes and persisted sessions hold state between runs
> - Queue wakes, adapter output, and adapter identity changes can leave stale or false execution state
> - This pull request makes those state transitions safer and adds regression coverage
> - The benefit is more reliable issue execution and safer operator recovery

## Linked Issues or Issue Description

No public issue was found after searching the Paperclip issue and PR lists for `heartbeat review transition`, `stale executor wake`, and `Claude authentication stdout`. The underlying problems are described here as required by `CONTRIBUTING.md`.

**What happened?**

- A queued executor wake could pass an earlier review-state read and start after the Issue moved to `in_review`.
- Claude parsed output could be empty while raw assistant stdout contained authentication wording. The parser could then report a false login requirement.
- An adapter identity change could leave an incompatible persisted session or per-Issue model override. A managed Codex home could also retain unsafe permissions.

**Expected behavior**

- A queued executor wake must revalidate the Issue and cancel when the Issue is no longer executable.
- Raw Claude assistant stdout must not be authentication evidence by itself.
- Adapter identity changes must invalidate incompatible state. Managed Codex home permissions must be private and repairable through an explicit operator command.

**Steps to reproduce**

1. Queue an executor run for an Issue.
2. Transition the Issue to `in_review` while the heartbeat worker is claiming the run.
3. Observe that an old worker can continue unless the claim and review check are serialized.
4. Return null parsed Claude output with assistant text that contains authentication wording.
5. Observe a false login-required result unless the parser uses structured errors and stderr only.

**Paperclip version or commit**

- Base commit: `6a4e2e1b8c7129f6f913ae458ab0be9cba50bd6a`.
- PR commit: `8d924600b3a1449d282320fe2c892a7c88ce6d1b`.

**Deployment mode**

- Local development and self-hosted source deployment.

**Installation method**

- Built from source with pnpm.

**Agent adapter(s) involved**

- Claude Code and Codex.
- The queue and session changes are Paperclip core behavior.

**Database mode**

- Embedded PostgreSQL for the isolated deployment smoke test.

**Additional context**

- No database schema or migration files changed.
- The patch keeps permission repair dry-run by default and requires explicit operator confirmation before applying changes.

## What Changed

- Prevent raw Claude assistant stdout from being treated as login-required evidence when parsed output is empty.
- Enforce private permissions for managed Codex homes and add a UUID-scoped, dry-run-by-default remediation command.
- Invalidate persisted agent sessions after adapter identity changes and remove incompatible per-Issue model overrides.
- Claim queued Issue runs, wake requests, and assignee execution locks in one transaction. Cancel stale executor wakes during review transitions.
- Add focused regression tests and document the Codex home remediation workflow.

## Verification

- Claude parser test: 40/40 passed.
- Heartbeat process recovery test: 101/101 passed.
- Workspace-busy compatibility test: 15/15 passed.
- Related heartbeat and execution-policy tests: 337/337 passed.
- Comment-wake batching test: 12/12 passed.
- `pnpm -r typecheck` passed for all applicable projects.
- `pnpm build` passed.
- GitHub CI passed typecheck, build, server tests, workspace tests, serialized suites, E2E, policy, and security checks.
- The local stable runner still reports known macOS `/tmp` versus `/private/var` path canonicalization and project-skill workspace-scope failures on the clean base commit. These failures are outside this patch.

## Risks

- Heartbeat claim ordering changes concurrency behavior around Issue review transitions. The regression test covers the stale executor wake race.
- Adapter session invalidation can require an agent to authenticate again after its adapter identity changes.
- Permission repair changes only the managed Codex home and is guarded by UUID validation, symlink checks, dry-run output, and explicit confirmation.
- No schema change is included. The patch can be rolled back by reverting this PR.

## Model Used

- OpenAI GPT-5 via Codex. Used repository analysis, GitNexus impact analysis, code execution, focused tests, build verification, and an isolated deployment smoke test.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
