### PR TITLE
Serialize periodic issue graph recovery passes

### DIFF
--- a/doc/plans/2026-08-13-issue-graph-liveness-single-flight-rollout.md
+++ b/doc/plans/2026-08-13-issue-graph-liveness-single-flight-rollout.md
@@ -1,0 +1,91 @@
+# Issue graph liveness single-flight rollout
+
+## Purpose
+
+This plan deploys the periodic issue graph liveness fix without editing an installed `npx` cache in place. The change serializes the full periodic recovery chain, gives each dependency-wake census one cursor owner, and emits telemetry that can prove the rollout is healthy.
+
+The rollout is complete only after an authenticated API probe stays responsive during a slow-page test and one full census completes without a repeated page.
+
+## Invariants
+
+- At most one periodic heartbeat recovery invocation is active in one server process.
+- An interval that fires during an active pass is skipped. Other scheduler timer work continues.
+- A census page owns one immutable `cursorIn`. The next cursor is committed only after that page finishes.
+- An empty page after a non-null cursor ends the current census. It does not re-query page zero in the same interval.
+- A failed page retains its input cursor for a later retry.
+- Targeted workspace-finalization reconciliation does not read or mutate the global census cursor.
+- The company run-cap claimers still serialize. Unrelated foreign-key-style company writes must not wait behind that claim lock.
+
+## Pre-deployment gates
+
+1. Merge the reviewed patch through the normal upstream release process.
+2. Build an immutable package from the reviewed commit. Record the commit, package version, and SHA-256 manifest.
+3. Compare the candidate package with the installed package. Inventory every local production patch before replacement.
+4. Confirm that the candidate contains the production company-lock mode and its two concurrency tests:
+   - the multi-claimer test proves the company cap remains enforced;
+   - the `FOR KEY SHARE` test proves unrelated company writes remain live.
+5. Run the server typecheck and the focused tests:
+
+   ```text
+   vitest run server/src/lib/scheduler-single-flight.test.ts
+   vitest run server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+   vitest run server/src/__tests__/heartbeat-company-concurrency.test.ts
+   ```
+
+6. Run a staging slow-page test with an interval shorter than the injected page delay. Capture structured logs for the active invocation and the skipped interval.
+7. Obtain the normal deployment approval. Do not treat a passing build or a matching hash as deployment authorization.
+
+## Deployment
+
+1. Choose an attended maintenance window. Record the live package version, process start time, source hashes for the changed files, and authenticated health latency.
+2. Stop the server through its supported service or launcher boundary.
+3. Install the immutable candidate package through the supported package path. Do not edit, rename, or partially replace files in the live `npx` cache.
+4. Start the server through the same service or launcher boundary.
+5. Read back the bound process, package version, process start time, and source hashes. Stop if any value differs from the approved candidate.
+
+## Acceptance probes
+
+Run these checks in order:
+
+1. Confirm that the static health probe and an authenticated API probe both succeed.
+2. Confirm that unrelated authenticated issue reads and a disposable non-financial write stay responsive while a slow backstop page runs.
+3. Observe at least one complete census. Group telemetry by `censusId` and order it by `pageIndex`.
+4. For every census, verify:
+   - one active `invocationId` at a time;
+   - each `cursorIn` appears once before `censusCompleted=true`;
+   - each page's `cursorOut` equals the next page's `cursorIn`;
+   - `candidateCount` is at most 500;
+   - `companyCount` and `wakeCount` are present;
+   - an overlapping tick reports the active invocation and does not start a page.
+5. Confirm that heartbeat timer work continues while an overlap is skipped.
+6. Run the company run-cap claim tests against the deployed candidate or an executable-identical staging build.
+7. Confirm that no authenticated-read starvation, unrelated-write starvation, repeated page, or recovery burst appears during the observation window.
+
+## Telemetry fields
+
+The recovery chain reports `invocationId` and `durationMs`. The dependency-wake backstop reports:
+
+- `invocationId`
+- `censusId`
+- `pageIndex`
+- `cursorIn` and `cursorOut`
+- `candidateCount` and `candidateLimitSkipped`
+- `companyCount`
+- `wakeCount`
+- `censusCompleted` and `cursorResetReason`
+- `durationMs`
+
+A failed page reports the same identity and cursor fields before cursor commit. An overlapping pass reports the active invocation and its current duration.
+
+## Stop and rollback conditions
+
+Stop or roll back if any of these conditions occurs:
+
+- two periodic recovery invocations overlap;
+- a cursor repeats before its census completes;
+- a failed page advances the cursor;
+- authenticated issue reads or unrelated writes become unresponsive;
+- the company claim cap or non-key-write concurrency tests fail;
+- the deployed version or file hashes do not match the approved package.
+
+Restore the complete prior immutable package through the supported installer, restart through the launcher, and read back the version and hashes. A restart resets the process-local census cursor to page zero, so verify one fresh census after rollback. Preserve the failed candidate logs and package for review.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -88,6 +88,7 @@ import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
 import { ensureDecisionSigningSecret } from "./services/decision-signing.js";
 import { createDecisionRetentionNotifyOriginAgent, createDecisionWakeOriginAgent } from "./services/decision-wakeup.js";
+import { createSchedulerSingleFlight } from "./lib/scheduler-single-flight.js";
 import {
   coordinateHeartbeatSchedulerShutdown,
   loadWithoutCoordinatedShutdownSignalHooks,
@@ -1214,6 +1215,85 @@ export async function startServer(): Promise<StartedServer> {
     };
     await runRetentionSweep();
 
+    const periodicHeartbeatRecovery = createSchedulerSingleFlight(async ({ invocationId }) => {
+      const startedAtMs = Date.now();
+      try {
+        const reaped = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 });
+        const promotion = await heartbeat.promoteDueScheduledRetries();
+        await heartbeat.resumeQueuedRuns();
+        const stranded = await heartbeat.reconcileStrandedAssignedIssues();
+        if (
+          promotion.promoted > 0 ||
+          stranded.assignmentDispatched > 0 ||
+          stranded.dispatchRequeued > 0 ||
+          stranded.continuationRequeued > 0 ||
+          stranded.successfulRunHandoffEscalated > 0 ||
+          stranded.escalated > 0
+        ) {
+          logger.warn(
+            {
+              invocationId,
+              promotedScheduledRetries: promotion.promoted,
+              promotedScheduledRetryRunIds: promotion.runIds,
+              ...stranded,
+            },
+            "periodic heartbeat recovery changed assigned issue state",
+          );
+        }
+
+        const issueGraph = await heartbeat.reconcileIssueGraphLiveness();
+        if (issueGraph.escalationsCreated > 0 || issueGraph.dependencyWakesHealed > 0) {
+          logger.warn(
+            { invocationId, ...issueGraph },
+            "periodic issue-graph liveness reconciliation changed issue graph state",
+          );
+        }
+
+        const taskWatchdogs = await heartbeat.reconcileTaskWatchdogs();
+        if (taskWatchdogs.triggered > 0) {
+          logger.warn(
+            { invocationId, ...taskWatchdogs },
+            "periodic task-watchdog reconciliation triggered watchdog work",
+          );
+        }
+
+        const activeRunOutput = await heartbeat.scanSilentActiveRuns();
+        if (activeRunOutput.created > 0 || activeRunOutput.escalated > 0) {
+          logger.warn({ invocationId, ...activeRunOutput }, "periodic active-run output watchdog created review work");
+        }
+
+        const staleLocks = await heartbeat.sweepStaleIssueLocks();
+        if (staleLocks.cleared > 0) {
+          logger.warn({ invocationId, ...staleLocks }, "periodic stale-lock sweeper cleared issue locks");
+        }
+
+        const productivity = await heartbeat.reconcileProductivityReviews();
+        if (productivity.created > 0 || productivity.updated > 0 || productivity.failed > 0) {
+          logger.warn(
+            { invocationId, ...productivity },
+            "periodic productivity reconciliation created or updated review work",
+          );
+        }
+
+        logger.info(
+          {
+            invocationId,
+            durationMs: Date.now() - startedAtMs,
+            reaped: reaped.reaped,
+            promotedScheduledRetries: promotion.promoted,
+            issueGraphFindings: issueGraph.findings,
+            issueGraphCandidates: issueGraph.dependencyWakeBackstopChecked,
+            issueGraphWakes: issueGraph.dependencyWakesHealed,
+            issueGraphSingleFlightSkipped: issueGraph.dependencyWakeBackstopSingleFlightSkipped,
+          },
+          "periodic heartbeat recovery pass completed",
+        );
+      } catch (err) {
+        logger.error({ err, invocationId, durationMs: Date.now() - startedAtMs }, "periodic heartbeat recovery failed");
+        throw err;
+      }
+    });
+
     startHeartbeatSchedulerInterval(() => {
       // Track the outer async callback as well as the work it starts. Shutdown
       // can then wait through an already-running suppression check before it
@@ -1330,61 +1410,18 @@ export async function startServer(): Promise<StartedServer> {
 
         if (heartbeatSchedulerStopped) return;
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
-          // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-          // persisted queued work is still being driven forward.
-          trackHeartbeatSchedulerWork(heartbeat
-            .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
-            .then(() => heartbeat.promoteDueScheduledRetries())
-            .then(async (promotion) => {
-              await heartbeat.resumeQueuedRuns();
-              const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
-              if (
-                promotion.promoted > 0 ||
-                reconciled.assignmentDispatched > 0 ||
-                reconciled.dispatchRequeued > 0 ||
-                reconciled.continuationRequeued > 0 ||
-                reconciled.successfulRunHandoffEscalated > 0 ||
-                reconciled.escalated > 0
-              ) {
-                logger.warn(
-                  { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
-                  "periodic heartbeat recovery changed assigned issue state",
-                );
-              }
-            })
-            .then(async () => {
-              const reconciled = await heartbeat.reconcileIssueGraphLiveness();
-              if (reconciled.escalationsCreated > 0 || reconciled.dependencyWakesHealed > 0) {
-                logger.warn({ ...reconciled }, "periodic issue-graph liveness reconciliation changed issue graph state");
-              }
-            })
-            .then(async () => {
-              const reconciled = await heartbeat.reconcileTaskWatchdogs();
-              if (reconciled.triggered > 0) {
-                logger.warn({ ...reconciled }, "periodic task-watchdog reconciliation triggered watchdog work");
-              }
-            })
-            .then(async () => {
-              const scanned = await heartbeat.scanSilentActiveRuns();
-              if (scanned.created > 0 || scanned.escalated > 0) {
-                logger.warn({ ...scanned }, "periodic active-run output watchdog created review work");
-              }
-            })
-            .then(async () => {
-              const swept = await heartbeat.sweepStaleIssueLocks();
-              if (swept.cleared > 0) {
-                logger.warn({ ...swept }, "periodic stale-lock sweeper cleared issue locks");
-              }
-            })
-            .then(async () => {
-              const reviewed = await heartbeat.reconcileProductivityReviews();
-              if (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0) {
-                logger.warn({ ...reviewed }, "periodic productivity reconciliation created or updated review work");
-              }
-            })
-            .catch((err) => {
-              logger.error({ err }, "periodic heartbeat recovery failed");
-            }));
+          const recoveryPass = periodicHeartbeatRecovery.start();
+          if (recoveryPass.started) {
+            trackHeartbeatSchedulerWork(recoveryPass.promise);
+          } else {
+            logger.info(
+              {
+                activeInvocationId: recoveryPass.activeInvocationId,
+                activeDurationMs: recoveryPass.activeDurationMs,
+              },
+              "periodic heartbeat recovery skipped overlapping interval",
+            );
+          }
         }
       })().catch((err) => {
         logger.error({ err }, "heartbeat scheduler tick failed");

--- a/server/src/lib/scheduler-single-flight.test.ts
+++ b/server/src/lib/scheduler-single-flight.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSchedulerSingleFlight } from "./scheduler-single-flight.js";
+
+describe("createSchedulerSingleFlight", () => {
+  it("keeps a slow paginated backstop pass single-flight across interval callbacks", async () => {
+    let releasePage!: () => void;
+    const pageGate = new Promise<void>((resolve) => {
+      releasePage = resolve;
+    });
+    let pageCursor: string | null = null;
+    const visitedCursorIns: Array<string | null> = [];
+
+    const visitPage = vi.fn(async () => {
+      const cursorIn = pageCursor;
+      visitedCursorIns.push(cursorIn);
+      await pageGate;
+      pageCursor = "page-1-last-candidate";
+    });
+    const singleFlight = createSchedulerSingleFlight(visitPage);
+
+    const firstInterval = singleFlight.start();
+    expect(firstInterval.started).toBe(true);
+    await vi.waitFor(() => expect(visitPage).toHaveBeenCalledTimes(1));
+
+    const overlappingInterval = singleFlight.start();
+    expect(overlappingInterval).toMatchObject({
+      started: false,
+      activeInvocationId: firstInterval.started ? firstInterval.invocationId : undefined,
+    });
+    expect(visitedCursorIns).toEqual([null]);
+    expect(pageCursor).toBeNull();
+
+    releasePage();
+    if (firstInterval.started) await firstInterval.promise;
+
+    expect(visitPage).toHaveBeenCalledTimes(1);
+    expect(pageCursor).toBe("page-1-last-candidate");
+
+    const nextInterval = singleFlight.start();
+    expect(nextInterval.started).toBe(true);
+    if (nextInterval.started) await nextInterval.promise;
+
+    expect(visitPage).toHaveBeenCalledTimes(2);
+    expect(visitedCursorIns).toEqual([null, "page-1-last-candidate"]);
+  });
+});

--- a/server/src/lib/scheduler-single-flight.ts
+++ b/server/src/lib/scheduler-single-flight.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "node:crypto";
+
+export type SingleFlightTaskStart<T> =
+  | {
+      started: true;
+      invocationId: string;
+      promise: Promise<T>;
+    }
+  | {
+      started: false;
+      activeInvocationId: string;
+      activeDurationMs: number;
+    };
+
+export function createSchedulerSingleFlight<T>(task: (context: { invocationId: string }) => Promise<T>) {
+  let active: {
+    invocationId: string;
+    startedAtMs: number;
+    promise: Promise<T>;
+  } | null = null;
+
+  return {
+    start(): SingleFlightTaskStart<T> {
+      if (active) {
+        return {
+          started: false,
+          activeInvocationId: active.invocationId,
+          activeDurationMs: Math.max(0, Date.now() - active.startedAtMs),
+        };
+      }
+
+      const invocationId = randomUUID();
+      const startedAtMs = Date.now();
+      let promise: Promise<T>;
+      promise = Promise.resolve()
+        .then(() => task({ invocationId }))
+        .finally(() => {
+          if (active?.promise === promise) active = null;
+        });
+      active = { invocationId, startedAtMs, promise };
+
+      return { started: true, invocationId, promise };
+    },
+  };
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -144,20 +145,53 @@ type ResolvedDependencyWakeBackstopOptions = {
   source?: ResolvedDependencyWakeBackstopSource;
 };
 
-type LatestIssueRun = Pick<
-  typeof heartbeatRuns.$inferSelect,
-  | "id"
-  | "agentId"
-  | "status"
-  | "error"
-  | "errorCode"
-  | "contextSnapshot"
-  | "livenessState"
-  | "startedAt"
-  | "createdAt"
-> & {
-  resultJson?: unknown;
-} | null;
+function createResolvedDependencyWakeBackstopResult(input: {
+  invocationId: string;
+  censusId: string | null;
+  pageIndex: number | null;
+  cursorIn: string | null;
+}) {
+  return {
+    invocationId: input.invocationId,
+    censusId: input.censusId,
+    pageIndex: input.pageIndex,
+    cursorIn: input.cursorIn,
+    cursorOut: input.cursorIn,
+    censusCompleted: false,
+    singleFlightSkipped: 0,
+    checked: 0,
+    healed: 0,
+    existingWakeSkipped: 0,
+    livePathSkipped: 0,
+    interactionSkipped: 0,
+    pauseHoldSkipped: 0,
+    notReadySkipped: 0,
+    candidateLimitSkipped: 0,
+    deferredOrFailed: 0,
+    enqueueFailed: 0,
+    companyCount: 0,
+    issueIds: [] as string[],
+  };
+}
+
+type ResolvedDependencyWakeBackstopResult = ReturnType<typeof createResolvedDependencyWakeBackstopResult>;
+
+type LatestIssueRun =
+  | (Pick<
+      typeof heartbeatRuns.$inferSelect,
+      | "id"
+      | "agentId"
+      | "status"
+      | "error"
+      | "errorCode"
+      | "contextSnapshot"
+      | "livenessState"
+      | "startedAt"
+      | "createdAt"
+    > & {
+      resultJson?: unknown;
+    })
+  | null;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
 type StrandedRecoveryCause =
@@ -769,7 +803,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   const budgets = budgetService(db);
   const instanceSettings = instanceSettingsService(db);
   const runLogStore = getRunLogStore();
-  let resolvedDependencyWakeBackstopCandidateCursor: string | null = null;
+  let resolvedDependencyWakeBackstopPagination = {
+    cursor: null as string | null,
+    censusId: null as string | null,
+    nextPageIndex: 0,
+  };
+  let resolvedDependencyWakeBackstopInFlight: {
+    invocationId: string;
+    startedAtMs: number;
+    promise: Promise<ResolvedDependencyWakeBackstopResult>;
+  } | null = null;
 
   const getCurrentUserRedactionOptions = async () => ({
     enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
@@ -5117,21 +5160,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "created" as const, escalationIssueId: escalation.id };
   }
 
-  async function reconcileResolvedDependencyWakeBackstop(opts?: ResolvedDependencyWakeBackstopOptions) {
-    const result = {
-      checked: 0,
-      healed: 0,
-      existingWakeSkipped: 0,
-      livePathSkipped: 0,
-      interactionSkipped: 0,
-      pauseHoldSkipped: 0,
-      notReadySkipped: 0,
-      candidateLimitSkipped: 0,
-      deferredOrFailed: 0,
-      enqueueFailed: 0,
-      issueIds: [] as string[],
-    };
-
+  async function runResolvedDependencyWakeBackstop(
+    opts: ResolvedDependencyWakeBackstopOptions | undefined,
+    invocation: {
+      invocationId: string;
+      censusId: string | null;
+      pageIndex: number | null;
+      cursorIn: string | null;
+    },
+  ) {
+    const startedAtMs = Date.now();
+    const result = createResolvedDependencyWakeBackstopResult(invocation);
     const source = opts?.source ?? "issue_graph_liveness.backstop";
     const requestedByActorId = source === "workspace.finalize"
       ? "heartbeat_finalize"
@@ -5140,6 +5179,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       ? "workspace_finalize_reconciliation"
       : "issue_graph_liveness_reconciliation";
     const useCursor = !opts?.blockerIssueId;
+    let cursorResetReason: "census_complete" | "empty_page" | null = null;
+
+    logger.info(
+      {
+        invocationId: invocation.invocationId,
+        censusId: invocation.censusId,
+        pageIndex: invocation.pageIndex,
+        cursorIn: invocation.cursorIn,
+        source,
+        companyId: opts?.companyId ?? null,
+        blockerIssueId: opts?.blockerIssueId ?? null,
+        candidateLimit: RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT,
+      },
+      "issue graph liveness backstop pass started",
+    );
 
     const queryCandidates = (afterIssueId: string | null) => {
       const filters = [
@@ -5186,170 +5240,298 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT);
     };
 
-    let candidateRows = await queryCandidates(useCursor ? resolvedDependencyWakeBackstopCandidateCursor : null);
-    if (useCursor && candidateRows.length === 0 && resolvedDependencyWakeBackstopCandidateCursor) {
-      resolvedDependencyWakeBackstopCandidateCursor = null;
-      candidateRows = await queryCandidates(null);
-    }
-    const totalCandidateCount = candidateRows[0]?.totalCount ?? 0;
-    const candidates = candidateRows.map(({ totalCount: _totalCount, ...candidate }) => candidate);
-    result.checked = candidates.length;
-    result.candidateLimitSkipped = Math.max(0, totalCandidateCount - candidates.length);
-    const lastCandidate = candidates[candidates.length - 1] ?? null;
-    if (useCursor) {
-      resolvedDependencyWakeBackstopCandidateCursor =
-        result.candidateLimitSkipped > 0 && lastCandidate ? lastCandidate.id : null;
-    }
-    if (result.candidateLimitSkipped > 0) {
-      logger.warn(
-        {
-          processed: candidates.length,
-          skipped: result.candidateLimitSkipped,
-          limit: RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT,
-          nextCursor: useCursor ? resolvedDependencyWakeBackstopCandidateCursor : null,
-          source,
-          blockerIssueId: opts?.blockerIssueId ?? null,
-        },
-        "issue graph liveness backstop deferred resolved dependency wake candidates past page limit",
-      );
-    }
-
-    const candidatesByCompany = new Map<string, typeof candidates>();
-    for (const candidate of candidates) {
-      const companyCandidates = candidatesByCompany.get(candidate.companyId) ?? [];
-      companyCandidates.push(candidate);
-      candidatesByCompany.set(candidate.companyId, companyCandidates);
-    }
-
-    for (const [companyId, companyCandidates] of candidatesByCompany.entries()) {
-      const readinessMap = await issuesSvc.listDependencyReadiness(
-        companyId,
-        companyCandidates.map((candidate) => candidate.id),
-      );
-
-      for (const candidate of companyCandidates) {
-        const agentId = candidate.assigneeAgentId;
-        if (!agentId) continue;
-
-        const readiness = readinessMap.get(candidate.id);
-        const resolvedBlockerIssueId = readiness?.blockerIssueIds[0] ?? null;
-        if (
-          !readiness ||
-          !readiness.isDependencyReady ||
-          readiness.blockerIssueIds.length === 0 ||
-          !resolvedBlockerIssueId
-        ) {
-          result.notReadySkipped += 1;
-          continue;
-        }
-
-        const idempotencyKeys = readiness.blockerIssueIds.map((blockerIssueId) =>
-          buildIssueBlockersResolvedWakeIdempotencyKey({
-            dependentIssueId: candidate.id,
-            resolvedBlockerIssueId: blockerIssueId,
-          })
+    try {
+      const candidateRows = await queryCandidates(useCursor ? invocation.cursorIn : null);
+      if (useCursor && candidateRows.length === 0 && invocation.cursorIn) {
+        resolvedDependencyWakeBackstopPagination = {
+          cursor: null,
+          censusId: null,
+          nextPageIndex: 0,
+        };
+        result.cursorOut = null;
+        result.censusCompleted = true;
+        cursorResetReason = "empty_page";
+        return result;
+      }
+      const totalCandidateCount = candidateRows[0]?.totalCount ?? 0;
+      const candidates = candidateRows.map(({ totalCount: _totalCount, ...candidate }) => candidate);
+      result.checked = candidates.length;
+      result.candidateLimitSkipped = Math.max(0, totalCandidateCount - candidates.length);
+      const lastCandidate = candidates[candidates.length - 1] ?? null;
+      const cursorOut = useCursor && result.candidateLimitSkipped > 0 && lastCandidate ? lastCandidate.id : null;
+      result.cursorOut = cursorOut;
+      if (result.candidateLimitSkipped > 0) {
+        logger.warn(
+          {
+            invocationId: invocation.invocationId,
+            censusId: invocation.censusId,
+            pageIndex: invocation.pageIndex,
+            processed: candidates.length,
+            skipped: result.candidateLimitSkipped,
+            limit: RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT,
+            cursorIn: invocation.cursorIn,
+            cursorOut,
+            source,
+            blockerIssueId: opts?.blockerIssueId ?? null,
+          },
+          "issue graph liveness backstop deferred resolved dependency wake candidates past page limit",
         );
-        const idempotencyKey = buildIssueBlockersResolvedWakeIdempotencyKey({
-          dependentIssueId: candidate.id,
-          resolvedBlockerIssueId,
-        });
-        const existingWake = await findExistingIssueBlockersResolvedWakeForAnyKey(db, {
+      }
+
+      const candidatesByCompany = new Map<string, typeof candidates>();
+      for (const candidate of candidates) {
+        const companyCandidates = candidatesByCompany.get(candidate.companyId) ?? [];
+        companyCandidates.push(candidate);
+        candidatesByCompany.set(candidate.companyId, companyCandidates);
+      }
+      result.companyCount = candidatesByCompany.size;
+
+      for (const [companyId, companyCandidates] of candidatesByCompany.entries()) {
+        const readinessMap = await issuesSvc.listDependencyReadiness(
           companyId,
-          idempotencyKeys,
-        });
-        if (existingWake) {
-          result.existingWakeSkipped += 1;
-          continue;
-        }
+          companyCandidates.map((candidate) => candidate.id),
+        );
 
-        if (
-          await hasActiveExecutionPath(companyId, candidate.id, agentId) ||
-          await hasQueuedIssueWake(companyId, candidate.id, agentId)
-        ) {
-          result.livePathSkipped += 1;
-          continue;
-        }
+        for (const candidate of companyCandidates) {
+          const agentId = candidate.assigneeAgentId;
+          if (!agentId) continue;
 
-        if (await hasPendingWakeInteraction(companyId, candidate.id)) {
-          result.interactionSkipped += 1;
-          continue;
-        }
-
-        if (await isAutomaticRecoverySuppressedByPauseHold(db, companyId, candidate.id, treeControlSvc)) {
-          result.pauseHoldSkipped += 1;
-          continue;
-        }
-
-        try {
-          const wake = await deps.enqueueWakeup(agentId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
-            payload: {
-              issueId: candidate.id,
-              resolvedBlockerIssueId,
-              blockerIssueIds: readiness.blockerIssueIds,
-              backstop: payloadBackstop,
-            },
-            idempotencyKey,
-            requestedByActorType: "system",
-            requestedByActorId,
-            contextSnapshot: {
-              issueId: candidate.id,
-              taskId: candidate.id,
-              wakeReason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
-              source,
-              resolvedBlockerIssueId,
-              blockerIssueIds: readiness.blockerIssueIds,
-            },
-          });
-          if (!wake) {
-            // enqueueWakeup returns null for normal deferred/skipped paths
-            // such as disabled wake-on-demand or concurrency gating. That is
-            // not an enqueue error, but the backstop still did not heal now.
-            result.deferredOrFailed += 1;
+          const readiness = readinessMap.get(candidate.id);
+          const resolvedBlockerIssueId = readiness?.blockerIssueIds[0] ?? null;
+          if (
+            !readiness ||
+            !readiness.isDependencyReady ||
+            readiness.blockerIssueIds.length === 0 ||
+            !resolvedBlockerIssueId
+          ) {
+            result.notReadySkipped += 1;
             continue;
           }
 
-          result.healed += 1;
-          result.issueIds.push(candidate.id);
-
-          await logActivity(db, {
-            companyId,
-            actorType: "system",
-            actorId: "issue_graph_liveness_backstop",
-            agentId,
-            runId: opts?.runId ?? null,
-            action: "issue.blockers_resolved_wake_emitted",
-            entityType: "issue",
-            entityId: candidate.id,
-            details: {
-              source,
-              wakeupRunId: wake.id,
-              idempotencyKey,
-              resolvedBlockerIssueId,
-              blockerIssueIds: readiness.blockerIssueIds,
-            },
-          });
-        } catch (err) {
-          result.deferredOrFailed += 1;
-          result.enqueueFailed += 1;
-          logger.warn(
-            { err, issueId: candidate.id, agentId, idempotencyKey, source },
-            "failed to enqueue dependency wake from issue graph liveness backstop",
+          const idempotencyKeys = readiness.blockerIssueIds.map((blockerIssueId) =>
+            buildIssueBlockersResolvedWakeIdempotencyKey({
+              dependentIssueId: candidate.id,
+              resolvedBlockerIssueId: blockerIssueId,
+            }),
           );
+          const idempotencyKey = buildIssueBlockersResolvedWakeIdempotencyKey({
+            dependentIssueId: candidate.id,
+            resolvedBlockerIssueId,
+          });
+          const existingWake = await findExistingIssueBlockersResolvedWakeForAnyKey(db, {
+            companyId,
+            idempotencyKeys,
+          });
+          if (existingWake) {
+            result.existingWakeSkipped += 1;
+            continue;
+          }
+
+          if (
+            (await hasActiveExecutionPath(companyId, candidate.id, agentId)) ||
+            (await hasQueuedIssueWake(companyId, candidate.id, agentId))
+          ) {
+            result.livePathSkipped += 1;
+            continue;
+          }
+
+          if (await hasPendingWakeInteraction(companyId, candidate.id)) {
+            result.interactionSkipped += 1;
+            continue;
+          }
+
+          if (await isAutomaticRecoverySuppressedByPauseHold(db, companyId, candidate.id, treeControlSvc)) {
+            result.pauseHoldSkipped += 1;
+            continue;
+          }
+
+          try {
+            const wake = await deps.enqueueWakeup(agentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
+              payload: {
+                issueId: candidate.id,
+                resolvedBlockerIssueId,
+                blockerIssueIds: readiness.blockerIssueIds,
+                backstop: payloadBackstop,
+              },
+              idempotencyKey,
+              requestedByActorType: "system",
+              requestedByActorId,
+              contextSnapshot: {
+                issueId: candidate.id,
+                taskId: candidate.id,
+                wakeReason: ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
+                source,
+                resolvedBlockerIssueId,
+                blockerIssueIds: readiness.blockerIssueIds,
+              },
+            });
+            if (!wake) {
+              // enqueueWakeup returns null for normal deferred/skipped paths
+              // such as disabled wake-on-demand or concurrency gating. That is
+              // not an enqueue error, but the backstop still did not heal now.
+              result.deferredOrFailed += 1;
+              continue;
+            }
+
+            result.healed += 1;
+            result.issueIds.push(candidate.id);
+
+            await logActivity(db, {
+              companyId,
+              actorType: "system",
+              actorId: "issue_graph_liveness_backstop",
+              agentId,
+              runId: opts?.runId ?? null,
+              action: "issue.blockers_resolved_wake_emitted",
+              entityType: "issue",
+              entityId: candidate.id,
+              details: {
+                source,
+                wakeupRunId: wake.id,
+                idempotencyKey,
+                resolvedBlockerIssueId,
+                blockerIssueIds: readiness.blockerIssueIds,
+              },
+            });
+          } catch (err) {
+            result.deferredOrFailed += 1;
+            result.enqueueFailed += 1;
+            logger.warn(
+              { err, issueId: candidate.id, agentId, idempotencyKey, source },
+              "failed to enqueue dependency wake from issue graph liveness backstop",
+            );
+          }
         }
       }
-    }
 
-    if (result.healed > 0) {
-      logger.warn(
-        { healed: result.healed, issueIds: result.issueIds, source, blockerIssueId: opts?.blockerIssueId ?? null },
-        "issue graph liveness backstop healed resolved blocked dependency wakes",
+      if (useCursor) {
+        if (cursorOut) {
+          resolvedDependencyWakeBackstopPagination = {
+            cursor: cursorOut,
+            censusId: invocation.censusId,
+            nextPageIndex: (invocation.pageIndex ?? 0) + 1,
+          };
+        } else {
+          resolvedDependencyWakeBackstopPagination = {
+            cursor: null,
+            censusId: null,
+            nextPageIndex: 0,
+          };
+          result.censusCompleted = true;
+          cursorResetReason = "census_complete";
+        }
+      }
+
+      if (result.healed > 0) {
+        logger.warn(
+          { healed: result.healed, issueIds: result.issueIds, source, blockerIssueId: opts?.blockerIssueId ?? null },
+          "issue graph liveness backstop healed resolved blocked dependency wakes",
+        );
+      }
+
+      return result;
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          invocationId: invocation.invocationId,
+          censusId: invocation.censusId,
+          pageIndex: invocation.pageIndex,
+          cursorIn: invocation.cursorIn,
+          cursorOut: invocation.cursorIn,
+          durationMs: Date.now() - startedAtMs,
+          source,
+          companyId: opts?.companyId ?? null,
+          blockerIssueId: opts?.blockerIssueId ?? null,
+        },
+        "issue graph liveness backstop pass failed before cursor commit",
+      );
+      throw err;
+    } finally {
+      logger.info(
+        {
+          invocationId: invocation.invocationId,
+          censusId: invocation.censusId,
+          pageIndex: invocation.pageIndex,
+          cursorIn: invocation.cursorIn,
+          cursorOut: result.cursorOut,
+          censusCompleted: result.censusCompleted,
+          cursorResetReason,
+          candidateCount: result.checked,
+          candidateLimitSkipped: result.candidateLimitSkipped,
+          companyCount: result.companyCount,
+          wakeCount: result.healed,
+          durationMs: Date.now() - startedAtMs,
+          source,
+          companyId: opts?.companyId ?? null,
+          blockerIssueId: opts?.blockerIssueId ?? null,
+        },
+        "issue graph liveness backstop pass finished",
       );
     }
+  }
 
-    return result;
+  async function reconcileResolvedDependencyWakeBackstop(opts?: ResolvedDependencyWakeBackstopOptions) {
+    const invocationId = randomUUID();
+    const useCursor = !opts?.blockerIssueId;
+    if (!useCursor) {
+      return runResolvedDependencyWakeBackstop(opts, {
+        invocationId,
+        censusId: null,
+        pageIndex: null,
+        cursorIn: null,
+      });
+    }
+
+    if (resolvedDependencyWakeBackstopInFlight) {
+      const result = createResolvedDependencyWakeBackstopResult({
+        invocationId,
+        censusId: resolvedDependencyWakeBackstopPagination.censusId,
+        pageIndex: resolvedDependencyWakeBackstopPagination.nextPageIndex,
+        cursorIn: resolvedDependencyWakeBackstopPagination.cursor,
+      });
+      result.singleFlightSkipped = 1;
+      logger.info(
+        {
+          invocationId,
+          activeInvocationId: resolvedDependencyWakeBackstopInFlight.invocationId,
+          activeDurationMs: Date.now() - resolvedDependencyWakeBackstopInFlight.startedAtMs,
+          censusId: result.censusId,
+          pageIndex: result.pageIndex,
+          cursorIn: result.cursorIn,
+          cursorOut: result.cursorOut,
+          candidateCount: 0,
+          companyCount: 0,
+          wakeCount: 0,
+          source: opts?.source ?? "issue_graph_liveness.backstop",
+        },
+        "issue graph liveness backstop skipped overlapping pass",
+      );
+      return result;
+    }
+
+    const invocation = {
+      invocationId,
+      censusId: resolvedDependencyWakeBackstopPagination.censusId ?? randomUUID(),
+      pageIndex: resolvedDependencyWakeBackstopPagination.nextPageIndex,
+      cursorIn: resolvedDependencyWakeBackstopPagination.cursor,
+    };
+    const promise = runResolvedDependencyWakeBackstop(opts, invocation);
+    resolvedDependencyWakeBackstopInFlight = {
+      invocationId,
+      startedAtMs: Date.now(),
+      promise,
+    };
+    try {
+      return await promise;
+    } finally {
+      if (resolvedDependencyWakeBackstopInFlight?.promise === promise) {
+        resolvedDependencyWakeBackstopInFlight = null;
+      }
+    }
   }
 
   async function reconcileIssueGraphLiveness(opts?: {
@@ -5419,6 +5601,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       dependencyWakeCandidateLimitSkipped: 0,
       dependencyWakeDeferredOrFailed: 0,
       dependencyWakeEnqueueFailed: 0,
+      dependencyWakeBackstopSingleFlightSkipped: 0,
       dependencyWakeIssueIds: [] as string[],
       issueIds: [] as string[],
       escalationIssueIds: [] as string[],
@@ -5438,6 +5621,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     result.dependencyWakeCandidateLimitSkipped = dependencyWakeBackstop.candidateLimitSkipped;
     result.dependencyWakeDeferredOrFailed = dependencyWakeBackstop.deferredOrFailed;
     result.dependencyWakeEnqueueFailed = dependencyWakeBackstop.enqueueFailed;
+    result.dependencyWakeBackstopSingleFlightSkipped = dependencyWakeBackstop.singleFlightSkipped;
     result.dependencyWakeIssueIds = dependencyWakeBackstop.issueIds;
 
     if (!autoRecoveryEnabled) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their work
> - The heartbeat scheduler runs recovery work for issue and run liveness
> - The interval can start a second recovery chain before the first chain completes
> - The issue graph backstop also changes one shared pagination cursor during each pass
> - Slow issue reads can therefore repeat pages and increase API load
> - This pull request adds one active recovery chain and invocation-safe page state
> - The benefit is bounded recovery work with clear telemetry and live timer scheduling

## Linked Issues or Issue Description

**What happened?**

The heartbeat interval can start a new recovery chain while the prior chain is active. The issue graph liveness backstop also reads and changes one process-level cursor. A slow 500-candidate page can therefore overlap with a new pass and repeat work.

**Expected behavior**

Only one periodic recovery chain must run in each server process. One census must visit each candidate page once. The scheduler must keep timer work live while it skips an overlapping recovery pass.

**Steps to reproduce**

1. Seed more than one page of dependency-wake candidates.
2. Delay one backstop page past the heartbeat interval.
3. Start the next interval before the first page completes.
4. Observe that the previous code starts another recovery chain and can read the same cursor.

**Paperclip version or commit**

master at 44694328a

**Deployment mode**

Self-hosted server

**Installation method**

npm or pnpm global install

**Agent adapter(s) involved**

Not adapter-specific. This is a core scheduler bug.

**Database mode**

External Postgres in the observed deployment. The single-flight regression test is database independent.

**Access context**

Both board and agent traffic can be affected by the extra recovery load.

**Node.js version**

v24.13.1

**Operating system**

Windows for development. The scheduler bug is platform independent.

**Relevant logs or output**

A slow recovery page can produce an overlap skip. The new log includes the active invocation ID and active duration.

**Relevant config (if applicable)**

The recovery interval is shorter than the delayed candidate page.

**Additional context**

A GitHub search found no close duplicate. This change does not alter database locks or migrations.

## What Changed

- Add a single-flight boundary around the full periodic heartbeat recovery chain.
- Replace the shared bare cursor with census, page, and invocation state.
- Commit the next cursor only after candidate processing completes.
- Reset the census on an empty terminal page without reading page zero in the same interval.
- Add structured invocation, duration, cursor, candidate, company, wake, and overlap telemetry.
- Add a slow-page concurrency regression test.
- Add a guarded immutable-package rollout and rollback plan.

## Verification

- server TypeScript check passed.
- The scheduler single-flight regression passed: 1 test.
- The workspace-finalize liveness regression passed in isolation.
- The existing claim-lock concurrency test file passed: 3 tests.
- The full liveness file completed its behavior assertions. One embedded Postgres afterEach hook failed with 57P02. The affected test passed in an isolated rerun.
- Git whitespace validation passed.
- GitHub CI completed 27 passing checks. The MCP US-9 e2e shard failed on a 409 action_not_pending approval race outside the changed code. The contributor token cannot rerun upstream Actions.

## Risks

- The single-flight boundary is process-local. Each server process owns one recovery pass.
- A failed page keeps its input cursor. The next interval retries that page.
- A direct workspace-finalize check does not use the global census cursor.
- A production rollout must use an immutable package and preserve any downstream claim-lock patch.
- Roll back the package if authenticated API latency regresses or cursor telemetry repeats before census completion.

> This is a scoped scheduler bug fix. ROADMAP.md has no duplicate planned core work.

## Model Used

- OpenAI Codex, GPT-5 family. The runtime did not expose the exact model ID or context window. High reasoning, tool use, and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes or Closes or Refs OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket ID or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge