### PR TITLE
fix: preserve pinned execution workspaces

### DIFF
--- a/cli/src/__tests__/secrets.test.ts
+++ b/cli/src/__tests__/secrets.test.ts
@@ -137,6 +137,9 @@ describe("secrets CLI helpers", () => {
     delete process.env.PAPERCLIP_SECRETS_AWS_REGION;
     delete process.env.AWS_REGION;
     delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_SESSION_TOKEN;
     delete process.env.PAPERCLIP_SECRETS_AWS_DEPLOYMENT_ID;
     delete process.env.PAPERCLIP_SECRETS_AWS_KMS_KEY_ID;
   });

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -258,6 +258,7 @@ Invariants:
 - single assignee only
 - task must trace to company goal chain via `goal_id`, `parent_id`, or project-goal linkage
 - `in_progress` requires assignee
+- a non-null `execution_workspace_id` with an absent or `reuse_existing` preference is a durable workspace pin: create/update normalizes an absent preference to `reuse_existing`, realization must not silently replace the pin, and unavailable pins fail with a named workspace-reuse reason
 - terminal states: `done | cancelled`
 
 ## 7.7 `issue_comments`

--- a/packages/adapters/claude-local/src/server/execute.acp-fallback.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.acp-fallback.test.ts
@@ -113,6 +113,7 @@ describe("claude_local ACP startup fallback", () => {
 
   it("trusts the Paperclip API URL when network access is allowlisted", async () => {
     const paperclipApiUrl = "http://127.0.0.1:4310";
+    vi.stubEnv("PAPERCLIP_API_URL", paperclipApiUrl);
     vi.stubEnv("PAPERCLIP_RUNTIME_API_URL", paperclipApiUrl);
     const ctx = buildContext({ networkScope: "allowlist" });
 

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -90,6 +90,7 @@ const tailscaleAuthFlagNames = new Set([
 let tailscaleAuth = false;
 let bindMode: BindMode | null = null;
 let bindHost: string | null = null;
+const managedRuntimeExposure = process.env.PAPERCLIP_MANAGED_RUNTIME_EXPOSURE === "tailscale_https";
 const forwardedArgs: string[] = [];
 
 for (let index = 0; index < cliArgs.length; index += 1) {
@@ -133,6 +134,10 @@ if (!bindMode && process.env.npm_config_bind && BIND_MODES.includes(process.env.
 if (!bindHost && process.env.npm_config_bind_host) {
   bindHost = process.env.npm_config_bind_host;
 }
+if (managedRuntimeExposure) {
+  bindMode = "custom";
+  bindHost = "127.0.0.1";
+}
 if (bindMode === "custom" && !bindHost) {
   console.error("[paperclip] --bind custom requires --bind-host <host>");
   process.exit(1);
@@ -174,7 +179,7 @@ if (tailscaleAuth || bindMode) {
   } else {
     env.PAPERCLIP_DEPLOYMENT_MODE = "authenticated";
     env.PAPERCLIP_DEPLOYMENT_EXPOSURE = "private";
-    env.PAPERCLIP_AUTH_BASE_URL_MODE = "auto";
+    env.PAPERCLIP_AUTH_BASE_URL_MODE = managedRuntimeExposure ? "explicit" : "auto";
     console.log(
       `[paperclip] dev mode: authenticated/private (bind=${effectiveBind}${bindHost ? `:${bindHost}` : ""})`,
     );

--- a/server/src/__tests__/app-hmr-port.test.ts
+++ b/server/src/__tests__/app-hmr-port.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveViteHmrHost, resolveViteHmrPort } from "../app.ts";
+import { resolveViteHmrHost, resolveViteHmrPort, resolveViteHmrProtocol } from "../app.ts";
 
 describe("resolveViteHmrPort", () => {
   it("uses serverPort + 10000 when the result stays in range", () => {
@@ -19,13 +19,29 @@ describe("resolveViteHmrPort", () => {
 });
 
 describe("resolveViteHmrHost", () => {
-  it("omits wildcard bind hosts so Vite uses the browser hostname", () => {
+  it("omits wildcard and loopback bind hosts so Vite uses the browser hostname", () => {
     expect(resolveViteHmrHost("0.0.0.0")).toBeUndefined();
     expect(resolveViteHmrHost("::")).toBeUndefined();
+    expect(resolveViteHmrHost("127.0.0.1")).toBeUndefined();
+    expect(resolveViteHmrHost("::1")).toBeUndefined();
+    expect(resolveViteHmrHost("localhost")).toBeUndefined();
   });
 
-  it("keeps concrete bind hosts", () => {
-    expect(resolveViteHmrHost("127.0.0.1")).toBe("127.0.0.1");
+  it("keeps externally addressable concrete bind hosts", () => {
     expect(resolveViteHmrHost("paperclip-dev")).toBe("paperclip-dev");
+  });
+});
+
+describe("resolveViteHmrProtocol", () => {
+  it("accepts supported websocket protocols", () => {
+    expect(resolveViteHmrProtocol(undefined)).toBeUndefined();
+    expect(resolveViteHmrProtocol("ws")).toBe("ws");
+    expect(resolveViteHmrProtocol("wss")).toBe("wss");
+  });
+
+  it("rejects unsupported websocket protocols", () => {
+    expect(() => resolveViteHmrProtocol("https")).toThrow(
+      "PAPERCLIP_VITE_HMR_PROTOCOL must be ws or wss",
+    );
   });
 });

--- a/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
+++ b/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
@@ -359,7 +359,6 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       responsibleUserId: "responsible-user",
       assigneeAgentId: agentId,
       identifier: "PAP-9122",
-      executionWorkspaceId: sharedExecutionWorkspaceId,
       executionWorkspaceSettings: {
         mode: "isolated_workspace",
       },

--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -1039,7 +1039,7 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
   });
 
   it.each([
-    ["workspace-runtime fresh worktree reuse", "fresh_realize" as const, null],
+    ["workspace-runtime fresh worktree reuse", "fresh_realize" as const, "source-workspace"],
     ["workspace-runtime persisted restore", "persisted_restore" as const, "source-workspace"],
   ])("contains mid-change branch divergence at %s", async (_name, callSite, expectedWorkspaceId) => {
     const repoRoot = await createGitRepo();

--- a/server/src/__tests__/heartbeat-workspace-busy.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-busy.test.ts
@@ -45,6 +45,8 @@ import {
   heartbeatService,
 } from "../services/heartbeat.ts";
 import { instanceSettingsService } from "../services/instance-settings.ts";
+import { issueService } from "../services/issues.ts";
+import { assertCanManageExecutionWorkspaceRuntimeServices } from "../routes/workspace-runtime-service-authz.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -486,6 +488,104 @@ describeEmbeddedPostgres("shared-workspace run serialization", () => {
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.scheduledRetryReason, WORKSPACE_BUSY_RETRY_REASON));
     expect(retryRuns).toHaveLength(0);
+  });
+
+  it("preserves an explicit isolated workspace pin under shared-workspace contention", async () => {
+    const fixture = await seedWorkspaceFixture({
+      issueWorkspaceSettings: { sharedWorkspaceConcurrency: "allow" },
+    });
+    const sourceIssueId = randomUUID();
+    const pinnedExecutionWorkspaceId = randomUUID();
+
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId: fixture.companyId,
+      title: "Completed source issue",
+      status: "done",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: fixture.holderAgentId,
+      projectId: fixture.projectId,
+      projectWorkspaceId: fixture.projectWorkspaceId,
+      issueNumber: 3,
+      identifier: `SRC-${sourceIssueId.slice(0, 8)}`,
+      completedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: pinnedExecutionWorkspaceId,
+      companyId: fixture.companyId,
+      projectId: fixture.projectId,
+      projectWorkspaceId: fixture.projectWorkspaceId,
+      sourceIssueId,
+      mode: "isolated_workspace",
+      strategyType: "project_primary",
+      name: "Pinned isolated workspace",
+      status: "active",
+      cwd: workspaceCwd,
+      providerType: "local_fs",
+    });
+    await db
+      .update(issues)
+      .set({ executionWorkspaceId: pinnedExecutionWorkspaceId })
+      .where(eq(issues.id, sourceIssueId));
+
+    const pinnedIssue = await issueService(db).create(fixture.companyId, {
+      title: "Run in the pinned isolated workspace",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: fixture.agentId,
+      projectId: fixture.projectId,
+      projectWorkspaceId: fixture.projectWorkspaceId,
+      executionWorkspaceId: pinnedExecutionWorkspaceId,
+    });
+    expect(pinnedIssue.executionWorkspacePreference).toBe("reuse_existing");
+    expect(pinnedIssue.executionWorkspaceSettings).toEqual({
+      mode: "isolated_workspace",
+      workspaceStrategy: { type: "project_primary" },
+    });
+
+    const run = await heartbeat.invoke(
+      fixture.agentId,
+      "assignment",
+      { issueId: pinnedIssue.id, wakeReason: "issue_assigned" },
+      "system",
+    );
+    expect(run).not.toBeNull();
+
+    const finishedRun = await waitForRunToLeaveActiveStates(run!.id);
+    expect(finishedRun?.status).toBe("succeeded");
+    expect(finishedRun?.errorCode).not.toBe(WORKSPACE_BUSY_ERROR_CODE);
+    expect(executedRunIds).toContain(run!.id);
+
+    const realizedIssue = await db
+      .select({
+        executionWorkspaceId: issues.executionWorkspaceId,
+        executionWorkspacePreference: issues.executionWorkspacePreference,
+        executionWorkspaceSettings: issues.executionWorkspaceSettings,
+      })
+      .from(issues)
+      .where(eq(issues.id, pinnedIssue.id))
+      .then((rows) => rows[0] ?? null);
+    expect(realizedIssue).toMatchObject({
+      executionWorkspaceId: pinnedExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: {
+        mode: "isolated_workspace",
+        workspaceStrategy: { type: "project_primary" },
+      },
+    });
+
+    await expect(assertCanManageExecutionWorkspaceRuntimeServices(db, {
+      actor: {
+        type: "agent",
+        agentId: fixture.agentId,
+        companyId: fixture.companyId,
+        source: "agent_key",
+      },
+    } as any, {
+      companyId: fixture.companyId,
+      executionWorkspaceId: pinnedExecutionWorkspaceId,
+    })).resolves.toBeUndefined();
   });
 
   it("defers a run whose issue targets a busy shared workspace and schedules a bounded retry", async () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -41,6 +41,7 @@ import {
   stripHostWorkspaceProvisionForLowTrustSandbox,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForModelChange,
+  shouldReusePinnedExecutionWorkspaceForRun,
   stripConfiguredModelFromSessionParams,
   stripPaperclipSessionMetadataFromSessionParams,
   normalizeSessionParams,
@@ -1658,6 +1659,33 @@ describe("effective run execution workspace config freshness", () => {
       requestedShouldReuseExisting: true,
       existingExecutionWorkspaceAvailable: true,
     });
+  });
+
+  it("does not reuse an available shared pin for a low-trust isolated run", () => {
+    expect(shouldReusePinnedExecutionWorkspaceForRun({
+      requestedShouldReuseExisting: true,
+      trustPresetKind: "low_trust_review",
+      requestedExecutionWorkspaceMode: "isolated_workspace",
+      existingExecutionWorkspaceMode: "shared_workspace",
+    })).toBe(false);
+  });
+
+  it("reuses an available isolated pin for a low-trust isolated run", () => {
+    expect(shouldReusePinnedExecutionWorkspaceForRun({
+      requestedShouldReuseExisting: true,
+      trustPresetKind: "low_trust_review",
+      requestedExecutionWorkspaceMode: "isolated_workspace",
+      existingExecutionWorkspaceMode: "isolated_workspace",
+    })).toBe(true);
+  });
+
+  it("keeps unavailable low-trust pins on the named reuse-failure path", () => {
+    expect(shouldReusePinnedExecutionWorkspaceForRun({
+      requestedShouldReuseExisting: true,
+      trustPresetKind: "low_trust_review",
+      requestedExecutionWorkspaceMode: "isolated_workspace",
+      existingExecutionWorkspaceMode: null,
+    })).toBe(true);
   });
 
   it.each([

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -24,6 +24,8 @@ import {
   preflightLowTrustWorkspaceIsolation,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE,
+  PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE,
   provisionExecutionWorkspaceForFreshnessDecision,
   reconcileReusedExecutionWorkspaceProjectWorkspaceId,
   resolveExecutionWorkspaceConfigFreshness,
@@ -1633,8 +1635,29 @@ describe("effective run execution workspace config freshness", () => {
         throw new Error("restore command failed");
       },
       realizeWorkspace,
-    })).rejects.toThrow(/restore command failed/);
+    })).rejects.toMatchObject({
+      code: PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE,
+      message: expect.stringContaining("restore command failed"),
+      resultJson: {
+        executionWorkspaceReuse: expect.objectContaining({
+          reason: PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE,
+          executionWorkspaceId: "workspace-old",
+        }),
+      },
+    });
     expect(realizeWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("treats a workspace id without a preference as an explicit reuse pin", () => {
+    expect(resolveExecutionWorkspaceReuseRequestForIssue({
+      issueExecutionWorkspaceId: "workspace-old",
+      issueExecutionWorkspacePreference: null,
+      existingExecutionWorkspaceStatus: "active",
+    })).toEqual({
+      requestedExecutionWorkspaceId: "workspace-old",
+      requestedShouldReuseExisting: true,
+      existingExecutionWorkspaceAvailable: true,
+    });
   });
 
   it.each([
@@ -1672,7 +1695,16 @@ describe("effective run execution workspace config freshness", () => {
         ? async () => ({ id: "workspace-old", warnings: [] })
         : null,
       realizeWorkspace,
-    })).rejects.toThrow(/could not be restored/);
+    })).rejects.toMatchObject({
+      code: PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE,
+      message: expect.stringContaining("could not be restored"),
+      resultJson: {
+        executionWorkspaceReuse: expect.objectContaining({
+          reason: PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE,
+          executionWorkspaceId: "workspace-old",
+        }),
+      },
+    });
     expect(realizeWorkspace).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -26,6 +26,8 @@ import {
   parseSessionCompactionPolicy,
   PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE,
   PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE,
+  PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE,
+  ExecutionWorkspaceReuseFailure,
   provisionExecutionWorkspaceForFreshnessDecision,
   reconcileReusedExecutionWorkspaceProjectWorkspaceId,
   resolveExecutionWorkspaceConfigFreshness,
@@ -41,7 +43,7 @@ import {
   stripHostWorkspaceProvisionForLowTrustSandbox,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForModelChange,
-  shouldReusePinnedExecutionWorkspaceForRun,
+  isPinnedExecutionWorkspaceIncompatibleWithTrust,
   stripConfiguredModelFromSessionParams,
   stripPaperclipSessionMetadataFromSessionParams,
   normalizeSessionParams,
@@ -1661,31 +1663,58 @@ describe("effective run execution workspace config freshness", () => {
     });
   });
 
-  it("does not reuse an available shared pin for a low-trust isolated run", () => {
-    expect(shouldReusePinnedExecutionWorkspaceForRun({
+  it("marks an available shared pin incompatible with a low-trust isolated run", () => {
+    expect(isPinnedExecutionWorkspaceIncompatibleWithTrust({
       requestedShouldReuseExisting: true,
       trustPresetKind: "low_trust_review",
       requestedExecutionWorkspaceMode: "isolated_workspace",
       existingExecutionWorkspaceMode: "shared_workspace",
-    })).toBe(false);
+    })).toBe(true);
   });
 
-  it("reuses an available isolated pin for a low-trust isolated run", () => {
-    expect(shouldReusePinnedExecutionWorkspaceForRun({
+  it("accepts an available isolated pin for a low-trust isolated run", () => {
+    expect(isPinnedExecutionWorkspaceIncompatibleWithTrust({
       requestedShouldReuseExisting: true,
       trustPresetKind: "low_trust_review",
       requestedExecutionWorkspaceMode: "isolated_workspace",
       existingExecutionWorkspaceMode: "isolated_workspace",
-    })).toBe(true);
+    })).toBe(false);
   });
 
-  it("keeps unavailable low-trust pins on the named reuse-failure path", () => {
-    expect(shouldReusePinnedExecutionWorkspaceForRun({
+  it("keeps unavailable low-trust pins on the named availability-failure path", () => {
+    expect(isPinnedExecutionWorkspaceIncompatibleWithTrust({
       requestedShouldReuseExisting: true,
       trustPresetKind: "low_trust_review",
       requestedExecutionWorkspaceMode: "isolated_workspace",
       existingExecutionWorkspaceMode: null,
-    })).toBe(true);
+    })).toBe(false);
+  });
+
+  it("reports a named incompatibility without realizing a replacement workspace", () => {
+    const metadata = buildWorkspaceConfigMetadata();
+    const workspaceConfigFreshness = resolveExecutionWorkspaceConfigFreshness({
+      hasExistingWorkspace: true,
+      existingWorkspaceMetadata: persistedWorkspaceConfigFingerprint(metadata),
+      nextMetadata: metadata,
+    });
+    const failure = new ExecutionWorkspaceReuseFailure({
+      reason: PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE,
+      issueRef: { id: "issue-1", identifier: "PAP-42" },
+      runId: "run-1",
+      executionWorkspaceId: "workspace-shared",
+      workspaceConfigFreshness,
+    });
+
+    expect(failure).toMatchObject({
+      code: PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE,
+      message: expect.stringContaining("incompatible with the run's isolation policy"),
+      resultJson: {
+        executionWorkspaceReuse: expect.objectContaining({
+          reason: PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE,
+          executionWorkspaceId: "workspace-shared",
+        }),
+      },
+    });
   });
 
   it.each([

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2853,6 +2853,71 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
+  it("normalizes an explicit execution workspace id into a durable reuse pin", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary workspace",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Pinned workspace",
+      status: "active",
+      providerType: "git_worktree",
+      providerRef: `/tmp/${executionWorkspaceId}`,
+    });
+
+    const created = await svc.create(companyId, {
+      title: "Pinned issue",
+      projectId,
+      executionWorkspaceId,
+    });
+
+    expect(created.executionWorkspaceId).toBe(executionWorkspaceId);
+    expect(created.executionWorkspacePreference).toBe("reuse_existing");
+    expect(created.executionWorkspaceSettings).toEqual({
+      mode: "isolated_workspace",
+      workspaceStrategy: { type: "git_worktree" },
+    });
+
+    const unpinned = await svc.create(companyId, {
+      title: "Pin on update",
+      projectId,
+    });
+    const updated = await svc.update(unpinned.id, { executionWorkspaceId });
+
+    expect(updated?.executionWorkspaceId).toBe(executionWorkspaceId);
+    expect(updated?.executionWorkspacePreference).toBe("reuse_existing");
+    expect(updated?.executionWorkspaceSettings).toEqual({
+      mode: "isolated_workspace",
+      workspaceStrategy: { type: "git_worktree" },
+    });
+  });
+
   it("inherits responsible user for agent-created child issues", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -4148,7 +4148,7 @@ describeEmbeddedPostgres("tool access service", () => {
       schemaHash: "s1",
     }).returning();
     const canonicalArguments = canonicalToolArguments({ key: "alpha", value: "one" });
-    const invocationValues = [1, 2, 3].map(() => ({
+    const invocationValues = [1, 2, 3, 4].map(() => ({
       companyId: company.id,
       applicationId: application.id,
       connectionId: connection.id,
@@ -4160,7 +4160,7 @@ describeEmbeddedPostgres("tool access service", () => {
       approvalState: "pending" as const,
       status: "awaiting_approval" as const,
     }));
-    const [validInvocation, missingSignatureInvocation, oldSecretInvocation] =
+    const [validInvocation, missingSignatureInvocation, oldSecretInvocation, inFlightInvocation] =
       await db.insert(toolInvocations).values(invocationValues).returning();
     const validSignedArguments = signToolArguments({
       invocationId: validInvocation.id,
@@ -4174,7 +4174,7 @@ describeEmbeddedPostgres("tool access service", () => {
       canonicalArguments,
       signingSecret: "old-secret",
     });
-    const [validRequest, missingSignatureRequest, oldSecretRequest] = await db.insert(toolActionRequests).values([
+    const [validRequest, missingSignatureRequest, oldSecretRequest, inFlightRequest] = await db.insert(toolActionRequests).values([
       {
         companyId: company.id,
         invocationId: validInvocation.id,
@@ -4190,6 +4190,7 @@ describeEmbeddedPostgres("tool access service", () => {
         canonicalArgumentsHash: "args-hash",
         canonicalArgumentsSummary: { summary: canonicalArguments, sha256: "args-hash", sizeBytes: canonicalArguments.length },
         signedArguments: null,
+        createdAt: new Date(Date.now() - 60_000),
       },
       {
         companyId: company.id,
@@ -4198,6 +4199,14 @@ describeEmbeddedPostgres("tool access service", () => {
         canonicalArgumentsHash: "args-hash",
         canonicalArgumentsSummary: { summary: canonicalArguments, sha256: "args-hash", sizeBytes: canonicalArguments.length },
         signedArguments: oldSecretSignedArguments,
+      },
+      {
+        companyId: company.id,
+        invocationId: inFlightInvocation.id,
+        status: "pending",
+        canonicalArgumentsHash: "args-hash",
+        canonicalArgumentsSummary: { summary: canonicalArguments, sha256: "args-hash", sizeBytes: canonicalArguments.length },
+        signedArguments: null,
       },
     ]).returning();
 
@@ -4209,6 +4218,7 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(statusById.get(validRequest.id)).toBe("pending");
     expect(statusById.get(missingSignatureRequest.id)).toBe("cancelled");
     expect(statusById.get(oldSecretRequest.id)).toBe("cancelled");
+    expect(statusById.get(inFlightRequest.id)).toBe("pending");
   });
 
   it("tracks new profile tools, reviews mixed allow/block decisions, and clears pending counts", async () => {

--- a/server/src/__tests__/workspace-runtime-routes-authz.test.ts
+++ b/server/src/__tests__/workspace-runtime-routes-authz.test.ts
@@ -25,7 +25,12 @@ const mockEnvironmentService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
 
-const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockWorkspaceOperationRecorder = vi.hoisted(() => ({
+  recordOperation: vi.fn(async (input: { run: () => Promise<unknown> }) => await input.run()),
+}));
+const mockWorkspaceOperationService = vi.hoisted(() => ({
+  createRecorder: vi.fn(() => mockWorkspaceOperationRecorder),
+}));
 const mockHeartbeatService = vi.hoisted(() => ({}));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
@@ -34,6 +39,8 @@ const mockAccessService = vi.hoisted(() => ({
 }));
 const mockAssertCanManageProjectWorkspaceRuntimeServices = vi.hoisted(() => vi.fn());
 const mockAssertCanManageExecutionWorkspaceRuntimeServices = vi.hoisted(() => vi.fn());
+const mockEnsurePersistedExecutionWorkspaceAvailable = vi.hoisted(() => vi.fn());
+const mockStartRuntimeServicesForWorkspaceControl = vi.hoisted(() => vi.fn());
 
 vi.mock("../telemetry.js", () => ({
   getTelemetryClient: mockGetTelemetryClient,
@@ -51,8 +58,15 @@ vi.mock("../services/index.js", () => ({
 }));
 
 vi.mock("../services/workspace-runtime.js", () => ({
+  buildWorkspaceRuntimeDesiredStatePatch: vi.fn(() => ({
+    desiredState: "running",
+    serviceStates: null,
+  })),
   cleanupExecutionWorkspaceArtifacts: vi.fn(),
-  startRuntimeServicesForWorkspaceControl: vi.fn(),
+  ensurePersistedExecutionWorkspaceAvailable: mockEnsurePersistedExecutionWorkspaceAvailable,
+  listConfiguredRuntimeServiceEntries: vi.fn(() => [{ serviceIndex: 0 }]),
+  runWorkspaceJobForControl: vi.fn(),
+  startRuntimeServicesForWorkspaceControl: mockStartRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace: vi.fn(),
   stopRuntimeServicesForProjectWorkspace: vi.fn(),
 }));
@@ -79,8 +93,15 @@ function registerWorkspaceRouteMocks() {
   }));
 
   vi.doMock("../services/workspace-runtime.js", () => ({
+    buildWorkspaceRuntimeDesiredStatePatch: vi.fn(() => ({
+      desiredState: "running",
+      serviceStates: null,
+    })),
     cleanupExecutionWorkspaceArtifacts: vi.fn(),
-    startRuntimeServicesForWorkspaceControl: vi.fn(),
+    ensurePersistedExecutionWorkspaceAvailable: mockEnsurePersistedExecutionWorkspaceAvailable,
+    listConfiguredRuntimeServiceEntries: vi.fn(() => [{ serviceIndex: 0 }]),
+    runWorkspaceJobForControl: vi.fn(),
+    startRuntimeServicesForWorkspaceControl: mockStartRuntimeServicesForWorkspaceControl,
     stopRuntimeServicesForExecutionWorkspace: vi.fn(),
     stopRuntimeServicesForProjectWorkspace: vi.fn(),
   }));
@@ -129,6 +150,10 @@ async function createExecutionWorkspaceApp(actor: Record<string, unknown>) {
     next();
   });
   app.use("/api", executionWorkspaceRoutes({} as any));
+  app.use((err: unknown, _req: unknown, _res: unknown, next: (error: unknown) => void) => {
+    app.locals.lastRouteError = err;
+    next(err);
+  });
   app.use(errorHandler);
   return app;
 }
@@ -283,6 +308,13 @@ describe.sequential("workspace runtime service route authorization", () => {
     mockExecutionWorkspaceService.update.mockResolvedValue(buildExecutionWorkspace());
     mockAssertCanManageProjectWorkspaceRuntimeServices.mockResolvedValue(undefined);
     mockAssertCanManageExecutionWorkspaceRuntimeServices.mockResolvedValue(undefined);
+    mockEnsurePersistedExecutionWorkspaceAvailable.mockResolvedValue({
+      strategy: "project_primary",
+      cwd: "/tmp/workspace",
+      warnings: [],
+      created: false,
+    });
+    mockStartRuntimeServicesForWorkspaceControl.mockResolvedValue([]);
   });
 
   it("rejects agent callers for project workspace runtime service mutations when workspace auth denies access", async () => {
@@ -473,6 +505,45 @@ describe.sequential("workspace runtime service route authorization", () => {
     expect(res.body.error).toContain("Missing permission");
     expect(mockExecutionWorkspaceService.getById).toHaveBeenCalledWith(executionWorkspaceId);
     expect(mockAssertCanManageExecutionWorkspaceRuntimeServices).toHaveBeenCalled();
+  }, 15000);
+
+  it("returns 200 for an agent allowed to start its pinned execution workspace runtime", async () => {
+    const workspace = buildExecutionWorkspace({
+      id: executionWorkspaceId,
+      projectId: null,
+      config: {
+        workspaceRuntime: {
+          services: [{ name: "dev", command: "pnpm dev", port: 3100 }],
+        },
+        desiredState: "stopped",
+      },
+    });
+    mockExecutionWorkspaceService.getById.mockResolvedValue(workspace);
+    mockExecutionWorkspaceService.update.mockResolvedValue(workspace);
+    const app = await createExecutionWorkspaceApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .send({});
+
+    expect(
+      res.status,
+      app.locals.lastRouteError instanceof Error
+        ? app.locals.lastRouteError.stack ?? app.locals.lastRouteError.message
+        : JSON.stringify(res.body),
+    ).toBe(200);
+    expect(mockAssertCanManageExecutionWorkspaceRuntimeServices).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ companyId: "company-1", executionWorkspaceId }),
+    );
+    expect(mockStartRuntimeServicesForWorkspaceControl).toHaveBeenCalled();
   }, 15000);
 
   it("rejects agent callers that patch execution workspace command config", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Router, type Request as ExpressRequest } from "express";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -139,8 +140,36 @@ export function resolveViteHmrPort(serverPort: number): number {
 
 export function resolveViteHmrHost(bindHost: string): string | undefined {
   const normalized = bindHost.trim().toLowerCase();
-  if (normalized === "0.0.0.0" || normalized === "::") return undefined;
+  if (
+    normalized === "0.0.0.0"
+    || normalized === "::"
+    || normalized === "127.0.0.1"
+    || normalized === "::1"
+    || normalized === "localhost"
+  ) return undefined;
   return bindHost;
+}
+
+export function resolveViteHmrProtocol(value: string | undefined): "ws" | "wss" | undefined {
+  if (!value) return undefined;
+  if (value === "ws" || value === "wss") return value;
+  throw new Error("PAPERCLIP_VITE_HMR_PROTOCOL must be ws or wss");
+}
+
+export function listenViteHmrServer(server: HttpServer, port: number, bindHost: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, bindHost);
+  });
 }
 
 export function shouldServeViteDevHtml(req: ExpressRequest): boolean {
@@ -512,6 +541,8 @@ export async function createApp(
   });
   const hostServiceCleanup = createPluginHostServiceCleanup(lifecycle, hostServicesDisposers);
   let viteHtmlRenderer: ReturnType<typeof createCachedViteHtmlRenderer> | null = null;
+  let viteDevServer: { close(): Promise<void> } | null = null;
+  let viteHmrServer: HttpServer | null = null;
   const loader = pluginLoader(
     db,
     {
@@ -642,20 +673,36 @@ export async function createApp(
     const publicUiRoot = path.resolve(uiRoot, "public");
     const hmrPort = resolveViteHmrPort(opts.serverPort);
     const hmrHost = resolveViteHmrHost(opts.bindHost);
+    const hmrProtocol = resolveViteHmrProtocol(process.env.PAPERCLIP_VITE_HMR_PROTOCOL);
+    const hmrServer = createHttpServer((_req, res) => {
+      res.writeHead(426, { "Content-Type": "text/plain" });
+      res.end("Upgrade Required");
+    });
     const { createServer: createViteServer } = await import("vite");
     const vite = await createViteServer({
       root: uiRoot,
       appType: "custom",
       server: {
+        host: opts.bindHost,
         middlewareMode: true,
         hmr: {
+          server: hmrServer,
           ...(hmrHost ? { host: hmrHost } : {}),
+          ...(hmrProtocol ? { protocol: hmrProtocol } : {}),
           port: hmrPort,
           clientPort: hmrPort,
         },
         allowedHosts: privateHostnameGateEnabled ? Array.from(privateHostnameAllowSet) : undefined,
       },
     });
+    try {
+      await listenViteHmrServer(hmrServer, hmrPort, opts.bindHost);
+    } catch (error) {
+      await vite.close();
+      throw error;
+    }
+    viteDevServer = vite;
+    viteHmrServer = hmrServer;
     viteHtmlRenderer = createCachedViteHtmlRenderer({
       vite,
       uiRoot,
@@ -829,6 +876,8 @@ export async function createApp(
     }
     devWatcher?.close();
     viteHtmlRenderer?.dispose();
+    void viteDevServer?.close().catch(() => undefined);
+    viteHmrServer?.close();
     hostServiceCleanup.disposeAll();
     hostServiceCleanup.teardown();
     // Cancel every live setup-token login session, so each direct child stops

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -311,7 +311,7 @@ export function defaultIssueExecutionWorkspaceSettingsForProject(
 
 export function issueExecutionWorkspaceModeForPersistedWorkspace(
   mode: string | null | undefined,
-): IssueExecutionWorkspaceSettings["mode"] {
+): ParsedExecutionWorkspaceMode {
   if (mode === null || mode === undefined) {
     return "agent_default";
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -394,6 +394,10 @@ const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
 const CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE = "configuration_incomplete";
+export const PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE =
+  "pinned_execution_workspace_restore_failed";
+export const PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE =
+  "pinned_execution_workspace_unavailable";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_WAKE_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE = "execution_review_participant_recovery";
@@ -4334,7 +4338,11 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
 }): ExecutionWorkspaceReuseRequestForIssue {
   const requestedExecutionWorkspaceId = readNonEmptyString(input.issueExecutionWorkspaceId);
   const requestedShouldReuseExisting =
-    input.issueExecutionWorkspacePreference === "reuse_existing" && requestedExecutionWorkspaceId !== null;
+    requestedExecutionWorkspaceId !== null &&
+    (
+      input.issueExecutionWorkspacePreference === "reuse_existing" ||
+      input.issueExecutionWorkspacePreference == null
+    );
 
   return {
     requestedExecutionWorkspaceId,
@@ -4365,8 +4373,12 @@ export function resolveExecutionWorkspaceReuseProvisioningPolicy(input: {
   };
 }
 
-function formatInheritedExecutionWorkspaceReuseFailure(input: {
-  reason: "inherited_workspace_reuse_failed" | "inherited_workspace_reuse_unavailable";
+type ExecutionWorkspaceReuseFailureReason =
+  | typeof PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE
+  | typeof PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE;
+
+function formatPinnedExecutionWorkspaceReuseFailure(input: {
+  reason: ExecutionWorkspaceReuseFailureReason;
   issueRef: WorkspaceReuseIssueRef;
   runId: string;
   executionWorkspaceId: string | null | undefined;
@@ -4380,14 +4392,45 @@ function formatInheritedExecutionWorkspaceReuseFailure(input: {
     : input.cause != null
       ? String(input.cause)
       : null;
-  const remediation = input.reason === "inherited_workspace_reuse_failed"
-    ? "Inspect the referenced execution workspace restore/provision logs, repair or unarchive the workspace, or intentionally clear the issue's reuse_existing workspace binding before retrying."
-    : "Repair or unarchive the referenced execution workspace, or intentionally clear the issue's reuse_existing workspace binding before retrying.";
+  const remediation = input.reason === PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE
+    ? "Inspect the pinned execution workspace restore/provision logs, repair or unarchive the workspace, or intentionally clear the issue's execution workspace binding before retrying."
+    : "Repair or unarchive the pinned execution workspace, or intentionally clear the issue's execution workspace binding before retrying.";
   const message = causeMessage
-    ? `Issue ${issueLabel} requested inherited execution workspace reuse for ${workspaceLabel}, but the workspace could not be restored because ${causeMessage}.`
-    : `Issue ${issueLabel} requested inherited execution workspace reuse for ${workspaceLabel}, but the workspace could not be restored.`;
+    ? `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but the workspace could not be restored because ${causeMessage}.`
+    : `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but the workspace could not be restored.`;
 
   return `${message} ${remediation}`;
+}
+
+export class ExecutionWorkspaceReuseFailure extends Error {
+  code: ExecutionWorkspaceReuseFailureReason;
+  resultJson: Record<string, unknown>;
+
+  constructor(input: {
+    reason: ExecutionWorkspaceReuseFailureReason;
+    issueRef: WorkspaceReuseIssueRef;
+    runId: string;
+    executionWorkspaceId: string | null | undefined;
+    workspaceConfigFreshness: ExecutionWorkspaceConfigFreshnessDecision;
+    cause?: unknown;
+  }) {
+    super(formatPinnedExecutionWorkspaceReuseFailure(input));
+    this.name = "ExecutionWorkspaceReuseFailure";
+    this.code = input.reason;
+    this.resultJson = {
+      executionWorkspaceReuse: {
+        reason: input.reason,
+        issueId: input.issueRef?.id ?? null,
+        issueIdentifier: input.issueRef?.identifier ?? null,
+        executionWorkspaceId: input.executionWorkspaceId ?? null,
+        workspaceConfigFreshnessAction: input.workspaceConfigFreshness.action,
+      },
+    };
+  }
+}
+
+function isExecutionWorkspaceReuseFailure(error: unknown): error is ExecutionWorkspaceReuseFailure {
+  return error instanceof ExecutionWorkspaceReuseFailure;
 }
 
 export async function provisionExecutionWorkspaceForFreshnessDecision<T extends { warnings?: string[] }>(input: {
@@ -4418,15 +4461,15 @@ export async function provisionExecutionWorkspaceForFreshnessDecision<T extends 
   }
 
   let restored: T | null = null;
-  let reuseFailure: string | null = null;
+  let reuseFailure: ExecutionWorkspaceReuseFailure | null = null;
   try {
     restored = (await input.restoreExistingWorkspace?.()) ?? null;
   } catch (error) {
     if (isWorkspaceValidationFailure(error)) {
       throw error;
     }
-    reuseFailure = formatInheritedExecutionWorkspaceReuseFailure({
-      reason: "inherited_workspace_reuse_failed",
+    reuseFailure = new ExecutionWorkspaceReuseFailure({
+      reason: PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE,
       issueRef: input.issueRef,
       runId: input.runId,
       executionWorkspaceId: input.existingExecutionWorkspaceId,
@@ -4436,8 +4479,8 @@ export async function provisionExecutionWorkspaceForFreshnessDecision<T extends 
   }
 
   if (!restored) {
-    reuseFailure = reuseFailure ?? formatInheritedExecutionWorkspaceReuseFailure({
-      reason: "inherited_workspace_reuse_unavailable",
+    reuseFailure = reuseFailure ?? new ExecutionWorkspaceReuseFailure({
+      reason: PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE,
       issueRef: input.issueRef,
       runId: input.runId,
       executionWorkspaceId: input.existingExecutionWorkspaceId,
@@ -4445,7 +4488,7 @@ export async function provisionExecutionWorkspaceForFreshnessDecision<T extends 
     });
   }
 
-  if (reuseFailure) throw new Error(reuseFailure);
+  if (reuseFailure) throw reuseFailure;
   if (!restored) {
     throw new Error("Expected restored execution workspace after reuse fallback handling");
   }
@@ -13816,7 +13859,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueSettings: issueExecutionWorkspaceSettings,
       legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
     });
-    const requestedExecutionWorkspaceMode =
+    let requestedExecutionWorkspaceMode =
       trustPreset.kind === "low_trust_review" && resolvedExecutionWorkspaceMode === "shared_workspace"
         ? "isolated_workspace"
         : resolvedExecutionWorkspaceMode;
@@ -13981,6 +14024,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const reusableExistingExecutionWorkspace = workspaceReuseRequest.existingExecutionWorkspaceAvailable
       ? existingExecutionWorkspace
       : null;
+    if (
+      requestedShouldReuseExisting &&
+      reusableExistingExecutionWorkspace &&
+      (
+        issueExecutionWorkspaceSettings?.mode == null ||
+        issueExecutionWorkspaceSettings.mode === "inherit" ||
+        issueExecutionWorkspaceSettings.mode === "reuse_existing"
+      )
+    ) {
+      requestedExecutionWorkspaceMode = issueExecutionWorkspaceModeForPersistedWorkspace(
+        reusableExistingExecutionWorkspace.mode,
+      );
+    }
     const requestedReusableExecutionWorkspaceConfig = reusableExistingExecutionWorkspace?.config ?? null;
     const localEnvironment = await environmentsSvc.ensureLocalEnvironment(agent.companyId);
     const resolvedInstanceSettings = await instanceSettings.get();
@@ -14726,7 +14782,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (issueId && persistedExecutionWorkspace) {
       const nextIssueWorkspaceMode = issueExecutionWorkspaceModeForPersistedWorkspace(persistedExecutionWorkspace.mode);
       const shouldSwitchIssueToExistingWorkspace =
-        issueRef?.executionWorkspacePreference === "reuse_existing" ||
+        requestedShouldReuseExisting ||
         requestedExecutionWorkspaceMode === "isolated_workspace" ||
         requestedExecutionWorkspaceMode === "operator_branch";
       const nextIssuePatch: Record<string, unknown> = {};
@@ -16085,11 +16141,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
       const workspaceValidationFailure = isWorkspaceValidationFailure(err) ? err : null;
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
+      const executionWorkspaceReuseFailure = isExecutionWorkspaceReuseFailure(err) ? err : null;
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode((await getRun(run.id).catch(() => null))?.errorCode);
       const failureErrorCode =
         workspaceValidationFailure?.code
         ?? configurationIncompleteFailure?.code
+        ?? executionWorkspaceReuseFailure?.code
         ?? recordedResponsibleUserDenialCode
         ?? "adapter_failed";
       logger.error({ err, runId }, "heartbeat execution failed");
@@ -16117,7 +16175,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
           errorCode: failureErrorCode,
           errorMessage: message,
-          resultJson: workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
+          resultJson:
+            workspaceValidationFailure?.resultJson
+            ?? configurationIncompleteFailure?.resultJson
+            ?? executionWorkspaceReuseFailure?.resultJson
+            ?? null,
         }),
         stdoutExcerpt,
         stderrExcerpt,
@@ -16229,11 +16291,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           // recovery path routes it to a human owner instead of looping retries.
           const workspaceValidationSetupFailure = isWorkspaceValidationFailure(outerErr) ? outerErr : null;
           const configurationIncompleteSetupFailure = isConfigurationIncompleteFailure(outerErr) ? outerErr : null;
+          const executionWorkspaceReuseSetupFailure = isExecutionWorkspaceReuseFailure(outerErr) ? outerErr : null;
           const recordedResponsibleUserDenialCode =
             normalizeResponsibleUserDenialCode((await getRun(runId).catch(() => null))?.errorCode);
           const setupFailureErrorCode =
             workspaceValidationSetupFailure?.code ??
             configurationIncompleteSetupFailure?.code ??
+            executionWorkspaceReuseSetupFailure?.code ??
             recordedResponsibleUserDenialCode ??
             "setup_failed";
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
@@ -16247,7 +16311,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 errorCode: setupFailureErrorCode,
                 errorMessage: message,
                 resultJson:
-                  workspaceValidationSetupFailure?.resultJson ?? configurationIncompleteSetupFailure?.resultJson ?? null,
+                  workspaceValidationSetupFailure?.resultJson
+                  ?? configurationIncompleteSetupFailure?.resultJson
+                  ?? executionWorkspaceReuseSetupFailure?.resultJson
+                  ?? null,
               }),
             } : {}),
           }).catch(() => ({ run: null, updated: false as const }));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4355,6 +4355,25 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
   };
 }
 
+export function shouldReusePinnedExecutionWorkspaceForRun(input: {
+  requestedShouldReuseExisting: boolean;
+  trustPresetKind: TrustPresetResolution["kind"];
+  requestedExecutionWorkspaceMode: ReturnType<typeof resolveExecutionWorkspaceMode>;
+  existingExecutionWorkspaceMode: string | null;
+}): boolean {
+  if (!input.requestedShouldReuseExisting) return false;
+
+  // A durable pin cannot weaken the low-trust isolation boundary. An available
+  // non-isolated pin is bypassed so the policy can provision a fresh isolated workspace.
+  // Missing or archived pins still flow through the named reuse-failure path.
+  return !(
+    input.trustPresetKind === "low_trust_review"
+    && input.requestedExecutionWorkspaceMode === "isolated_workspace"
+    && input.existingExecutionWorkspaceMode !== null
+    && input.existingExecutionWorkspaceMode !== "isolated_workspace"
+  );
+}
+
 export function resolveExecutionWorkspaceReuseProvisioningPolicy(input: {
   requestedShouldReuseExisting: boolean;
   workspaceConfigFreshness: ExecutionWorkspaceConfigFreshnessDecision;
@@ -14020,8 +14039,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueExecutionWorkspacePreference: issueRef?.executionWorkspacePreference ?? null,
       existingExecutionWorkspaceStatus: existingExecutionWorkspace?.status ?? null,
     });
-    const requestedShouldReuseExisting = workspaceReuseRequest.requestedShouldReuseExisting;
-    const reusableExistingExecutionWorkspace = workspaceReuseRequest.existingExecutionWorkspaceAvailable
+    const requestedShouldReuseExisting = shouldReusePinnedExecutionWorkspaceForRun({
+      requestedShouldReuseExisting: workspaceReuseRequest.requestedShouldReuseExisting,
+      trustPresetKind: trustPreset.kind,
+      requestedExecutionWorkspaceMode,
+      existingExecutionWorkspaceMode: workspaceReuseRequest.existingExecutionWorkspaceAvailable
+        ? existingExecutionWorkspace?.mode ?? null
+        : null,
+    });
+    const reusableExistingExecutionWorkspace = requestedShouldReuseExisting
+      && workspaceReuseRequest.existingExecutionWorkspaceAvailable
       ? existingExecutionWorkspace
       : null;
     if (

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -398,6 +398,8 @@ export const PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE =
   "pinned_execution_workspace_restore_failed";
 export const PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE =
   "pinned_execution_workspace_unavailable";
+export const PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE =
+  "pinned_execution_workspace_incompatible";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_WAKE_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE = "execution_review_participant_recovery";
@@ -4355,7 +4357,7 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
   };
 }
 
-export function shouldReusePinnedExecutionWorkspaceForRun(input: {
+export function isPinnedExecutionWorkspaceIncompatibleWithTrust(input: {
   requestedShouldReuseExisting: boolean;
   trustPresetKind: TrustPresetResolution["kind"];
   requestedExecutionWorkspaceMode: ReturnType<typeof resolveExecutionWorkspaceMode>;
@@ -4363,10 +4365,7 @@ export function shouldReusePinnedExecutionWorkspaceForRun(input: {
 }): boolean {
   if (!input.requestedShouldReuseExisting) return false;
 
-  // A durable pin cannot weaken the low-trust isolation boundary. An available
-  // non-isolated pin is bypassed so the policy can provision a fresh isolated workspace.
-  // Missing or archived pins still flow through the named reuse-failure path.
-  return !(
+  return (
     input.trustPresetKind === "low_trust_review"
     && input.requestedExecutionWorkspaceMode === "isolated_workspace"
     && input.existingExecutionWorkspaceMode !== null
@@ -4394,7 +4393,8 @@ export function resolveExecutionWorkspaceReuseProvisioningPolicy(input: {
 
 type ExecutionWorkspaceReuseFailureReason =
   | typeof PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE
-  | typeof PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE;
+  | typeof PINNED_EXECUTION_WORKSPACE_UNAVAILABLE_ERROR_CODE
+  | typeof PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE;
 
 function formatPinnedExecutionWorkspaceReuseFailure(input: {
   reason: ExecutionWorkspaceReuseFailureReason;
@@ -4411,12 +4411,17 @@ function formatPinnedExecutionWorkspaceReuseFailure(input: {
     : input.cause != null
       ? String(input.cause)
       : null;
+  const incompatible = input.reason === PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE;
   const remediation = input.reason === PINNED_EXECUTION_WORKSPACE_RESTORE_FAILED_ERROR_CODE
     ? "Inspect the pinned execution workspace restore/provision logs, repair or unarchive the workspace, or intentionally clear the issue's execution workspace binding before retrying."
-    : "Repair or unarchive the pinned execution workspace, or intentionally clear the issue's execution workspace binding before retrying.";
-  const message = causeMessage
-    ? `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but the workspace could not be restored because ${causeMessage}.`
-    : `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but the workspace could not be restored.`;
+    : incompatible
+      ? "Pin an isolated workspace, change the task trust policy, or intentionally clear the issue's execution workspace binding before retrying."
+      : "Repair or unarchive the pinned execution workspace, or intentionally clear the issue's execution workspace binding before retrying.";
+  const message = incompatible
+    ? `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but that workspace is incompatible with the run's isolation policy.`
+    : causeMessage
+      ? `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but the workspace could not be restored because ${causeMessage}.`
+      : `Issue ${issueLabel} pinned execution workspace ${workspaceLabel}, but the workspace could not be restored.`;
 
   return `${message} ${remediation}`;
 }
@@ -14039,7 +14044,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueExecutionWorkspacePreference: issueRef?.executionWorkspacePreference ?? null,
       existingExecutionWorkspaceStatus: existingExecutionWorkspace?.status ?? null,
     });
-    const requestedShouldReuseExisting = shouldReusePinnedExecutionWorkspaceForRun({
+    const pinnedExecutionWorkspaceIncompatibleWithTrust = isPinnedExecutionWorkspaceIncompatibleWithTrust({
       requestedShouldReuseExisting: workspaceReuseRequest.requestedShouldReuseExisting,
       trustPresetKind: trustPreset.kind,
       requestedExecutionWorkspaceMode,
@@ -14047,13 +14052,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? existingExecutionWorkspace?.mode ?? null
         : null,
     });
-    const reusableExistingExecutionWorkspace = requestedShouldReuseExisting
-      && workspaceReuseRequest.existingExecutionWorkspaceAvailable
+    const requestedShouldReuseExisting = workspaceReuseRequest.requestedShouldReuseExisting;
+    const reusableExistingExecutionWorkspace = workspaceReuseRequest.existingExecutionWorkspaceAvailable
       ? existingExecutionWorkspace
       : null;
     if (
       requestedShouldReuseExisting &&
       reusableExistingExecutionWorkspace &&
+      !pinnedExecutionWorkspaceIncompatibleWithTrust &&
       (
         issueExecutionWorkspaceSettings?.mode == null ||
         issueExecutionWorkspaceSettings.mode === "inherit" ||
@@ -14554,6 +14560,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       inferredMetadata: inferredExistingWorkspaceConfigMetadata,
       nextMetadata: latestWorkspaceConfigMetadata,
     });
+    if (pinnedExecutionWorkspaceIncompatibleWithTrust) {
+      throw new ExecutionWorkspaceReuseFailure({
+        reason: PINNED_EXECUTION_WORKSPACE_INCOMPATIBLE_ERROR_CODE,
+        issueRef,
+        runId: run.id,
+        executionWorkspaceId: workspaceReuseRequest.requestedExecutionWorkspaceId,
+        workspaceConfigFreshness,
+      });
+    }
     const workspaceReuseProvisioningPolicy = resolveExecutionWorkspaceReuseProvisioningPolicy({
       requestedShouldReuseExisting,
       workspaceConfigFreshness,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -247,6 +247,20 @@ function assertExplicitPinnedWorktreeIssueRunnable(input: {
   }
 }
 
+function normalizePinnedExecutionWorkspaceSettings(
+  settings: Record<string, unknown> | null,
+  workspace: { mode: string; strategyType: string },
+) {
+  return {
+    ...(settings ?? {}),
+    mode: issueExecutionWorkspaceModeForPersistedWorkspace(workspace.mode),
+    workspaceStrategy: {
+      ...parseObject(settings?.workspaceStrategy),
+      type: workspace.strategyType,
+    },
+  };
+}
+
 function readStringFromRecord(record: unknown, key: string) {
   if (!record || typeof record !== "object") return null;
   const value = (record as Record<string, unknown>)[key];
@@ -4813,6 +4827,8 @@ export function issueService(db: Db) {
         id: executionWorkspaces.id,
         companyId: executionWorkspaces.companyId,
         projectId: executionWorkspaces.projectId,
+        mode: executionWorkspaces.mode,
+        strategyType: executionWorkspaces.strategyType,
       })
       .from(executionWorkspaces)
       .where(eq(executionWorkspaces.id, executionWorkspaceId))
@@ -6989,6 +7005,11 @@ export function issueService(db: Db) {
         let executionWorkspacePreference = issueData.executionWorkspacePreference ?? null;
         let executionWorkspaceSettings =
           (issueData.executionWorkspaceSettings as Record<string, unknown> | null | undefined) ?? null;
+        let validatedExecutionWorkspace: {
+          projectId: string;
+          mode: string;
+          strategyType: string;
+        } | null = null;
         const workspaceInheritanceIssueId = skipExecutionWorkspaceInheritance
           ? null
           : inheritExecutionWorkspaceFromIssueId ?? issueData.parentId ?? null;
@@ -7033,6 +7054,7 @@ export function issueService(db: Db) {
         }
         if (issueData.projectId == null && executionWorkspaceId) {
           const workspace = await assertValidExecutionWorkspace(companyId, null, executionWorkspaceId, tx);
+          validatedExecutionWorkspace = workspace;
           issueData.projectId = workspace.projectId;
         }
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
@@ -7089,7 +7111,19 @@ export function issueService(db: Db) {
           await assertValidProjectWorkspace(companyId, issueData.projectId, projectWorkspaceId, tx);
         }
         if (executionWorkspaceId) {
-          await assertValidExecutionWorkspace(companyId, issueData.projectId, executionWorkspaceId, tx);
+          validatedExecutionWorkspace ??= await assertValidExecutionWorkspace(
+            companyId,
+            issueData.projectId,
+            executionWorkspaceId,
+            tx,
+          );
+        }
+        if (executionWorkspaceId && executionWorkspacePreference == null && validatedExecutionWorkspace) {
+          executionWorkspacePreference = "reuse_existing";
+          executionWorkspaceSettings = normalizePinnedExecutionWorkspaceSettings(
+            executionWorkspaceSettings,
+            validatedExecutionWorkspace,
+          );
         }
         if (isolatedWorkspacesEnabled && issueData.executionWorkspaceSettings !== undefined) {
           assertExplicitPinnedWorktreeIssueRunnable({
@@ -7573,11 +7607,11 @@ export function issueService(db: Db) {
         issueData.projectWorkspaceId !== undefined ? issueData.projectWorkspaceId : existing.projectWorkspaceId;
       const nextExecutionWorkspaceId =
         issueData.executionWorkspaceId !== undefined ? issueData.executionWorkspaceId : existing.executionWorkspaceId;
-      const nextExecutionWorkspacePreference =
+      let nextExecutionWorkspacePreference =
         issueData.executionWorkspacePreference !== undefined
           ? issueData.executionWorkspacePreference
           : existing.executionWorkspacePreference;
-      const nextExecutionWorkspaceSettings =
+      let nextExecutionWorkspaceSettings =
         issueData.executionWorkspaceSettings !== undefined
           ? parseIssueExecutionWorkspaceSettings(issueData.executionWorkspaceSettings)
           : parseIssueExecutionWorkspaceSettings(existing.executionWorkspaceSettings);
@@ -7587,7 +7621,11 @@ export function issueService(db: Db) {
           : null;
       }
       let validatedProjectWorkspace: { projectId: string } | null = null;
-      let validatedExecutionWorkspace: { projectId: string } | null = null;
+      let validatedExecutionWorkspace: {
+        projectId: string;
+        mode: string;
+        strategyType: string;
+      } | null = null;
       if (!nextProjectId && nextProjectWorkspaceId) {
         const workspace = await assertValidProjectWorkspace(existing.companyId, null, nextProjectWorkspaceId);
         validatedProjectWorkspace = workspace;
@@ -7607,8 +7645,33 @@ export function issueService(db: Db) {
       }
       if (nextExecutionWorkspaceId) {
         if (!validatedExecutionWorkspace) {
-          await assertValidExecutionWorkspace(existing.companyId, nextProjectId, nextExecutionWorkspaceId);
+          validatedExecutionWorkspace = await assertValidExecutionWorkspace(
+            existing.companyId,
+            nextProjectId,
+            nextExecutionWorkspaceId,
+          );
         }
+      }
+      if (
+        nextExecutionWorkspaceId &&
+        nextExecutionWorkspacePreference == null &&
+        validatedExecutionWorkspace &&
+        (
+          issueData.executionWorkspaceId !== undefined ||
+          issueData.executionWorkspacePreference !== undefined
+        )
+      ) {
+        nextExecutionWorkspacePreference = "reuse_existing";
+        nextExecutionWorkspaceSettings = parseIssueExecutionWorkspaceSettings(
+          normalizePinnedExecutionWorkspaceSettings(
+            nextExecutionWorkspaceSettings ? { ...nextExecutionWorkspaceSettings } : null,
+            validatedExecutionWorkspace,
+          ),
+        );
+        patch.executionWorkspacePreference = "reuse_existing";
+        patch.executionWorkspaceSettings = nextExecutionWorkspaceSettings
+          ? { ...nextExecutionWorkspaceSettings }
+          : null;
       }
       if (isolatedWorkspacesEnabled && issueData.executionWorkspaceSettings !== undefined) {
         assertExplicitPinnedWorktreeIssueRunnable({

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -147,6 +147,7 @@ type OAuthProviderEndpoints = {
 };
 
 const oauthRegistrationFlights = new Map<string, Promise<unknown>>();
+const PENDING_ACTION_REQUEST_SIGNING_GRACE_MS = 5_000;
 
 async function oauthSingleFlight<T>(
   flights: Map<string, Promise<unknown>>,
@@ -6749,10 +6750,19 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       const invocationById = new Map(invocations.map((invocation) => [invocation.id, invocation]));
       let visibleRequests = requests;
       if (status === "pending") {
+        const hiddenInFlightRequestIds = new Set<string>();
+        const signingGraceDeadline = now().getTime() - PENDING_ACTION_REQUEST_SIGNING_GRACE_MS;
         const invalidRequestIds = requests
           .filter((request) => {
             const invocation = invocationById.get(request.invocationId);
             if (!invocation) return true;
+            if (!request.signedArguments && request.createdAt.getTime() > signingGraceDeadline) {
+              // recordInvocation inserts the pending row before executeTestCall adds
+              // its signed payload. A concurrent review-queue poll must not cancel
+              // that short-lived intermediate state.
+              hiddenInFlightRequestIds.add(request.id);
+              return false;
+            }
             try {
               return !readSignedToolArgumentsPayload({
                 signedArguments: request.signedArguments,
@@ -6775,6 +6785,9 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
             ));
           const invalidIds = new Set(invalidRequestIds);
           visibleRequests = requests.filter((request) => !invalidIds.has(request.id));
+        }
+        if (hiddenInFlightRequestIds.size > 0) {
+          visibleRequests = visibleRequests.filter((request) => !hiddenInFlightRequestIds.has(request.id));
         }
       }
       if (visibleRequests.length === 0) return [];


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The execution workspace service gives each task an isolated repository workspace.
> - A saved workspace ID is a durable pin, even when an older record has no saved preference.
> - The previous flow could replace that pin after a reuse failure and hide the failure reason.
> - Low-trust runs must reject incompatible non-isolated pins without replacing the durable binding.
> - Managed HTTPS previews also need one scoped HMR listener per browser endpoint.
> - Tool approvals need a short signing grace so polling cannot cancel an action while its signed payload is being stored.
> - This pull request preserves durable workspace pins and contains the canary listener.
> - The benefit is stable workspace identity and clearer recovery when a pinned workspace is unavailable.

## Linked Issues or Issue Description

Refs #4745

**What happened?**

A task with an explicit execution workspace ID could receive a new workspace when reuse failed. Older tasks with no stored workspace preference were affected. Managed HTTPS previews could also expose an HMR listener outside the intended browser endpoint.

**Expected behavior**

Paperclip must treat an explicit execution workspace ID as a durable pin. It must report a named reuse failure instead of silently replacing the workspace. Managed previews must keep the HMR listener on the scoped browser endpoint.

**Steps to reproduce**

1. Save an execution workspace ID on a task with no workspace preference.
2. Make the saved workspace unavailable.
3. Start a run for the task.
4. Observe whether Paperclip replaces the workspace or reports the reuse failure.

**Paperclip version or commit**

Current `master` before this pull request.

**Deployment mode**

Local server and managed HTTPS preview.

**Installation method**

Source checkout with pnpm.

**Agent adapter(s) involved**

The behavior is adapter-independent. Regression coverage includes the Claude local adapter runtime boundary.

## What Changed

- Treat every explicit execution workspace ID as a durable `reuse_existing` pin.
- Preserve the saved workspace mode and strategy when the service normalizes older records.
- Stop workspace fallback after a pinned reuse failure and include the named failure in run metadata.
- Reject non-isolated pinned workspaces for low-trust runs with a named incompatibility result while preserving the task binding.
- Scope managed HTTPS HMR listeners to loopback browser endpoints and validate `ws` and `wss` protocols.
- Keep newly recorded tool approvals hidden during their signing grace period instead of cancelling them as malformed.
- Add regression tests for workspace reuse, failure reporting, listener containment, and ambient runtime isolation.
- Document the durable workspace pin behavior in the V1 implementation specification.

## Verification

- `pnpm -r typecheck`
- `pnpm build`
- All projects in `scripts/run-vitest-stable.mjs` passed. This includes 334 server files with 3,747 passing tests and 446 UI files with 3,876 passing tests.
- Focused workspace, HMR, CLI secrets, and Claude fallback regression suites passed.
- Focused heartbeat execution-workspace coverage passed with 143 tests.
- Focused tool-access service coverage passed with 126 tests.
- The exact tool-approval Playwright scenario passed locally.
- Latest-head GitHub Actions passed every required lane: policy, typecheck, build, general and serialized server tests, all three browser shards, and the release canary dry run.

## Risks

- Older tasks with an unavailable explicit workspace now fail with a named reuse error. They no longer receive a silent replacement workspace.
- Low-trust runs with an available non-isolated pin now fail with a named incompatibility result; an operator must provide an isolated compatible workspace.
- Managed preview proxies must provide a loopback browser host and a valid `ws` or `wss` HMR protocol.
- This change has no database migration.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, exact model ID `gpt-5.6-sol`, with frontier reasoning, repository tool use, and code execution. The Codex runtime managed the context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
