### PR TITLE
fix(openclaw-gateway): send agent timeout in seconds, not milliseconds

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -72,7 +72,7 @@ describe("buildAgentParams", () => {
       sessionKey: "agent:meridian:paperclip:issue:issue-456",
       idempotencyKey: "run-123",
       agentId: "meridian",
-      timeout: 30_000,
+      timeout: 30, // seconds — OpenClaw multiplies this by 1000
     });
   });
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -491,8 +491,13 @@ export function buildAgentParams(input: {
     agentParams.agentId = input.configuredAgentId;
   }
 
+  // OpenClaw reads agent.timeout as SECONDS (resolveAgentTimeoutMs -> overrideSeconds * 1000).
+  // Sending milliseconds turned a 300s deadline into 83 hours: Paperclip gave up after five
+  // minutes while the run kept going inside OpenClaw, holding the agent's session key. The next
+  // timer wake then collided with that zombie and timed out too — 655 of 655 timer runs failed
+  // this way before 2026-08-12.
   if (typeof agentParams.timeout !== "number") {
-    agentParams.timeout = input.waitTimeoutMs;
+    agentParams.timeout = Math.ceil(input.waitTimeoutMs / 1000);
   }
 
   return agentParams;


### PR DESCRIPTION
## The bug

`buildAgentParams` passes `waitTimeoutMs` straight into `agent.timeout`:

```ts
if (typeof agentParams.timeout !== "number") {
  agentParams.timeout = input.waitTimeoutMs;
}
```

OpenClaw resolves that field through `resolveAgentTimeoutMs`, which treats it as **seconds**:

```js
const overrideSeconds = normalizeNumber(opts.overrideSeconds);
if (overrideSeconds !== void 0) {
  ...
  return clampTimeoutMs(overrideSeconds * 1e3);
}
```

So a 300s deadline is sent as `300000` and read as 300000 seconds — about 83 hours.

## Why it matters

Paperclip abandons the run when its own `agent.wait` deadline passes, but the run keeps executing inside OpenClaw, holding the agent's session key. With `sessionKeyStrategy=issue`, timer wakes have no issue id and fall back to the agent's fixed session key — so the next scheduled heartbeat collides with the still-running zombie and times out in turn, spawning another.

On the instance where this was found, every scheduled heartbeat failed this way: **655 timer runs, 655 `timed_out`, zero successes**, across ten agents and four months. Event-driven runs (assignment/automation) succeeded occasionally because they use issue-scoped session keys.

Observed in the run logs, before and after the fix:

```
before:  "timeout":600000     # read as 600000 seconds
after:   "timeout":2100       # matches the agent's configured timeoutSec
```

After the change, heartbeat runs on the same instance complete in 20-60s with exit code 0.

## Changes

- `buildAgentParams` converts to seconds via `Math.ceil(waitTimeoutMs / 1000)`. An explicit `timeout` in `payloadTemplate` is still passed through untouched.
- Updated the assertion in `execute.test.ts` that pinned the old behaviour.