### PR TITLE
fix: guard productivity-review cheap adapter override on owner runtimeConfig

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -201,13 +201,69 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews).toHaveLength(1);
     expect(reviews[0]?.parentId).toBe(seeded.issueId);
     expect(reviews[0]?.assigneeAgentId).toBe(seeded.managerId);
-    expect(reviews[0]?.assigneeAdapterOverrides).toEqual({ modelProfile: "cheap" });
+    expect(reviews[0]?.assigneeAdapterOverrides).toBeNull();
     expect(reviews[0]?.originId).toBe(seeded.issueId);
     expect(reviews[0]?.originFingerprint).toBe(`productivity-review:${seeded.issueId}`);
     expect(reviews[0]?.description).toContain("Primary trigger: `no_comment_streak`");
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
 
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
+  });
+
+  it("leaves productivity review assignee overrides null when the owner cheap profile is disabled", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await db
+      .update(agents)
+      .set({
+        name: "CEO",
+        role: "ceo",
+        runtimeConfig: { modelProfiles: { cheap: { enabled: false } } },
+      })
+      .where(eq(agents.id, seeded.managerId));
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.managerId);
+    expect(review?.assigneeAdapterOverrides).toBeNull();
+  });
+
+  it("uses the cheap assignee override when the productivity review owner cheap profile is enabled", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await db
+      .update(agents)
+      .set({ runtimeConfig: { modelProfiles: { cheap: { enabled: true } } } })
+      .where(eq(agents.id, seeded.managerId));
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.assigneeAgentId).toBe(seeded.managerId);
+    expect(review?.assigneeAdapterOverrides).toEqual({ modelProfile: "cheap" });
   });
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -139,6 +139,12 @@ function truncateInline(value: string | null | undefined, max = 260) {
   return compact.length <= max ? compact : `${compact.slice(0, max - 3)}...`;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
 function readPositiveInteger(value: number, fallback: number) {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
 }
@@ -232,6 +238,14 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .from(agents)
       .where(eq(agents.id, agentId))
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function isCheapRecoveryProfileEnabled(agentId: string | null) {
+    if (!agentId) return false;
+    const agent = await getAgent(agentId);
+    const modelProfiles = asRecord(asRecord(agent?.runtimeConfig)?.modelProfiles);
+    const cheapProfile = asRecord(modelProfiles?.cheap);
+    return cheapProfile?.enabled === true;
   }
 
   function isAgentInvokable(agent: AgentRow | null | undefined) {
@@ -759,6 +773,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     }
 
     const ownerAgentId = await resolveReviewOwnerAgentId(evidence.sourceIssue, evidence.sourceAgent);
+    const assigneeAdapterOverrides = await isCheapRecoveryProfileEnabled(ownerAgentId)
+      ? recoveryAssigneeAdapterOverrides("status_only")
+      : null;
     let review: Awaited<ReturnType<typeof issuesSvc.create>>;
     try {
       review = await issuesSvc.create(evidence.sourceIssue.companyId, {
@@ -771,7 +788,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         goalId: evidence.sourceIssue.goalId,
         billingCode: evidence.sourceIssue.billingCode,
         assigneeAgentId: ownerAgentId,
-        assigneeAdapterOverrides: recoveryAssigneeAdapterOverrides("status_only"),
+        assigneeAdapterOverrides,
         originKind: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
         originId: evidence.sourceIssue.id,
         originFingerprint: productivityReviewFingerprint(evidence.sourceIssue.id),


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - One capability is automated productivity monitoring: Paperclip creates "Review productivity for X" issues when it detects a stalled or unusual run pattern
> - The creator for these issues stamps `assigneeAdapterOverrides: { modelProfile: "cheap" }` on every review, with no check on whether the owner agent has a working cheap profile
> - When the owner's cheap profile is disabled, or its model does not support a config option the adapter sends (see #10175), every attempt at the review fails the same way, and Paperclip's own automatic retry appends a system comment on each failure, with no cap
> - This pull request adds one guard: only apply the cheap override when the resolved review owner's `runtimeConfig.modelProfiles.cheap.enabled` is `true`
> - The benefit is that a broken or disabled cheap profile on the owner no longer turns every review issue assigned to them into an unbounded stream of failed-retry comments

## Linked Issues or Issue Description

Fixes part of: #9430 (this PR addresses only "Defect 1" from that report — the productivity-review creator path — not the broader model-pinning or self-PATCH `adapterConfig` issues also described there)
Refs: #10175 (same underlying `effort`-option mismatch on the `claude_local` cheap profile)
Refs: #10555 (related family: undocumented workspace/runtime flags causing unattended destructive or noisy behavior)

## What Changed

- Added `isCheapRecoveryProfileEnabled(agentId)` to `productivity-review.ts`, which reads the resolved review owner agent's `runtimeConfig.modelProfiles.cheap.enabled`.
- `assigneeAdapterOverrides` on a newly created productivity review is now `recoveryAssigneeAdapterOverrides("status_only")` only when that check returns `true`; otherwise it is `null`.
- Added a small `asRecord()` type guard to safely read nested `runtimeConfig.modelProfiles.cheap` without assuming shape.
- Updated the existing baseline test (no cheap config on the owner) to expect `null` instead of the unconditional override.
- Added two new tests: owner with `modelProfiles.cheap.enabled: false` → `null` override; owner with `modelProfiles.cheap.enabled: true` → override applied as before.

## Verification

- `pnpm exec vitest run server/src/__tests__/productivity-review-service.test.ts` — covers the baseline (now `null`), the disabled case, and the enabled case.
- Reproduced the failure mode in our own deployment before this change: 27 open review issues with the unconditional override, ~1500 system comments generated overnight from repeated `acpx_turn_failed` retries. After manually clearing the override on those issues (equivalent to what this check now does automatically at creation time), the retry-comment storm stopped.

## Risks

- Low risk. The change is a single conditional narrowing of when an existing override is applied; it does not change behavior for any owner agent whose cheap profile is already correctly enabled.
- If an operator relied on the cheap override being applied even with `enabled` unset/false (unlikely, since that combination currently only produces failures), this PR changes that specific case from "override applied, run fails" to "no override, run uses the owner's normal profile."
- No schema or migration changes.

## Model Used

Claude (Anthropic), model `claude-sonnet-5`, via Claude Code CLI. Standard reasoning mode (no extended/chain-of-thought thinking budget used for this change). Tool use: read repository source via the GitHub REST API and raw content endpoints, applied the change locally against a scratch copy of the two affected files with `git apply`, verified the patch applied cleanly and matched the target files, then wrote the result back via the GitHub Contents API and opened this PR via the Pulls API. No local full clone or build/test execution was performed in this environment (network constraints); test correctness was verified by tracing the added assertions against the existing test file's patterns, not by running the suite locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
