### PR TITLE
fix(projects): resync skill folder on project rename (#11099)

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -2715,6 +2715,67 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     });
   });
 
+  it("resyncs a project's skill folder once per scan, not once per skill (#11365)", async () => {
+    // ensureProjectFolder's resync takes a `pg_advisory_xact_lock` inside its
+    // own db.transaction, once per call. Scanning N skills that all belong to
+    // the same project must resolve/resync that project's folder once, not N
+    // times, so the db.transaction call count for the scan must not scale
+    // with the number of imported skills. Two otherwise-identical companies
+    // are scanned (one with 1 skill, one with 3) and their transaction counts
+    // compared, so the assertion doesn't depend on unrelated transactions
+    // (e.g. bundled-skill reconciliation) that also run once per scan.
+    async function seedProjectWithSkills(skillNames: string[]) {
+      const companyId = randomUUID();
+      const projectId = randomUUID();
+      const workspaceId = randomUUID();
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-skill-project-folder-count-"));
+      cleanupDirs.add(workspaceDir);
+      for (const skillName of skillNames) {
+        const skillDir = path.join(workspaceDir, "skills", skillName);
+        await fs.mkdir(skillDir, { recursive: true });
+        await fs.writeFile(path.join(skillDir, "SKILL.md"), `---\nname: ${skillName}\n---\n`, "utf8");
+      }
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+      await db.insert(projects).values({ id: projectId, companyId, name: "Skills Project" });
+      await db.insert(projectWorkspaces).values({
+        id: workspaceId,
+        companyId,
+        projectId,
+        name: "Primary",
+        cwd: workspaceDir,
+        isPrimary: true,
+      });
+      return { companyId, projectId };
+    }
+
+    async function scanAndCountTransactions(companyId: string, projectId: string, expectedImportCount: number) {
+      const originalTransaction = db.transaction.bind(db);
+      const transactionSpy = vi.spyOn(db, "transaction").mockImplementation(
+        ((...args: Parameters<typeof db.transaction>) => originalTransaction(...args)) as typeof db.transaction,
+      );
+      try {
+        const result = await svc.scanProjectWorkspaces(companyId, { projectIds: [projectId] });
+        expect(result.imported).toHaveLength(expectedImportCount);
+        return transactionSpy.mock.calls.length;
+      } finally {
+        transactionSpy.mockRestore();
+      }
+    }
+
+    const single = await seedProjectWithSkills(["alpha"]);
+    const multiple = await seedProjectWithSkills(["alpha", "bravo", "charlie"]);
+
+    const singleSkillTransactionCount = await scanAndCountTransactions(single.companyId, single.projectId, 1);
+    const multiSkillTransactionCount = await scanAndCountTransactions(multiple.companyId, multiple.projectId, 3);
+
+    expect(multiSkillTransactionCount).toBe(singleSkillTransactionCount);
+  });
+
   async function seedCompany(companyId: string) {
     await db.insert(companies).values({
       id: companyId,

--- a/server/src/__tests__/project-rename-folder-resync.test.ts
+++ b/server/src/__tests__/project-rename-folder-resync.test.ts
@@ -106,4 +106,30 @@ describeEmbeddedPostgres("project rename resyncs its skill folder", () => {
     const thirdResync = await folderSvc.renameProjectFolder(companyId, "project-renamed", "Zeta");
     expect(thirdResync?.slug).toBe(firstResync?.slug);
   });
+
+  it("converges instead of drifting when two renamed projects both target the same slug", async () => {
+    const companyId = await seedCompany();
+    const folderSvc = folderService(db);
+
+    await folderSvc.ensureProjectFolder(companyId, "project-a", "Alpha");
+    await folderSvc.ensureProjectFolder(companyId, "project-b", "Beta");
+
+    // Both projects are renamed to the same desired name, so one keeps the
+    // clean slug and the other must resolve a stable, deterministic suffix.
+    const firstA = await folderSvc.renameProjectFolder(companyId, "project-a", "Zeta");
+    const firstB = await folderSvc.renameProjectFolder(companyId, "project-b", "Zeta");
+    expect(firstA?.slug).toBe("zeta");
+    expect(firstB?.slug).not.toBe("zeta");
+    expect(firstB?.slug?.startsWith("zeta-")).toBe(true);
+
+    // Repeated rescans, in either processing order, must not change either
+    // project's resolved slug: no drift, no flip-flopping which project holds
+    // the clean slug.
+    for (let i = 0; i < 3; i += 1) {
+      const rescanB = await folderSvc.renameProjectFolder(companyId, "project-b", "Zeta");
+      const rescanA = await folderSvc.renameProjectFolder(companyId, "project-a", "Zeta");
+      expect(rescanA?.slug).toBe(firstA?.slug);
+      expect(rescanB?.slug).toBe(firstB?.slug);
+    }
+  });
 });

--- a/server/src/__tests__/project-rename-folder-resync.test.ts
+++ b/server/src/__tests__/project-rename-folder-resync.test.ts
@@ -85,4 +85,25 @@ describeEmbeddedPostgres("project rename resyncs its skill folder", () => {
     const result = await folderSvc.renameProjectFolder(companyId, "project-without-folder", "New Name");
     expect(result).toBeNull();
   });
+
+  it("keeps a collision-resolved slug stable across repeated resyncs (#11365)", async () => {
+    const companyId = await seedCompany();
+    const folderSvc = folderService(db);
+
+    const sibling = await folderSvc.ensureProjectFolder(companyId, "project-sibling", "Zeta");
+    expect(sibling).toMatchObject({ name: "Zeta", slug: "zeta" });
+
+    await folderSvc.ensureProjectFolder(companyId, "project-renamed", "Other Name");
+
+    const firstResync = await folderSvc.renameProjectFolder(companyId, "project-renamed", "Zeta");
+    expect(firstResync?.name).toBe("Zeta");
+    expect(firstResync?.slug).not.toBe("zeta");
+    expect(firstResync?.slug?.startsWith("zeta-")).toBe(true);
+
+    const secondResync = await folderSvc.renameProjectFolder(companyId, "project-renamed", "Zeta");
+    expect(secondResync?.slug).toBe(firstResync?.slug);
+
+    const thirdResync = await folderSvc.renameProjectFolder(companyId, "project-renamed", "Zeta");
+    expect(thirdResync?.slug).toBe(firstResync?.slug);
+  });
 });

--- a/server/src/__tests__/project-rename-folder-resync.test.ts
+++ b/server/src/__tests__/project-rename-folder-resync.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, folders, projects as projectsTable } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { projectService } from "../services/projects.js";
+import { folderService } from "../services/folders.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres project rename resync tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// Regression test for #11099: renaming a project left its system-managed
+// skill folder (systemKey `project:<id>`) on the old name and slug forever.
+describeEmbeddedPostgres("project rename resyncs its skill folder", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let prefixCounter = 0;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-project-rename-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(folders);
+    await db.delete(projectsTable);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany(): Promise<string> {
+    prefixCounter += 1;
+    const [company] = await db
+      .insert(companies)
+      .values({ name: "Resync Co", issuePrefix: `RSC${prefixCounter}` })
+      .returning();
+    return company.id;
+  }
+
+  it("renames the project's skill folder's name and slug when the project is renamed", async () => {
+    const companyId = await seedCompany();
+    const projects = projectService(db);
+    const folderSvc = folderService(db);
+
+    const project = await projects.create(companyId, { name: "Example Project" });
+    const folder = await folderSvc.ensureProjectFolder(companyId, project.id, project.name);
+    expect(folder).toMatchObject({ name: "Example Project", slug: "example-project" });
+
+    const renamed = await projects.update(project.id, { name: "Renamed Example" });
+    expect(renamed?.name).toBe("Renamed Example");
+
+    const resynced = await folderSvc.getFolder(companyId, folder.id);
+    expect(resynced).toMatchObject({ name: "Renamed Example", slug: "renamed-example" });
+  });
+
+  it("resyncs the folder on the next ensureProjectFolder call even without an explicit rename call", async () => {
+    const companyId = await seedCompany();
+    const folderSvc = folderService(db);
+
+    const folder = await folderSvc.ensureProjectFolder(companyId, "project-1", "Example Project");
+    expect(folder).toMatchObject({ name: "Example Project", slug: "example-project" });
+
+    const rescanned = await folderSvc.ensureProjectFolder(companyId, "project-1", "Renamed Example");
+    expect(rescanned).toMatchObject({
+      id: folder.id,
+      name: "Renamed Example",
+      slug: "renamed-example",
+    });
+  });
+
+  it("does not create a folder for a project that never had one", async () => {
+    const companyId = await seedCompany();
+    const folderSvc = folderService(db);
+
+    const result = await folderSvc.renameProjectFolder(companyId, "project-without-folder", "New Name");
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -5987,12 +5987,15 @@ export function companySkillService(db: Db) {
         : null;
       const projectId = asString(incomingMeta.projectId);
       const projectName = asString(incomingMeta.projectName);
-      const projectFolder = !existing && incomingKind === "project_scan" && projectId && projectName
+      // Always resolve the project folder (not just for new skills) so a rescan
+      // of an already-imported project resyncs its folder on a rename.
+      // existing?.folderId still wins below, preserving manual folder moves.
+      const projectFolder = incomingKind === "project_scan" && projectId && projectName
         ? await folderSvc.ensureProjectFolder(companyId, projectId, projectName)
         : null;
       const values: ImportedSkillPersistValues = {
         companyId,
-        folderId: bundledFolder?.id ?? projectFolder?.id ?? existing?.folderId ?? null,
+        folderId: bundledFolder?.id ?? (existing ? existing.folderId ?? null : projectFolder?.id ?? null),
         key: skill.key,
         slug: skill.slug,
         name: skill.name,

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -4902,6 +4902,10 @@ export function companySkillService(db: Db) {
     const invalidSelections: Array<{ workspaceId: string; path: string; slug?: string }> = [];
     const rediscoveredSelections = new Set<string>();
     const scannedProjectIds = new Set<string>();
+    // Shared across every per-skill upsertImportedSkills call in this scan so
+    // each project's folder is resolved/resynced once per scan, not once per
+    // scanned skill.
+    const projectFoldersById = new Map<string, Awaited<ReturnType<typeof folderSvc.ensureProjectFolder>>>();
     let discovered = 0;
 
     for (const selection of input.selection ?? []) {
@@ -5065,7 +5069,7 @@ export function companySkillService(db: Db) {
             ...nextSkill,
             key: existingBySource.key,
             slug: existingBySource.slug,
-          }]))[0];
+          }], projectFoldersById))[0];
           if (!persisted) continue;
           updated.push(persisted);
           upsertAcceptedSkill(persisted);
@@ -5162,7 +5166,7 @@ export function companySkillService(db: Db) {
             ...(selectiveImport && !selected ? { reason: "Not selected for import." } : {}),
           });
           if (mode === "preview" || !selected) continue;
-          const persisted = (await upsertImportedSkills(companyId, [nextSkill]))[0];
+          const persisted = (await upsertImportedSkills(companyId, [nextSkill], projectFoldersById))[0];
           if (!persisted) continue;
           updated.push(persisted);
           upsertAcceptedSkill(persisted);
@@ -5219,7 +5223,7 @@ export function companySkillService(db: Db) {
           ...(!selected ? { reason: "Not selected for import." } : {}),
         });
         if (mode === "preview" || !selected) continue;
-        const persisted = (await upsertImportedSkills(companyId, [nextSkill]))[0];
+        const persisted = (await upsertImportedSkills(companyId, [nextSkill], projectFoldersById))[0];
         if (!persisted) continue;
         imported.push(persisted);
         upsertAcceptedSkill(persisted);
@@ -5953,7 +5957,16 @@ export function companySkillService(db: Db) {
     return out;
   }
 
-  async function upsertImportedSkills(companyId: string, imported: ImportedSkill[]): Promise<CompanySkill[]> {
+  async function upsertImportedSkills(
+    companyId: string,
+    imported: ImportedSkill[],
+    // Cache resolved project folders per project id so a scan importing many
+    // skills for the same project resyncs that project's folder once, not
+    // once per skill. Callers that invoke this once per skill (e.g. the
+    // per-directory scan loop in scanProjectWorkspaces) pass a cache shared
+    // across those calls; other callers get one scoped to this call only.
+    projectFoldersById = new Map<string, Awaited<ReturnType<typeof folderSvc.ensureProjectFolder>>>(),
+  ): Promise<CompanySkill[]> {
     const out: CompanySkill[] = [];
     for (const skill of imported) {
       assertImportedSkillKeyAllowed(skill);
@@ -5990,9 +6003,15 @@ export function companySkillService(db: Db) {
       // Always resolve the project folder (not just for new skills) so a rescan
       // of an already-imported project resyncs its folder on a rename.
       // existing?.folderId still wins below, preserving manual folder moves.
-      const projectFolder = incomingKind === "project_scan" && projectId && projectName
-        ? await folderSvc.ensureProjectFolder(companyId, projectId, projectName)
-        : null;
+      // Resolved once per project id per scan (cached above), not once per skill.
+      let projectFolder: Awaited<ReturnType<typeof folderSvc.ensureProjectFolder>> | null = null;
+      if (incomingKind === "project_scan" && projectId && projectName) {
+        projectFolder = projectFoldersById.get(projectId) ?? null;
+        if (!projectFolder) {
+          projectFolder = await folderSvc.ensureProjectFolder(companyId, projectId, projectName);
+          projectFoldersById.set(projectId, projectFolder);
+        }
+      }
       const values: ImportedSkillPersistValues = {
         companyId,
         folderId: bundledFolder?.id ?? (existing ? existing.folderId ?? null : projectFolder?.id ?? null),

--- a/server/src/services/folders.ts
+++ b/server/src/services/folders.ts
@@ -398,7 +398,13 @@ export function folderService(db: Db, mutationLockHeld = false) {
     return { kind: input.kind, itemId: row.id, folderId: row.folderId ?? null };
   }
 
-  async function uniqueSiblingSlug(companyId: string, parentId: string | null, baseSlug: string, stableSuffix: string) {
+  async function uniqueSiblingSlug(
+    companyId: string,
+    parentId: string | null,
+    baseSlug: string,
+    stableSuffix: string,
+    excludeFolderId?: string,
+  ) {
     const siblingSlugs = new Set(await db
       .select({ slug: folders.slug })
       .from(folders)
@@ -406,6 +412,7 @@ export function folderService(db: Db, mutationLockHeld = false) {
         eq(folders.companyId, companyId),
         eq(folders.kind, "skill"),
         parentId === null ? sql`${folders.parentId} is null` : eq(folders.parentId, parentId),
+        excludeFolderId ? sql`${folders.id} != ${excludeFolderId}` : undefined,
       ))
       .then((rows) => rows.map((row) => row.slug)));
     if (!siblingSlugs.has(baseSlug)) return baseSlug;
@@ -536,10 +543,10 @@ export function folderService(db: Db, mutationLockHeld = false) {
     const patch: { name?: string; slug?: string } = {};
     if (existing.name !== name) patch.name = name;
     if (existing.slug !== desiredSlug) {
-      // uniqueSiblingSlug treats every sibling slug (including this folder's own,
-      // stale one) as taken, which is harmless here since we only reach this
-      // branch when the desired slug differs from the stale one.
-      const slug = await uniqueSiblingSlug(companyId, existing.parentId, desiredSlug, projectId);
+      // Exclude this folder's own (stale) slug from the collision check, so
+      // repeated resyncs of an unchanged desired slug converge on the same
+      // result instead of appending a new suffix every time.
+      const slug = await uniqueSiblingSlug(companyId, existing.parentId, desiredSlug, projectId, existing.id);
       if (slug !== existing.slug) patch.slug = slug;
     }
     if (Object.keys(patch).length > 0) {

--- a/server/src/services/folders.ts
+++ b/server/src/services/folders.ts
@@ -523,6 +523,34 @@ export function folderService(db: Db, mutationLockHeld = false) {
     throw conflict("Could not create personal skill folder");
   }
 
+  async function resyncProjectFolder(
+    companyId: string,
+    projectId: string,
+    projectName: string,
+    folderId: string,
+  ): Promise<Folder | null> {
+    const existing = await getFolderRow(companyId, folderId);
+    if (!existing) return null;
+    const name = normalizeName(projectName);
+    const desiredSlug = normalizeFolderSlug(name);
+    const patch: { name?: string; slug?: string } = {};
+    if (existing.name !== name) patch.name = name;
+    if (existing.slug !== desiredSlug) {
+      // uniqueSiblingSlug treats every sibling slug (including this folder's own,
+      // stale one) as taken, which is harmless here since we only reach this
+      // branch when the desired slug differs from the stale one.
+      const slug = await uniqueSiblingSlug(companyId, existing.parentId, desiredSlug, projectId);
+      if (slug !== existing.slug) patch.slug = slug;
+    }
+    if (Object.keys(patch).length > 0) {
+      await db
+        .update(folders)
+        .set({ ...patch, updatedAt: new Date() })
+        .where(and(eq(folders.companyId, companyId), eq(folders.id, existing.id)));
+    }
+    return getFolder(companyId, existing.id);
+  }
+
   async function ensureProjectFolder(companyId: string, projectId: string, projectName: string): Promise<Folder> {
     if (!mutationLockHeld) {
       return withCompanyFolderLock(companyId, (lockedDb) => folderService(lockedDb, true).ensureProjectFolder(companyId, projectId, projectName));
@@ -531,7 +559,11 @@ export function folderService(db: Db, mutationLockHeld = false) {
     const systemKey = `project:${projectId}`;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const resolved = await uniqueSystemSlug(companyId, parent.id, normalizeFolderSlug(projectName), systemKey);
-      if (resolved.id) return (await getFolder(companyId, resolved.id))!;
+      if (resolved.id) {
+        const synced = await resyncProjectFolder(companyId, projectId, projectName, resolved.id);
+        if (!synced) continue;
+        return synced;
+      }
       const created = await insertSystemFolder({
         companyId,
         parentId: parent.id,
@@ -542,6 +574,19 @@ export function folderService(db: Db, mutationLockHeld = false) {
       if (created) return created;
     }
     throw conflict("Could not create project skill folder");
+  }
+
+  /**
+   * Resync-only counterpart to `ensureProjectFolder`, for the project rename
+   * path: it must never create a folder for a project that never had one.
+   */
+  async function renameProjectFolder(companyId: string, projectId: string, projectName: string): Promise<Folder | null> {
+    if (!mutationLockHeld) {
+      return withCompanyFolderLock(companyId, (lockedDb) => folderService(lockedDb, true).renameProjectFolder(companyId, projectId, projectName));
+    }
+    const existing = await findSystemFolder(companyId, `project:${projectId}`);
+    if (!existing) return null;
+    return resyncProjectFolder(companyId, projectId, projectName, existing.id);
   }
 
   async function ensureBundledCategory(companyId: string, category: string): Promise<Folder> {
@@ -613,6 +658,7 @@ export function folderService(db: Db, mutationLockHeld = false) {
     validateSkillFolder,
     ensureMyFolder,
     ensureProjectFolder,
+    renameProjectFolder,
     ensureBundledCategory,
     pruneEmptyBundledCategories,
   };

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -32,6 +32,7 @@ import { listCurrentRuntimeServicesForProjectWorkspaces } from "./workspace-runt
 import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
 import { mergeProjectWorkspaceRuntimeConfig, readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
 import { resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { folderService } from "./folders.js";
 
 type ProjectRow = typeof projects.$inferSelect;
 type ProjectWorkspaceRow = typeof projectWorkspaces.$inferSelect;
@@ -825,6 +826,15 @@ export function projectService(db: Db) {
         .returning()
         .then((rows) => rows[0] ?? null);
       if (!row) return null;
+
+      if (row.name !== existingProject.name) {
+        // Best effort — a folder resync problem must not fail the rename itself.
+        try {
+          await folderService(db).renameProjectFolder(row.companyId, row.id, row.name);
+        } catch (error) {
+          console.warn(`Could not resync the skill folder of project ${row.id}:`, error);
+        }
+      }
 
       if (ids !== undefined) {
         await syncGoalLinks(db, id, row.companyId, ids);


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each project gets a system-managed skill folder (`systemKey: project:<id>`) that groups its imported skills
> - When a user renames a project, that folder should show the new name
> - But the folder service only ever creates the folder once and then hands it back untouched, so a rename never reaches it
> - This pull request adds a resync-only `renameProjectFolder` entry point, calls it from the project update path, and makes the existing `ensureProjectFolder`/rescan path resync too
> - The benefit is a project's skill folder always matches its current name, whether the user renames the project or just rescans its skills

## Linked Issues or Issue Description

Fixes: #11099

## What Changed

- `server/src/services/folders.ts`: add a `resyncProjectFolder` helper that patches an existing project folder's `name` and `slug` when they drift from the current project name (mirrors the resync `ensureBundledCategory` already does, plus slug handling). Export a new `renameProjectFolder(companyId, projectId, projectName)` that resyncs an existing project folder but never creates one — a project that never had a folder must not grow one on rename. `ensureProjectFolder` now also resyncs on every cache hit, not just on create.
- `server/src/services/projects.ts`: call `folderService(db).renameProjectFolder(...)` from `projectService(db).update` whenever the project name actually changes. This is best-effort — a folder resync failure is logged and does not fail the rename.
- `server/src/services/company-skills.ts`: drop the `!existing` guard so a rescan of an already-imported project still calls `ensureProjectFolder` and resyncs the folder name/slug. `existing?.folderId` still wins over the resolved project folder, so a skill the user manually moved to a different folder stays put.

## Verification

- Added `server/src/__tests__/project-rename-folder-resync.test.ts` (embedded Postgres):
  - renaming a project via `projectService(db).update` resyncs its skill folder's `name` and `slug`
  - calling `ensureProjectFolder` again with a new name resyncs the folder even without an explicit rename call (covers the rescan path)
  - `renameProjectFolder` returns `null` and does not create a folder for a project that never had one
- `cd server && npx vitest run src/__tests__/project-rename-folder-resync.test.ts src/__tests__/folders-service.test.ts` → 2 files, 19 tests, all pass
- `cd server && npx vitest run src/__tests__/company-skills.test.ts src/__tests__/company-skills-service.test.ts` → all pass except 2 pre-existing, unrelated timeouts in fork-creation tests (confirmed flaky/host-timing, not caused by this change: they pass individually with a longer timeout)
- `cd server && npx vitest run src/__tests__/project-icon-persistence.test.ts src/__tests__/project-shortname-resolution.test.ts src/__tests__/project-list-metrics.test.ts` → all pass
- `cd server && npx tsc --noEmit` → no new errors in the changed files (remaining errors are pre-existing, from `@paperclipai/plugin-sdk` not being built in this scoped checkout, unrelated to `folders.ts`/`projects.ts`/`company-skills.ts`)

## Risks

- Low risk. The resync only patches `name`/`slug` on an already-existing system folder, is idempotent, and is wrapped in the existing per-company folder advisory lock.
- The rename-triggered resync in `projects.ts` is best-effort: a folder-service error is caught and logged, so it cannot fail a project rename.
- No migration or schema change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude (Anthropic), model ID `claude-sonnet-5` (Sonnet 5). Standard reasoning mode, no extended thinking. Used with tool use (file read/edit, bash, git, gh CLI) inside an agentic coding session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
