### PR TITLE
fix(ui): use a fictional tailnet hostname in the vite proxy test

### DIFF
--- a/ui/src/lib/vite-api-proxy.test.ts
+++ b/ui/src/lib/vite-api-proxy.test.ts
@@ -22,8 +22,8 @@ describe("createApiProxy", () => {
   });
 
   it("injects x-forwarded-host and defaults x-forwarded-proto to http on plain sockets", () => {
-    const setHeader = fireProxyReq({ headers: { host: "goldie.gerbil-company.ts.net:3101" } });
-    expect(setHeader).toHaveBeenCalledWith("x-forwarded-host", "goldie.gerbil-company.ts.net:3101");
+    const setHeader = fireProxyReq({ headers: { host: "dev-box.tail1234.ts.net:3101" } });
+    expect(setHeader).toHaveBeenCalledWith("x-forwarded-host", "dev-box.tail1234.ts.net:3101");
     expect(setHeader).toHaveBeenCalledWith("x-forwarded-proto", "http");
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The UI dev server proxies `/api` to the backend and injects `x-forwarded-host`; a unit test asserts that injection with a sample Host header
> - The sample Host header is a contributor's real machine and tailnet hostname, committed to the public repository
> - Real personal hostnames do not belong in a public codebase, and this one also contains the contributor's OS username, so `scripts/check-forbidden-tokens.mjs` (which forbids the local username) blocks `npm` publishing from that contributor's machine
> - This pull request replaces the fixture with a fictional tailnet-style hostname
> - The benefit is no personal identifiers in the test fixtures and a passing forbidden-token check for every contributor

## Linked Issues or Issue Description

No existing issue. Description follows the bug template:

**What happened?**

`ui/src/lib/vite-api-proxy.test.ts` uses a real contributor dev-machine hostname as its `Host` header fixture. `node scripts/check-forbidden-tokens.mjs` fails on that contributor's machine because the hostname contains their OS username, blocking the publish flow. Introduced in #10718.

**Expected behavior**

Test fixtures use fictional hostnames. The forbidden-token check passes on every contributor machine.

**Steps to reproduce**

1. On a machine whose OS username appears in the fixture hostname, run `node scripts/check-forbidden-tokens.mjs`.
2. The check reports the two lines in `ui/src/lib/vite-api-proxy.test.ts` and blocks with exit code 1.

## What Changed

- `ui/src/lib/vite-api-proxy.test.ts`: the `Host` fixture is now `dev-box.tail1234.ts.net:3101` (fictional). The test only asserts that whatever host arrives is injected as `x-forwarded-host`, so the value is arbitrary.

## Verification

- `pnpm vitest run src/lib/vite-api-proxy.test.ts` in `ui/` — 5 tests pass.
- `node scripts/check-forbidden-tokens.mjs` — "No forbidden tokens found" on the previously affected machine.
- Note: git history retains the old value; this removes it from the current tree only.

## Risks

None. A test fixture string with no behavioral coupling.

## Model Used

- Claude (Anthropic), Claude Fable 5 (`claude-fable-5`), via Claude Code CLI with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge