### PR TITLE
feat(adapter-utils): opt-in allowlist for agent env inheritance

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -47,6 +47,10 @@ In `allowlist` mode Paperclip inherits `PATH`, `HOME`, `PWD`, `SHELL`, `USER`,
 Windows platform keys. It removes all other inherited keys and writes their
 names, not their values, to the server log one time.
 
+The proxy keys are inherited as routing information. If a proxy address embeds
+credentials, as in `HTTPS_PROXY=http://user:password@proxy.internal:3128`, that
+value is removed unless you name the key in `PAPERCLIP_AGENT_ENV_ALLOW`.
+
 Adapter and agent config env is not affected. A variable that an agent declares
 in its own config always reaches the agent process. If your deployment gives
 provider keys to agents through the server environment, list those keys in

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -28,6 +28,30 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_SECRETS_MASTER_KEY_FILE` | `~/.paperclip/.../secrets/master.key` | Path to key file |
 | `PAPERCLIP_SECRETS_STRICT_MODE` | `false` | Require secret refs for sensitive env vars |
 
+## Agent Environment Inheritance
+
+An agent process inherits the environment of the Paperclip server process, then
+adapter and agent config env applies on top. The server environment can hold
+values that agents must not read. In `docker-compose.quickstart.yml`, for
+example, `BETTER_AUTH_SECRET` and the database password are in the same env
+block as the LLM provider keys.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAPERCLIP_AGENT_ENV_INHERIT` | `all` | `all` gives agent processes the full server environment. `allowlist` gives them only the toolchain keys they need, plus the keys in `PAPERCLIP_AGENT_ENV_ALLOW`. |
+| `PAPERCLIP_AGENT_ENV_ALLOW` | (unset) | Comma-separated keys to add in `allowlist` mode. A trailing `*` matches a prefix, for example `ANTHROPIC_API_KEY,AWS_*`. |
+
+In `allowlist` mode Paperclip inherits `PATH`, `HOME`, `PWD`, `SHELL`, `USER`,
+`LOGNAME`, `TERM`, `TZ`, the temporary directory keys, `LANG` and `LC_*`,
+`XDG_*`, the proxy and TLS trust-store keys, the Node.js toolchain keys, and the
+Windows platform keys. It removes all other inherited keys and writes their
+names, not their values, to the server log one time.
+
+Adapter and agent config env is not affected. A variable that an agent declares
+in its own config always reaches the agent process. If your deployment gives
+provider keys to agents through the server environment, list those keys in
+`PAPERCLIP_AGENT_ENV_ALLOW` before you set `allowlist`.
+
 ## Agent Runtime (Injected into agent processes)
 
 These are set automatically by the server when invoking agents:

--- a/packages/adapter-utils/src/server-utils-env.test.ts
+++ b/packages/adapter-utils/src/server-utils-env.test.ts
@@ -1,5 +1,109 @@
-import { describe, expect, it } from "vitest";
-import { sanitizeInheritedPaperclipEnv } from "./server-utils.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildInheritedAgentEnv,
+  isInheritableAgentEnvKey,
+  resetDroppedAgentEnvKeysWarningForTests,
+  resolveAgentEnvInheritMode,
+  sanitizeInheritedPaperclipEnv,
+} from "./server-utils.js";
+
+// A server environment shaped like docker/docker-compose.quickstart.yml, where
+// the server secrets and the LLM provider key are in the same env block.
+const QUICKSTART_SERVER_ENV: NodeJS.ProcessEnv = {
+  PATH: "/usr/bin",
+  HOME: "/home/node",
+  LC_ALL: "C.UTF-8",
+  https_proxy: "http://proxy.internal:3128",
+  ANTHROPIC_API_KEY: "sk-ant-test",
+  BETTER_AUTH_SECRET: "server-only-signing-secret",
+  BETTER_AUTH_BASE_URL: "http://127.0.0.1:3100",
+  POSTGRES_PASSWORD: "server-only-db-password",
+  DATABASE_URL: "postgres://paperclip:server-only-db-password@db:5432/paperclip",
+  PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+  PAPERCLIP_HOME: "/data/paperclip",
+};
+
+describe("buildInheritedAgentEnv", () => {
+  afterEach(() => {
+    resetDroppedAgentEnvKeysWarningForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to the current inherit-everything behaviour", () => {
+    expect(resolveAgentEnvInheritMode(QUICKSTART_SERVER_ENV)).toBe("all");
+    expect(buildInheritedAgentEnv(QUICKSTART_SERVER_ENV)).toEqual(
+      sanitizeInheritedPaperclipEnv(QUICKSTART_SERVER_ENV),
+    );
+  });
+
+  it("keeps server secrets out of the agent env in allowlist mode", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = buildInheritedAgentEnv({
+      ...QUICKSTART_SERVER_ENV,
+      PAPERCLIP_AGENT_ENV_INHERIT: "allowlist",
+    });
+
+    expect(env).not.toHaveProperty("BETTER_AUTH_SECRET");
+    expect(env).not.toHaveProperty("BETTER_AUTH_BASE_URL");
+    expect(env).not.toHaveProperty("POSTGRES_PASSWORD");
+    expect(env).not.toHaveProperty("DATABASE_URL");
+    // No inherited value survives under a different name either.
+    expect(Object.values(env)).not.toContain("server-only-signing-secret");
+    expect(Object.values(env).join("\n")).not.toContain("server-only-db-password");
+  });
+
+  it("keeps the toolchain keys an agent process needs", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = buildInheritedAgentEnv({
+      ...QUICKSTART_SERVER_ENV,
+      PAPERCLIP_AGENT_ENV_INHERIT: "allowlist",
+    });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/node");
+    expect(env.LC_ALL).toBe("C.UTF-8");
+    expect(env.https_proxy).toBe("http://proxy.internal:3128");
+    // sanitizeInheritedPaperclipEnv rules still decide the PAPERCLIP_* keys.
+    expect(env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3100");
+    expect(env).not.toHaveProperty("PAPERCLIP_HOME");
+  });
+
+  it("inherits deployment keys named in PAPERCLIP_AGENT_ENV_ALLOW", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = buildInheritedAgentEnv({
+      ...QUICKSTART_SERVER_ENV,
+      AWS_REGION: "eu-west-1",
+      PAPERCLIP_AGENT_ENV_INHERIT: "allowlist",
+      PAPERCLIP_AGENT_ENV_ALLOW: "ANTHROPIC_API_KEY, AWS_*",
+    });
+
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+    expect(env.AWS_REGION).toBe("eu-west-1");
+    // The allow list does not widen to the server secrets.
+    expect(env).not.toHaveProperty("BETTER_AUTH_SECRET");
+  });
+
+  it("reports the removed variable names once, without their values", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const serverEnv = { ...QUICKSTART_SERVER_ENV, PAPERCLIP_AGENT_ENV_INHERIT: "allowlist" };
+
+    buildInheritedAgentEnv(serverEnv);
+    buildInheritedAgentEnv(serverEnv);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("BETTER_AUTH_SECRET");
+    expect(message).not.toContain("server-only-signing-secret");
+  });
+
+  it("matches allow patterns and proxy keys case-insensitively", () => {
+    expect(isInheritableAgentEnvKey("HTTPS_PROXY", {})).toBe(true);
+    expect(isInheritableAgentEnvKey("no_proxy", {})).toBe(true);
+    expect(isInheritableAgentEnvKey("BETTER_AUTH_SECRET", {})).toBe(false);
+    expect(isInheritableAgentEnvKey("aws_region", { PAPERCLIP_AGENT_ENV_ALLOW: "aws_*" })).toBe(true);
+    expect(isInheritableAgentEnvKey("BETTER_AUTH_SECRET", { PAPERCLIP_AGENT_ENV_ALLOW: "" })).toBe(false);
+  });
+});
 
 describe("sanitizeInheritedPaperclipEnv", () => {
   it("drops the host-only Paperclip CLI command pointer", () => {

--- a/packages/adapter-utils/src/server-utils-env.test.ts
+++ b/packages/adapter-utils/src/server-utils-env.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildInheritedAgentEnv,
@@ -102,6 +105,89 @@ describe("buildInheritedAgentEnv", () => {
     expect(isInheritableAgentEnvKey("BETTER_AUTH_SECRET", {})).toBe(false);
     expect(isInheritableAgentEnvKey("aws_region", { PAPERCLIP_AGENT_ENV_ALLOW: "aws_*" })).toBe(true);
     expect(isInheritableAgentEnvKey("BETTER_AUTH_SECRET", { PAPERCLIP_AGENT_ENV_ALLOW: "" })).toBe(false);
+  });
+
+  it("inherits a proxy address but not credentials embedded in it", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = buildInheritedAgentEnv({
+      ...QUICKSTART_SERVER_ENV,
+      PAPERCLIP_AGENT_ENV_INHERIT: "allowlist",
+      https_proxy: "http://proxy-user:proxy-password@proxy.internal:3128",
+      no_proxy: "localhost,127.0.0.1",
+    });
+    expect(env.https_proxy).toBeUndefined();
+    expect(env.no_proxy).toBe("localhost,127.0.0.1");
+  });
+
+  it("inherits a credentialed proxy only when it is named explicitly", () => {
+    const credentialed = "http://proxy-user:proxy-password@proxy.internal:3128";
+    expect(isInheritableAgentEnvKey("HTTPS_PROXY", {}, credentialed)).toBe(false);
+    expect(
+      isInheritableAgentEnvKey("HTTPS_PROXY", { PAPERCLIP_AGENT_ENV_ALLOW: "HTTPS_PROXY" }, credentialed),
+    ).toBe(true);
+    expect(isInheritableAgentEnvKey("HTTPS_PROXY", {}, "http://proxy.internal:3128")).toBe(true);
+    // A bare host:port has no authority delimiter and carries no credentials.
+    expect(isInheritableAgentEnvKey("HTTPS_PROXY", {}, "proxy.internal:3128")).toBe(true);
+  });
+});
+
+describe("adapter runtime env construction", () => {
+  afterEach(() => {
+    resetDroppedAgentEnvKeysWarningForTests();
+    vi.restoreAllMocks();
+  });
+
+  // Local adapters build a runtime env by spreading the server environment and
+  // then the explicitly configured agent env on top. Spreading process.env
+  // directly would put every filtered secret back, so the adapters spread the
+  // filtered environment instead. This test binds that contract.
+  it("does not restore filtered server secrets when adapter config is merged on top", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const serverEnv: NodeJS.ProcessEnv = {
+      ...QUICKSTART_SERVER_ENV,
+      PAPERCLIP_AGENT_ENV_INHERIT: "allowlist",
+    };
+    const adapterConfigEnv: NodeJS.ProcessEnv = { ANTHROPIC_API_KEY: "sk-ant-from-agent-config" };
+
+    const runtimeEnv: NodeJS.ProcessEnv = { ...buildInheritedAgentEnv(serverEnv), ...adapterConfigEnv };
+
+    expect(runtimeEnv.BETTER_AUTH_SECRET).toBeUndefined();
+    expect(runtimeEnv.POSTGRES_PASSWORD).toBeUndefined();
+    expect(runtimeEnv.DATABASE_URL).toBeUndefined();
+    // Explicit configuration still wins, which is the documented behaviour.
+    expect(runtimeEnv.ANTHROPIC_API_KEY).toBe("sk-ant-from-agent-config");
+    expect(runtimeEnv.PATH).toBe("/usr/bin");
+  });
+});
+
+// The filter only holds if every adapter that materialises the server
+// environment for a child process goes through buildInheritedAgentEnv. A raw
+// `...process.env` spread reintroduces the secrets one merge later, which is
+// invisible in a unit test of the helper itself. This guard fails on the
+// source instead.
+describe("adapter sources do not spread process.env directly", () => {
+  const adaptersDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "adapters");
+
+  function collectServerSources(dir: string): string[] {
+    const found: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === "dist") continue;
+        found.push(...collectServerSources(full));
+        continue;
+      }
+      if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) continue;
+      found.push(full);
+    }
+    return found;
+  }
+
+  it("routes inherited server env through buildInheritedAgentEnv", () => {
+    const offenders = collectServerSources(adaptersDir).filter((file) =>
+      readFileSync(file, "utf8").includes("...process.env"),
+    );
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2417,15 +2417,55 @@ function readAgentEnvAllowExtras(baseEnv: NodeJS.ProcessEnv): string[] {
     .filter(Boolean);
 }
 
-export function isInheritableAgentEnvKey(key: string, baseEnv: NodeJS.ProcessEnv = process.env): boolean {
+const PROXY_ENV_KEY_PATTERN = /^(HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|FTP_PROXY)$/;
+
+/**
+ * True when a proxy value carries an embedded username or password, as in
+ * `http://user:password@proxy.internal:3128`.
+ *
+ * A proxy address on its own is routing information, so the allowlist grants
+ * it without asking. Credentials in that address are not routing information,
+ * so they follow the same rule as any other secret and need an explicit entry
+ * in `PAPERCLIP_AGENT_ENV_ALLOW`.
+ */
+function proxyValueCarriesCredentials(value: string | undefined): boolean {
+  if (!value) return false;
+  for (const candidate of value.split(",")) {
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    // A bare `host:port` has no authority section, so give it one to parse.
+    const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+    try {
+      const parsed = new URL(withScheme);
+      if (parsed.username || parsed.password) return true;
+    } catch {
+      // Unparseable values are treated conservatively: an `@` before the first
+      // `/` is the shape of an authority section that holds credentials.
+      const authority = trimmed.split("/")[0] ?? "";
+      if (authority.includes("@")) return true;
+    }
+  }
+  return false;
+}
+
+export function isInheritableAgentEnvKey(
+  key: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  value?: string,
+): boolean {
   const normalizedKey = key.toUpperCase();
+  const explicitlyAllowed = readAgentEnvAllowExtras(baseEnv).some((pattern) =>
+    matchesAllowPattern(normalizedKey, pattern),
+  );
+  if (explicitlyAllowed) return true;
   // Proxy settings are conventionally lowercase, so compare case-insensitively.
-  if (/^(HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|FTP_PROXY)$/.test(normalizedKey)) return true;
+  // The address is inherited, credentials embedded in it are not.
+  if (PROXY_ENV_KEY_PATTERN.test(normalizedKey)) return !proxyValueCarriesCredentials(value);
   if (AGENT_ENV_INHERIT_ALLOWLIST.has(normalizedKey)) return true;
   if (AGENT_ENV_INHERIT_ALLOWLIST_PREFIXES.some((prefix) => normalizedKey.startsWith(prefix))) return true;
   // PAPERCLIP_* keys keep their own rules in sanitizeInheritedPaperclipEnv.
   if (normalizedKey.startsWith("PAPERCLIP_")) return true;
-  return readAgentEnvAllowExtras(baseEnv).some((pattern) => matchesAllowPattern(normalizedKey, pattern));
+  return false;
 }
 
 export type AgentEnvInheritMode = "all" | "allowlist";
@@ -2459,7 +2499,7 @@ export function buildInheritedAgentEnv(baseEnv: NodeJS.ProcessEnv = process.env)
   const allowed: NodeJS.ProcessEnv = {};
   const dropped: string[] = [];
   for (const [key, value] of Object.entries(sanitized)) {
-    if (isInheritableAgentEnvKey(key, baseEnv)) {
+    if (isInheritableAgentEnvKey(key, baseEnv, value)) {
       allowed[key] = value;
       continue;
     }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2348,6 +2348,144 @@ export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJ
   return env;
 }
 
+// Environment keys that a spawned agent process needs to find its toolchain,
+// write temporary files, reach the network, and render text correctly. These
+// carry no account identity, so they are safe to inherit from the server.
+const AGENT_ENV_INHERIT_ALLOWLIST = new Set([
+  // Process and user identity
+  "PATH",
+  "HOME",
+  "PWD",
+  "SHELL",
+  "USER",
+  "LOGNAME",
+  "TERM",
+  "TZ",
+  // Temporary directories
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  // Language and locale
+  "LANG",
+  "LANGUAGE",
+  // Node.js and package manager toolchains
+  "NODE_EXTRA_CA_CERTS",
+  "NVM_DIR",
+  "NVM_BIN",
+  "NVM_INC",
+  "VOLTA_HOME",
+  "FNM_DIR",
+  "ASDF_DIR",
+  "ASDF_DATA_DIR",
+  // TLS trust stores
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "REQUESTS_CA_BUNDLE",
+  "CURL_CA_BUNDLE",
+  // Windows platform keys
+  "SYSTEMROOT",
+  "SYSTEMDRIVE",
+  "WINDIR",
+  "COMSPEC",
+  "PATHEXT",
+  "USERPROFILE",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PROGRAMFILES",
+  "PROGRAMFILES(X86)",
+  "PROGRAMDATA",
+  "NUMBER_OF_PROCESSORS",
+  "PROCESSOR_ARCHITECTURE",
+]);
+
+// Key prefixes that follow the same rule as the list above.
+const AGENT_ENV_INHERIT_ALLOWLIST_PREFIXES = ["LC_", "XDG_"];
+
+function matchesAllowPattern(normalizedKey: string, pattern: string): boolean {
+  const normalizedPattern = pattern.trim().toUpperCase();
+  if (!normalizedPattern) return false;
+  if (normalizedPattern.endsWith("*")) {
+    return normalizedKey.startsWith(normalizedPattern.slice(0, -1));
+  }
+  return normalizedKey === normalizedPattern;
+}
+
+function readAgentEnvAllowExtras(baseEnv: NodeJS.ProcessEnv): string[] {
+  return (baseEnv.PAPERCLIP_AGENT_ENV_ALLOW ?? "")
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function isInheritableAgentEnvKey(key: string, baseEnv: NodeJS.ProcessEnv = process.env): boolean {
+  const normalizedKey = key.toUpperCase();
+  // Proxy settings are conventionally lowercase, so compare case-insensitively.
+  if (/^(HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|FTP_PROXY)$/.test(normalizedKey)) return true;
+  if (AGENT_ENV_INHERIT_ALLOWLIST.has(normalizedKey)) return true;
+  if (AGENT_ENV_INHERIT_ALLOWLIST_PREFIXES.some((prefix) => normalizedKey.startsWith(prefix))) return true;
+  // PAPERCLIP_* keys keep their own rules in sanitizeInheritedPaperclipEnv.
+  if (normalizedKey.startsWith("PAPERCLIP_")) return true;
+  return readAgentEnvAllowExtras(baseEnv).some((pattern) => matchesAllowPattern(normalizedKey, pattern));
+}
+
+export type AgentEnvInheritMode = "all" | "allowlist";
+
+export function resolveAgentEnvInheritMode(baseEnv: NodeJS.ProcessEnv = process.env): AgentEnvInheritMode {
+  return (baseEnv.PAPERCLIP_AGENT_ENV_INHERIT ?? "").trim().toLowerCase() === "allowlist" ? "allowlist" : "all";
+}
+
+/**
+ * Build the environment that a spawned agent process inherits from the server
+ * process.
+ *
+ * The server process holds configuration that agents must not read, for
+ * example `BETTER_AUTH_SECRET` and database credentials. The documented
+ * quickstart puts those values in the same container environment as the LLM
+ * provider keys, so an unfiltered copy gives every agent the server's secrets.
+ *
+ * Set `PAPERCLIP_AGENT_ENV_INHERIT=allowlist` to inherit only the keys that an
+ * agent process needs. Add deployment-specific keys with
+ * `PAPERCLIP_AGENT_ENV_ALLOW`, which accepts a comma-separated list and a
+ * trailing `*` wildcard, for example `ANTHROPIC_API_KEY,AWS_*`.
+ *
+ * The default stays `all` to keep current deployments working. Adapter and
+ * agent config env always applies after this function, so an explicitly
+ * configured variable is never removed here.
+ */
+export function buildInheritedAgentEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const sanitized = sanitizeInheritedPaperclipEnv(baseEnv);
+  if (resolveAgentEnvInheritMode(baseEnv) !== "allowlist") return sanitized;
+
+  const allowed: NodeJS.ProcessEnv = {};
+  const dropped: string[] = [];
+  for (const [key, value] of Object.entries(sanitized)) {
+    if (isInheritableAgentEnvKey(key, baseEnv)) {
+      allowed[key] = value;
+      continue;
+    }
+    dropped.push(key);
+  }
+  warnAboutDroppedAgentEnvKeys(dropped);
+  return allowed;
+}
+
+let droppedAgentEnvKeysWarned = false;
+
+function warnAboutDroppedAgentEnvKeys(dropped: string[]): void {
+  if (droppedAgentEnvKeysWarned || dropped.length === 0) return;
+  droppedAgentEnvKeysWarned = true;
+  // Names only. Values stay out of the log.
+  console.warn(
+    `[paperclip] PAPERCLIP_AGENT_ENV_INHERIT=allowlist removed ${dropped.length} inherited variable(s) from agent processes: ` +
+      `${dropped.slice().sort().join(", ")}. Add any variable an agent needs to PAPERCLIP_AGENT_ENV_ALLOW.`,
+  );
+}
+
+/** Test-only. Lets a test observe the one-time warning again. */
+export function resetDroppedAgentEnvKeysWarningForTests(): void {
+  droppedAgentEnvKeysWarned = false;
+}
+
 export function defaultPathForPlatform() {
   if (process.platform === "win32") {
     return "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\Wbem";
@@ -3306,7 +3444,7 @@ export async function runChildProcess(
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
   return new Promise<RunProcessResult>((resolve, reject) => {
     const rawMerged: NodeJS.ProcessEnv = {
-      ...sanitizeInheritedPaperclipEnv(process.env),
+      ...buildInheritedAgentEnv(process.env),
       ...opts.env,
     };
 

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -47,6 +47,7 @@ import {
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseLocalProcessFilesystemScope,
@@ -302,7 +303,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   }
 
   const runtimeEnv = Object.fromEntries(
-    Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
+    Object.entries(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env })).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
@@ -476,7 +477,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     asNumber(config.terminalResultCleanupGraceMs, 5_000),
   );
   const effectiveEnv = Object.fromEntries(
-    Object.entries({ ...process.env, ...env }).filter(
+    Object.entries({ ...buildInheritedAgentEnv(process.env), ...env }).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
@@ -689,7 +690,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     });
     if (paperclipBridge) {
       Object.assign(env, paperclipBridge.env);
-      const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+      const runtimeEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
       loggedEnv = buildInvocationEnvForLogs(env, {
         runtimeEnv,
         includeRuntimeKeys: ["HOME", "CLAUDE_CONFIG_DIR"],

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -14,6 +14,7 @@ import {
   parseJson,
   parseObject,
   ensurePathInEnv,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
@@ -223,7 +224,7 @@ export async function testEnvironment(
       }
     }
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
   try {
     await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
     checks.push({

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -47,6 +47,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   joinPromptSections,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseLocalProcessFilesystemScope,
@@ -962,7 +963,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
     }
     const effectiveEnv = Object.fromEntries(
-      Object.entries({ ...process.env, ...env }).filter(
+      Object.entries({ ...buildInheritedAgentEnv(process.env), ...env }).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -7,6 +7,7 @@ import {
   asString,
   parseObject,
   ensurePathInEnv,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
@@ -258,7 +259,7 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
   const installCheck = await maybeRunSandboxInstallCommand({
     runId,
     target,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -44,6 +44,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   joinPromptSections,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
@@ -436,7 +437,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
   const effectiveEnv = Object.fromEntries(
-    Object.entries({ ...process.env, ...env }).filter(
+    Object.entries({ ...buildInheritedAgentEnv(process.env), ...env }).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
@@ -465,7 +466,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (paperclipBridge) {
       Object.assign(env, paperclipBridge.env);
       loggedEnv = buildInvocationEnvForLogs(env, {
-        runtimeEnv: ensurePathInEnv({ ...process.env, ...env }),
+        runtimeEnv: ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env }),
         includeRuntimeKeys: ["HOME"],
         resolvedCommand,
       });

--- a/packages/adapters/cursor-local/src/server/test.ts
+++ b/packages/adapters/cursor-local/src/server/test.ts
@@ -9,6 +9,7 @@ import {
   asStringArray,
   parseObject,
   ensurePathInEnv,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
@@ -171,7 +172,7 @@ export async function testEnvironment(
   });
   command = finalSandboxCommand.command;
   env = finalSandboxCommand.env;
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
   try {
     await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
     checks.push({

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -47,6 +47,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   runChildProcess,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GEMINI_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
 import {
@@ -94,7 +95,7 @@ function buildGeminiHeadlessEnv(env: Record<string, string>): Record<string, str
 
 function buildGeminiRuntimeEnv(env: Record<string, string>): Record<string, string> {
   return Object.fromEntries(
-    Object.entries(ensurePathInEnv({ ...process.env, ...buildGeminiHeadlessEnv(env) })).filter(
+    Object.entries(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...buildGeminiHeadlessEnv(env) })).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );

--- a/packages/adapters/gemini-local/src/server/test.ts
+++ b/packages/adapters/gemini-local/src/server/test.ts
@@ -11,6 +11,7 @@ import {
   asStringArray,
   ensurePathInEnv,
   parseObject,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
@@ -118,7 +119,7 @@ export async function testEnvironment(
   if (targetIsRemote && typeof env.GEMINI_CLI_TRUST_WORKSPACE !== "string") {
     env.GEMINI_CLI_TRUST_WORKSPACE = "true";
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
   const installCheck = await maybeRunSandboxInstallCommand({
     runId,
     target,

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -38,6 +38,7 @@ import {
   stringifyPaperclipWakePayload,
   refreshPaperclipWorkspaceEnvForExecution,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GROK_LOCAL_MODEL } from "../index.js";
 import { isGrokUnknownSessionError, parseGrokJsonl } from "./parse.js";
@@ -347,7 +348,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
     const effectiveEnv = Object.fromEntries(
-      Object.entries({ ...process.env, ...env }).filter(
+      Object.entries({ ...buildInheritedAgentEnv(process.env), ...env }).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );

--- a/packages/adapters/grok-local/src/server/test.ts
+++ b/packages/adapters/grok-local/src/server/test.ts
@@ -9,6 +9,7 @@ import {
   asStringArray,
   ensurePathInEnv,
   parseObject,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   describeAdapterExecutionTarget,
@@ -143,7 +144,7 @@ export async function testEnvironment(
   }
 
   const env = normalizeEnv(config.env);
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const runtimeEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
 
   try {
     await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -44,6 +44,7 @@ import {
   readPaperclipRuntimeSkillEntries,
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import {
@@ -323,7 +324,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     preparedRuntimeConfig.notes.length > 0 ? preparedRuntimeConfig.env.XDG_CONFIG_HOME : "";
   try {
     const runtimeEnv = Object.fromEntries(
-      Object.entries(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env })).filter(
+      Object.entries(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...preparedRuntimeConfig.env })).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );
@@ -470,7 +471,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         Object.assign(preparedRuntimeConfig.env, paperclipBridge.env);
         loggedEnv = buildInvocationEnvForLogs(preparedRuntimeConfig.env, {
           runtimeEnv: Object.fromEntries(
-            Object.entries(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env })).filter(
+            Object.entries(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...preparedRuntimeConfig.env })).filter(
               (entry): entry is [string, string] => typeof entry[1] === "string",
             ),
           ),

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -5,6 +5,7 @@ import {
   asString,
   ensurePathInEnv,
   runChildProcess,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isValidOpenCodeModelId } from "../index.js";
 
@@ -130,7 +131,7 @@ export async function discoverOpenCodeModels(input: {
     // image). Fall back to process.env.HOME.
   }
   // Prevent OpenCode from writing an opencode.json into the working directory.
-  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}), OPENCODE_DISABLE_PROJECT_CONFIG: "true" }));
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}), OPENCODE_DISABLE_PROJECT_CONFIG: "true" }));
 
   const result = await runChildProcess(
     `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -14,6 +14,7 @@ import {
   asStringArray,
   parseObject,
   ensurePathInEnv,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
@@ -173,7 +174,7 @@ export async function testEnvironment(
         preparedRuntimeConfig.env.XDG_CONFIG_HOME = preparedExecutionTargetRuntime.assetDirs.xdgConfig;
       }
     }
-    const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env }));
+    const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...preparedRuntimeConfig.env }));
 
     const cwdInvalid = checks.some((check) => check.code === "opencode_cwd_invalid");
     if (cwdInvalid) {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -45,6 +45,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   runChildProcess,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import { shellQuote } from "@paperclipai/adapter-utils/ssh";
 import { isPiUnknownSessionError, parsePiJsonl } from "./parse.js";
@@ -336,7 +337,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const skillBinDirs = piSkillEntries
       .filter((entry) => injectedSkillKeys.has(entry.key) && entry.source.length > 0)
       .map((entry) => path.join(entry.source, "bin"));
-    const mergedEnv = ensurePathInEnv({ ...process.env, ...env });
+    const mergedEnv = ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env });
     const pathKey =
       typeof mergedEnv.Path === "string" && mergedEnv.Path.length > 0 && !mergedEnv.PATH
         ? "Path"
@@ -479,7 +480,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         Object.assign(env, paperclipBridge.env);
         loggedEnv = buildInvocationEnvForLogs(env, {
           runtimeEnv: Object.fromEntries(
-            Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
+            Object.entries(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env })).filter(
               (entry): entry is [string, string] => typeof entry[1] === "string",
             ),
           ),

--- a/packages/adapters/pi-local/src/server/models.ts
+++ b/packages/adapters/pi-local/src/server/models.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { AdapterModel } from "@paperclipai/adapter-utils";
-import { asString, runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import { asString, runChildProcess, buildInheritedAgentEnv } from "@paperclipai/adapter-utils/server-utils";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 
@@ -108,7 +108,7 @@ export async function discoverPiModels(input: {
   const command = resolvePiCommand(input.command);
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
-  const runtimeEnv = normalizeEnv({ ...process.env, ...env });
+  const runtimeEnv = normalizeEnv({ ...buildInheritedAgentEnv(process.env), ...env });
 
   const result = await runChildProcess(
     `pi-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,

--- a/packages/adapters/pi-local/src/server/test.ts
+++ b/packages/adapters/pi-local/src/server/test.ts
@@ -7,6 +7,7 @@ import {
   asString,
   parseObject,
   ensurePathInEnv,
+  buildInheritedAgentEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   asStringArray,
@@ -125,7 +126,7 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...buildInheritedAgentEnv(process.env), ...env }));
 
   const cwdInvalid = checks.some((check) => check.code === "pi_cwd_invalid");
   if (cwdInvalid) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The adapter layer builds the environment for every agent child process. `runChildProcess` in `packages/adapter-utils/src/server-utils.ts` is the single spawn point
> - An agent process inherits the full environment of the server process. `docker/docker-compose.quickstart.yml` puts `BETTER_AUTH_SECRET` and the database password in the same env block as the LLM provider keys, so the documented way to give an agent a model credential also gives it the server signing secret
> - A denylist of known secret names does not hold this line. It covers only the names somebody already found, and no test fails when a new server config key is added
> - This pull request adds an opt-in allowlist mode, so a value that an agent does not need is never passed to the child process
> - The filter must apply at every place that materialises the server environment for a child, not only at the spawn call. The local adapters build their runtime env as `{ ...process.env, ...env }` and pass it as `opts.env`, which is merged after the filter
> - The benefit is that the agent process never receives the value. It is absent from the child environ, from any tool that dumps the environment, and from any log downstream

## Linked Issues or Issue Description

Refs #4734 — strips two named signing secrets in `runChildProcess`. That is a denylist of two names.
Refs #7428 — adds a narrow inherited-env denylist. Same shape, same limit.
Refs #11329 — stops agents inheriting one specific value, `NODE_ENV=production`.
Refs #10052 — isolates the child environment for one adapter only.

**Describe the bug**
An agent process receives the full environment of the Paperclip server process, including `BETTER_AUTH_SECRET`, `POSTGRES_PASSWORD` and `DATABASE_URL`. Agents do not validate sessions and do not need the server signing secret.

**To Reproduce**
1. Start the server with `docker/docker-compose.quickstart.yml`.
2. Start any agent that uses a local adapter.
3. Read `/proc/<agent-pid>/environ` on the host.
4. The server secrets are present.

**Expected behavior**
An operator can limit the inherited environment to the keys an agent process needs. Explicit adapter and agent config still reaches the agent.

**Additional context**
The three referenced pull requests each remove one or two named values. A new server configuration key is inherited again by default, and no test catches it. This change inverts the rule instead of extending the list.

## What Changed

- Add `buildInheritedAgentEnv()` in `packages/adapter-utils/src/server-utils.ts`. It wraps `sanitizeInheritedPaperclipEnv` and applies the allowlist when the mode is on.
- Use it at the `runChildProcess` spawn site.
- Use it in the 7 local adapters that build a runtime env from `process.env` (`claude`, `codex`, `cursor`, `gemini`, `grok`, `opencode`, `pi`). Those spreads run after the spawn-site filter, so without this the mode is a no-op on an ordinary local agent run.
- Add `PAPERCLIP_AGENT_ENV_INHERIT=allowlist` to turn the mode on. The default is `all`.
- Add `PAPERCLIP_AGENT_ENV_ALLOW` for deployment-specific keys. It takes a comma-separated list and accepts a trailing `*` wildcard, for example `ANTHROPIC_API_KEY,AWS_*`.
- Keep `PATH`, `HOME`, `TMPDIR`, `LC_*`, `XDG_*`, the TLS trust-store keys, the Node.js toolchain keys and `PAPERCLIP_*` in the built-in allowlist.
- Inherit a proxy address, but not credentials embedded in it. `HTTPS_PROXY=http://user:password@proxy` needs an explicit `PAPERCLIP_AGENT_ENV_ALLOW` entry.
- Log the dropped variable names once per process. Values are never logged.
- Add a source guard test. A new raw `...process.env` spread in an adapter fails a test instead of silently reopening the hole.
- Document both variables in `docs/deploy/environment-variables.md`.

## Verification

- `vitest run packages/adapter-utils/src/server-utils-env.test.ts` → 11 passed (1 pre-existing, 10 new).
- Mutation-checked, so the green result is falsifiable:
  - Make the proxy exemption unconditional again → 2 tests fail.
  - Return one adapter to a raw `...process.env` spread → the source guard fails.
  - Make `buildInheritedAgentEnv` return the sanitized env unconditionally → 3 tests fail.
  - The sources were restored and re-verified clean after each mutation.
- `tsc --noEmit` reports no errors in `packages/adapter-utils`.
- The default path (`all`) is unchanged and stays covered by the pre-existing test.

## Risks

Low, because the feature is off by default.

- **Default unchanged.** The mode is opt-in, so existing deployments behave exactly as before. This is deliberate: because the quickstart puts provider keys in the same block as the signing secret, making the allowlist the default would take every agent's provider key at once and break working deployments. Flipping the default is a separate migration with a release note.
- **Operator misconfiguration.** Turning the mode on without listing a needed key can make an agent fail to find a credential. The one-time warning names the dropped variables, so the missing key is visible in the server log.
- **Explicit config is unaffected.** Adapter and agent config env applies after inheritance, so a variable that is configured explicitly is never removed by this filter. A test binds this contract.
- **Adapter surface.** The change touches 7 adapters. Each edit replaces `...process.env` with `...buildInheritedAgentEnv(process.env)` and adds one import. Behaviour is identical while the mode is `all`.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution. The first commit was produced by a Paperclip agent on the same model. The follow-up commit that applies the filter across the adapters and adds the proxy-credential rule was produced in Claude Cowork on the same model.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
