### PR TITLE
fix(plugin-sdk): namespace worker RPC request ids

### DIFF
--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -379,7 +379,11 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
       if (nextOutboundId >= MAX_OUTBOUND_ID) {
         nextOutboundId = 1;
       }
-      const id = nextOutboundId++;
+      // Namespace worker→host request ids so they can never collide with the
+      // host's numeric host→worker ids on this bidirectional JSON-RPC channel.
+      // A collision lets a request consume the other direction's response,
+      // resolve as null, and leave real async work outside its invocation scope.
+      const id = `worker:${nextOutboundId++}`;
       const timeout = timeoutMs ?? rpcTimeoutMs;
       let settled = false;
 

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -155,6 +155,81 @@ describe("worker performAction context", () => {
   });
 });
 
+describe("worker outbound request ids", () => {
+  it("namespaces worker-to-host ids away from host numeric ids", async () => {
+    const hostToWorker = new PassThrough();
+    const workerToHost = new PassThrough();
+    const hostReadline = createInterface({ input: workerToHost });
+    const pending = new Map<number, (response: JsonRpcResponse) => void>();
+    const outboundIds: Array<string | number | null> = [];
+
+    const plugin = definePlugin({
+      async setup(ctx) {
+        ctx.data.register("probe", async () => ctx.companies.get("company-a"));
+      },
+    });
+    const worker = startWorkerRpcHost({ plugin, stdin: hostToWorker, stdout: workerToHost });
+
+    function callWorker(id: number, method: string, params: unknown) {
+      const result = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, (response) => {
+          if ("error" in response && response.error) {
+            reject(new Error(response.error.message));
+            return;
+          }
+          resolve((response as { result?: unknown }).result);
+        });
+      });
+      hostToWorker.write(serializeMessage(createRequest(method, params, id)));
+      return result;
+    }
+
+    hostReadline.on("line", (line) => {
+      const message = parseMessage(line);
+      if (isJsonRpcResponse(message)) {
+        if (typeof message.id === "number") {
+          pending.get(message.id)?.(message);
+          pending.delete(message.id);
+        }
+        return;
+      }
+      if (!isJsonRpcRequest(message) || message.method !== "companies.get") return;
+      outboundIds.push(message.id);
+      hostToWorker.write(serializeMessage(createSuccessResponse(message.id, { id: "company-a" })));
+    });
+
+    try {
+      await callWorker(1, "initialize", {
+        manifest: {
+          id: "paperclip.rpc-id-test",
+          apiVersion: 1,
+          version: "1.0.0",
+          displayName: "RPC id test",
+          description: "RPC id test",
+          author: "Paperclip",
+          categories: ["automation"],
+          capabilities: ["companies.read"],
+          entrypoints: { worker: "dist/worker.js" },
+        },
+        config: {},
+        instanceInfo: { instanceId: "test", hostVersion: "0.0.0" },
+        apiVersion: 1,
+      });
+      await expect(callWorker(2, "getData", {
+        key: "probe",
+        companyId: "company-a",
+        params: {},
+      })).resolves.toEqual({ id: "company-a" });
+      expect(outboundIds).toEqual(["worker:1"]);
+    } finally {
+      worker.stop();
+      hostReadline.close();
+      hostToWorker.destroy();
+      workerToHost.destroy();
+    }
+  });
+});
+
 describe("worker invocation scope propagation", () => {
   it("keeps overlapping company scopes local to each getData invocation", async () => {
     const hostToWorker = new PassThrough();


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their plugin workers.
> - The plugin SDK carries bidirectional JSON-RPC traffic over one channel.
> - Both directions currently allocate numeric request IDs from the same range.
> - Concurrent requests can therefore consume the other direction's response.
> - This pull request namespaces worker-to-host IDs as `worker:<number>`.
> - The benefit is deterministic response ownership without protocol or API changes.

## Linked Issues or Issue Description

**What happened?**

Concurrent host-to-worker and worker-to-host requests could use the same numeric JSON-RPC ID. A response could then settle the wrong pending request. The affected call could resolve with an invalid value, while the real async work continued outside its invocation scope.

**Expected behavior**

Request IDs from opposite directions must never collide on a shared bidirectional channel.

**Steps to reproduce**

1. Start a plugin worker that issues host RPC calls while the host is also sending worker RPC calls.
2. Allow both request counters to allocate the same numeric ID.
3. Observe that one response can be consumed by the pending request from the other direction.

**Paperclip version or commit**

Reproduced on the plugin SDK before commit `b05086951`, based on current `master`.

**Deployment mode**

Self-hosted server.

## What Changed

- Namespace worker-to-host request IDs as `worker:<number>`.
- Keep host-to-worker numeric IDs unchanged.
- Preserve the existing wraparound and timeout behavior.

## Verification

- `pnpm --filter @paperclipai/plugin-sdk test`
- `pnpm --filter @paperclipai/plugin-sdk typecheck`
- The fix also passed a live plugin canary that previously exposed response-ID collisions.

## Risks

Low risk. JSON-RPC 2.0 permits string IDs. The change affects only worker-originated request correlation.

## Model Used

OpenAI GPT-5.6-sol through Codex, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket ID
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] Documentation changes are not required for this internal correlation fix
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
