### PR TITLE
feat(ui): detect browser locale and switch existing translations

### DIFF
--- a/ui/src/components/LanguageSelect.test.tsx
+++ b/ui/src/components/LanguageSelect.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { i18n } from "@/i18n";
+
+import { LanguageSelect } from "./LanguageSelect";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  await callback();
+  await Promise.resolve();
+  await new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+describe("LanguageSelect", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    localStorage.clear();
+    void i18n.changeLanguage("en");
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+    localStorage.clear();
+    void i18n.changeLanguage("en");
+  });
+
+  it("persists Simplified Chinese and updates translated chrome", async () => {
+    const root = createRoot(container);
+    await act(() => {
+      root.render(<LanguageSelect />);
+    });
+
+    const select = container.querySelector("select");
+    expect(select).not.toBeNull();
+    expect(container.textContent).toContain("Language");
+
+    await act(() => {
+      select!.value = "zh-CN";
+      select!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(localStorage.getItem("paperclip.locale")).toBe("zh-CN");
+    expect(i18n.language).toBe("zh-CN");
+    expect(container.textContent).toContain("语言");
+
+    await act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/LanguageSelect.tsx
+++ b/ui/src/components/LanguageSelect.tsx
@@ -1,0 +1,53 @@
+import { Languages } from "lucide-react";
+
+import { i18n, setAppLocale, useTranslation } from "@/i18n";
+import { supportedLocales } from "@/i18n/locales";
+import { cn } from "@/lib/utils";
+
+interface LanguageSelectProps {
+  className?: string;
+}
+
+function localeNativeName(tag: string): string {
+  try {
+    return new Intl.DisplayNames([tag], { type: "language" }).of(tag) ?? tag;
+  } catch {
+    return tag;
+  }
+}
+
+export function LanguageSelect({ className }: LanguageSelectProps) {
+  const { t } = useTranslation();
+  const label = t("settings.language.label");
+  const description = t("settings.language.description");
+  const current = supportedLocales.includes(i18n.language) ? i18n.language : "en";
+
+  return (
+    <label
+      className={cn(
+        "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/60",
+        className,
+      )}
+    >
+      <span className="mt-0.5 rounded-lg border border-border bg-background/70 p-2 text-muted-foreground">
+        <Languages className="size-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">{label}</span>
+        <span className="block text-xs text-muted-foreground">{description}</span>
+        <select
+          aria-label={label}
+          className="mt-2 h-8 w-full rounded-md border border-input bg-background px-2 text-sm"
+          value={current}
+          onChange={(event) => setAppLocale(event.target.value)}
+        >
+          {supportedLocales.map((locale) => (
+            <option key={locale} value={locale}>
+              {localeNativeName(locale)}
+            </option>
+          ))}
+        </select>
+      </span>
+    </label>
+  );
+}

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -17,6 +17,7 @@ import { useSidebar } from "../context/SidebarContext";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import { LanguageSelect } from "./LanguageSelect";
 import { ThemeToggle } from "./ThemeToggle";
 import { SidebarServerInfo } from "./SidebarServerInfo";
 import { Badge } from "@/components/ui/badge";
@@ -253,6 +254,7 @@ export function SidebarAccountMenu({
                 onClick={() => setOpen(false)}
               />
               <ThemeToggle variant="menu-action" onAfterToggle={() => setOpen(false)} />
+              <LanguageSelect />
               {deploymentMode === "authenticated" ? (
                 <button
                   type="button"

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -1,11 +1,12 @@
 import i18n, { type InitOptions, type TOptions } from "i18next";
 import { initReactI18next, useTranslation as useReactI18nextTranslation } from "react-i18next";
 
-import { DEFAULT_LOCALE, i18nextResources, supportedLocales } from "./locales";
+import { DEFAULT_LOCALE, i18nextResources, localeMessages, supportedLocales } from "./locales";
+import { persistLocale, resolveInitialLocale } from "./resolve-locale";
 
 const i18nextOptions: InitOptions = {
   resources: i18nextResources,
-  lng: DEFAULT_LOCALE,
+  lng: resolveInitialLocale(),
   fallbackLng: DEFAULT_LOCALE,
   supportedLngs: supportedLocales,
   defaultNS: "translation",
@@ -20,6 +21,12 @@ void i18n.use(initReactI18next).init(i18nextOptions).catch((error: unknown) => {
 
 export function t(key: string, options: TOptions = {}) {
   return i18n.t(key, options);
+}
+
+export function setAppLocale(locale: string) {
+  if (!(locale in localeMessages)) return;
+  persistLocale(locale);
+  void i18n.changeLanguage(locale);
 }
 
 export const useTranslation = useReactI18nextTranslation;

--- a/ui/src/i18n/locale-validation.test.ts
+++ b/ui/src/i18n/locale-validation.test.ts
@@ -7,6 +7,7 @@ import { validateLocaleMessages } from "./locale-validation";
 describe("locale validation", () => {
   it("resolves English messages with key and default fallbacks", () => {
     expect(t("app.noCompanies.title")).toBe(en.app.noCompanies.title);
+    expect(t("settings.language.label")).toBe(en.settings.language.label);
     expect(t("app.missing", { defaultValue: "Fallback" })).toBe("Fallback");
     expect(t("app.missing")).toBe("app.missing");
   });

--- a/ui/src/i18n/locales/ar.json
+++ b/ui/src/i18n/locales/ar.json
@@ -5,5 +5,11 @@
       "description": "ابدأ بإنشاء شركة.",
       "newCompany": "شركة جديدة"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/bn.json
+++ b/ui/src/i18n/locales/bn.json
@@ -5,5 +5,11 @@
       "description": "একটি কোম্পানি তৈরি করে শুরু করুন।",
       "newCompany": "নতুন কোম্পানি"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/cs.json
+++ b/ui/src/i18n/locales/cs.json
@@ -5,5 +5,11 @@
       "description": "Začněte vytvořením společnosti.",
       "newCompany": "Nová společnost"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/da.json
+++ b/ui/src/i18n/locales/da.json
@@ -5,5 +5,11 @@
       "description": "Kom i gang ved at oprette en virksomhed.",
       "newCompany": "Ny virksomhed"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/de.json
+++ b/ui/src/i18n/locales/de.json
@@ -5,5 +5,11 @@
       "description": "Beginnen Sie, indem Sie ein Unternehmen erstellen.",
       "newCompany": "Neues Unternehmen"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/el.json
+++ b/ui/src/i18n/locales/el.json
@@ -5,5 +5,11 @@
       "description": "Ξεκινήστε δημιουργώντας μια εταιρεία.",
       "newCompany": "Νέα εταιρεία"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -5,5 +5,11 @@
       "description": "Get started by creating a company.",
       "newCompany": "New Company"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/es.json
+++ b/ui/src/i18n/locales/es.json
@@ -5,5 +5,11 @@
       "description": "Comienza creando una empresa.",
       "newCompany": "Nueva empresa"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/fa.json
+++ b/ui/src/i18n/locales/fa.json
@@ -5,5 +5,11 @@
       "description": "با ایجاد یک شرکت شروع کنید.",
       "newCompany": "شرکت جدید"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/fi.json
+++ b/ui/src/i18n/locales/fi.json
@@ -5,5 +5,11 @@
       "description": "Aloita luomalla yritys.",
       "newCompany": "Uusi yritys"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/fil.json
+++ b/ui/src/i18n/locales/fil.json
@@ -5,5 +5,11 @@
       "description": "Magsimula sa paggawa ng kumpanya.",
       "newCompany": "Bagong Kumpanya"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -5,5 +5,11 @@
       "description": "Commencez par créer une entreprise.",
       "newCompany": "Nouvelle entreprise"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/he.json
+++ b/ui/src/i18n/locales/he.json
@@ -5,5 +5,11 @@
       "description": "התחילו ביצירת חברה.",
       "newCompany": "חברה חדשה"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/hi.json
+++ b/ui/src/i18n/locales/hi.json
@@ -5,5 +5,11 @@
       "description": "कंपनी बनाकर शुरुआत करें.",
       "newCompany": "नई कंपनी"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/hu.json
+++ b/ui/src/i18n/locales/hu.json
@@ -5,5 +5,11 @@
       "description": "Kezdje egy vállalat létrehozásával.",
       "newCompany": "Új vállalat"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/id.json
+++ b/ui/src/i18n/locales/id.json
@@ -5,5 +5,11 @@
       "description": "Mulai dengan membuat perusahaan.",
       "newCompany": "Perusahaan Baru"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/it.json
+++ b/ui/src/i18n/locales/it.json
@@ -5,5 +5,11 @@
       "description": "Inizia creando un'azienda.",
       "newCompany": "Nuova azienda"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ja.json
+++ b/ui/src/i18n/locales/ja.json
@@ -5,5 +5,11 @@
       "description": "会社を作成して始めましょう。",
       "newCompany": "新しい会社"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -5,5 +5,11 @@
       "description": "회사를 만들어 시작하세요.",
       "newCompany": "새 회사"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/mr.json
+++ b/ui/src/i18n/locales/mr.json
@@ -5,5 +5,11 @@
       "description": "कंपनी तयार करून सुरुवात करा.",
       "newCompany": "नवीन कंपनी"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ms.json
+++ b/ui/src/i18n/locales/ms.json
@@ -5,5 +5,11 @@
       "description": "Mulakan dengan mencipta syarikat.",
       "newCompany": "Syarikat Baharu"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/nb.json
+++ b/ui/src/i18n/locales/nb.json
@@ -5,5 +5,11 @@
       "description": "Kom i gang ved å opprette et selskap.",
       "newCompany": "Nytt selskap"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/nl.json
+++ b/ui/src/i18n/locales/nl.json
@@ -5,5 +5,11 @@
       "description": "Begin door een bedrijf aan te maken.",
       "newCompany": "Nieuw bedrijf"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/pa.json
+++ b/ui/src/i18n/locales/pa.json
@@ -5,5 +5,11 @@
       "description": "ਕੰਪਨੀ ਬਣਾਕੇ ਸ਼ੁਰੂ ਕਰੋ।",
       "newCompany": "ਨਵੀਂ ਕੰਪਨੀ"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/pl.json
+++ b/ui/src/i18n/locales/pl.json
@@ -5,5 +5,11 @@
       "description": "Zacznij od utworzenia firmy.",
       "newCompany": "Nowa firma"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/pt-BR.json
+++ b/ui/src/i18n/locales/pt-BR.json
@@ -5,5 +5,11 @@
       "description": "Comece criando uma empresa.",
       "newCompany": "Nova empresa"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/pt-PT.json
+++ b/ui/src/i18n/locales/pt-PT.json
@@ -5,5 +5,11 @@
       "description": "Comece por criar uma empresa.",
       "newCompany": "Nova empresa"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ro.json
+++ b/ui/src/i18n/locales/ro.json
@@ -5,5 +5,11 @@
       "description": "Începeți prin crearea unei companii.",
       "newCompany": "Companie nouă"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ru.json
+++ b/ui/src/i18n/locales/ru.json
@@ -5,5 +5,11 @@
       "description": "Начните с создания компании.",
       "newCompany": "Новая компания"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/sv.json
+++ b/ui/src/i18n/locales/sv.json
@@ -5,5 +5,11 @@
       "description": "Kom igång genom att skapa ett företag.",
       "newCompany": "Nytt företag"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/sw.json
+++ b/ui/src/i18n/locales/sw.json
@@ -5,5 +5,11 @@
       "description": "Anza kwa kuunda kampuni.",
       "newCompany": "Kampuni Mpya"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ta.json
+++ b/ui/src/i18n/locales/ta.json
@@ -5,5 +5,11 @@
       "description": "ஒரு நிறுவனத்தை உருவாக்கி தொடங்குங்கள்.",
       "newCompany": "புதிய நிறுவனம்"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/te.json
+++ b/ui/src/i18n/locales/te.json
@@ -5,5 +5,11 @@
       "description": "కంపెనీని సృష్టించడం ద్వారా ప్రారంభించండి.",
       "newCompany": "కొత్త కంపెనీ"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/th.json
+++ b/ui/src/i18n/locales/th.json
@@ -5,5 +5,11 @@
       "description": "เริ่มต้นด้วยการสร้างบริษัท",
       "newCompany": "บริษัทใหม่"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/tr.json
+++ b/ui/src/i18n/locales/tr.json
@@ -5,5 +5,11 @@
       "description": "Bir şirket oluşturarak başlayın.",
       "newCompany": "Yeni Şirket"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/uk.json
+++ b/ui/src/i18n/locales/uk.json
@@ -5,5 +5,11 @@
       "description": "Почніть зі створення компанії.",
       "newCompany": "Нова компанія"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/ur.json
+++ b/ui/src/i18n/locales/ur.json
@@ -5,5 +5,11 @@
       "description": "کمپنی بنا کر شروع کریں۔",
       "newCompany": "نئی کمپنی"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/vi.json
+++ b/ui/src/i18n/locales/vi.json
@@ -5,5 +5,11 @@
       "description": "Bắt đầu bằng cách tạo một công ty.",
       "newCompany": "Công ty mới"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "Language",
+      "description": "Board UI language. Untranslated screens stay in English."
+    }
   }
 }

--- a/ui/src/i18n/locales/zh-CN.json
+++ b/ui/src/i18n/locales/zh-CN.json
@@ -5,5 +5,11 @@
       "description": "通过创建公司开始。",
       "newCompany": "新公司"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "语言",
+      "description": "看板界面语言。尚未翻译的页面仍显示英文。"
+    }
   }
 }

--- a/ui/src/i18n/locales/zh-TW.json
+++ b/ui/src/i18n/locales/zh-TW.json
@@ -5,5 +5,11 @@
       "description": "從建立公司開始。",
       "newCompany": "新公司"
     }
+  },
+  "settings": {
+    "language": {
+      "label": "語言",
+      "description": "看板介面語言。尚未翻譯的頁面仍顯示英文。"
+    }
   }
 }

--- a/ui/src/i18n/resolve-locale.test.ts
+++ b/ui/src/i18n/resolve-locale.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_LOCALE } from "./locales";
+import { normalizeBrowserLocale, resolveInitialLocale } from "./resolve-locale";
+
+describe("normalizeBrowserLocale", () => {
+  it("maps Simplified Chinese tags to zh-CN", () => {
+    expect(normalizeBrowserLocale("zh-CN")).toBe("zh-CN");
+    expect(normalizeBrowserLocale("zh")).toBe("zh-CN");
+    expect(normalizeBrowserLocale("zh-Hans")).toBe("zh-CN");
+    expect(normalizeBrowserLocale("zh_CN")).toBe("zh-CN");
+  });
+
+  it("maps Traditional Chinese tags to zh-TW", () => {
+    expect(normalizeBrowserLocale("zh-TW")).toBe("zh-TW");
+    expect(normalizeBrowserLocale("zh-HK")).toBe("zh-TW");
+    expect(normalizeBrowserLocale("zh-Hant")).toBe("zh-TW");
+  });
+
+  it("falls back to English for unknown tags", () => {
+    expect(normalizeBrowserLocale(null)).toBe(DEFAULT_LOCALE);
+    expect(normalizeBrowserLocale("")).toBe(DEFAULT_LOCALE);
+    expect(normalizeBrowserLocale("xx-YY")).toBe(DEFAULT_LOCALE);
+  });
+});
+
+describe("resolveInitialLocale", () => {
+  it("stays on English during tests", () => {
+    expect(
+      resolveInitialLocale({
+        stored: "zh-CN",
+        navigatorLanguage: "zh-CN",
+        mode: "test",
+      }),
+    ).toBe(DEFAULT_LOCALE);
+  });
+
+  it("prefers a stored locale over the browser language", () => {
+    expect(
+      resolveInitialLocale({
+        stored: "zh-TW",
+        navigatorLanguage: "en-US",
+        mode: "development",
+      }),
+    ).toBe("zh-TW");
+  });
+
+  it("uses the browser language when nothing is stored", () => {
+    expect(
+      resolveInitialLocale({
+        stored: null,
+        navigatorLanguage: "zh-CN",
+        mode: "development",
+      }),
+    ).toBe("zh-CN");
+  });
+});

--- a/ui/src/i18n/resolve-locale.ts
+++ b/ui/src/i18n/resolve-locale.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_LOCALE, localeMessages, supportedLocales } from "./locales";
+
+export const LOCALE_STORAGE_KEY = "paperclip.locale";
+
+export function normalizeBrowserLocale(
+  tag: string | null | undefined,
+  available: readonly string[] = supportedLocales,
+): string {
+  if (!tag) return DEFAULT_LOCALE;
+  const normalized = tag.trim().replaceAll("_", "-");
+  if (!normalized) return DEFAULT_LOCALE;
+
+  const availableSet = new Set(available);
+  if (availableSet.has(normalized)) return normalized;
+
+  const lower = normalized.toLowerCase();
+  const caseInsensitive = available.find((item) => item.toLowerCase() === lower);
+  if (caseInsensitive) return caseInsensitive;
+
+  const [language, region] = lower.split("-");
+  if (language === "zh") {
+    if (region === "tw" || region === "hk" || region === "mo" || region === "hant") {
+      return availableSet.has("zh-TW") ? "zh-TW" : DEFAULT_LOCALE;
+    }
+    return availableSet.has("zh-CN") ? "zh-CN" : DEFAULT_LOCALE;
+  }
+
+  const exactLanguage = available.find((item) => item.toLowerCase() === language);
+  if (exactLanguage) return exactLanguage;
+  return DEFAULT_LOCALE;
+}
+
+export function readStoredLocale(): string | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    return localStorage.getItem(LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function persistLocale(locale: string) {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  } catch {
+    // Ignore quota / private-mode failures; the session language still changes.
+  }
+}
+
+export function resolveInitialLocale(input?: {
+  stored?: string | null;
+  navigatorLanguage?: string | null;
+  mode?: string;
+}): string {
+  const mode = input?.mode ?? import.meta.env.MODE;
+  if (mode === "test") return DEFAULT_LOCALE;
+
+  const stored = input?.stored === undefined ? readStoredLocale() : input.stored;
+  if (stored && stored in localeMessages) return stored;
+
+  const navigatorLanguage =
+    input?.navigatorLanguage === undefined
+      ? typeof navigator === "undefined"
+        ? null
+        : navigator.language
+      : input.navigatorLanguage;
+  return normalizeBrowserLocale(navigatorLanguage);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The board UI already has an i18next catalog, including zh-CN and zh-TW
> - Startup still hardcoded the English locale, so existing translations never appeared
> - Operators also had no control to pick a locale
> - This pull request detects the browser language, persists a choice, and adds an account-menu language switcher
> - The benefit is that shipped locale files become usable without waiting for a full string extraction

## Linked Issues or Issue Description

Refs #9410
Refs #2760
Refs #3319

**Problem / motivation**
The i18n catalog exists, but the board always starts in English. Users with a Chinese (or other) browser never see the translated empty-state strings.

**Proposed solution**
Resolve the initial locale from localStorage, then from the browser language. Add a language select in the account menu. Keep English as the fallback and as the test default.

**Alternatives considered**
Hardcoding zh-CN as the default would break English tests and surprise non-Chinese operators.

**Roadmap alignment**
ROADMAP.md has no i18n item. This change only activates existing catalog files. It does not extract the remaining hardcoded English strings. That work stays in #9410.

## What Changed

- Resolve the initial i18next language from storage, then from the browser tag
- Map zh / zh-Hans to zh-CN and zh-Hant / zh-TW / zh-HK to zh-TW
- Keep English during Vitest so catalog tests stay stable
- Add an account-menu language select and persist paperclip.locale
- Add switcher strings to every locale file; translate zh-CN and zh-TW

## Verification

```
pnpm --filter @paperclipai/ui exec vitest run src/i18n/resolve-locale.test.ts src/i18n/locale-validation.test.ts src/components/LanguageSelect.test.tsx src/components/SidebarAccountMenu.test.tsx
```

Result: 4 files, 18 tests passed.

Manual: open the board, use the account menu language select, choose Simplified Chinese. The empty-company card and the language row switch. Other screens stay English until #9410.

## Risks

Low risk. Default English is unchanged when the browser is not a supported locale. Test mode ignores navigator.language. Untranslated screens stay in English, which the switcher description states.

I searched GitHub for duplicate or related PRs. I found issues #9410, #2760, #3319, #9614, #2151, #5924, #1171. I found no open PR that adds a locale switcher.

## Model Used

Cursor Grok 4.6 (cursor-grok-4.6). Tool use and local test execution. No Opus / Fable.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge