### PR TITLE
fix(docker): build required workspace packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,26 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
+RUN pnpm --filter @paperclipai/shared build
+RUN pnpm --filter @paperclipai/db build
+RUN pnpm --filter @paperclipai/adapter-utils build
+RUN pnpm --filter "@paperclipai/adapter-*" build
+RUN pnpm --filter @paperclipai/hermes-paperclip-adapter build
+RUN pnpm --filter @paperclipai/mcp-server build \
+  && pnpm --filter @paperclipai/google-sheets-mcp-server build \
+  && pnpm --filter @paperclipai/kv-demo-mcp-server build
+RUN pnpm --filter @paperclipai/skills-catalog build \
+  && pnpm --filter @paperclipai/teams-catalog build
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/plugin-sdk build
+RUN pnpm --filter paperclipai build
 RUN pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
+RUN test -f packages/adapter-utils/dist/index.js \
+  && test -f packages/mcp-server/dist/stdio.js \
+  && test -f packages/google-sheets-mcp-server/dist/stdio.js \
+  && test -f packages/kv-demo-mcp-server/dist/main.js \
+  || (echo "ERROR: required package build output missing" && exit 1)
 
 FROM base AS production
 ARG USER_UID=1000


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The production container includes the server, UI, CLI, adapters, catalogs, and MCP server packages.
> - The Docker dependency stage installed these packages, but the build stage compiled only the UI, plugin SDK, and server.
> - This left package source in the image without guaranteed `dist` output.
> - This pull request builds each required runtime workspace package before it creates the production image.
> - It also fails the image build when key adapter utility or MCP outputs are missing.
> - The benefit is a reproducible production image with complete runtime artifacts.

## Linked Issues or Issue Description

**Describe the bug**

A local `docker compose up -d --build` image can include workspace package source without compiled output for adapter utilities, MCP servers, adapters, catalogs, and the CLI.

**To Reproduce**

Build the production target from a clean Docker cache. Inspect the expected `dist` files under the affected workspace packages.

**Expected behavior**

The production image contains compiled output for every required runtime workspace package. The image build stops if key outputs are absent.

**Additional context**

The package manifests were already copied into the dependency stage. The missing part was an explicit and reproducible build sequence.

## What Changed

- Build shared and database packages before their consumers.
- Build adapter utilities and all supported adapter packages.
- Build the Paperclip MCP server and the optional Google Sheets and KV demo MCP servers. This does not start them.
- Build the skills catalog, teams catalog, and CLI.
- Verify key adapter utility and MCP output files during the image build.

## Verification

- Ran `docker compose up -d --build` successfully.
- Verified `/api/health` returns `status: ok`.
- Verified `packages/adapter-utils/dist/index.js` exists in the container.
- Verified all three MCP server entry points exist in the container.
- Verified each tracked adapter package has a `dist` directory in the container.

## Risks

- The image build takes longer because it compiles more workspace packages.
- The MCP server packages remain inactive unless a user configures and starts them.
- There is no database or API behavior change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, exact model ID `gpt-5.6-sol`, with reasoning, tool use, code execution, and repository access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
