### PR TITLE
fix: preserve watchdog subtree descendants

### DIFF
--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -446,6 +446,33 @@ describe.sequential("issue goal context routes", () => {
     expect(res.body.attachments).toEqual([]);
   });
 
+  it("surfaces non-watchdog child and descendant relationships in heartbeat context", async () => {
+    mockDb.execute.mockResolvedValueOnce([
+      { ...legacyProjectLinkedIssue, originKind: null, createdAt: new Date("2026-03-24T11:00:00Z") },
+      {
+        id: "child-1", companyId: "company-1", identifier: "PAP-582", title: "Blocked child",
+        status: "blocked", parentId: legacyProjectLinkedIssue.id, assigneeAgentId: null, assigneeUserId: null,
+        originKind: null, updatedAt: new Date("2026-03-24T12:01:00Z"), createdAt: new Date("2026-03-24T11:01:00Z"),
+      },
+      {
+        id: "grandchild-1", companyId: "company-1", identifier: "PAP-583", title: "Review grandchild",
+        status: "in_review", parentId: "child-1", assigneeAgentId: null, assigneeUserId: null,
+        originKind: null, updatedAt: new Date("2026-03-24T12:02:00Z"), createdAt: new Date("2026-03-24T11:02:00Z"),
+      },
+    ]);
+
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.children).toEqual([expect.objectContaining({ id: "child-1", parentId: legacyProjectLinkedIssue.id })]);
+    expect(res.body.descendants).toEqual([
+      expect.objectContaining({ id: "child-1", status: "blocked" }),
+      expect.objectContaining({ id: "grandchild-1", parentId: "child-1", status: "in_review" }),
+    ]);
+  });
+
   it("preserves direct continuation summary lookup in GET /issues/:id/heartbeat-context", async () => {
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue({
       key: "continuation-summary",

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -451,12 +451,14 @@ describe.sequential("issue goal context routes", () => {
       { ...legacyProjectLinkedIssue, originKind: null, createdAt: new Date("2026-03-24T11:00:00Z") },
       {
         id: "child-1", companyId: "company-1", identifier: "PAP-582", title: "Blocked child",
-        status: "blocked", parentId: legacyProjectLinkedIssue.id, assigneeAgentId: null, assigneeUserId: null,
+        status: "blocked", projectId: legacyProjectLinkedIssue.projectId, parentId: legacyProjectLinkedIssue.id,
+        assigneeAgentId: null, assigneeUserId: null,
         originKind: null, updatedAt: new Date("2026-03-24T12:01:00Z"), createdAt: new Date("2026-03-24T11:01:00Z"),
       },
       {
         id: "grandchild-1", companyId: "company-1", identifier: "PAP-583", title: "Review grandchild",
-        status: "in_review", parentId: "child-1", assigneeAgentId: null, assigneeUserId: null,
+        status: "in_review", projectId: legacyProjectLinkedIssue.projectId, parentId: "child-1",
+        assigneeAgentId: null, assigneeUserId: null,
         originKind: null, updatedAt: new Date("2026-03-24T12:02:00Z"), createdAt: new Date("2026-03-24T11:02:00Z"),
       },
     ]);
@@ -471,6 +473,40 @@ describe.sequential("issue goal context routes", () => {
       expect.objectContaining({ id: "child-1", status: "blocked" }),
       expect.objectContaining({ id: "grandchild-1", parentId: "child-1", status: "in_review" }),
     ]);
+  });
+
+  it("filters heartbeat descendants through issue-read authorization", async () => {
+    mockDb.execute.mockResolvedValueOnce([
+      { ...legacyProjectLinkedIssue, originKind: null, createdAt: new Date("2026-03-24T11:00:00Z") },
+      {
+        id: "visible-child", companyId: "company-1", identifier: "PAP-582", title: "Visible child",
+        status: "blocked", projectId: legacyProjectLinkedIssue.projectId, parentId: legacyProjectLinkedIssue.id,
+        assigneeAgentId: null, assigneeUserId: null, originKind: null,
+        updatedAt: new Date("2026-03-24T12:01:00Z"), createdAt: new Date("2026-03-24T11:01:00Z"),
+      },
+      {
+        id: "hidden-child", companyId: "company-1", identifier: "PAP-583", title: "Hidden child",
+        status: "in_review", projectId: legacyProjectLinkedIssue.projectId, parentId: legacyProjectLinkedIssue.id,
+        assigneeAgentId: null, assigneeUserId: null, originKind: null,
+        updatedAt: new Date("2026-03-24T12:02:00Z"), createdAt: new Date("2026-03-24T11:02:00Z"),
+      },
+    ]);
+    mockAccessService.decide.mockImplementation(async (input) => ({
+      allowed: input.resource.issueId !== "hidden-child",
+      action: input.action,
+      reason: input.resource.issueId === "hidden-child" ? "deny_scope" : "allow_test",
+      explanation: "Test-scoped issue visibility.",
+    }));
+
+    const res = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.children.map((child: { id: string }) => child.id)).toEqual(["visible-child"]);
+    expect(res.body.descendants.map((child: { id: string }) => child.id)).toEqual(["visible-child"]);
+    expect(JSON.stringify(res.body)).not.toContain("hidden-child");
+    expect(JSON.stringify(res.body)).not.toContain("Hidden child");
   });
 
   it("preserves direct continuation summary lookup in GET /issues/:id/heartbeat-context", async () => {

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -1315,6 +1315,30 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     expectNoCanary(bulkSummary.body, ...forbiddenMarkers);
   });
 
+  it("filters unauthorized heartbeat descendants for issue-scoped low-trust tokens", async () => {
+    const fixture = await seedLowTrustFixture(db);
+    const [hiddenChild] = await db.insert(issues).values({
+      companyId: fixture.company.id,
+      projectId: fixture.projects.allowed.id,
+      parentId: fixture.issues.assignedReview.id,
+      title: `Hidden heartbeat child ${fixture.canaries.issueSibling}`,
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: fixture.agents.standard.id,
+      responsibleUserId: "board-user",
+    }).returning();
+    const app = createApp(db, skillTestActor(fixture));
+
+    const root = await request(app)
+      .get(`/api/issues/${fixture.issues.assignedReview.id}/heartbeat-context`);
+
+    expect(root.status, JSON.stringify(root.body)).toBe(200);
+    expect(root.body.children).toEqual([]);
+    expect(root.body.descendants).toEqual([]);
+    expect(JSON.stringify(root.body)).not.toContain(hiddenChild!.id);
+    expectNoCanary(root.body, fixture.canaries.issueSibling);
+  });
+
   it("counts blocked inbox issues with the low-trust boundary applied in the database", async () => {
     const fixture = await seedLowTrustFixture(db);
     await db.insert(issues).values([

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -13,6 +13,7 @@ function issue(overrides: Partial<TaskWatchdogClassifierIssue> = {}): TaskWatchd
     identifier: "PAP-1",
     title: "Source",
     status: "todo",
+    projectId: null,
     parentId: null,
     assigneeAgentId: "agent-1",
     assigneeUserId: null,

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -306,6 +306,32 @@ describe("task watchdog subtree classifier", () => {
     expect(result.includedIssueIds).toEqual([sourceId]);
   });
 
+  it("summarizes mixed terminal descendants while excluding a reusable watchdog branch", () => {
+    const result = classify({
+      issues: [
+        issue({ status: "done" }),
+        issue({ id: "done-child", identifier: "PAP-2", parentId: sourceId, originKind: null, status: "done" }),
+        issue({ id: "blocked-child", identifier: "PAP-3", parentId: sourceId, originKind: null, status: "blocked" }),
+        issue({ id: "review-child", identifier: "PAP-4", parentId: sourceId, originKind: null, status: "in_review" }),
+        issue({ id: watchdogId, identifier: "PAP-5", parentId: sourceId, originKind: "task_watchdog", status: "todo" }),
+        issue({ id: "watchdog-work", identifier: "PAP-6", parentId: watchdogId, originKind: null, status: "blocked" }),
+      ],
+    });
+
+    expect(result.state).toBe("stopped");
+    if (result.state !== "stopped") return;
+    expect(result.includedIssueIds).toEqual([sourceId, "blocked-child", "done-child", "review-child"]);
+    expect(result.stoppedLeaves.map((leaf) => [leaf.issueId, leaf.status])).toEqual([
+      ["blocked-child", "blocked"],
+      ["review-child", "in_review"],
+    ]);
+    expect(result.terminalLeafSummaries.map((leaf) => [leaf.issueId, leaf.status])).toEqual([
+      ["blocked-child", "blocked"],
+      ["done-child", "done"],
+      ["review-child", "in_review"],
+    ]);
+  });
+
   it("defers a stopped verdict for an issue created inside the first-run grace window", () => {
     const createdAt = new Date("2026-06-18T16:32:45.731Z");
     const result = classify({

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -229,6 +229,46 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdog?.triggerCount).toBe(1);
   });
 
+  it("keeps null-origin descendants in the database walk and reuses the watchdog child", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-MIXED", status: "done" });
+    const doneId = await seedIssue(companyId, { identifier: "WDOG-DONE", parentId: sourceId, status: "done" });
+    const blockedId = await seedIssue(companyId, { identifier: "WDOG-BLOCKED", parentId: sourceId, status: "blocked" });
+    const reviewId = await seedIssue(companyId, { identifier: "WDOG-REVIEW", parentId: sourceId, status: "in_review" });
+    const agentId = await seedAgent(companyId);
+    const reusableWatchdogId = await seedIssue(companyId, {
+      identifier: "WDOG-REUSABLE",
+      parentId: sourceId,
+      originKind: "task_watchdog",
+      originId: sourceId,
+      status: "done",
+      assigneeAgentId: agentId,
+    });
+    const watchdogDescendantId = await seedIssue(companyId, {
+      identifier: "WDOG-INTERNAL",
+      parentId: reusableWatchdogId,
+      status: "blocked",
+    });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 1 });
+    expect(wakes).toHaveLength(1);
+    const context = wakes[0]?.opts?.contextSnapshot as any;
+    expect(context.terminalLeafSummaries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ issueId: doneId, status: "done" }),
+      expect.objectContaining({ issueId: blockedId, status: "blocked" }),
+      expect.objectContaining({ issueId: reviewId, status: "in_review" }),
+    ]));
+    expect(context.terminalLeafSummaries.map((leaf: any) => leaf.issueId)).not.toContain(watchdogDescendantId);
+    const watchdogIssues = await db.select().from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "task_watchdog")));
+    expect(watchdogIssues).toHaveLength(1);
+    expect(watchdogIssues[0]?.id).toBe(reusableWatchdogId);
+  });
+
   it("does not append duplicate review comments for an already-open same-fingerprint review", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-DUPE", status: "done" });

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -22,6 +22,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { buildPaperclipWakePayload } from "../services/heartbeat.ts";
 import { taskWatchdogService } from "../services/task-watchdogs.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -257,12 +258,24 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(result).toMatchObject({ checked: 1, triggered: 1 });
     expect(wakes).toHaveLength(1);
     const context = wakes[0]?.opts?.contextSnapshot as any;
-    expect(context.terminalLeafSummaries).toEqual(expect.arrayContaining([
+    const expectedTerminalLeaves = expect.arrayContaining([
       expect.objectContaining({ issueId: doneId, status: "done" }),
       expect.objectContaining({ issueId: blockedId, status: "blocked" }),
       expect.objectContaining({ issueId: reviewId, status: "in_review" }),
-    ]));
+    ]);
+    expect(context.terminalLeafSummaries).toEqual(expectedTerminalLeaves);
+    expect(context.taskWatchdog.terminalLeafSummaries).toEqual(expectedTerminalLeaves);
     expect(context.terminalLeafSummaries.map((leaf: any) => leaf.issueId)).not.toContain(watchdogDescendantId);
+    expect(context.taskWatchdog.terminalLeafSummaries.map((leaf: any) => leaf.issueId)).not.toContain(watchdogDescendantId);
+
+    const adapterWakePayload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: context,
+    });
+    expect(adapterWakePayload?.taskWatchdog).toMatchObject({
+      terminalLeafSummaries: expectedTerminalLeaves,
+    });
     const watchdogIssues = await db.select().from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "task_watchdog")));
     expect(watchdogIssues).toHaveLength(1);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -392,6 +392,7 @@ function noopTaskWatchdogService(): TaskWatchdogService {
         includedIssueIds: [],
         stopFingerprint: "task_watchdog_stop:unavailable",
         stoppedLeaves: [],
+        terminalLeafSummaries: [],
         stopSnapshot: {
           version: 2,
           fingerprint: "task_watchdog_stop:unavailable",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -149,7 +149,7 @@ import {
   resolveTaskWatchdogMutationScope,
   taskWatchdogScopeAllowsIssueMutation,
 } from "../services/task-watchdog-scope.js";
-import type { TaskWatchdogServiceDeps, taskWatchdogService } from "../services/task-watchdogs.js";
+import { loadTaskWatchdogSubtreeIssues, type TaskWatchdogServiceDeps, type taskWatchdogService } from "../services/task-watchdogs.js";
 import { logger } from "../middleware/logger.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { privateJsonEtag } from "../middleware/private-json-etag.js";
@@ -5758,6 +5758,18 @@ export function issueRoutes(
     res.json(removed);
   });
 
+  const compactWatchdogSubtreeIssue = (issue: Awaited<ReturnType<typeof loadTaskWatchdogSubtreeIssues>>[number]) => ({
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    status: issue.status,
+    parentId: issue.parentId,
+    assigneeAgentId: issue.assigneeAgentId,
+    assigneeUserId: issue.assigneeUserId,
+    originKind: issue.originKind,
+    updatedAt: issue.updatedAt,
+  });
+
   router.get("/issues/:id/heartbeat-context", async (req, res) => {
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, getIssueById(req, id), "Issue not found");
@@ -5786,6 +5798,7 @@ export function issueRoutes(
       continuationSummary,
       currentExecutionWorkspace,
       activeRecoveryAction,
+      watchdogSubtreeIssues,
     ] =
       await Promise.all([
         resolveIssueProjectAndGoal(issue),
@@ -5801,6 +5814,7 @@ export function issueRoutes(
         documentsSvc.getIssueDocumentByKey(issue.id, ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY),
         currentExecutionWorkspacePromise,
         recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id),
+        loadTaskWatchdogSubtreeIssues(db, issue.companyId, issue.id),
       ]);
     const recoveryActionsByRelationIssue = await relationRecoveryActionMap(
       recoveryActionsSvc,
@@ -5861,6 +5875,12 @@ export function issueRoutes(
         originId: issue.originId,
         updatedAt: issue.updatedAt,
       },
+      children: watchdogSubtreeIssues
+        .filter((descendant) => descendant.id !== issue.id && descendant.parentId === issue.id)
+        .map(compactWatchdogSubtreeIssue),
+      descendants: watchdogSubtreeIssues
+        .filter((descendant) => descendant.id !== issue.id)
+        .map(compactWatchdogSubtreeIssue),
       ancestors: ancestors.map((ancestor) => ({
         id: ancestor.id,
         identifier: ancestor.identifier,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5759,12 +5759,15 @@ export function issueRoutes(
     res.json(removed);
   });
 
-  const compactWatchdogSubtreeIssue = (issue: Awaited<ReturnType<typeof loadTaskWatchdogSubtreeIssues>>[number]) => ({
+  const compactWatchdogSubtreeIssue = (
+    issue: Awaited<ReturnType<typeof loadTaskWatchdogSubtreeIssues>>[number],
+    readableIssueIds: ReadonlySet<string>,
+  ) => ({
     id: issue.id,
     identifier: issue.identifier,
     title: issue.title,
     status: issue.status,
-    parentId: issue.parentId,
+    parentId: issue.parentId && readableIssueIds.has(issue.parentId) ? issue.parentId : null,
     assigneeAgentId: issue.assigneeAgentId,
     assigneeUserId: issue.assigneeUserId,
     originKind: issue.originKind,
@@ -5850,6 +5853,8 @@ export function issueRoutes(
       issueWorkMode: issue.workMode,
       includeForIssueComment: wakeCommentId !== null,
     });
+    const readableWatchdogSubtreeIssues = await filterIssuesForActor(req, watchdogSubtreeIssues);
+    const readableWatchdogSubtreeIssueIds = new Set(readableWatchdogSubtreeIssues.map((row) => row.id));
 
     const response = {
       issue: {
@@ -5876,12 +5881,12 @@ export function issueRoutes(
         originId: issue.originId,
         updatedAt: issue.updatedAt,
       },
-      children: watchdogSubtreeIssues
+      children: readableWatchdogSubtreeIssues
         .filter((descendant) => descendant.id !== issue.id && descendant.parentId === issue.id)
-        .map(compactWatchdogSubtreeIssue),
-      descendants: watchdogSubtreeIssues
+        .map((descendant) => compactWatchdogSubtreeIssue(descendant, readableWatchdogSubtreeIssueIds)),
+      descendants: readableWatchdogSubtreeIssues
         .filter((descendant) => descendant.id !== issue.id)
-        .map(compactWatchdogSubtreeIssue),
+        .map((descendant) => compactWatchdogSubtreeIssue(descendant, readableWatchdogSubtreeIssueIds)),
       ancestors: ancestors.map((ancestor) => ({
         id: ancestor.id,
         identifier: ancestor.identifier,

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -61,6 +61,7 @@ export type TaskWatchdogClassifierIssue = Pick<
   | "identifier"
   | "title"
   | "status"
+  | "projectId"
   | "parentId"
   | "assigneeAgentId"
   | "assigneeUserId"
@@ -865,7 +866,7 @@ export async function upsertIssueWatchdogForIssue(
 export async function loadTaskWatchdogSubtreeIssues(db: Db, companyId: string, watchedIssueId: string) {
   const rows = await db.execute(sql`
     WITH RECURSIVE watched_issues AS (
-      SELECT id, company_id, identifier, title, status, parent_id, assignee_agent_id,
+      SELECT id, company_id, identifier, title, status, project_id, parent_id, assignee_agent_id,
         assignee_user_id, origin_kind, updated_at, created_at, 0 AS depth
       FROM issues
       WHERE company_id = ${companyId}
@@ -874,7 +875,7 @@ export async function loadTaskWatchdogSubtreeIssues(db: Db, companyId: string, w
         AND harness_kind IS NULL
       UNION ALL
       SELECT child.id, child.company_id, child.identifier, child.title, child.status,
-        child.parent_id, child.assignee_agent_id, child.assignee_user_id, child.origin_kind,
+        child.project_id, child.parent_id, child.assignee_agent_id, child.assignee_user_id, child.origin_kind,
         child.updated_at, child.created_at, watched_issues.depth + 1
       FROM issues child
       JOIN watched_issues ON child.parent_id = watched_issues.id
@@ -884,7 +885,7 @@ export async function loadTaskWatchdogSubtreeIssues(db: Db, companyId: string, w
         AND child.origin_kind IS DISTINCT FROM ${TASK_WATCHDOG_ORIGIN_KIND}
         AND watched_issues.depth < ${TASK_WATCHDOG_SUBTREE_MAX_DEPTH - 1}
     )
-    SELECT id, company_id AS "companyId", identifier, title, status,
+    SELECT id, company_id AS "companyId", identifier, title, status, project_id AS "projectId",
       parent_id AS "parentId", assignee_agent_id AS "assigneeAgentId",
       assignee_user_id AS "assigneeUserId", origin_kind AS "originKind",
       updated_at AS "updatedAt", created_at AS "createdAt"

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -172,6 +172,7 @@ export type TaskWatchdogClassifierResult =
     includedIssueIds: string[];
     stopFingerprint: string;
     stoppedLeaves: TaskWatchdogStoppedLeaf[];
+    terminalLeafSummaries: TaskWatchdogStoppedLeaf[];
     stopSnapshot: TaskWatchdogStopSnapshot;
     pendingInteractionsByIssueId: TaskWatchdogPendingInteractionsByIssueId;
   }
@@ -181,6 +182,7 @@ export type TaskWatchdogClassifierResult =
     includedIssueIds: string[];
     stopFingerprint: string;
     stoppedLeaves: TaskWatchdogStoppedLeaf[];
+    terminalLeafSummaries: TaskWatchdogStoppedLeaf[];
     stopSnapshot: TaskWatchdogStopSnapshot;
     pendingInteractionsByIssueId: TaskWatchdogPendingInteractionsByIssueId;
   };
@@ -484,9 +486,8 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
       .sort((left, right) => left.id.localeCompare(right.id))] as const)
     .filter(([, waits]) => waits.length > 0));
 
-  const leaves = included
+  const terminalLeafSummaries = included
     .filter((issue) => (includedChildrenByParentId.get(issue.id) ?? []).length === 0)
-    .filter((issue) => !isTerminalIssueStatus(issue.status))
     .sort((left, right) => left.id.localeCompare(right.id))
     .map((issue) => ({
       issueId: issue.id,
@@ -503,6 +504,7 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
       latestDocumentAt: optionalIso(issue.latestDocumentAt),
       latestWorkProductAt: optionalIso(issue.latestWorkProductAt),
     }));
+  const leaves = terminalLeafSummaries.filter((leaf) => !isTerminalIssueStatus(leaf.status));
   const materialLeaves = leaves.map(materialLeaf);
   const stopFingerprint = stableStopFingerprint({
     companyId: input.watchdog.companyId,
@@ -527,6 +529,7 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
       includedIssueIds: includedIds,
       stopFingerprint,
       stoppedLeaves: leaves,
+      terminalLeafSummaries,
       stopSnapshot: currentStopSnapshot,
       pendingInteractionsByIssueId,
     };
@@ -538,6 +541,7 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
     includedIssueIds: includedIds,
     stopFingerprint,
     stoppedLeaves: leaves,
+    terminalLeafSummaries,
     stopSnapshot: currentStopSnapshot,
     pendingInteractionsByIssueId,
   };
@@ -728,6 +732,7 @@ function watchdogWakeContext(input: {
     watchedIssueIdentifier: input.sourceIssue.identifier,
     stopFingerprint: input.classification.stopFingerprint,
     stoppedLeaves: input.classification.stoppedLeaves,
+    terminalLeafSummaries: input.classification.terminalLeafSummaries,
     customInstructions: input.watchdog.instructions,
     resumeIntent: true,
     followUpRequested: true,
@@ -857,68 +862,42 @@ export async function upsertIssueWatchdogForIssue(
   return { watchdog: toIssueWatchdog(insertResult.row), created: insertResult.created };
 }
 
+export async function loadTaskWatchdogSubtreeIssues(db: Db, companyId: string, watchedIssueId: string) {
+  const rows = await db.execute(sql`
+    WITH RECURSIVE watched_issues AS (
+      SELECT id, company_id, identifier, title, status, parent_id, assignee_agent_id,
+        assignee_user_id, origin_kind, updated_at, created_at, 0 AS depth
+      FROM issues
+      WHERE company_id = ${companyId}
+        AND id = ${watchedIssueId}
+        AND hidden_at IS NULL
+        AND harness_kind IS NULL
+      UNION ALL
+      SELECT child.id, child.company_id, child.identifier, child.title, child.status,
+        child.parent_id, child.assignee_agent_id, child.assignee_user_id, child.origin_kind,
+        child.updated_at, child.created_at, watched_issues.depth + 1
+      FROM issues child
+      JOIN watched_issues ON child.parent_id = watched_issues.id
+      WHERE child.company_id = ${companyId}
+        AND child.hidden_at IS NULL
+        AND child.harness_kind IS NULL
+        AND child.origin_kind IS DISTINCT FROM ${TASK_WATCHDOG_ORIGIN_KIND}
+        AND watched_issues.depth < ${TASK_WATCHDOG_SUBTREE_MAX_DEPTH - 1}
+    )
+    SELECT id, company_id AS "companyId", identifier, title, status,
+      parent_id AS "parentId", assignee_agent_id AS "assigneeAgentId",
+      assignee_user_id AS "assigneeUserId", origin_kind AS "originKind",
+      updated_at AS "updatedAt", created_at AS "createdAt"
+    FROM watched_issues
+  `);
+  return (Array.isArray(rows) ? rows : []) as TaskWatchdogClassifierIssue[];
+}
+
 export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) {
   const issuesSvc = issueService(db);
 
   async function loadWatchdogSubtreeIssues(companyId: string, watchedIssueId: string) {
-    const rows = await db.execute(sql`
-      WITH RECURSIVE watched_issues AS (
-        SELECT
-          id,
-          company_id,
-          identifier,
-          title,
-          status,
-          parent_id,
-          assignee_agent_id,
-          assignee_user_id,
-          origin_kind,
-          updated_at,
-          created_at,
-          0 AS depth
-        FROM issues
-        WHERE company_id = ${companyId}
-          AND id = ${watchedIssueId}
-          AND hidden_at IS NULL
-          AND harness_kind IS NULL
-        UNION ALL
-        SELECT
-          child.id,
-          child.company_id,
-          child.identifier,
-          child.title,
-          child.status,
-          child.parent_id,
-          child.assignee_agent_id,
-          child.assignee_user_id,
-          child.origin_kind,
-          child.updated_at,
-          child.created_at,
-          watched_issues.depth + 1
-        FROM issues child
-        JOIN watched_issues ON child.parent_id = watched_issues.id
-        WHERE child.company_id = ${companyId}
-          AND child.hidden_at IS NULL
-          AND child.harness_kind IS NULL
-          AND child.origin_kind <> ${TASK_WATCHDOG_ORIGIN_KIND}
-          AND watched_issues.depth < ${TASK_WATCHDOG_SUBTREE_MAX_DEPTH - 1}
-      )
-      SELECT
-        id,
-        company_id AS "companyId",
-        identifier,
-        title,
-        status,
-        parent_id AS "parentId",
-        assignee_agent_id AS "assigneeAgentId",
-        assignee_user_id AS "assigneeUserId",
-        origin_kind AS "originKind",
-        updated_at AS "updatedAt",
-        created_at AS "createdAt"
-      FROM watched_issues
-    `);
-
-    return (Array.isArray(rows) ? rows : []) as TaskWatchdogClassifierIssue[];
+    return loadTaskWatchdogSubtreeIssues(db, companyId, watchedIssueId);
   }
 
   async function collectClassifierInput(companyId: string, watchdog: IssueWatchdogRow) {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -697,6 +697,7 @@ function watchdogWakeContext(input: {
       watchedIssueIdentifier: input.sourceIssue.identifier,
       watchedIssueTitle: input.sourceIssue.title,
       stopFingerprint: input.classification.stopFingerprint,
+      terminalLeafSummaries: input.classification.terminalLeafSummaries,
       pendingInteractions: input.classification.pendingInteractionsByIssueId,
       pendingApprovals: Object.fromEntries(Object.entries(input.classification.stopSnapshot.waitsByIssueId)
         .filter(([, waits]) => waits.pendingApprovalIds.length > 0)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Task watchdogs inspect issue trees when execution stops.
> - The subtree query excluded child issues that had no origin kind.
> - The heartbeat context also did not show the real issue tree.
> - This pull request makes the subtree query null-safe and reuses it for both paths.
> - The benefit is that watchdogs receive complete and consistent stop evidence.

## Linked Issues or Issue Description

**What happened?**

A task watchdog omitted real child issues when their `origin_kind` value was `NULL`. The watched issue heartbeat context also omitted those child and descendant relationships. The watchdog wake could then contain an empty leaf summary.

**Expected behavior**

The subtree walk must include all descendants reached through `parent_id`. It must exclude only `task_watchdog` branches and their descendants. The watchdog wake and heartbeat context must show the same real subtree.

**Steps to reproduce**

1. Create a watched issue.
2. Add child issues with `NULL` origin kinds in `done`, `blocked`, and `in_review` states.
3. Add a reusable `task_watchdog` child with its own child.
4. Run the watchdog reconciliation.
5. Observe that the real children are absent from the old query because SQL treats `NULL <> value` as unknown.

**Paperclip version or commit**

The issue reproduces on commit `23a1b025c2cf05de611c5511fe6607ee266c49d3`.

**Deployment mode**

Local development from source with embedded Postgres.

## What Changed

- Use `IS DISTINCT FROM` so the recursive query keeps descendants with a null origin kind.
- Reuse one subtree loader for watchdog evaluation and heartbeat context.
- Add `children` and `descendants` summaries to heartbeat context.
- Add `terminalLeafSummaries` to the watchdog wake payload.
- Add classifier, route, and embedded Postgres regression tests.

## Verification

- `pnpm exec vitest run server/src/__tests__/task-watchdogs-classifier.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts server/src/__tests__/issues-goal-context-routes.test.ts`
- Result: 3 test files passed. 46 tests passed.
- `pnpm --filter @paperclipai/server typecheck`
- Result: passed.

## Risks

- Low risk. The recursive query still has the existing depth, company, hidden issue, and harness issue limits.
- Heartbeat context now performs the same bounded subtree query that the watchdog service uses.

> This fix supports the enforced outcomes work in `ROADMAP.md`. It does not add a new product capability.

## Model Used

- OpenAI GPT-5 Codex. The run used reasoning, repository tools, code execution, and test execution. The context window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
