### PR TITLE
fix(adapters): skip ACP session/set_config_option for gemini_local

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -499,22 +499,24 @@ describe("shared ACPX engine runtime behavior", () => {
     });
   });
 
-  it("keeps Claude startup model handling and Gemini session config handling unchanged", async () => {
+  it("keeps Claude startup model handling and skips ACP session config for Gemini", async () => {
     const claude = await runExecutor({ agent: "claude", model: "claude-opus-4-7" });
     expect((claude.meta[0]?.env as Record<string, string>).ANTHROPIC_MODEL).toBe(
       "claude-opus-4-7",
     );
     expect(claude.configOptions).toEqual([]);
 
+    // Gemini's ACP server does not implement session/set_config_option — any
+    // call fails the whole run with a JSON-RPC "Method not found" (-32601)
+    // error. Model is passed as a `--model` startup flag instead; effort and
+    // fast-mode have no equivalent for gemini and are simply dropped.
     const gemini = await runExecutor({
       agent: "gemini",
       model: "gemini-2.5-pro",
       thinkingEffort: "high",
     });
-    expect(gemini.configOptions).toEqual([
-      { key: "model", value: "gemini-2.5-pro" },
-      { key: "effort", value: "high" },
-    ]);
+    expect(gemini.configOptions).toEqual([]);
+    expect(gemini.meta[0]?.command).toBe("gemini --acp --model gemini-2.5-pro");
   });
 
   it("does not inject CODEX_CONFIG or session config when Codex overrides are absent", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1693,6 +1693,15 @@ async function buildRuntime(input: {
       agentCommandShell = normalized;
       agentCommand = normalized;
     }
+    // Gemini's ACP server does not implement session/set_config_option (see
+    // sessionConfigOptions below), so the model must be selected at startup via
+    // the `--model` CLI flag instead — mirroring the gemini-local adapter's own
+    // CLI-lane behavior. Skip if the command already specifies one (e.g. a
+    // user-configured agentCommand) to avoid passing --model twice.
+    if (requestedModel && !agentCommandShell.split(/\s+/).includes("--model")) {
+      agentCommandShell = `${agentCommandShell} --model ${shellQuote(requestedModel)}`;
+      agentCommand = agentCommand ? `${agentCommand} --model ${requestedModel}` : agentCommand;
+    }
   }
   const childStderrDir = path.join(stateDir, "run-stderr");
   const childStderrLogPath = agentCommand ? path.join(childStderrDir, `${runId}.log`) : null;
@@ -2127,20 +2136,34 @@ function sessionConfigOptions(prepared: AcpxPreparedRuntime): Array<{ key: strin
   // Claude and Codex runtime config is pre-set via startup env vars; skip
   // set_config_option to avoid ACP-server picker validation rejecting valid
   // backend model IDs that are not advertised by the local ACP server.
+  // Gemini's ACP server (`gemini --acp`) does not implement session/set_config_option
+  // at all — any call to it fails the whole run with a JSON-RPC "Method not found"
+  // (-32601) error, not just a value-rejection. Model is instead passed as a
+  // `--model` startup flag (see resolveBuiltInAgentCommand below); effort and
+  // fast-mode have no such fallback for gemini and are simply unsupported for now.
   if (
     prepared.requestedModel &&
     prepared.acpxAgent !== "claude" &&
-    prepared.acpxAgent !== "codex"
+    prepared.acpxAgent !== "codex" &&
+    prepared.acpxAgent !== "gemini"
   ) {
     options.push({ key: "model", value: prepared.requestedModel });
   }
-  if (prepared.requestedThinkingEffort && prepared.acpxAgent !== "codex") {
+  if (
+    prepared.requestedThinkingEffort &&
+    prepared.acpxAgent !== "codex" &&
+    prepared.acpxAgent !== "gemini"
+  ) {
     options.push({
       key: "effort",
       value: prepared.requestedThinkingEffort,
     });
   }
-  if (prepared.fastMode && prepared.acpxAgent !== "codex") {
+  if (
+    prepared.fastMode &&
+    prepared.acpxAgent !== "codex" &&
+    prepared.acpxAgent !== "gemini"
+  ) {
     options.push(
       { key: "service_tier", value: "fast" },
       { key: "features.fast_mode", value: "true" },


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The ACPX runtime is the shared engine that drives ACP-protocol coding agents (Claude, Codex, Gemini) from a single execution path.
> - The runtime sends `session/set_config_option` to configure model, effort, and fast-mode on every ACP agent, but Gemini's ACP server does not implement that RPC method at all.
> - Every `gemini_local` ACP run that requests a model fails outright with a JSON-RPC "Method not found" (-32601) error, because the shared code path never excluded Gemini the way it already excludes Claude and Codex.
> - This pull request excludes `gemini` from the `session/set_config_option` path and instead passes `--model <model>` on the `gemini --acp` startup command, mirroring the working CLI-lane behavior already used by the sibling `gemini-local` adapter package.
> - The benefit is that `gemini_local` ACP runs with an explicit model no longer crash on startup.

## Linked Issues or Issue Description

Fixes: #11230

## What Changed

- Excludes `gemini` from the ACP config-option path (model, effort, fast-mode) in `packages/adapter-utils/src/acpx-engine/execute.ts`, alongside the existing `claude`/`codex` exclusion.
- Passes `--model <model>` on the `gemini --acp` startup command when a model is requested, instead of relying on the unsupported `session/set_config_option` call.
- Updates the shared ACPX runtime test (`execute.test.ts`) to assert the new Gemini behavior: empty `configOptions` and a resolved command that includes `--model <model>`.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` passes.
- `packages/adapter-utils/src/acpx-engine/execute.test.ts`: 109/109 passing.
- Full `packages/adapter-utils` package suite: only a pre-existing, unrelated `ssh-fixture.test.ts` failure, confirmed identical on unmodified `upstream/master` — an environment-dependent SSH git-merge fixture, not touched by this change.
- Reproduced the original failure against a live self-hosted Paperclip instance (2026.722.0) before this fix, and confirmed the failure mode matches exactly what is described in #11230.

## Risks

- Low risk. The change only narrows an existing per-agent exclusion list and adds a startup flag already proven to work on the sibling CLI-lane adapter; it does not alter behavior for `claude` or `codex`.
- Effort and fast-mode are also excluded for `gemini`, since the root cause (`session/set_config_option` unimplemented) applies to the whole RPC method, not just the `model` key. Neither has a startup-flag equivalent for Gemini CLI today, so they are simply unsupported for `gemini_local` for now — happy to follow up if that is wanted.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), agentic coding mode with tool use (file edit, test execution, git).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found for #11230)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs cover this internal ACPX behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending re-check after this description update)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending re-review)
- [x] I will address all Greptile and reviewer comments before requesting merge