### PR TITLE
fix(server): honor visible-issue write authorization on recovery action resolution

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1888,6 +1888,141 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("allows the standard-trust recovery owner to resolve recovery on a source issue assigned to a different agent", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    // The source issue is visibly assigned to another agent (non-null, not the
+    // actor) and is NOT checked out (status != in_progress): resolution must be
+    // gated by assertRecoveryActionAuthority's owner grant, not by the generic
+    // assignee-ownership block.
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: managerId })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: coderId,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:cross-assignee-owner-resolution",
+      evidence: { latestIssueStatus: "blocked" },
+      nextAction: "Restore a live execution path.",
+      wakePolicy: { type: "manual" },
+    });
+    const runId = randomUUID();
+    const app = createApp({
+      type: "agent",
+      agentId: coderId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    await seedHeartbeatRun({
+      companyId,
+      agentId: coderId,
+      runId,
+      issueId: sourceIssueId,
+    });
+
+    const resolved = await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "done",
+        resolutionNote: "Recovery owner verified the work while another agent held assignment.",
+      });
+
+    expect(resolved.status, JSON.stringify(resolved.body)).toBe(200);
+    expect(resolved.body.issue).toMatchObject({
+      id: sourceIssueId,
+      status: "done",
+      activeRecoveryAction: null,
+    });
+    expect(resolved.body.recoveryAction).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "owner_completed",
+    });
+  });
+
+  it("rejects recovery resolution by an agent that is neither the assignee nor the recovery owner", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const peerId = randomUUID();
+    await db.insert(agents).values({
+      id: peerId,
+      companyId,
+      name: "Peer",
+      role: "engineer",
+      status: "idle",
+      reportsTo: managerId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: coderId })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:non-owner-peer-resolution",
+      evidence: { latestIssueStatus: "blocked" },
+      nextAction: "Restore a live execution path.",
+      wakePolicy: { type: "manual" },
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: peerId,
+      companyId,
+      runId: randomUUID(),
+      source: "agent_jwt",
+    });
+
+    const rejected = await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "done",
+        resolutionNote: "A non-owner peer should not be able to clear this recovery.",
+      });
+
+    expect(rejected.status, JSON.stringify(rejected.body)).toBe(403);
+    expect(rejected.body).toMatchObject({
+      error: "Agent cannot resolve another owner's recovery action",
+      details: {
+        issueId: sourceIssueId,
+        recoveryActionId: action.id,
+        actorAgentId: peerId,
+        assigneeAgentId: coderId,
+        recoveryOwnerAgentId: managerId,
+        source: "recovery_action_resolution",
+      },
+    });
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue?.status).toBe("blocked");
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "active",
+      outcome: null,
+      resolvedAt: null,
+    });
+  });
+
   it("rejects blocked recovery resolution when the source issue has no first-class blockers", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6219,7 +6219,7 @@ export function issueRoutes(
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { allowVisibleIssueWrite: true }))) return;
     const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id);
     if (
       !(await assertRecoveryActionAuthority(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Recovery actions are part of the enforced-outcomes system: they route stalled or ambiguous issues back to an owner who must resolve them
> - #10804 made visible-issue writes default-open for comment, update, child creation, and assignment: the generic assignee-ownership block now steps aside and the operation-specific gate decides
> - But `POST /issues/:id/recovery-actions/resolve` still calls the generic mutation gate without `allowVisibleIssueWrite`
> - So a standard-trust agent that owns the active recovery action, but is not the issue's current assignee, gets a 403 from the generic gate before `assertRecoveryActionAuthority` can apply its owner grant — that grant is dead code for this scenario
> - This pull request passes `{ allowVisibleIssueWrite: true }` on the resolve route, the same option the sibling write routes pass
> - `assertRecoveryActionAuthority` still runs immediately after and enforces the recovery-specific predicate (assignee, checkout-management override, or recovery-action owner)
> - The benefit is that recovery resolution follows the same authorization model as every other visible-issue write, and the recovery owner can actually resolve the action they own

## Linked Issues or Issue Description

- Refs #11266 — the resolve route is the residual gap after #10804 unified the other write channels
- Related merged PR: #10804 (feat(auth): default-open visible issue writes)
- Related open PRs in the same area (different defects, linked for context): #8596 (stale source-scoped recovery resolution authority for historical sweeps), #11111 (restamp task watchdog mutation scope after the run's own writes)

## What Changed

- `server/src/routes/issues.ts`: the `POST /issues/:id/recovery-actions/resolve` route now calls `assertAgentIssueMutationAllowed(req, res, existing, { allowVisibleIssueWrite: true })`, mirroring `PATCH /issues/:id` and the other unified write routes
- `server/src/__tests__/issue-recovery-actions.test.ts`: two new regression tests that pin the authorization matrix on the resolve route

## Verification

- New test: a standard-trust recovery-action owner resolves recovery on a source issue assigned to a different agent. Before this fix the route returned 403 from the generic gate. Now it returns 200 and the recovery action resolves
- New test: an agent that is neither the assignee nor the recovery owner still gets rejected — `assertRecoveryActionAuthority` denies it, so the change does not widen access beyond the recovery predicate
- Commands:
  - `pnpm --filter @paperclipai/server vitest run src/__tests__/issue-recovery-actions.test.ts` → 46 passed (44 pre-existing + 2 new)
  - `pnpm --filter @paperclipai/server typecheck` → clean

## Risks

- Low risk. One-line behavioral change on one route
- The change removes one redundant generic check on a route that has a stricter operation-specific gate directly after it. The effective access set only grows by the case the recovery gate already intends to allow (the recovery-action owner). The negative test pins that non-owners stay denied

## Model Used

- Claude (Anthropic) — Claude Fable 5, model id claude-fable-5, via Claude Code with repository tools, shell and test execution enabled

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation covers this route's authorization matrix; the tests document it)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge
