### PR TITLE
fix(adapters): probe bubblewrap namespace support

### DIFF
--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -320,6 +320,8 @@ For Linux local coding adapters, `filesystemScope: "workspace"` adds host-level 
 
 `networkScope` is also disabled by default and can be enabled independently or together with filesystem confinement. `"deny"` creates a private network namespace with no egress. `"allowlist"` keeps direct sockets blocked and injects an HTTP(S) proxy that accepts only exact `networkAllowlist` hostnames (optionally with a port); list the coding provider endpoint and every other required API origin explicitly. For example, a standard Codex API-key setup normally needs `api.openai.com`, while Claude setups may need `api.anthropic.com` or their configured Bedrock, Vertex, or gateway origins. Wildcards are intentionally unsupported. Install `bwrap` on the Paperclip host before enabling either scope. Auto engine selection uses the CLI lane while a scope is enabled; explicit ACP mode is rejected because ACP processes are not yet covered by the spawn wrapper.
 
+Paperclip probes the complete Bubblewrap namespace path before starting an adapter. If the kernel denies unprivileged user namespaces, Paperclip retries only through `sudo -n --preserve-env -- <resolved-bwrap>`; the fallback succeeds only when the operator has installed a passwordless rule scoped to that exact Bubblewrap binary. Paperclip adds `--uid` and `--gid` to return the sandboxed process to the server identity and masks the resolved `sudo` executable inside the sandbox. If the scoped rule is absent or fails, the run fails closed before Codex starts. Do not grant general passwordless sudo to the Paperclip account.
+
 ### Output parsing
 
 Codex emits JSONL events. Parse line-by-line and extract:

--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -10,6 +10,7 @@ import {
   parseLocalProcessNetworkAllowlist,
   parseLocalProcessNetworkScope,
   parseLocalProcessSandboxExtraPaths,
+  probeLocalProcessSandboxCapability,
 } from "./local-process-sandbox.js";
 import { runChildProcess } from "./server-utils.js";
 
@@ -37,6 +38,113 @@ describe("local process sandbox", () => {
       { path: "/var/lib/tool", access: "rw" },
     ]);
     expect(() => parseLocalProcessSandboxExtraPaths(["relative"])).toThrow("must be an absolute path");
+  });
+
+  it("detects a host where Bubblewrap cannot create a user namespace", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-bwrap-probe-"));
+    cleanup.push(root);
+    const fakeBwrap = path.join(root, "bwrap");
+    await fs.writeFile(
+      fakeBwrap,
+      "#!/bin/sh\necho 'bwrap: No permissions to create a new namespace' >&2\nexit 1\n",
+      { mode: 0o755 },
+    );
+
+    await expect(probeLocalProcessSandboxCapability({
+      command: fakeBwrap,
+      cwd: root,
+      env: process.env,
+    })).resolves.toEqual({
+      supported: false,
+      reason: "user_namespace_unavailable",
+      detail: "bwrap: No permissions to create a new namespace",
+    });
+  });
+
+  it("uses a narrowly scoped sudo Bubblewrap fallback when user namespaces are unavailable", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-bwrap-sudo-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const fakeBwrap = path.join(root, "bwrap");
+    const fakeSudo = path.join(root, "sudo");
+    const argsLog = path.join(root, "bwrap-args.log");
+    await fs.mkdir(workspace);
+    await fs.writeFile(fakeBwrap, [
+      "#!/bin/sh",
+      "if [ \"$PAPERCLIP_TEST_PRIVILEGED\" != 1 ]; then",
+      "  echo 'bwrap: No permissions to create a new namespace' >&2",
+      "  exit 1",
+      "fi",
+      "printf '%s\\n' \"$*\" >> \"$PAPERCLIP_TEST_ARGS_FILE\"",
+      "sandbox_cwd=",
+      "while [ \"$#\" -gt 0 ] && [ \"$1\" != \"--\" ]; do",
+      "  if [ \"$1\" = \"--chdir\" ]; then shift; sandbox_cwd=$1; fi",
+      "  shift",
+      "done",
+      "shift",
+      "[ -n \"$sandbox_cwd\" ] && cd \"$sandbox_cwd\"",
+      "exec \"$@\"",
+      "",
+    ].join("\n"), { mode: 0o755 });
+    await fs.writeFile(fakeSudo, [
+      "#!/bin/sh",
+      "[ \"$1\" = \"-n\" ] && shift",
+      "[ \"$1\" = \"--preserve-env\" ] && shift",
+      "[ \"$1\" = \"--\" ] && shift",
+      "PAPERCLIP_TEST_PRIVILEGED=1 exec \"$@\"",
+      "",
+    ].join("\n"), { mode: 0o755 });
+
+    const result = await runChildProcess("filesystem-sandbox-sudo-fallback", process.execPath, [
+      "-e",
+      "require('node:fs').writeFileSync('workspace-ok.txt', String(process.getuid?.()))",
+    ], {
+      cwd: workspace,
+      env: { PATH: `${root}:${process.env.PATH ?? ""}`, PAPERCLIP_TEST_ARGS_FILE: argsLog },
+      timeoutSec: 10,
+      graceSec: 1,
+      onLog: async () => {},
+      localProcessSandbox: {
+        workspaceDir: workspace,
+        filesystemScope: "workspace",
+        command: fakeBwrap,
+      },
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    await expect(fs.readFile(path.join(workspace, "workspace-ok.txt"), "utf8"))
+      .resolves.toBe(String(process.getuid?.()));
+    const generatedArgs = await fs.readFile(argsLog, "utf8");
+    expect(generatedArgs).toContain(`--uid ${process.getuid?.()} --gid ${process.getgid?.()}`);
+    expect(generatedArgs).toContain(`--ro-bind /dev/null ${fakeSudo}`);
+    expect(generatedArgs).toContain(`--bind ${workspace} ${workspace}`);
+    expect(generatedArgs).not.toContain(path.join(root, "outside"));
+  });
+
+  it("fails closed when user namespaces and the scoped sudo fallback are unavailable", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-bwrap-no-sudo-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const fakeBwrap = path.join(root, "bwrap");
+    await fs.mkdir(workspace);
+    await fs.writeFile(
+      fakeBwrap,
+      "#!/bin/sh\necho 'bwrap: No permissions to create a new namespace' >&2\nexit 1\n",
+      { mode: 0o755 },
+    );
+
+    await expect(runChildProcess("filesystem-sandbox-no-sudo", process.execPath, ["-e", "process.exit(0)"], {
+      cwd: workspace,
+      env: { PATH: root },
+      timeoutSec: 10,
+      graceSec: 1,
+      onLog: async () => {},
+      localProcessSandbox: {
+        workspaceDir: workspace,
+        filesystemScope: "workspace",
+        command: fakeBwrap,
+      },
+    })).rejects.toThrow("cannot start Bubblewrap (user_namespace_unavailable)");
   });
 
   it("parses network scopes and exact-host allowlists", () => {
@@ -290,12 +398,13 @@ describe("local process sandbox", () => {
   });
 
   it.runIf(Boolean(process.env.PAPERCLIP_TEST_BWRAP))(
-    "prevents reads outside the workspace while allowing workspace writes",
+    "prevents reads and writes outside the workspace while allowing workspace writes",
     async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-sandbox-integration-"));
       cleanup.push(root);
       const workspace = path.join(root, "workspace");
       const outside = path.join(root, "canary.txt");
+      const outsideWrite = path.join(root, "outside-write.txt");
       const allowed = path.join(root, "allowed.txt");
       await fs.mkdir(workspace);
       await fs.writeFile(outside, "host-secret", "utf8");
@@ -307,6 +416,9 @@ describe("local process sandbox", () => {
         "  if (!['ENOENT', 'EACCES'].includes(error.code)) throw error;",
         "}",
         `if (fs.readFileSync(${JSON.stringify(allowed)}, 'utf8') !== 'allowed-value') process.exit(8);`,
+        `try { fs.writeFileSync(${JSON.stringify(outsideWrite)}, 'denied'); process.exit(7); } catch (error) {`,
+        "  if (!['ENOENT', 'EACCES', 'EROFS'].includes(error.code)) throw error;",
+        "}",
         "fs.writeFileSync('workspace-ok.txt', 'ok');",
       ].join("\n");
       const result = await runChildProcess("filesystem-sandbox-test", process.execPath, ["-e", script], {
@@ -325,6 +437,7 @@ describe("local process sandbox", () => {
 
       expect(result.exitCode, result.stderr).toBe(0);
       await expect(fs.readFile(path.join(workspace, "workspace-ok.txt"), "utf8")).resolves.toBe("ok");
+      await expect(fs.lstat(outsideWrite)).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
 

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { spawn } from "node:child_process";
 import http from "node:http";
 import net from "node:net";
 import os from "node:os";
@@ -70,6 +71,87 @@ const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", 
 const SANDBOX_PROXY_PORT = 31_337;
 const UNIX_SOCKET_PATH_MAX_BYTES = 107;
 const NETWORK_PROXY_TEMP_PREFIX = "paperclip-network-sandbox-";
+const SANDBOX_PROBE_TIMEOUT_MS = 5_000;
+
+export interface LocalProcessSandboxCapability {
+  supported: boolean;
+  reason: "supported" | "command_unavailable" | "user_namespace_unavailable" | "probe_failed" | "probe_timeout";
+  detail: string | null;
+}
+
+export async function probeLocalProcessSandboxCapability(input: {
+  command?: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  commandArgsPrefix?: string[];
+}): Promise<LocalProcessSandboxCapability> {
+  if (process.platform !== "linux") {
+    return { supported: false, reason: "probe_failed", detail: "Local process sandboxing is Linux-only." };
+  }
+  const command = input.command?.trim() || "bwrap";
+  const timeoutMs = input.timeoutMs ?? SANDBOX_PROBE_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    let settled = false;
+    let stderr = "";
+    let timer: ReturnType<typeof setTimeout>;
+    const finish = (result: LocalProcessSandboxCapability) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const child = spawn(command, [...(input.commandArgsPrefix ?? []),
+      "--die-with-parent",
+      "--new-session",
+      "--unshare-pid",
+      "--unshare-ipc",
+      "--unshare-uts",
+      "--ro-bind",
+      "/",
+      "/",
+      "--",
+      "/bin/true",
+    ], {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      if (stderr.length < 8_192) stderr += chunk;
+    });
+    child.once("error", (error: NodeJS.ErrnoException) => {
+      finish({
+        supported: false,
+        reason: error.code === "ENOENT" ? "command_unavailable" : "probe_failed",
+        detail: error.message,
+      });
+    });
+    child.once("close", (code) => {
+      const detail = stderr.trim() || (code === 0 ? null : `Bubblewrap capability probe exited with code ${code}.`);
+      if (code === 0) {
+        finish({ supported: true, reason: "supported", detail: null });
+        return;
+      }
+      const namespaceUnavailable = /(?:no permissions|operation not permitted).*?(?:namespace|userns)|(?:namespace|userns).*?(?:no permissions|operation not permitted)/i.test(detail ?? "");
+      finish({
+        supported: false,
+        reason: namespaceUnavailable ? "user_namespace_unavailable" : "probe_failed",
+        detail,
+      });
+    });
+    timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish({
+        supported: false,
+        reason: "probe_timeout",
+        detail: `Bubblewrap capability probe timed out after ${timeoutMs}ms.`,
+      });
+    }, timeoutMs);
+    timer.unref?.();
+  });
+}
 
 function normalizeAbsolutePath(candidate: string, label: string): string {
   const trimmed = candidate.trim();

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
 import {
   buildLocalProcessSandboxSpawnTarget,
+  probeLocalProcessSandboxCapability,
   type LocalProcessSandboxOptions,
 } from "./local-process-sandbox.js";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
@@ -2383,13 +2384,60 @@ async function resolveSpawnTarget(
         `Local process confinement requires Bubblewrap, but "${requestedSandboxCommand}" was not found in PATH. Install bwrap or configure filesystemSandboxCommand.`,
       );
     }
+    const directCapability = await probeLocalProcessSandboxCapability({
+      command: sandboxCommand,
+      cwd,
+      env,
+    });
+    let sandboxLauncher: { command: string; argsPrefix: string[] } = {
+      command: sandboxCommand,
+      argsPrefix: [],
+    };
+    let sandboxSudoCommand: string | null = null;
+    if (!directCapability.supported) {
+      const sudoCommand = await resolveCommandPath("sudo", cwd, env);
+      if (typeof process.getuid !== "function" || typeof process.getgid !== "function") {
+        throw new Error("Scoped sudo Bubblewrap fallback requires a POSIX UID and GID.");
+      }
+      const privilegeDropArgs = ["--uid", String(process.getuid()), "--gid", String(process.getgid())];
+      const sudoArgsPrefix = ["-n", "--preserve-env", "--", sandboxCommand, ...privilegeDropArgs];
+      const sudoCapability = sudoCommand && directCapability.reason === "user_namespace_unavailable"
+        ? await probeLocalProcessSandboxCapability({
+            command: sudoCommand,
+            commandArgsPrefix: sudoArgsPrefix,
+            cwd,
+            env,
+          })
+        : null;
+      if (!sudoCommand || !sudoCapability?.supported) {
+        const sudoDetail = sudoCapability?.detail ? ` Scoped sudo fallback failed: ${sudoCapability.detail}` : "";
+        throw new Error(
+          `Local process confinement cannot start Bubblewrap (${directCapability.reason}): ${directCapability.detail ?? "no diagnostic available"}.${sudoDetail}`,
+        );
+      }
+      sandboxLauncher = {
+        command: sudoCommand,
+        argsPrefix: sudoArgsPrefix,
+      };
+      sandboxSudoCommand = sudoCommand;
+    }
     const sandboxTarget = await buildLocalProcessSandboxSpawnTarget({
       executable,
       args,
       cwd,
       options: options.localProcessSandbox,
     });
-    return { ...sandboxTarget, command: sandboxCommand };
+    if (sandboxSudoCommand) {
+      const chdirIndex = sandboxTarget.args.indexOf("--chdir");
+      if (chdirIndex < 0) throw new Error("Bubblewrap spawn target is missing --chdir.");
+      // Prevent the confined child from reusing Paperclip's narrowly scoped sudo rule to escape.
+      sandboxTarget.args.splice(chdirIndex, 0, "--ro-bind", "/dev/null", sandboxSudoCommand);
+    }
+    return {
+      ...sandboxTarget,
+      command: sandboxLauncher.command,
+      args: [...sandboxLauncher.argsPrefix, ...sandboxTarget.args],
+    };
   }
 
   if (process.platform !== "win32") {

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -105,7 +105,7 @@ Core fields:
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
 - filesystemScope (string, optional): set to "workspace" to confine local CLI filesystem access with Bubblewrap. Off by default. The workspace and managed CODEX_HOME remain writable; other host paths are hidden.
 - filesystemExtraPaths (array, optional): additional absolute host paths exposed inside the workspace sandbox. String entries are read-only; object entries use { path: "/absolute/path", access: "ro" | "rw" }.
-- filesystemSandboxCommand (string, optional): Bubblewrap executable name or absolute path; defaults to "bwrap". Linux only.
+- filesystemSandboxCommand (string, optional): Bubblewrap executable name or absolute path; defaults to "bwrap". Linux only. Paperclip probes it before launch and, when unprivileged user namespaces are denied, can use only a passwordless sudo rule scoped to the resolved Bubblewrap binary.
 - networkScope (string, optional): "deny" blocks all network egress; "allowlist" permits only networkAllowlist targets through Paperclip's HTTP(S) proxy. Off by default.
 - networkAllowlist (string[], optional): exact hostnames, hostname:port entries, or origin URLs. Include the configured Codex provider origin, such as "api.openai.com" or a custom model provider gateway.
 
@@ -120,7 +120,7 @@ Operational fields:
 - warmHandleIdleMs (number, optional): warm ACP process idle timeout when engine="acp"; defaults to 0
 
 Notes:
-- filesystemScope and networkScope are spawn-level confinement and are orthogonal to Codex approval/sandbox flags. Both require Bubblewrap on the host and select the CLI engine in auto mode; engine="acp" is rejected because ACP confinement is not yet supported. networkScope="allowlist" injects HTTP_PROXY/HTTPS_PROXY for the CLI while its private network namespace blocks direct sockets, so every required provider/API hostname must be listed explicitly.
+- filesystemScope and networkScope are spawn-level confinement and are orthogonal to Codex approval/sandbox flags. Both require Bubblewrap on the host and select the CLI engine in auto mode; engine="acp" is rejected because ACP confinement is not yet supported. Paperclip probes Bubblewrap before starting Codex. If the kernel denies unprivileged user namespaces, it attempts sudo with an explicit UID/GID drop and masks sudo inside the sandbox; without that exact scoped rule it fails closed. networkScope="allowlist" injects HTTP_PROXY/HTTPS_PROXY for the CLI while its private network namespace blocks direct sockets, so every required provider/API hostname must be listed explicitly.
 - Prompts are piped via stdin (Codex receives "-" prompt argument).
 - If instructionsFilePath is configured, Paperclip prepends that file's contents to the stdin prompt on every run.
 - Codex exec automatically applies repo-scoped AGENTS.md instructions from the active workspace. Paperclip cannot suppress that discovery in exec mode, so repo AGENTS.md files may still apply even when you only configured an explicit instructionsFilePath.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters can use Bubblewrap to limit file and network access.
> - Paperclip checked only that the Bubblewrap file existed.
> - Some Linux hosts do not permit unprivileged user namespaces.
> - On these hosts, Bubblewrap stopped before Codex could run a read command or apply a patch.
> - This pull request probes the complete namespace path before Codex starts.
> - It uses a scoped sudo path only when that path is available.
> - The benefit is reliable confinement that still fails closed.

## Linked Issues or Issue Description

**What happened?**

A local Codex run failed before command execution when the host denied unprivileged user namespaces. The error was `bwrap: No permissions to create a new namespace`.

**Expected behavior**

Paperclip must detect this host limit before it starts Codex. It must use a supported, least-privilege Bubblewrap path or stop before the child process starts.

**Steps to reproduce**

1. Use a Linux host that denies unprivileged user namespaces.
2. Configure a local Codex agent with `filesystemScope: "workspace"`.
3. Start the agent and run a read command or an authorized patch.
4. Observe that Bubblewrap stops before the command starts.

**Paperclip version or commit**

The problem reproduces from commit `23a1b025c2cf05de611c5511fe6607ee266c49d3`.

**Deployment mode**

Self-hosted server on Linux.

**Agent adapter(s) involved**

Codex. The shared local-process helper also serves other local adapters.

**Relevant logs or output**

```text
bwrap: No permissions to create a new namespace
```

Related pull requests: #11161, #9504.

## What Changed

- Add a bounded Bubblewrap capability probe before local adapter launch.
- Detect the user-namespace permission error.
- Retry through a non-interactive sudo rule that is scoped to the resolved Bubblewrap file.
- Preserve the run environment and add an explicit UID and GID drop.
- Hide the sudo file inside the child sandbox.
- Stop before Codex starts when the direct path and scoped fallback both fail.
- Add tests for detection, fallback launch, workspace binds, UID and GID drop, sudo masking, and fail-closed behavior.
- Add a real-Bubblewrap assertion for an out-of-scope write.
- Document the operator behavior.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/local-process-sandbox.test.ts packages/adapters/codex-local/src/server/codex-args.test.ts`
  - 24 tests passed.
  - 4 environment-gated Bubblewrap tests were skipped.
- `pnpm --filter @paperclipai/adapter-utils typecheck`
  - Passed.
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
  - Passed.
- `git diff --check`
  - Passed.

## Risks

- The fallback needs a passwordless sudo rule for the exact Bubblewrap file.
- The rule must permit environment preservation.
- A wrong sudo rule can be too broad. The documentation tells operators not to grant general sudo.
- The child runs with the original server UID and GID.
- Paperclip hides sudo inside the sandbox to prevent reuse by the child.
- Hosts without the scoped rule fail closed.
- Rollback is one commit because there is no data migration.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with `gpt-5`. The deployment did not expose a more specific model suffix or context-window value. The model used reasoning, repository tools, shell execution, and web access to official Codex sources.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
