### PR TITLE
fix(recovery): keep edgeless recovery resumable

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1099,7 +1099,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(issues)
       .where(eq(issues.id, input.issueId))
       .then((rows) => rows[0] ?? null);
-    expect(sourceIssue?.status).toBe("blocked");
+    expect(sourceIssue?.status).toBe("todo");
 
     return action;
   }
@@ -1391,7 +1391,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const issue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, secondAttempt.issueId)).then((rows) => {
         const row = rows[0] ?? null;
-        return row?.status === "blocked" ? row : null;
+        return row?.status === "todo" ? row : null;
       })
     );
     expect(issue?.monitorNextCheckAt).toBeNull();
@@ -2424,7 +2424,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
-  it("blocks the issue when process-loss retry is exhausted and the immediate continuation recovery also fails", async () => {
+  it("returns the issue to todo when process-loss continuation recovery is exhausted", async () => {
     mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
 
     const { companyId, agentId, runId, issueId } = await seedRunFixture({
@@ -2467,15 +2467,15 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       retryOfRunId: runId,
     });
 
-    const blockedIssue = await waitForValue(async () =>
+    const recoveredIssue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const issue = rows[0] ?? null;
-        return issue?.status === "blocked" ? issue : null;
+        return issue?.status === "todo" ? issue : null;
       })
     );
-    expect(blockedIssue?.status).toBe("blocked");
-    expect(blockedIssue?.executionRunId).toBeNull();
-    expect(blockedIssue?.checkoutRunId).toBeNull();
+    expect(recoveredIssue?.status).toBe("todo");
+    expect(recoveredIssue?.executionRunId).toBeNull();
+    expect(recoveredIssue?.checkoutRunId).toBeNull();
     if (!continuationRun?.id) throw new Error("Expected continuation recovery run to exist");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
@@ -2936,7 +2936,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(issues)
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await db
       .select({ id: issueRecoveryActions.id, status: issueRecoveryActions.status, sourceIssueId: issueRecoveryActions.sourceIssueId })
@@ -3104,7 +3104,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     mockAdapterExecute.mockClear();
   });
 
-  it("blocks a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
+  it("returns a git-sensitive local adapter issue to todo with a recovery action when its project id is missing", async () => {
     mockAdapterExecute.mockClear();
     const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
     const projectId = randomUUID();
@@ -3166,7 +3166,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const issue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const row = rows[0] ?? null;
-        return row?.status === "blocked" ? row : null;
+        return row?.status === "todo" ? row : null;
       }),
     );
     expect(issue?.executionRunId).toBeNull();
@@ -3198,7 +3198,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(validationComment).toBeTruthy();
   });
 
-  it("blocks before dispatch when a declared secret ref has no binding instead of emitting an opaque setup failure", async () => {
+  it("returns a missing-secret-binding issue to todo with a recovery action before dispatch", async () => {
     const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
     const svc = secretService(db);
     const secretName = `unbound-runtime-${randomUUID()}`;
@@ -3259,7 +3259,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const issue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const row = rows[0] ?? null;
-        return row?.status === "blocked" ? row : null;
+        return row?.status === "todo" ? row : null;
       }),
     );
     expect(issue?.executionRunId).toBeNull();
@@ -3673,7 +3673,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(JSON.stringify(recoveryAction.evidence)).not.toContain("sk-test-successful-handoff-secret");
 
     const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(sourceIssue?.status).toBe("blocked");
+    expect(sourceIssue?.status).toBe("todo");
     await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
@@ -4637,7 +4637,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.assigneeAgentId).toBe(agentId);
   });
 
-  it("retries a pending execution-review participant once before blocking with a recovery action", async () => {
+  it("retries a pending execution-review participant once before returning it to todo with a recovery action", async () => {
     const { companyId, agentId, issueId, runId, stageId } = await seedInReviewParticipantRunFixture();
     const heartbeat = heartbeatService(db);
 
@@ -4680,10 +4680,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         .from(issues)
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
-      return row?.status === "blocked" ? row : null;
+      return row?.status === "todo" ? row : null;
     }, 8_000);
     expect(sourceIssue).toMatchObject({
-      status: "blocked",
+      status: "todo",
       assigneeAgentId: agentId,
       executionRunId: null,
     });
@@ -4718,7 +4718,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     )).toBe(true);
   });
 
-  it("blocks failed execution-review recovery under the reviewer when the source assignee differs", async () => {
+  it("returns failed execution-review recovery to the source assignee with a reviewer-owned action", async () => {
     const { companyId, agentId, issueId, runId, wakeupRequestId, stageId } =
       await seedInReviewParticipantRunFixture({
         wakeReason: "execution_review_participant_recovery",
@@ -4790,11 +4790,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         .from(issues)
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
-      return row?.status === "blocked" ? row : null;
+      return row?.status === "todo" ? row : null;
     });
     expect(sourceIssue).toMatchObject({
-      status: "blocked",
-      assigneeAgentId: agentId,
+      status: "todo",
+      assigneeAgentId: sourceAssigneeAgentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
@@ -5086,7 +5086,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         )),
       db.select({ body: issueComments.body }).from(issueComments).where(eq(issueComments.issueId, issueId)),
     ]);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
     expect(continuationRuns).toHaveLength(3);
     expect(comments.some((comment) => comment.body.includes(interactionId))).toBe(true);
   });
@@ -5487,7 +5487,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
-  it("blocks assigned todo work after the one automatic dispatch recovery was already used", async () => {
+  it("keeps assigned todo work with its original owner after bounded dispatch recovery is exhausted", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",
       runStatus: "failed",
@@ -5495,6 +5495,30 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       runErrorCode: "process_lost",
       runError: "Authorization: Bearer sk-test-recovery-secret",
     });
+    for (const ageMs of [120_000, 60_000]) {
+      const createdAt = new Date(Date.now() - ageMs);
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assignment_recovery",
+          retryReason: "assignment_recovery",
+          source: "issue.assignment_recovery",
+        },
+        errorCode: "process_lost",
+        error: "prior dispatch recovery failed",
+        startedAt: createdAt,
+        finishedAt: createdAt,
+        createdAt,
+        updatedAt: createdAt,
+      });
+    }
     const longRecoveryOwnerName = "R".repeat(161);
     await db.update(agents).set({ name: longRecoveryOwnerName }).where(eq(agents.id, agentId));
     const heartbeat = heartbeatService(db);
@@ -5505,7 +5529,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue).toMatchObject({ status: "todo", assigneeAgentId: agentId });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -5520,7 +5544,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
-    expect(comments[0]?.body).toContain("retried dispatch");
+    expect(comments[0]?.body).toContain("exhausted bounded dispatch retries");
     expect(comments[0]?.body).not.toContain("sk-test-recovery-secret");
     expect(JSON.stringify(comments[0]?.metadata)).not.toContain("sk-test-recovery-secret");
     const failureSummary = commentMetadataRows(comments[0]).find((row) =>
@@ -5907,7 +5931,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
-  it("blocks stranded in-progress work after the continuation retry was already used", async () => {
+  it("returns stranded in-progress work to todo after the continuation retry was used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
@@ -5921,7 +5945,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -6057,7 +6081,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -6198,7 +6222,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -6584,7 +6608,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -6672,7 +6696,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(1);
   });
 
-  it("blocks stranded in-progress work after a productive continuation retry was already used", async () => {
+  it("returns stranded in-progress work to todo after a productive continuation retry was used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
@@ -6688,7 +6712,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -6864,7 +6888,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.continuationRequeued).toBe(0);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    expect(issue?.status).toBe("todo");
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -636,7 +636,7 @@ async function expectContainedWorkspaceBranchFailure(input: {
   });
   const issueById = new Map(issueRows.map((issue) => [issue.id, issue]));
   expect(issueById.get(input.sourceIssueId)).toMatchObject({
-    status: "blocked",
+    status: "todo",
     executionRunId: null,
     checkoutRunId: null,
   });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
@@ -17,6 +17,9 @@ import {
   issueRecoveryActions,
   issueRelations,
   issues,
+  routines,
+  routineRuns,
+  routineTriggers,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -143,6 +146,9 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(environments);
     await db.delete(issueInboxArchives);
+    await db.delete(routineRuns);
+    await db.delete(routineTriggers);
+    await db.delete(routines);
     await db.delete(issues);
     await db.delete(agents);
     await db.delete(companies);
@@ -316,7 +322,9 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
     expect(updatedIssue).toMatchObject({
-      status: "blocked",
+      status: "todo",
+      assigneeAgentId: coderId,
+      executionRunId: null,
     });
     const recoveryIssues = await db
       .select()
@@ -329,6 +337,195 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       sourceIssueId: sourceIssue.id,
       recoveryCause: "stranded_assigned_issue",
     });
+  });
+
+  it.each([
+    {
+      kind: "schedule",
+      trigger: {
+        cronExpression: "0 * * * *",
+        timezone: "UTC",
+        nextRunAt: new Date("2026-05-14T19:00:00.000Z"),
+      },
+    },
+    { kind: "api", trigger: {} },
+  ] as const)("completes an execution shell when its active routine has an enabled $kind trigger", async ({ kind, trigger }) => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    const routineId = randomUUID();
+    const triggerId = randomUUID();
+    const routineRunId = randomUUID();
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "Recurring recovery check",
+      assigneeAgentId: coderId,
+      status: "active",
+    });
+    await db.insert(routineTriggers).values({
+      id: triggerId,
+      companyId,
+      routineId,
+      kind,
+      enabled: true,
+      ...trigger,
+    });
+    await db.insert(routineRuns).values({
+      id: routineRunId,
+      companyId,
+      routineId,
+      triggerId,
+      source: kind,
+      status: "issue_created",
+      linkedIssueId: sourceIssueId,
+    });
+    await db
+      .update(issues)
+      .set({ originKind: "routine_execution", originId: routineId, originRunId: routineRunId })
+      .where(eq(issues.id, sourceIssueId));
+    const sourceIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssueId))
+      .then((rows) => rows[0]!);
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "process lost",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    expect(result).toMatchObject({ status: "done", executionRunId: null });
+    const [routineRun] = await db.select().from(routineRuns).where(eq(routineRuns.id, routineRunId));
+    expect(routineRun).toMatchObject({ status: "completed", linkedIssueId: sourceIssueId });
+    expect(routineRun?.completedAt).toBeInstanceOf(Date);
+    expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+    const [activity] = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, sourceIssueId));
+    expect(activity?.details).toMatchObject({
+      source: "recovery.complete_armed_routine_execution",
+      routineId,
+    });
+  });
+
+  it.each(["done", "cancelled"] as const)(
+    "preserves a %s issue when recovery receives a stale non-terminal preimage",
+    async (terminalStatus) => {
+      const { sourceIssue, sourceIssueId, coderId } = await seedCompany();
+      await db.update(issues).set({ status: terminalStatus }).where(eq(issues.id, sourceIssueId));
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.escalateStrandedAssignedIssue({
+        issue: sourceIssue,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "process lost",
+          errorCode: "process_lost",
+          contextSnapshot: {},
+          livenessState: "needs_followup",
+        },
+      });
+
+      expect(result).toBeNull();
+      const [currentIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(currentIssue?.status).toBe(terminalStatus);
+      expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+    },
+  );
+
+  it("never writes blocked when a run binds between recovery preflight and the status transition", async () => {
+    const { companyId, coderId, sourceIssue, sourceIssueId } = await seedCompany();
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: coderId,
+      invocationSource: "manual",
+      status: "running",
+      startedAt: new Date("2026-05-13T18:00:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId, recoveryRaceBind: true },
+    });
+    await db.execute(sql`
+      create or replace function test_bind_issue_on_recovery_action()
+      returns trigger as $$
+      declare bound_run_id uuid;
+      begin
+        select id into bound_run_id
+        from heartbeat_runs
+        where company_id = new.company_id
+          and context_snapshot ->> 'recoveryRaceBind' = 'true'
+        order by created_at desc
+        limit 1;
+        if bound_run_id is not null then
+          update issues
+          set checkout_run_id = bound_run_id,
+              execution_run_id = bound_run_id,
+              execution_locked_at = now()
+          where id = new.source_issue_id;
+        end if;
+        return new;
+      end;
+      $$ language plpgsql
+    `);
+    await db.execute(sql`
+      create trigger test_bind_issue_on_recovery_action_trigger
+      after insert on issue_recovery_actions
+      for each row execute function test_bind_issue_on_recovery_action()
+    `);
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    try {
+      const result = await recovery.escalateStrandedAssignedIssue({
+        issue: sourceIssue,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "adapter failed",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        },
+      });
+
+      expect(result).toBeNull();
+      const [currentIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(currentIssue).toMatchObject({
+        status: "in_progress",
+        checkoutRunId: runId,
+        executionRunId: runId,
+      });
+      const [recoveryAction] = await db
+        .select()
+        .from(issueRecoveryActions)
+        .where(eq(issueRecoveryActions.sourceIssueId, sourceIssueId));
+      expect(recoveryAction).toMatchObject({ status: "cancelled", outcome: "false_positive" });
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+    } finally {
+      await db.execute(sql`
+        drop trigger if exists test_bind_issue_on_recovery_action_trigger on issue_recovery_actions
+      `);
+      await db.execute(sql`drop function if exists test_bind_issue_on_recovery_action()`);
+    }
   });
 
   it.each([
@@ -382,6 +579,84 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       );
     },
   );
+
+  it("backs off before retrying a failed assignment recovery", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ status: "todo" }).where(eq(issues.id, sourceIssueId));
+    const now = new Date();
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: coderId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "adapter failed",
+      errorCode: "adapter_failed",
+      startedAt: new Date(now.getTime() - 2_000),
+      finishedAt: new Date(now.getTime() - 1_000),
+      createdAt: new Date(now.getTime() - 3_000),
+      contextSnapshot: { issueId: sourceIssueId, retryReason: "assignment_recovery" },
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result).toMatchObject({ dispatchRequeued: 0, escalated: 0, skipped: 1 });
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({ status: "todo", assigneeAgentId: coderId });
+    expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("keeps exhausted assignment recovery in todo and wakes the original assignee from an action", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ status: "todo" }).where(eq(issues.id, sourceIssueId));
+    const base = Date.now() - 10 * 60_000;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const createdAt = new Date(base + attempt * 60_000);
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId: coderId,
+        invocationSource: "automation",
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        startedAt: createdAt,
+        finishedAt: new Date(createdAt.getTime() + 1_000),
+        createdAt,
+        contextSnapshot: { issueId: sourceIssueId, retryReason: "assignment_recovery" },
+      });
+    }
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result).toMatchObject({ dispatchRequeued: 0, escalated: 1 });
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({
+      status: "todo",
+      assigneeAgentId: coderId,
+      executionRunId: null,
+    });
+    expect(
+      await db.select().from(issueRelations).where(eq(issueRelations.issueId, sourceIssueId)),
+    ).toHaveLength(0);
+    const [action] = await db.select().from(issueRecoveryActions);
+    expect(action).toMatchObject({
+      sourceIssueId,
+      status: "active",
+      ownerAgentId: coderId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      coderId,
+      expect.objectContaining({ reason: "source_scoped_recovery_action" }),
+    );
+  });
 
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
@@ -832,7 +1107,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     }));
   });
 
-  it("blocks a cross-agent review participant with incomplete configuration", async () => {
+  it("returns a cross-agent review failure to todo with an explicit configuration action", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     const stageId = randomUUID();
     await db.update(issues).set({
@@ -881,8 +1156,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(result).toMatchObject({ escalated: 1, reviewParticipantRequeued: 0 });
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
-      status: "blocked",
-      assigneeAgentId: managerId,
+      status: "todo",
+      assigneeAgentId: coderId,
     });
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");
@@ -947,7 +1222,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     expect(result).toMatchObject({ escalated: 1, skipped: 0 });
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
-    expect(updatedIssue?.status).toBe("blocked");
+    expect(updatedIssue?.status).toBe("todo");
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");
     const [action] = await db.select().from(issueRecoveryActions);
@@ -1163,7 +1438,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
-  it("keeps the source issue blocked when source-scoped wakeup is claimed synchronously", async () => {
+  it("does not overwrite source progress when a recovery wake is claimed synchronously", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
     const enqueueWakeup = vi.fn(async () => {
@@ -1192,7 +1467,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
 
     const [afterFirst] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(afterFirst?.status).toBe("blocked");
+    expect(afterFirst?.status).toBe("in_progress");
     expect(afterFirst?.assigneeAgentId).toBe(coderId);
 
     const secondLatestRun = {
@@ -1221,7 +1496,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       attemptCount: 2,
     });
     const [afterSecond] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(afterSecond?.status).toBe("blocked");
+    expect(afterSecond?.status).toBe("in_progress");
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id));
     expect(comments).toHaveLength(1);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16500,6 +16500,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (!issue) return null;
       if (issue.executionRunId && issue.executionRunId !== run.id) return null;
 
+      const runContext = parseObject(run.contextSnapshot);
+      const runRecoveryActionId = readNonEmptyString(runContext.recoveryActionId);
+      if (
+        readNonEmptyString(runContext.wakeReason) === "source_scoped_recovery_action" &&
+        runRecoveryActionId
+      ) {
+        const activeRecoveryAction = await tx
+          .select({ id: issueRecoveryActions.id })
+          .from(issueRecoveryActions)
+          .where(
+            and(
+              eq(issueRecoveryActions.id, runRecoveryActionId),
+              eq(issueRecoveryActions.companyId, issue.companyId),
+              eq(issueRecoveryActions.sourceIssueId, issue.id),
+              inArray(issueRecoveryActions.status, ["active", "escalated"]),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (activeRecoveryAction) return { kind: "released" as const };
+      }
+
       // Workspace-validation recovery: if the finalizing run failed workspace
       // validation, surface the primary issue for the blocked-recovery comment path.
       // Sibling lock cleanup is already done above; only the primary issue carries

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7470,6 +7470,8 @@ export function issueService(db: Db) {
       data: Partial<typeof issues.$inferInsert> & {
         labelIds?: string[];
         blockedByIssueIds?: string[];
+        expectedStatuses?: Array<(typeof issues.$inferSelect)["status"]>;
+        requireExecutionUnbound?: boolean;
         actorAgentId?: string | null;
         actorUserId?: string | null;
       },
@@ -7488,10 +7490,13 @@ export function issueService(db: Db) {
       const {
         labelIds: nextLabelIds,
         blockedByIssueIds,
+        expectedStatuses,
+        requireExecutionUnbound,
         actorAgentId,
         actorUserId,
         ...issueData
       } = data;
+      if (expectedStatuses !== undefined && !expectedStatuses.includes(existing.status)) return null;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -7645,6 +7650,8 @@ export function issueService(db: Db) {
           .for("update")
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!receiptExisting) return null;
+        if (expectedStatuses !== undefined && !expectedStatuses.includes(receiptExisting.status)) return null;
+        if (requireExecutionUnbound && receiptExisting.executionRunId) return null;
         const [previousLabelsByIssueId, previousRelationSummaries] = await Promise.all([
           nextLabelIds !== undefined
             ? labelMapForIssues(tx, [id])
@@ -7675,7 +7682,13 @@ export function issueService(db: Db) {
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(eq(issues.id, id))
+          .where(
+            and(
+              eq(issues.id, id),
+              expectedStatuses === undefined ? undefined : inArray(issues.status, expectedStatuses),
+              requireExecutionUnbound ? isNull(issues.executionRunId) : undefined,
+            ),
+          )
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -26,6 +26,9 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  routines,
+  routineRuns,
+  routineTriggers,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -366,6 +369,8 @@ const INTERACTION_CONTINUATION_REQUEUE_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const ASSIGNMENT_RECOVERY_MAX_ATTEMPTS = 3;
+const ASSIGNMENT_RECOVERY_BASE_BACKOFF_MS = 60_000;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
 const PROVIDER_QUOTA_ERROR_RE =
@@ -840,10 +845,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
-  async function summarizeRecentContinuationRetries(
+  async function summarizeRecentAutomaticRecoveryRetries(
     companyId: string,
     issueId: string,
     agentId: string,
+    expectedRetryReason: "assignment_recovery" | "issue_continuation_needed",
     errorCodeToMatch: string | null,
     since: Date | null = null,
   ) {
@@ -872,7 +878,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     for (const row of rows) {
       const ctx = parseObject(row.contextSnapshot);
       const retryReason = readNonEmptyString(ctx.retryReason);
-      if (retryReason !== "issue_continuation_needed") break;
+      if (retryReason !== expectedRetryReason) break;
       if (
         !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
           row.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
@@ -3128,7 +3134,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     previousStatus: StrandedPreviousStatus;
     latestRun: LatestIssueRun;
   }) {
-    const updated = await issuesSvc.update(input.issue.id, { status: "blocked" });
+    const updated = await issuesSvc.update(input.issue.id, {
+      status: "blocked",
+      expectedStatuses: [input.previousStatus],
+      requireExecutionUnbound: true,
+    });
     if (!updated) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -3246,7 +3256,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const blockedByIssueIds = [...new Set([...existingBlockers.map((row) => row.id), ...openChildren.map((row) => row.id)])];
     if (blockedByIssueIds.length === 0) return null;
 
-    const updated = await issuesSvc.update(issue.id, { status: "blocked", blockedByIssueIds });
+    const updated = await issuesSvc.update(issue.id, {
+      status: "blocked",
+      blockedByIssueIds,
+      expectedStatuses: [issue.status],
+      requireExecutionUnbound: true,
+    });
     if (!updated) return null;
 
     const waitingOn = formatIssueLinksForComment([...openChildren, ...existingBlockers]);
@@ -3307,6 +3322,131 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
+    const preflight = await db.transaction(async (tx) => {
+      let currentIssue = await tx
+        .select()
+        .from(issues)
+        .where(eq(issues.id, input.issue.id))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (currentIssue?.executionRunId) {
+        const terminalBindingRunId =
+          input.latestRun?.id === currentIssue.executionRunId && isTerminalIssueRun(input.latestRun)
+            ? input.latestRun.id
+            : null;
+        if (!terminalBindingRunId) return { handled: true, issue: null } as const;
+        currentIssue = await tx
+          .update(issues)
+          .set({
+            checkoutRunId: currentIssue.checkoutRunId === terminalBindingRunId
+              ? null
+              : currentIssue.checkoutRunId,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(issues.id, currentIssue.id),
+              eq(issues.executionRunId, terminalBindingRunId),
+            ),
+          )
+          .returning()
+          .then((rows) => rows[0] ?? null);
+      }
+      if (
+        !currentIssue ||
+        (currentIssue.status !== "todo" &&
+          currentIssue.status !== "in_progress" &&
+          currentIssue.status !== "in_review")
+      ) {
+        return { handled: true, issue: null } as const;
+      }
+      if (currentIssue.originKind !== "routine_execution" || !currentIssue.originId) {
+        return { handled: false, issue: currentIssue } as const;
+      }
+
+      const armedRoutine = await tx
+        .select({ id: routines.id })
+        .from(routines)
+        .innerJoin(
+          routineTriggers,
+          and(
+            eq(routineTriggers.companyId, routines.companyId),
+            eq(routineTriggers.routineId, routines.id),
+            eq(routineTriggers.enabled, true),
+            or(
+              eq(routineTriggers.kind, "api"),
+              and(eq(routineTriggers.kind, "schedule"), isNotNull(routineTriggers.nextRunAt)),
+            ),
+          ),
+        )
+        .where(
+          and(
+            eq(routines.id, currentIssue.originId),
+            eq(routines.companyId, currentIssue.companyId),
+            eq(routines.status, "active"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (!armedRoutine) return { handled: false, issue: currentIssue } as const;
+
+      const updated = await issuesSvc.update(
+        currentIssue.id,
+        {
+          status: "done",
+          expectedStatuses: [currentIssue.status],
+          requireExecutionUnbound: true,
+        },
+        tx,
+      );
+      if (!updated) return { handled: true, issue: null } as const;
+
+      if (currentIssue.originRunId) {
+        const completedAt = new Date();
+        await tx
+          .update(routineRuns)
+          .set({ status: "completed", completedAt, updatedAt: completedAt })
+          .where(
+            and(
+              eq(routineRuns.id, currentIssue.originRunId),
+              eq(routineRuns.companyId, currentIssue.companyId),
+              eq(routineRuns.routineId, armedRoutine.id),
+            ),
+          );
+      }
+
+      await logActivity(tx as unknown as Db, {
+        companyId: currentIssue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: currentIssue.id,
+        details: {
+          identifier: currentIssue.identifier,
+          status: "done",
+          previousStatus: currentIssue.status,
+          source: "recovery.complete_armed_routine_execution",
+          routineId: armedRoutine.id,
+          latestRunId: input.latestRun?.id ?? null,
+          latestRunStatus: input.latestRun?.status ?? null,
+          latestRunErrorCode: input.latestRun?.errorCode ?? null,
+        },
+      });
+      return { handled: true, issue: updated } as const;
+    });
+    if (preflight.handled) return preflight.issue;
+    input = {
+      ...input,
+      issue: preflight.issue,
+      previousStatus: preflight.issue.status as StrandedPreviousStatus,
+    };
+
     if (isStrandedIssueRecoveryIssue(input.issue)) {
       return escalateStrandedRecoveryIssueInPlace({
         issue: input.issue,
@@ -3336,12 +3476,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const targetStatus = blockerIds.length > 0 ? "blocked" : "todo";
     const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
+      status: targetStatus,
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      assigneeAgentId: targetStatus === "blocked"
+        ? recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId
+        : input.issue.assigneeAgentId,
+      expectedStatuses: [input.previousStatus],
+      requireExecutionUnbound: true,
     });
-    if (!updated) return null;
+    if (!updated) {
+      await recoveryActionsSvc.resolveActiveForIssue({
+        companyId: input.issue.companyId,
+        sourceIssueId: input.issue.id,
+        actionId: recoveryAction.id,
+        status: "cancelled",
+        outcome: "false_positive",
+        resolutionNote:
+          "Recovery escalation was cancelled because the source issue changed status or acquired an execution binding before the transition.",
+      });
+      return null;
+    }
     if (isProviderQuotaWait) return updated;
 
     const recoveryOwner = recoveryAction.ownerAgentId ? await getAgent(recoveryAction.ownerAgentId) : null;
@@ -3449,7 +3605,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityId: input.issue.id,
       details: {
         identifier: input.issue.identifier,
-        status: "blocked",
+        status: targetStatus,
         previousStatus: input.previousStatus,
         source: input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
           ? "recovery.reconcile_successful_run_handoff_missing_state"
@@ -3479,7 +3635,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryCause,
     });
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (
+      targetStatus === "blocked" &&
+      recoveryAction.ownerAgentId &&
+      recoveryAction.ownerAgentId === input.issue.assigneeAgentId
+    ) {
       const [currentIssue] = await db
         .select({
           status: issues.status,
@@ -3490,6 +3650,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(1);
       if (
         currentIssue &&
+        currentIssue.status !== "done" &&
+        currentIssue.status !== "cancelled" &&
         (currentIssue.status !== "blocked" ||
           currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
       ) {
@@ -3497,6 +3659,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           status: "blocked",
           blockedByIssueIds: blockerIds,
           assigneeAgentId: recoveryAction.ownerAgentId,
+          expectedStatuses: [currentIssue.status],
+          requireExecutionUnbound: true,
         });
         if (reblocked) return reblocked;
       }
@@ -3784,7 +3948,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             recoveryCause: "configuration_incomplete",
             comment:
               "Paperclip classified the latest adapter failure as `configuration_incomplete`. " +
-              "Moving the issue to `blocked` with the configuration fix recorded instead of creating a recovery takeover.",
+              "Recording an explicit recovery action with the configuration fix instead of creating a recovery takeover.",
           });
           if (updated) {
             latestRun = await persistAdapterFailureRecoveryClassification(latestRun, adapterFailureClassification);
@@ -3832,10 +3996,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             agentId,
             acceptedInteractionResolvedAt,
           );
-          const { consecutive } = await summarizeRecentContinuationRetries(
+          const { consecutive } = await summarizeRecentAutomaticRecoveryRetries(
             issue.companyId,
             issue.id,
             agentId,
+            "issue_continuation_needed",
             CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE,
             acceptedInteractionResolvedAt,
           );
@@ -3854,7 +4019,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               comment:
                 `Paperclip stopped requeueing accepted interaction \`${acceptedContinuationInteraction.id}\` after ` +
                 `${consecutive} consecutive continuation wakes were cancelled while waiting on review. ` +
-                "Moving the issue to `blocked` so the missing execution path is visible for intervention.",
+                "Recording an explicit recovery action so the missing execution path is visible for intervention.",
             });
             if (updated) {
               result.escalated += 1;
@@ -3950,7 +4115,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             recoveryOwnerAgentId: participantAgentId,
             comment:
               "Paperclip classified the active review participant's latest adapter failure as " +
-              "`configuration_incomplete`. Moving the issue to `blocked` with the configuration fix " +
+              "`configuration_incomplete`. Recording an explicit recovery action with the configuration fix " +
               "recorded instead of repeatedly requeueing the reviewer.",
           });
           if (updated) {
@@ -4066,26 +4231,45 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
-          const updated = await escalateStrandedAssignedIssue({
-            issue,
-            previousStatus: "todo",
-            latestRun,
-            notice: {
-              body:
-                "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
-                "but it still has no live execution path. " +
-                "Moving it to `blocked` so it is visible for intervention.",
-              title: "No live execution path",
-              tone: "danger",
-            },
-          });
-          if (updated) {
-            result.escalated += 1;
-            result.issueIds.push(issue.id);
-          } else {
-            result.skipped += 1;
+          const { consecutive, latestFinishedAt } = await summarizeRecentAutomaticRecoveryRetries(
+            issue.companyId,
+            issue.id,
+            agentId,
+            "assignment_recovery",
+            readNonEmptyString(latestRun.errorCode),
+          );
+          if (consecutive >= ASSIGNMENT_RECOVERY_MAX_ATTEMPTS) {
+            const updated = await escalateStrandedAssignedIssue({
+              issue,
+              previousStatus: "todo",
+              latestRun,
+              recoveryOwnerAgentId: agentId,
+              notice: {
+                body:
+                  "Paperclip exhausted bounded dispatch retries for this assigned `todo` issue after a lost wake/run. " +
+                  "Keeping it in `todo` with an explicit recovery action owned by the original assignee.",
+                title: "No live execution path",
+                tone: "danger",
+              },
+            });
+            if (updated) {
+              result.escalated += 1;
+              result.issueIds.push(issue.id);
+            } else {
+              result.skipped += 1;
+            }
+            continue;
           }
-          continue;
+
+          if (latestFinishedAt) {
+            const elapsed = Date.now() - latestFinishedAt.getTime();
+            const requiredDelay = ASSIGNMENT_RECOVERY_BASE_BACKOFF_MS *
+              Math.pow(2, Math.max(0, consecutive - 1));
+            if (elapsed < requiredDelay) {
+              result.skipped += 1;
+              continue;
+            }
+          }
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
@@ -4163,7 +4347,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               latestRun: successfulRun,
               comment:
                 "Paperclip automatically retried continuation for this assigned `in_progress` issue and the retry " +
-                "made progress, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
+                "made progress, but it still has no live execution path. Recording an explicit recovery action for intervention.",
             });
             if (updated) {
               result.escalated += 1;
@@ -4217,8 +4401,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             notice: {
               body:
                 "Paperclip detected a non-retryable failure on this issue's continuation run " +
-                `(\`${classification.errorCode}\`). Skipping automatic retries and moving it to \`blocked\` ` +
-                "so it is visible for intervention.",
+                `(\`${classification.errorCode}\`). Skipping automatic retries and recording an explicit recovery action ` +
+                "so it remains visible for intervention.",
               title: "Continuation failed",
               tone: "danger",
             },
@@ -4233,10 +4417,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
-          const { consecutive, latestFinishedAt } = await summarizeRecentContinuationRetries(
+          const { consecutive, latestFinishedAt } = await summarizeRecentAutomaticRecoveryRetries(
             issue.companyId,
             issue.id,
             agentId,
+            "issue_continuation_needed",
             classification.errorCode,
           );
           if (consecutive >= classification.maxAttempts) {
@@ -4249,7 +4434,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
                 body:
                   "Paperclip automatically retried continuation for this assigned `in_progress` issue after its live " +
                   `execution disappeared, but it still has no live execution path${attemptCopy}. ` +
-                  "Moving it to `blocked` so it is visible for intervention.",
+                  "Recording an explicit recovery action so it remains visible for intervention.",
                 title: "No live execution path",
                 tone: "danger",
               },

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3853,6 +3853,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      if (
+        issue.status === "todo" &&
+        await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id)
+      ) {
+        result.skipped += 1;
+        continue;
+      }
+
       const agent = await getAgent(agentId);
       const agentInvokable = agent && agent.companyId === issue.companyId
         ? await isAgentInvokable(agent)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for teams of AI agents.
> - The recovery service keeps issue state aligned with agent execution state.
> - Terminal-run recovery can find an assigned issue with no live execution path.
> - The old path used `blocked` even when the issue had no unresolved blocker.
> - An edgeless blocked issue has no dependency event that can make it active again.
> - A source-scoped recovery action must own the next recovery step without competing with normal dispatch.
> - This pull request keeps recovery state resumable and makes the recovery action explicit.
> - The benefit is safer recovery with bounded retries and race-resistant state changes.

## Linked Issues or Issue Description

- Refs #5991
- Refs #6750
- Refs #3882

## What Changed

- Keep a stranded issue in `todo` when it has no unresolved blocker.
- Preserve the original assignee for edgeless recovery.
- Create a source-scoped recovery action for operator attention.
- Retry assignment recovery up to three times with exponential backoff.
- Complete a routine execution issue when its active routine still has an enabled API or scheduled trigger.
- Add compare-and-set guards for issue status and execution binding.
- Cancel a recovery action when a concurrent issue change wins the race.
- Do not dispatch a `todo` issue while an active source-scoped recovery action owns it.
- Do not create another recovery action when the current action wake fails.
- Add regression tests for retry limits, routine completion, terminal-state preservation, execution-binding races, and recovery-action wake recursion.

## Verification

- `vitest run server/src/__tests__/heartbeat-workspace-branch-containment.test.ts` passed with 6 tests passed.
- `vitest run server/src/__tests__/issue-recovery-actions.test.ts` passed.
- The Windows run of `vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` passed 93 tests and skipped 2 tests. Five hot-restart tests could not start `pwsh.exe` in the local environment.
- `tsc --noEmit -p server/tsconfig.json` passed.
- `git diff --check` passed.

## Risks

- This change alters recovery routing for edgeless issues. They stay in `todo` instead of moving to `blocked`.
- The recovery action remains active so operators can find and classify the failure.
- Normal dispatch pauses while that active action owns the issue.
- A failed action wake releases its run binding and leaves the same action active. It does not create another action wake.
- Routine completion is limited to active routines with an enabled API trigger or a scheduled trigger with a next run time.
- Conditional writes prevent recovery from overwriting a concurrent terminal state or a new execution binding.
- This change has no database migration.
- `ROADMAP.md` lists self-healing runs and automatic recovery as shipped. This pull request fixes that existing capability and does not add a new roadmap feature.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, with xhigh reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge