### PR TITLE
fix(adapter-utils): preserve read-only sandbox extra paths

### DIFF
--- a/packages/adapter-utils/README.md
+++ b/packages/adapter-utils/README.md
@@ -30,6 +30,14 @@ helpers in [`src/ssh.ts`](./src/ssh.ts):
 calls for adapters that want a per-run remote workspace and an automatic
 `restoreWorkspace()` finally hook.
 
+## Local process sandbox mounts
+
+When a local process uses the workspace filesystem scope, Bubblewrap mounts
+managed paths, extra paths, and the workspace from shallowest to deepest. This
+keeps the most specific access mode effective: a read-only extra path inside
+the workspace stays read-only, while a read-only parent path does not make the
+workspace read-only.
+
 The invariant is pinned by the `no-remote-git contract` case in
 [`src/ssh-fixture.test.ts`](./src/ssh-fixture.test.ts), which asserts that a
 remote-only commit propagates to the local worktree through the

--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -96,6 +96,57 @@ describe("local process sandbox", () => {
     expect(target.args.slice(-3)).toEqual([process.execPath, "-e", "console.log('ok')"]);
   });
 
+  it("keeps a read-only extra path inside the workspace read-only", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-nested-ro-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const protectedPath = path.join(workspace, "secrets");
+    await fs.mkdir(protectedPath, { recursive: true });
+
+    const target = await buildLocalProcessSandboxSpawnTarget({
+      executable: process.execPath,
+      args: ["-e", "process.exit(0)"],
+      cwd: workspace,
+      options: {
+        workspaceDir: workspace,
+        filesystemScope: "workspace",
+        extraPaths: [{ path: protectedPath, access: "ro" }],
+      },
+    });
+
+    const workspaceMount = target.args.findIndex((value, index) =>
+      value === "--bind" && target.args[index + 1] === workspace && target.args[index + 2] === workspace);
+    const protectedMount = target.args.findIndex((value, index) =>
+      value === "--ro-bind" && target.args[index + 1] === protectedPath && target.args[index + 2] === protectedPath);
+    expect(workspaceMount).toBeGreaterThanOrEqual(0);
+    expect(protectedMount).toBeGreaterThan(workspaceMount);
+  });
+
+  it("keeps the workspace writable when a read-only extra path contains it", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-parent-ro-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+
+    const target = await buildLocalProcessSandboxSpawnTarget({
+      executable: process.execPath,
+      args: ["-e", "process.exit(0)"],
+      cwd: workspace,
+      options: {
+        workspaceDir: workspace,
+        filesystemScope: "workspace",
+        extraPaths: [{ path: root, access: "ro" }],
+      },
+    });
+
+    const parentMount = target.args.findIndex((value, index) =>
+      value === "--ro-bind" && target.args[index + 1] === root && target.args[index + 2] === root);
+    const workspaceMount = target.args.findIndex((value, index) =>
+      value === "--bind" && target.args[index + 1] === workspace && target.args[index + 2] === workspace);
+    expect(parentMount).toBeGreaterThanOrEqual(0);
+    expect(workspaceMount).toBeGreaterThan(parentMount);
+  });
+
   it("binds a confined absolute alias to the synchronized workspace", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-alias-"));
     cleanup.push(root);

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -79,6 +79,16 @@ function normalizeAbsolutePath(candidate: string, label: string): string {
   return path.resolve(trimmed);
 }
 
+function pathDepth(candidate: string): number {
+  let depth = 0;
+  let current = path.resolve(candidate);
+  while (current !== path.dirname(current)) {
+    depth += 1;
+    current = path.dirname(current);
+  }
+  return depth;
+}
+
 async function pathExists(candidate: string): Promise<boolean> {
   return fs.lstat(candidate).then(() => true).catch(() => false);
 }
@@ -407,9 +417,25 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
     if (networkScope === "allowlist") {
       for (const nodePath of await executableReadPaths(process.execPath)) await mount(nodePath, "ro");
     }
-    for (const managedPath of input.options.managedPaths ?? []) await mount(managedPath.path, managedPath.access);
-    for (const extraPath of input.options.extraPaths ?? []) await mount(extraPath.path, extraPath.access);
-    await mount(workspaceDir, "rw");
+    // Bubblewrap applies later bind mounts over earlier parent mounts. Mount
+    // ancestors first so a more specific extra or managed path keeps its
+    // declared access mode inside the workspace (and the workspace remains
+    // writable when a read-only path contains it).
+    const orderedMounts = [
+      ...(input.options.managedPaths ?? []),
+      ...(input.options.extraPaths ?? []),
+      { path: workspaceDir, access: "rw" as const },
+    ]
+      .map((entry, index) => ({
+        ...entry,
+        normalizedPath: normalizeAbsolutePath(entry.path, "Sandbox path"),
+        index,
+      }))
+      .sort(
+        (left, right) =>
+          pathDepth(left.normalizedPath) - pathDepth(right.normalizedPath) || left.index - right.index,
+      );
+    for (const entry of orderedMounts) await mount(entry.normalizedPath, entry.access);
     for (const [index, alias] of (input.options.pathAliases ?? []).entries()) {
       const aliasPath = normalizeAbsolutePath(alias.path, `Sandbox pathAliases[${index}].path`);
       const aliasTarget = normalizeAbsolutePath(alias.target, `Sandbox pathAliases[${index}].target`);


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs local agents inside filesystem sandboxes.
> - The adapter-utils local-process sandbox builds fresh-root Bubblewrap mounts.
> - Bubblewrap applies later bind mounts over earlier parent mounts.
> - The workspace mount was emitted after extra paths.
> - A read-only extra path inside the workspace was therefore remounted writable.
> - This pull request orders managed paths, extra paths, and the workspace by path depth.
> - The benefit is that configured read-only boundaries remain effective without making the workspace read-only.

## Linked Issues or Issue Description

Fixes: #10753

Related PRs: #10842, #11026, and #11159. Those changes address merged-`/usr` system-path ordering or symlink conflicts. This PR addresses a successful but incorrect nested bind outcome.

## What Changed

- Order managed paths, extra paths, and the workspace from shallowest to deepest before mounting them.
- Preserve caller order for paths at the same depth.
- Add regression tests for read-only paths inside the workspace and read-only parents around the workspace.
- Document the mount-order invariant in the adapter-utils README.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `pnpm --filter @paperclipai/adapter-utils build` — passed.
- `git diff --check` — passed.
- `pnpm exec vitest run packages/adapter-utils/src/local-process-sandbox.test.ts --reporter=dot` — attempted on Windows; the existing suite requires Linux and Bubblewrap and stopped at the repository's platform guard before exercising these tests.
- `pnpm -r typecheck` — attempted; the recursive workspace check exceeded the 180-second local timeout while running the repository's postinstall-dependent plugin checks.

## Risks

- Low risk. The patch changes mount order only.
- It does not add paths or broaden access.
- Same-depth path order remains stable.
- The behavior is limited to Linux Bubblewrap sandbox construction.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, with high-reasoning tool use, code execution, and repository operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #123` / `Closes: #123` / `Refs: #123` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
