### PR TITLE
feat(adapters): support Antigravity CLI (agy) and Windows SSH bridge launching

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -2111,6 +2111,10 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       bridgeToken,
       bridgeAsset,
       timeoutMs: bridgeTimeoutMs,
+      // Long-thinking agents (e.g. agy with extended reasoning) can exceed the
+      // default 30s bridge response window; inherit the run timeout so a
+      // legitimate slow step is not misreported as "timeout waiting for response".
+      responseTimeoutMs: bridgeTimeoutMs,
       maxBodyBytes,
       shellCommand,
     });

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -1523,13 +1523,29 @@ describe("sandbox callback bridge", () => {
     const startScript = capturedScripts.join("\n");
     // Windows (MSYS/git bash) detection gate (uname -s matched case-insensitively).
     expect(startScript).toContain("mingw|msys|cygwin|^nt");
-    // Wrapper .cmd generation: crlf header, env baking, node invocation.
+    // Wrapper .cmd generation: crlf header, env baking, PowerShell Start-Process
+    // (writes the real Windows PID so teardown can taskkill it), and a persisted
+    // task name so stop() can end/delete the scheduled task.
     expect(startScript).toContain("printf '@echo off");
     expect(startScript).toContain("PAPERCLIP_BRIDGE_QUEUE_DIR");
+    expect(startScript).toContain("Start-Process");
+    expect(startScript).toContain("-PassThru");
+    expect(startScript).toContain("task-name.txt");
     // schtasks one-shot registration + run (detaches the process from the SSH session).
     expect(startScript).toContain("schtasks /create");
     expect(startScript).toContain("schtasks /run");
     // POSIX fallback is preserved for non-Windows targets.
     expect(startScript).toContain("nohup");
+
+    // Tear down explicitly so the Windows stop branch runs and is captured
+    // (afterEach would otherwise stop the bridge after the assertions).
+    await bridge.stop();
+
+    const stopScript = capturedScripts.join("\n");
+    // stop() must tear down the Windows bridge via schtasks /end + /delete and
+    // taskkill (git bash kill cannot address Windows PIDs).
+    expect(stopScript).toContain("schtasks /end");
+    expect(stopScript).toContain("schtasks /delete");
+    expect(stopScript).toContain("taskkill /PID");
   });
 });

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -1521,6 +1521,10 @@ describe("sandbox callback bridge", () => {
     });
 
     const startScript = capturedScripts.join("\n");
+    if (process.env.PAPERCLIP_DUMP_START_SCRIPT) {
+      // eslint-disable-next-line no-console
+      console.log(`\n===DUMP_START_SCRIPT_BEGIN===\n${startScript}\n===DUMP_START_SCRIPT_END===`);
+    }
     // Windows (MSYS/git bash) detection gate (uname -s matched case-insensitively).
     expect(startScript).toContain("mingw|msys|cygwin|^nt");
     // Wrapper .cmd generation: crlf header, env baking, PowerShell Start-Process
@@ -1531,6 +1535,13 @@ describe("sandbox callback bridge", () => {
     expect(startScript).toContain("Start-Process");
     expect(startScript).toContain("-PassThru");
     expect(startScript).toContain("task-name.txt");
+    // The PowerShell command line is assembled in a bash variable with
+    // escaped double quotes (\"$NODE_WIN\"), so paths with spaces survive
+    // cmd.exe's pass-through to PowerShell.
+    expect(startScript).toContain("PSCMD=");
+    expect(startScript).toContain('\\"$NODE_WIN\\"');
+    expect(startScript).toContain('\\"$ENTRY_WIN\\"');
+    expect(startScript).toContain('powershell -NoProfile -ExecutionPolicy Bypass -Command "%s"');
     // schtasks one-shot registration + run (detaches the process from the SSH session).
     expect(startScript).toContain("schtasks /create");
     expect(startScript).toContain("schtasks /run");

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -1460,4 +1460,76 @@ describe("sandbox callback bridge", () => {
     expect(script).toContain("/workspace/b");
     expect(script).toContain("/workspace/c");
   });
+
+  it("emits a schtasks-based launch script for MSYS/Cygwin/Windows targets", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-runtime-"));
+    cleanupDirs.push(rootDir);
+
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    await mkdir(remoteWorkspaceDir, { recursive: true });
+
+    const runner = createExecRunner();
+    const capturedScripts: string[] = [];
+    const capturingRunner = {
+      execute: async (input: {
+        command: string;
+        args?: string[];
+        cwd?: string;
+        env?: Record<string, string>;
+        stdin?: string;
+        timeoutMs?: number;
+      }): Promise<RunProcessResult> => {
+        if ((input.command === "sh" || input.command === "bash") && typeof input.args?.[1] === "string") {
+          capturedScripts.push(input.args[1]);
+        }
+        return runner.execute(input);
+      },
+    };
+
+    const bridgeAsset = await createSandboxCallbackBridgeAsset();
+    cleanupFns.push(bridgeAsset.cleanup);
+
+    const prepared = await prepareCommandManagedRuntime({
+      runner,
+      spec: {
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+      },
+      adapterKey: "bridge-test",
+      workspaceLocalDir: remoteWorkspaceDir,
+      assets: [
+        {
+          key: "bridge",
+          localDir: bridgeAsset.localDir,
+        },
+      ],
+    });
+
+    const queueDir = path.posix.join(prepared.runtimeRootDir, "paperclip-bridge");
+    const bridgeToken = createSandboxCallbackBridgeToken();
+
+    const bridge = await startSandboxCallbackBridgeServer({
+      runner: capturingRunner,
+      remoteCwd: remoteWorkspaceDir,
+      assetRemoteDir: prepared.assetDirs.bridge,
+      queueDir,
+      bridgeToken,
+      timeoutMs: 30_000,
+    });
+    cleanupFns.push(async () => {
+      await bridge.stop();
+    });
+
+    const startScript = capturedScripts.join("\n");
+    // Windows (MSYS/git bash) detection gate (uname -s matched case-insensitively).
+    expect(startScript).toContain("mingw|msys|cygwin|^nt");
+    // Wrapper .cmd generation: crlf header, env baking, node invocation.
+    expect(startScript).toContain("printf '@echo off");
+    expect(startScript).toContain("PAPERCLIP_BRIDGE_QUEUE_DIR");
+    // schtasks one-shot registration + run (detaches the process from the SSH session).
+    expect(startScript).toContain("schtasks /create");
+    expect(startScript).toContain("schtasks /run");
+    // POSIX fallback is preserved for non-Windows targets.
+    expect(startScript).toContain("nohup");
+  });
 });

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1073,7 +1073,11 @@ export async function startSandboxCallbackBridgeServer(input: {
       `    printf 'set %s=%s\\r\\n' ${shellQuote(key)} ${shellQuote(String(value).replace(/\r?\n/g, " "))}`,
     ).join("\n"),
     `    printf 'set PAPERCLIP_BRIDGE_QUEUE_DIR=%s\\r\\n' "$QUEUE_WIN"`,
-    `    printf 'powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Start-Process -FilePath ''%s'' -ArgumentList ''%s'' -WorkingDirectory ''%s'' -WindowStyle Hidden -RedirectStandardOutput ''%s'' -RedirectStandardError ''%s'' -PassThru; $p.Id | Out-File -FilePath ''%s'' -Encoding ascii"\\r\\n' "$NODE_WIN" "$ENTRY_WIN" "$CWD_WIN" "$LOG_WIN" "$ERR_WIN" "$PID_WIN"`,
+    // Build the PowerShell command line in a bash variable first: double-quoted
+    // strings expand $NODE_WIN etc. while keeping literal quotes, avoiding
+    // single-quote nesting inside the printf format string.
+    `  PSCMD="\\$p = Start-Process -FilePath \\"$NODE_WIN\\" -ArgumentList \\"$ENTRY_WIN\\" -WorkingDirectory \\"$CWD_WIN\\" -WindowStyle Hidden -RedirectStandardOutput \\"$LOG_WIN\\" -RedirectStandardError \\"$ERR_WIN\\" -PassThru; \\$p.Id | Out-File -FilePath \\"$PID_WIN\\" -Encoding ascii"`,
+    `  printf 'powershell -NoProfile -ExecutionPolicy Bypass -Command "%s"\\r\\n' "$PSCMD"`,
     `  } > ${shellQuote(wrapperCmdPath)}`,
     `  printf '%s' ${shellQuote(winTaskName)} > ${shellQuote(taskNameFile)}`,
     `  MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /create /tn ${winTaskName} /tr \"$WRAPPER_WIN\" /sc once /st 23:59 /f" >/dev/null 2>&1 || true`,

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1035,19 +1035,52 @@ export async function startSandboxCallbackBridgeServer(input: {
     maxBodyBytes: input.maxBodyBytes,
   });
   const nodeCommand = input.nodeCommand?.trim() || "node";
+  // Windows (git bash / MSYS / Cygwin) background processes started with
+  // `nohup ... &` are killed when the SSH session that spawned them closes
+  // (MSYS process model). Launch the bridge through a wrapper .cmd file
+  // registered as a one-shot schtasks task instead, so the node process
+  // detaches from the parent SSH session and survives it.
+  const winTaskName = `paperclip-bridge-${Math.random().toString(36).slice(2, 10)}`;
+  const wrapperCmdPath = path.posix.join(directories.rootDir, `start-${winTaskName}.cmd`);
+  const wrapperWinPath = `C:${wrapperCmdPath.replace(/\//g, "\\")}`;
+  const startScript = [
+    `mkdir -p ${shellQuote(directories.requestsDir)} ${shellQuote(directories.responsesDir)} ${shellQuote(directories.logsDir)}`,
+    `rm -f ${shellQuote(directories.readyFile)} ${shellQuote(directories.pidFile)}`,
+    `if uname -s 2>/dev/null | grep -qiE 'mingw|msys|cygwin|^nt'; then`,
+    // Windows: write a wrapper .cmd that starts node detached, then run it
+    // via schtasks so the process outlives the SSH session.
+    `  NODE_BIN="$(command -v ${shellQuote(nodeCommand)} 2>/dev/null || echo ${shellQuote(nodeCommand)})"`,
+    `  NODE_WIN="$(cygpath -w "$NODE_BIN" 2>/dev/null || echo "$NODE_BIN")"`,
+    `  ENTRY_WIN="$(cygpath -w ${shellQuote(remoteEntrypoint)} 2>/dev/null || echo ${shellQuote(remoteEntrypoint)})"`,
+    `  LOG_WIN="$(cygpath -w ${shellQuote(directories.logFile)} 2>/dev/null || echo ${shellQuote(directories.logFile)})"`,
+    `  WRAPPER_WIN="$(cygpath -w ${shellQuote(wrapperCmdPath)} 2>/dev/null || echo ${shellQuote(wrapperWinPath)})"`,
+    `  QUEUE_WIN="$(cygpath -w ${shellQuote(String(env.PAPERCLIP_BRIDGE_QUEUE_DIR ?? input.queueDir))} 2>/dev/null || echo ${shellQuote(String(env.PAPERCLIP_BRIDGE_QUEUE_DIR ?? input.queueDir))})"`,
+    // Bridge env vars must be baked into the wrapper because schtasks
+    // launches the .cmd in a fresh environment that does not inherit the
+    // SSH session's variables. The queue dir is converted to a native
+    // Windows path because the node bridge runs as a Windows process.
+    `  {`,
+    `    printf '@echo off\\r\\n'`,
+    Object.entries({ ...env, PAPERCLIP_BRIDGE_QUEUE_DIR: undefined }).map(([key, value]) =>
+      `    printf 'set %s=%s\\r\\n' ${shellQuote(key)} ${shellQuote(String(value).replace(/\r?\n/g, " "))}`,
+    ).join("\n"),
+    `    printf 'set PAPERCLIP_BRIDGE_QUEUE_DIR=%s\\r\\n' "$QUEUE_WIN"`,
+    `    printf '"%s" "%s" >> "%s" 2>&1\\r\\n' "$NODE_WIN" "$ENTRY_WIN" "$LOG_WIN"`,
+    `  } > ${shellQuote(wrapperCmdPath)}`,
+    `  MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /create /tn ${winTaskName} /tr \\"$WRAPPER_WIN\\" /sc once /st 23:59 /f" >/dev/null 2>&1 || true`,
+    `  MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /run /tn ${winTaskName}" >/dev/null 2>&1`,
+    `  echo '{"pid":0}'`,
+    `else`,
+    `  nohup ${shellQuote(nodeCommand)} ${shellQuote(remoteEntrypoint)} ` +
+      `>> ${shellQuote(directories.logFile)} 2>&1 < /dev/null &`,
+    "  pid=$!",
+    `  printf '%s\\n' "$pid" > ${shellQuote(directories.pidFile)}`,
+    "  printf '{\"pid\":%s}\\n' \"$pid\"",
+    `fi`,
+  ].join("\n");
   const startResult = await input.runner.execute({
     command: shellCommand,
-    args: shellCommandArgs(
-      [
-        `mkdir -p ${shellQuote(directories.requestsDir)} ${shellQuote(directories.responsesDir)} ${shellQuote(directories.logsDir)}`,
-        `rm -f ${shellQuote(directories.readyFile)} ${shellQuote(directories.pidFile)}`,
-        `nohup ${shellQuote(nodeCommand)} ${shellQuote(remoteEntrypoint)} ` +
-          `>> ${shellQuote(directories.logFile)} 2>&1 < /dev/null &`,
-        "pid=$!",
-        `printf '%s\\n' \"$pid\" > ${shellQuote(directories.pidFile)}`,
-        "printf '{\"pid\":%s}\\n' \"$pid\"",
-      ].join("\n"),
-    ),
+    args: shellCommandArgs(startScript),
     cwd: input.remoteCwd,
     env: {
       [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1039,10 +1039,15 @@ export async function startSandboxCallbackBridgeServer(input: {
   // `nohup ... &` are killed when the SSH session that spawned them closes
   // (MSYS process model). Launch the bridge through a wrapper .cmd file
   // registered as a one-shot schtasks task instead, so the node process
-  // detaches from the parent SSH session and survives it.
+  // detaches from the parent SSH session and survives it. The wrapper uses
+  // PowerShell Start-Process -PassThru so the real Windows PID lands in the
+  // pid file (git bash `kill` cannot address Windows PIDs), and the task name
+  // is persisted so stop() can end/delete the task and kill the process.
   const winTaskName = `paperclip-bridge-${Math.random().toString(36).slice(2, 10)}`;
   const wrapperCmdPath = path.posix.join(directories.rootDir, `start-${winTaskName}.cmd`);
   const wrapperWinPath = `C:${wrapperCmdPath.replace(/\//g, "\\")}`;
+  const taskNameFile = path.posix.join(directories.rootDir, "task-name.txt");
+  const windowsStderrLogFile = `${directories.logFile}.err`;
   const startScript = [
     `mkdir -p ${shellQuote(directories.requestsDir)} ${shellQuote(directories.responsesDir)} ${shellQuote(directories.logsDir)}`,
     `rm -f ${shellQuote(directories.readyFile)} ${shellQuote(directories.pidFile)}`,
@@ -1053,6 +1058,9 @@ export async function startSandboxCallbackBridgeServer(input: {
     `  NODE_WIN="$(cygpath -w "$NODE_BIN" 2>/dev/null || echo "$NODE_BIN")"`,
     `  ENTRY_WIN="$(cygpath -w ${shellQuote(remoteEntrypoint)} 2>/dev/null || echo ${shellQuote(remoteEntrypoint)})"`,
     `  LOG_WIN="$(cygpath -w ${shellQuote(directories.logFile)} 2>/dev/null || echo ${shellQuote(directories.logFile)})"`,
+    `  ERR_WIN="$(cygpath -w ${shellQuote(windowsStderrLogFile)} 2>/dev/null || echo ${shellQuote(windowsStderrLogFile)})"`,
+    `  PID_WIN="$(cygpath -w ${shellQuote(directories.pidFile)} 2>/dev/null || echo ${shellQuote(directories.pidFile)})"`,
+    `  CWD_WIN="$(cygpath -w ${shellQuote(input.remoteCwd)} 2>/dev/null || echo ${shellQuote(input.remoteCwd)})"`,
     `  WRAPPER_WIN="$(cygpath -w ${shellQuote(wrapperCmdPath)} 2>/dev/null || echo ${shellQuote(wrapperWinPath)})"`,
     `  QUEUE_WIN="$(cygpath -w ${shellQuote(String(env.PAPERCLIP_BRIDGE_QUEUE_DIR ?? input.queueDir))} 2>/dev/null || echo ${shellQuote(String(env.PAPERCLIP_BRIDGE_QUEUE_DIR ?? input.queueDir))})"`,
     // Bridge env vars must be baked into the wrapper because schtasks
@@ -1065,9 +1073,10 @@ export async function startSandboxCallbackBridgeServer(input: {
       `    printf 'set %s=%s\\r\\n' ${shellQuote(key)} ${shellQuote(String(value).replace(/\r?\n/g, " "))}`,
     ).join("\n"),
     `    printf 'set PAPERCLIP_BRIDGE_QUEUE_DIR=%s\\r\\n' "$QUEUE_WIN"`,
-    `    printf '"%s" "%s" >> "%s" 2>&1\\r\\n' "$NODE_WIN" "$ENTRY_WIN" "$LOG_WIN"`,
+    `    printf 'powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Start-Process -FilePath ''%s'' -ArgumentList ''%s'' -WorkingDirectory ''%s'' -WindowStyle Hidden -RedirectStandardOutput ''%s'' -RedirectStandardError ''%s'' -PassThru; $p.Id | Out-File -FilePath ''%s'' -Encoding ascii"\\r\\n' "$NODE_WIN" "$ENTRY_WIN" "$CWD_WIN" "$LOG_WIN" "$ERR_WIN" "$PID_WIN"`,
     `  } > ${shellQuote(wrapperCmdPath)}`,
-    `  MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /create /tn ${winTaskName} /tr \\"$WRAPPER_WIN\\" /sc once /st 23:59 /f" >/dev/null 2>&1 || true`,
+    `  printf '%s' ${shellQuote(winTaskName)} > ${shellQuote(taskNameFile)}`,
+    `  MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /create /tn ${winTaskName} /tr \"$WRAPPER_WIN\" /sc once /st 23:59 /f" >/dev/null 2>&1 || true`,
     `  MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /run /tn ${winTaskName}" >/dev/null 2>&1`,
     `  echo '{"pid":0}'`,
     `else`,
@@ -1100,9 +1109,14 @@ export async function startSandboxCallbackBridgeServer(input: {
       `    cat ${shellQuote(directories.readyFile)}`,
       "    exit 0",
       "  fi",
-      `  if [ -s ${shellQuote(directories.logFile)} ] && ! kill -0 \"$(cat ${shellQuote(directories.pidFile)} 2>/dev/null)\" 2>/dev/null; then`,
-      `    cat ${shellQuote(directories.logFile)} >&2`,
-      "    exit 1",
+      // git bash `kill -0` cannot address Windows PIDs, so the liveness
+      // check is skipped on MSYS/Cygwin/Windows targets; readiness is
+      // signalled by the ready file alone there.
+      `  if uname -s 2>/dev/null | grep -qiE 'mingw|msys|cygwin|^nt'; then :; else`,
+      `    if [ -s ${shellQuote(directories.logFile)} ] && ! kill -0 \"$(cat ${shellQuote(directories.pidFile)} 2>/dev/null)\" 2>/dev/null; then`,
+      `      cat ${shellQuote(directories.logFile)} >&2`,
+      "      exit 1",
+      "    fi",
       "  fi",
       "  i=$((i + 1))",
       "  sleep 0.05",
@@ -1148,16 +1162,36 @@ export async function startSandboxCallbackBridgeServer(input: {
         command: shellCommand,
         args: shellCommandArgs(
           [
-            `if [ -s ${shellQuote(directories.pidFile)} ]; then`,
-            `  pid="$(cat ${shellQuote(directories.pidFile)})"`,
-            "  kill \"$pid\" 2>/dev/null || true",
-            "  i=0",
-            "  while kill -0 \"$pid\" 2>/dev/null && [ \"$i\" -lt 40 ]; do",
-            "    i=$((i + 1))",
-            "    sleep 0.05",
-            "  done",
+            // On Windows targets the bridge runs as a schtasks one-shot task
+            // with a real Windows PID (written by the wrapper's PowerShell
+            // Start-Process -PassThru). git bash `kill` cannot address Windows
+            // PIDs, so teardown ends/deletes the scheduled task and uses
+            // taskkill on the recorded PID.
+            `if uname -s 2>/dev/null | grep -qiE 'mingw|msys|cygwin|^nt'; then`,
+            `  TASK="$(cat ${shellQuote(taskNameFile)} 2>/dev/null || true)"`,
+            `  if [ -n "$TASK" ]; then`,
+            `    MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /end /tn $TASK" >/dev/null 2>&1 || true`,
+            `    MSYS_NO_PATHCONV=1 cmd.exe /c "schtasks /delete /tn $TASK /f" >/dev/null 2>&1 || true`,
+            "  fi",
+            `  if [ -s ${shellQuote(directories.pidFile)} ]; then`,
+            `    WINPID="$(cat ${shellQuote(directories.pidFile)} 2>/dev/null || true)"`,
+            `    if [ -n "$WINPID" ]; then`,
+            `      MSYS_NO_PATHCONV=1 cmd.exe /c "taskkill /PID $WINPID /T /F" >/dev/null 2>&1 || true`,
+            "    fi",
+            "  fi",
+            `  rm -f ${shellQuote(directories.pidFile)} ${shellQuote(directories.readyFile)} ${shellQuote(taskNameFile)}`,
+            "else",
+            `  if [ -s ${shellQuote(directories.pidFile)} ]; then`,
+            `    pid="$(cat ${shellQuote(directories.pidFile)})"`,
+            "    kill \"$pid\" 2>/dev/null || true",
+            "    i=0",
+            "    while kill -0 \"$pid\" 2>/dev/null && [ \"$i\" -lt 40 ]; do",
+            "      i=$((i + 1))",
+            "      sleep 0.05",
+            "    done",
+            "  fi",
+            `  rm -f ${shellQuote(directories.pidFile)} ${shellQuote(directories.readyFile)}`,
             "fi",
-            `rm -f ${shellQuote(directories.pidFile)} ${shellQuote(directories.readyFile)}`,
           ].join("\n"),
         ),
         cwd: input.remoteCwd,

--- a/packages/adapter-utils/src/ssh.test.ts
+++ b/packages/adapter-utils/src/ssh.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { shellQuote } from "./ssh.js";
+
+describe("shellQuote", () => {
+  it("wraps a plain string in single quotes", () => {
+    expect(shellQuote("hello")).toBe("'hello'");
+  });
+
+  it("escapes embedded single quotes with the standard POSIX form", () => {
+    // 'it'\''s' parses back to: it's
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+
+  it("escapes multiple single quotes", () => {
+    expect(shellQuote("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+
+  it("leaves double quotes and backslashes intact", () => {
+    expect(shellQuote('say "hi" \\')).toBe("'say \"hi\" \\'");
+  });
+
+  it("produces a string that bash parses back to the original value", () => {
+    const cases = [
+      "hello world",
+      "it's a test",
+      'printf \'@echo off\\r\\n\'',
+      'PSCMD="\\$p = Start-Process -FilePath \\"$NODE_WIN\\""',
+      "unclosed'quote'and'more",
+    ];
+    for (const value of cases) {
+      const quoted = shellQuote(value);
+      // Round-trip through bash -c echo to prove the quoting survives.
+      const { execFileSync } = require("node:child_process");
+      const out = execFileSync("bash", ["-c", `printf '%s' ${quoted}`], {
+        encoding: "utf8",
+      });
+      expect(out).toBe(value);
+    }
+  });
+});

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -5,6 +5,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { Transform } from "node:stream";
+import { gzipSync } from "node:zlib";
 import type { CommandManagedRuntimeRunner } from "./command-managed-runtime.js";
 import { readSanitizedOriginRemoteUrl } from "./git-workspace-sync.js";
 import type { RunProcessResult } from "./server-utils.js";
@@ -148,7 +149,16 @@ interface LocalGitWorkspaceSnapshot {
 }
 
 export function shellQuote(value: string) {
-  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+  // Standard POSIX single-quote escaping: close the quote, emit a literal
+  // quote via backslash in the bare context, reopen. The previous form
+  // ('\"'\" pairs) only survives when the result is later wrapped in double
+  // quotes; OpenSSH argv serialization does not do that, so scripts
+  // containing single quotes were mangled or failed with "unexpected EOF".
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function gzipBase64(value: string): string {
+  return gzipSync(Buffer.from(value, "utf8")).toString("base64");
 }
 
 function isValidShellEnvKey(value: string) {
@@ -1199,11 +1209,21 @@ export async function runSshCommand(
         : `exec sh -c ${shellQuote(remoteCommand)}`,
     ].join(" && ");
 
+    const remoteTmpScript = `/tmp/paperclip-remote-${process.pid}-${Math.random().toString(36).slice(2, 8)}.sh`;
+    // The remote script can contain single quotes and backslashes (e.g.
+    // bridge wrapper .cmd generation with printf format strings). Passing it
+    // as a shell-quoted literal is unsafe: OpenSSH re-quotes argv during
+    // serialization, so the quoting is mangled and the remote shell fails
+    // with "unexpected EOF". Transport the script gzip+base64 instead (no
+    // quotes/backslashes in the alphabet; compressed to stay under the
+    // ~8KB remote command limit), decode it into a temp file, then execute
+    // it with stdin inherited so callers can still pipe data.
+    const encodedScript = gzipBase64(remoteScript);
     sshArgs.push(
       "-p",
       String(config.port),
       `${config.username}@${config.host}`,
-      `sh -c ${shellQuote(remoteScript)}`,
+      `sh -c 'echo ${encodedScript} | base64 -d | gzip -d > ${remoteTmpScript} && sh ${remoteTmpScript}'`,
     );
 
     return options.stdin != null

--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -53,7 +53,8 @@ Core fields:
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Gemini model id. Defaults to auto.
 - engine (string, optional): leave unset/auto to use ACP when prerequisites pass and fall back to the Gemini CLI with diagnostics. Use "cli" to pin the CLI lane or "acp" to require ACP.
-- sandbox (boolean, optional): run in sandbox mode (default: false, passes --sandbox=none)
+- cliCompat (string, optional): "gemini" (default) or "agy" to drive the Google Antigravity CLI. In agy mode the CLI lane emits --dangerously-skip-permissions instead of --approval-mode yolo, drops --sandbox=none (agy uses a plain --sandbox bool flag), maps session resume to --conversation, and parses agy's stream-json event schema.
+- sandbox (boolean, optional): run in sandbox mode (default: false, passes --sandbox=none; ignored in agy mode)
 - command (string, optional): defaults to "gemini"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/gemini-local/src/server/acp.ts
+++ b/packages/adapters/gemini-local/src/server/acp.ts
@@ -70,6 +70,15 @@ export function resolveGeminiExecutionEngine(config: Record<string, unknown>): G
 export async function resolveGeminiExecutionEngineForRun(
   input: GeminiEngineResolutionInput,
 ): Promise<GeminiEngineSelection> {
+  // agy has no ACP server (no `agy --acp`), so cliCompat="agy" pins the CLI
+  // lane whenever the user did not explicitly request ACP. This prevents auto
+  // engine selection from silently running Gemini ACP and bypassing the agy
+  // command/flags/parser entirely.
+  const rawEngine = typeof input.config.engine === "string" ? input.config.engine.trim().toLowerCase() : "";
+  const cliCompat = typeof input.config.cliCompat === "string" ? input.config.cliCompat.trim().toLowerCase() : "";
+  if (cliCompat === "agy" && rawEngine !== "acp") {
+    return { engine: "cli", explicit: true };
+  }
   const selection = normalizeEngine(input.config.engine);
   if (selection.explicit || selection.engine !== "acp") return selection;
 

--- a/packages/adapters/gemini-local/src/server/config-schema.ts
+++ b/packages/adapters/gemini-local/src/server/config-schema.ts
@@ -31,7 +31,7 @@ export function getConfigSchema(): AdapterConfigSchema {
           { value: "gemini", label: "Gemini CLI" },
           { value: "agy", label: "Antigravity CLI (agy)" },
         ],
-        hint: "When using the CLI lane, adapt flag/output parsing to the target CLI. agy shares stream-json/--prompt with Gemini but uses --dangerously-skip-permissions instead of --approval-mode yolo.",
+        hint: "When using the CLI lane, adapt flag/output parsing to the target CLI. agy shares stream-json/--prompt with Gemini but uses --dangerously-skip-permissions instead of --approval-mode yolo. Selecting agy forces the CLI lane (agy has no ACP server).",
       },
       {
         key: "agentCommand",

--- a/packages/adapters/gemini-local/src/server/config-schema.ts
+++ b/packages/adapters/gemini-local/src/server/config-schema.ts
@@ -23,6 +23,17 @@ export function getConfigSchema(): AdapterConfigSchema {
         hint: "Auto uses ACP when prerequisites pass and falls back to Gemini CLI with diagnostics.",
       },
       {
+        key: "cliCompat",
+        label: "CLI compatibility",
+        type: "select",
+        default: "gemini",
+        options: [
+          { value: "gemini", label: "Gemini CLI" },
+          { value: "agy", label: "Antigravity CLI (agy)" },
+        ],
+        hint: "When using the CLI lane, adapt flag/output parsing to the target CLI. agy shares stream-json/--prompt with Gemini but uses --dangerously-skip-permissions instead of --approval-mode yolo.",
+      },
+      {
         key: "agentCommand",
         label: "ACP server command",
         type: "text",

--- a/packages/adapters/gemini-local/src/server/execute.cli-compat.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.cli-compat.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  executeGeminiAcp,
+  readPaperclipRuntimeSkillEntries,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+} = vi.hoisted(() => {
+  const runAdapterExecutionTargetProcess = vi.fn(
+    async (_runId: string, _target: unknown, _command: string, _args: string[]) => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ event: "init", conversation_id: "agy-conv-1", init: { cwd: "C:\\ws" } }),
+        JSON.stringify({
+          event: "step_update",
+          step_update: { conversation_id: "agy-conv-1", step_index: 2, state: "DONE", step_type: "agent_response", text_delta: "AGY-READY" },
+        }),
+        JSON.stringify({
+          event: "result",
+          result: {
+            conversation_id: "agy-conv-1",
+            status: "SUCCESS",
+            response: "AGY-READY",
+            usage: { input_tokens: 100, output_tokens: 10, cache_read_tokens: 0, total_tokens: 110 },
+          },
+        }),
+      ].join("\n"),
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    }),
+  );
+  return {
+    ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+    ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+    executeGeminiAcp: vi.fn(async () => {
+      throw new Error("ACP not used in cli lane");
+    }),
+    readPaperclipRuntimeSkillEntries: vi.fn(async () => []),
+    resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "agy"),
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+vi.mock("./acp.js", () => ({
+  createGeminiAcpExecutor: () => executeGeminiAcp,
+  formatGeminiAcpFallbackMessage: (reason: string) =>
+    `[paperclip] Gemini ACP default unavailable; falling back to Gemini CLI. ${reason} Set engine=acp to require ACP or engine=cli to silence this fallback.\n`,
+  resolveGeminiExecutionEngineForRun: async (ctx: { config: Record<string, unknown> }) => {
+    if (ctx.config.engine === "cli") return { engine: "cli", explicit: true };
+    if (ctx.config.engine === "acp") return { engine: "acp", explicit: true };
+    return { engine: "acp", explicit: false };
+  },
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    readPaperclipRuntimeSkillEntries,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildContext(config: Record<string, unknown> = {}, runtime: Record<string, unknown> = {}) {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Antigravity Coder",
+      adapterType: "gemini_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+      ...runtime,
+    },
+    config: {
+      engine: "cli",
+      env: {},
+      ...config,
+    },
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+describe("gemini_local cliCompat=agy CLI lane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits agy flags and parses agy stream-json output", async () => {
+    const ctx = buildContext({ cliCompat: "agy", command: "agy" });
+
+    const result = await execute(ctx as never);
+
+    expect(executeGeminiAcp).not.toHaveBeenCalled();
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+
+    const [, , , args] = vi.mocked(runAdapterExecutionTargetProcess).mock.calls[0] as unknown as [unknown, unknown, unknown, string[]];
+    expect(args).toContain("--output-format");
+    expect(args).toContain("stream-json");
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).toContain("--prompt");
+    expect(args).not.toContain("--approval-mode");
+    expect(args).not.toContain("yolo");
+    expect(args.some((arg) => String(arg).startsWith("--sandbox"))).toBe(false);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("AGY-READY");
+    expect(result.sessionId).toBe("agy-conv-1");
+    expect(result.usage).toMatchObject({ inputTokens: 100, outputTokens: 10 });
+  });
+
+  it("maps session resume to --conversation in agy mode", async () => {
+    const ctx = buildContext(
+      { cliCompat: "agy", command: "agy" },
+      { sessionId: "agy-conv-9", sessionParams: { cwd: process.cwd() } },
+    );
+
+    await execute(ctx as never);
+
+    const [, , , args] = vi.mocked(runAdapterExecutionTargetProcess).mock.calls[0] as unknown as [unknown, unknown, unknown, string[]];
+    expect(args).toContain("--conversation");
+    expect(args).toContain("agy-conv-9");
+    expect(args).not.toContain("--resume");
+  });
+
+  it("keeps gemini flags and parser when cliCompat is unset", async () => {
+    const ctx = buildContext({ command: "gemini" });
+
+    await execute(ctx as never);
+
+    const [, , , args] = vi.mocked(runAdapterExecutionTargetProcess).mock.calls[0] as unknown as [unknown, unknown, unknown, string[]];
+    expect(args).toContain("--approval-mode");
+    expect(args).toContain("yolo");
+    expect(args).toContain("--sandbox=none");
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("passes through extraArgs in agy mode", async () => {
+    const ctx = buildContext({ cliCompat: "agy", command: "agy", extraArgs: ["--effort", "high"] });
+
+    await execute(ctx as never);
+
+    const [, , , args] = vi.mocked(runAdapterExecutionTargetProcess).mock.calls[0] as unknown as [unknown, unknown, unknown, string[]];
+    expect(args).toContain("--effort");
+    expect(args).toContain("high");
+  });
+});

--- a/packages/adapters/gemini-local/src/server/execute.cli-compat.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.cli-compat.test.ts
@@ -51,6 +51,10 @@ vi.mock("./acp.js", () => ({
   formatGeminiAcpFallbackMessage: (reason: string) =>
     `[paperclip] Gemini ACP default unavailable; falling back to Gemini CLI. ${reason} Set engine=acp to require ACP or engine=cli to silence this fallback.\n`,
   resolveGeminiExecutionEngineForRun: async (ctx: { config: Record<string, unknown> }) => {
+    // Mirrors acp.ts: cliCompat="agy" pins the CLI lane unless engine=acp.
+    const cliCompat = typeof ctx.config.cliCompat === "string" ? ctx.config.cliCompat.trim().toLowerCase() : "";
+    const rawEngine = typeof ctx.config.engine === "string" ? ctx.config.engine.trim().toLowerCase() : "";
+    if (cliCompat === "agy" && rawEngine !== "acp") return { engine: "cli", explicit: true };
     if (ctx.config.engine === "cli") return { engine: "cli", explicit: true };
     if (ctx.config.engine === "acp") return { engine: "acp", explicit: true };
     return { engine: "acp", explicit: false };
@@ -161,6 +165,20 @@ describe("gemini_local cliCompat=agy CLI lane", () => {
     expect(args).toContain("yolo");
     expect(args).toContain("--sandbox=none");
     expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("forces the CLI lane when cliCompat=agy and engine is auto", async () => {
+    // engine left unset (auto): agy has no ACP server, so the run must go
+    // through the CLI lane with agy flags instead of Gemini ACP.
+    const ctx = buildContext({ cliCompat: "agy", command: "agy", engine: undefined });
+
+    const result = await execute(ctx as never);
+
+    expect(executeGeminiAcp).not.toHaveBeenCalled();
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+    const [, , , args] = vi.mocked(runAdapterExecutionTargetProcess).mock.calls[0] as unknown as [unknown, unknown, unknown, string[]];
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(result.exitCode).toBe(0);
   });
 
   it("passes through extraArgs in agy mode", async () => {

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -55,6 +55,7 @@ import {
   isGeminiTransientNetworkError,
   isGeminiTurnLimitResult,
   isGeminiSessionUnrecoverableError,
+  parseAgyJsonl,
   parseGeminiJsonl,
 } from "./parse.js";
 import { firstNonEmptyLine } from "./utils.js";
@@ -233,6 +234,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const command = asString(config.command, "gemini");
   const model = asString(config.model, DEFAULT_GEMINI_LOCAL_MODEL).trim();
   const sandbox = asBoolean(config.sandbox, false);
+  // CLI compatibility mode: "gemini" (default) or "agy" (Google Antigravity CLI).
+  // agy shares the stream-json/--prompt shape with gemini but differs in the
+  // approval flag (--dangerously-skip-permissions vs --approval-mode yolo),
+  // sandbox flag syntax, resume flag (--conversation vs --resume), and its
+  // stream-json event schema.
+  const cliCompat = asString(config.cliCompat, "gemini").trim().toLowerCase() === "agy" ? "agy" : "gemini";
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -509,8 +516,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
-    notes.push("Added --approval-mode yolo for unattended execution.");
+    const notes: string[] = []; 
+    if (cliCompat === "agy") {
+      notes.push("Prompt is passed to Antigravity CLI (agy) via --prompt for non-interactive execution.");
+      notes.push("Added --dangerously-skip-permissions for unattended execution.");
+    } else {
+      notes.push("Prompt is passed to Gemini via --prompt for non-interactive execution.");
+      notes.push("Added --approval-mode yolo for unattended execution.");
+    }
     notes.push("Set headless terminal/browser env so Gemini fails fast instead of opening interactive auth or color prompts.");
     if (executionTargetIsRemote) {
       notes.push("Set GEMINI_CLI_TRUST_WORKSPACE=true for remote headless execution.");
@@ -571,6 +584,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const buildArgs = (resumeSessionId: string | null) => {
+    if (cliCompat === "agy") {
+      const args = ["--output-format", "stream-json"];
+      if (resumeSessionId) args.push("--conversation", resumeSessionId);
+      if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
+      args.push("--dangerously-skip-permissions");
+      if (extraArgs.length > 0) args.push(...extraArgs);
+      args.push("--prompt", prompt);
+      return args;
+    }
     const args = ["--output-format", "stream-json"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
     if (model && model !== DEFAULT_GEMINI_LOCAL_MODEL) args.push("--model", model);
@@ -622,7 +644,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     });
     return {
       proc,
-      parsed: parseGeminiJsonl(proc.stdout),
+      parsed:
+        cliCompat === "agy"
+          ? parseAgyJsonl(proc.stdout)
+          : parseGeminiJsonl(proc.stdout),
     };
   };
 

--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -3,6 +3,7 @@ import {
   detectGeminiAuthRequired,
   isGeminiTransientNetworkError,
   isGeminiSessionUnrecoverableError,
+  parseAgyJsonl,
   parseGeminiJsonl,
 } from "./parse.js";
 
@@ -211,5 +212,101 @@ describe("isGeminiTransientNetworkError", () => {
     expect(
       isGeminiTransientNetworkError("", "Error: unknown session 'abc-123'"),
     ).toBe(false);
+  });
+});
+
+describe("parseAgyJsonl", () => {
+  it("extracts conversation id, streamed text, response, and usage", () => {
+    const stdout = [
+      JSON.stringify({ event: "init", conversation_id: "conv-1", init: { cwd: "C:\\ws" } }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: { conversation_id: "conv-1", step_index: 0, state: "DONE", step_type: "user_input" },
+      }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: { conversation_id: "conv-1", step_index: 2, state: "ACTIVE", step_type: "agent_response", text_delta: "PONG" },
+      }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          conversation_id: "conv-1",
+          step_index: 2,
+          state: "DONE",
+          step_type: "agent_response",
+          text_delta: "\n",
+          duration_seconds: 1.7,
+          usage: { input_tokens: 21962, output_tokens: 67, cache_read_tokens: 0, total_tokens: 22029 },
+        },
+      }),
+      JSON.stringify({
+        event: "result",
+        result: {
+          conversation_id: "conv-1",
+          status: "SUCCESS",
+          response: "PONG\n",
+          duration_seconds: 2.7,
+          num_turns: 1,
+          usage: { input_tokens: 22060, output_tokens: 70, thinking_tokens: 65, cache_read_tokens: 0, total_tokens: 22130 },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseAgyJsonl(stdout);
+
+    expect(parsed.sessionId).toBe("conv-1");
+    expect(parsed.summary).toBe("PONG");
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.resultEvent).toMatchObject({ event: "result", status: "SUCCESS", response: "PONG\n" });
+    expect(parsed.usage.inputTokens).toBe(44022); // 21962 + 22060
+    expect(parsed.usage.outputTokens).toBe(137); // 67 + 70
+  });
+
+  it("accumulates streamed text across multiple agent_response deltas", () => {
+    const stdout = [
+      JSON.stringify({ event: "step_update", step_update: { step_type: "agent_response", state: "ACTIVE", text_delta: "Hel" } }),
+      JSON.stringify({ event: "step_update", step_update: { step_type: "agent_response", state: "ACTIVE", text_delta: "lo " } }),
+      JSON.stringify({ event: "step_update", step_update: { step_type: "agent_response", state: "DONE", text_delta: "world" } }),
+      JSON.stringify({ event: "result", result: { status: "SUCCESS", response: "Hello world" } }),
+    ].join("\n");
+
+    const parsed = parseAgyJsonl(stdout);
+
+    expect(parsed.summary).toBe("Hello world");
+  });
+
+  it("reports a non-success result status as an error", () => {
+    const stdout = [
+      JSON.stringify({ event: "result", result: { status: "ERROR", response: "Something broke", error: "rate limited" } }),
+    ].join("\n");
+
+    const parsed = parseAgyJsonl(stdout);
+
+    expect(parsed.errorMessage).toBe("rate limited");
+    expect(parsed.summary).toBe("Something broke");
+  });
+
+  it("extracts an error event", () => {
+    const stdout = [
+      JSON.stringify({ event: "error", error: "not authenticated" }),
+    ].join("\n");
+
+    const parsed = parseAgyJsonl(stdout);
+
+    expect(parsed.errorMessage).toBe("not authenticated");
+  });
+
+  it("ignores unrelated event types", () => {
+    const stdout = [
+      JSON.stringify({ event: "init", conversation_id: "conv-9" }),
+      JSON.stringify({ event: "some_unknown", payload: { x: 1 } }),
+      JSON.stringify({ event: "result", result: { status: "SUCCESS", response: "ok" } }),
+    ].join("\n");
+
+    const parsed = parseAgyJsonl(stdout);
+
+    expect(parsed.sessionId).toBe("conv-9");
+    expect(parsed.summary).toBe("ok");
+    expect(parsed.errorMessage).toBeNull();
   });
 });

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -199,6 +199,91 @@ export function parseGeminiJsonl(stdout: string) {
   };
 }
 
+/**
+ * Parse Google Antigravity CLI (agy) stream-json output.
+ *
+ * agy emits NDJSON lines shaped as:
+ *   {"event":"init","conversation_id":"...","init":{...}}
+ *   {"event":"step_update","step_update":{"conversation_id":"...","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"..."}}
+ *   {"event":"result","result":{"conversation_id":"...","status":"SUCCESS","response":"...","usage":{"input_tokens":N,"output_tokens":N,"cache_read_tokens":N}}}
+ *
+ * This is structurally different from Gemini CLI's stream-json schema
+ * (top-level `type` events vs a nested `event` discriminator), so it gets a
+ * dedicated parser that returns the same shape as parseGeminiJsonl.
+ */
+export function parseAgyJsonl(stdout: string) {
+  let sessionId: string | null = null;
+  const textParts: string[] = [];
+  let errorMessage: string | null = null;
+  let costUsd: number | null = null;
+  let resultEvent: Record<string, unknown> | null = null;
+  let question: { prompt: string; choices: Array<{ key: string; label: string; description?: string }> } | null = null;
+  const usage = {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+  };
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const event = parseJson(line);
+    if (!event) continue;
+
+    const conversationId = asString(event.conversation_id, "").trim();
+    if (conversationId) sessionId = conversationId;
+
+    const eventType = asString(event.event, "").trim();
+
+    if (eventType === "step_update") {
+      const stepUpdate = parseObject(event.step_update);
+      const stepType = asString(stepUpdate.step_type, "").trim();
+      const state = asString(stepUpdate.state, "").trim();
+      if (stepType === "agent_response" && (state === "ACTIVE" || state === "DONE")) {
+        const delta = asString(stepUpdate.text_delta, "").trim();
+        if (delta) textParts.push(delta);
+      }
+      const stepUsage = stepUpdate.usage ?? event.usage;
+      if (stepUsage) accumulateUsage(usage, stepUsage);
+      continue;
+    }
+
+    if (eventType === "result") {
+      const result = parseObject(event.result);
+      resultEvent = { ...event, ...result };
+      const status = asString(result.status, "").toLowerCase();
+      if (status && status !== "success") {
+        const text = asErrorText(result.error ?? result.message ?? result.response).trim();
+        errorMessage = text || `Antigravity exited with status ${status}`;
+      }
+      const resultText = asString(result.response, "").trim();
+      if (resultText && textParts.length === 0) textParts.push(resultText);
+      const resultUsage = result.usage ?? event.usage;
+      if (resultUsage) accumulateUsage(usage, resultUsage);
+      costUsd =
+        asNumber(result.total_cost_usd, asNumber(result.cost_usd, asNumber(result.cost, costUsd ?? 0))) || costUsd;
+      continue;
+    }
+
+    if (eventType === "error") {
+      const text = asErrorText(event.error ?? event.message ?? event.detail).trim();
+      if (text) errorMessage = text;
+      continue;
+    }
+  }
+
+  return {
+    sessionId,
+    summary: textParts.join("").trim(),
+    usage,
+    costUsd,
+    errorMessage,
+    resultEvent,
+    question,
+  };
+}
+
 export function isGeminiSessionUnrecoverableError(stdout: string, stderr: string): boolean {
   const haystack = `${stdout}\n${stderr}`
     .split(/\r?\n/)

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -241,8 +241,8 @@ export function parseAgyJsonl(stdout: string) {
       const stepType = asString(stepUpdate.step_type, "").trim();
       const state = asString(stepUpdate.state, "").trim();
       if (stepType === "agent_response" && (state === "ACTIVE" || state === "DONE")) {
-        const delta = asString(stepUpdate.text_delta, "").trim();
-        if (delta) textParts.push(delta);
+        const delta = asString(stepUpdate.text_delta, "");
+        if (delta.length > 0) textParts.push(delta);
       }
       const stepUsage = stepUpdate.usage ?? event.usage;
       if (stepUsage) accumulateUsage(usage, stepUsage);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI-agent companies
> - The gemini_local adapter runs the Gemini CLI; it executes agents through the shared ACPX engine and the sandbox callback bridge
> - The sandbox callback bridge launches a node process on the execution target with `nohup ... &`
> - On Windows targets reached over SSH (git bash / MSYS), a background process started with `nohup &` dies when the SSH session closes; the MSYS process model does not detach it
> - The Gemini CLI flag set and stream-json schema differ from the Google Antigravity CLI (agy), which is another headless Google agent CLI
> - This pull request adds a Windows-safe bridge launch path (schtasks one-shot task + wrapper .cmd) and a `cliCompat: "agy"` mode to gemini_local so Paperclip can drive agy over SSH on Windows
> - It also fixes two latent transport bugs the Windows path exposed: shellQuote's non-standard escaping, and OpenSSH argv re-quoting of scripts that contain single quotes
> - The benefit is that Windows SSH execution targets work for the callback bridge, Antigravity CLI agents can be onboarded like any other local CLI adapter, and any SSH script containing quotes is no longer mangled

## Linked Issues or Issue Description

**Agent or provider:**
Antigravity CLI (agy) — the headless CLI of Google Antigravity. Driven through the existing `gemini_local` adapter via a new `cliCompat: "agy"` mode, because both CLIs share the `--prompt` / `--output-format stream-json` contract.

**Why this adapter is useful:**
Lets Paperclip onboard agents that run on Windows machines reached over SSH. Without this change the sandbox callback bridge process dies with the SSH session (MSYS kills `nohup &` children), so no adapter can hold a remote run open on Windows; and gemini_local hard-codes Gemini CLI flags and parsing, so agy cannot be used as an agent runtime at all.

**How the agent is invoked:**
`agy --output-format stream-json --dangerously-skip-permissions --prompt "<prompt>"` (non-interactive print mode). Resume maps to `--conversation <id>`. Output is NDJSON with `event: init|step_update|result` and a nested `result` object. Install: official `install.cmd`; binary at `%LOCALAPPDATA%\agy\bin\agy.exe`.

**Additional context:**
- Root cause 1 (bridge process death): `startSandboxCallbackBridgeServer` starts the node bridge with `nohup ... &`, which does not survive the closing SSH session on MSYS/git bash. The fix detects MSYS/Cygwin/Windows on the remote (`uname -s`) and launches the bridge through a generated wrapper `.cmd` registered as a one-shot `schtasks` task. The wrapper uses PowerShell `Start-Process -PassThru` so the real Windows PID is written to the pid file, and the task name is persisted to `task-name.txt` so `stop()` can `schtasks /end` + `schtasks /delete` + `taskkill /PID /T /F`.
- Root cause 2 (transport): scripts containing single quotes or backslashes (bridge wrapper generation uses `printf '...'` format strings) were mangled by two quoting layers — `shellQuote` emitted a non-standard `'\"'\"` escape that only survives double-quote wrapping, and OpenSSH re-quotes argv during serialization, producing `unexpected EOF` on the remote. The fix ships the remote script gzip+base64 (alphabet has no quotes/backslashes, compressed to stay under the ~8KB remote command limit), decodes it to a temp file, and runs it with stdin inherited so callers can still pipe data.
- Root cause 3 (flags/parsing): gemini_local's CLI lane always emits `--approval-mode yolo` and `--sandbox=none` and parses Gemini's stream-json event schema; agy rejects those flags and emits a different event schema. The `cliCompat` switch (default `"gemini"`) selects the agy flag set and the new `parseAgyJsonl` parser, and pins the CLI lane (agy has no ACP server).
- Root cause 4 (bridge response window): the default 30s bridge response timeout misreported long-thinking agents (agy extended reasoning) as "timeout waiting for response"; `responseTimeoutMs` now inherits the run timeout.
- Verified end-to-end: an agy agent run through a `driver=ssh` environment (Windows OpenSSH, git bash default shell) returned `exitCode 0`, extracted the agy conversation id as `session_id_after`, recorded usage tokens, and posted the issue comment.

## What Changed

- `packages/adapter-utils/src/sandbox-callback-bridge.ts`: on MSYS/Cygwin/Windows remotes, write a wrapper `.cmd` (env vars baked in, queue dir as native Windows path) that starts node via PowerShell `Start-Process -PassThru` writing the real PID, persist the schtasks task name, and tear down with `schtasks /end` + `/delete` + `taskkill`; readiness skips the git-bash `kill -0` check on Windows (cannot address Windows PIDs); Linux/macOS keep the existing `nohup &` path
- `packages/adapter-utils/src/ssh.ts`: `shellQuote` now uses standard POSIX `'\''` escaping; `runSshCommand` transports the remote script gzip+base64 (decode to temp file, execute with stdin inherited) so scripts containing quotes/backslashes survive OpenSSH argv serialization and stay under the remote command length limit
- `packages/adapter-utils/src/execution-target.ts`: bridge `responseTimeoutMs` inherits the run timeout instead of the 30s default
- `packages/adapters/gemini-local/src/server/parse.ts`: add `parseAgyJsonl` for agy's `event`/`step_update`/`result` stream-json schema (conversation id, `text_delta` streaming with whitespace preserved, `result.response`, usage)
- `packages/adapters/gemini-local/src/server/execute.ts`: read `cliCompat`; branch `buildArgs` (approval flag, sandbox flag, resume flag) and the stdout parser on it; adjust command notes
- `packages/adapters/gemini-local/src/server/acp.ts`: `cliCompat="agy"` pins the CLI lane when engine is auto (agy has no ACP server)
- `packages/adapters/gemini-local/src/server/config-schema.ts`: add `cliCompat` select field
- `packages/adapters/gemini-local/src/index.ts`: document `cliCompat`
- Tests: `parseAgyJsonl` unit tests, agy CLI-lane arg/parser tests (`execute.cli-compat.test.ts`), Windows bridge launch-script + teardown assertions, `shellQuote` round-trip tests through real `bash -c`

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` and `pnpm --filter @paperclipai/adapter-gemini-local typecheck` pass
- `pnpm vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts` passes (24/24)
- `pnpm vitest run packages/adapter-utils/src/ssh.test.ts` passes (5/5, bash round-trip)
- `pnpm vitest run packages/adapters/gemini-local/src/server/parse.test.ts` + `execute.cli-compat.test.ts` pass (29/29)
- End-to-end on a real Windows SSH target (git bash as the OpenSSH default shell): an agy agent run through a `driver=ssh` environment returned `exitCode 0`; bridge startup, wrapper .cmd generation, schtasks launch, real PID capture, and teardown were exercised; the issue comment reached `satisfied`; a long run (246k input tokens) succeeded after the response-timeout fix
- Manual remote check: `nohup node ... &` dies with the SSH session in git bash; schtasks + PowerShell Start-Process keeps node alive after the session closes; `schtasks /end` + `/delete` + `taskkill /PID /T /F` cleans up parent and child processes
- Note: `packages/adapter-utils/src/acpx-engine/execute.test.ts` has pre-existing flaky 5s timeouts on this WSL host (baseline fails 3-8 tests without these changes); `execute.remote.test.ts` has one pre-existing mock-environment failure; neither is introduced by this PR

## Risks

- Low. The bridge Windows branch only activates when the remote `uname -s` matches MSYS/Cygwin/Windows; Linux/macOS behavior is unchanged (same `nohup` script as before)
- The wrapper `.cmd` bakes bridge env vars at launch time; env values containing `%` or newlines could be mangled (newlines are sanitized; `%` is a documented Windows .cmd escape caveat, low likelihood in practice)
- `shellQuote` now emits standard `'\''`; the previous form only worked when double-quote wrapped, so any caller relying on that broken behavior would have received mangled commands already — this is a strict improvement
- Remote scripts are now transported gzip+base64: requires `base64` and `gzip` on the remote (present on git bash, MSYS, and all common Linux/macOS distributions; minimal Alpine/scratch images ship both via busybox)
- `cliCompat` defaults to `"gemini"`, so existing gemini_local users see no behavioral change
- agy resume maps to `--conversation`; conversation ids are stable across runs in testing but agy may rotate them under TOS changes (falls back to a fresh session, same as Gemini)

## Model Used

- Provider: DeepSeek (API), model `deepseek-v4-flash`, default context window, no reasoning mode, standard agent tool loop — used to write the adapter changes, the transport fixes, the tests, run the suite, and verify the end-to-end Windows SSH runs against the live Antigravity CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (CI not run yet — draft PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (not run yet — draft PR)
- [x] I will address all Greptile and reviewer comments before requesting merge
