### PR TITLE
fix(ui): keep MDXEditor body text readable in dark mode

### DIFF
--- a/ui/src/components/MdxEditorThemeStyles.test.ts
+++ b/ui/src/components/MdxEditorThemeStyles.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const stylesheet = readFileSync(fileURLToPath(new URL("../index.css", import.meta.url)), "utf8");
+
+function cssBlock(selector: string): string {
+  const start = stylesheet.indexOf(`${selector} {`);
+  expect(start, `Missing CSS selector: ${selector}`).toBeGreaterThanOrEqual(0);
+
+  const bodyStart = stylesheet.indexOf("{", start);
+  const bodyEnd = stylesheet.indexOf("\n}", bodyStart);
+  expect(bodyStart, `Missing CSS block start: ${selector}`).toBeGreaterThanOrEqual(0);
+  expect(bodyEnd, `Missing CSS block end: ${selector}`).toBeGreaterThan(bodyStart);
+
+  return stylesheet.slice(bodyStart + 1, bodyEnd);
+}
+
+/**
+ * MDXEditor ships its own theme variables on its own root class, taken from its
+ * LIGHT palette — `._editorRoot_… { --baseTextContrast: var(--slate-12); }` — and
+ * gates the dark values behind a `.dark-theme` class we do not apply. It then
+ * paints the editor body with `color: var(--baseTextContrast)`.
+ *
+ * Our override lands on the SAME element as that class. A bare
+ * `.paperclip-mdxeditor` selector is specificity 0,1,0, identical to the
+ * package's, so the winner would be decided by stylesheet order alone — and when
+ * the package's sheet is later in the bundle, editor bodies (task descriptions,
+ * comment composers) render near-black on the dark background.
+ *
+ * The `:root` prefix takes ours to 0,2,0 so it wins regardless of order. It
+ * reads like redundant decoration, which is exactly why it needs a test: these
+ * assertions fail if someone "cleans it up".
+ */
+describe("MDXEditor theme integration", () => {
+  it("out-specifies the package's own root class rather than relying on stylesheet order", () => {
+    // A bare `.paperclip-mdxeditor { … }` block at column zero is the
+    // regression: it ties with `._editorRoot_…` instead of beating it.
+    // Descendant rules (`.paperclip-mdxeditor .foo`) are already 0,2,0 and are
+    // deliberately not matched here, nor is the indented block inside @media.
+    expect(
+      /^\.paperclip-mdxeditor\s*\{/m.test(stylesheet),
+      "Theme variables must not be declared on a bare .paperclip-mdxeditor selector",
+    ).toBe(false);
+    expect(
+      /^\.paperclip-mdxeditor-scope\s*,/m.test(stylesheet),
+      "Theme variables must not be declared on a bare .paperclip-mdxeditor-scope selector",
+    ).toBe(false);
+
+    expect(stylesheet).toContain(":root .paperclip-mdxeditor-scope,\n:root .paperclip-mdxeditor {");
+  });
+
+  it("maps the package's text variables onto our own theme tokens", () => {
+    const block = cssBlock(":root .paperclip-mdxeditor");
+
+    // The one that caused the bug: the editor body reads --baseTextContrast.
+    expect(block).toContain("--baseTextContrast: var(--foreground)");
+    expect(block).toContain("--baseText: var(--muted-foreground)");
+    expect(block).toContain("--baseTextEmphasis: var(--foreground)");
+    expect(block).toContain("color: var(--foreground)");
+  });
+});

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1163,9 +1163,21 @@
   }
 }
 
-/* MDXEditor theme integration */
-.paperclip-mdxeditor-scope,
-.paperclip-mdxeditor {
+/* MDXEditor theme integration.
+ *
+ * The `:root` prefix is load-bearing, not decoration. @mdxeditor/editor defines
+ * this same set of variables on its own root class — `._editorRoot_… {
+ * --baseTextContrast: var(--slate-12); … }` — from its LIGHT palette; its dark
+ * values are gated behind a `.dark-theme` class we never apply. That class and
+ * `.paperclip-mdxeditor` are both specificity 0,1,0 and land on the SAME
+ * element, so without the prefix the winner is decided purely by stylesheet
+ * order. When the package's sheet lands later, `--baseTextContrast` resolves to
+ * near-black and every editor body — task descriptions, comment composers —
+ * renders dark-on-dark in dark mode. `:root` takes these to 0,2,0 so the
+ * outcome no longer depends on bundling order.
+ */
+:root .paperclip-mdxeditor-scope,
+:root .paperclip-mdxeditor {
   --baseBase: var(--background);
   --baseBg: transparent;
   --baseBgSubtle: color-mix(in oklab, var(--accent) 35%, transparent);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Task descriptions and comment composers are rich-text fields, rendered by MDXEditor and themed in `ui/src/index.css`
> - MDXEditor sets `--baseTextContrast` on its own root class from its light palette, and its dark values need a `.dark-theme` class that Paperclip does not apply
> - Paperclip corrects this with `.paperclip-mdxeditor`, but both selectors are specificity 0,1,0 and apply to the same element, so stylesheet order decides the winner
> - When the package stylesheet is later in the bundle, editor body text becomes near-black on the dark background and users cannot read what they type
> - This pull request adds a `:root` prefix to the theme integration block, which makes it specificity 0,2,0
> - The benefit is that dark mode text stays readable and does not depend on CSS bundling order

## Linked Issues or Issue Description

No existing issue found. Description follows the bug report template.

**What happened?**

In dark mode, text in MDXEditor fields renders near-black on the dark background. This affects the task description field in the new task dialog, the task detail description, and comment composers. Plain `<input>` and `<textarea>` fields are correct, because Tailwind preflight gives them `color: inherit`.

The cause is a CSS specificity tie. `@mdxeditor/editor` paints its content area with:

```css
._contentEditable_… { color: var(--baseTextContrast); }
._editorRoot_…      { --baseTextContrast: var(--slate-12); }  /* light palette, near-black */
```

The package's dark values are behind a `.dark-theme` class that Paperclip does not apply. `ui/src/index.css` sets `--baseTextContrast: var(--foreground)` on `.paperclip-mdxeditor` to correct this, but `.paperclip-mdxeditor` and `._editorRoot_…` are both specificity 0,1,0, and both apply to the same element. The winner is therefore decided by stylesheet order alone. `ui/src/main.tsx` imports `index.css` after the package stylesheet, so the source order is correct, but the order in the served bundle is not guaranteed to match.

**Expected behavior**

Editor body text uses `--foreground` and stays readable in dark mode, whatever the order of the bundled stylesheets.

**Steps to reproduce**

1. Set the UI to dark mode.
2. Open the new task dialog.
3. Type into the description field.
4. The text is near-black on the dark background.

Reproduced in Brave on Linux and on Windows, against `@mdxeditor/editor@3.55.0`.

**Paperclip version or commit**

Reproduced on `master`.

**Deployment mode**

Self-hosted.

## What Changed

- Prefixed the MDXEditor theme integration block in `ui/src/index.css` with `:root`, which raises it to specificity 0,2,0 and makes it win over the package's own root class independently of stylesheet order.
- Added a comment that records why the prefix is load-bearing, so it is not removed as noise later.

## Verification

- `npx vitest run ui/src/components/MdxEditorThemeStyles.test.ts` — the new regression test. It fails when the `:root` prefix is removed and passes with it.
- `npx vitest run ui/src/components/MarkdownAccentStyles.test.ts ui/src/components/MarkdownListStyles.test.ts ui/src/lib/ui-font-assets.test.ts` — 3 files, 5 tests, all pass. These are the other tests that read `ui/src/index.css`.
- Manual: in dark mode, open the new task dialog and type in the description field. Text is readable. The same fix was run as a local CSS override for several hours in Brave before this PR.

## Risks

Low risk. The change is one CSS selector prefix, with no change to declarations. It raises specificity for a block that is already meant to win, so it can only change results where the package stylesheet was previously overriding Paperclip's own theme values.

Note for reviewers: #8297 upgrades `@mdxeditor/editor` to 4.0.4. This fix is not tied to the generated class hashes, so it holds across that upgrade. If 4.x changes how the editor root is themed, the prefix stays harmless.

## Model Used

Claude Opus 5 (model ID `claude-opus-5`), 1M context, with extended thinking and tool use, via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable — `ui/src/components/MdxEditorThemeStyles.test.ts` asserts the override is not declared on a bare `.paperclip-mdxeditor` selector. Verified it fails when the `:root` prefix is removed and passes with it.
- [x] I have updated relevant documentation to reflect my changes — the reasoning is recorded as a comment at the change site
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — 28 checks pass. `e2e shard (2/3)` fails on an unrelated tool-gateway race; see the CI note in the comments.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)