### PR TITLE
fix(hermes): preserve resumed task context

### DIFF
--- a/packages/adapters/hermes/src/server/config-schema.ts
+++ b/packages/adapters/hermes/src/server/config-schema.ts
@@ -2,7 +2,8 @@ import type { AdapterConfigSchema } from "@paperclipai/adapter-utils";
 
 import {
   DEFAULT_GRACE_SEC,
-  DEFAULT_TIMEOUT_SEC,
+  DEFAULT_MAX_TURNS_PER_RUN,
+  DEFAULT_SCALED_TIMEOUT_SEC,
   VALID_PROVIDERS,
 } from "../shared/constants.js";
 
@@ -35,7 +36,7 @@ export function getConfigSchema(): AdapterConfigSchema {
         key: "timeoutSec",
         label: "Timeout seconds",
         type: "number",
-        default: DEFAULT_TIMEOUT_SEC,
+        default: DEFAULT_SCALED_TIMEOUT_SEC,
       },
       {
         key: "graceSec",
@@ -48,6 +49,7 @@ export function getConfigSchema(): AdapterConfigSchema {
         key: "maxTurnsPerRun",
         label: "Max turns per run",
         type: "number",
+        default: DEFAULT_MAX_TURNS_PER_RUN,
         hint: "Optional Hermes --max-turns limit for tool-calling iterations.",
       },
       {

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -157,6 +157,8 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       timedOut: false,
       stdout: [
         "Session: planning",
+        "session id: planning",
+        "session saved: example",
         "Resume this session with:",
         "hermes --resume example",
         "This is ordinary answer content.",
@@ -173,6 +175,8 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(result.resultJson).toMatchObject({
       result: [
         "Session: planning",
+        "session id: planning",
+        "session saved: example",
         "Resume this session with:",
         "hermes --resume example",
         "This is ordinary answer content.",

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -180,6 +180,35 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     });
   });
 
+  it("parses quiet sessions enabled through extraArgs", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        "Answer text",
+        "",
+        "session_id: 20260814_144930_03a3ec",
+      ].join("\n"),
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx({
+      quiet: false,
+      extraArgs: ["-Q"],
+    });
+    const result = await execute(ctx as any);
+
+    expect(result.sessionParams).toEqual({
+      sessionId: "20260814_144930_03a3ec",
+    });
+    expect(result.resultJson).toMatchObject({
+      result: "Answer text",
+    });
+  });
+
   it("preserves footer-shaped answer prose and does not persist it as a session", async () => {
     vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
       exitCode: 0,

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -150,6 +150,36 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     });
   });
 
+  it("uses only the canonical terminal quiet-mode session line", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        "Answer text",
+        "session_id: 20260101_010101_deadbeef",
+        "Still part of the answer.",
+        "",
+        "session_id: 20260814_144930_03a3ec",
+      ].join("\n"),
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx();
+    const result = await execute(ctx as any);
+
+    expect(result.sessionParams).toEqual({ sessionId: "20260814_144930_03a3ec" });
+    expect(result.resultJson).toMatchObject({
+      result: [
+        "Answer text",
+        "session_id: 20260101_010101_deadbeef",
+        "Still part of the answer.",
+      ].join("\n"),
+    });
+  });
+
   it("preserves footer-shaped answer prose and does not persist it as a session", async () => {
     vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
       exitCode: 0,

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -118,7 +118,7 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(noisyArgs).not.toContain("-Q");
   });
 
-  it("captures the Hermes 0.20 non-quiet session footer", async () => {
+  it("does not trust the Hermes 0.20 non-quiet footer as session metadata", async () => {
     vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
       exitCode: 0,
       signal: null,
@@ -138,10 +138,15 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     const { ctx } = makeCtx({ quiet: false });
     const result = await execute(ctx as any);
 
-    expect(result.sessionParams).toEqual({ sessionId: "20260814_144930_03a3ec" });
+    expect(result.sessionParams).toBeUndefined();
     expect(result.resultJson).toMatchObject({
-      result: "Answer text",
-      session_id: "20260814_144930_03a3ec",
+      result: [
+        "Answer text",
+        "",
+        "Resume this session with:",
+        "hermes --resume 20260814_144930_03a3ec",
+        "Session: 20260814_144930_03a3ec",
+      ].join("\n"),
     });
   });
 

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -145,6 +145,36 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     });
   });
 
+  it("preserves footer-shaped answer prose and does not persist it as a session", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        "Session: planning",
+        "Resume this session with:",
+        "hermes --resume example",
+        "This is ordinary answer content.",
+      ].join("\n"),
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx({ quiet: false });
+    const result = await execute(ctx as any);
+
+    expect(result.sessionParams).toBeUndefined();
+    expect(result.resultJson).toMatchObject({
+      result: [
+        "Session: planning",
+        "Resume this session with:",
+        "hermes --resume example",
+        "This is ordinary answer content.",
+      ].join("\n"),
+    });
+  });
+
   it("sends only the wake delta when resuming and does not reinject managed instructions", async () => {
     const { ctx } = makeCtx({ instructionsFilePath: "/managed/AGENTS.md" });
     (ctx.runtime as any).sessionParams = { sessionId: "20260814_155413_3d2fdf" };

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -29,7 +29,7 @@ vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
 
 // Mock fs and path resolution to avoid real file reads in execute()
 vi.mock("node:fs/promises", () => ({
-  readFile: vi.fn(async () => ""),
+  readFile: vi.fn(async () => "MANAGED_AGENT_INSTRUCTIONS"),
   writeFile: vi.fn(async () => undefined),
   mkdir: vi.fn(async () => undefined),
   rm: vi.fn(async () => undefined),
@@ -102,6 +102,100 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
     const opts = lastCall[3] as Record<string, unknown>;
     expect(opts.onSpawn).toBe(onSpawn);
+  });
+
+  it("enables quiet mode by default and allows an explicit opt-out", async () => {
+    const { ctx } = makeCtx();
+    await execute(ctx as any);
+
+    const mocked = vi.mocked(serverUtils.runChildProcess);
+    const defaultArgs = mocked.mock.calls.at(-1)?.[2] as string[];
+    expect(defaultArgs).toContain("-Q");
+
+    const { ctx: noisyCtx } = makeCtx({ quiet: false });
+    await execute(noisyCtx as any);
+    const noisyArgs = mocked.mock.calls.at(-1)?.[2] as string[];
+    expect(noisyArgs).not.toContain("-Q");
+  });
+
+  it("captures the Hermes 0.20 non-quiet session footer", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        "Answer text",
+        "",
+        "Resume this session with:",
+        "  hermes --resume 20260814_144930_03a3ec",
+        "Session: 20260814_144930_03a3ec",
+      ].join("\n"),
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx({ quiet: false });
+    const result = await execute(ctx as any);
+
+    expect(result.sessionParams).toEqual({ sessionId: "20260814_144930_03a3ec" });
+    expect(result.resultJson).toMatchObject({
+      result: "Answer text",
+      session_id: "20260814_144930_03a3ec",
+    });
+  });
+
+  it("sends only the wake delta when resuming and does not reinject managed instructions", async () => {
+    const { ctx } = makeCtx({ instructionsFilePath: "/managed/AGENTS.md" });
+    (ctx.runtime as any).sessionParams = { sessionId: "20260814_155413_3d2fdf" };
+    (ctx.context as any).paperclipWake = {
+      reason: "issue_commented",
+      issue: {
+        id: "issue-1",
+        identifier: "TES-10",
+        title: "你是谁？",
+        status: "in_progress",
+        priority: "medium",
+        workMode: "standard",
+      },
+      latestCommentId: "comment-1",
+      commentWindow: { requestedCount: 1, includedCount: 1, missingCount: 0 },
+      comments: [{
+        id: "comment-1",
+        body: "帮我看看今天有什么 ai 新闻",
+        createdAt: "2026-08-14T07:57:08.550Z",
+      }],
+      fallbackFetchNeeded: false,
+    };
+    (ctx.context as any).paperclipTaskMarkdown = [
+      "Paperclip task context:",
+      '- Issue: "TES-10"',
+      "Latest wake comment:",
+      "帮我看看今天有什么 ai 新闻",
+    ].join("\n");
+    (ctx.context as any).paperclipTaskMarkdownCompact = [
+      "Paperclip task context:",
+      '- Issue: "TES-10"',
+      "",
+      "Latest wake comment:",
+      "```text",
+      "帮我看看今天有什么 ai 新闻",
+      "```",
+      "",
+      "Use this task context as the current assignment.",
+    ].join("\n");
+
+    await execute(ctx as any);
+
+    const args = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)?.[2] as string[];
+    const prompt = args[args.indexOf("-q") + 1];
+    expect(args).toContain("--resume");
+    expect(prompt).toContain("## Paperclip Resume Delta");
+    expect(prompt.match(/帮我看看今天有什么 ai 新闻/g)).toHaveLength(1);
+    expect(prompt).not.toContain("MANAGED_AGENT_INSTRUCTIONS");
+    expect(prompt).toContain("Paperclip task context:");
+    expect(prompt).not.toContain("Latest wake comment:");
+    expect(prompt).not.toContain("Paperclip runtime identity:");
   });
 
   it("runChildProcess opts type includes onSpawn", () => {

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -157,6 +157,7 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       timedOut: false,
       stdout: [
         "Session: planning",
+        "session_id: planning",
         "session id: planning",
         "session saved: example",
         "Resume this session with:",
@@ -175,6 +176,7 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(result.resultJson).toMatchObject({
       result: [
         "Session: planning",
+        "session_id: planning",
         "session id: planning",
         "session saved: example",
         "Resume this session with:",

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -261,8 +261,9 @@ export function buildPrompt(
 // Output parsing
 // ---------------------------------------------------------------------------
 
-/** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
-const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
+/** Canonical terminal session line emitted by Hermes quiet mode. */
+const SESSION_ID_REGEX =
+  /(?:^|\n)session_id:\s*(\d{8}_\d{6}_[a-z0-9]+)\s*$/i;
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
@@ -329,7 +330,7 @@ function parseHermesOutput(
   if (sessionMatch?.[1]) {
     result.sessionId = sessionMatch?.[1] ?? null;
     // The response is everything before the session_id line
-    const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
+    const sessionLineIdx = sessionMatch.index ?? -1;
     if (sessionLineIdx > 0) {
       result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
     }

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -291,7 +291,6 @@ function cleanResponse(raw: string): string {
       const t = line.trim();
       if (!t) return true; // keep blank lines for paragraph separation
       if (t.startsWith("[tool]") || t.startsWith("[hermes]") || t.startsWith("[paperclip]")) return false;
-      if (t.startsWith("session_id:")) return false;
       if (/^\[\d{4}-\d{2}-\d{2}T/.test(t)) return false;
       if (/^\[done\]\s*┊/.test(t)) return false;
       if (/^┊\s*[\p{Emoji_Presentation}]/u.test(t) && !/^┊\s*💬/.test(t)) return false;
@@ -312,7 +311,11 @@ function cleanResponse(raw: string): string {
 // Output parsing
 // ---------------------------------------------------------------------------
 
-function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
+function parseHermesOutput(
+  stdout: string,
+  stderr: string,
+  options: { quietMode: boolean },
+): ParsedOutput {
   const combined = stdout + "\n" + stderr;
   const result: ParsedOutput = {};
 
@@ -320,7 +323,9 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
   //   <response text>
   //
   //   session_id: <id>
-  const sessionMatch = stdout.match(SESSION_ID_REGEX);
+  const sessionMatch = options.quietMode
+    ? stdout.match(SESSION_ID_REGEX)
+    : null;
   if (sessionMatch?.[1]) {
     result.sessionId = sessionMatch?.[1] ?? null;
     // The response is everything before the session_id line
@@ -591,7 +596,9 @@ export async function execute(
   });
 
   // ── Parse output ───────────────────────────────────────────────────────
-  const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
+  const parsed = parseHermesOutput(result.stdout || "", result.stderr || "", {
+    quietMode: useQuiet,
+  });
 
   await ctx.onLog(
     "stdout",

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -133,6 +133,47 @@ function renderConditionalSections(template: string, vars: Record<string, unknow
   );
 }
 
+function fencePaperclipTaskText(value: string): string {
+  const longestBacktickRun = Math.max(
+    2,
+    ...Array.from(value.matchAll(/`+/g), (match) => match[0].length),
+  );
+  const fence = "`".repeat(longestBacktickRun + 1);
+  return [fence + "text", value, fence].join("\n");
+}
+
+function readLatestWakeCommentBody(context: Record<string, unknown>): string {
+  const directComment = context.paperclipWakeComment;
+  if (directComment && typeof directComment === "object" && !Array.isArray(directComment)) {
+    const body = (directComment as Record<string, unknown>).body;
+    if (typeof body === "string" && body.trim()) return body.trim();
+  }
+
+  const wake = context.paperclipWake;
+  if (!wake || typeof wake !== "object" || Array.isArray(wake)) return "";
+  const comments = (wake as Record<string, unknown>).comments;
+  if (!Array.isArray(comments)) return "";
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    if (!comment || typeof comment !== "object" || Array.isArray(comment)) continue;
+    const body = (comment as Record<string, unknown>).body;
+    if (typeof body === "string" && body.trim()) return body.trim();
+  }
+  return "";
+}
+
+function stripLatestWakeCommentFromTaskMarkdown(
+  taskMarkdown: string,
+  context: Record<string, unknown>,
+): string {
+  const commentBody = readLatestWakeCommentBody(context);
+  if (!taskMarkdown || !commentBody) return taskMarkdown;
+  const section = `\n\nLatest wake comment:\n${fencePaperclipTaskText(commentBody)}`;
+  const sectionIndex = taskMarkdown.lastIndexOf(section);
+  if (sectionIndex < 0) return taskMarkdown;
+  return taskMarkdown.slice(0, sectionIndex) + taskMarkdown.slice(sectionIndex + section.length);
+}
+
 export function buildPrompt(
   ctx: AdapterExecutionContext,
   config: Record<string, unknown>,
@@ -160,15 +201,22 @@ export function buildPrompt(
     paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "") + "/api";
   }
 
-  const paperclipTaskMarkdown = selectPaperclipTaskMarkdown(context, {
+  const selectedPaperclipTaskMarkdown = selectPaperclipTaskMarkdown(context, {
     resumedSession: options.resumedSession === true,
   });
   const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, {
     resumedSession: options.resumedSession === true,
     // The task-context markdown is the authoritative brief on this lane; keep
     // the wake prompt's description copy out so the prompt carries it once.
-    suppressIssueDescription: paperclipTaskMarkdown.length > 0,
+    suppressIssueDescription: selectedPaperclipTaskMarkdown.length > 0,
   });
+  const shouldUseResumeDeltaPrompt = options.resumedSession === true && wakePrompt.length > 0;
+  // Resume deltas already carry the complete pending-comment batch. Keep the
+  // selected compact/full task brief, but remove its duplicate latest-comment
+  // section so Hermes sees each user comment exactly once.
+  const paperclipTaskMarkdown = shouldUseResumeDeltaPrompt
+    ? stripLatestWakeCommentFromTaskMarkdown(selectedPaperclipTaskMarkdown, context)
+    : selectedPaperclipTaskMarkdown;
   const sessionHandoffMarkdown = cfgString(context.paperclipSessionHandoffMarkdown)?.trim() || "";
   const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake) || "";
 
@@ -198,7 +246,7 @@ export function buildPrompt(
     paperclipRunIdEnv: "PAPERCLIP_RUN_ID",
   };
 
-  const rendered = isPaperclipRecoveryWakePayload(context.paperclipWake)
+  const rendered = shouldUseResumeDeltaPrompt || isPaperclipRecoveryWakePayload(context.paperclipWake)
     ? ""
     : renderTemplate(renderConditionalSections(template, vars), vars);
   return joinPromptSections([
@@ -217,7 +265,11 @@ export function buildPrompt(
 const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
 
 /** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+const SESSION_ID_REGEX_LEGACY =
+  /^(?:session[_ ](?:id|saved)|session):\s*([a-zA-Z0-9_-]+)/im;
+
+/** Hermes 0.20+ non-quiet resume footer: "hermes --resume <id>" */
+const SESSION_ID_REGEX_RESUME = /\bhermes\s+--resume\s+([a-zA-Z0-9_-]+)/i;
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
@@ -247,6 +299,9 @@ function cleanResponse(raw: string): string {
       if (!t) return true; // keep blank lines for paragraph separation
       if (t.startsWith("[tool]") || t.startsWith("[hermes]") || t.startsWith("[paperclip]")) return false;
       if (t.startsWith("session_id:")) return false;
+      if (/^session:\s*\S+/i.test(t)) return false;
+      if (/^resume this session with:/i.test(t)) return false;
+      if (/^hermes\s+--resume\s+\S+/i.test(t)) return false;
       if (/^\[\d{4}-\d{2}-\d{2}T/.test(t)) return false;
       if (/^\[done\]\s*┊/.test(t)) return false;
       if (/^┊\s*[\p{Emoji_Presentation}]/u.test(t) && !/^┊\s*💬/.test(t)) return false;
@@ -285,7 +340,7 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
     }
   } else {
     // Legacy format (non-quiet mode)
-    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
+    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY) ?? combined.match(SESSION_ID_REGEX_RESUME);
     if (legacyMatch?.[1]) {
       result.sessionId = legacyMatch?.[1] ?? null;
     }
@@ -349,6 +404,11 @@ export async function execute(
   const prevSessionId = cfgString(
     (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.sessionId,
   );
+  const context = (ctx as any).context || {};
+  const resumedWakePrompt = prevSessionId
+    ? renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: true })
+    : "";
+  const shouldUseResumeDeltaPrompt = Boolean(prevSessionId) && resumedWakePrompt.length > 0;
 
   // ── Resolve provider (defense in depth) ────────────────────────────────
   // Priority chain:
@@ -386,7 +446,7 @@ export async function execute(
   // when present, inject that bundle into the Hermes prompt.
   const instructionsFilePath = cfgString(config.instructionsFilePath);
   let agentInstructions = "";
-  if (instructionsFilePath) {
+  if (instructionsFilePath && !shouldUseResumeDeltaPrompt) {
     try {
       agentInstructions = await fs.readFile(instructionsFilePath, "utf-8");
       const loadedInstructionsLength = agentInstructions.length;
@@ -416,7 +476,10 @@ export async function execute(
 
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
-  const useQuiet = cfgBoolean(config.quiet) === true; // default false
+  // The config schema defaults quiet mode to true. Keep the runtime default in
+  // sync so agents created before schema values were persisted also get clean,
+  // parseable output. Users can still explicitly opt out with quiet=false.
+  const useQuiet = cfgBoolean(config.quiet) !== false;
   const args: string[] = ["chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -264,10 +264,6 @@ export function buildPrompt(
 /** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
 const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
 
-/** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY =
-  /^session[_ ](?:id|saved):\s*([a-zA-Z0-9_-]+)/im;
-
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
   /tokens?[:\s]+(\d+)\s*(?:input|in)\b.*?(\d+)\s*(?:output|out)\b/i;
@@ -333,13 +329,9 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
       result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
     }
   } else {
-    // Legacy format (non-quiet mode)
-    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
-    if (legacyMatch?.[1]) {
-      result.sessionId = legacyMatch[1];
-    }
-    // In non-quiet mode, extract clean response from stdout by
-    // filtering out tool lines, system messages, and noise
+    // Non-quiet session-looking text is ambiguous because it can be ordinary
+    // answer prose. Preserve the response, but never persist a session id from
+    // this lane; resumable metadata is trusted only from quiet-mode output.
     const cleaned = cleanResponse(stdout);
     if (cleaned.length > 0) {
       result.response = cleaned;

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -601,13 +601,13 @@ export async function execute(
     quietMode: useQuiet,
   });
 
+  if (parsed.sessionId) {
+    await ctx.onLog("stdout", `[hermes] Session: ${parsed.sessionId}\n`);
+  }
   await ctx.onLog(
     "stdout",
     `[hermes] Exit code: ${result.exitCode ?? "null"}, timed out: ${result.timedOut}\n`,
   );
-  if (parsed.sessionId) {
-    await ctx.onLog("stdout", `[hermes] Session: ${parsed.sessionId}\n`);
-  }
 
   // ── Build result ───────────────────────────────────────────────────────
   const executionResult: AdapterExecutionResult = {

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -266,10 +266,15 @@ const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
 
 /** Regex for legacy session output format */
 const SESSION_ID_REGEX_LEGACY =
-  /^(?:session[_ ](?:id|saved)|session):\s*([a-zA-Z0-9_-]+)/im;
+  /^session[_ ](?:id|saved):\s*([a-zA-Z0-9_-]+)/im;
 
-/** Hermes 0.20+ non-quiet resume footer: "hermes --resume <id>" */
-const SESSION_ID_REGEX_RESUME = /\bhermes\s+--resume\s+([a-zA-Z0-9_-]+)/i;
+/**
+ * Hermes 0.20+ non-quiet footer. Require the complete terminal block and the
+ * same id on both lines so answer prose that mentions Session or --resume is
+ * never interpreted as resumable metadata.
+ */
+const SESSION_FOOTER_REGEX =
+  /(?:^|\n)(?:[ \t]*\n)*[ \t]*Resume this session with:[ \t]*\n[ \t]*hermes[ \t]+--resume[ \t]+([a-zA-Z0-9_-]+)[ \t]*\n[ \t]*Session:[ \t]*\1[ \t]*(?:\n[ \t]*)*$/i;
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
@@ -299,9 +304,6 @@ function cleanResponse(raw: string): string {
       if (!t) return true; // keep blank lines for paragraph separation
       if (t.startsWith("[tool]") || t.startsWith("[hermes]") || t.startsWith("[paperclip]")) return false;
       if (t.startsWith("session_id:")) return false;
-      if (/^session:\s*\S+/i.test(t)) return false;
-      if (/^resume this session with:/i.test(t)) return false;
-      if (/^hermes\s+--resume\s+\S+/i.test(t)) return false;
       if (/^\[\d{4}-\d{2}-\d{2}T/.test(t)) return false;
       if (/^\[done\]\s*┊/.test(t)) return false;
       if (/^┊\s*[\p{Emoji_Presentation}]/u.test(t) && !/^┊\s*💬/.test(t)) return false;
@@ -340,13 +342,18 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
     }
   } else {
     // Legacy format (non-quiet mode)
-    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY) ?? combined.match(SESSION_ID_REGEX_RESUME);
-    if (legacyMatch?.[1]) {
-      result.sessionId = legacyMatch?.[1] ?? null;
+    const footerMatch = stdout.match(SESSION_FOOTER_REGEX);
+    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
+    const sessionMatch = footerMatch ?? legacyMatch;
+    if (sessionMatch?.[1]) {
+      result.sessionId = sessionMatch[1];
     }
     // In non-quiet mode, extract clean response from stdout by
     // filtering out tool lines, system messages, and noise
-    const cleaned = cleanResponse(stdout);
+    const responseText = footerMatch?.index == null
+      ? stdout
+      : stdout.slice(0, footerMatch.index);
+    const cleaned = cleanResponse(responseText);
     if (cleaned.length > 0) {
       result.response = cleaned;
     }

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -472,6 +472,8 @@ export async function execute(
   // sync so agents created before schema values were persisted also get clean,
   // parseable output. Users can still explicitly opt out with quiet=false.
   const useQuiet = cfgBoolean(config.quiet) !== false;
+  const effectiveQuiet = useQuiet ||
+    extraArgs?.some((arg) => arg === "-Q" || arg === "--quiet") === true;
   const args: string[] = ["chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 
@@ -598,7 +600,7 @@ export async function execute(
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "", {
-    quietMode: useQuiet,
+    quietMode: effectiveQuiet,
   });
 
   if (parsed.sessionId) {

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -268,14 +268,6 @@ const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
 const SESSION_ID_REGEX_LEGACY =
   /^session[_ ](?:id|saved):\s*([a-zA-Z0-9_-]+)/im;
 
-/**
- * Hermes 0.20+ non-quiet footer. Require the complete terminal block and the
- * same id on both lines so answer prose that mentions Session or --resume is
- * never interpreted as resumable metadata.
- */
-const SESSION_FOOTER_REGEX =
-  /(?:^|\n)(?:[ \t]*\n)*[ \t]*Resume this session with:[ \t]*\n[ \t]*hermes[ \t]+--resume[ \t]+([a-zA-Z0-9_-]+)[ \t]*\n[ \t]*Session:[ \t]*\1[ \t]*(?:\n[ \t]*)*$/i;
-
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
   /tokens?[:\s]+(\d+)\s*(?:input|in)\b.*?(\d+)\s*(?:output|out)\b/i;
@@ -342,18 +334,13 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
     }
   } else {
     // Legacy format (non-quiet mode)
-    const footerMatch = stdout.match(SESSION_FOOTER_REGEX);
     const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
-    const sessionMatch = footerMatch ?? legacyMatch;
-    if (sessionMatch?.[1]) {
-      result.sessionId = sessionMatch[1];
+    if (legacyMatch?.[1]) {
+      result.sessionId = legacyMatch[1];
     }
     // In non-quiet mode, extract clean response from stdout by
     // filtering out tool lines, system messages, and noise
-    const responseText = footerMatch?.index == null
-      ? stdout
-      : stdout.slice(0, footerMatch.index);
-    const cleaned = cleanResponse(responseText);
+    const cleaned = cleanResponse(stdout);
     if (cleaned.length > 0) {
       result.response = cleaned;
     }

--- a/packages/adapters/hermes/src/server/prompt-rendering.test.ts
+++ b/packages/adapters/hermes/src/server/prompt-rendering.test.ts
@@ -105,6 +105,7 @@ test("renders scoped planning wake authority before the Hermes default workflow"
 });
 
 test("renders resume deltas instead of full scoped-wake boilerplate when continuing a session", () => {
+  const wakeComment = "Please add the resume-delta case.";
   const prompt = buildPrompt(baseContext({
     paperclipWake: {
       reason: "issue_commented",
@@ -118,17 +119,103 @@ test("renders resume deltas instead of full scoped-wake boilerplate when continu
       },
       latestCommentId: "comment-2",
       commentWindow: { requestedCount: 1, includedCount: 1, missingCount: 0 },
-      comments: [{ id: "comment-2", body: "Please add the resume-delta case.", createdAt: "2026-06-23T00:00:00.000Z" }],
+      comments: [{ id: "comment-2", body: wakeComment, createdAt: "2026-06-23T00:00:00.000Z" }],
       fallbackFetchNeeded: false,
     },
+    paperclipTaskMarkdown: [
+      "Paperclip task context:",
+      '- Issue: "PAP-11750"',
+      "",
+      "Issue description:",
+      "```text",
+      "Full brief already present in the resumed session.",
+      "```",
+      "",
+      "Latest wake comment:",
+      "```text",
+      wakeComment,
+      "```",
+      "",
+      "Use this task context as the current assignment.",
+    ].join("\n"),
+    paperclipTaskMarkdownCompact: [
+      "Paperclip task context:",
+      '- Issue: "PAP-11750"',
+      "",
+      "Latest wake comment:",
+      "```text",
+      wakeComment,
+      "```",
+      "",
+      "Use this task context as the current assignment.",
+    ].join("\n"),
   }), {}, { resumedSession: true });
 
   expect(prompt).toContain("## Paperclip Resume Delta");
   expect(prompt).toContain("You are resuming an existing Paperclip session.");
   expect(prompt).toContain("Focus on the new wake delta below");
-  expect(prompt).toContain("Please add the resume-delta case.");
+  expect(prompt.match(new RegExp(wakeComment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))).toHaveLength(1);
   expect(prompt).toContain("- fallback fetch needed: no");
+  expect(prompt).toContain("Paperclip task context:");
+  expect(prompt).not.toContain("Full brief already present in the resumed session.");
+  expect(prompt).not.toContain("Latest wake comment:");
+  expect(prompt).not.toContain("Paperclip runtime identity:");
+  expect(prompt).not.toContain("Paperclip API guidance:");
   expect(prompt).not.toContain("Before generic repo exploration or boilerplate heartbeat updates");
+});
+
+test("keeps the full task brief for assignment-shaped resumed wakes", () => {
+  const description = "Build the TES-9 dashboard fix.";
+  const wakeComment = "Please preserve the full issue brief while resuming.";
+  const prompt = buildPrompt(baseContext({
+    paperclipWake: {
+      reason: "issue_reopened_via_comment",
+      issue: {
+        id: "issue-1",
+        identifier: "TES-9",
+        title: "Fix Hermes dashboard sessions",
+        description,
+        descriptionTruncated: false,
+        status: "in_progress",
+        priority: "medium",
+        workMode: "standard",
+      },
+      latestCommentId: "comment-reopen",
+      commentWindow: { requestedCount: 1, includedCount: 1, missingCount: 0 },
+      comments: [{ id: "comment-reopen", body: wakeComment, createdAt: "2026-08-14T08:00:00.000Z" }],
+      fallbackFetchNeeded: false,
+    },
+    paperclipTaskMarkdown: [
+      "Paperclip task context:",
+      '- Issue: "TES-9"',
+      "",
+      "Issue description:",
+      "```text",
+      description,
+      "```",
+      "",
+      "Latest wake comment:",
+      "```text",
+      wakeComment,
+      "```",
+      "",
+      "Use this task context as the current assignment.",
+    ].join("\n"),
+    paperclipTaskMarkdownCompact: [
+      "Paperclip task context:",
+      '- Issue: "TES-9"',
+      "- issue description: omitted from this resume delta; fetch the issue if you need the latest brief",
+    ].join("\n"),
+  }), {}, { resumedSession: true });
+
+  expect(prompt).toContain("## Paperclip Resume Delta");
+  expect(prompt).toContain("Paperclip task context:");
+  expect(prompt).toContain("Issue description:");
+  expect(prompt).toContain(description);
+  expect(prompt.match(new RegExp(wakeComment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))).toHaveLength(1);
+  expect(prompt).not.toContain("Latest wake comment:");
+  expect(prompt).not.toContain("- issue description: omitted from this resume delta");
+  expect(prompt).not.toContain("Paperclip runtime identity:");
 });
 
 test("renders comment wake batch guidance without defaulting to a full-thread refetch", () => {

--- a/packages/adapters/hermes/src/shared/constants.ts
+++ b/packages/adapters/hermes/src/shared/constants.ts
@@ -14,6 +14,15 @@ export const HERMES_CLI = "hermes";
 /** Default timeout for a single execution run (seconds). */
 export const DEFAULT_TIMEOUT_SEC = 1800;
 
+/** Default Hermes tool-calling turn limit used by the create form. */
+export const DEFAULT_MAX_TURNS_PER_RUN = 1000;
+
+/** Timeout paired with the default turn limit (20 seconds per turn). */
+export const DEFAULT_SCALED_TIMEOUT_SEC = Math.max(
+  DEFAULT_TIMEOUT_SEC,
+  DEFAULT_MAX_TURNS_PER_RUN * 20,
+);
+
 /** Grace period after SIGTERM before SIGKILL (seconds). */
 export const DEFAULT_GRACE_SEC = 10;
 

--- a/packages/adapters/hermes/src/ui/build-config.test.ts
+++ b/packages/adapters/hermes/src/ui/build-config.test.ts
@@ -25,6 +25,23 @@ describe("buildHermesConfig", () => {
       provider: "openrouter",
       quiet: true,
       persistSession: false,
+      maxTurnsPerRun: 12,
+      timeoutSec: 1800,
+    });
+  });
+
+  it("keeps the legacy run-limit fallback when schema values are unavailable", () => {
+    const config = buildHermesConfig({
+      model: "",
+      cwd: "",
+      command: "",
+      extraArgs: "",
+      thinkingEffort: "",
+      promptTemplate: "",
+      maxTurnsPerRun: 1000,
+    } as any);
+
+    expect(config).toMatchObject({
       maxTurnsPerRun: 1000,
       timeoutSec: 20000,
     });

--- a/packages/adapters/hermes/src/ui/build-config.test.ts
+++ b/packages/adapters/hermes/src/ui/build-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { buildHermesConfig } from "./build-config.js";
+
+describe("buildHermesConfig", () => {
+  it("persists schema-driven Hermes settings", () => {
+    const config = buildHermesConfig({
+      model: "",
+      cwd: "",
+      command: "",
+      extraArgs: "",
+      thinkingEffort: "",
+      promptTemplate: "",
+      maxTurnsPerRun: 1000,
+      adapterSchemaValues: {
+        provider: "openrouter",
+        quiet: true,
+        persistSession: false,
+        maxTurnsPerRun: 12,
+      },
+    } as any);
+
+    expect(config).toMatchObject({
+      provider: "openrouter",
+      quiet: true,
+      persistSession: false,
+      maxTurnsPerRun: 12,
+    });
+  });
+});

--- a/packages/adapters/hermes/src/ui/build-config.test.ts
+++ b/packages/adapters/hermes/src/ui/build-config.test.ts
@@ -17,6 +17,7 @@ describe("buildHermesConfig", () => {
         quiet: true,
         persistSession: false,
         maxTurnsPerRun: 12,
+        timeoutSec: 1800,
       },
     } as any);
 
@@ -24,7 +25,8 @@ describe("buildHermesConfig", () => {
       provider: "openrouter",
       quiet: true,
       persistSession: false,
-      maxTurnsPerRun: 12,
+      maxTurnsPerRun: 1000,
+      timeoutSec: 20000,
     });
   });
 });

--- a/packages/adapters/hermes/src/ui/build-config.ts
+++ b/packages/adapters/hermes/src/ui/build-config.ts
@@ -13,6 +13,7 @@
 import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 
 import {
+  DEFAULT_MAX_TURNS_PER_RUN,
   DEFAULT_TIMEOUT_SEC,
 } from "../shared/constants.js";
 
@@ -47,11 +48,14 @@ export function buildHermesConfig(
   // default is normally hidden. Retain this fallback only for callers that do
   // not provide schema values (for example, older onboarding integrations).
   ac.timeoutSec = DEFAULT_TIMEOUT_SEC;
-  if (!v.adapterSchemaValues && v.maxTurnsPerRun > 0) {
-    ac.maxTurnsPerRun = v.maxTurnsPerRun;
+  if (!v.adapterSchemaValues) {
+    const maxTurnsPerRun = v.maxTurnsPerRun > 0
+      ? v.maxTurnsPerRun
+      : DEFAULT_MAX_TURNS_PER_RUN;
+    ac.maxTurnsPerRun = maxTurnsPerRun;
     // Scale timeout to match: ~20s per tool turn is generous headroom.
     // Never go below the default (1800s / 30 min).
-    ac.timeoutSec = Math.max(DEFAULT_TIMEOUT_SEC, v.maxTurnsPerRun * 20);
+    ac.timeoutSec = Math.max(DEFAULT_TIMEOUT_SEC, maxTurnsPerRun * 20);
   }
 
   // Session persistence (default: on)

--- a/packages/adapters/hermes/src/ui/build-config.ts
+++ b/packages/adapters/hermes/src/ui/build-config.ts
@@ -81,6 +81,13 @@ export function buildHermesConfig(
     ac.promptTemplate = v.promptTemplate;
   }
 
+  // Hermes's adapter-specific fields are rendered from config-schema.ts and
+  // stored here by SchemaConfigFields. Preserve them when creating an agent;
+  // schema values intentionally win over the legacy defaults above.
+  if (v.adapterSchemaValues) {
+    Object.assign(ac, v.adapterSchemaValues);
+  }
+
   // Heartbeat config is handled by Paperclip itself
 
   return ac;

--- a/packages/adapters/hermes/src/ui/build-config.ts
+++ b/packages/adapters/hermes/src/ui/build-config.ts
@@ -43,8 +43,11 @@ export function buildHermesConfig(
   // Execution limits — let the user configure these from the Paperclip UI.
   // timeoutSec: wall-clock kill timeout for the hermes child process.
   // maxTurnsPerRun: maps to Hermes's --max-turns (agent tool-calling iterations).
+  // Hermes's create UI is schema-driven, so the shared form's 1000-turn
+  // default is normally hidden. Retain this fallback only for callers that do
+  // not provide schema values (for example, older onboarding integrations).
   ac.timeoutSec = DEFAULT_TIMEOUT_SEC;
-  if (v.maxTurnsPerRun > 0) {
+  if (!v.adapterSchemaValues && v.maxTurnsPerRun > 0) {
     ac.maxTurnsPerRun = v.maxTurnsPerRun;
     // Scale timeout to match: ~20s per tool turn is generous headroom.
     // Never go below the default (1800s / 30 min).
@@ -83,18 +86,9 @@ export function buildHermesConfig(
 
   // Hermes's adapter-specific fields are rendered from config-schema.ts and
   // stored here by SchemaConfigFields. Preserve them when creating an agent;
-  // schema values intentionally win over the legacy defaults above.
+  // schema values intentionally win over the legacy fallback above.
   if (v.adapterSchemaValues) {
     Object.assign(ac, v.adapterSchemaValues);
-  }
-
-  // The shared create form also supplies run limits. SchemaConfigFields
-  // materializes number defaults (maxTurnsPerRun=0, timeoutSec=1800), so those
-  // defaults must not erase an explicit shared-form turn limit or its scaled
-  // timeout.
-  if (v.maxTurnsPerRun > 0) {
-    ac.maxTurnsPerRun = v.maxTurnsPerRun;
-    ac.timeoutSec = Math.max(DEFAULT_TIMEOUT_SEC, v.maxTurnsPerRun * 20);
   }
 
   // Heartbeat config is handled by Paperclip itself

--- a/packages/adapters/hermes/src/ui/build-config.ts
+++ b/packages/adapters/hermes/src/ui/build-config.ts
@@ -88,6 +88,15 @@ export function buildHermesConfig(
     Object.assign(ac, v.adapterSchemaValues);
   }
 
+  // The shared create form also supplies run limits. SchemaConfigFields
+  // materializes number defaults (maxTurnsPerRun=0, timeoutSec=1800), so those
+  // defaults must not erase an explicit shared-form turn limit or its scaled
+  // timeout.
+  if (v.maxTurnsPerRun > 0) {
+    ac.maxTurnsPerRun = v.maxTurnsPerRun;
+    ac.timeoutSec = Math.max(DEFAULT_TIMEOUT_SEC, v.maxTurnsPerRun * 20);
+  }
+
   // Heartbeat config is handled by Paperclip itself
 
   return ac;

--- a/packages/adapters/hermes/src/ui/index.ts
+++ b/packages/adapters/hermes/src/ui/index.ts
@@ -3,5 +3,8 @@
  * and agent configuration forms.
  */
 
-export { parseHermesStdoutLine } from "./parse-stdout.js";
+export {
+  createHermesStdoutParser,
+  parseHermesStdoutLine,
+} from "./parse-stdout.js";
 export { buildHermesConfig } from "./build-config.js";

--- a/packages/adapters/hermes/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.test.ts
@@ -78,4 +78,16 @@ describe("parseHermesStdoutLine — ANSI stripping", () => {
     const result = parseHermesStdoutLine("\x1b[0m", TS);
     expect(result).toHaveLength(0);
   });
+
+  it("keeps session-shaped lines visible as assistant text", () => {
+    expect(
+      parseHermesStdoutLine("session_id: 20260814_144930_03a3ec", TS),
+    ).toEqual([
+      {
+        kind: "assistant",
+        ts: TS,
+        text: "session_id: 20260814_144930_03a3ec",
+      },
+    ]);
+  });
 });

--- a/packages/adapters/hermes/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.test.ts
@@ -78,27 +78,4 @@ describe("parseHermesStdoutLine — ANSI stripping", () => {
     const result = parseHermesStdoutLine("\x1b[0m", TS);
     expect(result).toHaveLength(0);
   });
-
-  it("keeps Hermes 0.20 non-quiet footer lines in assistant output", () => {
-    for (const line of [
-      "hermes --resume 20260814_144930_03a3ec",
-      "Session: 20260814_144930_03a3ec",
-    ]) {
-      expect(parseHermesStdoutLine(line, TS)).toEqual([
-        { kind: "assistant", ts: TS, text: line },
-      ]);
-    }
-  });
-
-  it("does not classify footer-shaped answer prose as system metadata", () => {
-    for (const line of [
-      "Resume this session with:",
-      "hermes --resume example",
-      "Session: planning",
-    ]) {
-      expect(parseHermesStdoutLine(line, TS)).toEqual([
-        { kind: "assistant", ts: TS, text: line },
-      ]);
-    }
-  });
 });

--- a/packages/adapters/hermes/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.test.ts
@@ -79,13 +79,13 @@ describe("parseHermesStdoutLine — ANSI stripping", () => {
     expect(result).toHaveLength(0);
   });
 
-  it("renders Hermes 0.20 resume footer lines as system metadata", () => {
+  it("keeps Hermes 0.20 non-quiet footer lines in assistant output", () => {
     for (const line of [
       "hermes --resume 20260814_144930_03a3ec",
       "Session: 20260814_144930_03a3ec",
     ]) {
       expect(parseHermesStdoutLine(line, TS)).toEqual([
-        { kind: "system", ts: TS, text: line },
+        { kind: "assistant", ts: TS, text: line },
       ]);
     }
   });

--- a/packages/adapters/hermes/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.test.ts
@@ -78,4 +78,16 @@ describe("parseHermesStdoutLine — ANSI stripping", () => {
     const result = parseHermesStdoutLine("\x1b[0m", TS);
     expect(result).toHaveLength(0);
   });
+
+  it("renders Hermes 0.20 resume footer lines as system metadata", () => {
+    for (const line of [
+      "Resume this session with:",
+      "hermes --resume 20260814_144930_03a3ec",
+      "Session: 20260814_144930_03a3ec",
+    ]) {
+      expect(parseHermesStdoutLine(line, TS)).toEqual([
+        { kind: "system", ts: TS, text: line },
+      ]);
+    }
+  });
 });

--- a/packages/adapters/hermes/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseHermesStdoutLine } from "./parse-stdout.js";
+import {
+  createHermesStdoutParser,
+  parseHermesStdoutLine,
+} from "./parse-stdout.js";
 
 const TS = "2026-06-29T12:00:00.000Z";
 
@@ -87,6 +90,40 @@ describe("parseHermesStdoutLine — ANSI stripping", () => {
         kind: "assistant",
         ts: TS,
         text: "session_id: 20260814_144930_03a3ec",
+      },
+    ]);
+  });
+
+  it("classifies a canonical session line only after matching server confirmation", () => {
+    const parser = createHermesStdoutParser();
+    expect(parser.parseLine("session_id: 20260814_144930_03a3ec", TS)).toEqual([]);
+    expect(parser.parseLine("[hermes] Session: 20260814_144930_03a3ec", TS)).toEqual([
+      {
+        kind: "system",
+        ts: TS,
+        text: "session_id: 20260814_144930_03a3ec",
+      },
+      {
+        kind: "system",
+        ts: TS,
+        text: "[hermes] Session: 20260814_144930_03a3ec",
+      },
+    ]);
+  });
+
+  it("releases an unconfirmed session-shaped line as assistant text", () => {
+    const parser = createHermesStdoutParser();
+    expect(parser.parseLine("session_id: 20260814_144930_03a3ec", TS)).toEqual([]);
+    expect(parser.parseLine("[hermes] Exit code: 0, timed out: false", TS)).toEqual([
+      {
+        kind: "assistant",
+        ts: TS,
+        text: "session_id: 20260814_144930_03a3ec",
+      },
+      {
+        kind: "system",
+        ts: TS,
+        text: "[hermes] Exit code: 0, timed out: false",
       },
     ]);
   });

--- a/packages/adapters/hermes/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.test.ts
@@ -81,12 +81,23 @@ describe("parseHermesStdoutLine — ANSI stripping", () => {
 
   it("renders Hermes 0.20 resume footer lines as system metadata", () => {
     for (const line of [
-      "Resume this session with:",
       "hermes --resume 20260814_144930_03a3ec",
       "Session: 20260814_144930_03a3ec",
     ]) {
       expect(parseHermesStdoutLine(line, TS)).toEqual([
         { kind: "system", ts: TS, text: line },
+      ]);
+    }
+  });
+
+  it("does not classify footer-shaped answer prose as system metadata", () => {
+    for (const line of [
+      "Resume this session with:",
+      "hermes --resume example",
+      "Session: planning",
+    ]) {
+      expect(parseHermesStdoutLine(line, TS)).toEqual([
+        { kind: "assistant", ts: TS, text: line },
       ]);
     }
   });

--- a/packages/adapters/hermes/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.ts
@@ -223,7 +223,12 @@ export function parseHermesStdoutLine(
   }
 
   // ── Session info line ────────────────────────────────────────────────
-  if (trimmed.startsWith("session_id:")) {
+  if (
+    trimmed.startsWith("session_id:") ||
+    /^session:\s*\S+/i.test(trimmed) ||
+    /^resume this session with:/i.test(trimmed) ||
+    /^hermes\s+--resume\s+\S+/i.test(trimmed)
+  ) {
     return [{ kind: "system", ts, text: trimmed }];
   }
 

--- a/packages/adapters/hermes/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.ts
@@ -286,3 +286,64 @@ export function parseHermesStdoutLine(
   // ── Regular assistant output ───────────────────────────────────────────
   return [{ kind: "assistant", ts, text: trimmed }];
 }
+
+const CANONICAL_SESSION_LINE_REGEX =
+  /^session_id:\s*(\d{8}_\d{6}_[a-z0-9]+)$/i;
+const CONFIRMED_SESSION_LINE_REGEX =
+  /^\[hermes\]\s+Session:\s*(\d{8}_\d{6}_[a-z0-9]+)$/i;
+
+/**
+ * Delay a canonical session-shaped line by one log entry. The server emits a
+ * matching [hermes] Session confirmation immediately after trusted quiet-mode
+ * metadata; without that confirmation, the buffered line is ordinary answer
+ * text and remains visible as assistant output.
+ */
+export function createHermesStdoutParser() {
+  let pendingSessionLine: { text: string; ts: string; sessionId: string } | null = null;
+
+  return {
+    parseLine(line: string, ts: string): TranscriptEntry[] {
+      const trimmed = stripAnsi(line).trim();
+      const sessionMatch = trimmed.match(CANONICAL_SESSION_LINE_REGEX);
+
+      if (pendingSessionLine) {
+        const pending = pendingSessionLine;
+        pendingSessionLine = null;
+        const confirmationMatch = trimmed.match(CONFIRMED_SESSION_LINE_REGEX);
+        if (confirmationMatch?.[1] === pending.sessionId) {
+          return [
+            { kind: "system", ts: pending.ts, text: pending.text },
+            ...parseHermesStdoutLine(line, ts),
+          ];
+        }
+
+        const flushed: TranscriptEntry[] = [
+          { kind: "assistant", ts: pending.ts, text: pending.text },
+        ];
+        if (sessionMatch?.[1]) {
+          pendingSessionLine = {
+            text: trimmed,
+            ts,
+            sessionId: sessionMatch[1],
+          };
+          return flushed;
+        }
+        return [...flushed, ...parseHermesStdoutLine(line, ts)];
+      }
+
+      if (sessionMatch?.[1]) {
+        pendingSessionLine = {
+          text: trimmed,
+          ts,
+          sessionId: sessionMatch[1],
+        };
+        return [];
+      }
+
+      return parseHermesStdoutLine(line, ts);
+    },
+    reset() {
+      pendingSessionLine = null;
+    },
+  };
+}

--- a/packages/adapters/hermes/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.ts
@@ -224,9 +224,7 @@ export function parseHermesStdoutLine(
 
   // ── Session info line ────────────────────────────────────────────────
   if (
-    trimmed.startsWith("session_id:") ||
-    /^session:\s+\d{8}_\d{6}_[a-z0-9]+$/i.test(trimmed) ||
-    /^hermes\s+--resume\s+\d{8}_\d{6}_[a-z0-9]+$/i.test(trimmed)
+    trimmed.startsWith("session_id:")
   ) {
     return [{ kind: "system", ts, text: trimmed }];
   }

--- a/packages/adapters/hermes/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.ts
@@ -222,11 +222,6 @@ export function parseHermesStdoutLine(
     return [];
   }
 
-  // ── Session info line ────────────────────────────────────────────────
-  if (trimmed.startsWith("session_id:")) {
-    return [{ kind: "system", ts, text: trimmed }];
-  }
-
   // ── Quiet-mode tool/message lines (prefixed with ┊) ────────────────────
   if (trimmed.includes(TOOL_OUTPUT_PREFIX)) {
     // Assistant message: ┊ 💬 {text}

--- a/packages/adapters/hermes/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.ts
@@ -223,9 +223,7 @@ export function parseHermesStdoutLine(
   }
 
   // ── Session info line ────────────────────────────────────────────────
-  if (
-    trimmed.startsWith("session_id:")
-  ) {
+  if (trimmed.startsWith("session_id:")) {
     return [{ kind: "system", ts, text: trimmed }];
   }
 

--- a/packages/adapters/hermes/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes/src/ui/parse-stdout.ts
@@ -225,9 +225,8 @@ export function parseHermesStdoutLine(
   // ── Session info line ────────────────────────────────────────────────
   if (
     trimmed.startsWith("session_id:") ||
-    /^session:\s*\S+/i.test(trimmed) ||
-    /^resume this session with:/i.test(trimmed) ||
-    /^hermes\s+--resume\s+\S+/i.test(trimmed)
+    /^session:\s+\d{8}_\d{6}_[a-z0-9]+$/i.test(trimmed) ||
+    /^hermes\s+--resume\s+\d{8}_\d{6}_[a-z0-9]+$/i.test(trimmed)
   ) {
     return [{ kind: "system", ts, text: trimmed }];
   }

--- a/ui/src/adapters/hermes-local/index.ts
+++ b/ui/src/adapters/hermes-local/index.ts
@@ -1,11 +1,16 @@
 import type { UIAdapterModule } from "../types";
-import { parseHermesStdoutLine, buildHermesConfig } from "@paperclipai/hermes-paperclip-adapter/ui";
+import {
+  buildHermesConfig,
+  createHermesStdoutParser,
+  parseHermesStdoutLine,
+} from "@paperclipai/hermes-paperclip-adapter/ui";
 import { SchemaConfigFields } from "../schema-config-fields";
 
 export const hermesLocalUIAdapter: UIAdapterModule = {
   type: "hermes_local",
   label: "Hermes",
   parseStdoutLine: parseHermesStdoutLine,
+  createStdoutParser: createHermesStdoutParser,
   ConfigFields: SchemaConfigFields,
   buildAdapterConfig: buildHermesConfig,
 };


### PR DESCRIPTION
## Thinking Path

- Traced repeated Hermes task conversations through prompt construction, CLI output parsing, and the adapter UI config path.
- Confirmed resumed Hermes wakes were dropping the selected task brief while repeating the latest comment through both the wake delta and task markdown.
- Kept the fix inside the Hermes adapter: stable workflow instructions are skipped on resume, but compact or assignment-shaped task context remains available.
- Aligned the runtime default with the existing Hermes quiet-mode schema default so session metadata is consistently parseable.
- Kept resumable session persistence on Hermes quiet-mode session_id output; non-quiet footer text is not trusted as session state.
- Preserved adapter schema values when creating Hermes agents from the dashboard.
- Deliberately excluded the generic heartbeat fingerprint change because #9977 already covers that shared session-continuity concern.

## Linked Issues or Issue Description

Related public work:

- Refs #9977 — shared task-session fingerprint and persistence work; this PR does not duplicate those server changes.
- Refs #10445 — broader Hermes output-parser hardening; this PR keeps session persistence on the unambiguous quiet-mode output path.
- Refs #10106 — timeout-specific canonical session preservation; this PR addresses prompt and adapter behavior on normal resumed wakes.

**What happened?**

After a Hermes task received a follow-up comment, a resumed invocation could repeat the comment in both the resume delta and task markdown. The resume path could also discard useful selected task context. Dashboard-created Hermes agents could lose adapter schema values, and non-quiet footer-shaped answer text must not be trusted as resumable session metadata.

**Expected behavior**

A resumed Hermes invocation should receive the current wake delta once, retain the appropriate compact or full task brief, skip stable workflow and managed instructions already present in the session, and persist only unambiguous quiet-mode session metadata.

**Steps to reproduce**

1. Create a local Hermes agent with persisted sessions.
2. Assign an issue and let Hermes establish a session.
3. Add a follow-up comment and inspect the next Hermes user prompt.
4. Observe duplicate comment text or missing task context.
5. Run Hermes without quiet mode on Hermes 0.20 and inspect the response/session metadata.

**Paperclip version or commit**

aac6ce82e

**Deployment mode**

Local development, built from source.

**Agent adapter(s) involved**

Hermes local adapter only.

## What Changed

- Keep selected compact task context on ordinary resumed comments and the full task brief for assignment-shaped resumed wakes.
- Remove only the duplicated latest-comment section when the wake delta already carries that comment.
- Skip the default workflow prompt and managed instruction bundle on resumed Hermes delta wakes.
- Default Hermes runtime execution to quiet mode while preserving explicit quiet: false.
- Leave non-quiet footer-shaped text visible as assistant output and never persist it as session state.
- Align visible Hermes schema defaults with the established 1000-turn / 20000-second create defaults while preserving explicit schema selections.
- Preserve Hermes adapter schema values in dashboard-created agent configs.
- Add focused prompt, execution, output parsing, and UI config tests.

## Verification

- pnpm --filter @paperclipai/hermes-paperclip-adapter test — 9 files, 75 tests passed.
- pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck — passed.
- pnpm --filter @paperclipai/ui typecheck — passed.
- pnpm check:token-gates — passed.
- pnpm -r typecheck — passed.
- pnpm build — passed.
- git diff --check origin/master...HEAD — passed.
- The full Vitest sweep was also attempted. Unrelated existing macOS path assertions (/tmp vs /private/tmp), workspace auto-port behavior, and project-skill containment tests failed; none of those source or test files are changed here.

## Risks

- Resume prompts are intentionally shorter. Tests cover ordinary comment resumes and assignment-shaped resumed wakes to prevent loss of task context.
- Quiet mode now follows the schema's existing default at runtime; users who require verbose Hermes output can still set quiet: false.
- Session persistence trusts quiet-mode session_id output; users who explicitly disable quiet mode retain footer text but do not persist it as session state.
- No Claude adapter or shared heartbeat/session logic is changed.

## Model Used

OpenAI Codex based on GPT-5, with repository inspection, code execution, local service debugging, and test/build verification. The exact serving model id and context-window size are not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes/Closes/Refs OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: Hermes-internal behavior only)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
