### PR TITLE
fix: set charset=utf-8 on text attachment responses (#11256)

### DIFF
--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -387,6 +387,30 @@ describe("GET /api/assets/:assetId/content", () => {
     expect(Buffer.compare(Buffer.from(res.body as Buffer), utf8Body)).toBe(0);
   });
 
+  it("does not label structurally-valid-but-ambiguous Windows-1252 bytes as charset=utf-8", async () => {
+    // 0xC2 0xA9 is well-formed UTF-8 for a single "(c)" character, but the
+    // same two bytes are also well-formed Windows-1252 for two separate
+    // characters. Structural UTF-8 validity alone can't tell those apart, so
+    // this asset must be served without a charset, not mislabeled utf-8.
+    const windows1252Body = Buffer.from([0xc2, 0xa9]);
+    const storage = createStorageService();
+    (storage.getObject as ReturnType<typeof vi.fn>).mockResolvedValue({
+      stream: Readable.from(windows1252Body),
+      contentType: "text/plain",
+      contentLength: windows1252Body.length,
+    });
+    getAssetByIdMock.mockResolvedValue({ ...createAsset(), contentType: "text/plain" });
+
+    const app = await createApp(storage);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/assets/asset-1/content").buffer(true).responseType("blob"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain");
+    expect(Buffer.compare(Buffer.from(res.body as Buffer), windows1252Body)).toBe(0);
+  });
+
   it("streams a text asset larger than the attachment max-bytes cap unlabeled instead of buffering it", async () => {
     // Valid ASCII/UTF-8 content, so the only reason this should stay unlabeled
     // is that the known size exceeds the buffering cap and full-body UTF-8

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import express from "express";
 import request from "supertest";
@@ -328,5 +329,61 @@ describe("POST /api/companies/:companyId/logo", () => {
     expect(res.status).toBe(422);
     expect(res.body.error).toBe("SVG could not be sanitized");
     expect(createAssetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/assets/:assetId/content", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/assets.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    createAssetMock.mockReset();
+    getAssetByIdMock.mockReset();
+    logActivityMock.mockReset();
+  });
+
+  it("does not label a legacy-encoded (non-UTF-8) text asset as charset=utf-8", async () => {
+    // 0xE9 is "é" in Latin-1/Windows-1252, an invalid standalone byte in UTF-8.
+    const latin1Body = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+    const storage = createStorageService();
+    (storage.getObject as ReturnType<typeof vi.fn>).mockResolvedValue({
+      stream: Readable.from(latin1Body),
+      contentType: "text/plain",
+      contentLength: latin1Body.length,
+    });
+    getAssetByIdMock.mockResolvedValue({ ...createAsset(), contentType: "text/plain" });
+
+    const app = await createApp(storage);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/assets/asset-1/content").buffer(true).responseType("blob"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain");
+    expect(Buffer.compare(Buffer.from(res.body as Buffer), latin1Body)).toBe(0);
+  });
+
+  it("still labels valid UTF-8 text assets as charset=utf-8", async () => {
+    const utf8Body = Buffer.from("café 日本語", "utf8");
+    const storage = createStorageService();
+    (storage.getObject as ReturnType<typeof vi.fn>).mockResolvedValue({
+      stream: Readable.from(utf8Body),
+      contentType: "text/plain",
+      contentLength: utf8Body.length,
+    });
+    getAssetByIdMock.mockResolvedValue({ ...createAsset(), contentType: "text/plain" });
+
+    const app = await createApp(storage);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/assets/asset-1/content").buffer(true).responseType("blob"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain; charset=utf-8");
+    expect(Buffer.compare(Buffer.from(res.body as Buffer), utf8Body)).toBe(0);
   });
 });

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -386,4 +386,31 @@ describe("GET /api/assets/:assetId/content", () => {
     expect(res.headers["content-type"]).toBe("text/plain; charset=utf-8");
     expect(Buffer.compare(Buffer.from(res.body as Buffer), utf8Body)).toBe(0);
   });
+
+  it("streams a text asset larger than the attachment max-bytes cap unlabeled instead of buffering it", async () => {
+    // Valid ASCII/UTF-8 content, so the only reason this should stay unlabeled
+    // is that the known size exceeds the buffering cap and full-body UTF-8
+    // validation is skipped in favor of streaming.
+    const oversizedBody = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1, "a");
+    const storage = createStorageService();
+    (storage.getObject as ReturnType<typeof vi.fn>).mockResolvedValue({
+      stream: Readable.from(oversizedBody),
+      contentType: "text/plain",
+      contentLength: oversizedBody.length,
+    });
+    getAssetByIdMock.mockResolvedValue({
+      ...createAsset(),
+      contentType: "text/plain",
+      byteSize: oversizedBody.length,
+    });
+
+    const app = await createApp(storage);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/assets/asset-1/content").buffer(true).responseType("blob"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain");
+    expect(Buffer.compare(Buffer.from(res.body as Buffer), oversizedBody)).toBe(0);
+  });
 });

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -4,6 +4,8 @@ import {
   INLINE_ATTACHMENT_TYPES,
   inferOfficeAttachmentContentTypeFromFilename,
   isInlineAttachmentContentType,
+  isTextualAttachmentContentType,
+  isValidUtf8Buffer,
   matchesContentType,
   normalizeContentType,
   normalizeUploadAttachmentContentType,
@@ -243,5 +245,53 @@ describe("withUtf8CharsetIfTextual", () => {
     expect(withUtf8CharsetIfTextual(undefined)).toBe("");
     expect(withUtf8CharsetIfTextual(null)).toBe("");
     expect(withUtf8CharsetIfTextual("")).toBe("");
+  });
+
+  it("leaves textual content types unlabeled when the bytes are not confirmed UTF-8", () => {
+    expect(withUtf8CharsetIfTextual("text/plain", { validatedUtf8: false })).toBe("text/plain");
+    expect(withUtf8CharsetIfTextual("application/json", { validatedUtf8: false })).toBe("application/json");
+  });
+
+  it("still leaves binary content types unchanged regardless of validatedUtf8", () => {
+    expect(withUtf8CharsetIfTextual("application/pdf", { validatedUtf8: false })).toBe("application/pdf");
+    expect(withUtf8CharsetIfTextual("image/png", { validatedUtf8: true })).toBe("image/png");
+  });
+});
+
+describe("isTextualAttachmentContentType", () => {
+  it("identifies text/*, application/json, and *+json as textual", () => {
+    expect(isTextualAttachmentContentType("text/plain")).toBe(true);
+    expect(isTextualAttachmentContentType("text/markdown; charset=utf-8")).toBe(true);
+    expect(isTextualAttachmentContentType("application/json")).toBe(true);
+    expect(isTextualAttachmentContentType("application/ld+json")).toBe(true);
+  });
+
+  it("does not treat binary/media types as textual", () => {
+    for (const contentType of ["application/pdf", "application/zip", "image/png", "video/mp4"]) {
+      expect(isTextualAttachmentContentType(contentType)).toBe(false);
+    }
+  });
+
+  it("handles empty or missing input", () => {
+    expect(isTextualAttachmentContentType(undefined)).toBe(false);
+    expect(isTextualAttachmentContentType(null)).toBe(false);
+    expect(isTextualAttachmentContentType("")).toBe(false);
+  });
+});
+
+describe("isValidUtf8Buffer", () => {
+  it("accepts valid UTF-8 including multi-byte characters", () => {
+    expect(isValidUtf8Buffer(Buffer.from("hello world"))).toBe(true);
+    expect(isValidUtf8Buffer(Buffer.from("café 日本語", "utf8"))).toBe(true);
+  });
+
+  it("rejects bytes that are not well-formed UTF-8", () => {
+    // 0xE9 is "é" in Latin-1/Windows-1252 but is an invalid standalone UTF-8 byte.
+    const latin1Bytes = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+    expect(isValidUtf8Buffer(latin1Bytes)).toBe(false);
+  });
+
+  it("treats an empty buffer as valid", () => {
+    expect(isValidUtf8Buffer(Buffer.alloc(0))).toBe(true);
   });
 });

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -329,11 +329,20 @@ describe("isValidUtf8Buffer", () => {
     expect(isValidUtf8Buffer(euroSignBytes)).toBe(false);
   });
 
-  it("treats two independent code points beyond U+00FF as confident UTF-8", () => {
-    // Two separate multi-byte sequences coincidentally forming well-formed
-    // UTF-8 out of legacy single-byte text is negligibly unlikely, so this
-    // is trusted even though each "€" individually would not be.
-    expect(isValidUtf8Buffer(Buffer.from("€€", "utf8"))).toBe(true);
+  it("does not treat a repeated identical code point as confident UTF-8", () => {
+    // "€€" is two repeats of the *same* code point (U+20AC), which is also
+    // what a legacy Windows-1252 document with the same repeated digraph
+    // would decode to. Repetition of an identical code point isn't
+    // independent evidence, so this must not be trusted.
+    expect(isValidUtf8Buffer(Buffer.from("€€", "utf8"))).toBe(false);
+  });
+
+  it("treats two distinct code points beyond U+00FF as confident UTF-8", () => {
+    // Two distinct multi-byte sequences ("€" and "£") coincidentally forming
+    // well-formed UTF-8 out of legacy single-byte text is negligibly
+    // unlikely, so this is trusted even though each individually would not
+    // be.
+    expect(isValidUtf8Buffer(Buffer.from("€£", "utf8"))).toBe(true);
   });
 });
 

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -296,6 +296,29 @@ describe("isValidUtf8Buffer", () => {
   it("treats an empty buffer as valid", () => {
     expect(isValidUtf8Buffer(Buffer.alloc(0))).toBe(true);
   });
+
+  it("does not treat structurally-valid-but-ambiguous Windows-1252 bytes as confident UTF-8", () => {
+    // 0xC2 0xA9 is well-formed UTF-8 for the single character "(c)" (U+00A9),
+    // but the very same two bytes are also well-formed Windows-1252/Latin-1
+    // for two separate characters ("A" + "(c)"). Structural validity alone
+    // can't tell those apart, so this must not be treated as confirmed UTF-8.
+    const windows1252Bytes = Buffer.from([0xc2, 0xa9]);
+    expect(isValidUtf8Buffer(windows1252Bytes)).toBe(false);
+  });
+
+  it("does not treat lone Latin-1 Supplement characters as confident UTF-8 without stronger evidence", () => {
+    // "cafe" + U+00E9 alone only produces ambiguous Latin-1 Supplement bytes
+    // (0xC3 0xA9), which collide with valid Windows-1252 text the same way
+    // as the case above, so it is not confirmed UTF-8 on its own.
+    expect(isValidUtf8Buffer(Buffer.from("cafeé", "utf8"))).toBe(false);
+  });
+
+  it("treats Latin-1 Supplement characters as confident UTF-8 once a code point beyond that range is also present", () => {
+    // Adding a CJK character (a 3-byte UTF-8 sequence) can't arise by chance
+    // from single-byte legacy text, so it's strong evidence the whole buffer
+    // really is UTF-8, including the earlier ambiguous character.
+    expect(isValidUtf8Buffer(Buffer.from("cafeé 日本語", "utf8"))).toBe(true);
+  });
 });
 
 describe("canBufferForUtf8Validation", () => {

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -313,11 +313,27 @@ describe("isValidUtf8Buffer", () => {
     expect(isValidUtf8Buffer(Buffer.from("cafeé", "utf8"))).toBe(false);
   });
 
-  it("treats Latin-1 Supplement characters as confident UTF-8 once a code point beyond that range is also present", () => {
-    // Adding a CJK character (a 3-byte UTF-8 sequence) can't arise by chance
-    // from single-byte legacy text, so it's strong evidence the whole buffer
-    // really is UTF-8, including the earlier ambiguous character.
+  it("treats a lone ambiguous character as confident UTF-8 once at least one more non-ASCII code point is also present", () => {
+    // A single ambiguous character plus CJK characters (3-byte UTF-8
+    // sequences) reaches the two-code-point threshold, so the whole buffer
+    // is trusted, including the earlier ambiguous character.
     expect(isValidUtf8Buffer(Buffer.from("cafeé 日本語", "utf8"))).toBe(true);
+  });
+
+  it("does not treat a single 3-byte sequence beyond U+00FF as confident UTF-8 on its own", () => {
+    // 0xE2 0x82 0xAC is the UTF-8 encoding of "€" (U+20AC), but the same
+    // three bytes are also well-formed Windows-1252 for "â‚¬" - three
+    // unrelated legacy characters. A lone multi-byte coincidence, however
+    // many bytes it spans, isn't reliable evidence of the source encoding.
+    const euroSignBytes = Buffer.from([0xe2, 0x82, 0xac]);
+    expect(isValidUtf8Buffer(euroSignBytes)).toBe(false);
+  });
+
+  it("treats two independent code points beyond U+00FF as confident UTF-8", () => {
+    // Two separate multi-byte sequences coincidentally forming well-formed
+    // UTF-8 out of legacy single-byte text is negligibly unlikely, so this
+    // is trusted even though each "€" individually would not be.
+    expect(isValidUtf8Buffer(Buffer.from("€€", "utf8"))).toBe(true);
   });
 });
 

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeContentType,
   normalizeUploadAttachmentContentType,
   parseAllowedTypes,
+  withUtf8CharsetIfTextual,
 } from "../attachment-types.js";
 
 describe("parseAllowedTypes", () => {
@@ -197,5 +198,50 @@ describe("isInlineAttachmentContentType", () => {
     expect(INLINE_ATTACHMENT_TYPES).not.toContain("text/html");
     expect(isInlineAttachmentContentType("text/html")).toBe(false);
     expect(isInlineAttachmentContentType("application/zip")).toBe(false);
+  });
+});
+
+describe("withUtf8CharsetIfTextual", () => {
+  it("adds charset=utf-8 to text/* types", () => {
+    expect(withUtf8CharsetIfTextual("text/markdown")).toBe("text/markdown; charset=utf-8");
+    expect(withUtf8CharsetIfTextual("text/plain")).toBe("text/plain; charset=utf-8");
+    expect(withUtf8CharsetIfTextual("text/csv")).toBe("text/csv; charset=utf-8");
+    expect(withUtf8CharsetIfTextual("text/html")).toBe("text/html; charset=utf-8");
+  });
+
+  it("adds charset=utf-8 to application/json and *+json types", () => {
+    expect(withUtf8CharsetIfTextual("application/json")).toBe("application/json; charset=utf-8");
+    expect(withUtf8CharsetIfTextual("application/ld+json")).toBe("application/ld+json; charset=utf-8");
+  });
+
+  it("is case-insensitive when matching the base type", () => {
+    expect(withUtf8CharsetIfTextual("Text/Markdown")).toBe("Text/Markdown; charset=utf-8");
+  });
+
+  it("preserves an existing charset instead of duplicating it", () => {
+    expect(withUtf8CharsetIfTextual("text/plain; charset=iso-8859-1")).toBe(
+      "text/plain; charset=iso-8859-1",
+    );
+    expect(withUtf8CharsetIfTextual("text/markdown; charset=utf-8")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+  });
+
+  it("leaves binary/media content types unchanged", () => {
+    for (const contentType of [
+      "application/pdf",
+      "application/zip",
+      "image/png",
+      "video/mp4",
+      "application/octet-stream",
+    ]) {
+      expect(withUtf8CharsetIfTextual(contentType)).toBe(contentType);
+    }
+  });
+
+  it("handles empty or missing input", () => {
+    expect(withUtf8CharsetIfTextual(undefined)).toBe("");
+    expect(withUtf8CharsetIfTextual(null)).toBe("");
+    expect(withUtf8CharsetIfTextual("")).toBe("");
   });
 });

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  canBufferForUtf8Validation,
   DEFAULT_ALLOWED_TYPES,
   INLINE_ATTACHMENT_TYPES,
   inferOfficeAttachmentContentTypeFromFilename,
@@ -7,6 +8,7 @@ import {
   isTextualAttachmentContentType,
   isValidUtf8Buffer,
   matchesContentType,
+  MAX_ATTACHMENT_BYTES,
   normalizeContentType,
   normalizeUploadAttachmentContentType,
   parseAllowedTypes,
@@ -293,5 +295,25 @@ describe("isValidUtf8Buffer", () => {
 
   it("treats an empty buffer as valid", () => {
     expect(isValidUtf8Buffer(Buffer.alloc(0))).toBe(true);
+  });
+});
+
+describe("canBufferForUtf8Validation", () => {
+  it("allows sizes at or below the attachment max-bytes cap", () => {
+    expect(canBufferForUtf8Validation(0)).toBe(true);
+    expect(canBufferForUtf8Validation(1024)).toBe(true);
+    expect(canBufferForUtf8Validation(MAX_ATTACHMENT_BYTES)).toBe(true);
+  });
+
+  it("rejects sizes above the attachment max-bytes cap", () => {
+    expect(canBufferForUtf8Validation(MAX_ATTACHMENT_BYTES + 1)).toBe(false);
+    expect(canBufferForUtf8Validation(MAX_ATTACHMENT_BYTES * 100)).toBe(false);
+  });
+
+  it("rejects unknown or invalid sizes so unbounded streams are never buffered", () => {
+    expect(canBufferForUtf8Validation(null)).toBe(false);
+    expect(canBufferForUtf8Validation(undefined)).toBe(false);
+    expect(canBufferForUtf8Validation(Number.NaN)).toBe(false);
+    expect(canBufferForUtf8Validation(-1)).toBe(false);
   });
 });

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -540,6 +540,39 @@ describe("issue attachment routes", () => {
     expect(res.headers["content-type"]).toBe("application/x-msdownload");
   });
 
+  it("does not label a legacy-encoded (non-UTF-8) text attachment as charset=utf-8", async () => {
+    // 0xE9 is "é" in Latin-1/Windows-1252, an invalid standalone byte in UTF-8.
+    const latin1Body = Buffer.from([0x63, 0x61, 0x66, 0xe9]);
+    const storage = createStorageService(latin1Body);
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("text/plain", "legacy.txt"));
+
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/attachments/attachment-1/content")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain");
+    expect(Buffer.compare(res.body as Buffer, latin1Body)).toBe(0);
+  });
+
+  it("still labels valid UTF-8 text attachments as charset=utf-8", async () => {
+    const utf8Body = Buffer.from("café 日本語", "utf8");
+    const storage = createStorageService(utf8Body);
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("text/plain", "notes.txt"));
+
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/attachments/attachment-1/content")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain; charset=utf-8");
+    expect(Buffer.compare(res.body as Buffer, utf8Body)).toBe(0);
+  });
+
   it("keeps image attachments inline for previews", async () => {
     const storage = createStorageService();
     mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("image/png", "preview.png"));

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -4,6 +4,7 @@ import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StorageService } from "../storage/types.js";
+import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
@@ -571,6 +572,28 @@ describe("issue attachment routes", () => {
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toBe("text/plain; charset=utf-8");
     expect(Buffer.compare(res.body as Buffer, utf8Body)).toBe(0);
+  });
+
+  it("streams a text attachment larger than the attachment max-bytes cap unlabeled instead of buffering it", async () => {
+    // Valid ASCII/UTF-8 content, so the only reason this should stay unlabeled
+    // is that the known size exceeds the buffering cap and full-body UTF-8
+    // validation is skipped in favor of streaming.
+    const oversizedBody = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1, "a");
+    const storage = createStorageService(oversizedBody);
+    mockIssueService.getAttachmentById.mockResolvedValue({
+      ...makeAttachment("text/plain", "huge.txt"),
+      byteSize: oversizedBody.length,
+    });
+
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/attachments/attachment-1/content")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain");
+    expect(Buffer.compare(res.body as Buffer, oversizedBody)).toBe(0);
   });
 
   it("keeps image attachments inline for previews", async () => {

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -515,6 +515,31 @@ describe("issue attachment routes", () => {
     expect(res.headers["x-content-type-options"]).toBe("nosniff");
   });
 
+  it("serves markdown attachments with an explicit utf-8 charset", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("text/markdown", "notes.md"));
+
+    const app = await createApp(storage);
+    const res = await request(app).get("/api/attachments/attachment-1/content");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+  });
+
+  it("does not add a charset to binary attachment content types", async () => {
+    const storage = createStorageService();
+    mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("application/x-msdownload", "payload.exe"));
+
+    const app = await createApp(storage);
+    const res = await request(app)
+      .get("/api/attachments/attachment-1/content")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/x-msdownload");
+  });
+
   it("keeps image attachments inline for previews", async () => {
     const storage = createStorageService();
     mockIssueService.getAttachmentById.mockResolvedValue(makeAttachment("image/png", "preview.png"));

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -136,15 +136,46 @@ export function isInlineAttachmentContentType(contentType: string): boolean {
 }
 
 /**
+ * Whether `contentType` is one of the textual MIME families (`text/*`,
+ * `application/json`, `*+json`) that `withUtf8CharsetIfTextual` may label as
+ * UTF-8.
+ */
+export function isTextualAttachmentContentType(contentType: string | null | undefined): boolean {
+  const baseType = (contentType ?? "").split(";")[0]!.trim().toLowerCase();
+  return baseType.startsWith("text/") || baseType === "application/json" || baseType.endsWith("+json");
+}
+
+/**
+ * Whether `buffer` decodes as well-formed UTF-8. Upload/storage paths accept
+ * arbitrary bytes for textual MIME types (no encoding is enforced at write
+ * time), so callers must confirm the actual bytes are UTF-8 before asserting
+ * `charset=utf-8` on a response - otherwise a legacy-encoded upload (e.g.
+ * Latin-1, Shift-JIS) would be mislabeled and mis-rendered by browsers.
+ */
+export function isValidUtf8Buffer(buffer: Buffer): boolean {
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Append `; charset=utf-8` to textual content types (`text/*`, `application/json`,
  * `*+json`) that don't already declare a charset. Binary/media content types and
  * content types with an existing charset parameter are returned unchanged.
  *
- * Stored attachment/asset bytes are UTF-8; without an explicit charset, browsers
- * may guess the wrong encoding when rendering text content inline (e.g. CJK
- * mojibake).
+ * Pass `validatedUtf8: false` when the underlying bytes have not been (or
+ * cannot be) confirmed as valid UTF-8 - e.g. a partial range read, or a
+ * buffer that failed `isValidUtf8Buffer` - to keep the content type unlabeled
+ * so browsers fall back to their own encoding guess, same as before this
+ * charset behavior existed.
  */
-export function withUtf8CharsetIfTextual(contentType: string | null | undefined): string {
+export function withUtf8CharsetIfTextual(
+  contentType: string | null | undefined,
+  options?: { validatedUtf8?: boolean },
+): string {
   const trimmed = (contentType ?? "").trim();
   if (!trimmed) return trimmed;
   const [base, ...params] = trimmed.split(";");
@@ -153,6 +184,7 @@ export function withUtf8CharsetIfTextual(contentType: string | null | undefined)
   if (hasCharset) return trimmed;
   const isTextual = baseType.startsWith("text/") || baseType === "application/json" || baseType.endsWith("+json");
   if (!isTextual) return trimmed;
+  if (options?.validatedUtf8 === false) return trimmed;
   return `${trimmed}; charset=utf-8`;
 }
 

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -146,19 +146,39 @@ export function isTextualAttachmentContentType(contentType: string | null | unde
 }
 
 /**
- * Whether `buffer` decodes as well-formed UTF-8. Upload/storage paths accept
- * arbitrary bytes for textual MIME types (no encoding is enforced at write
- * time), so callers must confirm the actual bytes are UTF-8 before asserting
- * `charset=utf-8` on a response - otherwise a legacy-encoded upload (e.g.
- * Latin-1, Shift-JIS) would be mislabeled and mis-rendered by browsers.
+ * Whether `buffer` can be confidently identified as UTF-8. Upload/storage
+ * paths accept arbitrary bytes for textual MIME types (no encoding is
+ * enforced at write time), so callers must confirm the actual bytes are
+ * UTF-8 before asserting `charset=utf-8` on a response - otherwise a
+ * legacy-encoded upload (e.g. Latin-1, Shift-JIS) would be mislabeled and
+ * mis-rendered by browsers.
+ *
+ * Structural well-formedness alone isn't proof: every byte pair a
+ * single-byte legacy encoding (Windows-1252, Latin-1) can produce in the
+ * 0x80-0xFF range is *also* a structurally valid 2-byte UTF-8 sequence
+ * decoding to a Latin-1 Supplement code point (U+0080-U+00FF). For example
+ * the bytes `C2 A9` are simultaneously well-formed UTF-8 for "©" (c)
+ * and well-formed Windows-1252 for "Â©" (Ac) - `TextDecoder`
+ * can't tell those apart. A 3-byte or 4-byte UTF-8 sequence can't arise by
+ * chance from single-byte legacy text, so we only trust the decode once it
+ * contains a code point outside that ambiguous collision range; buffers
+ * whose only non-ASCII evidence sits in the Latin-1 Supplement range are
+ * treated as unverified and left unlabeled, matching this module's
+ * documented fallback of letting the browser sniff the encoding itself.
  */
 export function isValidUtf8Buffer(buffer: Buffer): boolean {
+  let text: string;
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(buffer);
-    return true;
+    text = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
   } catch {
     return false;
   }
+  const hasAmbiguousCodePoint = /[\u0080-\u00ff]/.test(text);
+  if (!hasAmbiguousCodePoint) return true;
+  // Some code point sits in the ambiguous Latin-1 Supplement range - only
+  // trust the decode if the text also contains a code point beyond that
+  // range, which can't be produced by chance from single-byte legacy text.
+  return /[\u0100-\uffff]/.test(text) || /[\u{10000}-\u{10ffff}]/u.test(text);
 }
 
 /**

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -202,6 +202,22 @@ export function isAllowedContentType(contentType: string): boolean {
 export const MAX_ATTACHMENT_BYTES =
   Number(process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES) || 10 * 1024 * 1024;
 
+/**
+ * Full-body UTF-8 validation requires buffering the whole object into memory
+ * (see `isValidUtf8Buffer`). Reuse the upload-time size cap as the buffering
+ * cap too, so a textual attachment can never force more than `MAX_ATTACHMENT_BYTES`
+ * into memory on read - anything larger (or of unknown size) is served unlabeled
+ * instead of buffered, matching the pre-existing streaming behavior for binary content.
+ */
+export function canBufferForUtf8Validation(knownSizeBytes: number | null | undefined): boolean {
+  return (
+    typeof knownSizeBytes === "number" &&
+    Number.isFinite(knownSizeBytes) &&
+    knownSizeBytes >= 0 &&
+    knownSizeBytes <= MAX_ATTACHMENT_BYTES
+  );
+}
+
 export function normalizeIssueAttachmentMaxBytes(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return Math.min(DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES, MAX_ATTACHMENT_BYTES);

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -162,14 +162,18 @@ export function isTextualAttachmentContentType(contentType: string | null | unde
  * encoding of "€", is also valid Windows-1252 for "â‚¬" - three unrelated
  * legacy characters). A single non-ASCII code point, however many bytes it
  * spans, is therefore never reliable evidence on its own. What makes a
- * coincidence implausible is *repetition*: each additional, independent
- * non-ASCII code point multiplies the odds against chance alignment, so we
- * require at least two of them (real UTF-8 text using accents, CJK, emoji,
- * etc. naturally has many; a legacy-encoded document coincidentally
- * producing two or more well-formed multi-byte sequences is negligible).
- * Buffers with fewer than two non-ASCII code points are treated as
- * unverified and left unlabeled, matching this module's documented
- * fallback of letting the browser sniff the encoding itself.
+ * coincidence implausible is *repetition* of *distinct* code points: each
+ * additional, independent non-ASCII code point multiplies the odds against
+ * chance alignment, so we require at least two distinct ones (real UTF-8
+ * text using accents, CJK, emoji, etc. naturally has many; a legacy-encoded
+ * document coincidentally producing two or more distinct well-formed
+ * multi-byte sequences is negligible). Counting repeats of the *same* code
+ * point is not enough evidence: a legacy document with the same digraph
+ * repeated (e.g. Windows-1252 "Â©Â©", two repeats of the same two-byte
+ * collision) would otherwise pass. Buffers with fewer than two distinct
+ * non-ASCII code points are treated as unverified and left unlabeled,
+ * matching this module's documented fallback of letting the browser sniff
+ * the encoding itself.
  */
 export function isValidUtf8Buffer(buffer: Buffer): boolean {
   let text: string;
@@ -178,13 +182,18 @@ export function isValidUtf8Buffer(buffer: Buffer): boolean {
   } catch {
     return false;
   }
-  const nonAsciiCodePoints = text.match(/[^\u0000-\u007f]/gu) ?? [];
-  if (nonAsciiCodePoints.length === 0) return true;
-  // At least one non-ASCII code point present - only trust the decode if
-  // there are two or more; a lone one can arise by chance from legacy
-  // single-byte text (see the "€" example above), but two independent
-  // coincidences in the same buffer are negligibly unlikely.
-  return nonAsciiCodePoints.length >= 2;
+  // Scan code points directly (rather than `text.match(/.../gu)`) so we can
+  // stop as soon as two distinct non-ASCII code points are found, instead of
+  // materializing every match into an array up front - important for large
+  // (up to MAX_ATTACHMENT_BYTES) buffers of non-ASCII text.
+  const distinctNonAscii = new Set<string>();
+  for (const char of text) {
+    if (char.codePointAt(0)! > 0x7f) {
+      distinctNonAscii.add(char);
+      if (distinctNonAscii.size >= 2) return true;
+    }
+  }
+  return distinctNonAscii.size === 0;
 }
 
 /**

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -135,6 +135,27 @@ export function isInlineAttachmentContentType(contentType: string): boolean {
   return matchesContentType(contentType, [...INLINE_ATTACHMENT_TYPES]);
 }
 
+/**
+ * Append `; charset=utf-8` to textual content types (`text/*`, `application/json`,
+ * `*+json`) that don't already declare a charset. Binary/media content types and
+ * content types with an existing charset parameter are returned unchanged.
+ *
+ * Stored attachment/asset bytes are UTF-8; without an explicit charset, browsers
+ * may guess the wrong encoding when rendering text content inline (e.g. CJK
+ * mojibake).
+ */
+export function withUtf8CharsetIfTextual(contentType: string | null | undefined): string {
+  const trimmed = (contentType ?? "").trim();
+  if (!trimmed) return trimmed;
+  const [base, ...params] = trimmed.split(";");
+  const baseType = base.trim().toLowerCase();
+  const hasCharset = params.some((param) => param.trim().toLowerCase().startsWith("charset="));
+  if (hasCharset) return trimmed;
+  const isTextual = baseType.startsWith("text/") || baseType === "application/json" || baseType.endsWith("+json");
+  if (!isTextual) return trimmed;
+  return `${trimmed}; charset=utf-8`;
+}
+
 // ---------- Module-level singletons read once at startup ----------
 
 const allowedPatterns: string[] = parseAllowedTypes(

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -153,18 +153,23 @@ export function isTextualAttachmentContentType(contentType: string | null | unde
  * legacy-encoded upload (e.g. Latin-1, Shift-JIS) would be mislabeled and
  * mis-rendered by browsers.
  *
- * Structural well-formedness alone isn't proof: every byte pair a
+ * Structural well-formedness alone isn't proof: every byte sequence a
  * single-byte legacy encoding (Windows-1252, Latin-1) can produce in the
- * 0x80-0xFF range is *also* a structurally valid 2-byte UTF-8 sequence
- * decoding to a Latin-1 Supplement code point (U+0080-U+00FF). For example
- * the bytes `C2 A9` are simultaneously well-formed UTF-8 for "©" (c)
- * and well-formed Windows-1252 for "Â©" (Ac) - `TextDecoder`
- * can't tell those apart. A 3-byte or 4-byte UTF-8 sequence can't arise by
- * chance from single-byte legacy text, so we only trust the decode once it
- * contains a code point outside that ambiguous collision range; buffers
- * whose only non-ASCII evidence sits in the Latin-1 Supplement range are
- * treated as unverified and left unlabeled, matching this module's
- * documented fallback of letting the browser sniff the encoding itself.
+ * 0x80-0xFF range can *also* form a structurally valid multi-byte UTF-8
+ * sequence, and that holds for any sequence length - not just the 2-byte
+ * Latin-1 Supplement case (`C2 A9` is valid UTF-8 for "©" and valid
+ * Windows-1252 for "Â©"), but 3-byte sequences too (`E2 82 AC`, the UTF-8
+ * encoding of "€", is also valid Windows-1252 for "â‚¬" - three unrelated
+ * legacy characters). A single non-ASCII code point, however many bytes it
+ * spans, is therefore never reliable evidence on its own. What makes a
+ * coincidence implausible is *repetition*: each additional, independent
+ * non-ASCII code point multiplies the odds against chance alignment, so we
+ * require at least two of them (real UTF-8 text using accents, CJK, emoji,
+ * etc. naturally has many; a legacy-encoded document coincidentally
+ * producing two or more well-formed multi-byte sequences is negligible).
+ * Buffers with fewer than two non-ASCII code points are treated as
+ * unverified and left unlabeled, matching this module's documented
+ * fallback of letting the browser sniff the encoding itself.
  */
 export function isValidUtf8Buffer(buffer: Buffer): boolean {
   let text: string;
@@ -173,12 +178,13 @@ export function isValidUtf8Buffer(buffer: Buffer): boolean {
   } catch {
     return false;
   }
-  const hasAmbiguousCodePoint = /[\u0080-\u00ff]/.test(text);
-  if (!hasAmbiguousCodePoint) return true;
-  // Some code point sits in the ambiguous Latin-1 Supplement range - only
-  // trust the decode if the text also contains a code point beyond that
-  // range, which can't be produced by chance from single-byte legacy text.
-  return /[\u0100-\uffff]/.test(text) || /[\u{10000}-\u{10ffff}]/u.test(text);
+  const nonAsciiCodePoints = text.match(/[^\u0000-\u007f]/gu) ?? [];
+  if (nonAsciiCodePoints.length === 0) return true;
+  // At least one non-ASCII code point present - only trust the decode if
+  // there are two or more; a lone one can arise by chance from legacy
+  // single-byte text (see the "€" example above), but two independent
+  // coincidences in the same buffer are negligibly unlikely.
+  return nonAsciiCodePoints.length >= 2;
 }
 
 /**

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -6,7 +6,13 @@ import type { Db } from "@paperclipai/db";
 import { createAssetImageMetadataSchema } from "@paperclipai/shared";
 import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
-import { isAllowedContentType, MAX_ATTACHMENT_BYTES, withUtf8CharsetIfTextual } from "../attachment-types.js";
+import {
+  isAllowedContentType,
+  isTextualAttachmentContentType,
+  isValidUtf8Buffer,
+  MAX_ATTACHMENT_BYTES,
+  withUtf8CharsetIfTextual,
+} from "../attachment-types.js";
 import { assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 const SVG_CONTENT_TYPE = "image/svg+xml";
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
@@ -318,8 +324,32 @@ export function assetRoutes(db: Db, storage: StorageService) {
 
     const object = await storage.getObject(asset.companyId, asset.objectKey);
     const responseContentType = asset.contentType || object.contentType || "application/octet-stream";
-    res.setHeader("Content-Type", withUtf8CharsetIfTextual(responseContentType));
-    res.setHeader("Content-Length", String(asset.byteSize || object.contentLength || 0));
+
+    // Storage accepts arbitrary bytes for textual content types (upload never
+    // validates encoding), so only assert charset=utf-8 once the full body is
+    // confirmed to actually be valid UTF-8.
+    let bufferedBody: Buffer | null = null;
+    let responseHeaderContentType = responseContentType;
+    if (isTextualAttachmentContentType(responseContentType)) {
+      try {
+        const chunks: Buffer[] = [];
+        for await (const chunk of object.stream) {
+          chunks.push(chunk as Buffer);
+        }
+        bufferedBody = Buffer.concat(chunks);
+      } catch (err) {
+        next(err);
+        return;
+      }
+      responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType, {
+        validatedUtf8: isValidUtf8Buffer(bufferedBody),
+      });
+    } else {
+      responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType);
+    }
+
+    res.setHeader("Content-Type", responseHeaderContentType);
+    res.setHeader("Content-Length", String(bufferedBody ? bufferedBody.length : asset.byteSize || object.contentLength || 0));
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");
     if (responseContentType === SVG_CONTENT_TYPE) {
@@ -328,10 +358,14 @@ export function assetRoutes(db: Db, storage: StorageService) {
     const filename = asset.originalFilename ?? "asset";
     res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
 
-    object.stream.on("error", (err) => {
-      next(err);
-    });
-    object.stream.pipe(res);
+    if (bufferedBody) {
+      res.end(bufferedBody);
+    } else {
+      object.stream.on("error", (err) => {
+        next(err);
+      });
+      object.stream.pipe(res);
+    }
   });
 
   return router;

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -6,7 +6,7 @@ import type { Db } from "@paperclipai/db";
 import { createAssetImageMetadataSchema } from "@paperclipai/shared";
 import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
-import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { isAllowedContentType, MAX_ATTACHMENT_BYTES, withUtf8CharsetIfTextual } from "../attachment-types.js";
 import { assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 const SVG_CONTENT_TYPE = "image/svg+xml";
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
@@ -318,7 +318,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
 
     const object = await storage.getObject(asset.companyId, asset.objectKey);
     const responseContentType = asset.contentType || object.contentType || "application/octet-stream";
-    res.setHeader("Content-Type", responseContentType);
+    res.setHeader("Content-Type", withUtf8CharsetIfTextual(responseContentType));
     res.setHeader("Content-Length", String(asset.byteSize || object.contentLength || 0));
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -7,6 +7,7 @@ import { createAssetImageMetadataSchema } from "@paperclipai/shared";
 import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
 import {
+  canBufferForUtf8Validation,
   isAllowedContentType,
   isTextualAttachmentContentType,
   isValidUtf8Buffer,
@@ -330,7 +331,10 @@ export function assetRoutes(db: Db, storage: StorageService) {
     // confirmed to actually be valid UTF-8.
     let bufferedBody: Buffer | null = null;
     let responseHeaderContentType = responseContentType;
-    if (isTextualAttachmentContentType(responseContentType)) {
+    if (
+      isTextualAttachmentContentType(responseContentType) &&
+      canBufferForUtf8Validation(asset.byteSize ?? object.contentLength)
+    ) {
       try {
         const chunks: Buffer[] = [];
         for await (const chunk of object.stream) {
@@ -345,7 +349,9 @@ export function assetRoutes(db: Db, storage: StorageService) {
         validatedUtf8: isValidUtf8Buffer(bufferedBody),
       });
     } else {
-      responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType);
+      // Textual content too large (or of unknown size) to safely buffer for
+      // UTF-8 validation is streamed unlabeled instead, same as binary content.
+      responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType, { validatedUtf8: false });
     }
 
     res.setHeader("Content-Type", responseHeaderContentType);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -169,6 +169,7 @@ import {
   normalizeContentType,
   normalizeUploadAttachmentContentType,
   SVG_CONTENT_TYPE,
+  withUtf8CharsetIfTextual,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 import { createSecretProposalsService } from "../services/secret-proposals.js";
@@ -12749,7 +12750,7 @@ export function issueRoutes(
       objectContentType: object.contentType,
       originalFilename: attachment.originalFilename,
     });
-    res.setHeader("Content-Type", responseContentType);
+    res.setHeader("Content-Type", withUtf8CharsetIfTextual(responseContentType));
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");
     if (responseContentType === SVG_CONTENT_TYPE) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -163,6 +163,7 @@ import {
 } from "./workspace-command-authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import {
+  canBufferForUtf8Validation,
   GENERIC_ATTACHMENT_CONTENT_TYPES,
   isInlineAttachmentContentType,
   isTextualAttachmentContentType,
@@ -12761,7 +12762,10 @@ export function issueRoutes(
     let bufferedBody: Buffer | null = null;
     let responseHeaderContentType = responseContentType;
     if (isTextualAttachmentContentType(responseContentType)) {
-      if (range.kind === "range") {
+      if (range.kind === "range" || !canBufferForUtf8Validation(contentLength ?? object.contentLength)) {
+        // A range request only sees a slice of the bytes, which can't be validated
+        // reliably. An attachment too large (or of unknown size) to safely buffer
+        // for UTF-8 validation is streamed unlabeled instead, same as binary content.
         responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType, { validatedUtf8: false });
       } else {
         try {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -165,6 +165,8 @@ import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import {
   GENERIC_ATTACHMENT_CONTENT_TYPES,
   isInlineAttachmentContentType,
+  isTextualAttachmentContentType,
+  isValidUtf8Buffer,
   normalizeIssueAttachmentMaxBytes,
   normalizeContentType,
   normalizeUploadAttachmentContentType,
@@ -12750,7 +12752,37 @@ export function issueRoutes(
       objectContentType: object.contentType,
       originalFilename: attachment.originalFilename,
     });
-    res.setHeader("Content-Type", withUtf8CharsetIfTextual(responseContentType));
+
+    // Storage accepts arbitrary bytes for textual content types (upload never
+    // validates encoding), so only assert charset=utf-8 once the full body is
+    // confirmed to actually be valid UTF-8. A range request only sees a slice
+    // of the bytes, which can't be validated reliably, so it's always served
+    // unlabeled.
+    let bufferedBody: Buffer | null = null;
+    let responseHeaderContentType = responseContentType;
+    if (isTextualAttachmentContentType(responseContentType)) {
+      if (range.kind === "range") {
+        responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType, { validatedUtf8: false });
+      } else {
+        try {
+          const chunks: Buffer[] = [];
+          for await (const chunk of object.stream) {
+            chunks.push(chunk as Buffer);
+          }
+          bufferedBody = Buffer.concat(chunks);
+        } catch (err) {
+          next(err);
+          return;
+        }
+        responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType, {
+          validatedUtf8: isValidUtf8Buffer(bufferedBody),
+        });
+      }
+    } else {
+      responseHeaderContentType = withUtf8CharsetIfTextual(responseContentType);
+    }
+
+    res.setHeader("Content-Type", responseHeaderContentType);
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");
     if (responseContentType === SVG_CONTENT_TYPE) {
@@ -12762,9 +12794,11 @@ export function issueRoutes(
       : isInlineAttachmentContentType(responseContentType) ? "inline" : "attachment";
     res.setHeader("Content-Disposition", `${disposition}; filename=\"${filename.replaceAll("\"", "")}\"`);
 
-    object.stream.on("error", (err) => {
-      next(err);
-    });
+    if (!bufferedBody) {
+      object.stream.on("error", (err) => {
+        next(err);
+      });
+    }
     if (range.kind === "range") {
       const rangeLength = range.end - range.start + 1;
       res.status(206);
@@ -12774,8 +12808,12 @@ export function issueRoutes(
       return;
     }
 
-    res.setHeader("Content-Length", String(contentLength || object.contentLength || 0));
-    object.stream.pipe(res);
+    res.setHeader("Content-Length", String(bufferedBody ? bufferedBody.length : contentLength || object.contentLength || 0));
+    if (bufferedBody) {
+      res.end(bufferedBody);
+    } else {
+      object.stream.pipe(res);
+    }
   });
 
   router.delete("/attachments/:attachmentId", async (req, res) => {


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents and users open attachment and asset content directly through `/api/attachments/{attachmentId}/content` and `/api/assets/{assetId}/content`
> - Those routes set `Content-Type` from the stored MIME type only, with no charset parameter
> - Browsers pick a default encoding when no charset is present, and that guess can be wrong for text content, so valid UTF-8 bytes render as mojibake for CJK text
> - This pull request adds a shared helper that appends `charset=utf-8` to textual content types (`text/*`, `application/json`, `*+json`) on both routes, leaving binary/media types and any already-explicit charset untouched
> - The benefit is that text attachments and assets with non-Latin text render correctly when opened directly in a browser

## Linked Issues or Issue Description

Fixes: #11256

Searched GitHub for duplicate or related PRs (`charset attachment`, `11256`) — found none open or closed that address this.

## What Changed

- Added `withUtf8CharsetIfTextual()` in `server/src/attachment-types.ts`. It appends `; charset=utf-8` to `text/*`, `application/json`, and `*+json` content types that don't already declare a charset. Binary/media types and content types with an existing charset are returned unchanged.
- Applied the helper to the `Content-Type` header set by `GET /api/attachments/:attachmentId/content` in `server/src/routes/issues.ts`.
- Applied the helper to the `Content-Type` header set by `GET /api/assets/:assetId/content` in `server/src/routes/assets.ts`.
- Added unit tests for `withUtf8CharsetIfTextual` covering text types, `application/json`/`*+json`, case-insensitivity, preserving an existing charset, binary types, and empty input.
- Added integration tests on the attachment content route confirming markdown attachments now get `text/markdown; charset=utf-8` and binary attachments (`application/x-msdownload`) are unchanged.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/attachment-types.test.ts` — 29/29 passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-attachment-routes.test.ts --reporter=verbose` — the two new charset tests pass (`serves markdown attachments with an explicit utf-8 charset`, `does not add a charset to binary attachment content types`). A handful of unrelated multipart-upload tests in this file (and in `assets.test.ts`) time out in this sandbox on unmodified `master` too (multer/multipart parsing under CI sandbox constraints) — confirmed pre-existing and unrelated to this change by running the same test against unmodified `master`.
- Manual: `withUtf8CharsetIfTextual("text/markdown")` → `"text/markdown; charset=utf-8"`; `withUtf8CharsetIfTextual("application/pdf")` → `"application/pdf"` (unchanged).

## Risks

Low risk. The change only appends a charset parameter to a small set of textual MIME types when one isn't already present; binary/media `Content-Type` values are untouched. `isInlineAttachmentContentType()` and the SVG CSP check still run against the pre-charset content type, so inline/download and CSP behavior is unaffected.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), Anthropic. Used via Claude Code with tool use (file read/edit, bash, test execution) to reproduce, implement, and verify this fix. No extended-thinking/reasoning mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
