### PR TITLE
fix(ui): complete searchable task assignee workflow

### DIFF
--- a/ui/src/components/task-chat/TaskChatComposer.test.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.test.tsx
@@ -633,6 +633,40 @@ describe("TaskChatComposer", () => {
     );
   });
 
+  it("can clear the current assignee from the searchable combobox", async () => {
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TaskChatComposer
+        onAdd={onAdd}
+        workMode="standard"
+        enableReassign
+        reassignOptions={[{ id: "user:u1", label: "Sam" }]}
+        currentAssigneeValue="user:u1"
+      />,
+    );
+
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="task-chat-composer-assignee"]');
+    flushSync(() => trigger?.click());
+    await flushAsync();
+
+    const noAssigneeOption = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
+    ).find((button) => button !== trigger && button.textContent?.includes("No assignee"));
+    expect(noAssigneeOption).not.toBeUndefined();
+
+    flushSync(() => noAssigneeOption?.click());
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    typeText("Please unassign this.");
+    pressKey("Enter", { metaKey: true });
+    await flushAsync();
+
+    expect(onAdd).toHaveBeenCalledWith(
+      "Please unassign this.",
+      undefined,
+      { assigneeAgentId: null, assigneeUserId: null },
+    );
+  });
+
   describe("draft persistence", () => {
     const draftKey = "task-chat-draft:issue-1";
 

--- a/ui/src/components/task-chat/TaskChatComposer.test.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.test.tsx
@@ -599,6 +599,8 @@ describe("TaskChatComposer", () => {
     );
     const trigger = container.querySelector<HTMLButtonElement>('[data-testid="task-chat-composer-assignee"]');
     expect(trigger?.textContent).toContain("Sam");
+    expect(trigger?.className).toContain("min-w-0");
+    expect(trigger?.className).not.toContain("shrink-0");
 
     flushSync(() => trigger?.click());
     await flushAsync();
@@ -617,7 +619,9 @@ describe("TaskChatComposer", () => {
     expect(samOption).toBeUndefined();
 
     flushSync(() => clippyOption?.click());
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     expect(trigger?.textContent).toContain("Clippy");
+    expect(document.activeElement).toBe(editable());
 
     typeText("Please take this.");
     pressKey("Enter", { metaKey: true });

--- a/ui/src/components/task-chat/TaskChatComposer.test.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.test.tsx
@@ -580,24 +580,53 @@ describe("TaskChatComposer", () => {
     expect(editable().textContent).toBe(`[/deploy](${SLASH_HREF}) `);
   });
 
-  it("shows the assignee combobox only when reassign is enabled, with the current label", () => {
+  it("shows a searchable assignee combobox and selects a filtered assignee", async () => {
+    const onAdd = vi.fn().mockResolvedValue(undefined);
     render(<TaskChatComposer onAdd={vi.fn()} workMode="standard" />);
     expect(container.querySelector('[data-testid="task-chat-composer-assignee"]')).toBeNull();
 
     render(
       <TaskChatComposer
-        onAdd={vi.fn()}
+        onAdd={onAdd}
         workMode="standard"
         enableReassign
         reassignOptions={[
-          { id: "agent:a1", label: "Clippy" },
-          { id: "user:u1", label: "Sam" },
+          { id: "agent:a1", label: "Clippy", searchText: "engineering" },
+          { id: "user:u1", label: "Sam", searchText: "board" },
         ]}
         currentAssigneeValue="user:u1"
       />,
     );
-    const trigger = container.querySelector('[data-testid="task-chat-composer-assignee"]');
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="task-chat-composer-assignee"]');
     expect(trigger?.textContent).toContain("Sam");
+
+    flushSync(() => trigger?.click());
+    await flushAsync();
+
+    const searchInput = document.body.querySelector<HTMLInputElement>('input[placeholder="Search assignees…"]');
+    expect(searchInput).not.toBeNull();
+    flushSync(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(searchInput, "engineering");
+      searchInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const optionButtons = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button[type="button"]'));
+    const clippyOption = optionButtons.find((button) => button.textContent?.includes("Clippy"));
+    const samOption = optionButtons.find((button) => button.textContent?.includes("Sam") && button !== trigger);
+    expect(clippyOption).not.toBeUndefined();
+    expect(samOption).toBeUndefined();
+
+    flushSync(() => clippyOption?.click());
+    expect(trigger?.textContent).toContain("Clippy");
+
+    typeText("Please take this.");
+    pressKey("Enter", { metaKey: true });
+    await flushAsync();
+    expect(onAdd).toHaveBeenCalledWith(
+      "Please take this.",
+      undefined,
+      { assigneeAgentId: "a1", assigneeUserId: null },
+    );
   });
 
   describe("draft persistence", () => {

--- a/ui/src/components/task-chat/TaskChatComposer.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.tsx
@@ -534,6 +534,7 @@ export function TaskChatComposer({
             searchPlaceholder="Search assignees…"
             emptyMessage="No matches."
             onChange={setPendingAssignee}
+            onConfirm={() => editorRef.current?.focus()}
             disabled={disabled}
             triggerTestId="task-chat-composer-assignee"
             className="h-8 gap-1.5 bg-transparent px-2.5 text-xs hover:bg-accent"

--- a/ui/src/components/task-chat/TaskChatComposer.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.tsx
@@ -107,6 +107,9 @@ function shouldImplicitlyReopenComment(issueStatus: string | undefined, assignee
 }
 
 function parseAssigneeValue(value: string): CommentReassignment | undefined {
+  if (!value) {
+    return { assigneeAgentId: null, assigneeUserId: null };
+  }
   if (value.startsWith("agent:")) {
     const id = value.slice("agent:".length);
     return id ? { assigneeAgentId: id, assigneeUserId: null } : undefined;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The task composer lets an operator send work and change the assignee in one action.
> - The assignee control must support fast search when a company has many agents.
> - The searchable control must also preserve the clear-assignee and keyboard-focus behavior.
> - The current flow can omit the clear-assignee change and leave focus outside the editor.
> - This pull request completes the searchable task-assignee workflow and adds focused regression tests.
> - The benefit is a faster and more reliable task assignment flow.

## Linked Issues or Issue Description

Related: #11263

**What happened?**

The chat-style task composer has a searchable assignee control. Selecting "No assignee" does not produce an explicit clear-assignee update. Selecting an assignee also leaves keyboard focus outside the message editor.

**Expected behavior**

The control filters assignees by label and search text. It sends an explicit clear-assignee update for "No assignee." It returns focus to the message editor after a selection.

**Steps to reproduce**

1. Open a task that uses the chat-style task composer.
2. Open the assignee control and search for an assignee.
3. Select an assignee or select "No assignee."
4. Continue typing and submit the message.

**Paperclip version or commit**

`0ee0543e5b`

**Deployment mode**

Local development from `master`. The behavior is in the shared UI and is not deployment-specific.

## What Changed

- Parse the empty assignee value as an explicit request to clear both assignee fields.
- Return focus to the message editor after the operator confirms an assignee selection.
- Test search-text filtering, agent reassignment, focus restoration, and clearing the current assignee.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/components/task-chat/TaskChatComposer.test.tsx` (28 tests pass).
- `pnpm --filter @paperclipai/ui typecheck` passes.
- `pnpm check:token-gates` reports all three gates clean.

## Risks

- Low risk. The change is limited to pending assignee parsing, focus restoration, and focused tests.
- The clear-assignee path now sends explicit `null` values instead of omitting the reassignment payload.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The exact service revision and context-window size are not exposed. The model used reasoning, repository tools, code execution, and GitHub tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
