### PR TITLE
fix(ui): fetch the web app manifest with credentials

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <!-- PAPERCLIP_FAVICON_END -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <script>
       (() => {
         const key = "paperclip.theme";

--- a/ui/src/lib/pwa-install-mode.test.ts
+++ b/ui/src/lib/pwa-install-mode.test.ts
@@ -17,4 +17,14 @@ describe("PWA install mode", () => {
     expect(html).not.toContain('name="apple-mobile-web-app-capable"');
     expect(html).not.toContain('name="apple-mobile-web-app-status-bar-style"');
   });
+
+  it("fetches the manifest with credentials so authenticating proxies can serve it", () => {
+    const html = readFileSync(resolve(uiRoot, "index.html"), "utf8");
+
+    // Browsers fetch <link rel="manifest"> in "omit credentials" mode unless
+    // the link opts in. Same-origin that opt-in is a no-op, but behind an
+    // authenticating reverse proxy (e.g. a managed-hosting front door) the
+    // cookie-less fetch is rejected on every page load.
+    expect(html).toContain('rel="manifest" href="/site.webmanifest" crossorigin="use-credentials"');
+  });
 });

--- a/ui/src/lib/pwa-install-mode.test.ts
+++ b/ui/src/lib/pwa-install-mode.test.ts
@@ -22,9 +22,9 @@ describe("PWA install mode", () => {
     const html = readFileSync(resolve(uiRoot, "index.html"), "utf8");
 
     // Browsers fetch <link rel="manifest"> in "omit credentials" mode unless
-    // the link opts in. Same-origin that opt-in is a no-op, but behind an
-    // authenticating reverse proxy (e.g. a managed-hosting front door) the
-    // cookie-less fetch is rejected on every page load.
+    // the link opts in. Behind an authenticating reverse proxy (e.g. a
+    // managed-hosting front door), the cookie-less request is rejected on
+    // every page load.
     expect(html).toContain('rel="manifest" href="/site.webmanifest" crossorigin="use-credentials"');
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The web UI is a PWA-capable SPA; `ui/index.html` links `/site.webmanifest` so browsers can read app metadata
> - Browsers fetch `<link rel="manifest">` in "omit credentials" mode unless the link opts in with `crossorigin="use-credentials"`
> - Self-hosted this is harmless, but when Paperclip runs behind an authenticating reverse proxy (a managed hosting front door), the cookie-less manifest request is rejected with 401 on every page load and logs a console error pair on each navigation
> - This pull request adds `crossorigin="use-credentials"` to the manifest link so the request carries the same session cookies as every other same-origin asset request
> - The benefit is a clean console and a servable manifest in proxied deployments, with self-hosted behavior unchanged

## Linked Issues or Issue Description

No existing issue. Description follows the bug template:

**What happened?**

On every page load behind an authenticating reverse proxy, the browser logs `Failed to load resource: the server responded with a status of 401` for `/site.webmanifest`, plus `Manifest fetch from … failed, code 401`. The proxy rejects the request because the browser sends the manifest fetch without cookies.

**Expected behavior**

The manifest request carries the same session credentials as every other same-origin asset request, so the proxy can authenticate and serve it. No console errors.

**Steps to reproduce**

1. Serve Paperclip behind a reverse proxy that requires a session cookie for all app routes.
2. Sign in and load any page.
3. Open the browser console: the manifest fetch fails with 401 while all other assets load.

## What Changed

- `ui/index.html`: the manifest link now carries `crossorigin="use-credentials"`.
- `ui/src/lib/pwa-install-mode.test.ts`: a regression test asserts the attribute stays on the link.

## Verification

- `pnpm vitest run src/lib/pwa-install-mode.test.ts` in `ui/` — 2 tests pass.
- Manual check of the rendered link tag in `ui/index.html`.

## Risks

Low risk. The manifest is same-origin, so `use-credentials` only switches the fetch from "omit" to the include behavior all other same-origin requests already have. Self-hosted deployments see no change. Cross-origin manifest hosting is not used in this project.

## Model Used

- Claude (Anthropic), Claude Fable 5 (`claude-fable-5`), via Claude Code CLI with extended thinking and tool use (code search, edit, test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge