### PR TITLE
fix(server): audit and suppress stale skip-missed runs

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -2326,14 +2326,97 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     await db.update(routines).set({ createdAt: new Date("2025-01-01T00:00:01.000Z") }).where(eq(routines.id, newRoutine.id));
     const { trigger: oldTrigger } = await svc.createTrigger(oldRoutine.id, { kind: "schedule", cronExpression: "0 0 * * *", timezone: "UTC" }, {});
     const { trigger: newTrigger } = await svc.createTrigger(newRoutine.id, { kind: "schedule", cronExpression: "0 0 * * *", timezone: "UTC" }, {});
+    const tickNow = new Date("2026-07-16T02:30:00.000Z");
     await db.update(routineTriggers).set({ nextRunAt: new Date("2020-01-01T00:00:00.000Z") }).where(eq(routineTriggers.id, oldTrigger.id));
-    await db.update(routineTriggers).set({ nextRunAt: new Date("2020-01-01T00:00:00.000Z") }).where(eq(routineTriggers.id, newTrigger.id));
+    await db.update(routineTriggers).set({ nextRunAt: new Date("2026-07-16T02:00:00.000Z") }).where(eq(routineTriggers.id, newTrigger.id));
 
-    expect(await svc.tickScheduledTriggers(new Date())).toEqual({ triggered: 1 });
+    expect(await svc.tickScheduledTriggers(tickNow)).toEqual({ triggered: 1 });
     const oldRuns = await db.select().from(routineRuns).where(eq(routineRuns.routineId, oldRoutine.id));
     expect(oldRuns).toMatchObject([{ status: "skipped", failureReason: "worktree_execution_cutoff", linkedIssueId: null }]);
     const newRuns = await db.select().from(routineRuns).where(eq(routineRuns.routineId, newRoutine.id));
     expect(newRuns).toMatchObject([{ status: "issue_created" }]);
+  });
+
+  it("suppresses stale skip_missed schedules with multiple due occurrences", async () => {
+    const { companyId, routine, svc } = await seedFixture();
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "schedule",
+      cronExpression: "0 * * * *",
+      timezone: "UTC",
+    }, {});
+    const scheduledFor = new Date("2026-07-16T00:00:00.000Z");
+    const now = new Date("2026-07-16T02:30:00.000Z");
+    await db.update(routineTriggers).set({ nextRunAt: scheduledFor }).where(eq(routineTriggers.id, trigger.id));
+
+    expect(await svc.tickScheduledTriggers(now)).toEqual({ triggered: 0 });
+    expect(await db.select().from(issues).where(eq(issues.companyId, companyId))).toHaveLength(0);
+
+    const [run] = await db.select().from(routineRuns).where(eq(routineRuns.routineId, routine.id));
+    expect(run).toMatchObject({
+      source: "schedule",
+      status: "skipped",
+      failureReason: "missed_schedule",
+      linkedIssueId: null,
+      triggerPayload: {
+        catchUpPolicy: "skip_missed",
+        scheduledFor: scheduledFor.toISOString(),
+        nextMissedOccurrenceAt: "2026-07-16T01:00:00.000Z",
+        suppressedAt: now.toISOString(),
+        nextRunAt: "2026-07-16T03:00:00.000Z",
+      },
+    });
+    expect(run?.completedAt).not.toBeNull();
+
+    const updatedTrigger = await db
+      .select()
+      .from(routineTriggers)
+      .where(eq(routineTriggers.id, trigger.id))
+      .then((rows) => rows[0]);
+    expect(updatedTrigger?.nextRunAt).toEqual(new Date("2026-07-16T03:00:00.000Z"));
+    expect(updatedTrigger?.lastResult).toMatch(/missed/i);
+
+    const [audit] = await db.select().from(activityLog).where(eq(activityLog.entityId, run!.id));
+    expect(audit).toMatchObject({
+      action: "routine.run_skipped",
+      entityType: "routine_run",
+      details: {
+        routineId: routine.id,
+        triggerId: trigger.id,
+        source: "schedule",
+        status: "skipped",
+        reason: "missed_schedule",
+        catchUpPolicy: "skip_missed",
+        scheduledFor: scheduledFor.toISOString(),
+        nextMissedOccurrenceAt: "2026-07-16T01:00:00.000Z",
+        suppressedAt: now.toISOString(),
+        nextRunAt: "2026-07-16T03:00:00.000Z",
+      },
+    });
+  });
+
+  it("dispatches one ordinarily due skip_missed schedule occurrence", async () => {
+    const { companyId, routine, svc } = await seedFixture();
+    const { trigger } = await svc.createTrigger(routine.id, {
+      kind: "schedule",
+      cronExpression: "0 * * * *",
+      timezone: "UTC",
+    }, {});
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: new Date("2026-07-16T02:00:00.000Z") })
+      .where(eq(routineTriggers.id, trigger.id));
+
+    expect(await svc.tickScheduledTriggers(new Date("2026-07-16T02:30:00.000Z"))).toEqual({ triggered: 1 });
+
+    const runs = await db.select().from(routineRuns).where(eq(routineRuns.routineId, routine.id));
+    expect(runs).toMatchObject([{ status: "issue_created" }]);
+    expect(await db.select().from(issues).where(eq(issues.companyId, companyId))).toHaveLength(1);
+    const updatedTrigger = await db
+      .select()
+      .from(routineTriggers)
+      .where(eq(routineTriggers.id, trigger.id))
+      .then((rows) => rows[0]);
+    expect(updatedTrigger?.nextRunAt).toEqual(new Date("2026-07-16T03:00:00.000Z"));
   });
 
   it("coalesces multiple missed sub-hourly ticks into one catch-up run", async () => {
@@ -2506,10 +2589,10 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       .where(eq(projects.id, projectId));
     await db
       .update(routineTriggers)
-      .set({ nextRunAt: pastDue })
+      .set({ nextRunAt: new Date("2026-07-16T02:00:00.000Z") })
       .where(eq(routineTriggers.id, trigger.id));
 
-    const resumedResult = await svc.tickScheduledTriggers(new Date());
+    const resumedResult = await svc.tickScheduledTriggers(new Date("2026-07-16T02:30:00.000Z"));
     expect(resumedResult.triggered).toBe(1);
 
     const issuesAfterResume = await db

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -262,6 +262,7 @@ function nextResultText(status: string, issueId?: string | null) {
   if (status === "issue_created" && issueId) return `Created execution issue ${issueId}`;
   if (status === "coalesced") return "Coalesced into an existing live execution issue";
   if (status === "skipped_paused") return "Skipped because the project is paused";
+  if (status === "skipped_missed") return "Skipped missed scheduled occurrences";
   if (status === "skipped") return "Skipped because a live execution issue already exists";
   if (status === "completed") return "Execution issue completed";
   if (status === "failed") return "Execution failed";
@@ -1419,7 +1420,9 @@ export function routineService(
           ? "skipped_paused"
           : input.reason === "no_external_activity"
             ? "skipped_no_activity"
-            : "skipped_worktree_execution_cutoff",
+            : input.reason === "missed_schedule"
+              ? "skipped_missed"
+              : "skipped_worktree_execution_cutoff",
         nextRunAt: input.nextRunAt,
       }, txDb);
       return createdRun;
@@ -3054,6 +3057,14 @@ export function routineService(
 
         let runCount = 1;
         let claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, now);
+        const nextOccurrenceAfterDue = row.routine.catchUpPolicy === "skip_missed"
+          ? nextCronTickInTimeZone(
+            row.trigger.cronExpression,
+            row.trigger.timezone,
+            row.trigger.nextRunAt,
+          )
+          : null;
+        const staleSkipMissed = nextOccurrenceAfterDue !== null && nextOccurrenceAfterDue <= now;
 
         if (!projectPaused && !worktreeSuppressed && row.routine.catchUpPolicy === "enqueue_missed_with_cap") {
           if (isSubHourlyCronExpression(row.trigger.cronExpression, row.trigger.timezone, now)) {
@@ -3093,6 +3104,24 @@ export function routineService(
             source: "schedule",
             reason: worktreeSuppressed ? "worktree_execution_cutoff" : "paused",
             nextRunAt: claimedNextRunAt,
+          });
+          continue;
+        }
+
+        if (staleSkipMissed) {
+          await recordSuppressedAutomaticRun({
+            routine: row.routine,
+            trigger: row.trigger,
+            source: "schedule",
+            reason: "missed_schedule",
+            nextRunAt: claimedNextRunAt,
+            details: {
+              catchUpPolicy: "skip_missed",
+              scheduledFor: row.trigger.nextRunAt.toISOString(),
+              nextMissedOccurrenceAt: nextOccurrenceAfterDue.toISOString(),
+              suppressedAt: now.toISOString(),
+              nextRunAt: claimedNextRunAt?.toISOString() ?? null,
+            },
           });
           continue;
         }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Scheduled routines create work at cron boundaries
> - A routine can use `skip_missed` to avoid replay after downtime
> - The scheduler still dispatched one stale run when several cron occurrences were due
> - A normal scheduler tick must still dispatch once when only one occurrence is due
> - This pull request separates those two cases and records a durable skipped run for stale work
> - The benefit is safe restart behavior with an audit trail and no lost normal tick

## Linked Issues or Issue Description

Fixes #3108

Supersedes #3133. That pull request has been inactive since April and does not record durable suppression evidence.

## What Changed

- Detect a stale `skip_missed` schedule only when the next cron occurrence after the stored due time is also due.
- Advance the trigger to the first future occurrence without creating an execution issue.
- Record the suppression in `routine_runs`, the trigger result, and `activity_log` with the scheduled, suppressed, and next-run times.
- Keep one dispatch for an ordinary due tick.
- Keep `enqueue_missed_with_cap` behavior unchanged.
- Add focused regression tests for the stale and ordinary cases.

## Verification

- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts`: 63 passed after rebase onto current `origin/master`.
- Eight adjacent routine scheduler suites: 98 passed.
- `pnpm -r typecheck`: passed.
- `pnpm build`: passed.
- UTC general server tests: 3,762 passed and 4 skipped.
- UTC UI tests: 3,896 passed.
- The skills catalog package test passed with system npm 10. The host npm 12 client returns a different `npm pack --json` shape.
- The broader database package lane reached 104 passing tests and one host-only failure because `psql` is not installed (`spawn psql ENOENT`).

## Risks

- The change affects scheduler restart behavior for `skip_missed` routines.
- The stale boundary is narrow. The scheduler suppresses only when at least two occurrences are due.
- The change uses existing skipped-run and activity-log records. It adds no migration.
- Project-pause and worktree suppression checks keep their existing precedence.

> This change is a focused correction to the completed Scheduled Routines roadmap item. It does not add a new roadmap feature.

## Model Used

- OpenAI Codex, GPT-5 family. The exact runtime model ID and context-window size were not exposed. The agent used reasoning, repository tools, test execution, and GitHub tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
