### PR TITLE
fix: suppress non-publishable run-output fragments instead of posting them as issue comments

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentParams, resolveClaimedApiKeyPath, resolveSessionKey } from "./execute.js";
+import {
+  buildAgentParams,
+  isPublishableRunSummary,
+  resolveClaimedApiKeyPath,
+  resolveSessionKey,
+  selectRunSummary,
+} from "./execute.js";
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -121,5 +127,116 @@ describe("resolveClaimedApiKeyPath", () => {
   it("falls back to the shared default when value is not a string", () => {
     expect(resolveClaimedApiKeyPath(42)).toBe(DEFAULT_PATH);
     expect(resolveClaimedApiKeyPath({})).toBe(DEFAULT_PATH);
+  });
+});
+
+describe("isPublishableRunSummary", () => {
+  it("rejects torn-stream structural fragments", () => {
+    expect(isPublishableRunSummary("{")).toBe(false);
+    expect(isPublishableRunSummary("}")).toBe(false);
+    expect(isPublishableRunSummary("[{")).toBe(false);
+    expect(isPublishableRunSummary("...")).toBe(false);
+    expect(isPublishableRunSummary('{"summary": "partial resu')).toBe(false);
+  });
+
+  it("keeps short answers and complete JSON publishable", () => {
+    expect(isPublishableRunSummary("Done.")).toBe(true);
+    expect(isPublishableRunSummary("OK — merged.")).toBe(true);
+    expect(isPublishableRunSummary('{"summary": "done"}')).toBe(true);
+    expect(isPublishableRunSummary("All done { see notes }")).toBe(true);
+  });
+});
+
+describe("selectRunSummary", () => {
+  it("prefers the stream summary on a normal end", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "Final answer.",
+        summaryFromPayload: "Payload text.",
+        streamEndedAbnormally: false,
+      }),
+    ).toBe("Final answer.");
+  });
+
+  it("falls back to the payload summary when the stream produced nothing", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "",
+        summaryFromPayload: "Payload text.",
+        streamEndedAbnormally: false,
+      }),
+    ).toBe("Payload text.");
+  });
+
+  it("falls through to the payload when the stream summary is a torn fragment", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "{",
+        summaryFromPayload: "Payload text.",
+        streamEndedAbnormally: false,
+      }),
+    ).toBe("Payload text.");
+    expect(
+      selectRunSummary({
+        summaryFromEvents: '{"summary": "cut of',
+        summaryFromPayload: "Payload text.",
+        streamEndedAbnormally: false,
+      }),
+    ).toBe("Payload text.");
+  });
+
+  // Complete JSON from the stream is well-formed output, not a torn fragment.
+  it("keeps a complete JSON stream summary on a normal end", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: '{"summary": "done"}',
+        summaryFromPayload: "Payload text.",
+        streamEndedAbnormally: false,
+      }),
+    ).toBe('{"summary": "done"}');
+  });
+
+  it("prefers the payload summary when the stream ended abnormally", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "Partial sentence that got cut",
+        summaryFromPayload: "Payload summary.",
+        streamEndedAbnormally: true,
+      }),
+    ).toBe("Payload summary.");
+  });
+
+  it("keeps a publishable stream summary on abnormal end only when no payload exists", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "Recovered and finished.",
+        summaryFromPayload: null,
+        streamEndedAbnormally: true,
+      }),
+    ).toBe("Recovered and finished.");
+  });
+
+  it("returns null instead of emitting garbage", () => {
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "{",
+        summaryFromPayload: null,
+        streamEndedAbnormally: true,
+      }),
+    ).toBeNull();
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "",
+        summaryFromPayload: null,
+        streamEndedAbnormally: false,
+      }),
+    ).toBeNull();
+    expect(
+      selectRunSummary({
+        summaryFromEvents: "[{",
+        summaryFromPayload: "[",
+        streamEndedAbnormally: false,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1008,6 +1008,61 @@ function extractRuntimeServicesFromMeta(meta: Record<string, unknown> | null): A
   return reports;
 }
 
+/**
+ * Structural-garbage gate for run summaries (defence in depth for upstream
+ * paperclipai/paperclip#11265). Duplicated from the server's
+ * heartbeat-run-summary predicate because the dependency direction is
+ * server -> adapter; the adapter package cannot import server code. It targets
+ * torn-stream fragments (a lone `{`), NOT brevity: short answers such as
+ * "Done." stay publishable and there is deliberately no length floor.
+ */
+export function isPublishableRunSummary(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+
+  // Pure whitespace/punctuation fragments ("{", "}", "[{", "...") carry no
+  // publishable content: require at least one letter or digit.
+  if (!/[\p{L}\p{N}]/u.test(trimmed)) return false;
+
+  // Text that starts like a JSON object/array must actually be complete,
+  // parseable JSON. A truncated stream fragment (`{"summary": "par`) fails
+  // here; a COMPLETE JSON document is deliberately kept publishable because
+  // it is well-formed output rather than torn-stream garbage.
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      JSON.parse(trimmed);
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Chooses the run summary between the accumulated stream deltas and the
+ * well-formed payload text. On a normal end the stream still wins (it is the
+ * richer final answer), but a torn-stream fragment never shadows the payload,
+ * and an abnormal stream end always prefers the payload.
+ */
+export function selectRunSummary(input: {
+  summaryFromEvents: string | null;
+  summaryFromPayload: string | null;
+  streamEndedAbnormally: boolean;
+}): string | null {
+  const fromEvents = input.summaryFromEvents?.trim() || null;
+  const fromPayload = input.summaryFromPayload?.trim() || null;
+  const ordered = input.streamEndedAbnormally
+    ? [fromPayload, fromEvents]
+    : [fromEvents, fromPayload];
+  for (const candidate of ordered) {
+    if (candidate !== null && isPublishableRunSummary(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 function extractResultText(value: unknown): string | null {
   const record = asRecord(value);
   if (!record) return null;
@@ -1368,7 +1423,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         extractResultText(acceptedPayload) ??
         extractResultText(asRecord(latestResultPayload)) ??
         null;
-      const summary = summaryFromEvents || summaryFromPayload || null;
+      // The timeout/error wait statuses return early above, so the reachable
+      // abnormal-end marker here is a lifecycle/error event captured from the
+      // stream while the run still finished "ok".
+      const summary = selectRunSummary({
+        summaryFromEvents,
+        summaryFromPayload,
+        streamEndedAbnormally: lifecycleError !== null,
+      });
 
       const acceptedResult = asRecord(acceptedPayload?.result);
       const latestPayload = asRecord(latestResultPayload);

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -8,6 +8,7 @@ import {
   agentWakeupRequests,
   companies,
   createDb,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issues,
@@ -43,7 +44,9 @@ async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
 
-async function createControlledGatewayServer() {
+async function createControlledGatewayServer(options?: {
+  waitPayloadExtra?: Record<string, unknown>;
+}) {
   const server = createServer();
   const wss = new WebSocketServer({ server });
   const agentPayloads: Array<Record<string, unknown>> = [];
@@ -129,6 +132,7 @@ async function createControlledGatewayServer() {
               status: "ok",
               startedAt: 1,
               endedAt: 2,
+              ...(options?.waitPayloadExtra ?? {}),
             },
           }),
         );
@@ -1685,6 +1689,120 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         retryReason: "missing_issue_comment",
         modelProfile: "cheap",
       });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 20_000);
+
+  it("suppresses a non-publishable run summary fragment instead of posting it as an issue comment", async () => {
+    // Regression for upstream paperclipai/paperclip#11265: a run torn down
+    // mid-stream can persist a lone "{" as its result text. That fragment must
+    // never be published as an issue comment; instead the run gets an
+    // error-level run event naming the suppressed fragment.
+    const gateway = await createControlledGatewayServer({
+      waitPayloadExtra: { message: "{" },
+    });
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Suppress garbage summary",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+      gateway.releaseFirstWait();
+
+      // Once the source run reaches a terminal issue-comment status, the
+      // comment publication step has already run for it.
+      await waitFor(async () => {
+        const sourceRun = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return (
+          sourceRun?.status === "succeeded" &&
+          sourceRun.issueCommentStatus !== null &&
+          sourceRun.issueCommentStatus !== "pending"
+        );
+      });
+
+      const comments = await db
+        .select()
+        .from(issueComments)
+        .where(eq(issueComments.issueId, issueId));
+      expect(comments.filter((comment) => comment.body.trim() === "{")).toHaveLength(0);
+      expect(comments).toHaveLength(0);
+
+      const suppressionEvents = await db
+        .select()
+        .from(heartbeatRunEvents)
+        .where(and(eq(heartbeatRunEvents.runId, firstRun!.id), eq(heartbeatRunEvents.level, "error")));
+      expect(suppressionEvents.length).toBeGreaterThan(0);
+      const suppressionEvent = suppressionEvents.find((event) => {
+        const payload = (event.payload ?? {}) as Record<string, unknown>;
+        return payload.reason === "non_publishable_run_summary";
+      });
+      expect(suppressionEvent).toBeTruthy();
+      expect(suppressionEvent?.message).toContain("Suppressed non-publishable run summary");
+      expect((suppressionEvent?.payload as Record<string, unknown>).suppressedFragment).toBe("{");
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   summarizeHeartbeatRunResultJson,
   buildHeartbeatRunIssueComment,
+  isPublishableRunSummary,
   mergeHeartbeatRunResultJson,
+  readHeartbeatRunCommentCandidate,
 } from "../services/heartbeat-run-summary.js";
 
 describe("summarizeHeartbeatRunResultJson", () => {
@@ -62,6 +64,104 @@ describe("buildHeartbeatRunIssueComment", () => {
 
   it("returns null when there is no usable final text", () => {
     expect(buildHeartbeatRunIssueComment({ costUsd: 1.2 })).toBeNull();
+  });
+
+  it("suppresses lone brace/bracket fragments from torn streams", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: "{" })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ summary: "}" })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ summary: "[" })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ summary: "[{" })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ result: "{" })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ message: "[{" })).toBeNull();
+  });
+
+  it("suppresses pure whitespace/punctuation fragments", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: "..." })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ summary: "—" })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ summary: "-- ~~ !!" })).toBeNull();
+  });
+
+  it("suppresses text that starts like JSON but fails to parse", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: '{"summary": "partial resu' })).toBeNull();
+    expect(buildHeartbeatRunIssueComment({ summary: '[{"type": "text",' })).toBeNull();
+  });
+
+  // Fall-through is deliberate: a torn `summary` fragment must not shadow a
+  // well-formed `result`/`message` candidate from the same payload.
+  it("falls through to the next candidate when an earlier one is garbage", () => {
+    expect(
+      buildHeartbeatRunIssueComment({ summary: "{", result: "Recovered the deploy." }),
+    ).toBe("Recovered the deploy.");
+    expect(
+      buildHeartbeatRunIssueComment({ summary: "[{", message: "completed" }),
+    ).toBe("completed");
+  });
+
+  it("keeps legitimate short answers publishable", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: "Done." })).toBe("Done.");
+    expect(buildHeartbeatRunIssueComment({ result: "OK — merged." })).toBe("OK — merged.");
+  });
+});
+
+describe("isPublishableRunSummary", () => {
+  it("rejects lone or unbalanced brace/bracket fragments", () => {
+    expect(isPublishableRunSummary("{")).toBe(false);
+    expect(isPublishableRunSummary("}")).toBe(false);
+    expect(isPublishableRunSummary("[")).toBe(false);
+    expect(isPublishableRunSummary("]")).toBe(false);
+    expect(isPublishableRunSummary("[{")).toBe(false);
+    expect(isPublishableRunSummary(" { ")).toBe(false);
+  });
+
+  it("rejects pure whitespace and punctuation", () => {
+    expect(isPublishableRunSummary("")).toBe(false);
+    expect(isPublishableRunSummary("   \n\t")).toBe(false);
+    expect(isPublishableRunSummary("...")).toBe(false);
+    expect(isPublishableRunSummary("—")).toBe(false);
+    expect(isPublishableRunSummary("*** --- !!!")).toBe(false);
+  });
+
+  it("rejects text that starts like a JSON object/array but fails JSON.parse", () => {
+    expect(isPublishableRunSummary('{"summary": "partial resu')).toBe(false);
+    expect(isPublishableRunSummary('[{"type": "text", "text": "cut off')).toBe(false);
+    expect(isPublishableRunSummary('{"a": 1,')).toBe(false);
+  });
+
+  // Decided behavior: a COMPLETE, parseable JSON object/array stays
+  // publishable. The guard targets torn-stream structural garbage, not
+  // adapters that legitimately return a JSON-shaped final summary; a complete
+  // document is well-formed output, so publication policy stays unchanged.
+  it("keeps complete, parseable JSON publishable", () => {
+    expect(isPublishableRunSummary('{"summary": "done", "cost": 1.2}')).toBe(true);
+    expect(isPublishableRunSummary('["step one", "step two"]')).toBe(true);
+  });
+
+  it("keeps short answers and real sentences publishable without a length floor", () => {
+    expect(isPublishableRunSummary("Done.")).toBe(true);
+    expect(isPublishableRunSummary("OK — merged.")).toBe(true);
+    expect(isPublishableRunSummary("ok")).toBe(true);
+    expect(isPublishableRunSummary("Fixed the deploy config and posted the issue update.")).toBe(true);
+    expect(isPublishableRunSummary("## Summary\n\n- fixed deploy config")).toBe(true);
+  });
+
+  it("does not reject prose that merely contains braces mid-text", () => {
+    expect(isPublishableRunSummary("All done { see notes below }")).toBe(true);
+    expect(isPublishableRunSummary("Use `${VAR}` for interpolation.")).toBe(true);
+  });
+});
+
+describe("readHeartbeatRunCommentCandidate", () => {
+  it("returns the first non-empty candidate even when it is garbage", () => {
+    expect(readHeartbeatRunCommentCandidate({ summary: "{" })).toBe("{");
+    expect(readHeartbeatRunCommentCandidate({ result: "[{" })).toBe("[{");
+    expect(readHeartbeatRunCommentCandidate({ summary: " ", message: "}" })).toBe("}");
+  });
+
+  it("returns null when no text candidate exists at all", () => {
+    expect(readHeartbeatRunCommentCandidate(null)).toBeNull();
+    expect(readHeartbeatRunCommentCandidate({})).toBeNull();
+    expect(readHeartbeatRunCommentCandidate({ costUsd: 1.2 })).toBeNull();
+    expect(readHeartbeatRunCommentCandidate({ summary: "   " })).toBeNull();
   });
 });
 

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -41,6 +41,7 @@ function buildContext(
 
 async function createMockGatewayServer(options?: {
   waitPayload?: Record<string, unknown>;
+  assistantDeltas?: string[];
 }) {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -106,32 +107,22 @@ async function createMockGatewayServer(options?: {
           }),
         );
 
-        socket.send(
-          JSON.stringify({
-            type: "event",
-            event: "agent",
-            payload: {
-              runId,
-              seq: 1,
-              stream: "assistant",
-              ts: Date.now(),
-              data: { delta: "cha" },
-            },
-          }),
-        );
-        socket.send(
-          JSON.stringify({
-            type: "event",
-            event: "agent",
-            payload: {
-              runId,
-              seq: 2,
-              stream: "assistant",
-              ts: Date.now(),
-              data: { delta: "chacha" },
-            },
-          }),
-        );
+        const assistantDeltas = options?.assistantDeltas ?? ["cha", "chacha"];
+        assistantDeltas.forEach((delta, index) => {
+          socket.send(
+            JSON.stringify({
+              type: "event",
+              event: "agent",
+              payload: {
+                runId,
+                seq: index + 1,
+                stream: "assistant",
+                ts: Date.now(),
+                data: { delta },
+              },
+            }),
+          );
+        });
         return;
       }
 
@@ -560,6 +551,39 @@ describe("openclaw gateway adapter execute", () => {
           status: "running",
         }),
       ]);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("prefers the well-formed payload summary over a torn stream fragment", async () => {
+    // Regression for upstream paperclipai/paperclip#11265: a stream torn down
+    // mid-delta leaves a lone "{" as the accumulated assistant text. That
+    // fragment must not shadow the well-formed payload summary.
+    const gateway = await createMockGatewayServer({
+      assistantDeltas: ["{"],
+      waitPayload: {
+        runId: "run-123",
+        status: "ok",
+        startedAt: 1,
+        endedAt: 2,
+        summary: "Payload summary text.",
+      },
+    });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.summary).toBe("Payload summary text.");
     } finally {
       await gateway.close();
     }

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -92,6 +92,57 @@ export function summarizeHeartbeatRunResultJson(
   return Object.keys(summary).length > 0 ? summary : null;
 }
 
+const RUN_COMMENT_CANDIDATE_FIELDS = ["summary", "result", "message"] as const;
+
+/**
+ * Structural-garbage gate for run summaries that are about to be published as
+ * issue comments. It targets torn-stream fragments (a run torn down mid-stream
+ * can leave a lone `{` as its whole "summary"), NOT brevity: legitimate short
+ * answers such as "Done." or "OK — merged." stay publishable, and there is
+ * deliberately no length floor.
+ */
+export function isPublishableRunSummary(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+
+  // Pure whitespace/punctuation fragments ("{", "}", "[{", "...", "—") carry
+  // no publishable content: require at least one letter or digit.
+  if (!/[\p{L}\p{N}]/u.test(trimmed)) return false;
+
+  // Text that starts like a JSON object/array must actually be complete,
+  // parseable JSON. A truncated stream fragment (`{"summary": "par`) fails
+  // here; a COMPLETE JSON document is deliberately kept publishable because
+  // it is well-formed adapter output rather than torn-stream garbage.
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      JSON.parse(trimmed);
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * First non-empty trimmed comment candidate (summary/result/message),
+ * WITHOUT the publishability gate. Lets callers distinguish "no candidate
+ * existed" from "a candidate existed but was rejected as non-publishable".
+ */
+export function readHeartbeatRunCommentCandidate(
+  resultJson: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) {
+    return null;
+  }
+
+  for (const key of RUN_COMMENT_CANDIDATE_FIELDS) {
+    const candidate = readCommentText(resultJson[key]);
+    if (candidate !== null) return candidate;
+  }
+  return null;
+}
+
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
 ): string | null {
@@ -99,10 +150,13 @@ export function buildHeartbeatRunIssueComment(
     return null;
   }
 
-  return (
-    readCommentText(resultJson.summary)
-    ?? readCommentText(resultJson.result)
-    ?? readCommentText(resultJson.message)
-    ?? null
-  );
+  // Fall-through is deliberate: a torn `summary` fragment must not shadow a
+  // well-formed `result`/`message` candidate from the same payload.
+  for (const key of RUN_COMMENT_CANDIDATE_FIELDS) {
+    const candidate = readCommentText(resultJson[key]);
+    if (candidate !== null && isPublishableRunSummary(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -108,6 +108,7 @@ import {
   HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS,
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
   mergeHeartbeatRunResultJson,
+  readHeartbeatRunCommentCandidate,
 } from "./heartbeat-run-summary.js";
 import {
   buildHeartbeatRunStopMetadata,
@@ -15938,6 +15939,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
               if (issueComment) {
                 await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
+              } else {
+                // Distinguish "no result text at all" (preserve historical
+                // behavior exactly) from "a candidate existed but was rejected
+                // as non-publishable" (torn-stream fragments such as a lone
+                // "{", see upstream paperclipai/paperclip#11265): surface the
+                // rejection explicitly as an error-level run event instead of
+                // silently posting garbage.
+                const rejectedCandidate = readHeartbeatRunCommentCandidate(persistedResultJson);
+                if (rejectedCandidate !== null) {
+                  await appendRunEvent(livenessRun, await nextRunEventSeq(livenessRun.id), {
+                    eventType: "lifecycle",
+                    stream: "system",
+                    level: "error",
+                    message: "Suppressed non-publishable run summary fragment; no issue comment was posted",
+                    payload: {
+                      reason: "non_publishable_run_summary",
+                      suppressedFragment: rejectedCandidate.slice(0, 200),
+                      suppressedFragmentLength: rejectedCandidate.length,
+                    },
+                  });
+                }
               }
             }
           } catch (err) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - After a run ends, the heartbeat pipeline publishes the run's output summary as an issue comment so humans and downstream recovery logic can see what the agent did
> - When an agent stream is torn mid-write, the "summary" can be a structural fragment: a lone `{`, `[{`, or a truncated JSON prefix
> - Today that fragment is published verbatim as an issue comment, and recovery logic then treats the garbage comment as real agent activity
> - This pull request adds a publishability gate: the server suppresses non-publishable fragments and records an explicit run event instead of posting a comment
> - The gateway adapter also gains payload-first summary selection, so an abnormal stream end prefers the intact payload summary over the torn stream text
> - The benefit is that issues no longer collect `{` comments, and recovery decisions stop keying off garbage output

## Linked Issues or Issue Description

- Fixes #11265
- Related open/closed PRs in the same area (different defects, linked for context): #670 (the original auto-post of run output as issue comment), #10043 and #9991 (ignore no-op heartbeat summary comments in watchdog stop fingerprints), #7505 (skip auto-mirror run-summary comment on cross-owner wakes)

## What Changed

- `server/src/services/heartbeat-run-summary.ts`: new exported `isPublishableRunSummary(text)` gate. It rejects torn-stream structural fragments (lone braces/brackets, truncated JSON prefixes, ellipsis-only text) and keeps short answers and complete JSON publishable. Summary candidate selection now applies the gate
- `server/src/services/heartbeat.ts`: when the only candidate is non-publishable, the server does not post an issue comment. It records an error-level lifecycle run event (`reason: non_publishable_run_summary`) with the truncated fragment and its length, so the suppression is visible in the run timeline
- `packages/adapters/openclaw-gateway/src/server/execute.ts`: new `selectRunSummary` that prefers the payload summary when the stream ends abnormally, falls back through publishable candidates, and returns null instead of emitting garbage. `isPublishableRunSummary` is applied on the adapter side too
- Tests in all three areas pin the new behavior (fragment suppression, run-event emission, wake batching interplay, adapter selection matrix)

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/heartbeat-run-summary.test.ts src/__tests__/heartbeat-comment-wake-batching.test.ts src/__tests__/openclaw-gateway-adapter.test.ts` → 42 passed
- `pnpm --filter @paperclipai/adapter-openclaw-gateway vitest run` (or `pnpm vitest run` inside `packages/adapters/openclaw-gateway`) → 22 passed
- `pnpm --filter @paperclipai/server typecheck` → clean; adapter `tsc --noEmit` → clean
- Manual check: with the gate in place, a run whose stream dies mid-JSON produces a run event and no issue comment; a normal run still posts its summary comment unchanged

## Risks

- Behavioral shift: fragments that were posted as comments before are now suppressed. The suppression is not silent — it is recorded as an error-level run event with the fragment content, so no information is lost
- Honest scope note 1: the retry-prevention piece needs an upstream design decision. `finalizeIssueCommentPolicy` does not gate on `issueCommentStatus`, and `enqueueMissingIssueCommentRetry` overwrites it. With this PR a suppressed fragment leads to at most one bounded retry. Fully preventing that retry touches the comment-policy state machine, and we did not want to redesign it unilaterally in this PR
- Honest scope note 2: while testing this change on an earlier release base we found that `packages/adapters/openclaw-gateway` was absent from the root `vitest.config.ts` projects list, so its tests did not run in CI there. Master has since added the entry (#4668), so CI on master covers the adapter tests in this PR. No action needed — noted for transparency

## Model Used

- Claude (Anthropic) — Claude Fable 5, model id claude-fable-5, via Claude Code with repository tools, shell and test execution enabled

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs describe the summary-comment pipeline; the run event and tests document the new behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge
