### PR TITLE
fix: trust successful Claude payloads over dirty exits

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1073,6 +1073,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const parsedIsError = asBoolean(parsed.is_error, false);
     const parsedSubtype = asString(parsed.subtype, "").trim().toLowerCase();
     const parsedSucceeded = parsedSubtype === "success" && !parsedIsError;
+    const dirtySuccessfulExit = parsedSucceeded && (proc.exitCode ?? 0) !== 0;
     const failed = !parsedSucceeded && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
@@ -1169,6 +1170,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       ...(providerQuota && transientRetryNotBefore ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
+      ...(dirtySuccessfulExit ? { dirtyExit: true, dirtyExitCode: proc.exitCode } : {}),
       ...(proc.terminalResultCleanup ? { unmanagedBackgroundTask: proc.terminalResultCleanup } : {}),
     };
 

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -1467,6 +1467,123 @@ describe("claude execute", () => {
       expect(result.errorMessage).toBeNull();
       expect(result.errorCode).toBeNull();
       expect(result.summary).toBe("Implemented the requested change.");
+      expect(result.resultJson).toMatchObject({
+        subtype: "success",
+        is_error: false,
+        dirtyExit: true,
+        dirtyExitCode: 1,
+      });
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps error_during_execution results as failures when the process exits nonzero", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-error-result-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(commandPath, {
+      exitCode: 1,
+      resultEvent: {
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        is_error: true,
+        result: "Tool execution failed.",
+        usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      },
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-error-result",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorMessage).toContain("Tool execution failed.");
+      expect(result.errorCode).toBeNull();
+      expect(result.errorFamily).toBeNull();
+      expect(result.resultJson?.dirtyExit).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps no-result transient upstream failures classified as transient", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-no-result-transient-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeTextFailingClaudeCommand(commandPath, {
+      stderr: "API Error: 529 overloaded_error\n",
+      exitCode: 1,
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-no-result-transient",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorMessage).toContain("overloaded_error");
+      expect(result.errorCode).toBe("claude_transient_upstream");
+      expect(result.errorFamily).toBe("transient_upstream");
+      expect(result.resultJson?.dirtyExit).toBeUndefined();
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/services/adapter-run-outcome.test.ts
+++ b/server/src/services/adapter-run-outcome.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { adapterResultCompletedSuccessfully } from "./adapter-run-outcome.js";
+
+describe("adapterResultCompletedSuccessfully", () => {
+  it("treats explicit dirty successful exits as completed while keeping the exit code visible", () => {
+    expect(
+      adapterResultCompletedSuccessfully({
+        exitCode: 1,
+        errorMessage: null,
+        timedOut: false,
+        resultJson: { dirtyExit: true, dirtyExitCode: 1 },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not accept a dirty-exit marker whose code does not match the raw exit code", () => {
+    expect(
+      adapterResultCompletedSuccessfully({
+        exitCode: 2,
+        errorMessage: null,
+        timedOut: false,
+        resultJson: { dirtyExit: true, dirtyExitCode: 1 },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps ordinary nonzero exits and timed-out results as incomplete", () => {
+    expect(
+      adapterResultCompletedSuccessfully({
+        exitCode: 1,
+        errorMessage: null,
+        timedOut: false,
+        resultJson: null,
+      }),
+    ).toBe(false);
+    expect(
+      adapterResultCompletedSuccessfully({
+        exitCode: 0,
+        errorMessage: null,
+        timedOut: true,
+        resultJson: { dirtyExit: true, dirtyExitCode: 0 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/adapter-run-outcome.ts
+++ b/server/src/services/adapter-run-outcome.ts
@@ -1,0 +1,19 @@
+export function adapterResultCompletedSuccessfully(input: {
+  timedOut?: boolean | null;
+  exitCode?: number | null;
+  errorMessage?: string | null;
+  resultJson?: Record<string, unknown> | null;
+}) {
+  if (input.timedOut || input.errorMessage) return false;
+  if ((input.exitCode ?? 0) === 0) return true;
+
+  const resultJson =
+    typeof input.resultJson === "object" && input.resultJson !== null && !Array.isArray(input.resultJson)
+      ? input.resultJson
+      : {};
+  const dirtyExitCode =
+    typeof resultJson.dirtyExitCode === "number" && Number.isFinite(resultJson.dirtyExitCode)
+      ? resultJson.dirtyExitCode
+      : Number.NaN;
+  return resultJson.dirtyExit === true && dirtyExitCode === input.exitCode;
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -80,6 +80,7 @@ import {
 // git-credentials module became its canonical home; existing importers keep working.
 export { scrubGitCredentialText };
 import { publishLiveEvent } from "./live-events.js";
+import { adapterResultCompletedSuccessfully } from "./adapter-run-outcome.js";
 import { normalizeResponsibleUserDenialCode } from "./responsible-user-denial-run-outcomes.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, listAdapterModelProfiles, runningProcesses } from "../adapters/index.js";
@@ -15740,7 +15741,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         outcome = latestRun.status;
       } else if (adapterResult.timedOut) {
         outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
+      } else if (adapterResultCompletedSuccessfully(adapterResult)) {
         outcome = "succeeded";
       } else {
         outcome = "failed";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat runs depend on adapter results to decide whether agent work succeeded, failed, timed out, or should retry.
> - The Claude local adapter can receive a terminal `subtype: "success"` result payload even when the CLI process exits nonzero.
> - The final server outcome path needs a durable marker for that dirty success so it does not treat the raw exit code as a failed run.
> - This pull request makes a successful Claude result payload win over a dirty process exit while preserving the raw exit code in `resultJson`.
> - The benefit is that successful work stops poisoning run outcomes, watchdog decisions, retries, and scorecards while dirty exits remain debuggable.

## Linked Issues or Issue Description

Related public PRs found during duplicate search: Refs #9548, Refs #10592, Refs #8573, Refs #4335. #9548 is broader and changes the adapter result contract. This PR keeps the fix narrow by adding an explicit dirty-success marker and a server-side outcome helper.

**What happened?**
Claude local runs that emitted a structured successful terminal payload could still exit with a nonzero process code. The adapter preserved the raw exit code, and the heartbeat server could classify the run as failed even though the payload said the work completed.

**Expected behavior**
When the parsed result has `subtype: "success"` and `is_error !== true`, the run should be recorded as successful work. The nonzero process exit should stay visible as debug metadata, not become a failed run or a transient upstream/auth error.

**Steps to reproduce**
1. Run a Claude local execution that writes a final `type: "result"`, `subtype: "success"`, `is_error: false` payload.
2. Make the Claude process exit with code `1` after that payload.
3. Observe that the adapter result carries the success payload and nonzero exit code.
4. Without this patch, heartbeat can treat the nonzero exit as a failure.

**Paperclip version or commit**
The PR is based on `paperclipai/paperclip` `master` at `67001ec6eb96ae601aa27bc91d9b2415d665334a`.

**Deployment mode**
Local or self-hosted Paperclip deployments that run agents through the `claude_local` adapter.

## What Changed

- Updated `claude_local` result classification to persist `dirtyExit: true` and `dirtyExitCode` when `subtype: "success"` with `is_error !== true` arrives with a nonzero process exit.
- Added a server-side adapter outcome helper so heartbeat finalization treats only that explicit dirty-success marker as completed work.
- Added regression coverage for dirty success, dirty-marker mismatch, ordinary nonzero exits, timed-out results, `error_during_execution`, and no-result transient upstream failures.

## Verification

- Provenance: fetched `paperclipai/paperclip` `master` at `67001ec6eb96ae601aa27bc91d9b2415d665334a`; commit `4d81b3e026cae0dccfc1e62bc5c16f91b25bfecd` contains that fetched head as its parent.
- `git diff --check`
- `node_modules/.bin/vitest run server/src/__tests__/claude-local-execute.test.ts server/src/services/adapter-run-outcome.test.ts` — 2 files passed, 29 tests passed.
- Attempted to refresh dependencies with `pnpm install --frozen-lockfile` after rebasing onto upstream; the local host killed the install with exit 137/SIGKILL and left dependency links incomplete. The focused Vitest suite was run after local link repair. Full typecheck/build should be taken from CI on the clean upstream-based PR branch.

## Risks

- Low-to-medium behavioral risk: only Claude results explicitly marked successful by payload can bypass a nonzero exit-code failure.
- Heartbeat requires `dirtyExit: true` and a matching `dirtyExitCode`, so ordinary nonzero exits, timed-out results, and parsed error payloads remain failures.
- CI should confirm broader server typecheck/build health because the local dependency install was killed by the host.

## Model Used

- OpenAI GPT-5 via Codex local agent, tool-assisted coding and shell execution. Exact runtime model sub-version/context window was not exposed by the environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI changes)
- [x] I have updated relevant documentation to reflect my changes (N/A: behavior is covered by regression tests; no user-facing docs)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
