### PR TITLE
fix: preserve review stage while issue is blocked

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1985,8 +1985,10 @@ describe("agent issue mutation checkout ownership", () => {
       expect(updatePatch).toMatchObject({ status: "blocked", actorAgentId: peerAgentId });
       expect(updatePatch).not.toHaveProperty("executionPolicy");
       expect(updatePatch).not.toHaveProperty("executionState");
-      expect(updatePatch).not.toHaveProperty("assigneeAgentId");
-      expect(updatePatch).not.toHaveProperty("assigneeUserId");
+      expect(updatePatch).toMatchObject({
+        assigneeAgentId: ownerAgentId,
+        assigneeUserId: null,
+      });
     });
 
     it("lets a watchdog run transition a watched issue to in_review with a live review path", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -441,6 +441,12 @@ describe("agent issue mutation checkout ownership", () => {
       isDependencyReady: false,
       unresolvedBlockerCount: 0,
     });
+    mockIssueService.getProposedDependencyReadiness.mockReset();
+    mockIssueService.getProposedDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: [],
+      isDependencyReady: false,
+      unresolvedBlockerCount: 0,
+    });
     mockIssueService.getRelationSummaries.mockReset();
     mockIssueService.getWakeableParentAfterChildCompletion.mockReset();
     mockIssueService.list.mockReset();
@@ -1989,6 +1995,85 @@ describe("agent issue mutation checkout ownership", () => {
         assigneeAgentId: ownerAgentId,
         assigneeUserId: null,
       });
+    });
+
+    it.each([
+      ["policy replacement", {
+        mode: "normal",
+        commentRequired: false,
+        stages: [{
+          id: "66666666-6666-4666-8666-666666666666",
+          type: "review",
+          approvalsNeeded: 1,
+          participants: [{ type: "agent", agentId: ownerAgentId }],
+        }],
+      }],
+      ["null policy", null],
+      ["current-stage removal", {
+        mode: "normal",
+        commentRequired: true,
+        stages: [{
+          id: "77777777-7777-4777-8777-777777777777",
+          type: "approval",
+          approvalsNeeded: 1,
+          participants: [{ type: "agent", agentId: peerAgentId }],
+        }],
+      }],
+      ["participant drift", {
+        mode: "normal",
+        commentRequired: true,
+        stages: [{
+          id: "66666666-6666-4666-8666-666666666666",
+          type: "review",
+          approvalsNeeded: 1,
+          participants: [{ type: "agent", agentId: peerAgentId }],
+        }],
+      }],
+    ])("rejects watchdog blocker normalization combined with %s", async (_label, requestedPolicy) => {
+      denyBaseBoundary();
+      const stageId = "66666666-6666-4666-8666-666666666666";
+      const executionPolicy = {
+        mode: "normal",
+        commentRequired: true,
+        stages: [{
+          id: stageId,
+          type: "review",
+          approvalsNeeded: 1,
+          participants: [{ type: "agent", agentId: ownerAgentId }],
+        }],
+      };
+      const executionState = {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: ownerAgentId },
+        returnAssignee: { type: "agent", agentId: "99999999-9999-4999-8999-999999999999" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      };
+      mockIssueService.getById.mockResolvedValue(makeIssue({
+        status: "in_review",
+        assigneeAgentId: ownerAgentId,
+        executionPolicy,
+        executionState,
+      }));
+      mockIssueService.getProposedDependencyReadiness.mockResolvedValue({
+        blockerIssueIds: ["88888888-8888-4888-8888-888888888888"],
+        isDependencyReady: false,
+        unresolvedBlockerCount: 1,
+      });
+
+      const app = await createApp(watchdogActor(), createWatchdogDb());
+      const res = await request(app).patch(`/api/issues/${issueId}`).send({
+        blockedByIssueIds: ["88888888-8888-4888-8888-888888888888"],
+        executionPolicy: requestedPolicy,
+      });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(422);
+      expect(res.body.error).toContain("executionPolicy cannot be changed while unresolved blockers suspend an active stage");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
     });
 
     it("lets a watchdog run transition a watched issue to in_review with a live review path", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1929,6 +1929,65 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ status }));
     });
 
+    it("lets an authorized watchdog block an active review without impersonating its reviewer", async () => {
+      denyBaseBoundary();
+      const stageId = "66666666-6666-4666-8666-666666666666";
+      const executionPolicy = {
+        mode: "normal",
+        commentRequired: true,
+        stages: [{
+          id: stageId,
+          type: "review",
+          approvalsNeeded: 1,
+          participants: [{ type: "agent", agentId: ownerAgentId }],
+        }],
+      };
+      const executionState = {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: ownerAgentId },
+        returnAssignee: { type: "agent", agentId: "99999999-9999-4999-8999-999999999999" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      };
+      const reviewIssue = makeIssue({
+        status: "in_review",
+        assigneeAgentId: ownerAgentId,
+        executionPolicy,
+        executionState,
+      });
+      mockIssueService.getById.mockResolvedValue(reviewIssue);
+      mockIssueService.getDependencyReadiness.mockResolvedValue({
+        blockerIssueIds: ["88888888-8888-4888-8888-888888888888"],
+        isDependencyReady: false,
+        unresolvedBlockerCount: 1,
+      });
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+        ...reviewIssue,
+        ...patch,
+      }));
+
+      const app = await createApp(watchdogActor(), createWatchdogDb());
+      const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "blocked" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(res.body).toMatchObject({
+        status: "blocked",
+        assigneeAgentId: ownerAgentId,
+        executionPolicy,
+        executionState,
+      });
+      const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(updatePatch).toMatchObject({ status: "blocked", actorAgentId: peerAgentId });
+      expect(updatePatch).not.toHaveProperty("executionPolicy");
+      expect(updatePatch).not.toHaveProperty("executionState");
+      expect(updatePatch).not.toHaveProperty("assigneeAgentId");
+      expect(updatePatch).not.toHaveProperty("assigneeUserId");
+    });
+
     it("lets a watchdog run transition a watched issue to in_review with a live review path", async () => {
       denyBaseBoundary();
       mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -22,6 +22,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getComment: vi.fn(),
   getDependencyReadiness: vi.fn(),
+  getProposedDependencyReadiness: vi.fn(),
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   list: vi.fn(),

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -221,6 +221,7 @@ describe("issue dependency wakeups in issue routes", () => {
           }),
         }),
       );
+      expect(mockWakeup).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   update: vi.fn(),
   getDependencyReadiness: vi.fn(),
+  getProposedDependencyReadiness: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   findMentionedAgents: vi.fn(async () => []),
@@ -153,6 +154,15 @@ describe("issue dependency wakeups in issue routes", () => {
     });
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "issue-1",
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+    mockIssueService.getProposedDependencyReadiness.mockResolvedValue({
       issueId: "issue-1",
       blockerIssueIds: [],
       unresolvedBlockerIssueIds: [],

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -12,6 +12,7 @@ const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
   getDependencyReadiness: vi.fn(),
+  getProposedDependencyReadiness: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
@@ -200,6 +201,11 @@ describe("issue execution policy routes", () => {
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       blockerIssueIds: [],
       isDependencyReady: false,
+      unresolvedBlockerCount: 0,
+    });
+    mockIssueService.getProposedDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: [],
+      isDependencyReady: true,
       unresolvedBlockerCount: 0,
     });
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
@@ -735,6 +741,11 @@ describe("issue execution policy routes", () => {
     };
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.getDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: ["77777777-7777-4777-8777-777777777777"],
+      isDependencyReady: false,
+      unresolvedBlockerCount: 1,
+    });
+    mockIssueService.getProposedDependencyReadiness.mockResolvedValue({
       blockerIssueIds: ["77777777-7777-4777-8777-777777777777"],
       isDependencyReady: false,
       unresolvedBlockerCount: 1,

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -809,6 +809,93 @@ describe("issue execution policy routes", () => {
     });
   });
 
+  it.each([
+    ["policy replacement", {
+      mode: "normal",
+      commentRequired: false,
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        approvalsNeeded: 1,
+        participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+      }],
+    }],
+    ["null policy", null],
+    ["current-stage removal", {
+      mode: "normal",
+      commentRequired: true,
+      stages: [{
+        id: "22222222-2222-4222-8222-222222222222",
+        type: "approval",
+        approvalsNeeded: 1,
+        participants: [{ type: "agent", agentId: "44444444-4444-4444-8444-444444444444" }],
+      }],
+    }],
+    ["participant drift", {
+      mode: "normal",
+      commentRequired: true,
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        approvalsNeeded: 1,
+        participants: [{ type: "agent", agentId: "55555555-5555-4555-8555-555555555555" }],
+      }],
+    }],
+  ])("rejects reviewer blocker normalization combined with %s", async (_label, requestedPolicy) => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+      }],
+    })!;
+    const executionState = {
+      status: "pending" as const,
+      currentStageId: "11111111-1111-4111-8111-111111111111",
+      currentStageIndex: 0,
+      currentStageType: "review" as const,
+      currentParticipant: { type: "agent" as const, agentId: "33333333-3333-4333-8333-333333333333" },
+      returnAssignee: { type: "agent" as const, agentId: "44444444-4444-4444-8444-444444444444" },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+    };
+    mockIssueService.getById.mockResolvedValue({
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Blocked active review",
+      executionPolicy: policy,
+      executionState,
+    });
+    mockIssueService.getProposedDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: ["77777777-7777-4777-8777-777777777777"],
+      isDependencyReady: false,
+      unresolvedBlockerCount: 1,
+    });
+
+    const reviewerApp = await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    });
+    const res = await request(reviewerApp)
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        blockedByIssueIds: ["77777777-7777-4777-8777-777777777777"],
+        executionPolicy: requestedPolicy,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("executionPolicy cannot be changed while unresolved blockers suspend an active stage");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("allows a board user to cancel a drifted pending agent review task", async () => {
     const policy = normalizeIssueExecutionPolicy({
       stages: [

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -200,7 +200,7 @@ describe("issue execution policy routes", () => {
     }));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       blockerIssueIds: [],
-      isDependencyReady: false,
+      isDependencyReady: true,
       unresolvedBlockerCount: 0,
     });
     mockIssueService.getProposedDependencyReadiness.mockResolvedValue({

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -765,7 +765,10 @@ describe("issue execution policy routes", () => {
     const blockerIssueId = "77777777-7777-4777-8777-777777777777";
     const blockerAdded = await request(reviewerApp)
       .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
-      .send({ blockedByIssueIds: [blockerIssueId] });
+      .send({
+        blockedByIssueIds: [blockerIssueId],
+        assigneeAgentId: "55555555-5555-4555-8555-555555555555",
+      });
 
     expect(blockerAdded.status, JSON.stringify(blockerAdded.body)).toBe(200);
     expect(blockerAdded.body).toMatchObject({
@@ -778,6 +781,8 @@ describe("issue execution policy routes", () => {
     expect(blockerPatch).toMatchObject({
       status: "blocked",
       blockedByIssueIds: [blockerIssueId],
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
     });
     expect(blockerPatch).not.toHaveProperty("executionPolicy");
     expect(blockerPatch).not.toHaveProperty("executionState");
@@ -798,8 +803,10 @@ describe("issue execution policy routes", () => {
     expect(dispositionPatch).toMatchObject({ status: "blocked" });
     expect(dispositionPatch).not.toHaveProperty("executionPolicy");
     expect(dispositionPatch).not.toHaveProperty("executionState");
-    expect(dispositionPatch).not.toHaveProperty("assigneeAgentId");
-    expect(dispositionPatch).not.toHaveProperty("assigneeUserId");
+    expect(dispositionPatch).toMatchObject({
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+    });
   });
 
   it("allows a board user to cancel a drifted pending agent review task", async () => {

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
   createChild: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
+  getDependencyReadiness: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
@@ -191,6 +192,16 @@ describe("issue execution policy routes", () => {
     vi.clearAllMocks();
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.addComment.mockImplementation(async (issueId: string, body: string) => ({
+      id: "66666666-6666-4666-8666-666666666666",
+      issueId,
+      body,
+    }));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: [],
+      isDependencyReady: false,
+      unresolvedBlockerCount: 0,
+    });
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
@@ -198,9 +209,22 @@ describe("issue execution policy routes", () => {
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
     mockDbSelect.mockImplementation(() => ({ from: mockDbSelectFrom }));
-    mockDbSelectFrom.mockImplementation(() => ({ where: mockDbSelectWhere }));
+    mockDbSelectFrom.mockImplementation(() => ({
+      innerJoin: () => ({ where: mockDbSelectWhere }),
+      where: mockDbSelectWhere,
+    }));
     mockDbSelectWhere.mockImplementation(() => ({
       for: () => ({
+        then: (onFulfilled: (rows: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
+          Promise.resolve([{
+            id: "55555555-5555-4555-8555-555555555555",
+            companyId: "company-1",
+            agentId: "33333333-3333-4333-8333-333333333333",
+            contextSnapshot: { issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+            permissions: null,
+          }]).then(onFulfilled, onRejected),
+      }),
+      limit: () => ({
         then: (onFulfilled: (rows: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
           Promise.resolve([{
             id: "55555555-5555-4555-8555-555555555555",
@@ -676,6 +700,95 @@ describe("issue execution policy routes", () => {
       }),
     );
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it("normalizes an active review with unresolved blockers to blocked without deciding the stage", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+      }],
+    })!;
+    const executionState = {
+      status: "pending" as const,
+      currentStageId: "11111111-1111-4111-8111-111111111111",
+      currentStageIndex: 0,
+      currentStageType: "review" as const,
+      currentParticipant: { type: "agent" as const, agentId: "33333333-3333-4333-8333-333333333333" },
+      returnAssignee: { type: "agent" as const, agentId: "44444444-4444-4444-8444-444444444444" },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+    };
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Blocked active review",
+      executionPolicy: policy,
+      executionState,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: ["77777777-7777-4777-8777-777777777777"],
+      isDependencyReady: false,
+      unresolvedBlockerCount: 1,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const reviewerApp = await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    });
+    const blockerIssueId = "77777777-7777-4777-8777-777777777777";
+    const blockerAdded = await request(reviewerApp)
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ blockedByIssueIds: [blockerIssueId] });
+
+    expect(blockerAdded.status, JSON.stringify(blockerAdded.body)).toBe(200);
+    expect(blockerAdded.body).toMatchObject({
+      status: "blocked",
+      executionPolicy: policy,
+      executionState,
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+    });
+    const blockerPatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(blockerPatch).toMatchObject({
+      status: "blocked",
+      blockedByIssueIds: [blockerIssueId],
+    });
+    expect(blockerPatch).not.toHaveProperty("executionPolicy");
+    expect(blockerPatch).not.toHaveProperty("executionState");
+    mockIssueService.update.mockClear();
+
+    const disposition = await request(reviewerApp)
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_progress", comment: "Changes are required, but the dependency is unresolved." });
+
+    expect(disposition.status, JSON.stringify(disposition.body)).toBe(200);
+    expect(disposition.body).toMatchObject({
+      status: "blocked",
+      executionPolicy: policy,
+      executionState,
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+    });
+    const dispositionPatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(dispositionPatch).toMatchObject({ status: "blocked" });
+    expect(dispositionPatch).not.toHaveProperty("executionPolicy");
+    expect(dispositionPatch).not.toHaveProperty("executionState");
+    expect(dispositionPatch).not.toHaveProperty("assigneeAgentId");
+    expect(dispositionPatch).not.toHaveProperty("assigneeUserId");
   });
 
   it("allows a board user to cancel a drifted pending agent review task", async () => {

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -593,10 +593,26 @@ describe("issue execution policy transitions", () => {
         requestedAssigneePatch: {},
         actor: { agentId: coderAgentId },
         preservePendingStageOnBlocked: true,
+        allowNonParticipantPendingStageBlock: true,
       });
 
       expect(suspended.patch).toEqual({ status: "blocked" });
       expect(suspended.decision).toBeUndefined();
+
+      expect(() => applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: pendingState,
+        },
+        policy,
+        requestedStatus: "blocked",
+        requestedAssigneePatch: {},
+        actor: { agentId: coderAgentId },
+        preservePendingStageOnBlocked: true,
+      })).toThrow("Only the active reviewer or approver can advance");
 
       const resumed = applyIssueExecutionPolicyTransition({
         issue: {

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -568,6 +568,66 @@ describe("issue execution policy transitions", () => {
         }),
       ).toThrow("Only the active reviewer or approver can advance");
     });
+    it("suspends and resumes the same pending stage without recording a blocker decision", () => {
+      const pendingState = {
+        status: "pending" as const,
+        currentStageId: reviewStageId,
+        currentStageIndex: 0,
+        currentStageType: "review" as const,
+        currentParticipant: { type: "agent" as const, agentId: qaAgentId },
+        returnAssignee: { type: "agent" as const, agentId: coderAgentId },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      };
+      const suspended = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: pendingState,
+        },
+        policy,
+        requestedStatus: "blocked",
+        requestedAssigneePatch: {},
+        actor: { agentId: coderAgentId },
+        preservePendingStageOnBlocked: true,
+      });
+
+      expect(suspended.patch).toEqual({ status: "blocked" });
+      expect(suspended.decision).toBeUndefined();
+
+      const resumed = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "blocked",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: pendingState,
+        },
+        policy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: "The blocker resolved; review now passes.",
+      });
+
+      expect(resumed.decision).toMatchObject({
+        stageId: reviewStageId,
+        stageType: "review",
+        outcome: "approved",
+      });
+      expect(resumed.patch).toMatchObject({
+        status: "in_review",
+        executionState: {
+          status: "pending",
+          completedStageIds: [reviewStageId],
+          currentStageType: "approval",
+        },
+      });
+    });
+
 
     it("board override can cancel an active review without recording an approval decision", () => {
       const result = applyIssueExecutionPolicyTransition({

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -596,7 +596,11 @@ describe("issue execution policy transitions", () => {
         allowNonParticipantPendingStageBlock: true,
       });
 
-      expect(suspended.patch).toEqual({ status: "blocked" });
+      expect(suspended.patch).toEqual({
+        status: "blocked",
+        assigneeAgentId: qaAgentId,
+        assigneeUserId: null,
+      });
       expect(suspended.decision).toBeUndefined();
 
       expect(() => applyIssueExecutionPolicyTransition({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9006,6 +9006,11 @@ export function issueRoutes(
         ? (await svc.getProposedDependencyReadiness(existing.id, requestedBlockerIds)).unresolvedBlockerCount > 0
         : (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0;
       if (hasUnresolvedBlocker) {
+        if (req.body.executionPolicy !== undefined) {
+          throw unprocessable(
+            "executionPolicy cannot be changed while unresolved blockers suspend an active stage",
+          );
+        }
         if (!actorIsActiveStageParticipant && req.actor.type === "agent") {
           const actorWatchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
           allowNonParticipantPendingStageBlock = actorWatchdogScope.kind === "watchdog";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8980,6 +8980,43 @@ export function issueRoutes(
       updateFields.executionPolicy !== undefined
         ? (updateFields.executionPolicy as NormalizedExecutionPolicy | null)
         : previousExecutionPolicy;
+    const existingExecutionState = parseIssueExecutionState(existing.executionState);
+    const activeStageParticipant = existingExecutionState?.status === "pending"
+      ? existingExecutionState.currentParticipant
+      : null;
+    const actorIsActiveStageParticipant = activeStageParticipant?.type === "agent"
+      ? activeStageParticipant.agentId === actor.agentId
+      : activeStageParticipant?.type === "user" && actor.actorType === "user"
+        ? activeStageParticipant.userId === actor.actorId
+        : false;
+    const blockerMutationRequested = Array.isArray(req.body.blockedByIssueIds);
+    const activeStageBlockingDispositionRequested =
+      updateFields.status === "blocked" ||
+      (updateFields.status === "in_progress" && actorIsActiveStageParticipant);
+    let preservePendingStageOnBlocked = false;
+    if (
+      activeStageParticipant &&
+      (blockerMutationRequested || activeStageBlockingDispositionRequested)
+    ) {
+      const requestedBlockerIds = blockerMutationRequested
+        ? [...new Set(req.body.blockedByIssueIds as string[])]
+        : null;
+      const hasUnresolvedBlocker = requestedBlockerIds
+        ? requestedBlockerIds.length > 0 && await db.select({ id: issueRows.id }).from(issueRows).where(and(
+          eq(issueRows.companyId, existing.companyId),
+          inArray(issueRows.id, requestedBlockerIds),
+          notInArray(issueRows.status, ["done", "cancelled"]),
+        )).limit(1).then((rows) => rows.length > 0)
+        : (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0;
+      if (hasUnresolvedBlocker) {
+        // Adding an unresolved dependency to an active stage is itself the
+        // server-owned blocked disposition. Likewise, translate the active
+        // participant's changes-requested status into that disposition: moving
+        // to in_progress cannot be valid until the blockers resolve.
+        updateFields.status = "blocked";
+        preservePendingStageOnBlocked = true;
+      }
+    }
     if (normalizedAssigneeAgentId !== undefined) {
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
@@ -9010,6 +9047,7 @@ export function issueRoutes(
       commentBody,
       reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
       monitorExplicitlyUpdated: req.body.executionPolicy !== undefined && monitorChanged,
+      preservePendingStageOnBlocked,
     });
     const decisionId = transition.decision ? randomUUID() : null;
     if (decisionId) {
@@ -9083,7 +9121,6 @@ export function issueRoutes(
       }
     }
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
-      const existingExecutionState = parseIssueExecutionState(existing.executionState);
       if (!existingExecutionState || existingExecutionState.status !== "pending") {
         if (reviewRequest !== null) {
           res.status(422).json({ error: "reviewRequest requires an active review or approval stage" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9099,11 +9099,7 @@ export function issueRoutes(
         ? [...new Set(req.body.blockedByIssueIds as string[])]
         : null;
       const hasUnresolvedBlocker = requestedBlockerIds
-        ? requestedBlockerIds.length > 0 && await db.select({ id: issueRows.id }).from(issueRows).where(and(
-          eq(issueRows.companyId, existing.companyId),
-          inArray(issueRows.id, requestedBlockerIds),
-          notInArray(issueRows.status, ["done", "cancelled"]),
-        )).limit(1).then((rows) => rows.length > 0)
+        ? (await svc.getProposedDependencyReadiness(existing.id, requestedBlockerIds)).unresolvedBlockerCount > 0
         : (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0;
       const [pendingInteraction, pendingApproval] = await Promise.all([
         db.select({ id: issueThreadInteractions.id }).from(issueThreadInteractions).where(and(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8994,6 +8994,7 @@ export function issueRoutes(
       updateFields.status === "blocked" ||
       (updateFields.status === "in_progress" && actorIsActiveStageParticipant);
     let preservePendingStageOnBlocked = false;
+    let allowNonParticipantPendingStageBlock = req.actor.type === "board";
     if (
       activeStageParticipant &&
       (blockerMutationRequested || activeStageBlockingDispositionRequested)
@@ -9002,13 +9003,13 @@ export function issueRoutes(
         ? [...new Set(req.body.blockedByIssueIds as string[])]
         : null;
       const hasUnresolvedBlocker = requestedBlockerIds
-        ? requestedBlockerIds.length > 0 && await db.select({ id: issueRows.id }).from(issueRows).where(and(
-          eq(issueRows.companyId, existing.companyId),
-          inArray(issueRows.id, requestedBlockerIds),
-          notInArray(issueRows.status, ["done", "cancelled"]),
-        )).limit(1).then((rows) => rows.length > 0)
+        ? (await svc.getProposedDependencyReadiness(existing.id, requestedBlockerIds)).unresolvedBlockerCount > 0
         : (await svc.getDependencyReadiness(existing.id)).unresolvedBlockerCount > 0;
       if (hasUnresolvedBlocker) {
+        if (!actorIsActiveStageParticipant && req.actor.type === "agent") {
+          const actorWatchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+          allowNonParticipantPendingStageBlock = actorWatchdogScope.kind === "watchdog";
+        }
         // Adding an unresolved dependency to an active stage is itself the
         // server-owned blocked disposition. Likewise, translate the active
         // participant's changes-requested status into that disposition: moving
@@ -9048,6 +9049,7 @@ export function issueRoutes(
       reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
       monitorExplicitlyUpdated: req.body.executionPolicy !== undefined && monitorChanged,
       preservePendingStageOnBlocked,
+      allowNonParticipantPendingStageBlock,
     });
     const decisionId = transition.decision ? randomUUID() : null;
     if (decisionId) {

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -54,6 +54,7 @@ type TransitionInput = {
   reviewRequest?: IssueExecutionState["reviewRequest"] | null;
   monitorExplicitlyUpdated?: boolean;
   preservePendingStageOnBlocked?: boolean;
+  allowNonParticipantPendingStageBlock?: boolean;
 };
 
 type TransitionResult = {
@@ -722,6 +723,9 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
     // stage, participant, return assignee, and policy intact so the same review
     // path can resume when dependency wakeup fires.
     if (requestedStatus === "blocked" && input.preservePendingStageOnBlocked) {
+      if (!principalsEqual(currentParticipant, actor) && !input.allowNonParticipantPendingStageBlock) {
+        throw unprocessable("Only the active reviewer or approver can advance the current execution stage");
+      }
       patch.status = "blocked";
       return { patch };
     }

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -53,6 +53,7 @@ type TransitionInput = {
   commentBody?: string | null;
   reviewRequest?: IssueExecutionState["reviewRequest"] | null;
   monitorExplicitlyUpdated?: boolean;
+  preservePendingStageOnBlocked?: boolean;
 };
 
 type TransitionResult = {
@@ -713,6 +714,16 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
       });
     if (!currentParticipant) {
       throw unprocessable(`No eligible ${activeStage.type} participant is configured for this issue`);
+    }
+
+    // Unresolved first-class blockers suspend an active stage; they do not
+    // decide it. The route enables this only after it has verified the blocker
+    // state (including task-watchdog subtree authorization). Keep the pending
+    // stage, participant, return assignee, and policy intact so the same review
+    // path can resume when dependency wakeup fires.
+    if (requestedStatus === "blocked" && input.preservePendingStageOnBlocked) {
+      patch.status = "blocked";
+      return { patch };
     }
 
     // An escalated review is deliberately held by a human who is not in the

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -727,6 +727,7 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
         throw unprocessable("Only the active reviewer or approver can advance the current execution stage");
       }
       patch.status = "blocked";
+      Object.assign(patch, patchForPrincipal(currentParticipant));
       return { patch };
     }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1334,6 +1334,48 @@ async function listUnresolvedBlockerIssueIds(
     )
     .then((rows) => rows.map((row) => row.id));
 }
+
+async function getProposedIssueDependencyReadiness(
+  dbOrTx: Pick<Db, "select">,
+  companyId: string,
+  issueId: string,
+  blockerIssueIds: string[],
+) {
+  const readiness = createIssueDependencyReadiness(issueId);
+  const uniqueBlockerIssueIds = [...new Set(blockerIssueIds.filter(Boolean))];
+  if (uniqueBlockerIssueIds.length === 0) return readiness;
+
+  const blockerRows = await dbOrTx
+    .select({
+      blockerIssueId: issues.id,
+      blockerStatus: issues.status,
+      blockerExecutionWorkspaceId: issues.executionWorkspaceId,
+    })
+    .from(issues)
+    .where(and(eq(issues.companyId, companyId), inArray(issues.id, uniqueBlockerIssueIds)));
+  const pendingFinalizeBlockerIssueIds = await listPendingFinalizeBlockerIssueIds(
+    dbOrTx,
+    companyId,
+    blockerRows.flatMap((row) =>
+      row.blockerStatus === "done" && row.blockerExecutionWorkspaceId
+        ? [{ blockerIssueId: row.blockerIssueId, executionWorkspaceId: row.blockerExecutionWorkspaceId }]
+        : []),
+  );
+
+  for (const row of blockerRows) {
+    readiness.blockerIssueIds.push(row.blockerIssueId);
+    const pendingFinalize = pendingFinalizeBlockerIssueIds.has(row.blockerIssueId);
+    if (row.blockerStatus !== "done" || pendingFinalize) {
+      readiness.unresolvedBlockerIssueIds.push(row.blockerIssueId);
+      readiness.unresolvedBlockerCount += 1;
+      readiness.allBlockersDone = false;
+      readiness.isDependencyReady = false;
+      if (pendingFinalize) readiness.pendingFinalizeBlockerIssueIds.push(row.blockerIssueId);
+    }
+  }
+  return readiness;
+}
+
 async function getProjectDefaultGoalId(
   db: ProjectGoalReader,
   companyId: string,
@@ -6371,6 +6413,25 @@ export function issueService(db: Db) {
       if (!issue) throw notFound("Issue not found");
       const readiness = await listIssueDependencyReadinessMap(dbOrTx, issue.companyId, [issueId]);
       return readiness.get(issueId) ?? createIssueDependencyReadiness(issueId);
+    },
+
+    getProposedDependencyReadiness: async (
+      issueId: string,
+      blockerIssueIds: string[],
+      dbOrTx: any = db,
+    ) => {
+      const issue = await dbOrTx
+        .select({ id: issues.id, companyId: issues.companyId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows: Array<{ id: string; companyId: string }>) => rows[0] ?? null);
+      if (!issue) throw notFound("Issue not found");
+      return getProposedIssueDependencyReadiness(
+        dbOrTx,
+        issue.companyId,
+        issue.id,
+        blockerIssueIds,
+      );
     },
 
     listDependencyReadiness: async (companyId: string, issueIds: string[], dbOrTx: any = db) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI-agent work through issue execution stages.
> - Review stages keep a current participant and a return assignee.
> - First-class blockers stop work until dependencies are complete.
> - An unresolved blocker can be added while a review stage is active.
> - The prior route left the issue in review and rejected both reviewer and watchdog recovery writes.
> - This pull request adds a blocked hold that keeps the current review stage intact.
> - The benefit is a valid waiting state that resumes the same review path after dependency resolution.

## Linked Issues or Issue Description

Refs #10504
Refs #4939

**What happened?**

An issue stayed in `in_review` after an unresolved first-class blocker was added. The active reviewer could not request changes because the service rejected `in_progress` with HTTP 422. An authorized task watchdog also could not set `blocked` because the execution-policy guard rejected a non-participant status change with HTTP 422.

**Expected behavior**

Paperclip must put the issue in a valid blocked wait. It must keep the policy, stage, reviewer, return assignee, work products, and workspace. It must wake the same reviewer path once after all blockers resolve.

**Steps to reproduce**

1. Create an issue with an active review stage.
2. Add an unresolved `blockedBy` dependency.
3. Ask the active reviewer to request changes.
4. Ask an authorized task watchdog to set the issue to `blocked`.
5. Observe the two HTTP 422 responses on the prior code.

**Paperclip version or commit**

Reproduced on the `master` history before commit `b68b313bcb9a768078b8e4e8395f67a92eaf2ae0`.

**Deployment mode**

Self-hosted server built from source.

**Agent adapter(s) involved**

Not adapter-specific. This is a core issue-transition bug.

**Database mode**

The regression tests use route fixtures. The blocker behavior applies to embedded PGlite and external PostgreSQL.

**Access context**

Agent bearer API keys for the active reviewer and the authorized task watchdog.

## What Changed

- Normalize an unresolved blocker on an active stage to `blocked` in the issue update route.
- Preserve the pending execution stage and do not record an approval or changes-requested decision for the blocked hold.
- Let the active reviewer and an authorized in-scope watchdog establish the same blocked hold.
- Keep normal issue-write and task-watchdog subtree authorization checks before the new transition.
- Add regressions for blocker addition, reviewer recovery, watchdog recovery, same-stage resume, and exactly-once dependency wakeup.
- Reject an `executionPolicy` write when unresolved blockers suspend an active stage.

## Verification

- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm exec vitest run server/src/__tests__/issue-execution-policy.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-dependency-wakeups-routes.test.ts --testTimeout 20000` passed: 4 files and 177 tests.
- `git diff --check origin/master...HEAD` passed.

## Risks

- Low risk. The new path applies only to a pending execution stage with an unresolved first-class blocker.
- The path does not approve, complete, or clear the stage.
- A client must send policy changes in a separate request after the blocker hold ends.
- Existing issue-write and watchdog subtree authorization still run first.
- Ordinary attempts to start blocked work still use the existing blocker guard.

> This change fixes a core bug. It does not add a roadmap feature.

## Model Used

- OpenAI Codex, model `gpt-5`. The exact context-window value is not exposed in this runtime. The model used reasoning, tool use, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My public branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

