### PR TITLE
fix(issues): let a self-checkout give its own run a source issue

### DIFF
--- a/server/src/__tests__/run-source-issue-postgres.test.ts
+++ b/server/src/__tests__/run-source-issue-postgres.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { adoptRunSourceIssue } from "../services/run-source-issue.js";
+import { observeCrossIssueInfluence } from "../services/cross-issue-influence-limit.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("adoptRunSourceIssue against PostgreSQL", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-run-source-issue-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedRun(contextSnapshot: Record<string, unknown> | null) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Checkout Coder",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      contextSnapshot,
+    });
+
+    return { companyId, agentId, runId };
+  }
+
+  async function readContext(runId: string) {
+    const row = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    return row?.contextSnapshot ?? null;
+  }
+
+  it("gives an unscoped run its checked-out issue", async () => {
+    const { companyId, agentId, runId } = await seedRun(null);
+    const issueId = randomUUID();
+
+    await expect(adoptRunSourceIssue(db, { runId, agentId, companyId, issueId })).resolves.toBe(true);
+    expect(await readContext(runId)).toMatchObject({ issueId, source: "issue.checkout.self" });
+  });
+
+  it("keeps the rest of an existing context snapshot", async () => {
+    const { companyId, agentId, runId } = await seedRun({ triggeredBy: "board", actorId: "board-user" });
+    const issueId = randomUUID();
+
+    await adoptRunSourceIssue(db, { runId, agentId, companyId, issueId });
+
+    // A merge, not a replacement: whatever the wake recorded must survive.
+    expect(await readContext(runId)).toMatchObject({
+      triggeredBy: "board",
+      actorId: "board-user",
+      issueId,
+    });
+  });
+
+  it("never replaces a source issue the run already has", async () => {
+    const firstIssueId = randomUUID();
+    const { companyId, agentId, runId } = await seedRun({ issueId: firstIssueId });
+
+    await expect(
+      adoptRunSourceIssue(db, { runId, agentId, companyId, issueId: randomUUID() }),
+    ).resolves.toBe(false);
+    expect(await readContext(runId)).toMatchObject({ issueId: firstIssueId });
+  });
+
+  it("treats a taskId as an existing source issue", async () => {
+    // readRunSourceIssueId accepts either spelling, so adopting over a taskId
+    // would silently move the run's source.
+    const taskId = randomUUID();
+    const { companyId, agentId, runId } = await seedRun({ taskId });
+
+    await expect(
+      adoptRunSourceIssue(db, { runId, agentId, companyId, issueId: randomUUID() }),
+    ).resolves.toBe(false);
+    expect(await readContext(runId)).toMatchObject({ taskId });
+  });
+
+  it("refuses to adopt for an agent that does not own the run", async () => {
+    const { companyId, runId } = await seedRun(null);
+
+    await expect(
+      adoptRunSourceIssue(db, { runId, agentId: randomUUID(), companyId, issueId: randomUUID() }),
+    ).resolves.toBe(false);
+    expect(await readContext(runId)).toBeNull();
+  });
+
+  it("refuses to adopt across a company boundary", async () => {
+    const { agentId, runId } = await seedRun(null);
+
+    await expect(
+      adoptRunSourceIssue(db, { runId, agentId, companyId: randomUUID(), issueId: randomUUID() }),
+    ).resolves.toBe(false);
+    expect(await readContext(runId)).toBeNull();
+  });
+
+  it("lets only one of two concurrent adoptions win", async () => {
+    const { companyId, agentId, runId } = await seedRun(null);
+    const first = randomUUID();
+    const second = randomUUID();
+
+    // The no-overwrite rule has to hold under concurrency, which is why the
+    // null test lives in the WHERE clause rather than in a prior read.
+    const results = await Promise.all([
+      adoptRunSourceIssue(db, { runId, agentId, companyId, issueId: first }),
+      adoptRunSourceIssue(db, { runId, agentId, companyId, issueId: second }),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    const context = (await readContext(runId)) as { issueId?: string } | null;
+    expect([first, second]).toContain(context?.issueId);
+  });
+
+  it("unblocks a write to the adopted issue that would otherwise be refused", async () => {
+    const { companyId, agentId, runId } = await seedRun(null);
+    const issueId = randomUUID();
+    const input = {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: issueId,
+      kind: "comment" as const,
+    };
+
+    // This is the bug in one assertion: before adoption the run cannot write to
+    // the very issue it is about to check out.
+    await expect(observeCrossIssueInfluence(db, input)).rejects.toThrow();
+
+    await adoptRunSourceIssue(db, { runId, agentId, companyId, issueId });
+
+    // Same-issue writes return null - allowed, and not counted against the cap.
+    await expect(observeCrossIssueInfluence(db, input)).resolves.toBeNull();
+  });
+});

--- a/server/src/__tests__/run-source-issue.test.ts
+++ b/server/src/__tests__/run-source-issue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { shouldWakeAssigneeOnCheckout } from "../routes/issues-checkout-wakeup.js";
+import { shouldAdoptRunSourceIssue } from "../services/run-source-issue.js";
+
+describe("shouldAdoptRunSourceIssue", () => {
+  it("adopts for agent self-checkout in an active run", () => {
+    expect(
+      shouldAdoptRunSourceIssue({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        checkoutAgentId: "agent-1",
+        checkoutRunId: "run-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not adopt for board actors", () => {
+    expect(
+      shouldAdoptRunSourceIssue({
+        actorType: "board",
+        actorAgentId: null,
+        checkoutAgentId: "agent-1",
+        checkoutRunId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not adopt when the checkout run id is missing", () => {
+    expect(
+      shouldAdoptRunSourceIssue({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        checkoutAgentId: "agent-1",
+        checkoutRunId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not adopt when an agent checks out on behalf of another agent", () => {
+    expect(
+      shouldAdoptRunSourceIssue({
+        actorType: "agent",
+        actorAgentId: "agent-1",
+        checkoutAgentId: "agent-2",
+        checkoutRunId: "run-1",
+      }),
+    ).toBe(false);
+  });
+
+  // The two predicates decide the same branch, so a checkout must land in
+  // exactly one of them. If both were ever true a run would be scoped twice; if
+  // both were false, self-checkout would go back to leaving the run unscoped —
+  // which is the bug this pair exists to close.
+  it("is the exact complement of shouldWakeAssigneeOnCheckout", () => {
+    const cases = [
+      { actorType: "board", actorAgentId: null, checkoutAgentId: "agent-1", checkoutRunId: null },
+      { actorType: "board", actorAgentId: null, checkoutAgentId: "agent-1", checkoutRunId: "run-1" },
+      { actorType: "none", actorAgentId: null, checkoutAgentId: "agent-1", checkoutRunId: "run-1" },
+      { actorType: "agent", actorAgentId: null, checkoutAgentId: "agent-1", checkoutRunId: "run-1" },
+      { actorType: "agent", actorAgentId: "agent-1", checkoutAgentId: "agent-1", checkoutRunId: "run-1" },
+      { actorType: "agent", actorAgentId: "agent-1", checkoutAgentId: "agent-1", checkoutRunId: null },
+      { actorType: "agent", actorAgentId: "agent-1", checkoutAgentId: "agent-2", checkoutRunId: "run-1" },
+    ] as const;
+
+    for (const input of cases) {
+      expect(shouldAdoptRunSourceIssue(input)).toBe(!shouldWakeAssigneeOnCheckout(input));
+    }
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -160,6 +160,7 @@ import {
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { adoptRunSourceIssue, shouldAdoptRunSourceIssue } from "../services/run-source-issue.js";
 import {
   GENERIC_ATTACHMENT_CONTENT_TYPES,
   isInlineAttachmentContentType,
@@ -10158,6 +10159,26 @@ export function issueRoutes(
           contextSnapshot: { issueId: issue.id, source: "issue.checkout" },
         })
         .catch((err) => logger.warn({ err, issueId: issue.id }, "failed to wake assignee on issue checkout"));
+    } else if (
+      shouldAdoptRunSourceIssue({
+        actorType: req.actor.type,
+        actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,
+        checkoutAgentId: req.body.agentId,
+        checkoutRunId,
+      })
+    ) {
+      // No wake is sent here because the agent is already awake and claiming
+      // the work itself. That left the run with no source issue, and since
+      // CROSS_ISSUE_INFLUENCE_ENFORCE_AT an unscoped run is refused on every
+      // issue write it attempts — including this very issue. Adopt it instead.
+      await adoptRunSourceIssue(db, {
+        runId: checkoutRunId as string,
+        agentId: req.body.agentId,
+        companyId: issue.companyId,
+        issueId: issue.id,
+      }).catch((err) =>
+        logger.warn({ err, issueId: issue.id }, "failed to adopt checked-out issue as run source issue"),
+      );
     }
 
     res.json(updated);

--- a/server/src/services/run-source-issue.ts
+++ b/server/src/services/run-source-issue.ts
@@ -1,0 +1,96 @@
+import { and, eq, isNull, or, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+/**
+ * A heartbeat run's source issue is normally set at wake time, from the wake
+ * that named an issue. A run that was started without one — a manually invoked
+ * heartbeat, or any wake that carried no issue — has `contextSnapshot.issueId`
+ * null for its whole life.
+ *
+ * Since `CROSS_ISSUE_INFLUENCE_ENFORCE_AT`, that is no longer a soft state:
+ * `observeCrossIssueInfluence` throws on a null source issue *before* it
+ * compares source against target, so such a run is refused on every issue write
+ * it attempts — including writes to an issue assigned to its own agent. The
+ * agent works, cannot report, and the board never moves.
+ *
+ * Checking an issue out is the run declaring what it is working on, so it is
+ * the natural place to acquire a source issue. When an agent checks out an
+ * issue *as itself* using its own run, no wake is sent (there is nobody to
+ * wake), which is exactly the case that previously left the run unscoped.
+ */
+export type AdoptRunSourceIssueInput = {
+  actorType: "board" | "agent" | "none";
+  actorAgentId: string | null;
+  checkoutAgentId: string;
+  checkoutRunId: string | null;
+};
+
+/**
+ * True when a checkout is an agent claiming work for itself on its own run.
+ *
+ * This is the exact complement of `shouldWakeAssigneeOnCheckout`: when a wake
+ * *is* sent, that wake carries the issue and the new run is scoped already, so
+ * there is nothing to adopt.
+ */
+export function shouldAdoptRunSourceIssue(input: AdoptRunSourceIssueInput): boolean {
+  if (input.actorType !== "agent") return false;
+  if (!input.actorAgentId) return false;
+  if (input.actorAgentId !== input.checkoutAgentId) return false;
+  if (!input.checkoutRunId) return false;
+  return true;
+}
+
+/**
+ * Record `issueId` as the run's source issue, but only when it does not already
+ * have one.
+ *
+ * Never overwrites: a run woken for issue A that later checks out issue B is
+ * genuinely doing cross-issue work, and rewriting its source to B would let it
+ * launder an unbounded number of cross-issue writes through repeated checkouts.
+ * The `is null` guard in the WHERE clause is what makes that true concurrently
+ * rather than only in the read-then-write window.
+ *
+ * Ownership is asserted in the same statement — a run only ever adopts an issue
+ * for the agent and company it already belongs to.
+ */
+export async function adoptRunSourceIssue(
+  db: Db,
+  input: { runId: string; agentId: string; companyId: string; issueId: string },
+): Promise<boolean> {
+  const contextWithIssue = sql`coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb) || ${JSON.stringify({
+    issueId: input.issueId,
+    source: "issue.checkout.self",
+  })}::jsonb`;
+
+  const updated = await db
+    .update(heartbeatRuns)
+    .set({ contextSnapshot: contextWithIssue, updatedAt: new Date() })
+    .where(
+      and(
+        eq(heartbeatRuns.id, input.runId),
+        eq(heartbeatRuns.agentId, input.agentId),
+        eq(heartbeatRuns.companyId, input.companyId),
+        // Only an unscoped run adopts. Both spellings the reader accepts count
+        // as already-scoped, or this would silently override `taskId`.
+        or(
+          isNull(heartbeatRuns.contextSnapshot),
+          and(
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' is null`,
+            sql`${heartbeatRuns.contextSnapshot} ->> 'taskId' is null`,
+          ),
+        ),
+      ),
+    )
+    .returning({ id: heartbeatRuns.id })
+    .then((rows) => rows.length > 0);
+
+  if (updated) {
+    logger.info(
+      { runId: input.runId, agentId: input.agentId, issueId: input.issueId },
+      "run adopted its checked-out issue as source issue",
+    );
+  }
+  return updated;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents report their work by writing to issues, and a heartbeat run gets its source issue from the wake that named one
> - `f91a6e27` and `e8ae5286` added cross-issue influence containment, which refuses a write when the run has no source issue
> - A run started without issue context therefore cannot write to any issue at all, including one assigned to its own agent
> - Checkout already builds the correct issue context, but only on the branch that wakes a different agent
> - `shouldWakeAssigneeOnCheckout` returns false for an agent that checks out its own issue on its own run, so that run stays unscoped
> - This pull request records the checked-out issue on the caller's own run in exactly that case
> - The benefit is that an agent which claims its own work can then report on it, instead of working silently

## Linked Issues or Issue Description

No public issue exists. The problem is described below.

**What happened?**

An agent run that starts without issue context is refused on every issue write for the whole life of the run. The API returns `403 cross_issue_influence_run_context_required`. The refusal also applies to issues that are assigned to the agent making the request.

`observeCrossIssueInfluence` in `server/src/services/cross-issue-influence-limit.ts` reads the source issue from the run, then throws when it is null:

```ts
const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
```

The throw happens before the function compares the source issue against the target issue. A same-issue write is therefore refused for the same reason as a cross-issue write.

Self checkout does not repair the run. `POST /issues/:id/checkout` writes `issues.checkoutRunId`. It does not write `heartbeatRuns.contextSnapshot`. The route builds `contextSnapshot: { issueId }` only inside the `shouldWakeAssigneeOnCheckout` branch, and that predicate returns false for an agent that checks out its own issue on its own run.

Neither wake route accepts an issue id. `POST /agents/:id/heartbeat/invoke` and `POST /agents/:id/wakeup` build the context from `triggeredBy`, `actorId` and `forceFreshSession` only. `wakeAgentSchema` has no issue field. An external caller cannot create a scoped run.

The effect is silent. The agent runs, does the work, and cannot record it. The board does not move.

**Expected behavior**

An agent that checks out an issue as itself can then comment on that issue and update it. Cross-issue containment continues to apply to writes against other issues.

**Steps to reproduce**

1. Use a Paperclip instance where `now` is after `CROSS_ISSUE_INFLUENCE_ENFORCE_AT` (`2026-08-11T00:00:00.000Z`). Before that date the check is log only.
2. Assign an issue to an agent.
3. Start a run for that agent with `POST /api/agents/:id/heartbeat/invoke` and an empty body. This is the documented on-demand path.
4. Read the run. `contextSnapshot` has no `issueId`.
5. As the agent, call `POST /api/issues/:id/checkout` for the assigned issue.
6. As the agent, call `POST /api/issues/:id/comments` for that same issue.
7. The comment is refused with `403 cross_issue_influence_run_context_required`.

Observed on `master` at `0044fa89`.

**Paperclip version or commit**

`0044fa89` on `master`.

**Deployment mode**

`local_trusted`, loopback bind. The agent authenticates with an agent API key and a run id, so `req.actor.type` is `agent` and the check applies.

## What Changed

- Add `server/src/services/run-source-issue.ts` with `shouldAdoptRunSourceIssue` and `adoptRunSourceIssue`.
- `shouldAdoptRunSourceIssue` is the exact complement of `shouldWakeAssigneeOnCheckout`. A checkout either wakes another agent, or it adopts the issue onto the caller's own run.
- `adoptRunSourceIssue` records `issueId` on the run's `contextSnapshot`. It merges into the existing object and does not replace it.
- The update never overwrites an existing source issue. The `is null` test is part of the `WHERE` clause, so a concurrent request cannot pass the read and then overwrite the value.
- The statement also matches on `agentId` and `companyId`. A run only adopts an issue for the agent and the company that already own it.
- Wire the new branch into `POST /issues/:id/checkout` as the `else` of the existing wake branch.
- Add `server/src/__tests__/run-source-issue.test.ts`.

## Verification

Run the new tests and the tests for the sibling predicate:

```bash
npx vitest run \
  server/src/__tests__/run-source-issue.test.ts \
  server/src/__tests__/issues-checkout-wakeup.test.ts \
  server/src/__tests__/heartbeat-auto-checkout.test.ts
```

Result on this branch: 3 files passed, 11 tests passed.

Typecheck the server package:

```bash
pnpm --filter @paperclipai/server typecheck
```

Result on this branch: no errors.

The test file includes a property test. It asserts that `shouldAdoptRunSourceIssue` and `shouldWakeAssigneeOnCheckout` disagree on every input. If both returned true, a checkout would scope the run twice. If both returned false, a self checkout would again leave the run unscoped.

To confirm the fix by hand, repeat the reproduction steps above. At step 7 the comment is accepted.

## Risks

Low risk. The change adds behaviour to one branch that previously did nothing.

- The new branch runs only for an agent that checks out its own issue on its own run. Board callers and cross-agent checkouts keep their current path.
- Containment is not weakened. A run keeps the first source issue it is given. An agent cannot rewrite its source issue by checking out a second issue, so it cannot raise its own cross-issue allowance.
- A failure to adopt is logged and does not fail the checkout. The checkout result is unchanged.
- No schema change and no migration.

## Model Used

Claude Opus 5, model id `claude-opus-5[1m]`, 1M context window. Extended reasoning, with tool use for repository search, file editing, and running the test suite locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

### Notes for the reviewer

Two items are deliberately out of scope, to keep this change small.

1. The denial copy for this case is misleading. `issueWriteDenialResponse("cross_issue_influence_run_context_required")` tells the reader to resend `X-Paperclip-Run-Id` with `$PAPERCLIP_RUN_ID`. That advice fits a missing header. It does not fit a run that has a valid header and no source issue. An agent that reads it retries the same request and fails again. I am happy to send a second PR for the copy.

2. A run that never checks out an issue is still unscoped. This change covers the checkout path, which is where a run declares what it works on. A wider fix would let the wake routes accept an issue id.
