### PR TITLE
fix(adapter-utils): redact env dumps and DSN passwords in transcripts

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -59,6 +59,7 @@ export {
   redactHomePathUserSegments,
   redactHomePathUserSegmentsInValue,
   redactTranscriptEntryPaths,
+  redactSecretsInText,
 } from "./log-redaction.js";
 export {
   REDACTED_COMMAND_TEXT_VALUE,

--- a/packages/adapter-utils/src/log-redaction.test.ts
+++ b/packages/adapter-utils/src/log-redaction.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { redactSecretsInText, redactTranscriptEntryPaths } from "./log-redaction.js";
+
+describe("redactSecretsInText", () => {
+  it("redacts a bare DATABASE_URL env-dump password", () => {
+    const sample =
+      "DATABASE_URL=postgres://paperclip:s3cr3tExamplePasswordValue32c@paperclip.example.rds.amazonaws.com:5432/paperclip?sslmode=require";
+    const out = redactSecretsInText(sample);
+    expect(out).not.toContain("s3cr3tExamplePasswordValue32c");
+    expect(out).toMatch(/_REDACTED>/);
+  });
+
+  it("redacts an inline connection-string password with no env-name anchor", () => {
+    const sample = "connect via postgresql://svc:MyInlinePass99word@db.internal:5432/app";
+    const out = redactSecretsInText(sample);
+    expect(out).not.toContain("MyInlinePass99word");
+    expect(out).toContain("<DB_PASSWORD_REDACTED>");
+    expect(out).toContain("db.internal");
+    expect(out).toContain("svc:");
+  });
+
+  it("redacts NAME=value env dumps for the sensitive family", () => {
+    const cases: Array<[string, string]> = [
+      ["K3_API_KEY", "sk-k3-AbCdEf0123456789xyz"],
+      ["OWM_API_KEY", "3f0011223344556677889900aabbccdd"],
+      ["PJM_API_KEY", "9e00112233445566778899aabbccdd0a"],
+      ["UKPN_API_KEY", "3d00112233445566778899aabbccdd79"],
+      ["URDB_API_KEY", "aBcDeF0123456789aBcDeF0123456789xyzw"],
+      ["NORDPOOL_USERNAME", "APICLIENT_EXAMPLE_ID"],
+      ["PAPERCLIP_API_KEY", "pc_example_0123456789abcdef0123"],
+      ["ENTSOE_API_KEY", "abcd1234-ef56-7890-abcd-ef1234567890"],
+      ["GRIDSTATUS_API_KEY", "421518443c3b4e13a544872d91c59f0a"],
+    ];
+    for (const [name, val] of cases) {
+      const sample = `PWD=/x\n${name}=${val}\nHOME=/y`;
+      const out = redactSecretsInText(sample);
+      expect(out, name).not.toContain(val);
+      expect(out, name).toContain("_REDACTED>");
+    }
+  });
+
+  it("redacts JSON and NDJSON-escaped env-dump forms", () => {
+    const json = '{"K3_API_KEY": "sk-k3-AbCdEf0123456789xyz"}';
+    expect(redactSecretsInText(json)).not.toContain("sk-k3-AbCdEf0123456789xyz");
+    const escaped = '\\"PJM_API_KEY\\": \\"9e00112233445566778899aabbccdd0a\\"';
+    expect(redactSecretsInText(escaped)).not.toContain("9e00112233445566778899aabbccdd0a");
+  });
+
+  it("redacts Anthropic and GitHub App token prefixes without a name anchor", () => {
+    const anthropic = "token=sk-ant-api03-AbCdEf0123456789_-ghIJKlmnop";
+    expect(redactSecretsInText(anthropic)).not.toContain("sk-ant-api03-AbCdEf");
+    const ghs = "hdr=ghs_AbCdEf0123456789AbCdEf0123456789ABCD";
+    expect(redactSecretsInText(ghs)).not.toContain("ghs_AbCdEf0123456789");
+  });
+
+  it("does not redact key names mentioned in prose", () => {
+    const sample = "We rotated PJM_API_KEY and DATABASE_URL after the leak.";
+    expect(redactSecretsInText(sample)).toBe(sample);
+  });
+
+  it("is idempotent", () => {
+    const sample =
+      "ANTHROPIC_API_KEY=sk-ant-api03-AbCdEf0123456789_-ghIJKlmnop\nPJM_API_KEY=9e00112233445566778899aabbccdd0a";
+    const once = redactSecretsInText(sample);
+    expect(redactSecretsInText(once)).toBe(once);
+  });
+});
+
+describe("redactTranscriptEntryPaths", () => {
+  it("redacts DATABASE_URL in stdout and tool_result before persist", () => {
+    const leak =
+      "DATABASE_URL=postgres://paperclip:s3cr3tExamplePasswordValue32c@host.example:5432/db";
+    const stdout = redactTranscriptEntryPaths({ kind: "stdout", ts: "t", text: leak });
+    if (stdout.kind !== "stdout") throw new Error("expected stdout");
+    expect(stdout.text).not.toContain("s3cr3tExamplePasswordValue32c");
+
+    const tool = redactTranscriptEntryPaths({
+      kind: "tool_result",
+      ts: "t",
+      toolUseId: "1",
+      content: leak,
+      isError: false,
+    });
+    if (tool.kind !== "tool_result") throw new Error("expected tool_result");
+    expect(tool.content).not.toContain("s3cr3tExamplePasswordValue32c");
+  });
+
+  it("redacts env dumps inside tool_call input strings", () => {
+    const entry = redactTranscriptEntryPaths({
+      kind: "tool_call",
+      ts: "t",
+      name: "bash",
+      input: { command: "echo PAPERCLIP_API_KEY=pc_example_0123456789abcdef0123" },
+    });
+    if (entry.kind !== "tool_call") throw new Error("expected tool_call");
+    expect(JSON.stringify(entry.input)).not.toContain("pc_example_0123456789abcdef0123");
+  });
+});

--- a/packages/adapter-utils/src/log-redaction.ts
+++ b/packages/adapter-utils/src/log-redaction.ts
@@ -27,6 +27,83 @@ const HOME_PATH_PATTERNS = [
   },
 ] as const;
 
+// Runtime counterpart to the S3-sink redactor in report_run.py.
+// Applied to child-process stdout/stderr and tool_result *before* those
+// bytes are persisted into transcripts. Catches `env | grep`, `printenv`,
+// and library errors that quote a DSN as cleartext `NAME=...` lines.
+const CONN_STRING_PASSWORD_RE =
+  /(postgres(?:ql)?|mysql|mysql2|mongodb(?:\+srv)?|redis|rediss|amqp|amqps):\/\/([^:@\s/\\"]+):([^@\s/\\"]+)@/gi;
+
+// Keep in lockstep with report_run.py `_ENV_DUMP_SECRET_NAMES` plus the
+// dedicated ENTSOE / GRIDSTATUS name-anchored patterns in that file.
+const ENV_DUMP_SECRET_NAMES = [
+  "ANTHROPIC_API_KEY",
+  "PAPERCLIP_API_KEY",
+  "STANDARD_POWER_API_KEY",
+  "GITHUB_TOKEN",
+  "K3_API_KEY",
+  "OWM_API_KEY",
+  "PJM_API_KEY",
+  "UKPN_API_KEY",
+  "URDB_API_KEY",
+  "NORDPOOL_USERNAME",
+  "NORDPOOL_PASSWORD",
+  "DATABASE_URL",
+  "ENTSOE_API_KEY",
+  "GRIDSTATUS_API_KEY",
+] as const;
+
+// Tokens + connection strings. The NAME anchor is what prevents false positives.
+const ENV_DUMP_VALUE_CHARSET = String.raw`[A-Za-z0-9/+=._\-:@?&%~]{4,}`;
+
+// Matches `NAME=value`, `NAME: value`, JSON `"NAME":"value"`, and the
+// NDJSON-escaped `\"NAME\": \"value\"` form. Optional backslash + quote
+// wrappers must be `\\?` (optional `\`), not `\?` (optional `?`) — the
+// latter never matches a bare `NAME=...` env dump.
+const ENV_DUMP_PATTERNS: Array<{ re: RegExp; name: string }> = ENV_DUMP_SECRET_NAMES.map(
+  (name) => ({
+    name,
+    re: new RegExp(
+      name + String.raw`\\?["']?\s*[=:]\s*\\?["']?` + ENV_DUMP_VALUE_CHARSET + String.raw`\\?["']?`,
+      "gi",
+    ),
+  }),
+);
+
+const ANTHROPIC_KEY_RE = /sk-ant-[A-Za-z0-9._-]{20,}/g;
+const GITHUB_APP_TOKEN_RE = /ghs_[A-Za-z0-9]{20,}/g;
+
+function redactSecrets(text: string): string {
+  if (!text) return text;
+  let out = text;
+  out = out.replace(CONN_STRING_PASSWORD_RE, (_m, scheme: string, user: string) =>
+    `${scheme}://${user}:<DB_PASSWORD_REDACTED>@`,
+  );
+  out = out.replace(ANTHROPIC_KEY_RE, "<ANTHROPIC_API_KEY_REDACTED>");
+  out = out.replace(GITHUB_APP_TOKEN_RE, "<GITHUB_APP_TOKEN_REDACTED>");
+  for (const { re, name } of ENV_DUMP_PATTERNS) {
+    out = out.replace(re, `${name}=<${name}_REDACTED>`);
+  }
+  return out;
+}
+
+function redactSecretsInValue<T>(value: T): T {
+  if (typeof value === "string") {
+    return redactSecrets(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSecretsInValue(entry)) as T;
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    redacted[key] = redactSecretsInValue(entry);
+  }
+  return redacted as T;
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   const proto = Object.getPrototypeOf(value);
@@ -60,7 +137,14 @@ export function redactHomePathUserSegmentsInValue<T>(value: T, opts?: HomePathRe
   return redacted as T;
 }
 
+/** Redact env dumps and connection-string passwords from free text. */
+export function redactSecretsInText(text: string): string {
+  return redactSecrets(text);
+}
+
 export function redactTranscriptEntryPaths(entry: TranscriptEntry, opts?: HomePathRedactionOptions): TranscriptEntry {
+  const redactText = (s: string) => redactSecrets(redactHomePathUserSegments(s, opts));
+
   switch (entry.kind) {
     case "assistant":
     case "thinking":
@@ -69,15 +153,15 @@ export function redactTranscriptEntryPaths(entry: TranscriptEntry, opts?: HomePa
     case "system":
     case "stdout":
     case "diff":
-      return { ...entry, text: redactHomePathUserSegments(entry.text, opts) };
+      return { ...entry, text: redactText(entry.text) };
     case "tool_call":
       return {
         ...entry,
         name: redactHomePathUserSegments(entry.name, opts),
-        input: redactHomePathUserSegmentsInValue(entry.input, opts),
+        input: redactSecretsInValue(redactHomePathUserSegmentsInValue(entry.input, opts)),
       };
     case "tool_result":
-      return { ...entry, content: redactHomePathUserSegments(entry.content, opts) };
+      return { ...entry, content: redactText(entry.content) };
     case "init":
       return {
         ...entry,
@@ -87,9 +171,9 @@ export function redactTranscriptEntryPaths(entry: TranscriptEntry, opts?: HomePa
     case "result":
       return {
         ...entry,
-        text: redactHomePathUserSegments(entry.text, opts),
+        text: redactText(entry.text),
         subtype: redactHomePathUserSegments(entry.subtype, opts),
-        errors: entry.errors.map((error) => redactHomePathUserSegments(error, opts)),
+        errors: entry.errors.map((error) => redactText(error)),
       };
     default:
       return entry;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Adapter runtimes persist child-process stdout, stderr, and tool results into run transcripts
> - Those transcripts currently apply home-path redaction but not shape-based secret redaction
> - A common diagnostic (`env`, `printenv`, `env | grep`, or a library error quoting a DSN) therefore writes cleartext `NAME=value` lines and connection-string passwords into persisted transcripts
> - This pull request applies NAME-anchored env-dump and DSN-password redaction at capture time, before those bytes become a transcript entry
> - The benefit is that leaked credentials never enter the persisted run log, instead of relying on a later sink-side scrub

## Linked Issues or Issue Description

No public GitHub issue. Bug:

- **What happened:** Agent child-process output containing `DATABASE_URL=postgres://user:password@host/...` and other `NAME=value` env dumps was persisted into run transcripts.
- **Expected:** Capture-time redaction should strip connection-string passwords and known secret env dumps before transcript persist.
- **Steps to reproduce:** Run a local adapter heartbeat that executes `env | grep DATABASE_URL` (or any command that prints a DSN). Inspect the resulting stdout / tool_result transcript entry.
- **Version:** current `master` (`packages/adapter-utils/src/log-redaction.ts` home-path-only path).
- **Deployment mode:** any adapter that persists transcripts through `redactTranscriptEntryPaths`.

Related open PRs (adjacent, not this capture path): #7724, #6373, #8841.

## What Changed

- Added connection-string password redaction (`scheme://user:PASS@host` → `<DB_PASSWORD_REDACTED>`).
- Added NAME-anchored env-dump redaction for the sensitive env family, including `DATABASE_URL`, `PAPERCLIP_API_KEY`, Anthropic/GitHub token prefixes, and ENTSOE/GRIDSTATUS keys.
- Applied the redactor to stdout/stderr/tool_result text, result errors, and tool_call input strings.
- Exported `redactSecretsInText` and added unit tests for bare env dumps, JSON/NDJSON forms, inline DSNs, prose non-matches, and transcript entry paths.

## Verification

```sh
pnpm exec vitest run packages/adapter-utils/src/log-redaction.test.ts
```

9/9 tests passed locally.

## Risks

- Over-redaction of prose that includes a secret name followed by `=`/`:` and a 4+ character value. Names are UPPER_SNAKE and specific enough that this should be rare.
- Downstream adapters only pick this up after the next adapter-utils release / platform deploy.

## Model Used

- Provider: xAI
- Model: Grok 4.5
- Tool use and code execution enabled
- No extended-thinking mode

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge