### PR TITLE
feat(cli): add `company purge` for company decommission

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -55,7 +55,8 @@
     "dotenv": "^17.4.2",
     "commander": "^13.1.0",
     "embedded-postgres": "^18.1.0-beta.16",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "postgres": "^3.4.9"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/cli/src/__tests__/company-purge.test.ts
+++ b/cli/src/__tests__/company-purge.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSteps,
+  orderSteps,
+  type ForeignKey,
+  type PurgeStep,
+} from "../commands/company-purge.js";
+
+function fk(
+  child: string,
+  childColumn: string,
+  parent: string,
+  deleteRule: string,
+): ForeignKey {
+  const [childSchema, childTable] = child.split(".");
+  const [parentSchema, parentTable] = parent.split(".");
+  return {
+    name: `${childTable}_${childColumn}_fkey`,
+    childSchema: childSchema!,
+    childTable: childTable!,
+    childColumn,
+    parentSchema: parentSchema!,
+    parentTable: parentTable!,
+    parentColumn: "id",
+    deleteRule,
+  };
+}
+
+function scopedSet(tables: string[]): Set<string> {
+  return new Set(tables);
+}
+
+function toTables(tables: string[]): Array<{ schema: string; table: string }> {
+  return tables.map((key) => {
+    const [schema, table] = key.split(".");
+    return { schema: schema!, table: table! };
+  });
+}
+
+function order(steps: PurgeStep[]): string[] {
+  return steps.map((step) => step.tableKey);
+}
+
+describe("buildSteps", () => {
+  it("emits one company_id delete per company-scoped table", () => {
+    const steps = buildSteps(toTables(["public.issues"]), [], scopedSet(["public.issues"]));
+    expect(steps).toHaveLength(1);
+    expect(steps[0]!.sql).toContain('DELETE FROM "public"."issues"');
+    expect(steps[0]!.sql).toContain("company_id = ANY($1)");
+  });
+
+  it("join-deletes NO ACTION children that have no company_id of their own", () => {
+    const steps = buildSteps(
+      toTables(["public.issues"]),
+      [fk("public.decision_effect_executions", "issue_id", "public.issues", "a")],
+      scopedSet(["public.issues"]),
+    );
+    const joined = steps.find((s) => s.tableKey === "public.decision_effect_executions");
+    expect(joined).toBeDefined();
+    expect(joined!.sql).toContain('USING "public"."issues" pa');
+    expect(joined!.sql).toContain("pa.company_id = ANY($1)");
+  });
+
+  it("leaves CASCADE and SET NULL children to Postgres", () => {
+    // status_card_updates -> issues is SET NULL: deleting those rows would
+    // destroy records that merely mention the company rather than belong to it.
+    const steps = buildSteps(
+      toTables(["public.issues"]),
+      [
+        fk("public.status_card_updates", "issue_id", "public.issues", "n"),
+        fk("public.issue_documents", "issue_id", "public.issues", "c"),
+      ],
+      scopedSet(["public.issues"]),
+    );
+    expect(order(steps)).toEqual(["public.issues"]);
+  });
+
+  it("keys join-deletes against companies on id rather than company_id", () => {
+    const steps = buildSteps(
+      [],
+      [fk("public.cli_auth_challenges", "company_id", "public.companies", "a")],
+      scopedSet([]),
+    );
+    expect(steps).toHaveLength(1);
+    expect(steps[0]!.sql).toContain("pa.id = ANY($1)");
+  });
+
+  it("covers plugin schemas the same way as public", () => {
+    const steps = buildSteps(
+      toTables(["plugin_llm_wiki_8f50.wiki_pages"]),
+      [],
+      scopedSet(["plugin_llm_wiki_8f50.wiki_pages"]),
+    );
+    expect(steps[0]!.sql).toContain('DELETE FROM "plugin_llm_wiki_8f50"."wiki_pages"');
+  });
+});
+
+describe("orderSteps", () => {
+  it("places restrictive children before the table they reference", () => {
+    // The exact bug in the API's delete: cost_events.heartbeat_run_id is
+    // NO ACTION, so heartbeat_runs must not be deleted first.
+    const scoped = scopedSet(["public.cost_events", "public.heartbeat_runs"]);
+    const fks = [fk("public.cost_events", "heartbeat_run_id", "public.heartbeat_runs", "a")];
+    const steps = orderSteps(
+      buildSteps(toTables(["public.heartbeat_runs", "public.cost_events"]), fks, scoped),
+      fks,
+    );
+    expect(order(steps)).toEqual(["public.cost_events", "public.heartbeat_runs"]);
+  });
+
+  it("ignores CASCADE edges when ordering", () => {
+    // CASCADE cannot raise a violation, so it must not constrain the order.
+    const scoped = scopedSet(["public.issue_documents", "public.issues"]);
+    const fks = [fk("public.issue_documents", "issue_id", "public.issues", "c")];
+    const steps = orderSteps(
+      buildSteps(toTables(["public.issues", "public.issue_documents"]), fks, scoped),
+      fks,
+    );
+    expect(order(steps)).toEqual(["public.issues", "public.issue_documents"]);
+  });
+
+  it("orders a multi-level restrictive chain leaf-first", () => {
+    const tables = ["public.a", "public.b", "public.c"];
+    const scoped = scopedSet(tables);
+    const fks = [
+      fk("public.c", "b_id", "public.b", "a"),
+      fk("public.b", "a_id", "public.a", "a"),
+    ];
+    const steps = orderSteps(buildSteps(toTables(tables), fks, scoped), fks);
+    expect(order(steps)).toEqual(["public.c", "public.b", "public.a"]);
+  });
+
+  it("keeps every step when a cycle cannot be ordered", () => {
+    // Cycles are deliberately left for the savepoint retry loop rather than
+    // broken here, but no step may be dropped on the way through.
+    const tables = ["public.x", "public.y"];
+    const scoped = scopedSet(tables);
+    const fks = [
+      fk("public.x", "y_id", "public.y", "a"),
+      fk("public.y", "x_id", "public.x", "a"),
+    ];
+    const steps = orderSteps(buildSteps(toTables(tables), fks, scoped), fks);
+    expect(order(steps).sort()).toEqual(["public.x", "public.y"]);
+  });
+
+  it("tolerates self-referencing tables", () => {
+    const scoped = scopedSet(["public.issues"]);
+    const fks = [fk("public.issues", "parent_id", "public.issues", "a")];
+    const steps = orderSteps(buildSteps(toTables(["public.issues"]), fks, scoped), fks);
+    expect(order(steps)).toEqual(["public.issues"]);
+  });
+});

--- a/cli/src/commands/client/company.ts
+++ b/cli/src/commands/client/company.ts
@@ -21,6 +21,7 @@ import {
   type CompanyImportTransferCreated,
   type CompanyImportTransferDeclaration,
 } from "@paperclipai/shared/company-import-transfer";
+import { registerCompanyPurgeCommand } from "../company-purge.js";
 import { getTelemetryClient, trackCompanyImported } from "../../telemetry.js";
 import { ApiRequestError, type PaperclipApiClient } from "../../client/http.js";
 import { openUrl } from "../../client/board-auth.js";
@@ -1344,6 +1345,11 @@ function assertDeleteFlags(opts: CompanyDeleteOptions): void {
 
 export function registerCompanyCommands(program: Command): void {
   const company = program.command("company").description("Company operations");
+
+  // Direct-to-Postgres teardown. Lives in its own module because, unlike every
+  // other company command, it does not go through the API — see the header of
+  // company-purge.ts for why the HTTP delete cannot do this job.
+  registerCompanyPurgeCommand(company);
 
   addCommonClientOptions(
     company

--- a/cli/src/commands/company-purge.ts
+++ b/cli/src/commands/company-purge.ts
@@ -1,0 +1,730 @@
+/**
+ * `paperclipai company purge` — hard-delete one or more companies and every
+ * row that belongs to them, directly against Postgres.
+ *
+ * Why this exists (and why it does not go through the API)
+ * --------------------------------------------------------
+ * `DELETE /api/companies/:id` (server/src/services/companies.ts -> remove())
+ * deletes a hand-maintained list of ~30 tables in a fixed order. That list has
+ * two structural problems:
+ *
+ *   1. Ordering. It deletes `heartbeat_runs` before `cost_events`, but
+ *      `cost_events.heartbeat_run_id -> heartbeat_runs` is ON DELETE NO ACTION,
+ *      so the whole transaction aborts with a foreign key violation on any
+ *      company that has cost history. The delete simply never succeeds.
+ *   2. Coverage. 145 tables carry a `company_id`, and plugins add more at
+ *      install time in their own `plugin_*` schemas. A list written by hand
+ *      cannot stay complete, and every gap is a future FK violation.
+ *
+ * This command fixes both by deriving the work from the live catalog instead
+ * of a literal list:
+ *
+ *   - Targets are discovered by introspection: every BASE TABLE in every schema
+ *     that has a `company_id` column. Plugin schemas are picked up for free.
+ *   - Tables that reference company-scoped rows but have no `company_id` of
+ *     their own (for example `decision_effect_executions`, `status_card_updates`)
+ *     are deleted through a join, but only when their FK is NO ACTION/RESTRICT.
+ *     CASCADE and SET NULL are left to Postgres, which is both correct and less
+ *     destructive.
+ *   - Order is discovered, not maintained. Every DELETE runs inside a SAVEPOINT;
+ *     a foreign key violation rolls back just that statement and the table is
+ *     retried on the next pass. The loop ends when a pass makes no progress.
+ *
+ * Foreign keys stay ENABLED throughout. It is tempting to reach for
+ * `session_replication_role = 'replica'` (the CLI's DB role is superuser, so it
+ * would work), but that disables FK *triggers* wholesale — including the ~88
+ * ON DELETE CASCADE edges and the plugin schemas that depend on them. You would
+ * trade a loud, safe failure for silent orphans. Letting Postgres keep checking
+ * is the point: if this command commits, referential integrity held.
+ *
+ * Safety model
+ * ------------
+ *   - Dry run is the default. The real DELETEs execute inside a transaction
+ *     that is then ROLLBACK'd, so a dry run reports exact per-table row counts
+ *     and proves the purge would succeed, with zero risk.
+ *   - `--apply` commits, and additionally requires `--yes` and `--confirm`.
+ *   - A backup runs before any committing purge unless `--no-backup`.
+ *   - Preflight refuses to run if a company *outside* the target set references
+ *     data *inside* it. Pass companies as a set to purge mutually-referencing
+ *     companies together.
+ */
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import postgres from "postgres";
+import type { Command } from "commander";
+import { formatDatabaseBackupResult, runDatabaseBackup } from "@paperclipai/db";
+import {
+  expandHomePrefix,
+  resolveDefaultBackupDir,
+  resolvePaperclipInstanceId,
+} from "../config/home.js";
+import { readConfig } from "../config/store.js";
+import path from "node:path";
+
+/** Postgres SQLSTATE for foreign_key_violation. */
+const FK_VIOLATION = "23503";
+
+const SYSTEM_SCHEMAS = ["pg_catalog", "information_schema", "pg_toast"];
+
+interface CompanyPurgeOptions {
+  config?: string;
+  apply?: boolean;
+  yes?: boolean;
+  confirm?: string;
+  backup?: boolean;
+  fkIndexes?: boolean;
+  json?: boolean;
+}
+
+interface TargetCompany {
+  id: string;
+  name: string;
+  issuePrefix: string;
+}
+
+/** A single DELETE the purge needs to land, plus how many rows it removed. */
+export interface PurgeStep {
+  /** Display key, e.g. `public.issues` or `public.status_card_updates <- issues`. */
+  label: string;
+  /** `schema.table` this step deletes from; used to order steps by FK depth. */
+  tableKey: string;
+  sql: string;
+  deleted: number | null;
+}
+
+export interface ForeignKey {
+  name: string;
+  childSchema: string;
+  childTable: string;
+  childColumn: string;
+  parentSchema: string;
+  parentTable: string;
+  parentColumn: string;
+  /** pg_constraint.confdeltype: a=NO ACTION, r=RESTRICT, c=CASCADE, n=SET NULL, d=SET DEFAULT */
+  deleteRule: string;
+}
+
+function quoteIdent(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function qualify(schema: string, table: string): string {
+  return `${quoteIdent(schema)}.${quoteIdent(table)}`;
+}
+
+function tableKey(schema: string, table: string): string {
+  return `${schema}.${table}`;
+}
+
+/**
+ * Mirrors db:backup's resolution so both commands agree on which database they
+ * are talking to: DATABASE_URL wins, then an explicit connection string in
+ * config, then the embedded Postgres port.
+ */
+function resolveConnectionString(configPath?: string): { value: string; source: string } {
+  const envUrl = process.env.DATABASE_URL?.trim();
+  if (envUrl) return { value: envUrl, source: "DATABASE_URL" };
+
+  const config = readConfig(configPath);
+  if (config?.database.mode === "postgres" && config.database.connectionString?.trim()) {
+    return {
+      value: config.database.connectionString.trim(),
+      source: "config.database.connectionString",
+    };
+  }
+
+  const port = config?.database.embeddedPostgresPort ?? 54329;
+  return {
+    value: `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`,
+    source: `embedded-postgres@${port}`,
+  };
+}
+
+/**
+ * Resolve free-form selectors (UUID, issue prefix, or exact name) to companies.
+ * Every selector must match exactly one company, so a typo fails loudly rather
+ * than silently purging a subset.
+ */
+async function resolveTargets(
+  sql: postgres.Sql,
+  selectors: string[],
+): Promise<TargetCompany[]> {
+  const rows = await sql<TargetCompany[]>`
+    SELECT id, name, issue_prefix AS "issuePrefix"
+    FROM public.companies
+  `;
+
+  const resolved = new Map<string, TargetCompany>();
+  for (const selector of selectors) {
+    const needle = selector.trim().toLowerCase();
+    const matches = rows.filter(
+      (row) =>
+        row.id.toLowerCase() === needle ||
+        row.issuePrefix.toLowerCase() === needle ||
+        row.name.toLowerCase() === needle,
+    );
+    if (matches.length === 0) {
+      throw new Error(`No company matched selector '${selector}'.`);
+    }
+    if (matches.length > 1) {
+      const detail = matches.map((m) => `${m.name} (${m.id})`).join(", ");
+      throw new Error(
+        `Selector '${selector}' is ambiguous and matched ${matches.length} companies: ${detail}. Use the company ID.`,
+      );
+    }
+    resolved.set(matches[0]!.id, matches[0]!);
+  }
+  return [...resolved.values()];
+}
+
+/** Every BASE TABLE, in any schema, carrying a `company_id` column. */
+async function discoverScopedTables(
+  sql: postgres.Sql,
+): Promise<Array<{ schema: string; table: string }>> {
+  const rows = await sql<Array<{ schema: string; table: string }>>`
+    SELECT c.table_schema AS schema, c.table_name AS table
+    FROM information_schema.columns c
+    JOIN information_schema.tables t
+      ON t.table_schema = c.table_schema
+     AND t.table_name = c.table_name
+     AND t.table_type = 'BASE TABLE'
+    WHERE c.column_name = 'company_id'
+      AND c.table_schema <> ALL(${SYSTEM_SCHEMAS})
+    ORDER BY 1, 2
+  `;
+  return rows;
+}
+
+/** All single-column foreign keys in the database, with their ON DELETE rule. */
+async function discoverForeignKeys(sql: postgres.Sql): Promise<ForeignKey[]> {
+  return sql<ForeignKey[]>`
+    SELECT
+      con.conname                        AS name,
+      cn.nspname                         AS "childSchema",
+      cl.relname                         AS "childTable",
+      ca.attname                         AS "childColumn",
+      pn.nspname                         AS "parentSchema",
+      pr.relname                         AS "parentTable",
+      pa.attname                         AS "parentColumn",
+      con.confdeltype                    AS "deleteRule"
+    FROM pg_constraint con
+    JOIN pg_class cl      ON cl.oid = con.conrelid
+    JOIN pg_namespace cn  ON cn.oid = cl.relnamespace
+    JOIN pg_class pr      ON pr.oid = con.confrelid
+    JOIN pg_namespace pn  ON pn.oid = pr.relnamespace
+    JOIN pg_attribute ca  ON ca.attrelid = con.conrelid AND ca.attnum = con.conkey[1]
+    JOIN pg_attribute pa  ON pa.attrelid = con.confrelid AND pa.attnum = con.confkey[1]
+    WHERE con.contype = 'f'
+      AND array_length(con.conkey, 1) = 1
+      AND cn.nspname <> ALL(${SYSTEM_SCHEMAS})
+  `;
+}
+
+/**
+ * Refuse to purge if a company outside the target set points at rows inside it.
+ * Deleting anyway would either fail on an FK or strand the outsider's data.
+ *
+ * The fix is almost always to widen the target set — mutually-referencing
+ * companies should be purged together.
+ */
+async function findExternalDependents(
+  sql: postgres.Sql,
+  fks: ForeignKey[],
+  scoped: Set<string>,
+  targetIds: string[],
+): Promise<Array<{ fk: string; count: number }>> {
+  const isCompaniesParent = (fk: ForeignKey) =>
+    fk.parentSchema === "public" && fk.parentTable === "companies";
+
+  const relevant = fks.filter(
+    (fk) =>
+      scoped.has(tableKey(fk.childSchema, fk.childTable)) &&
+      scoped.has(tableKey(fk.parentSchema, fk.parentTable)) &&
+      // A row's own `company_id` says which company owns it, not which company
+      // depends on it — every scoped table has one, and it is never a dependency.
+      // Other columns pointing at `companies` are real cross-company references
+      // and are checked separately below.
+      !(isCompaniesParent(fk) && fk.childColumn === "company_id"),
+  );
+
+  const hits: Array<{ fk: string; count: number }> = [];
+  for (const fk of relevant) {
+    // EXISTS + LIMIT 1 rather than count(*): this runs once per foreign key
+    // (hundreds of them), and all we need is whether the edge is clean. Only
+    // the rare dirty edge pays for an exact count.
+    // Which parent rows belong to the purge. `companies` is keyed on its own
+    // id; every other scoped table carries a company_id.
+    const parentFilter = isCompaniesParent(fk) ? "pa.id = ANY($1)" : "pa.company_id = ANY($1)";
+    const where = `${parentFilter} AND NOT (ch.company_id = ANY($1))`;
+    const from = `
+      FROM ${qualify(fk.childSchema, fk.childTable)} ch
+      JOIN ${qualify(fk.parentSchema, fk.parentTable)} pa
+        ON ch.${quoteIdent(fk.childColumn)} = pa.${quoteIdent(fk.parentColumn)}
+    `;
+
+    const [found] = await sql.unsafe<Array<{ dirty: boolean }>>(
+      `SELECT EXISTS (SELECT 1 ${from} WHERE ${where} LIMIT 1) AS dirty`,
+      [targetIds as never],
+    );
+    if (!found?.dirty) continue;
+
+    const [row] = await sql.unsafe<Array<{ count: number }>>(
+      `SELECT count(*)::int AS count ${from} WHERE ${where}`,
+      [targetIds as never],
+    );
+    hits.push({
+      fk: `${fk.childSchema}.${fk.childTable}.${fk.childColumn} -> ${fk.parentSchema}.${fk.parentTable}`,
+      count: row?.count ?? 0,
+    });
+  }
+  return hits;
+}
+
+/**
+ * Build every DELETE the purge needs:
+ *   - one per company-scoped table, keyed on `company_id`
+ *   - one per NO ACTION/RESTRICT foreign key arriving from a table that has no
+ *     `company_id`, joined back to the scoped parent
+ *
+ * CASCADE and SET NULL edges are deliberately omitted — Postgres already
+ * handles those, and deleting SET NULL children would destroy rows that merely
+ * mention the company rather than belong to it.
+ */
+export function buildSteps(
+  scopedTables: Array<{ schema: string; table: string }>,
+  fks: ForeignKey[],
+  scoped: Set<string>,
+): PurgeStep[] {
+  const steps: PurgeStep[] = scopedTables.map(({ schema, table }) => ({
+    label: tableKey(schema, table),
+    tableKey: tableKey(schema, table),
+    sql: `DELETE FROM ${qualify(schema, table)} WHERE company_id = ANY($1)`,
+    deleted: null,
+  }));
+
+  const restrictive = fks.filter(
+    (fk) =>
+      !scoped.has(tableKey(fk.childSchema, fk.childTable)) &&
+      (fk.deleteRule === "a" || fk.deleteRule === "r") &&
+      (scoped.has(tableKey(fk.parentSchema, fk.parentTable)) ||
+        (fk.parentSchema === "public" && fk.parentTable === "companies")),
+  );
+
+  for (const fk of restrictive) {
+    const isCompanies = fk.parentSchema === "public" && fk.parentTable === "companies";
+    const parentFilter = isCompanies ? "pa.id = ANY($1)" : "pa.company_id = ANY($1)";
+    steps.push({
+      label: `${fk.childSchema}.${fk.childTable} <- ${fk.parentTable}`,
+      tableKey: tableKey(fk.childSchema, fk.childTable),
+      sql: `
+        DELETE FROM ${qualify(fk.childSchema, fk.childTable)} ch
+        USING ${qualify(fk.parentSchema, fk.parentTable)} pa
+        WHERE ch.${quoteIdent(fk.childColumn)} = pa.${quoteIdent(fk.parentColumn)}
+          AND ${parentFilter}
+      `,
+      deleted: null,
+    });
+  }
+
+  return steps;
+}
+
+/**
+ * Sort steps so children are deleted before the tables they reference.
+ *
+ * The retry loop below is correct on its own, but order still matters for
+ * speed: a DELETE that violates a foreign key does all of its work *before*
+ * the constraint fires, so a bad initial order re-deletes (and discards) tens
+ * of thousands of rows on every pass. Seeding a good order turns what would be
+ * a dozen passes into roughly one.
+ *
+ * Only NO ACTION and RESTRICT edges constrain ordering — CASCADE and SET NULL
+ * are resolved by Postgres and cannot fail. Cycles are left for the retry loop
+ * rather than broken here.
+ */
+export function orderSteps(steps: PurgeStep[], fks: ForeignKey[]): PurgeStep[] {
+  const byTable = new Map<string, PurgeStep[]>();
+  for (const step of steps) {
+    const key = step.tableKey;
+    const list = byTable.get(key);
+    if (list) list.push(step);
+    else byTable.set(key, [step]);
+  }
+
+  // dependents[parent] = children that must be deleted first.
+  const dependents = new Map<string, Set<string>>();
+  const indegree = new Map<string, number>();
+  for (const key of byTable.keys()) indegree.set(key, 0);
+
+  for (const fk of fks) {
+    if (fk.deleteRule !== "a" && fk.deleteRule !== "r") continue;
+    const child = tableKey(fk.childSchema, fk.childTable);
+    const parent = tableKey(fk.parentSchema, fk.parentTable);
+    if (child === parent) continue;
+    if (!byTable.has(child) || !byTable.has(parent)) continue;
+    const set = dependents.get(parent) ?? new Set<string>();
+    if (set.has(child)) continue;
+    set.add(child);
+    dependents.set(parent, set);
+    indegree.set(parent, (indegree.get(parent) ?? 0) + 1);
+  }
+
+  // Kahn's algorithm: emit tables with no outstanding children first.
+  const queue = [...indegree.entries()].filter(([, n]) => n === 0).map(([k]) => k);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const key = queue.shift()!;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ordered.push(key);
+    for (const [parent, children] of dependents) {
+      if (!children.has(key)) continue;
+      children.delete(key);
+      const next = (indegree.get(parent) ?? 1) - 1;
+      indegree.set(parent, next);
+      if (next === 0) queue.push(parent);
+    }
+  }
+  // Anything left is part of a cycle; append it and let the retry loop sort it out.
+  for (const key of byTable.keys()) if (!seen.has(key)) ordered.push(key);
+
+  return ordered.flatMap((key) => byTable.get(key) ?? []);
+}
+
+/**
+ * Create temporary indexes on unindexed foreign key columns pointing at the
+ * tables this purge deletes from, and return the DROP statements to undo them.
+ *
+ * This is the difference between a purge that finishes in a minute and one that
+ * runs for hours. 315 of the schema's 616 foreign keys have no index on the
+ * child column, and Postgres enforces ON DELETE CASCADE / SET NULL with a
+ * per-row trigger: deleting one parent row scans each unindexed child table
+ * once. `heartbeat_runs` alone is referenced by 39 unindexed columns, three of
+ * them on `issue_comments` (~90k rows), so removing ~11k runs costs hundreds of
+ * thousands of sequential scans.
+ *
+ * The indexes are built inside the purge transaction, so a dry run measures the
+ * fast path and leaves nothing behind, and they are dropped again before commit
+ * — the schema is not permanently altered by a maintenance command.
+ *
+ * OPT-IN ONLY (`--fk-indexes`), because CREATE INDEX takes an ACCESS EXCLUSIVE
+ * lock on the table and this builds hundreds of them inside one uncommitted
+ * transaction. Postgres holds every one of those locks until the transaction
+ * ends, so against a running server it stalls all writes to the affected tables
+ * for the duration of the purge. Only use it with the service stopped.
+ */
+async function createHelperIndexes(
+  tx: postgres.TransactionSql,
+  deleteTargets: Set<string>,
+  onProgress: (message: string) => void,
+): Promise<string[]> {
+  const missing = await tx<
+    Array<{ schema: string; table: string; column: string }>
+  >`
+    SELECT cn.nspname AS schema, cl.relname AS table, ca.attname AS column
+    FROM pg_constraint con
+    JOIN pg_class cl      ON cl.oid = con.conrelid
+    JOIN pg_namespace cn  ON cn.oid = cl.relnamespace
+    JOIN pg_class pr      ON pr.oid = con.confrelid
+    JOIN pg_namespace pn  ON pn.oid = pr.relnamespace
+    JOIN pg_attribute ca  ON ca.attrelid = con.conrelid AND ca.attnum = con.conkey[1]
+    WHERE con.contype = 'f'
+      AND array_length(con.conkey, 1) = 1
+      AND pn.nspname || '.' || pr.relname = ANY(${[...deleteTargets]})
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_index i
+        WHERE i.indrelid = con.conrelid AND i.indkey[0] = con.conkey[1]
+      )
+  `;
+
+  // One FK column can back several constraints; build each index once.
+  const unique = new Map<string, { schema: string; table: string; column: string }>();
+  for (const row of missing) {
+    unique.set(`${row.schema}.${row.table}.${row.column}`, row);
+  }
+
+  const drops: string[] = [];
+  let n = 0;
+  for (const row of unique.values()) {
+    const indexName = `pcpurge_tmp_idx_${n++}`;
+    onProgress(`index ${n}/${unique.size} · ${row.table}.${row.column}`);
+    await tx.unsafe(
+      `CREATE INDEX ${quoteIdent(indexName)} ON ${qualify(row.schema, row.table)} (${quoteIdent(row.column)})`,
+    );
+    drops.push(`DROP INDEX ${qualify(row.schema, indexName)}`);
+  }
+  return drops;
+}
+
+/**
+ * Run every step to completion, discovering a workable order by retry.
+ *
+ * Each DELETE is wrapped in a SAVEPOINT. An FK violation means "a child of this
+ * table has not been deleted yet" — roll back that statement only and try again
+ * next pass. Any other error is a real failure and aborts the purge. The loop
+ * terminates when a full pass deletes nothing new; anything still pending at
+ * that point is reported as an unresolvable cycle rather than forced through.
+ */
+async function runSteps(
+  tx: postgres.TransactionSql,
+  steps: PurgeStep[],
+  targetIds: string[],
+  onProgress: (message: string) => void,
+): Promise<void> {
+  let pending = [...steps];
+  let savepoint = 0;
+  let pass = 0;
+  let done = 0;
+
+  while (pending.length > 0) {
+    const stillPending: PurgeStep[] = [];
+    let progressed = false;
+    pass += 1;
+
+    for (const step of pending) {
+      // Deletes on this schema can be slow: 315 of the database's foreign keys
+      // have no index on the child column, so each cascading parent row costs a
+      // scan of the child table. Naming the current table makes a long pass
+      // legible instead of looking like a hang.
+      onProgress(`pass ${pass} · ${done}/${steps.length} · ${step.label}`);
+      const name = `purge_sp_${savepoint++}`;
+      await tx.unsafe(`SAVEPOINT ${name}`);
+      try {
+        const result = await tx.unsafe(step.sql, [targetIds as never]);
+        await tx.unsafe(`RELEASE SAVEPOINT ${name}`);
+        step.deleted = result.count ?? 0;
+        progressed = true;
+        done += 1;
+      } catch (error) {
+        await tx.unsafe(`ROLLBACK TO SAVEPOINT ${name}`);
+        if ((error as { code?: string }).code !== FK_VIOLATION) throw error;
+        stillPending.push(step);
+      }
+    }
+
+    if (!progressed) {
+      const blocked = stillPending.map((s) => s.label).join(", ");
+      throw new Error(
+        `Purge stalled with ${stillPending.length} table(s) still blocked by foreign keys: ${blocked}. ` +
+          `This usually means a reference cycle, or a company that must be purged in the same set.`,
+      );
+    }
+
+    pending = stillPending;
+  }
+}
+
+function assertApplyFlags(opts: CompanyPurgeOptions, targets: TargetCompany[]): void {
+  if (!opts.yes) {
+    throw new Error("--apply requires --yes to confirm this destructive action.");
+  }
+  const confirm = opts.confirm?.trim();
+  if (!confirm) {
+    throw new Error(
+      "--apply requires --confirm <value> matching a target company ID, prefix, or name.",
+    );
+  }
+  const needle = confirm.toLowerCase();
+  const matched = targets.some(
+    (t) =>
+      t.id.toLowerCase() === needle ||
+      t.issuePrefix.toLowerCase() === needle ||
+      t.name.toLowerCase() === needle,
+  );
+  if (!matched) {
+    throw new Error(
+      `--confirm '${confirm}' does not match any target company. Expected one of: ` +
+        targets.map((t) => `${t.name} / ${t.issuePrefix} / ${t.id}`).join(" | "),
+    );
+  }
+}
+
+export async function companyPurgeCommand(
+  selectors: string[],
+  opts: CompanyPurgeOptions,
+): Promise<void> {
+  const apply = opts.apply === true;
+  const connection = resolveConnectionString(opts.config);
+  const sql = postgres(connection.value, { max: 1, onnotice: () => {} });
+
+  if (!opts.json) {
+    p.intro(pc.bgRed(pc.black(" paperclip company purge ")));
+    p.log.message(pc.dim(`Connection source: ${connection.source}`));
+    p.log.message(apply ? pc.red("Mode: APPLY (commits)") : pc.cyan("Mode: dry run (rolls back)"));
+  }
+
+  try {
+    const targets = await resolveTargets(sql, selectors);
+    const targetIds = targets.map((t) => t.id);
+    if (apply) assertApplyFlags(opts, targets);
+
+    if (!opts.json) {
+      p.log.step("Target companies");
+      for (const t of targets) {
+        p.log.message(`  ${pc.bold(t.name)} ${pc.dim(`${t.issuePrefix} · ${t.id}`)}`);
+      }
+    }
+
+    const scopedTables = await discoverScopedTables(sql);
+    const scoped = new Set(scopedTables.map((t) => tableKey(t.schema, t.table)));
+    const fks = await discoverForeignKeys(sql);
+
+    const dependents = await findExternalDependents(sql, fks, scoped, targetIds);
+    if (dependents.length > 0) {
+      const detail = dependents.map((d) => `${d.fk} (${d.count} row(s))`).join("; ");
+      throw new Error(
+        `Refusing to purge: companies outside the target set reference this data — ${detail}. ` +
+          `Add the referencing company to the same purge, or clear those references first.`,
+      );
+    }
+
+    const steps = orderSteps(buildSteps(scopedTables, fks, scoped), fks);
+    if (!opts.json) {
+      p.log.step(
+        `Plan: ${steps.length} delete(s) across ${scopedTables.length} company-scoped table(s)`,
+      );
+    }
+
+    // Back up before anything that commits. A dry run changes nothing, so it
+    // does not need one.
+    let backupPath: string | null = null;
+    if (apply && opts.backup !== false) {
+      const config = readConfig(opts.config);
+      const dir = path.resolve(
+        expandHomePrefix(
+          config?.database.backup.dir || resolveDefaultBackupDir(resolvePaperclipInstanceId()),
+        ),
+      );
+      const spinner = opts.json ? null : p.spinner();
+      spinner?.start("Backing up database before purge...");
+      const result = await runDatabaseBackup({
+        connectionString: connection.value,
+        backupDir: dir,
+        retention: { dailyDays: 30, weeklyWeeks: 4, monthlyMonths: 1 },
+        filenamePrefix: "paperclip-pre-purge",
+      });
+      backupPath = result.backupFile;
+      spinner?.stop(`Backup saved: ${formatDatabaseBackupResult(result)}`);
+    }
+
+    let companiesDeleted = 0;
+    const spinner = opts.json ? null : p.spinner();
+    spinner?.start("Deleting company data...");
+
+    await sql.begin(async (tx) => {
+      let dropIndexes: string[] = [];
+      if (opts.fkIndexes === true) {
+        dropIndexes = await createHelperIndexes(
+          tx,
+          new Set(steps.map((s) => s.tableKey)),
+          (message) => {
+            if (opts.json) process.stderr.write(`${message}\n`);
+            else spinner?.message(message);
+          },
+        );
+      }
+
+      await runSteps(tx, steps, targetIds, (message) => {
+        if (opts.json) process.stderr.write(`${message}\n`);
+        else spinner?.message(message);
+      });
+
+      const result = await tx.unsafe(`DELETE FROM public.companies WHERE id = ANY($1)`, [
+        targetIds as never,
+      ]);
+      companiesDeleted = result.count ?? 0;
+
+      // Leave the schema exactly as it was found.
+      for (const drop of dropIndexes) await tx.unsafe(drop);
+
+      if (!apply) {
+        // Everything above succeeded, which is the proof a real purge would
+        // work. Undo it.
+        throw new DryRunRollback();
+      }
+    }).catch((error) => {
+      if (error instanceof DryRunRollback) return;
+      throw error;
+    });
+
+    spinner?.stop(apply ? "Purge committed." : "Dry run complete (rolled back).");
+
+    const touched = steps
+      .filter((s) => (s.deleted ?? 0) > 0)
+      .sort((a, b) => (b.deleted ?? 0) - (a.deleted ?? 0));
+    const totalRows = touched.reduce((sum, s) => sum + (s.deleted ?? 0), 0);
+
+    if (opts.json) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            ok: true,
+            applied: apply,
+            backupPath,
+            companies: targets,
+            companiesDeleted,
+            totalRowsDeleted: totalRows,
+            tables: touched.map((s) => ({ table: s.label, rows: s.deleted })),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      p.log.step(`Rows ${apply ? "deleted" : "that would be deleted"}: ${totalRows}`);
+      for (const step of touched) {
+        p.log.message(`  ${String(step.deleted).padStart(8)}  ${step.label}`);
+      }
+      p.outro(
+        apply
+          ? pc.green(`Purged ${companiesDeleted} company/companies.`)
+          : pc.cyan("Nothing was changed. Re-run with --apply --yes --confirm <id> to commit."),
+      );
+    }
+  } finally {
+    await sql.end();
+  }
+}
+
+/** Sentinel used to unwind the transaction after a successful dry run. */
+class DryRunRollback extends Error {
+  constructor() {
+    super("dry-run rollback");
+    this.name = "DryRunRollback";
+  }
+}
+
+export function registerCompanyPurgeCommand(company: Command): void {
+  company
+    .command("purge")
+    .description(
+      "Hard-delete companies and all their data directly in Postgres (dry run by default)",
+    )
+    .argument("<selectors...>", "Company IDs, issue prefixes, or exact names")
+    .option("--config <path>", "Path to the Paperclip config file")
+    .option("--apply", "Commit the purge instead of rolling back", false)
+    .option("--yes", "Required with --apply to confirm this destructive action", false)
+    .option("--confirm <value>", "Required with --apply: a target company ID, prefix, or name")
+    .option("--no-backup", "Skip the pre-purge database backup (not recommended)")
+    .option(
+      "--fk-indexes",
+      "Build temporary indexes on unindexed foreign keys first. Much faster, but takes " +
+        "ACCESS EXCLUSIVE locks for the whole transaction — only use with the server stopped",
+      false,
+    )
+    .option("--json", "Emit JSON instead of formatted output", false)
+    .action(async (selectors: string[], opts: CompanyPurgeOptions) => {
+      try {
+        await companyPurgeCommand(selectors, opts);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify({ ok: false, error: message }, null, 2)}\n`);
+        } else {
+          p.log.error(pc.red(message));
+        }
+        process.exitCode = 1;
+      }
+    });
+}

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -256,6 +256,7 @@ pnpm exec paperclipai company import ./company --target new --new-company-name "
 pnpm exec paperclipai company import:preview <company-id> --payload-json '{...}'
 pnpm exec paperclipai company import:apply <company-id> --payload-json '{...}'
 pnpm exec paperclipai company delete <company-id-or-prefix> --yes --confirm <same-id-or-prefix>
+pnpm exec paperclipai company purge <selector...> [--apply --yes --confirm <value>]
 ```
 
 Examples:
@@ -275,6 +276,87 @@ Notes:
   an instance-wide setup command.
 - Deletion is server-gated by `PAPERCLIP_ENABLE_COMPANY_DELETION`.
 - With agent authentication, company deletion is company-scoped. Use the current company ID/prefix (for example via `--company-id` or `PAPERCLIP_COMPANY_ID`), not another company.
+
+### `company purge` — offline hard delete
+
+`company purge` is the direct-to-Postgres counterpart to `company delete`. Use it
+when `company delete` fails, which it does on any company with cost history.
+
+**Why it exists.** The API's `DELETE /api/companies/:id` deletes a hand-written
+list of ~30 tables in a fixed order. That list deletes `heartbeat_runs` before
+`cost_events`, but `cost_events.heartbeat_run_id -> heartbeat_runs` is
+`ON DELETE NO ACTION`, so the transaction aborts with a foreign key violation
+and the company is never removed. Separately, 145 tables carry a `company_id`
+and plugins add more in their own `plugin_*` schemas, so a hand-written list
+cannot stay complete.
+
+`company purge` derives the work from the live catalog instead:
+
+- targets every `BASE TABLE` in every schema with a `company_id` column, so
+  plugin schemas are covered automatically;
+- deletes rows in tables that reference company data but have no `company_id`
+  of their own (`decision_effect_executions`, `status_card_updates`, …) via a
+  join, but only where the FK is `NO ACTION`/`RESTRICT` — `CASCADE` and
+  `SET NULL` are left to Postgres;
+- discovers a working delete order instead of hardcoding one: steps are
+  topologically pre-sorted, and any step that still hits a foreign key
+  violation is rolled back to a savepoint and retried on the next pass.
+
+Foreign keys stay **enabled** for the whole run. Disabling them with
+`session_replication_role = 'replica'` would also disable the ~88 `ON DELETE
+CASCADE` edges and silently orphan rows; keeping Postgres in the loop means a
+successful commit is itself proof that referential integrity held.
+
+```sh
+# Dry run (default): executes every delete, reports counts, then rolls back.
+pnpm exec paperclipai company purge "cs development"
+
+# Purge several companies as one set.
+pnpm exec paperclipai company purge "cs consulting" "cs development" "cs website"
+
+# Commit. Requires all three flags.
+pnpm exec paperclipai company purge CSD --apply --yes --confirm CSD
+```
+
+Options:
+
+| Flag | Meaning |
+| --- | --- |
+| `--apply` | Commit. Without it the transaction is rolled back. |
+| `--yes` | Required with `--apply`. |
+| `--confirm <value>` | Required with `--apply`; must match a target ID, prefix, or name. |
+| `--no-backup` | Skip the pre-purge backup. Not recommended. |
+| `--fk-indexes` | Build temporary indexes on unindexed FK columns first. Only with the server stopped — see below. |
+| `--config <path>` | Config file used to resolve the connection string. |
+| `--json` | Machine-readable result on stdout; progress on stderr. |
+
+Notes:
+
+- **Selectors accept an ID, an issue prefix, or an exact name**, and each must
+  match exactly one company or the command fails.
+- **Purge mutually-referencing companies together.** Preflight refuses to run if
+  a company outside the target set references data inside it, because deleting
+  anyway would strand the outsider's rows. Passing the related companies in one
+  invocation makes those references internal to the set and the check passes.
+- **A dry run is a real rehearsal.** Every `DELETE` executes against live data
+  inside a transaction that is then rolled back, so the reported per-table row
+  counts are exact and a clean dry run proves the purge will commit.
+- **A backup runs first** for any `--apply`, into the configured backup dir with
+  the `paperclip-pre-purge` prefix, unless `--no-backup` is passed.
+- **Run it with the server stopped.** 315 of the schema's 616 foreign keys have
+  no index on the child column, so cascading deletes cost a child-table scan per
+  parent row — `heartbeat_runs` alone is referenced by 39 unindexed columns,
+  three of them on `issue_comments`. Large companies therefore take a long time
+  and hold a long-lived transaction. Stop the service, purge, start it again.
+- **`--fk-indexes` is opt-in and needs the service stopped.** It builds the
+  missing FK indexes first, which turns hours into minutes, but `CREATE INDEX`
+  takes an `ACCESS EXCLUSIVE` lock and Postgres holds every one of those locks
+  until the transaction ends. Against a running server this stalls all writes to
+  the affected tables for the whole purge. Without the flag the purge is slow but
+  takes no exclusive locks.
+- The command talks to Postgres directly using the same connection resolution as
+  `db:backup` (`DATABASE_URL`, then `config.database.connectionString`, then the
+  embedded Postgres port). It does not need the server to be running.
 
 ## Issue Commands
 

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -338,6 +338,13 @@ Notes:
   a company outside the target set references data inside it, because deleting
   anyway would strand the outsider's rows. Passing the related companies in one
   invocation makes those references internal to the set and the check passes.
+
+  This covers columns pointing at `companies` other than a row's own
+  `company_id` — currently `company_skills.forked_from_company_id` and
+  `cli_auth_challenges.requested_company_id`, both `ON DELETE SET NULL`. Without
+  the check, purging a company that a surviving company forked a skill from
+  would silently null that provenance instead of failing. Single-column foreign
+  keys only; the schema has no multi-column ones.
 - **A dry run is a real rehearsal.** Every `DELETE` executes against live data
   inside a transaction that is then rolled back, so the reported per-table row
   counts are exact and a clean dry run proves the purge will commit.


### PR DESCRIPTION
- [x] I searched the open PR list for similar PRs before opening this one.

## Linked Issues

Same `cost_events` → `heartbeat_runs` ordering failure:
Refs #6485, Refs #7942, Refs #8489, Refs #5014, Refs #5163, Refs #1659

The coverage half — the delete list not keeping up with new tables:
Refs #2096, Refs #7250, Refs #3038, Refs #3577

Deliberately `Refs` rather than `Fixes`: this PR does **not** repair
`DELETE /api/companies/:id`. It adds a working operator path alongside it. The
server-side fix is #6756 below, and these issues should stay open until that
lands.

## Related PRs

- **#6756** — `fix(server): delete cost_events + finance_events before heartbeat_runs in companies.remove()`. Fixes the ordering bug at the source. Complementary to this PR and arguably should land first; this one additionally covers the tables the hand-written list does not know about.
- **#2097** — `fix(server): complete FK dependency cleanup in company delete`. Same coverage problem, addressed by extending the list rather than deriving it.
- **#9684**, **#9593** — tests around company deletion cleanup.

If maintainers would rather solve this entirely server-side via #6756 and #2097,
this PR still has value as the offline/recovery path and as the thing that
covers plugin schemas — but I am happy to close it in favor of those.

## Thinking Path

Started from a concrete failure: `DELETE /api/companies/:id` returned an error on a company with cost history. Reproduced it by replaying `companyService.remove()`'s exact statement order inside a rolled-back transaction, which failed on statement 4:

```
ERROR: update or delete on table "heartbeat_runs" violates foreign key constraint
       "cost_events_heartbeat_run_id_heartbeat_runs_id_fk" on table "cost_events"
```

The list deletes `heartbeat_runs` before `cost_events`, but that FK is `ON DELETE NO ACTION`.

Fixing the order alone would leave the deeper problem: the list is hand-maintained, while 145 tables carry a `company_id` and plugins add more at install time in their own `plugin_*` schemas. Any new table with a NO ACTION FK silently breaks company deletion again, and nothing tests it.

I considered `session_replication_role = 'replica'` to sidestep ordering entirely, and rejected it — it disables FK triggers wholesale, including the ~88 `ON DELETE CASCADE` edges, so it converts a loud failure into silent orphans. Deriving the plan from the catalog and letting Postgres keep enforcing constraints gives the opposite property: if it commits, integrity held.

## Issue

`DELETE /api/companies/:id` cannot complete on any company that has cost history, so companies cannot be removed and their data accumulates indefinitely.

**Steps to reproduce**
1. Use a company with at least one row in `cost_events`.
2. `DELETE /api/companies/:id`.

**Expected:** company and its data are removed.
**Actual:** foreign key violation; the transaction aborts and nothing is deleted.

**Paperclip version/commit:** `master` @ `aac6ce82e`
**Deployment mode:** self-hosted, `authenticated` mode, embedded Postgres 18.1

**Root cause:** `server/src/services/companies.ts` → `remove()` deletes `heartbeat_runs` before `cost_events`, whose `heartbeat_run_id` FK is `ON DELETE NO ACTION`. Secondarily, its ~30-table list cannot cover the 145 `company_id`-bearing tables plus plugin schemas.

## What Changed

Adds `paperclipai company purge` (`cli/src/commands/company-purge.ts`), registered under the existing `company` command group. It talks to Postgres directly, using the same connection resolution as `db:backup`, because the HTTP path is the thing that is broken.

- **Discovers targets by introspection** — every `BASE TABLE` in every schema with a `company_id` column, so plugin schemas are covered automatically.
- **Handles tables with no `company_id`** (`decision_effect_executions`, `status_card_updates`, …) via a join back to the scoped parent, but only where the FK is `NO ACTION`/`RESTRICT`. `CASCADE` and `SET NULL` are left to Postgres — more correct and less destructive.
- **Discovers the delete order** — steps are topologically pre-sorted by FK depth, and anything that still hits a violation rolls back to a savepoint and is retried next pass. Ordering bugs of this class cannot be reintroduced by adding a table.
- **Preflight** refuses to run when a company outside the target set references data inside it, including non-`company_id` columns pointing at `companies` such as `company_skills.forked_from_company_id`. Related companies can be purged together as one set.
- **Docs** in `doc/CLI.md`, plus 10 unit tests over plan construction and ordering.

No change to server behavior or the existing `company delete` command.

## Verification

- `pnpm --filter paperclipai typecheck` — clean.
- 10 unit tests covering the exact `cost_events`/`heartbeat_runs` case, CASCADE/SET NULL exclusion, multi-level chains, cycles, self-references, and plugin schemas — all passing.
- End to end against a live instance: purged three companies totalling **833,577 rows across 58 tables**, then verified **zero orphaned rows across all 616 foreign keys** afterwards.
- Dry run verified as a true rehearsal: it executes every delete and rolls back, leaving row counts and company count unchanged.

## Risks

- **Direct database access.** This bypasses the API and its authorization. It is a host-side operator command, gated behind `--apply --yes --confirm`, with dry run as the default and an automatic backup before committing.
- **Irreversible when applied.** Mitigated by the pre-purge backup and by dry run being the default.
- **`--fk-indexes` takes `ACCESS EXCLUSIVE` locks** held for the whole transaction. It is opt-in and documented as requiring the service to be stopped; without it no exclusive locks are taken.
- **Preflight covers single-column foreign keys.** Multi-column FKs are not analyzed; none exist in the current schema.
- **New dependency `postgres`.** Already a transitive dependency via `@paperclipai/db`; promoted to a direct CLI dependency. Happy to drop it and route through `@paperclipai/db`'s drizzle client instead if you would rather not add it — the savepoint/retry loop is the only reason it uses the driver directly.

Lockfile intentionally not modified, per the contributor guidance about the refresh bot.

## Related finding (not addressed here)

315 of the schema's 616 foreign keys have no index on the child column. `heartbeat_runs` alone is referenced by 39 unindexed columns, three of them on `issue_comments`. This makes every cascading delete scan child tables per parent row — it slows far more than purges. Worth a separate change; happy to open an issue.

## Model Used

Claude Opus 5 (1M context), via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
