### PR TITLE
fix(issues): attach checkout run mutation context

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -410,6 +410,89 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     expect(checkoutActivity).toHaveLength(0);
   });
 
+  it("attaches an unassigned heartbeat_timer run to its checkout mutation boundary", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const peerAgentId = randomUUID();
+    const issueId = randomUUID();
+    const peerIssueId = randomUUID();
+    await db.update(heartbeatRuns).set({
+      invocationSource: "timer",
+      contextSnapshot: { wakeReason: "heartbeat_timer" },
+    }).where(eq(heartbeatRuns.id, currentRunId));
+    await db.insert(agents).values({
+      id: peerAgentId,
+      companyId,
+      name: "PeerAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: issueId,
+        companyId,
+        title: "Timer run checkout target",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: peerIssueId,
+        companyId,
+        title: "Peer boundary",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: peerAgentId,
+      },
+    ]);
+
+    const app = createApp(agentActor(companyId, agentId, currentRunId));
+    const checkout = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo"] });
+    expect(checkout.status, JSON.stringify(checkout.body)).toBe(200);
+
+    const run = await db.select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, currentRunId))
+      .then((rows) => rows[0]);
+    expect(run?.contextSnapshot).toMatchObject({
+      wakeReason: "heartbeat_timer",
+      issueId,
+      taskId: issueId,
+      checkoutContextSource: "issue.checkout",
+    });
+
+    const update = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Timer-scoped update" });
+    expect(update.status, JSON.stringify(update.body)).toBe(200);
+
+    const comment = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Timer-scoped comment" });
+    expect(comment.status, JSON.stringify(comment.body)).toBe(201);
+
+    const unassignedRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: unassignedRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "timer",
+      contextSnapshot: { wakeReason: "heartbeat_timer" },
+      startedAt: new Date(),
+    });
+    const crossBoundary = await request(createApp(agentActor(companyId, agentId, unassignedRunId)))
+      .patch(`/api/issues/${peerIssueId}`)
+      .send({ title: "Must stay denied" });
+    expect(crossBoundary.status, JSON.stringify(crossBoundary.body)).toBe(403);
+    expect(crossBoundary.body?.details?.code).toBe("cross_issue_influence_run_context_required");
+  });
+
   it("restricts admin force-release to board users with company access and writes an audit event", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7938,6 +7938,46 @@ export function issueService(db: Db) {
       await assertAssignableAgent(db, issueCompany.companyId, agentId, { kind: "work" });
 
       const now = new Date();
+      const attachCheckoutRunContext = async <T>(checkedOutIssue: T): Promise<T> => {
+        if (!checkoutRunId) return checkedOutIssue;
+        await db.transaction(async (tx) => {
+          const run = await tx
+            .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+            .from(heartbeatRuns)
+            .where(and(
+              eq(heartbeatRuns.id, checkoutRunId),
+              eq(heartbeatRuns.companyId, issueCompany.companyId),
+              eq(heartbeatRuns.agentId, agentId),
+            ))
+            .for("update")
+            .then((rows) => rows[0] ?? null);
+          // Authentication normally guarantees this match. Keep legacy board/test
+          // checkout behavior intact, but never attach context to a mismatched run.
+          if (!run) return;
+
+          const context = parseObject(run.contextSnapshot);
+          const sourceIssueId = [context.issueId, context.taskId]
+            .find((candidate) => typeof candidate === "string" && candidate.trim());
+          if (sourceIssueId) return;
+
+          await tx
+            .update(heartbeatRuns)
+            .set({
+              contextSnapshot: {
+                ...context,
+                issueId: id,
+                taskId: id,
+                checkoutContextSource: "issue.checkout",
+              },
+            })
+            .where(and(
+              eq(heartbeatRuns.id, checkoutRunId),
+              eq(heartbeatRuns.companyId, issueCompany.companyId),
+              eq(heartbeatRuns.agentId, agentId),
+            ));
+        });
+        return checkedOutIssue;
+      };
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issueCompany.companyId, id);
       if (
         activePauseHold &&
@@ -8004,7 +8044,7 @@ export function issueService(db: Db) {
 
       if (updated) {
         const [enriched] = await withIssueLabels(db, [updated]);
-        return enriched;
+        return attachCheckoutRunContext(enriched);
       }
 
       const current = await db
@@ -8046,7 +8086,7 @@ export function issueService(db: Db) {
           )
           .returning()
           .then((rows) => rows[0] ?? null);
-        if (adopted) return adopted;
+        if (adopted) return attachCheckoutRunContext(adopted);
       }
 
       if (
@@ -8066,7 +8106,7 @@ export function issueService(db: Db) {
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
           if (!row) throw notFound("Issue not found");
           const [enriched] = await withIssueLabels(db, [row]);
-          return enriched;
+          return attachCheckoutRunContext(enriched);
         }
       }
 
@@ -8109,7 +8149,7 @@ export function issueService(db: Db) {
             .then((rows) => rows[0] ?? null);
           if (adopted) {
             const [enriched] = await withIssueLabels(db, [adopted]);
-            return enriched;
+            return attachCheckoutRunContext(enriched);
           }
         }
       }
@@ -8123,7 +8163,7 @@ export function issueService(db: Db) {
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
         if (!row) throw notFound("Issue not found");
         const [enriched] = await withIssueLabels(db, [row]);
-        return enriched;
+        return attachCheckoutRunContext(enriched);
       }
 
       throw conflict("Issue checkout conflict", {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Heartbeat runs provide an audit boundary for agent task mutations
> - Timer heartbeat runs can start without a task in their context snapshot
> - Issue checkout records the run on the issue but did not attach the issue to the run snapshot
> - The cross-issue guard then rejected updates to the checked-out issue as unscoped
> - This pull request attaches an empty run context to the first successful checkout
> - The benefit is an auditable mutation boundary without a wider authorization rule

## Linked Issues or Issue Description

**What happened?**

An unassigned `heartbeat_timer` run could check out an issue. A later PATCH or comment on that same issue returned `cross_issue_influence_run_context_required`. Checkout stored the run ID on the issue, but the influence guard read the source issue only from the run context snapshot.

**Expected behavior**

A successful checkout must attach an unassigned run to the checked-out issue. Same-issue PATCH and comment requests must then succeed. An unassigned run that did not check out the target must still fail closed.

**Steps to reproduce**

1. Create a running timer heartbeat with no `issueId` or `taskId` in its context snapshot.
2. Check out an assigned todo issue with that run ID.
3. PATCH the checked-out issue or add a comment.
4. Observe the run-context 403 on the base commit.

**Paperclip version or commit**

`6a4e2e1b8c7129f6f913ae458ab0be9cba50bd6a`

**Deployment mode**

Self-hosted server with external PostgreSQL. The regression test uses embedded PostgreSQL.

## What Changed

- Attach `issueId`, `taskId`, and an audit source to an unassigned run after successful checkout.
- Preserve all existing context fields.
- Do not overwrite a run that already has an issue boundary.
- Add an API regression test for checkout, PATCH, comment, and the fail-closed cross-boundary case.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-stale-execution-lock-routes.test.ts` passes 12 tests.
- `pnpm --filter @paperclipai/server typecheck` passes.

## Risks

- Low risk. The change updates only the persisted context of the run that successfully checked out an issue.
- A run with an existing `issueId` or `taskId` keeps its original boundary.
- No schema or migration changes are present.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. This is a focused bug fix and does not overlap with planned roadmap work.

## Model Used

- OpenAI Codex, GPT-5 family. The exact service model suffix and context window are not exposed in this session. The agent used reasoning, repository tools, code execution, and embedded PostgreSQL tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
