### PR TITLE
fix(server): batch advisory productivity reviews

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -575,6 +575,15 @@ On startup and on the periodic recovery loop, Paperclip now does five things in 
 
 The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output. The productivity-review pass is later and separate; it reviews unusual progression patterns on assigned source issues, not stale run handles after a source issue already has a valid disposition.
 
+Productivity reviews have two delivery shapes:
+
+- no-comment and high-churn findings remain source-specific because an open review can hold continuation for that source
+- long-active findings are advisory and are grouped into one open manager batch; the batch receives one assignment wake and subsequent source findings are appended without another wake
+
+Long-active duration is measured from an issue-linked run that is actually `running`, using its process start (or adapter start when there is no process timestamp). Issue checkout age, queued time, and scheduled-retry time do not count as active execution. This keeps capacity waits visible to queue/liveness tooling without manufacturing productivity-review floods.
+
+Batch membership and finding comments are serialized per manager batch so overlapping recovery sweeps cannot append the same source twice. Wake delivery is also serialized and durably marked: if dispatch is interrupted, a later reconciliation retries the existing batch instead of creating another review issue.
+
 ## 11. Task Watchdog for Issue Trees
 
 A task watchdog watches a configured issue subtree after that subtree has stopped moving. It is a product-level verification and recovery mechanism for selected work, not a process monitor.
@@ -723,7 +732,7 @@ Do not fold watchdog work only because the run is quiet. The watchdog must still
 
 In the normal non-terminal case, critical silence can still create issue-backed evaluation work and block the source issue when blocking is necessary for correctness. In the source-resolved case, a completed source issue should not acquire a new manager review or blocker merely because an old run handle stayed active; only real unresolved work should block work.
 
-This is distinct from productivity review. Productivity review asks whether an assigned source issue has unusual progression patterns, such as no-comment terminal-run streaks, long active duration, or high churn. Source-resolved watchdog folding asks whether a stale active-run signal outlived a source issue that already reached a valid terminal disposition. One does not substitute for the other.
+This is distinct from productivity review. Productivity review asks whether an assigned source issue has unusual progression patterns, such as no-comment terminal-run streaks, actual long-running process duration, or high churn. Source-resolved watchdog folding asks whether a stale active-run signal outlived a source issue that already reached a valid terminal disposition. One does not substitute for the other.
 
 Detached process cleanup is operational hygiene, not source issue liveness. Cleanup should be best-effort and auditable. If cleanup fails but the source issue is already terminal with same-run durable evidence, Paperclip should preserve the cleanup failure on the run/watchdog audit trail and route only the cleanup concern to bounded recovery when a real owner/action remains.
 

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -3,6 +3,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
+  agentWakeupRequests,
   agents,
   companies,
   createDb,
@@ -158,6 +159,32 @@ describeEmbeddedPostgres("productivity review service", () => {
     }
 
     return runs;
+  }
+
+  async function insertRunningProcess(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    processStartedAt: Date;
+  }) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt: input.processStartedAt,
+      processStartedAt: input.processStartedAt,
+      lastUsefulActionAt: input.processStartedAt,
+      contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
+      livenessState: "healthy",
+      nextAction: "Finish the current implementation pass.",
+      createdAt: input.processStartedAt,
+      updatedAt: input.processStartedAt,
+    });
+    return runId;
   }
 
   async function listProductivityReviews(companyId: string) {
@@ -488,6 +515,12 @@ describeEmbeddedPostgres("productivity review service", () => {
       status: "in_progress",
       startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
     });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
     const service = productivityReviewService(db);
 
     const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
@@ -499,10 +532,282 @@ describeEmbeddedPostgres("productivity review service", () => {
     });
 
     expect(result.created).toBe(1);
+    expect(result.batched).toBe(1);
     const [review] = await listProductivityReviews(seeded.companyId);
-    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+    expect(review?.title).toBe("Review active-work productivity findings");
+    expect(review?.description).toContain("`long_active_duration`");
+    expect(review?.parentId).toBeNull();
+    expect(review?.originId).toBe(seeded.managerId);
+    expect(review?.originFingerprint).toBe(`productivity-review-batch:${seeded.managerId}`);
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("does not treat queued work or issue checkout age as active process time", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      status: "queued",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      contextSnapshot: { issueId: seeded.issueId, taskId: seeded.issueId },
+      createdAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      updatedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.batched).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("batches multiple long-running sources for one manager and wakes only once", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({ status: "in_progress" });
+    const secondIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: secondIssueId,
+      companyId: seeded.companyId,
+      title: "Implement export pipeline",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: seeded.coderId,
+      issueNumber: 2,
+      identifier: `${seeded.issuePrefix}-2`,
+      startedAt: new Date(now.getTime() - 8 * 60 * 60 * 1000),
+      createdAt: seeded.createdAt,
+      updatedAt: seeded.createdAt,
+    });
+    await Promise.all([
+      insertRunningProcess({
+        companyId: seeded.companyId,
+        agentId: seeded.coderId,
+        issueId: seeded.issueId,
+        processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      }),
+      insertRunningProcess({
+        companyId: seeded.companyId,
+        agentId: seeded.coderId,
+        issueId: secondIssueId,
+        processStartedAt: new Date(now.getTime() - 8 * 60 * 60 * 1000),
+      }),
+    ]);
+    const wakeups: Array<{ agentId: string; payload?: Record<string, unknown> | null }> = [];
+    const service = productivityReviewService(db, {
+      enqueueWakeup: async (agentId, opts) => {
+        wakeups.push({ agentId, payload: opts?.payload });
+        return { id: "batch-wake" };
+      },
+    });
+
+    const first = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    const thirdIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: thirdIssueId,
+      companyId: seeded.companyId,
+      title: "Implement billing pipeline",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: seeded.coderId,
+      issueNumber: 4,
+      identifier: `${seeded.issuePrefix}-4`,
+      startedAt: new Date(now.getTime() - 9 * 60 * 60 * 1000),
+      createdAt: seeded.createdAt,
+      updatedAt: seeded.createdAt,
+    });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: thirdIssueId,
+      processStartedAt: new Date(now.getTime() - 9 * 60 * 60 * 1000),
+    });
+    const second = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const third = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(first.created).toBe(1);
+    expect(first.batched).toBe(2);
+    expect(second.created).toBe(0);
+    expect(second.updated).toBe(1);
+    expect(second.batched).toBe(1);
+    expect(third.existing).toBe(1);
+    expect(third.batched).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]?.agentId).toBe(seeded.managerId);
+    expect(wakeups[0]?.payload?.sourceIssueIds).toEqual(expect.arrayContaining([seeded.issueId, secondIssueId]));
+    const batchedActivities = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.productivity_review_batched"));
+    expect(batchedActivities.map((entry) => entry.entityId)).toEqual(
+      expect.arrayContaining([seeded.issueId, secondIssueId, thirdIssueId]),
+    );
+  });
+
+  it("retries an interrupted batch wake without creating another batch", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({ status: "in_progress" });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    let attempts = 0;
+    const service = productivityReviewService(db, {
+      enqueueWakeup: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("simulated wake interruption");
+        return { id: "recovered-batch-wake" };
+      },
+    });
+
+    const interrupted = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const recovered = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(interrupted.failed).toBe(1);
+    expect(recovered.existing).toBe(1);
+    expect(attempts).toBe(2);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+    const wakeMarkers = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.productivity_review_batch_wake_delivered"));
+    expect(wakeMarkers).toHaveLength(1);
+  });
+
+  it("reconciles a persisted batch wake after the dispatch response is lost", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({ status: "in_progress" });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    let dispatchCalls = 0;
+    const service = productivityReviewService(db, {
+      enqueueWakeup: async (agentId, opts) => {
+        dispatchCalls += 1;
+        await db.insert(agentWakeupRequests).values({
+          companyId: seeded.companyId,
+          agentId,
+          source: opts?.source ?? "assignment",
+          reason: opts?.reason ?? null,
+          payload: opts?.payload ?? null,
+          status: "queued",
+          idempotencyKey: opts?.idempotencyKey ?? null,
+        });
+        throw new Error("simulated lost wake response");
+      },
+    });
+
+    const interrupted = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const recovered = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(interrupted.failed).toBe(1);
+    expect(recovered.existing).toBe(1);
+    expect(dispatchCalls).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+    const wakeMarkers = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.productivity_review_batch_wake_delivered"));
+    expect(wakeMarkers).toHaveLength(1);
+  });
+
+  it("retries a cancelled batch wake instead of marking it delivered", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({ status: "in_progress" });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    let dispatchCalls = 0;
+    const service = productivityReviewService(db, {
+      enqueueWakeup: async (agentId, opts) => {
+        dispatchCalls += 1;
+        if (dispatchCalls === 1) {
+          await db.insert(agentWakeupRequests).values({
+            companyId: seeded.companyId,
+            agentId,
+            source: opts?.source ?? "assignment",
+            reason: opts?.reason ?? null,
+            payload: opts?.payload ?? null,
+            status: "cancelled",
+            idempotencyKey: opts?.idempotencyKey ?? null,
+          });
+          throw new Error("simulated cancelled wake response");
+        }
+        return { id: "replacement-batch-wake" };
+      },
+    });
+
+    const interrupted = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const recovered = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(interrupted.failed).toBe(1);
+    expect(recovered.existing).toBe(1);
+    expect(dispatchCalls).toBe(2);
+    const wakeMarkers = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.productivity_review_batch_wake_delivered"));
+    expect(wakeMarkers).toHaveLength(1);
+  });
+
+  it("serializes overlapping batch reconciliation without duplicate membership or wake delivery", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({ status: "in_progress" });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    let wakeCount = 0;
+    const makeService = () => productivityReviewService(db, {
+      enqueueWakeup: async () => {
+        wakeCount += 1;
+        return { id: `batch-wake-${wakeCount}` };
+      },
+    });
+
+    await Promise.all([
+      makeService().reconcileProductivityReviews({ now, companyId: seeded.companyId }),
+      makeService().reconcileProductivityReviews({ now, companyId: seeded.companyId }),
+    ]);
+
+    const [batch] = await listProductivityReviews(seeded.companyId);
+    expect(batch).toBeDefined();
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+    expect(wakeCount).toBe(1);
+    const memberships = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.productivity_review_batched"));
+    expect(memberships).toHaveLength(1);
+    const appendComments = await db
+      .select()
+      .from(issueComments)
+      .where(and(
+        eq(issueComments.issueId, batch!.id),
+        sql`${issueComments.body} like 'Productivity batch findings added.%'`,
+      ));
+    expect(appendComments).toHaveLength(0);
   });
 
   it("skips a long-active candidate while its assignee is paused and reviews it once unpaused", async () => {
@@ -510,6 +815,12 @@ describeEmbeddedPostgres("productivity review service", () => {
     const seeded = await seedAssignedIssue({
       status: "in_progress",
       startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    await insertRunningProcess({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      processStartedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
     });
     await db.update(agents).set({ status: "paused" }).where(eq(agents.id, seeded.coderId));
     const service = productivityReviewService(db);

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
 import {
   activityLog,
+  agentWakeupRequests,
   agents,
   companies,
   costEvents,
@@ -12,7 +13,11 @@ import {
   projects,
 } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
-import { logActivity } from "./activity-log.js";
+import {
+  logActivity,
+  publishActivity,
+  type ActivityPublication,
+} from "./activity-log.js";
 import { budgetService } from "./budgets.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
@@ -36,6 +41,7 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CONSECUTIVE_NO_ACTION_REVIEWS = 3;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const DELIVERED_BATCH_WAKE_STATUSES = ["queued", "deferred_issue_execution", "claimed", "completed"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
@@ -44,11 +50,20 @@ export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review e
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 // Evidence only reads these run fields; selecting the full row detoasts
 // result_json/context_snapshot for up to MAX_RUNS_FOR_STREAK runs per issue.
 type ProductivityRunSample = Pick<
   HeartbeatRunRow,
-  "id" | "agentId" | "status" | "livenessState" | "createdAt" | "nextAction" | "usageJson"
+  | "id"
+  | "agentId"
+  | "status"
+  | "livenessState"
+  | "createdAt"
+  | "startedAt"
+  | "processStartedAt"
+  | "nextAction"
+  | "usageJson"
 >;
 type ProductivityReviewTrigger = "no_comment_streak" | "long_active_duration" | "high_churn";
 
@@ -96,6 +111,7 @@ type EnqueueWakeup = (
     triggerDetail?: "manual" | "ping" | "callback" | "system";
     reason?: string | null;
     payload?: Record<string, unknown> | null;
+    idempotencyKey?: string | null;
     requestedByActorType?: "user" | "agent" | "system";
     requestedByActorId?: string | null;
     contextSnapshot?: Record<string, unknown>;
@@ -104,6 +120,10 @@ type EnqueueWakeup = (
 
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
+}
+
+function productivityReviewBatchFingerprint(ownerAgentId: string) {
+  return `productivity-review-batch:${ownerAgentId}`;
 }
 
 function issueRunScopeSql(issueId: string) {
@@ -459,6 +479,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         status: heartbeatRuns.status,
         livenessState: heartbeatRuns.livenessState,
         createdAt: heartbeatRuns.createdAt,
+        startedAt: heartbeatRuns.startedAt,
+        processStartedAt: heartbeatRuns.processStartedAt,
         nextAction: heartbeatRuns.nextAction,
         usageJson: heartbeatRuns.usageJson,
       })
@@ -541,7 +563,15 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const activeRunCount = latestRuns.filter((run) =>
       ACTIVE_RUN_STATUSES.includes(run.status as (typeof ACTIVE_RUN_STATUSES)[number]),
     ).length;
-    const activeStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
+    // Queue age and issue checkout age are not execution time. Only a run with a
+    // process (or an adapter-start timestamp for non-process adapters) can trip
+    // the advisory long-active detector. This prevents queued/capacity-bound
+    // work from looking like six hours of active execution.
+    const activeStartedAt = latestRuns
+      .filter((run) => run.status === "running")
+      .map((run) => run.processStartedAt ?? run.startedAt)
+      .filter((value): value is Date => value !== null)
+      .sort((left, right) => left.getTime() - right.getTime())[0] ?? null;
     const elapsedMs = sourceIssue.status === "in_progress" && activeStartedAt
       ? Math.max(0, now.getTime() - activeStartedAt.getTime())
       : null;
@@ -702,6 +732,295 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       `- Runs/assignee comments: ${evidence.runCountLastHour}/${evidence.commentCountLastHour} in 1h, ${evidence.runCountLastSixHours}/${evidence.commentCountLastSixHours} in 6h`,
       `- Next action: ${evidence.nextAction ? truncateInline(evidence.nextAction, 300) : "none recorded"}`,
     ].join("\n");
+  }
+
+  function buildBatchFindingMarkdown(evidence: ProductivityReviewEvidence, prefix: string) {
+    return [
+      `### ${issueUiLink(evidence.sourceIssue, prefix)}`,
+      "",
+      `- Assigned agent: ${evidence.sourceAgent.name} (${evidence.sourceAgent.role})`,
+      `- Trigger: \`${evidence.trigger}\` (${formatTrigger(evidence.trigger)})`,
+      `- Reason: ${evidence.triggerReasons.join("; ")}`,
+      `- Running process elapsed: ${msToHuman(evidence.elapsedMs)}`,
+      `- Active queued/running/scheduled runs: ${evidence.activeRunCount}`,
+      `- Next action: ${evidence.nextAction ? truncateInline(evidence.nextAction, 300) : "none recorded"}`,
+    ].join("\n");
+  }
+
+  function buildBatchReviewMarkdown(evidence: ProductivityReviewEvidence[], prefix: string) {
+    return [
+      "Paperclip grouped advisory long-running-process findings into one manager review.",
+      "No continuation hold is applied by this batch. Source-specific no-comment and high-churn reviews remain separate because they can hold continuation.",
+      "",
+      "## Findings",
+      "",
+      evidence.map((entry) => buildBatchFindingMarkdown(entry, prefix)).join("\n\n"),
+      "",
+      "## Manager Decision",
+      "",
+      "- Close as productive when the listed long-running processes are expected.",
+      "- Comment with any source-specific decomposition, reroute, cancellation, or unblock action.",
+      "- Keep one batch open while reviewing; new advisory findings are appended without another wake.",
+    ].join("\n");
+  }
+
+  async function findOpenProductivityReviewBatch(
+    companyId: string,
+    ownerAgentId: string,
+    dbOrTx: Db | DbTransaction = db,
+  ) {
+    return dbOrTx
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, companyId),
+        eq(issues.originKind, PRODUCTIVITY_REVIEW_ORIGIN_KIND),
+        eq(issues.originId, ownerAgentId),
+        eq(issues.originFingerprint, productivityReviewBatchFingerprint(ownerAgentId)),
+        visibleIssueCondition(),
+        notInArray(issues.status, ["done", "cancelled"]),
+      ))
+      .orderBy(desc(issues.updatedAt), desc(issues.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function batchedSourceIds(
+    dbOrTx: Db | DbTransaction,
+    companyId: string,
+    batchIssueId: string,
+    sourceIssueIds: string[],
+  ) {
+    if (sourceIssueIds.length === 0) return new Set<string>();
+    const rows = await dbOrTx
+      .select({ sourceIssueId: activityLog.entityId })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.companyId, companyId),
+        eq(activityLog.action, "issue.productivity_review_batched"),
+        eq(activityLog.entityType, "issue"),
+        inArray(activityLog.entityId, sourceIssueIds),
+        sql`${activityLog.details}->>'batchIssueId' = ${batchIssueId}`,
+      ));
+    return new Set(rows.map((row) => row.sourceIssueId));
+  }
+
+  async function recordBatchedSources(
+    tx: DbTransaction,
+    batchIssueId: string,
+    ownerAgentId: string,
+    evidence: ProductivityReviewEvidence[],
+    publications: ActivityPublication[],
+  ) {
+    for (const entry of evidence) {
+      await logActivity(tx as unknown as Db, {
+        companyId: entry.sourceIssue.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "issue.productivity_review_batched",
+        entityType: "issue",
+        entityId: entry.sourceIssue.id,
+        agentId: ownerAgentId,
+        details: {
+          source: "productivity_review.reconcile",
+          batchIssueId,
+          sourceIssueId: entry.sourceIssue.id,
+          trigger: entry.trigger,
+          elapsedMs: entry.elapsedMs,
+        },
+      }, publications);
+    }
+  }
+
+  function batchWakeIdempotencyKey(batchIssueId: string) {
+    return `productivity_review_batch:${batchIssueId}`;
+  }
+
+  async function ensureBatchWakeDelivered(input: {
+    batchIssueId: string;
+    companyId: string;
+    ownerAgentId: string;
+    sourceIssueIds: string[];
+  }) {
+    if (!deps?.enqueueWakeup) return false;
+    const idempotencyKey = batchWakeIdempotencyKey(input.batchIssueId);
+    const publications: ActivityPublication[] = [];
+    const delivered = await db.transaction(async (tx) => {
+      const txDb = tx as unknown as Db;
+      await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`productivity-review-wake:${input.companyId}:${input.batchIssueId}`}, 0))`);
+      const marker = await tx
+        .select({ id: activityLog.id })
+        .from(activityLog)
+        .where(and(
+          eq(activityLog.companyId, input.companyId),
+          eq(activityLog.action, "issue.productivity_review_batch_wake_delivered"),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, input.batchIssueId),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (marker) return false;
+
+      const existingWake = await tx
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(and(
+          eq(agentWakeupRequests.companyId, input.companyId),
+          eq(agentWakeupRequests.idempotencyKey, idempotencyKey),
+          inArray(agentWakeupRequests.status, DELIVERED_BATCH_WAKE_STATUSES),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      if (!existingWake) {
+        const wake = await deps.enqueueWakeup!(input.ownerAgentId, {
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_assigned",
+          idempotencyKey,
+          payload: withRecoveryModelProfileHint({
+            issueId: input.batchIssueId,
+            sourceIssueIds: input.sourceIssueIds,
+            trigger: "long_active_duration",
+          }, "status_only"),
+          requestedByActorType: "system",
+          requestedByActorId: "productivity_review",
+          contextSnapshot: withRecoveryModelProfileHint({
+            issueId: input.batchIssueId,
+            taskId: input.batchIssueId,
+            wakeReason: "issue_assigned",
+            source: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+            productivityReviewTrigger: "long_active_duration",
+            productivityReviewBatch: true,
+          }, "status_only"),
+        });
+        // A null result means dispatch was suppressed or skipped. Leave the
+        // marker absent so a later reconciliation can retry once the agent is
+        // invokable again.
+        if (!wake) return false;
+      }
+
+      await logActivity(txDb, {
+        companyId: input.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "issue.productivity_review_batch_wake_delivered",
+        entityType: "issue",
+        entityId: input.batchIssueId,
+        agentId: input.ownerAgentId,
+        details: {
+          source: "productivity_review.reconcile",
+          idempotencyKey,
+        },
+      }, publications);
+      return true;
+    });
+    publications.forEach(publishActivity);
+    return delivered;
+  }
+
+  async function createOrUpdateLongActiveBatch(input: {
+    evidence: ProductivityReviewEvidence[];
+    ownerAgentId: string;
+    prefix: string;
+  }) {
+    const first = input.evidence[0];
+    if (!first) return { kind: "existing" as const, reviewIssueId: null, batched: 0 };
+    const companyId = first.sourceIssue.companyId;
+    const publications: ActivityPublication[] = [];
+    const outcome = await db.transaction(async (tx) => {
+      const txDb = tx as unknown as Db;
+      await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`productivity-review-batch:${companyId}:${input.ownerAgentId}`}, 0))`);
+      let batch = await findOpenProductivityReviewBatch(companyId, input.ownerAgentId, tx);
+      let created = false;
+      if (!batch) {
+        try {
+          batch = await issuesSvc.create(companyId, {
+            title: "Review active-work productivity findings",
+            description: buildBatchReviewMarkdown(input.evidence, input.prefix),
+            status: "todo",
+            priority: "medium",
+            assigneeAgentId: input.ownerAgentId,
+            assigneeAdapterOverrides: recoveryAssigneeAdapterOverrides("status_only"),
+            originKind: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+            originId: input.ownerAgentId,
+            originFingerprint: productivityReviewBatchFingerprint(input.ownerAgentId),
+            requestDepth: clampIssueRequestDepth(
+              Math.max(...input.evidence.map((entry) => entry.sourceIssue.requestDepth)) + 1,
+            ),
+          });
+          created = true;
+          await tx
+            .update(issues)
+            .set({ createdAt: first.generatedAt, updatedAt: first.generatedAt })
+            .where(eq(issues.id, batch.id));
+        } catch (error) {
+          const maybe = error as { code?: string; constraint?: string; message?: string };
+          const uniqueConflict = maybe.code === "23505" && (
+            maybe.constraint === "issues_active_productivity_review_uq" ||
+            typeof maybe.message === "string" && maybe.message.includes("issues_active_productivity_review_uq")
+          );
+          if (!uniqueConflict) throw error;
+          batch = await findOpenProductivityReviewBatch(companyId, input.ownerAgentId, tx);
+          if (!batch) throw error;
+        }
+      }
+
+      const alreadyBatched = await batchedSourceIds(
+        tx,
+        companyId,
+        batch.id,
+        input.evidence.map((entry) => entry.sourceIssue.id),
+      );
+      const additions = input.evidence.filter((entry) => !alreadyBatched.has(entry.sourceIssue.id));
+      if (additions.length > 0) {
+        if (!created) {
+          await issuesSvc.addComment(
+            batch.id,
+            [
+              "Productivity batch findings added.",
+              "",
+              additions.map((entry) => buildBatchFindingMarkdown(entry, input.prefix)).join("\n\n"),
+            ].join("\n"),
+            {},
+            { createdAt: first.generatedAt },
+            tx,
+          );
+          await tx
+            .update(issues)
+            .set({ updatedAt: first.generatedAt })
+            .where(eq(issues.id, batch.id));
+        }
+        await recordBatchedSources(tx, batch.id, input.ownerAgentId, additions, publications);
+        await logActivity(txDb, {
+          companyId,
+          actorType: "system",
+          actorId: "system",
+          action: created ? "issue.productivity_review_batch_created" : "issue.productivity_review_batch_updated",
+          entityType: "issue",
+          entityId: batch.id,
+          agentId: input.ownerAgentId,
+          details: {
+            source: "productivity_review.reconcile",
+            sourceIssueIds: additions.map((entry) => entry.sourceIssue.id),
+            findingCount: additions.length,
+          },
+        }, publications);
+      }
+      return {
+        kind: created ? "created" as const : additions.length > 0 ? "updated" as const : "existing" as const,
+        reviewIssueId: batch.id,
+        batched: additions.length,
+      };
+    });
+    publications.forEach(publishActivity);
+    await ensureBatchWakeDelivered({
+      batchIssueId: outcome.reviewIssueId,
+      companyId,
+      ownerAgentId: input.ownerAgentId,
+      sourceIssueIds: input.evidence.map((entry) => entry.sourceIssue.id),
+    });
+    return outcome;
   }
 
   async function createOrUpdateReview(
@@ -871,6 +1190,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       snoozed: 0,
       creationCapped: 0,
       noActionSuppressed: 0,
+      batched: 0,
       skipped: 0,
       failed: 0,
       reviewIssueIds: [] as string[],
@@ -878,6 +1198,12 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     };
 
     const prefixCache = new Map<string, string>();
+    const longActiveBatches = new Map<string, {
+      companyId: string;
+      ownerAgentId: string;
+      prefix: string;
+      evidence: ProductivityReviewEvidence[];
+    }>();
     for (const candidate of candidates) {
       if (!candidate.assigneeAgentId) {
         result.skipped += 1;
@@ -912,6 +1238,21 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         prefixCache.set(candidate.companyId, prefix);
       }
       try {
+        if (evidence.trigger === "long_active_duration") {
+          const ownerAgentId = await resolveReviewOwnerAgentId(evidence.sourceIssue, evidence.sourceAgent);
+          if (ownerAgentId) {
+            const key = `${candidate.companyId}:${ownerAgentId}`;
+            const group = longActiveBatches.get(key) ?? {
+              companyId: candidate.companyId,
+              ownerAgentId,
+              prefix,
+              evidence: [],
+            };
+            group.evidence.push(evidence);
+            longActiveBatches.set(key, group);
+            continue;
+          }
+        }
         const outcome = await createOrUpdateReview(evidence, { prefix, thresholds });
         if (outcome.kind === "created") result.created += 1;
         else if (outcome.kind === "updated") result.updated += 1;
@@ -930,6 +1271,29 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
             requestDepth: candidate.requestDepth,
           },
           "productivity review reconciliation skipped malformed candidate",
+        );
+      }
+    }
+
+    for (const batch of longActiveBatches.values()) {
+      try {
+        const outcome = await createOrUpdateLongActiveBatch(batch);
+        if (outcome.kind === "created") result.created += 1;
+        else if (outcome.kind === "updated") result.updated += 1;
+        else result.existing += 1;
+        result.batched += outcome.batched;
+        if (outcome.reviewIssueId) result.reviewIssueIds.push(outcome.reviewIssueId);
+      } catch (err) {
+        result.failed += batch.evidence.length;
+        result.failedIssueIds.push(...batch.evidence.map((entry) => entry.sourceIssue.id));
+        logger.warn(
+          {
+            err,
+            companyId: batch.companyId,
+            ownerAgentId: batch.ownerAgentId,
+            sourceIssueIds: batch.evidence.map((entry) => entry.sourceIssue.id),
+          },
+          "productivity review reconciliation skipped malformed long-active batch",
         );
       }
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip's productivity sweep currently creates one manager task and one assignment wake per qualifying source issue.
> - Long-active duration is advisory: unlike no-comment and high-churn findings, it does not hold source continuation.
> - The current detector measures issue checkout age, so queued/capacity-bound work can look like hours of execution and a single sweep can flood a manager with near-identical tasks.
> - Existing source-specific reviews, continuation holds, owner resolution, cheap status-only recovery, activity logging, and wake delivery are retained.
> - This change measures long-active duration only from an actually running issue-linked run and groups advisory findings into one open manager batch.
> - No-comment and high-churn reviews remain source-specific because their open review is a correctness boundary for continuation.

## Linked Issues or Issue Description

Refs #4904
Refs #5188
Refs #6481

Related work: #10666 adds a liveness gate but suppresses long-active findings whenever any active run exists; this PR instead distinguishes queue age from process time and batches genuinely long-running-process findings. #6972 proposes removing the trigger entirely. #11038 skips zero-run candidates. None provide manager-level batching or one-wake delivery.

Observed failure mode: a fleet sweep can create one Review productivity task for every issue whose checkout timestamp crossed six hours, even when work was queued or the agent had just started. The resulting review burst consumes manager capacity and paid agent wakes while obscuring the few actionable findings.

## What Changed

- Long-active duration now starts at the oldest issue-linked run that is actually running, preferring `processStartedAt` and falling back to adapter `startedAt`. Queued, scheduled-retry, issue `startedAt`, and execution-lock age no longer count as execution time.
- Advisory long-active findings are grouped by company and resolved manager into one open productivity-review batch.
- A newly created batch produces one cheap status-only assignment wake. Later findings append to the same batch without another wake.
- Immutable activity rows record each source-to-batch membership, providing dedupe and an inspectable audit trail without adding a table or migration.
- Advisory locks serialize batch membership and wake delivery across overlapping recovery sweeps.
- A durable wake marker and existing-wake reconciliation retry interrupted delivery without duplicating a persisted wake.
- No-comment and high-churn reviews keep the existing per-source lifecycle, creation caps, refresh rules, and continuation holds.
- Execution semantics documentation now records the split delivery model and active-time definition.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm exec vitest run server/src/__tests__/productivity-review-service.test.ts --pool=forks --maxWorkers=1 --testTimeout=15000` — 22/22 passed.
- `git diff --check` — passed.

Coverage proves:

- a 12-hour-old issue with only a queued run creates no review;
- two real long-running processes create one manager batch and one wake;
- a later third finding appends to that batch without another wake;
- rerunning unchanged evidence creates no duplicate batch or membership;
- overlapping reconciliations produce one membership, one finding, and one wake;
- dispatch failure retries the existing batch, and a persisted wake with a lost response is reconciled without another dispatch;
- a cancelled wake is retried and cannot be marked delivered;
- source-specific no-comment/high-churn behavior remains covered by the existing suite.

## Risks

- A provider that marks a run running before `processStartedAt` exists uses `startedAt` as the adapter execution boundary. That is conservative and still excludes queued time.
- One open batch can grow as new findings arrive. Membership is deduped, and each addition is appended once; closing the batch starts a fresh review window for future findings.
- Existing source-specific long-active reviews are left intact for audit. They do not create continuation holds because long-active remains advisory.
- The attention surface treats the batch as one review issue, which is intentional; source links are listed in the issue body/comments and membership activity.

## Model Used

- OpenAI Codex, GPT-5.6, agentic coding with repository and API tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issue identifiers or links
- [x] My branch name describes the change and contains no instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation
- [x] I have considered and documented risks
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

