### PR TITLE
fix(server): stable machine-readable error codes on authorization failures

### DIFF
--- a/server/src/__tests__/company-skills-routes.test.ts
+++ b/server/src/__tests__/company-skills-routes.test.ts
@@ -1246,7 +1246,11 @@ describe("company skill mutation permissions", () => {
       .send({ source: "https://github.com/acme/private-skill?token=secret#token=secret" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(401);
-    expect(res.body).toEqual({ error: "Authentication required" });
+    expect(res.body).toEqual({
+      error: "Authentication required",
+      code: "unauthorized",
+      details: { code: "unauthorized" },
+    });
     expect(JSON.stringify(res.body)).not.toContain("secret");
     expect(mockAccessService.decide).not.toHaveBeenCalled();
     expect(mockCompanySkillPolicyService.evaluate).not.toHaveBeenCalled();
@@ -1261,7 +1265,11 @@ describe("company skill mutation permissions", () => {
       .send({ description: "Updated" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(401);
-    expect(res.body).toEqual({ error: "Authentication required" });
+    expect(res.body).toEqual({
+      error: "Authentication required",
+      code: "unauthorized",
+      details: { code: "unauthorized" },
+    });
     expect(mockCompanySkillService.getById).not.toHaveBeenCalled();
     expect(mockCompanySkillPolicyService.evaluate).not.toHaveBeenCalled();
     expect(mockCompanySkillService.updateSkill).not.toHaveBeenCalled();

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -329,7 +329,11 @@ describe("cost routes", () => {
       .send({ budgetMonthlyCents: 2500 });
 
     expect(res.status).toBe(403);
-    expect(res.body).toEqual({ error: "Board access required" });
+    expect(res.body).toEqual({
+      error: "Board access required",
+      code: "forbidden",
+      details: { code: "forbidden" },
+    });
     expect(mockAgentService.update).not.toHaveBeenCalled();
     expect(mockBudgetService.upsertPolicy).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();
@@ -348,7 +352,11 @@ describe("cost routes", () => {
       .send({ budgetMonthlyCents: 2500 });
 
     expect(res.status).toBe(403);
-    expect(res.body).toEqual({ error: "Board access required" });
+    expect(res.body).toEqual({
+      error: "Board access required",
+      code: "forbidden",
+      details: { code: "forbidden" },
+    });
     expect(mockAgentService.update).not.toHaveBeenCalled();
     expect(mockBudgetService.upsertPolicy).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();

--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { HttpError } from "../errors.js";
+import { forbidden, HttpError, unauthorized } from "../errors.js";
 import { errorHandler } from "../middleware/error-handler.js";
 
 const recordResponsibleUserDenialOnActiveRunMock = vi.hoisted(() => vi.fn());
@@ -22,9 +22,11 @@ function makeReq(): Request {
 function makeRes(): Response {
   const res = {
     status: vi.fn(),
+    type: vi.fn(),
     json: vi.fn(),
   } as unknown as Response;
   (res.status as unknown as ReturnType<typeof vi.fn>).mockReturnValue(res);
+  (res.type as unknown as ReturnType<typeof vi.fn>).mockReturnValue(res);
   return res;
 }
 
@@ -85,6 +87,107 @@ describe("errorHandler", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "db exploded" });
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
+  });
+
+  it("emits a stable machine-readable code and forced JSON content type for forbidden()", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(forbidden(), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Forbidden",
+      code: "forbidden",
+      details: { code: "forbidden" },
+    });
+  });
+
+  it("emits a stable machine-readable code and forced JSON content type for unauthorized()", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(unauthorized(), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Unauthorized",
+      code: "unauthorized",
+      details: { code: "unauthorized" },
+    });
+  });
+
+  it("lets explicit details replace the forbidden() default code", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(forbidden("Custom denial", { code: "custom_denial" }), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Custom denial",
+      code: "custom_denial",
+      details: { code: "custom_denial" },
+    });
+  });
+
+  it("derives a default code for 403 HttpErrors thrown without details", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new HttpError(403, "Bare forbidden"), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Bare forbidden",
+      code: "forbidden",
+    });
+  });
+
+  it("derives a default code for 401 HttpErrors thrown without details", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new HttpError(401, "Bare unauthorized"), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Bare unauthorized",
+      code: "unauthorized",
+    });
+  });
+
+  it("derives a default code for 403 HttpErrors whose details lack a code", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new HttpError(403, "Denied with context", { reason: "quota" }), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Denied with context",
+      code: "forbidden",
+      details: { reason: "quota" },
+    });
+  });
+
+  it("does not derive an authorization code for non-authorization statuses", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new HttpError(404, "Not found"), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "Not found" });
   });
 
   it("records responsible-user denial codes on the active agent run", () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -886,6 +886,74 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
   });
 
+  it("emits a stable machine-readable code when issue read is outside the boundary", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .get(`/api/issues/${issueId}/comments`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.headers["content-type"]).toContain("application/json");
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.code).toBe("issue_read_denied");
+  });
+
+  it("emits a stable machine-readable code on the comment authorization-boundary 403", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action !== "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "deny_missing_grant" : "allow_explicit_grant",
+      explanation: input.action === "issue:comment" ? "Missing permission." : "Allowed by test default.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Denied comment." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.headers["content-type"]).toContain("application/json");
+    // This site routes through the shared issue-write denial copy, which
+    // carries its stable code inside `details` next to the denial prose.
+    expect(res.body.details.code).toBe("issue_write_not_visible");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("emits a stable machine-readable code on the checkout-conflict 409", async () => {
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.headers["content-type"]).toContain("application/json");
+    // The run-lock denial routes through the shared issue-write denial copy;
+    // its stable code lives inside `details` next to the extra context fields.
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(res.body.details).toEqual(
+      expect.objectContaining({
+        issueId,
+        assigneeAgentId: ownerAgentId,
+        actorAgentId: peerAgentId,
+      }),
+    );
+  });
+
+  it("emits a stable machine-readable code on the structured-comment-fields 403", async () => {
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Structured attempt.", presentation: { kind: "system_notice" } });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.headers["content-type"]).toContain("application/json");
+    expect(res.body.error).toBe("Only board users may set structured comment presentation or metadata");
+    expect(res.body.code).toBe("structured_comment_fields_board_only");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
   it("rejects peer agents from listing interactions when issue read is outside their boundary", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: false,

--- a/server/src/__tests__/private-hostname-guard.test.ts
+++ b/server/src/__tests__/private-hostname-guard.test.ts
@@ -49,6 +49,49 @@ describe("privateHostnameGuard", () => {
     expect(res.body?.error).toContain(`please run pnpm paperclipai allowed-hostname ${unknownHostname}`);
   });
 
+  it("keeps /api denials JSON with a stable code even when the client only accepts html", async () => {
+    const app = createApp({ enabled: true, allowedHostnames: ["some-other-host"] });
+    const res = await request(app)
+      .get("/api/health")
+      .set("Host", `${unknownHostname}:3100`)
+      .set("Accept", "text/html");
+    expect(res.status).toBe(403);
+    expect(res.headers["content-type"]).toContain("application/json");
+    expect(res.body?.error).toContain(`please run pnpm paperclipai allowed-hostname ${unknownHostname}`);
+    expect(res.body?.code).toBe("private_hostname_forbidden");
+  });
+
+  it("keeps missing-host /api denials JSON with a stable code regardless of Accept", async () => {
+    const middleware = privateHostnameGuard({
+      enabled: true,
+      allowedHostnames: [],
+      bindHost: "0.0.0.0",
+    });
+    const req = {
+      path: "/api/health",
+      header: () => undefined,
+      accepts: () => "html",
+    } as any;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      type: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+      json: vi.fn(),
+    } as any;
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.send).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.stringContaining("Missing Host header"),
+      code: "private_hostname_forbidden",
+    });
+  });
+
   it("blocks unknown hostnames on page routes with plain-text remediation command", async () => {
     const middleware = privateHostnameGuard({
       enabled: true,

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -13,12 +13,25 @@ export function badRequest(message: string, details?: unknown) {
   return new HttpError(400, message, details);
 }
 
-export function unauthorized(message = "Unauthorized") {
-  return new HttpError(401, message);
+/**
+ * 401 with a stable machine-readable default code so clients (and edge
+ * proxies) can distinguish app-level authentication failures from
+ * infrastructure blocks. Explicit `details` REPLACE the default wholesale
+ * (no merging): callers that pass details should include their own `code`
+ * when they need one — the central error handler still derives
+ * `code: "unauthorized"` when they do not.
+ */
+export function unauthorized(message = "Unauthorized", details?: unknown) {
+  return new HttpError(401, message, details ?? { code: "unauthorized" });
 }
 
+/**
+ * 403 with a stable machine-readable default code. Same replace semantics
+ * as `unauthorized`: explicit `details` win wholesale, and the central
+ * error handler derives `code: "forbidden"` for detail objects without one.
+ */
 export function forbidden(message = "Forbidden", details?: unknown) {
-  return new HttpError(403, message, details);
+  return new HttpError(403, message, details ?? { code: "forbidden" });
 }
 
 export function notFound(message = "Not found") {

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -102,9 +102,19 @@ export function errorHandler(
       const tc = getTelemetryClient();
       if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
     }
-    res.status(err.status).json({
+    // Belt-and-braces for authorization failures (#11267): every 401/403
+    // carries a stable top-level `code` even when the thrower passed no
+    // details.code, and the content type is forced to JSON so an edge proxy
+    // cannot content-negotiate the body into an HTML error page.
+    const derivedAuthzCode =
+      err.status === 401 ? "unauthorized" : err.status === 403 ? "forbidden" : null;
+    res.status(err.status).type("application/json").json({
       error: err.message,
-      ...(typeof details?.code === "string" ? { code: details.code } : {}),
+      ...(typeof details?.code === "string"
+        ? { code: details.code }
+        : derivedAuthzCode
+          ? { code: derivedAuthzCode }
+          : {}),
       ...(redactedSkillPolicyDenial && typeof details?.reason === "string" ? { reason: details.reason } : {}),
       ...(typeof details?.remediation === "string" || (structuredConnectionError && details?.remediation && typeof details.remediation === "object")
         ? { remediation: details.remediation }

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -65,15 +65,26 @@ export function privateHostnameGuard(opts: {
 
   return (req, res, next) => {
     const hostname = extractHostname(req);
-    const wantsJson = req.path.startsWith("/api") || req.accepts(["json", "html", "text"]) === "json";
+    const isApiRequest = req.path.startsWith("/api");
+    const wantsJson = isApiRequest || req.accepts(["json", "html", "text"]) === "json";
 
-    if (!hostname) {
-      const error = "Missing Host header. If you want to allow a hostname, run pnpm paperclipai allowed-hostname <host>.";
-      if (wantsJson) {
+    // API denials are unconditionally JSON with a stable machine-readable
+    // code and an explicit content type, regardless of Accept headers, so an
+    // edge proxy cannot re-skin the 403 as an HTML error page and make an
+    // app-level block look like a WAF block (paperclipai/paperclip#11267).
+    // Non-/api (page) requests keep the previous Accept-negotiated behavior.
+    const deny = (error: string) => {
+      if (isApiRequest) {
+        res.status(403).type("application/json").json({ error, code: "private_hostname_forbidden" });
+      } else if (wantsJson) {
         res.status(403).json({ error });
       } else {
         res.status(403).type("text/plain").send(error);
       }
+    };
+
+    if (!hostname) {
+      deny("Missing Host header. If you want to allow a hostname, run pnpm paperclipai allowed-hostname <host>.");
       return;
     }
 
@@ -82,11 +93,6 @@ export function privateHostnameGuard(opts: {
       return;
     }
 
-    const error = blockedHostnameMessage(hostname);
-    if (wantsJson) {
-      res.status(403).json({ error });
-    } else {
-      res.status(403).type("text/plain").send(error);
-    }
+    deny(blockedHostnameMessage(hostname));
   };
 }

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -23,6 +23,38 @@ function throwOrShadowResponsibleUserCompanyAccessDeny(
   throw new HttpError(403, message, { code });
 }
 
+/**
+ * Emit a machine-readable authorization denial directly on the response
+ * (for route-local authz helpers that respond instead of throwing
+ * `HttpError`). Always JSON with an explicit content type — so an edge
+ * proxy cannot content-negotiate the body into an HTML error page
+ * (paperclipai/paperclip#11267) — and a stable top-level `code` alongside
+ * the human-readable `error`.
+ */
+export function respondAuthzDenial(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+) {
+  res.status(status).type("application/json").json({
+    error: message,
+    code,
+    ...(details !== undefined ? { details } : {}),
+  });
+}
+
+/** 403 shorthand for `respondAuthzDenial`. */
+export function respondForbidden(
+  res: Response,
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+) {
+  respondAuthzDenial(res, 403, code, message, details);
+}
+
 export function assertAuthenticated(req: Request) {
   if (req.actor.type === "none") {
     throw unauthorized();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -154,7 +154,13 @@ import { logger } from "../middleware/logger.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { createRequestPromiseMemo } from "../lib/request-promise-memo.js";
-import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
+import {
+  assertBoard,
+  assertCompanyAccess,
+  getAccessibleResource,
+  getActorInfo,
+  respondForbidden,
+} from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
@@ -3803,7 +3809,7 @@ export function issueRoutes(
     const value = memoizeIssueReadDecision(req, key, () => decideIssueAccess(req, issue, "issue:read"));
     const decision = await value;
     if (decision.allowed) return true;
-    res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+    respondForbidden(res, "issue_read_denied", "Issue is outside this actor's authorization boundary");
     return false;
   }
 
@@ -3840,7 +3846,7 @@ export function issueRoutes(
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
-      res.status(403).json({ error: "Agent authentication required" });
+      respondForbidden(res, "agent_authentication_required", "Agent authentication required");
       return false;
     }
     const watchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
@@ -3931,7 +3937,7 @@ export function issueRoutes(
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
-      res.status(403).json({ error: "Agent authentication required" });
+      respondForbidden(res, "agent_authentication_required", "Agent authentication required");
       return false;
     }
     // Task-watchdog runs receive a scoped *grant* to mutate issues inside the
@@ -3980,16 +3986,18 @@ export function issueRoutes(
       // Past the run lock the issue is idle, so only channels that have not
       // adopted the default-open rule still refuse another agent's issue.
       if (!options.allowVisibleIssueWrite) {
-        res.status(403).json({
-          error: "Agent cannot mutate another agent's issue",
-          details: {
+        respondForbidden(
+          res,
+          "agent_cannot_mutate_other_agents_issue",
+          "Agent cannot mutate another agent's issue",
+          {
             issueId: issue.id,
             assigneeAgentId: issue.assigneeAgentId,
             actorAgentId,
             status: issue.status,
             securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
           },
-        });
+        );
         return false;
       }
       return true;
@@ -4716,12 +4724,14 @@ export function issueRoutes(
     const hasStructuredFields = input.presentation !== undefined || input.metadata !== undefined;
     if (!hasStructuredFields) return true;
     if (req.actor.type === "board") return true;
-    res.status(403).json({
-      error: "Only board users may set structured comment presentation or metadata",
-      details: {
+    respondForbidden(
+      res,
+      "structured_comment_fields_board_only",
+      "Only board users may set structured comment presentation or metadata",
+      {
         securityPrinciples: ["Least Privilege", "Secure Defaults", "Complete Mediation"],
       },
-    });
+    );
     return false;
   }
 
@@ -4827,7 +4837,7 @@ export function issueRoutes(
 
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
-      res.status(403).json({ error: "Agent authentication required" });
+      respondForbidden(res, "agent_authentication_required", "Agent authentication required");
       return false;
     }
     if (issue.assigneeAgentId === actorAgentId) return true;
@@ -4845,9 +4855,11 @@ export function issueRoutes(
       return true;
     }
 
-    res.status(403).json({
-      error: "Agent cannot resolve another owner's recovery action",
-      details: {
+    respondForbidden(
+      res,
+      "recovery_action_owner_mismatch",
+      "Agent cannot resolve another owner's recovery action",
+      {
         issueId: issue.id,
         recoveryActionId: activeRecoveryAction.id,
         actorAgentId,
@@ -4856,7 +4868,7 @@ export function issueRoutes(
         source: input.source,
         securityPrinciples: ["Least Privilege", "Complete Mediation", "Secure Defaults"],
       },
-    });
+    );
     return false;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Instances often run behind an edge proxy or tunnel, and agents call the HTTP API through that edge
> - When the API denies a request today, several authorization failures return a bodyless or prose-only 403, and some paths can content-negotiate into HTML
> - Behind an edge proxy such a 403 is indistinguishable from a WAF or proxy block, so operators misdiagnose app-level authorization denials as infrastructure problems and debug the wrong layer
> - This pull request gives authorization failures a stable machine-readable `code` and forces JSON on API denials
> - The thrown-`HttpError` layer gets default codes, the central error handler derives a code when the thrower did not set one, and the private-hostname guard answers `/api` requests with unconditional JSON
> - The benefit is that a client or operator can tell "the app said no, and here is why" apart from "something in front of the app ate the request"

## Linked Issues or Issue Description

- Fixes #11267
- Related PRs (client-side counterparts and adjacent status-code work, linked for context): #11020 and #11029 (blessed API client script that fails loudly on non-2xx), #3790 (return 409 for routine checkout conflicts)

## What Changed

- `server/src/errors.ts`: `unauthorized()` and `forbidden()` now default their details to `{ code: "unauthorized" }` / `{ code: "forbidden" }`. Explicit `details` still replace the default wholesale; no merge magic
- `server/src/middleware/error-handler.ts`: for 401/403 the handler surfaces `details.code` as a top-level `code`, derives `unauthorized`/`forbidden` when the thrower set none, and forces `application/json` so an edge proxy cannot re-skin the body
- `server/src/middleware/private-hostname-guard.ts`: denials on `/api` paths are now unconditionally JSON with `code: "private_hostname_forbidden"`, regardless of Accept headers. Non-API page requests keep the previous negotiated behavior
- `server/src/routes/authz.ts`: new `respondAuthzDenial(res, status, code, message, details?)` and `respondForbidden(...)` helpers for direct-response denial sites
- `server/src/routes/issues.ts`: the assert helpers that returned bare uncoded 401/403 bodies now respond through the helpers with stable codes: `issue_read_denied`, `agent_authentication_required`, `agent_cannot_mutate_other_agents_issue`, `structured_comment_fields_board_only`, `recovery_action_owner_mismatch`
- Tests: extended `error-handler`, `private-hostname-guard`, `issue-agent-mutation-ownership-routes`, and adjusted assertions in `company-skills-routes`, `costs-service`, and `issue-comment-reopen-routes`

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/error-handler.test.ts src/__tests__/private-hostname-guard.test.ts src/__tests__/company-skills-routes.test.ts src/__tests__/costs-service.test.ts src/__tests__/issue-comment-reopen-routes.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts` → 259 passed
- `pnpm --filter @paperclipai/server typecheck` → clean
- Manual check: `curl -H "Accept: text/html" https://<instance>/api/...` on a denied route returns `application/json` with `error` and `code` fields

## Risks

- Response bodies grow a `code` field on 401/403. Clients that `toEqual`-match exact error bodies will notice; clients that read `error` keep working. Two in-repo tests needed that adjustment and are updated in this PR
- Honest scope note: this PR converts the thrown-`HttpError` layer, the central error handler, the private-hostname guard, and the issue-route assert helpers. Master's issue-write denial copy system (`issueWriteDenialResponse`) already carries a stable `code` inside `details` at several issue-route sites; those sites are intentionally left untouched. Beyond that, about 119 direct `res.status(401|403).json(...)` sites across `server/src/routes/` still respond without a code (issues.ts ~67, agents.ts ~10, decisions.ts ~5, and a long tail). Converting them is mechanical follow-up work with the helpers from this PR; we kept this PR reviewable instead of touching every route
- Design note for maintainers: after this PR two code conventions coexist — top-level `code` (this PR, matching the error handler) and `details.code` (the existing issue-write denial copy). If you prefer one convention, we are happy to align in a follow-up

## Model Used

- Claude (Anthropic) — Claude Fable 5, model id claude-fable-5, via Claude Code with repository tools, shell and test execution enabled

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (the new codes are documented in the helpers' doc comments; no user-facing docs describe error bodies today)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge
