### PR TITLE
feat(agent-runtime): add + publish agent-runtime-grok image (SPC-30764)

### DIFF
--- a/.github/workflows/agent-runtime-images.yml
+++ b/.github/workflows/agent-runtime-images.yml
@@ -53,7 +53,7 @@ jobs:
           # the bake group (which has no such key -> "unknown key" error).
           docker buildx bake \
             -f docker/agent-runtime/buildx-bake.hcl \
-            base opencode pi codex gemini claude \
+            base opencode pi codex gemini claude grok \
             --push \
             --metadata-file=bake-metadata.json
           # Extract digests for cosign signing
@@ -63,12 +63,14 @@ jobs:
           CODEX_DIGEST=$(jq -r '."codex"."containerimage.digest"' bake-metadata.json)
           GEMINI_DIGEST=$(jq -r '."gemini"."containerimage.digest"' bake-metadata.json)
           CLAUDE_DIGEST=$(jq -r '."claude"."containerimage.digest"' bake-metadata.json)
+          GROK_DIGEST=$(jq -r '."grok"."containerimage.digest"' bake-metadata.json)
           echo "base_digest=$BASE_DIGEST" >> "$GITHUB_OUTPUT"
           echo "opencode_digest=$OPENCODE_DIGEST" >> "$GITHUB_OUTPUT"
           echo "pi_digest=$PI_DIGEST" >> "$GITHUB_OUTPUT"
           echo "codex_digest=$CODEX_DIGEST" >> "$GITHUB_OUTPUT"
           echo "gemini_digest=$GEMINI_DIGEST" >> "$GITHUB_OUTPUT"
           echo "claude_digest=$CLAUDE_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "grok_digest=$GROK_DIGEST" >> "$GITHUB_OUTPUT"
         env:
           VERSION: ${{ env.VERSION }}
           REGISTRY: ${{ env.REGISTRY }}
@@ -96,3 +98,7 @@ jobs:
       - name: Cosign sign claude
         run: |
           cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-claude@${{ steps.bake.outputs.claude_digest }}"
+
+      - name: Cosign sign grok
+        run: |
+          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-grok@${{ steps.bake.outputs.grok_digest }}"

--- a/docker/agent-runtime/Dockerfile.grok
+++ b/docker/agent-runtime/Dockerfile.grok
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.6
+ARG BASE_TAG=dev
+FROM paperclipai/agent-runtime-base:${BASE_TAG}
+
+USER root
+# xAI Grok Build CLI. Installs a `grok` bin plus the matching platform-native
+# binary via optionalDependencies (@xai-official/grok-linux-x64). The grok_local
+# adapter shells out to `grok --single --output-format streaming-json`; its
+# configured command defaults to `grok`, so no rename shim is needed (unlike
+# claude-code). Pinned for reproducible, supply-chain-auditable builds.
+RUN npm install -g @xai-official/grok@1.0.0 \
+    && { chown -R 1000:1000 /usr/lib/node_modules || true; }
+
+USER 1000:1000
+
+# Verify the CLI is on PATH for the adapter's command resolution / shim exec.
+RUN command -v grok >/dev/null 2>&1 || (echo "grok not on PATH"; exit 1)

--- a/docker/agent-runtime/buildx-bake.hcl
+++ b/docker/agent-runtime/buildx-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-  targets = ["base", "claude", "codex", "gemini", "opencode", "pi", "hermes"]
+  targets = ["base", "claude", "codex", "gemini", "grok", "opencode", "pi", "hermes"]
 }
 
 variable "VERSION" { default = "dev" }
@@ -82,6 +82,19 @@ target "hermes" {
   dockerfile = "docker/agent-runtime/Dockerfile.hermes"
   platforms = ["linux/amd64"]
   tags = ["${REGISTRY}/agent-runtime-hermes:${VERSION}"]
+  args = {
+    BASE_TAG = "${VERSION}"
+  }
+  contexts = {
+    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+  }
+}
+
+target "grok" {
+  context = "."
+  dockerfile = "docker/agent-runtime/Dockerfile.grok"
+  platforms = ["linux/amd64"]
+  tags = ["${REGISTRY}/agent-runtime-grok:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }


### PR DESCRIPTION
## Thinking Path

The `grok_local` adapter is already registered in the server adapter registry (`registry.ts`) and shells out to `grok --single --output-format streaming-json`. But **no runtime image installs the Grok Build CLI**, so every `grok_local` run fails with `grok not on PATH`. The fleet migration (SPC-30730) is blocked on this one missing artifact.

The recent `agent-runtime-*` images in `ghcr.io/paperclipai` are published exclusively by **this repo's** `.github/workflows/agent-runtime-images.yml` — its `GITHUB_TOKEN` carries org package-write. The Standard Power fork's token is denied (`permission_denied: The requested installation does not exist`), and a maintainer PAT returns 403 on push to the org namespace (pull=200, push=403). So the grok image can only be published from here — hence this upstream PR.

The publish workflow bakes an **explicit** target list (`base opencode pi codex gemini claude`) with per-image cosign steps, so a bake-HCL target or Dockerfile alone is inert — the workflow itself must be extended to build, digest-extract, and sign the new image.

## What Changed

- **`Dockerfile.grok`** — extends `agent-runtime-base` with `@xai-official/grok@1.0.0` (bin `grok`; platform-native binary via optionalDependencies). No rename shim — the adapter's configured command defaults to `grok`. Auth is a per-run `XAI_API_KEY` env var (no baked secret).
- **`buildx-bake.hcl`** — adds the `grok` target and includes it in the `default` group.
- **`agent-runtime-images.yml`** — adds `grok` to the baked target list, extracts its image digest, and cosign-signs it. **This is the half that actually publishes.**

## Verification

Built green on the Standard Power fork CI: `npm install -g @xai-official/grok@1.0.0` succeeds and `command -v grok` passes. `Dockerfile.grok` extends the base with no rename shim (adapter command defaults to `grok`). Only the org-namespace push failed on the fork (expected — org write is only available here).

## Post-merge

Once this merges and publishes `ghcr.io/paperclipai/agent-runtime-grok`, the Standard Power CTO agent finishes SPC-30764/SPC-30731/SPC-30730 autonomously: pin `runtimeImage` + `XAI_API_KEY` per agent via `adapterConfig`, run authenticated `grok models` to confirm tier IDs, validate one haiku agent end-to-end, then tiered bulk migration of the 103-agent fleet.
