### PR TITLE
chore(db): treat Drizzle migration snapshots as binary in diffs

### DIFF
--- a/packages/db/.gitattributes
+++ b/packages/db/.gitattributes
@@ -4,7 +4,11 @@
 # meaningfully text-merged — the id/prevId chain and schema state are computed,
 # so a line-level merge yields a snapshot matching no real `generate` run. The
 # only correct resolution is to renumber one migration and regenerate. Hence:
-#   linguist-generated=true  GitHub collapses the huge diff, excludes from stats
+#   linguist-generated=true  GitHub excludes them from language stats
+#   -diff                    git treats them as binary, so the huge line count
+#                            drops out of the PR +/- badge and GitHub shows
+#                            "Binary file not shown" instead of a 39k-line diff
 #   -merge                   git refuses to auto-merge and raises a loud conflict
 #                            instead of silently fabricating a bogus snapshot
-src/migrations/meta/** linguist-generated=true -merge
+# Note: -text is intentionally NOT set, so EOL normalization stays intact.
+src/migrations/meta/** linguist-generated=true -diff -merge


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip stores its state in a Postgres database, managed in `packages/db`.
> - The schema uses Drizzle. `drizzle-kit` writes a full-schema snapshot to `packages/db/src/migrations/meta/` for every migration.
> - Each snapshot is a large generated JSON file. One snapshot is about 39k lines.
> - PR #11240 marked these files `linguist-generated=true`. That collapses the file view and drops the files from language stats.
> - But `linguist-generated` does not change the PR line-count badge. Git still counts every snapshot line, so a PR that adds one migration shows a ~39k-line badge (two migrations show ~78k). PR #11237 shows +84,665 for this reason.
> - This pull request adds `-diff` to the same files, so git treats them as binary and their lines leave the +/- count.
> - The benefit is a pull request badge that reflects the real code change, not generated snapshot noise.

## Linked Issues or Issue Description

No existing issue. This is a small follow-up to merged PR #11240. Description follows the enhancement template:

**Problem / Motivation**
PR #11240 marked `packages/db/src/migrations/meta/**` as `linguist-generated=true`. That attribute collapses the diff in the Files-changed view and removes the files from language stats, but it does not remove their lines from the PR additions/deletions badge. Each Drizzle snapshot is a full copy of the schema (~39k lines), so any PR that adds a migration still shows a huge line count. PR #11237 shows +84,665, of which ~78k are two generated snapshots.

**Proposed Solution**
Add `-diff` to the same glob. Git then treats the snapshots as binary. `git diff --numstat` reports `-` for these files, so their lines leave the +/- badge and GitHub shows "Binary file not shown" in place of the full JSON.

**Alternatives Considered**
- Keep only `linguist-generated`: leaves the misleading ~39k/78k badge on every migration PR.
- Use the `binary` macro (`-diff -merge -text`): also disables EOL normalization. This repo has open CRLF/LF work, so `-text` is left unset on purpose.

## What Changed

- Added `-diff` to `src/migrations/meta/**` in `packages/db/.gitattributes`.
- Kept `linguist-generated=true` (language stats) and `-merge` (no auto-merge of generated snapshots).
- Left `-text` unset on purpose, so end-of-line normalization stays intact.
- Left the `.sql` migration files untouched, so their diffs stay visible for review.

## Verification

Check the attributes and confirm the snapshot is now treated as binary:

```
git check-attr linguist-generated diff merge -- \
  packages/db/src/migrations/meta/0031_snapshot.json \
  packages/db/src/migrations/0009_fast_jackal.sql

git diff --numstat origin/master...origin/feat/adapter-sandbox-login -- \
  packages/db/src/migrations/meta/0214_snapshot.json
```

Expected:

```
packages/db/src/migrations/meta/0031_snapshot.json: linguist-generated: true
packages/db/src/migrations/meta/0031_snapshot.json: diff: unset
packages/db/src/migrations/meta/0031_snapshot.json: merge: unset
packages/db/src/migrations/0009_fast_jackal.sql: linguist-generated: unspecified
packages/db/src/migrations/0009_fast_jackal.sql: diff: unspecified
packages/db/src/migrations/0009_fast_jackal.sql: merge: unspecified

-	-	packages/db/src/migrations/meta/0214_snapshot.json
```

The snapshot reports `-` in numstat (binary, not counted). The `.sql` migration keeps normal diff behavior. GitHub reads the rule from the PR tree, so the badge drops on the next PR that touches these files.

## Risks

Low risk. The change only affects how git and GitHub render and count generated files. It does not touch application code, the schema, or any migration.

- With `-diff`, GitHub and local `git diff` no longer show a text diff for a snapshot. This is intended; the files are generated and are not reviewed by hand. The raw file is still viewable.
- `-text` is left unset, so this change does not affect the CRLF/LF handling that other PRs (for example #8922) address.

## Model Used

Claude Opus 4.8 (Anthropic), model ID `claude-opus-4-8`, used through Claude Code with extended thinking and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass — not applicable; this change touches no code path, only git/GitHub file handling
- [x] I have added or updated tests where applicable — not applicable; `.gitattributes` behavior is verified with `git check-attr` and `git diff --numstat` (see Verification)
- [x] I have updated relevant documentation to reflect my changes — not applicable; the `.gitattributes` file documents its own rules inline
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
