### PR TITLE
fix(ui): stop onboarding dead-ending on the mission step for an existing company

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -92,6 +92,7 @@ import { useCompany } from "./context/CompanyContext";
 import { useDialogActions, useDialogState } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
 import {
+  EXISTING_COMPANY_ONBOARDING_STEP,
   isOnboardingWizardActive,
   shouldRedirectCompanylessRouteToOnboarding,
 } from "./lib/onboarding-route";
@@ -431,7 +432,10 @@ function OnboardingRoutePage() {
           <Button
             onClick={() =>
               matchedCompany
-                ? openOnboarding({ initialStep: 2, companyId: matchedCompany.id })
+                ? openOnboarding({
+                    initialStep: EXISTING_COMPANY_ONBOARDING_STEP,
+                    companyId: matchedCompany.id,
+                  })
                 : openOnboarding()
             }
           >

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+import type { AdapterEnvironmentTestResult, Goal } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
@@ -292,7 +292,7 @@ export function OnboardingWizard() {
   const {
     data: existingCompanyGoals,
     isError: existingCompanyGoalsFailed,
-    isFetching: missionRetrying,
+    isFetching: missionFetching,
     refetch: refetchExistingCompanyGoals,
   } = useQuery({
     queryKey: existingCompanyId
@@ -308,16 +308,21 @@ export function OnboardingWizard() {
   const missionUnresolved = isExistingCompanyMissionUnresolved({
     existingCompanyId,
     goalsLoaded: Boolean(existingCompanyGoals),
+    goalsFetching: missionFetching,
   });
 
-  // Hydrate once per company: the company's own goal is authoritative over any
-  // saved mission text (which may belong to an entirely different company), but
-  // a refetch must not clobber edits made after hydration.
-  const hydratedMissionCompanyIdRef = useRef<string | null>(null);
+  // Hydrate once per distinct read, not once per company. The company's own
+  // goal is authoritative over any saved mission text (which may belong to an
+  // entirely different company), and React Query keeps the same array
+  // reference until the data actually changes — so this runs once per server
+  // response rather than on every render, while a refetch that supersedes a
+  // cached mission still lands. Keying this on the company id instead would
+  // pin the wizard to whatever was in cache when it opened.
+  const hydratedMissionGoalsRef = useRef<Goal[] | null>(null);
   useEffect(() => {
     if (!existingCompanyId || !existingCompanyGoals) return;
-    if (hydratedMissionCompanyIdRef.current === existingCompanyId) return;
-    hydratedMissionCompanyIdRef.current = existingCompanyId;
+    if (hydratedMissionGoalsRef.current === existingCompanyGoals) return;
+    hydratedMissionGoalsRef.current = existingCompanyGoals;
     const mission = selectExistingCompanyMission(existingCompanyGoals);
     // Authoritative, not a fallback: a saved goal id may belong to a previous
     // run on a *different* company, and launch files the first task against
@@ -493,9 +498,9 @@ export function OnboardingWizard() {
     setCreatedCompanyGoalId(null);
     setCreatedProjectId(null);
     setCreatedIssueRef(null);
-    // reset() clears the mission it hydrated, so the next entry on the same
-    // company has to hydrate again.
-    hydratedMissionCompanyIdRef.current = null;
+    // reset() clears the mission it hydrated, so the next entry has to hydrate
+    // again even if the goals query hands back the very same cached read.
+    hydratedMissionGoalsRef.current = null;
   }
 
   function handleClose() {
@@ -1788,18 +1793,18 @@ export function OnboardingWizard() {
                       variant="ghost"
                       size="sm"
                       className="mt-1 -ml-2 h-7 text-xs"
-                      disabled={missionRetrying}
+                      disabled={missionFetching}
                       onClick={() => {
                         setError(null);
                         void refetchExistingCompanyGoals();
                       }}
                     >
-                      {missionRetrying ? (
+                      {missionFetching ? (
                         <Loader2 className="h-3 w-3 mr-1 animate-spin" />
                       ) : (
                         <RefreshCw className="h-3 w-3 mr-1" />
                       )}
-                      {missionRetrying ? "Retrying..." : "Retry"}
+                      {missionFetching ? "Retrying..." : "Retry"}
                     </Button>
                   )}
                 </div>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
@@ -38,12 +38,20 @@ import {
   selectDefaultCompanyGoalId,
   selectReusableOnboardingProject,
 } from "../lib/onboarding-launch";
+import {
+  planMissionPersistence,
+  selectExistingCompanyMission,
+} from "../lib/onboarding-mission";
 import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
 import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
-import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
+import {
+  canGoBackFromOnboardingStep,
+  canJumpToOnboardingStep,
+  resolveRouteOnboardingOptions,
+} from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
 import { FrontDoor } from "./FrontDoor";
 import { AgentCapsule } from "./AgentCapsule";
@@ -244,12 +252,61 @@ export function OnboardingWizard() {
     effectiveOnboardingOptions.initialStep
   ]);
 
-  // Backfill issue prefix for an existing company once companies are loaded.
+  // Backfill issue prefix and name for an existing company once companies are
+  // loaded. Entering on an existing company skips step 1, so the organization's
+  // name has to come from the company itself — otherwise the wizard renders a
+  // blank name on steps 3 and 5 and hires the lead agent with no organization
+  // in its instructions bundle.
   useEffect(() => {
-    if (!effectiveOnboardingOpen || !createdCompanyId || createdCompanyPrefix) return;
+    if (!effectiveOnboardingOpen || !createdCompanyId) return;
     const company = companies.find((c) => c.id === createdCompanyId);
-    if (company) setCreatedCompanyPrefix(company.issuePrefix);
-  }, [effectiveOnboardingOpen, createdCompanyId, createdCompanyPrefix, companies]);
+    if (!company) return;
+    if (!createdCompanyPrefix) setCreatedCompanyPrefix(company.issuePrefix);
+    // When the wizard was entered on an existing company the company is the
+    // only source of truth for its name — a stale localStorage wizard run from
+    // a different company must not label this one. When the company was instead
+    // created in this run, step 1 still owns the field, so only fill a blank.
+    if (createdCompanyId === existingCompanyId) {
+      if (companyName !== company.name) setCompanyName(company.name);
+    } else if (!companyName.trim()) {
+      setCompanyName(company.name);
+    }
+  }, [
+    existingCompanyId,
+    effectiveOnboardingOpen,
+    createdCompanyId,
+    createdCompanyPrefix,
+    companyName,
+    companies,
+  ]);
+
+  // Carry an existing company's mission into the wizard. The managed path never
+  // re-asks for the mission, so on this entry the mission is read back from the
+  // company's goal rather than retyped. The Review step and the lead agent's
+  // instructions bundle both read `companyGoal`, and `createdCompanyGoalId` is
+  // what the first task is filed against at launch.
+  const { data: existingCompanyGoals } = useQuery({
+    queryKey: existingCompanyId
+      ? queryKeys.goals.list(existingCompanyId)
+      : ["goals", "none", "onboarding-mission"],
+    queryFn: () => goalsApi.list(existingCompanyId!),
+    enabled: Boolean(existingCompanyId) && effectiveOnboardingOpen,
+  });
+
+  // Hydrate once per company: the company's own goal is authoritative over any
+  // saved mission text (which may belong to an entirely different company), but
+  // a refetch must not clobber edits made after hydration.
+  const hydratedMissionCompanyIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!existingCompanyId || !existingCompanyGoals) return;
+    if (hydratedMissionCompanyIdRef.current === existingCompanyId) return;
+    hydratedMissionCompanyIdRef.current = existingCompanyId;
+    const mission = selectExistingCompanyMission(existingCompanyGoals);
+    if (mission.goalId) {
+      setCreatedCompanyGoalId((current) => current ?? mission.goalId);
+    }
+    setCompanyGoal(mission.goalInput);
+  }, [existingCompanyId, existingCompanyGoals]);
 
   // Persist wizard state to localStorage on every change
   useEffect(() => {
@@ -416,6 +473,9 @@ export function OnboardingWizard() {
     setCreatedCompanyGoalId(null);
     setCreatedProjectId(null);
     setCreatedIssueRef(null);
+    // reset() clears the mission it hydrated, so the next entry on the same
+    // company has to hydrate again.
+    hydratedMissionCompanyIdRef.current = null;
   }
 
   function handleClose() {
@@ -570,8 +630,36 @@ export function OnboardingWizard() {
   // goal, then advance to naming the team lead. Guarded so revisiting the
   // mission step (e.g. via Back) doesn't create a duplicate company.
   async function handleConfirmMission() {
+    // The company already exists — entered on it, or created on a previous pass
+    // through this step. There is nothing to create, but the mission still has
+    // to be written to its company-level goal: early-returning here silently
+    // discarded whatever the user typed.
     if (createdCompanyId) {
-      setStep(3);
+      const plan = planMissionPersistence({
+        goalInput: companyGoal,
+        existingGoalId: createdCompanyGoalId,
+      });
+      if (plan.kind === "skip") {
+        setStep(3);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const goal =
+          plan.kind === "update"
+            ? await goalsApi.update(plan.goalId, plan.payload)
+            : await goalsApi.create(createdCompanyId, plan.payload);
+        setCreatedCompanyGoalId(goal.id);
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.goals.list(createdCompanyId)
+        });
+        setStep(3); // → Create your team lead
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to save mission");
+      } finally {
+        setLoading(false);
+      }
       return;
     }
     setLoading(true);
@@ -822,11 +910,19 @@ export function OnboardingWizard() {
           >
             <div className="w-full max-w-md mx-auto my-auto px-8 py-12 shrink-0">
               {/* 5-segment progress bar (brand .wsteps/.wstep) — segment N
-                  filled once step ≥ N. Completed segments jump back. */}
+                  filled once step ≥ N. Completed segments jump back, but never
+                  behind the entry step: a wizard entered on an existing company
+                  starts past "Name your company" and "Define your mission", and
+                  those steps do not apply to it. This is the same
+                  bound the Back button uses. */}
               <div className="flex items-center gap-1.5 mb-8">
                 {([1, 2, 3, 4, 5] as const).map((s) => {
                   const filled = step >= s;
-                  const canJump = s < step;
+                  const canJump = canJumpToOnboardingStep({
+                    targetStep: s,
+                    currentStep: step,
+                    entryStep: initialStep,
+                  });
                   return (
                     <button
                       key={s}
@@ -1655,7 +1751,10 @@ export function OnboardingWizard() {
               {/* Footer navigation */}
               <div className="flex items-center justify-between mt-8">
                 <div>
-                  {step > 1 && step > (effectiveOnboardingOptions.initialStep ?? 0) && (
+                  {canGoBackFromOnboardingStep({
+                    currentStep: step,
+                    entryStep: initialStep,
+                  }) && (
                     <Button
                       variant="ghost"
                       size="sm"

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -67,6 +67,7 @@ import {
   Check,
   Loader2,
   ChevronDown,
+  RefreshCw,
   X
 } from "lucide-react";
 
@@ -288,7 +289,12 @@ export function OnboardingWizard() {
   // company's goal rather than retyped. The Review step and the lead agent's
   // instructions bundle both read `companyGoal`, and `createdCompanyGoalId` is
   // what the first task is filed against at launch.
-  const { data: existingCompanyGoals, isError: existingCompanyGoalsFailed } = useQuery({
+  const {
+    data: existingCompanyGoals,
+    isError: existingCompanyGoalsFailed,
+    isFetching: missionRetrying,
+    refetch: refetchExistingCompanyGoals,
+  } = useQuery({
     queryKey: existingCompanyId
       ? queryKeys.goals.list(existingCompanyId)
       : ["goals", "none", "onboarding-mission"],
@@ -1773,6 +1779,29 @@ export function OnboardingWizard() {
               {visibleError && (
                 <div className="mt-3">
                   <p className="text-xs text-destructive">{visibleError}</p>
+                  {/* A failed mission read is the one error here the user can
+                      act on directly: it blocks the hire, and without this the
+                      only way back is closing the wizard or refocusing the
+                      window. */}
+                  {missionLoadFailed && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="mt-1 -ml-2 h-7 text-xs"
+                      disabled={missionRetrying}
+                      onClick={() => {
+                        setError(null);
+                        void refetchExistingCompanyGoals();
+                      }}
+                    >
+                      {missionRetrying ? (
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-3 w-3 mr-1" />
+                      )}
+                      {missionRetrying ? "Retrying..." : "Retry"}
+                    </Button>
+                  )}
                 </div>
               )}
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -39,6 +39,7 @@ import {
   selectReusableOnboardingProject,
 } from "../lib/onboarding-launch";
 import {
+  isExistingCompanyMissionUnresolved,
   planMissionPersistence,
   selectExistingCompanyMission,
 } from "../lib/onboarding-mission";
@@ -120,6 +121,8 @@ Work in this order:
 Propose, don't decide. Keep it conversational.`;
 const INCOMPLETE_ONBOARDING_STATE_MESSAGE =
   "Onboarding state is incomplete. Please restart onboarding and try again.";
+const MISSION_UNRESOLVED_MESSAGE =
+  "This organization's mission hasn't loaded yet, and your agent needs it. Check your connection and try again.";
 
 function loadSavedState(): Record<string, unknown> | null {
   try {
@@ -285,12 +288,20 @@ export function OnboardingWizard() {
   // company's goal rather than retyped. The Review step and the lead agent's
   // instructions bundle both read `companyGoal`, and `createdCompanyGoalId` is
   // what the first task is filed against at launch.
-  const { data: existingCompanyGoals } = useQuery({
+  const { data: existingCompanyGoals, isError: existingCompanyGoalsFailed } = useQuery({
     queryKey: existingCompanyId
       ? queryKeys.goals.list(existingCompanyId)
       : ["goals", "none", "onboarding-mission"],
     queryFn: () => goalsApi.list(existingCompanyId!),
     enabled: Boolean(existingCompanyId) && effectiveOnboardingOpen,
+  });
+
+  // Until that read lands the mission on screen is not this company's, so the
+  // lead agent must not be hired against it — see
+  // isExistingCompanyMissionUnresolved.
+  const missionUnresolved = isExistingCompanyMissionUnresolved({
+    existingCompanyId,
+    goalsLoaded: Boolean(existingCompanyGoals),
   });
 
   // Hydrate once per company: the company's own goal is authoritative over any
@@ -302,9 +313,12 @@ export function OnboardingWizard() {
     if (hydratedMissionCompanyIdRef.current === existingCompanyId) return;
     hydratedMissionCompanyIdRef.current = existingCompanyId;
     const mission = selectExistingCompanyMission(existingCompanyGoals);
-    if (mission.goalId) {
-      setCreatedCompanyGoalId((current) => current ?? mission.goalId);
-    }
+    // Authoritative, not a fallback: a saved goal id may belong to a previous
+    // run on a *different* company, and launch files the first task against
+    // whatever id is held here (it only re-reads when the id is null). Keeping
+    // the stale one would file this company's first task against another
+    // company's goal.
+    setCreatedCompanyGoalId(mission.goalId);
     setCompanyGoal(mission.goalInput);
   }, [existingCompanyId, existingCompanyGoals]);
 
@@ -702,6 +716,13 @@ export function OnboardingWizard() {
       setStep(5);
       return;
     }
+    // The hire seeds the agent's instructions from `companyGoal`. On an
+    // existing company that value is only trustworthy once the company's own
+    // goals have been read back.
+    if (missionUnresolved) {
+      setError(MISSION_UNRESOLVED_MESSAGE);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -864,7 +885,14 @@ export function OnboardingWizard() {
   if (!effectiveOnboardingOpen) return null;
 
   const launchStateIncomplete = step === 5 && (!createdCompanyId || !createdAgentId);
-  const visibleError = error ?? (launchStateIncomplete ? INCOMPLETE_ONBOARDING_STATE_MESSAGE : null);
+  // Explain the disabled hire button rather than leaving it inert and silent.
+  // Only once the read has actually failed — while it is still in flight the
+  // button just reads as loading.
+  const missionLoadFailed = missionUnresolved && existingCompanyGoalsFailed;
+  const visibleError =
+    error ??
+    (launchStateIncomplete ? INCOMPLETE_ONBOARDING_STATE_MESSAGE : null) ??
+    (missionLoadFailed ? MISSION_UNRESOLVED_MESSAGE : null);
 
   return (
     <Dialog
@@ -1807,7 +1835,9 @@ export function OnboardingWizard() {
                   {step === 4 && (
                     <Button
                       size="sm"
-                      disabled={!agentName.trim() || loading || adapterEnvLoading}
+                      disabled={
+                        !agentName.trim() || loading || adapterEnvLoading || missionUnresolved
+                      }
                       onClick={handleGiveHeartbeat}
                     >
                       {loading ? (

--- a/ui/src/lib/onboarding-goal.test.ts
+++ b/ui/src/lib/onboarding-goal.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseOnboardingGoalInput } from "./onboarding-goal";
+import {
+  formatOnboardingGoalInput,
+  parseOnboardingGoalInput,
+} from "./onboarding-goal";
 
 describe("parseOnboardingGoalInput", () => {
   it("uses a single-line goal as the title only", () => {
@@ -18,5 +21,33 @@ describe("parseOnboardingGoalInput", () => {
       title: "Ship the MVP",
       description: "Launch to 10 design partners\nMeasure retention",
     });
+  });
+});
+
+describe("formatOnboardingGoalInput", () => {
+  it("renders a title-only goal as a single line", () => {
+    expect(formatOnboardingGoalInput("Ship the MVP")).toBe("Ship the MVP");
+  });
+
+  it("renders a title and description as one editable block", () => {
+    expect(
+      formatOnboardingGoalInput("Ship the MVP", "Launch to 10 design partners"),
+    ).toBe("Ship the MVP\n\nLaunch to 10 design partners");
+  });
+
+  it("treats a null or blank description as absent", () => {
+    expect(formatOnboardingGoalInput("Ship the MVP", null)).toBe("Ship the MVP");
+    expect(formatOnboardingGoalInput("Ship the MVP", "   ")).toBe("Ship the MVP");
+  });
+
+  it("round-trips a parsed goal back to the same parse", () => {
+    const raw = "Ship the MVP\nLaunch to 10 design partners\nMeasure retention";
+    const parsed = parseOnboardingGoalInput(raw);
+
+    expect(
+      parseOnboardingGoalInput(
+        formatOnboardingGoalInput(parsed.title, parsed.description),
+      ),
+    ).toEqual(parsed);
   });
 });

--- a/ui/src/lib/onboarding-goal.ts
+++ b/ui/src/lib/onboarding-goal.ts
@@ -16,3 +16,22 @@ export function parseOnboardingGoalInput(raw: string): {
     description: description.length > 0 ? description : null,
   };
 }
+
+/**
+ * Inverse of {@link parseOnboardingGoalInput}: render a stored goal back into
+ * the single textarea the mission step edits. Used when the wizard is entered
+ * on a company that already has a mission, so the mission can be shown and
+ * re-saved instead of retyped from scratch.
+ */
+export function formatOnboardingGoalInput(
+  title: string,
+  description?: string | null,
+): string {
+  const trimmedTitle = title.trim();
+  const trimmedDescription = description?.trim() ?? "";
+
+  if (!trimmedTitle) return trimmedDescription;
+  if (!trimmedDescription) return trimmedTitle;
+
+  return `${trimmedTitle}\n\n${trimmedDescription}`;
+}

--- a/ui/src/lib/onboarding-mission.test.ts
+++ b/ui/src/lib/onboarding-mission.test.ts
@@ -1,0 +1,154 @@
+import type { Goal } from "@paperclipai/shared";
+import { describe, expect, it } from "vitest";
+import { parseOnboardingGoalInput } from "./onboarding-goal";
+import {
+  planMissionPersistence,
+  selectExistingCompanyMission,
+} from "./onboarding-mission";
+
+function goal(overrides: Partial<Goal> & Pick<Goal, "id" | "title">): Goal {
+  return {
+    companyId: "company-1",
+    description: null,
+    level: "company",
+    status: "active",
+    parentId: null,
+    ownerAgentId: null,
+    createdAt: new Date("2026-03-02T00:00:00Z"),
+    updatedAt: new Date("2026-03-02T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("selectExistingCompanyMission", () => {
+  it("reads the company goal back into the mission textarea", () => {
+    expect(
+      selectExistingCompanyMission([
+        goal({ id: "goal-1", title: "Ship the cloud onboarding walk" }),
+      ]),
+    ).toEqual({
+      goalId: "goal-1",
+      goalInput: "Ship the cloud onboarding walk",
+    });
+  });
+
+  it("includes the goal description below the title", () => {
+    expect(
+      selectExistingCompanyMission([
+        goal({
+          id: "goal-1",
+          title: "Ship the cloud onboarding walk",
+          description: "End to end, across all four apps.",
+        }),
+      ]),
+    ).toEqual({
+      goalId: "goal-1",
+      goalInput:
+        "Ship the cloud onboarding walk\n\nEnd to end, across all four apps.",
+    });
+  });
+
+  it("round-trips through the mission textarea's own parser", () => {
+    const mission = selectExistingCompanyMission([
+      goal({
+        id: "goal-1",
+        title: "Ship the cloud onboarding walk",
+        description: "End to end, across all four apps.",
+      }),
+    ]);
+
+    expect(parseOnboardingGoalInput(mission.goalInput)).toEqual({
+      title: "Ship the cloud onboarding walk",
+      description: "End to end, across all four apps.",
+    });
+  });
+
+  it("reports no mission when the company has no company-level goal", () => {
+    expect(
+      selectExistingCompanyMission([
+        goal({ id: "team-goal", title: "Nested", level: "team" }),
+      ]),
+    ).toEqual({ goalId: null, goalInput: "" });
+  });
+
+  it("reports no mission for a company with no goals at all", () => {
+    expect(selectExistingCompanyMission([])).toEqual({
+      goalId: null,
+      goalInput: "",
+    });
+  });
+});
+
+describe("planMissionPersistence", () => {
+  // Confirming the mission on a company that already exists used to early-return
+  // without writing anything, silently discarding what was typed.
+  it("updates the existing company goal instead of discarding the mission", () => {
+    expect(
+      planMissionPersistence({
+        goalInput: "Ship the cloud onboarding walk",
+        existingGoalId: "goal-1",
+      }),
+    ).toEqual({
+      kind: "update",
+      goalId: "goal-1",
+      payload: { title: "Ship the cloud onboarding walk", description: null },
+    });
+  });
+
+  it("splits a multi-line mission into title and description on update", () => {
+    expect(
+      planMissionPersistence({
+        goalInput: "Ship the walk\n\nEnd to end, across all four apps.",
+        existingGoalId: "goal-1",
+      }),
+    ).toEqual({
+      kind: "update",
+      goalId: "goal-1",
+      payload: {
+        title: "Ship the walk",
+        description: "End to end, across all four apps.",
+      },
+    });
+  });
+
+  it("clears a removed description rather than leaving the old one", () => {
+    expect(
+      planMissionPersistence({
+        goalInput: "Ship the walk",
+        existingGoalId: "goal-1",
+      }),
+    ).toMatchObject({ payload: { description: null } });
+  });
+
+  it("creates a company-level goal when the company has none yet", () => {
+    expect(
+      planMissionPersistence({
+        goalInput: "Ship the walk\n\nEnd to end.",
+        existingGoalId: null,
+      }),
+    ).toEqual({
+      kind: "create",
+      payload: {
+        title: "Ship the walk",
+        description: "End to end.",
+        level: "company",
+        status: "active",
+      },
+    });
+  });
+
+  it("omits an empty description when creating", () => {
+    expect(
+      planMissionPersistence({ goalInput: "Ship the walk", existingGoalId: null }),
+    ).toEqual({
+      kind: "create",
+      payload: { title: "Ship the walk", level: "company", status: "active" },
+    });
+  });
+
+  it("writes nothing when no mission was entered", () => {
+    expect(
+      planMissionPersistence({ goalInput: "   \n  ", existingGoalId: "goal-1" }),
+    ).toEqual({ kind: "skip" });
+  });
+});

--- a/ui/src/lib/onboarding-mission.test.ts
+++ b/ui/src/lib/onboarding-mission.test.ts
@@ -173,6 +173,26 @@ describe("isExistingCompanyMissionUnresolved", () => {
     ).toBe(false);
   });
 
+  it("holds the hire while a cached read is being superseded", () => {
+    expect(
+      isExistingCompanyMissionUnresolved({
+        existingCompanyId: "company-1",
+        goalsLoaded: true,
+        goalsFetching: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still ignores an in-flight read for a company created in this run", () => {
+    expect(
+      isExistingCompanyMissionUnresolved({
+        existingCompanyId: null,
+        goalsLoaded: false,
+        goalsFetching: true,
+      }),
+    ).toBe(false);
+  });
+
   it("never holds a company created in this run — step 2 typed its mission", () => {
     expect(
       isExistingCompanyMissionUnresolved({

--- a/ui/src/lib/onboarding-mission.test.ts
+++ b/ui/src/lib/onboarding-mission.test.ts
@@ -2,6 +2,7 @@ import type { Goal } from "@paperclipai/shared";
 import { describe, expect, it } from "vitest";
 import { parseOnboardingGoalInput } from "./onboarding-goal";
 import {
+  isExistingCompanyMissionUnresolved,
   planMissionPersistence,
   selectExistingCompanyMission,
 } from "./onboarding-mission";
@@ -150,5 +151,37 @@ describe("planMissionPersistence", () => {
     expect(
       planMissionPersistence({ goalInput: "   \n  ", existingGoalId: "goal-1" }),
     ).toEqual({ kind: "skip" });
+  });
+});
+
+describe("isExistingCompanyMissionUnresolved", () => {
+  it("holds the hire until the existing company's goals have been read", () => {
+    expect(
+      isExistingCompanyMissionUnresolved({
+        existingCompanyId: "company-1",
+        goalsLoaded: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("releases the hire once they land", () => {
+    expect(
+      isExistingCompanyMissionUnresolved({
+        existingCompanyId: "company-1",
+        goalsLoaded: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("never holds a company created in this run — step 2 typed its mission", () => {
+    expect(
+      isExistingCompanyMissionUnresolved({
+        existingCompanyId: undefined,
+        goalsLoaded: false,
+      }),
+    ).toBe(false);
+    expect(
+      isExistingCompanyMissionUnresolved({ existingCompanyId: null, goalsLoaded: false }),
+    ).toBe(false);
   });
 });

--- a/ui/src/lib/onboarding-mission.ts
+++ b/ui/src/lib/onboarding-mission.ts
@@ -30,6 +30,25 @@ export function selectExistingCompanyMission(goals: Goal[]): ExistingCompanyMiss
   };
 }
 
+/**
+ * Whether an existing company's mission has yet to be read back from the server.
+ *
+ * On an existing-company entry the mission is never typed — it is hydrated from
+ * the company's goals. Until that read lands (still in flight, or failed) the
+ * wizard's mission field still holds whatever the last run saved, which may
+ * belong to an entirely different company. Hiring the lead agent inside that
+ * window would seed its instructions with an empty or foreign mission and
+ * report nothing, so the hire waits for the read.
+ */
+export function isExistingCompanyMissionUnresolved(params: {
+  existingCompanyId?: string | null;
+  goalsLoaded: boolean;
+}): boolean {
+  if (!params.existingCompanyId) return false;
+
+  return !params.goalsLoaded;
+}
+
 export type MissionGoalPayload = {
   title: string;
   description?: string | null;

--- a/ui/src/lib/onboarding-mission.ts
+++ b/ui/src/lib/onboarding-mission.ts
@@ -1,0 +1,78 @@
+import type { Goal } from "@paperclipai/shared";
+
+import { formatOnboardingGoalInput, parseOnboardingGoalInput } from "./onboarding-goal";
+import { selectDefaultCompanyGoalId } from "./onboarding-launch";
+
+export type ExistingCompanyMission = {
+  goalId: string | null;
+  goalInput: string;
+};
+
+/**
+ * Read an existing company's mission back out of its goals, in the shape the
+ * wizard's mission textarea edits.
+ *
+ * The wizard can be entered on a company that already exists — the
+ * /{prefix}/onboarding route, or an in-app "add agent" entry. On those paths
+ * step 1 and step 2 never run, so the mission has to come from the company
+ * rather than from the form. Both the Review step and the lead agent's
+ * instructions bundle read it.
+ */
+export function selectExistingCompanyMission(goals: Goal[]): ExistingCompanyMission {
+  const goalId = selectDefaultCompanyGoalId(goals);
+  if (!goalId) return { goalId: null, goalInput: "" };
+
+  const goal = goals.find((entry) => entry.id === goalId) ?? null;
+
+  return {
+    goalId,
+    goalInput: goal ? formatOnboardingGoalInput(goal.title, goal.description) : "",
+  };
+}
+
+export type MissionGoalPayload = {
+  title: string;
+  description?: string | null;
+  level?: "company";
+  status?: "active";
+};
+
+export type MissionPersistencePlan =
+  | { kind: "skip" }
+  | { kind: "create"; payload: MissionGoalPayload }
+  | { kind: "update"; goalId: string; payload: MissionGoalPayload };
+
+/**
+ * Decide what confirming the mission has to write.
+ *
+ * The wizard used to early-return whenever a company id was already present,
+ * so a mission typed on an existing company was silently discarded. An existing
+ * company still needs no `companies.create` — but its mission must land on the
+ * company-level goal, updating the goal the company already has rather than
+ * creating a second one.
+ */
+export function planMissionPersistence(params: {
+  goalInput: string;
+  existingGoalId: string | null;
+}): MissionPersistencePlan {
+  const parsed = parseOnboardingGoalInput(params.goalInput);
+  if (!parsed.title) return { kind: "skip" };
+
+  if (params.existingGoalId) {
+    return {
+      kind: "update",
+      goalId: params.existingGoalId,
+      payload: { title: parsed.title, description: parsed.description },
+    };
+  }
+
+  return {
+    kind: "create",
+    payload: {
+      title: parsed.title,
+      ...(parsed.description ? { description: parsed.description } : {}),
+      level: "company",
+      status: "active",
+    },
+  };
+}

--- a/ui/src/lib/onboarding-mission.ts
+++ b/ui/src/lib/onboarding-mission.ts
@@ -43,8 +43,14 @@ export function selectExistingCompanyMission(goals: Goal[]): ExistingCompanyMiss
 export function isExistingCompanyMissionUnresolved(params: {
   existingCompanyId?: string | null;
   goalsLoaded: boolean;
+  goalsFetching?: boolean;
 }): boolean {
   if (!params.existingCompanyId) return false;
+  // Loaded data can be a cached read from before the wizard opened, with the
+  // current request still in flight. Cached goals are at least the right
+  // company's, but they are not necessarily its current mission, so an
+  // in-flight read counts as unresolved rather than as already answered.
+  if (params.goalsFetching) return true;
 
   return !params.goalsLoaded;
 }

--- a/ui/src/lib/onboarding-route.test.ts
+++ b/ui/src/lib/onboarding-route.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  canGoBackFromOnboardingStep,
+  canJumpToOnboardingStep,
+  EXISTING_COMPANY_ONBOARDING_STEP,
   isOnboardingPath,
   isOnboardingWizardActive,
   resolveRouteOnboardingOptions,
@@ -37,7 +40,21 @@ describe("resolveRouteOnboardingOptions", () => {
         companyPrefix: "pap",
         companies: [{ id: "company-1", issuePrefix: "PAP" }],
       }),
-    ).toEqual({ initialStep: 2, companyId: "company-1" });
+    ).toEqual({ initialStep: 3, companyId: "company-1" });
+  });
+
+  // A matched prefix used to land on step 2 ("Define your mission"), which was
+  // a hard dead-end — nothing prefilled the company name, "Confirm mission"
+  // gates on it, and the Back button is hidden at the entry step.
+  it("never lands an existing company on the name or mission steps", () => {
+    const resolved = resolveRouteOnboardingOptions({
+      pathname: "/pap/onboarding",
+      companyPrefix: "pap",
+      companies: [{ id: "company-1", issuePrefix: "PAP" }],
+    });
+
+    expect(resolved?.initialStep).toBe(EXISTING_COMPANY_ONBOARDING_STEP);
+    expect(resolved?.initialStep).toBeGreaterThan(2);
   });
 
   it("falls back to company creation when the prefixed company is missing", () => {
@@ -48,6 +65,80 @@ describe("resolveRouteOnboardingOptions", () => {
         companies: [],
       }),
     ).toEqual({ initialStep: 1 });
+  });
+});
+
+describe("onboarding step navigation bounds", () => {
+  const entryStep = EXISTING_COMPANY_ONBOARDING_STEP;
+
+  it("offers Back once a run has moved past its entry step", () => {
+    expect(canGoBackFromOnboardingStep({ currentStep: 4, entryStep })).toBe(true);
+  });
+
+  it("withholds Back on the entry step itself", () => {
+    expect(canGoBackFromOnboardingStep({ currentStep: entryStep, entryStep })).toBe(
+      false,
+    );
+  });
+
+  it("withholds Back on the first step of a fresh run", () => {
+    expect(canGoBackFromOnboardingStep({ currentStep: 1, entryStep: 0 })).toBe(false);
+  });
+
+  // The progress bar only checked "already completed", so a run entered on an
+  // existing company could still click its way to the name and mission steps
+  // that Back deliberately withholds — and step 2 was a trap (empty company
+  // name, permanently disabled "Confirm mission", no Back).
+  it("does not let an existing-company run jump to the name or mission steps", () => {
+    expect(canJumpToOnboardingStep({ targetStep: 1, currentStep: 5, entryStep })).toBe(
+      false,
+    );
+    expect(canJumpToOnboardingStep({ targetStep: 2, currentStep: 5, entryStep })).toBe(
+      false,
+    );
+  });
+
+  it("still lets an existing-company run jump back to completed later steps", () => {
+    expect(canJumpToOnboardingStep({ targetStep: 3, currentStep: 5, entryStep })).toBe(
+      true,
+    );
+    expect(canJumpToOnboardingStep({ targetStep: 4, currentStep: 5, entryStep })).toBe(
+      true,
+    );
+  });
+
+  it("leaves a fresh run able to jump back to every completed step", () => {
+    expect(canJumpToOnboardingStep({ targetStep: 1, currentStep: 3, entryStep: 0 })).toBe(
+      true,
+    );
+    expect(canJumpToOnboardingStep({ targetStep: 2, currentStep: 3, entryStep: 0 })).toBe(
+      true,
+    );
+  });
+
+  it("never offers a jump to the current or an unreached step", () => {
+    expect(canJumpToOnboardingStep({ targetStep: 3, currentStep: 3, entryStep: 0 })).toBe(
+      false,
+    );
+    expect(canJumpToOnboardingStep({ targetStep: 4, currentStep: 3, entryStep: 0 })).toBe(
+      false,
+    );
+  });
+
+  it("agrees with the Back button wherever both are offered", () => {
+    for (let currentStep = 1; currentStep <= 5; currentStep += 1) {
+      for (const entry of [0, 1, EXISTING_COMPANY_ONBOARDING_STEP]) {
+        const back = canGoBackFromOnboardingStep({ currentStep, entryStep: entry });
+        const jump = canJumpToOnboardingStep({
+          targetStep: currentStep - 1,
+          currentStep,
+          entryStep: entry,
+        });
+        // Back walks to currentStep - 1, so it may only be offered where that
+        // same step is a legal jump target.
+        expect(back && !jump).toBe(false);
+      }
+    }
   });
 });
 

--- a/ui/src/lib/onboarding-route.ts
+++ b/ui/src/lib/onboarding-route.ts
@@ -17,11 +17,24 @@ export function isOnboardingPath(pathname: string): boolean {
   return false;
 }
 
+/**
+ * The wizard step an already-existing company enters onboarding on: "Create
+ * your first agent".
+ *
+ * A company reached through /{prefix}/onboarding is already named and already
+ * has a mission, so step 1 (Name your company) and step 2 (Define your
+ * mission) do not apply — the managed path never re-asks for the mission.
+ * Entering on step 2 was a hard dead-end instead: nothing prefilled the company
+ * name, "Confirm mission" gates on it, and no Back button renders at the entry
+ * step.
+ */
+export const EXISTING_COMPANY_ONBOARDING_STEP = 3;
+
 export function resolveRouteOnboardingOptions(params: {
   pathname: string;
   companyPrefix?: string;
   companies: OnboardingRouteCompany[];
-}): { initialStep: 1 | 2; companyId?: string } | null {
+}): { initialStep: 1 | 3; companyId?: string } | null {
   const { pathname, companyPrefix, companies } = params;
 
   if (!isOnboardingPath(pathname)) return null;
@@ -40,7 +53,42 @@ export function resolveRouteOnboardingOptions(params: {
     return { initialStep: 1 };
   }
 
-  return { initialStep: 2, companyId: matchedCompany.id };
+  return {
+    initialStep: EXISTING_COMPANY_ONBOARDING_STEP,
+    companyId: matchedCompany.id,
+  };
+}
+
+/**
+ * Whether the wizard's Back button is offered on the current step.
+ *
+ * A run never walks back behind the step it entered on: those steps either do
+ * not apply to it (an existing company is already named, and its mission is
+ * never re-asked) or were already completed elsewhere.
+ */
+export function canGoBackFromOnboardingStep(params: {
+  currentStep: number;
+  entryStep: number;
+}): boolean {
+  return params.currentStep > 1 && params.currentStep > params.entryStep;
+}
+
+/**
+ * Whether a completed progress-bar segment can be clicked to jump back to it.
+ *
+ * Same bound as {@link canGoBackFromOnboardingStep}. The progress bar used to
+ * apply only the "already completed" half of the rule, which let a run entered
+ * on an existing company jump to the name and mission steps the Back button
+ * deliberately withholds — the dead-end this guard closes.
+ */
+export function canJumpToOnboardingStep(params: {
+  targetStep: number;
+  currentStep: number;
+  entryStep: number;
+}): boolean {
+  return (
+    params.targetStep < params.currentStep && params.targetStep >= params.entryStep
+  );
 }
 
 export function shouldRedirectCompanylessRouteToOnboarding(params: {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
+import { EXISTING_COMPANY_ONBOARDING_STEP } from "../lib/onboarding-route";
 import { MetricCard } from "../components/MetricCard";
 import { EmptyState } from "../components/EmptyState";
 import { StatusIcon } from "../components/StatusIcon";
@@ -226,7 +227,12 @@ export function Dashboard() {
             </p>
           </div>
           <button
-            onClick={() => openOnboarding({ initialStep: 2, companyId: selectedCompanyId! })}
+            onClick={() =>
+              openOnboarding({
+                initialStep: EXISTING_COMPANY_ONBOARDING_STEP,
+                companyId: selectedCompanyId!,
+              })
+            }
             className="text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100 underline underline-offset-2 shrink-0"
           >
             Create one here


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The onboarding wizard is the first-run flow. It names the organization, sets its mission, creates the first agent, connects a model, and files the first task
> - The wizard has two kinds of entry. A new user starts at step 1 and creates a company. An existing company enters later to add an agent — through `/{prefix}/onboarding`, the "Add Agent" button on the company launcher, or "Create one here" on the dashboard's no-agents banner
> - All three existing-company entries opened the wizard on step 2, "Define your mission". That step is a dead-end on this path: the company name is never prefilled, the CTA is disabled until the name is non-empty, the name is only settable on the skipped step 1, and no Back button renders at the entry step
> - The mission field on that screen was inert as well. `handleConfirmMission` returned early whenever a company id was present, so it never wrote the goal
> - This pull request lands those entries on step 3, "Create your first agent", carries the company's name and mission across instead of re-asking for them, and makes the mission actually persist if the step is ever shown
> - The benefit is that an existing company can add an agent again. Before this change, all three entry points opened a screen the user could not leave

## Linked Issues or Issue Description

No public GitHub issue exists. The problem follows the bug report template.

**What happened?**

Open the onboarding wizard on a company that already exists. The wizard shows step 2, "Define your mission". The organization name in the step header is empty. The "Confirm mission" button stays disabled. No Back button is shown. The user cannot go forward and cannot go back.

A second defect is on the same screen. If a user does get past the gate, for example with stale `localStorage` that supplies a company name, the mission they type is discarded. `handleConfirmMission` returns to step 3 before it calls `goalsApi.create`.

**Expected behavior**

A company that already exists is already named and already has a mission. The wizard must open on step 3, "Create your first agent". This is what all three entry points say they do. The button on the company launcher is labelled "Add Agent". The dashboard banner says "You have no agents. Create one here". The existing test for the route resolver is named "opens agent creation when the prefixed company exists".

If the mission step is shown, it must save what the user types.

**Steps to reproduce**

1. Use a Paperclip instance that has one company with an issue prefix, for example `PAP`.
2. Clear `localStorage` for the site, so no earlier wizard run is saved.
3. Open `/pap/onboarding`.
4. The wizard opens on "Define your mission". The organization name is empty.
5. Type a mission. The "Confirm mission" button stays disabled.
6. Look for a Back button. There is none.

The same dead-end occurs from the "Add Agent" button in `ui/src/App.tsx` and from "Create one here" in `ui/src/pages/Dashboard.tsx`. Both call `openOnboarding({ initialStep: 2, companyId })`.

**Paperclip version or commit**

`67001ec6e` on `master`.

**Deployment mode**

Reproduces in any mode. This is UI-only logic in `ui/src`, with no server or adapter involvement.

**Additional context**

The four conditions are independent and each one is verified by code read against `67001ec6e`:

- `ui/src/lib/onboarding-route.ts:43` returns `{ initialStep: 2, companyId }` for a matched prefix.
- `ui/src/components/OnboardingWizard.tsx:179` initialises `companyName` to `""`. The effect at L247 backfills the issue prefix only.
- `OnboardingWizard.tsx:1685` disables the CTA on `!companyName.trim() || !companyGoal.trim()`.
- `OnboardingWizard.tsx:1658` renders Back only when `step > 1 && step > (initialStep ?? 0)`. At the entry step this is false.
- `OnboardingWizard.tsx:573-576` returns early when `createdCompanyId` is set. L207-208 seeds it from the existing company.

## What Changed

- `resolveRouteOnboardingOptions` resolves a matched company prefix to `EXISTING_COMPANY_ONBOARDING_STEP` (step 3) instead of step 2. The new exported constant names the rule.
- `ui/src/App.tsx` and `ui/src/pages/Dashboard.tsx` use the same constant. Both had the identical dead-end.
- The wizard backfills the company name from the company record. On an existing-company entry the company record is authoritative, so a stale saved wizard run from a different company can no longer label this one. On a company created in the same run, step 1 still owns the field, so only a blank is filled.
- The wizard reads the company's mission back from its company-level goal into `companyGoal`, and the goal id into `createdCompanyGoalId`. The Review checklist and the lead agent's instructions bundle both read these values, and the first task is filed against that goal at launch. Hydration runs once per distinct read of that company's goals, so it does not re-run on every render but a refetch that supersedes a cached mission still lands. `reset()` clears the marker.
- `handleConfirmMission` persists the mission for a company that already exists. It updates that company's goal, or creates one if the company has none. It no longer discards the input.
- The progress bar's completed-segment jump applied only the "already completed" half of the rule. An existing-company run could click straight into the name and mission steps that Back withholds. Both controls now share one bound, extracted as `canGoBackFromOnboardingStep` and `canJumpToOnboardingStep`.
- The lead agent is not hired until that read resolves. Its instructions are composed from `companyGoal`, and until the company's own goals have been read that value still holds whatever the last run saved, which may belong to a different company. The instructions seeding is non-fatal, so without this gate a wrong mission would be written with no signal to anyone. An in-flight read counts as unresolved even when cached data is present, since `queryKeys.goals.list` is shared with the rest of the app.
- A failed mission read reports through the existing error channel and carries a Retry button that refetches it, rather than blocking the hire behind a message with no action.
- New `ui/src/lib/onboarding-mission.ts` holds `selectExistingCompanyMission`, `planMissionPersistence` and `isExistingCompanyMissionUnresolved`. New `formatOnboardingGoalInput` in `onboarding-goal.ts` is the inverse of `parseOnboardingGoalInput`.

## Verification

Run in `ui/`:

```
npx vitest run src/lib
```

1190 tests pass in 127 files. 13 tests are new in this change, plus new suites for the mission helpers.

New coverage:

- The route resolver returns step 3 for a matched prefix, and never returns a step at or below the mission step.
- The navigation bounds that close the trap: an existing-company run cannot jump to the name or mission steps, a fresh run can still jump back to every completed step, and the Back button is never offered where the same step is not a legal jump target.
- The mission read-back, including its round-trip through the existing `parseOnboardingGoalInput`.
- The update-vs-create decision that replaces the silent discard, including clearing a removed description and writing nothing when no mission was entered.
- The hire gate: held while the existing company's goals are unread, held while a cached read is being superseded, and never applied to a company created in this run, where step 2 typed the mission and no read gates anything.

Typecheck:

```
npx tsc --noEmit
```

Run in `ui/` before and after the change. The error set is identical, so this change adds no new type errors, and none of the errors it does report are in a file this PR touches.

Not done: this was verified by code read and by unit tests. It was not reproduced in a browser against a running instance.

## Risks

Low to moderate. The change is UI-only and touches one wizard.

- **Behavioral shift.** The three existing-company entry points now open step 3 rather than step 2. This is the intended fix. Anyone who relied on reaching the mission step from those entries must now edit the mission from the goal UI.
- **Extra request.** An existing-company entry issues one `goals.list` for that company, to read the mission back. It is gated on the wizard being open with an existing company id.
- **Saved state.** On an existing-company entry, the company record now overrides a saved company name and mission from an earlier wizard run. This is deliberate — the saved values may belong to a different company — but it does discard saved input on that path.
- **Briefly disabled CTA.** While that `goals.list` read is in flight, the step 4 Connect button is disabled. On a background refetch this is a short disabled window on an otherwise ready button. It is deliberate: hiring against a mission that is being superseded is the failure this closes.
- No migration, no schema change, no server change, no adapter change.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context, extended thinking, with tool use and code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

