### PR TITLE
feat(attention): surface manual board decisions

### DIFF
--- a/packages/shared/src/types/attention.ts
+++ b/packages/shared/src/types/attention.ts
@@ -9,6 +9,7 @@ export const ATTENTION_SOURCE_KINDS = [
   "productivity_review",
   "blocker_attention",
   "review",
+  "manual_issue",
   "failed_run",
   "budget_alert",
   "agent_error_alert",

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -449,6 +449,29 @@ describeEmbeddedPostgres("attention service", () => {
     expect(snoozedFeed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === interactionIssueId)).toBe(false);
   });
 
+  it("lets blocker attention supersede a generic manual-issue card", async () => {
+    const { companyId } = await seedCompany("ATB");
+    const transitionAt = new Date("2026-07-23T18:30:00.000Z");
+    const issueId = await insertIssue({
+      companyId,
+      identifier: "ATB-1",
+      title: "Blocked board decision",
+      status: "blocked",
+      assigneeUserId: "board-user",
+      unblockDescriptor: { owner: "board", action: "Approve the exception" },
+      blockedTransitionAt: transitionAt,
+    });
+
+    const feed = await attentionService(db).list(companyId, { userId: "board-user" });
+
+    expect(feed.items).toContainEqual(expect.objectContaining({
+      sourceKind: "blocker_attention",
+      subject: expect.objectContaining({ id: issueId }),
+      dedupKey: `blocked-owner:${issueId}:${transitionAt.toISOString()}`,
+    }));
+    expect(feed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === issueId)).toBe(false);
+  });
+
   it("returns ranked decision-only items for every active source and excludes non-human or transient rows", async () => {
     const { companyId, workerId, reviewerId } = await seedCompany("ATN");
     const baseTime = new Date("2026-07-09T12:00:00.000Z");

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -259,7 +259,7 @@ describeEmbeddedPostgres("attention service", () => {
     expect(feed.items.flatMap((item) => item.queues).some((queue) => queue.key === "internal-review")).toBe(false);
   });
 
-  it("surfaces WAT-shaped board-owned manual issues once and leaves in-review work to the review source", async () => {
+  it("surfaces WAT-shaped board-owned manual issues once and leaves blocker and review work to their specialized sources", async () => {
     const { companyId, workerId } = await seedCompany("ATM");
     const expectedIssueIds = await Promise.all([
       ["ATM-1", "Backlog board decision", "backlog"],
@@ -311,13 +311,15 @@ describeEmbeddedPostgres("attention service", () => {
     const feed = await attentionService(db).list(companyId, { userId: "board-user" });
     const manualItems = feed.items.filter((item) => item.sourceKind === "manual_issue");
 
-    expect(manualItems).toHaveLength(5);
-    expect(feed.countsBySourceKind.manual_issue).toBe(5);
+    expect(manualItems).toHaveLength(4);
+    expect(feed.countsBySourceKind.manual_issue).toBe(4);
     expect(new Set(manualItems.map((item) => item.subject.id))).toEqual(new Set([
       ...expectedIssueIds,
-      blockedIssueId,
       requestedUserDecisionIssueId,
     ]));
+    expect(feed.items.filter((item) => item.subject.id === blockedIssueId)).toEqual([
+      expect.objectContaining({ sourceKind: "blocker_attention" }),
+    ]);
     expect(feed.items.filter((item) => item.subject.id === inReviewIssueId)).toEqual([
       expect.objectContaining({ sourceKind: "review" }),
     ]);

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -169,6 +169,7 @@ describeEmbeddedPostgres("attention service", () => {
     executionState?: Record<string, unknown> | null;
     updatedAt?: Date;
     createdAt?: Date;
+    hiddenAt?: Date | null;
     unblockDescriptor?: { owner: { userId: string } | "board"; action: string } | null;
     blockedTransitionAt?: Date | null;
     harnessKind?: string | null;
@@ -195,6 +196,7 @@ describeEmbeddedPostgres("attention service", () => {
       harnessKind: input.harnessKind ?? null,
       createdAt: input.createdAt,
       updatedAt: input.updatedAt,
+      hiddenAt: input.hiddenAt ?? null,
     });
     return id;
   }
@@ -255,6 +257,196 @@ describeEmbeddedPostgres("attention service", () => {
     expect(feed.items.some((item) => item.subject.id === harnessIssueId)).toBe(false);
     expect(feed.countsBySourceKind.review ?? 0).toBe(0);
     expect(feed.items.flatMap((item) => item.queues).some((queue) => queue.key === "internal-review")).toBe(false);
+  });
+
+  it("surfaces WAT-shaped board-owned manual issues once and leaves in-review work to the review source", async () => {
+    const { companyId, workerId } = await seedCompany("ATM");
+    const expectedIssueIds = await Promise.all([
+      ["ATM-1", "Backlog board decision", "backlog"],
+      ["ATM-2", "Todo board decision", "todo"],
+      ["ATM-3", "Active board decision", "in_progress"],
+    ].map(([identifier, title, status], index) => insertIssue({
+      companyId,
+      identifier: identifier!,
+      title: title!,
+      status: status!,
+      assigneeUserId: "board-user",
+      updatedAt: new Date(`2026-07-09T12:0${index}:00.000Z`),
+    })));
+    const blockedIssueId = await insertIssue({
+      companyId,
+      identifier: "ATM-4",
+      title: "Blocked board decision",
+      status: "blocked",
+      assigneeUserId: "board-user",
+      updatedAt: new Date("2026-07-09T12:03:00.000Z"),
+    });
+    const requestedUserDecisionIssueId = await insertIssue({
+      companyId,
+      identifier: "ATM-11",
+      title: "Execution policy requests a user decision",
+      status: "todo",
+      executionState: pendingUserExecutionState("board-user"),
+      updatedAt: new Date("2026-07-09T12:04:00.000Z"),
+    });
+    const inReviewIssueId = await insertIssue({
+      companyId,
+      identifier: "ATM-13",
+      title: "Existing review source wins",
+      status: "in_review",
+      assigneeUserId: "board-user",
+      updatedAt: new Date("2026-07-09T12:05:00.000Z"),
+    });
+
+    await Promise.all([
+      insertIssue({ companyId, identifier: "ATM-5", title: "Different user", status: "todo", assigneeUserId: "someone-else" }),
+      insertIssue({ companyId, identifier: "ATM-6", title: "Agent owned", status: "todo", assigneeAgentId: workerId }),
+      insertIssue({ companyId, identifier: "ATM-7", title: "Completed", status: "done", assigneeUserId: "board-user" }),
+      insertIssue({ companyId, identifier: "ATM-8", title: "Cancelled", status: "cancelled", assigneeUserId: "board-user" }),
+      insertIssue({ companyId, identifier: "ATM-9", title: "Hidden", status: "todo", assigneeUserId: "board-user", hiddenAt: new Date("2026-07-09T12:00:00.000Z") }),
+      insertIssue({ companyId, identifier: "ATM-10", title: "Generated workflow row", status: "todo", assigneeUserId: "board-user", originKind: "issue_productivity_review" }),
+      insertIssue({ companyId, identifier: "ATM-12", title: "Agent execution participant", status: "todo", executionState: pendingAgentExecutionState(workerId) }),
+    ]);
+
+    const feed = await attentionService(db).list(companyId, { userId: "board-user" });
+    const manualItems = feed.items.filter((item) => item.sourceKind === "manual_issue");
+
+    expect(manualItems).toHaveLength(5);
+    expect(feed.countsBySourceKind.manual_issue).toBe(5);
+    expect(new Set(manualItems.map((item) => item.subject.id))).toEqual(new Set([
+      ...expectedIssueIds,
+      blockedIssueId,
+      requestedUserDecisionIssueId,
+    ]));
+    expect(feed.items.filter((item) => item.subject.id === inReviewIssueId)).toEqual([
+      expect.objectContaining({ sourceKind: "review" }),
+    ]);
+    for (const item of manualItems) {
+      expect(item).toMatchObject({
+        sourceKind: "manual_issue",
+        inlineResolvable: false,
+        relatedIssue: null,
+        subject: {
+          kind: "issue",
+          companyId,
+          href: expect.stringMatching(/^\/ATM\/issues\/ATM-/),
+        },
+        whyNow: expect.stringContaining("requires your"),
+        dedupKey: `manual_issue:${item.subject.id}`,
+      });
+      expect(item.decisionVerbs).toEqual([expect.objectContaining({ id: "review_issue" })]);
+    }
+    expect(manualItems.find((item) => item.subject.id === requestedUserDecisionIssueId)?.subject.metadata?.assigneeUserId).toBeNull();
+    for (const item of manualItems.filter((candidate) => candidate.subject.id !== requestedUserDecisionIssueId)) {
+      expect(item.subject.metadata?.assigneeUserId).toBe("board-user");
+    }
+  });
+
+  it("lets pending interactions and open decisions supersede a generic manual-issue card", async () => {
+    const { companyId, workerId } = await seedCompany("ATS");
+    const interactionIssueId = await insertIssue({
+      companyId,
+      identifier: "ATS-1",
+      title: "Formal interaction wins",
+      status: "todo",
+      assigneeUserId: "board-user",
+    });
+    const decisionIssueId = await insertIssue({
+      companyId,
+      identifier: "ATS-2",
+      title: "Formal decision wins",
+      status: "blocked",
+      assigneeUserId: "board-user",
+    });
+    const approvalIssueId = await insertIssue({
+      companyId,
+      identifier: "ATS-3",
+      title: "Formal approval wins",
+      status: "todo",
+      assigneeUserId: "board-user",
+    });
+    const secondApprovalIssueId = await insertIssue({
+      companyId,
+      identifier: "ATS-5",
+      title: "Same formal approval also wins",
+      status: "backlog",
+      assigneeUserId: "board-user",
+    });
+    const genericIssueId = await insertIssue({
+      companyId,
+      identifier: "ATS-4",
+      title: "Generic manual card remains",
+      status: "backlog",
+      assigneeUserId: "board-user",
+    });
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: interactionIssueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Choose through the formal interaction",
+      payload: { version: 1, prompt: "Proceed?" },
+    });
+    const approvalId = randomUUID();
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Choose through the formal approval" },
+    });
+    await db.insert(issueApprovals).values([
+      { companyId, issueId: approvalIssueId, approvalId },
+      { companyId, issueId: secondApprovalIssueId, approvalId },
+    ]);
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: workerId,
+      status: "succeeded",
+      contextSnapshot: { issueId: decisionIssueId },
+    });
+    await db.insert(decisions).values({
+      id: randomUUID(),
+      companyId,
+      originAgentId: workerId,
+      originIssueId: decisionIssueId,
+      originRunId: runId,
+      title: "Choose through the formal decision",
+      body: "A structured decision already exists.",
+      options: [],
+      status: "open",
+      expiresAt: new Date("2026-08-10T00:00:00.000Z"),
+      signedSpec: "test",
+      targetSnapshots: {},
+    });
+
+    const feed = await attentionService(db).list(companyId, { userId: "board-user" });
+
+    expect(feed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === interactionIssueId)).toBe(false);
+    expect(feed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === decisionIssueId)).toBe(false);
+    expect(feed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === approvalIssueId)).toBe(false);
+    expect(feed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === secondApprovalIssueId)).toBe(false);
+    expect(feed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === genericIssueId)).toBe(true);
+    expect(feed.items.some((item) => item.sourceKind === "issue_thread_interaction" && item.relatedIssue?.id === interactionIssueId)).toBe(true);
+    expect(feed.items.some((item) => item.sourceKind === "decision" && item.relatedIssue?.id === decisionIssueId)).toBe(true);
+    expect(feed.items.some((item) => item.sourceKind === "approval" && item.subject.id === approvalId)).toBe(true);
+
+    await db.insert(inboxDismissals).values({
+      companyId,
+      userId: "board-user",
+      itemKey: `attention:interaction:${interactionId}`,
+      kind: "snooze",
+      dismissedAt: new Date("2099-01-01T00:00:00.000Z"),
+      snoozedUntil: new Date("2099-01-02T00:00:00.000Z"),
+    });
+    const snoozedFeed = await attentionService(db).list(companyId, { userId: "board-user" });
+    expect(snoozedFeed.items.some((item) => item.sourceKind === "issue_thread_interaction" && item.relatedIssue?.id === interactionIssueId)).toBe(false);
+    expect(snoozedFeed.items.some((item) => item.sourceKind === "manual_issue" && item.subject.id === interactionIssueId)).toBe(false);
   });
 
   it("returns ranked decision-only items for every active source and excludes non-human or transient rows", async () => {

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -71,6 +71,7 @@ const ATTENTION_SOURCE_KINDS: AttentionSourceKind[] = [
   "productivity_review",
   "blocker_attention",
   "review",
+  "manual_issue",
   "failed_run",
   "budget_alert",
   "agent_error_alert",
@@ -93,8 +94,9 @@ const SOURCE_RANK: Record<AttentionSourceKind, number> = {
   decision: 6,
   issue_thread_interaction: 7,
   review: 8,
-  productivity_review: 9,
-  join_request: 10,
+  manual_issue: 9,
+  productivity_review: 10,
+  join_request: 11,
 };
 
 const PENDING_INTERACTION_STATUSES = ["pending"] as const;
@@ -1884,6 +1886,86 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
             images: [],
           },
         }));
+      }
+
+      // Manual board/user work has no formal interaction row to feed the desk.
+      // Surface it directly for the requesting user, unless a more specific
+      // Attention source already represents the same issue.
+      if (options.userId) {
+        const manualIssueCandidates = await db
+          .select({
+            id: issues.id,
+            assigneeUserId: issues.assigneeUserId,
+            executionState: issues.executionState,
+          })
+          .from(issues)
+          .where(and(
+            eq(issues.companyId, companyId),
+            eq(issues.originKind, "manual"),
+            or(eq(issues.assigneeUserId, options.userId), isNotNull(issues.executionState)),
+            inArray(issues.status, ["backlog", "todo", "in_progress", "blocked"]),
+            visibleIssueCondition(),
+          ))
+          .orderBy(desc(issues.updatedAt), desc(issues.id));
+        const manualIssueRows = manualIssueCandidates.filter((row) => {
+          if (row.assigneeUserId === options.userId) return true;
+          const executionState = parseIssueExecutionState(row.executionState);
+          return executionState?.status === "pending"
+            && executionState.currentParticipant?.type === "user"
+            && executionState.currentParticipant.userId === options.userId;
+        });
+        const manualIssueIds = manualIssueRows.map((row) => row.id);
+        const [manualIssueMap, openManualDecisionRows] = await Promise.all([
+          issueSummaryMap(db, companyId, manualIssueIds),
+          manualIssueIds.length === 0
+            ? Promise.resolve([])
+            : db
+              .select({ issueId: decisions.originIssueId })
+              .from(decisions)
+              .where(and(
+                eq(decisions.companyId, companyId),
+                eq(decisions.status, "open"),
+                inArray(decisions.originIssueId, manualIssueIds),
+              )),
+        ]);
+        const coveredIssueIds = new Set<string>(openManualDecisionRows.map((row) => row.issueId));
+        for (const row of approvalIssueRows) coveredIssueIds.add(row.issueId);
+        for (const row of visibleInteractionRows) coveredIssueIds.add(row.issueId);
+        for (const item of collected) {
+          if (item.sourceKind !== "approval" && item.sourceKind !== "decision" && item.sourceKind !== "issue_thread_interaction") {
+            continue;
+          }
+          if (item.relatedIssue) coveredIssueIds.add(item.relatedIssue.id);
+          const metadataIssueId = item.subject.metadata?.issueId;
+          if (typeof metadataIssueId === "string") coveredIssueIds.add(metadataIssueId);
+        }
+        for (const row of manualIssueRows) {
+          if (coveredIssueIds.has(row.id)) continue;
+          const issue = manualIssueMap.get(row.id);
+          if (!issue) continue;
+          add(createItem({
+            companyId,
+            sourceKind: "manual_issue",
+            subject: issueSubject(prefix, issue),
+            whyNow: "This manual issue requires your board or user disposition.",
+            decisionVerbs: decisionVerbs({
+              id: "review_issue",
+              label: "Review issue",
+              description: "Open the issue and record the disposition.",
+            }),
+            inlineResolvable: false,
+            entryRule: "Visible manual issue is non-terminal and assigned to the current user without a more specific Attention source.",
+            exitRule: "Issue becomes terminal, hidden, reassigned, or gains a more specific Attention source.",
+            dedupKey: `manual_issue:${issue.id}`,
+            severity: issue.status === "blocked" ? "high" : "medium",
+            activityAt: toIso(issue.updatedAt),
+            createdAt: toIso(issue.createdAt),
+            updatedAt: toIso(issue.updatedAt),
+            relatedIssue: null,
+            ...issueContext(issue),
+            detail: genericDetail(issue.title, []),
+          }));
+        }
       }
 
       const deduped = new Map<string, AttentionItem>();

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -1939,6 +1939,7 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
             continue;
           }
           if (item.relatedIssue) coveredIssueIds.add(item.relatedIssue.id);
+          if (item.sourceKind === "blocker_attention") coveredIssueIds.add(item.subject.id);
           const metadataIssueId = item.subject.metadata?.issueId;
           if (typeof metadataIssueId === "string") coveredIssueIds.add(metadataIssueId);
         }

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -1932,7 +1932,10 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
         for (const row of approvalIssueRows) coveredIssueIds.add(row.issueId);
         for (const row of visibleInteractionRows) coveredIssueIds.add(row.issueId);
         for (const item of collected) {
-          if (item.sourceKind !== "approval" && item.sourceKind !== "decision" && item.sourceKind !== "issue_thread_interaction") {
+          if (item.sourceKind !== "approval"
+            && item.sourceKind !== "decision"
+            && item.sourceKind !== "issue_thread_interaction"
+            && item.sourceKind !== "blocker_attention") {
             continue;
           }
           if (item.relatedIssue) coveredIssueIds.add(item.relatedIssue.id);

--- a/server/src/services/decision-queues.ts
+++ b/server/src/services/decision-queues.ts
@@ -238,7 +238,8 @@ async function sourceIssueId(
     }
     case "productivity_review":
     case "blocker_attention":
-    case "review": {
+    case "review":
+    case "manual_issue": {
       const row = await db.select({ id: issues.id })
         .from(issues)
         .where(and(eq(issues.companyId, companyId), eq(issues.id, sourceId), isNull(issues.hiddenAt)))

--- a/server/src/services/decision-retention.ts
+++ b/server/src/services/decision-retention.ts
@@ -115,7 +115,7 @@ async function resolveOrigin(
       ? await db.select({ issueId: issueRecoveryActions.sourceIssueId }).from(issueRecoveryActions)
         .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.id, sourceId)))
         .then((rows) => rows[0]?.issueId ?? null)
-      : (["productivity_review", "blocker_attention", "review"] as string[]).includes(sourceKind) ? sourceId : null;
+      : (["productivity_review", "blocker_attention", "review", "manual_issue"] as string[]).includes(sourceKind) ? sourceId : null;
     if (issueId) {
       const row = await db.select({ agentId: issues.createdByAgentId, issueId: issues.id }).from(issues)
         .where(and(eq(issues.companyId, companyId), eq(issues.id, issueId)))

--- a/ui/src/lib/attention.test.ts
+++ b/ui/src/lib/attention.test.ts
@@ -195,6 +195,7 @@ describe("sourceMeta + severityStyle", () => {
       "productivity_review",
       "blocker_attention",
       "review",
+      "manual_issue",
       "failed_run",
       "budget_alert",
       "agent_error_alert",
@@ -202,6 +203,7 @@ describe("sourceMeta + severityStyle", () => {
     for (const kind of kinds) {
       expect(sourceMeta(kind).label.length).toBeGreaterThan(0);
     }
+    expect(sourceMeta("manual_issue").label).toBe("Board decision");
   });
 
   it("maps escalation severity to distinct accents", () => {

--- a/ui/src/lib/attention.ts
+++ b/ui/src/lib/attention.ts
@@ -56,6 +56,7 @@ const SOURCE_META: Record<AttentionSourceKind, SourceMeta> = {
   productivity_review: { label: "Productivity review" },
   blocker_attention: { label: "Blocked dependency" },
   review: { label: "Review" },
+  manual_issue: { label: "Board decision" },
   failed_run: { label: "Failed run" },
   budget_alert: { label: "Budget" },
   agent_error_alert: { label: "Agent error" },
@@ -132,6 +133,7 @@ export function attentionKind(item: AttentionItem): AttentionKind {
     case "join_request":
     case "review":
     case "productivity_review":
+    case "manual_issue":
     default:
       return "review";
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip helps people manage AI agents and their work
> - The Attention feed is the board user's action queue
> - The feed already shows formal approvals, interactions, decisions, and reviews
> - A manual issue can still require a board decision without one of those formal records
> - Those issues are absent from Attention today
> - This pull request adds one read-only Attention item for each eligible manual issue
> - The benefit is a complete board queue without a second mutation path

## Linked Issues or Issue Description

Refs: #9311

**What existing behavior does this improve?**

The existing Attention feed from #9311 does not show a manual issue that needs a board or user decision.

**Subsystem affected**

Cross-cutting. This change updates shared Attention types, the server feed, and the UI source label.

**Current behavior**

A board user must scan the issue list for manual backlog, todo, active, or blocked work. The Attention feed shows a formal approval, interaction, decision, or review, but it does not show a manual issue with no formal record.

**Proposed behavior**

Add one `manual_issue` Attention item for an eligible manual issue. Link to the issue and label it `Board decision`. Do not add an inline mutation. Suppress the generic item when an open decision, pending interaction, pending approval, or existing review already represents the issue.

**Reason and benefit**

The board user gets one complete action queue. Stable deduplication prevents duplicate cards. A snoozed formal interaction stays authoritative and does not make the generic card reappear.

**Breaking changes**

None. The change adds one source kind to the existing typed Attention response.

## What Changed

- Added the `manual_issue` Attention source kind and the `Board decision` label.
- Added state-derived entries for visible manual issues assigned to the current user or waiting on that user in an execution policy.
- Kept in-review work on the existing review source.
- Added stable deduplication, dismissal, queue, and retention support.
- Added formal-source precedence for all linked approvals and for snoozed interactions.

## Verification

- `./node_modules/.bin/vitest run server/src/__tests__/attention-service.test.ts` -> 26 tests passed.
- `./node_modules/.bin/vitest run ui/src/lib/attention.test.ts` -> 52 tests passed.
- `./node_modules/.bin/tsc --noEmit -p packages/shared/tsconfig.json` -> exit code 0.
- Independent read-only review -> approved with 78 focused tests passed.
- `git diff --check` -> exit code 0.

## Risks

- Low risk. The new row is read-only and uses existing issue links.
- The server query is limited to visible manual issues in four non-review states.
- Formal decisions, interactions, approvals, and reviews keep precedence.

## Model Used

OpenAI Codex, GPT-5.6-based coding agent, tool use enabled. The exact runtime context window is not exposed by this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket ID
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented the risks
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
