### PR TITLE
fix(onboarding): do not restore wizard state for a company the user does not own

### DIFF
--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -7,8 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mocks (hoisted so vi.mock factories can close over them) ----------------
 
-const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
-
 const mockDialog = vi.hoisted(() => ({
   onboardingOpen: true,
   onboardingOptions: {} as { initialStep?: number; companyId?: string },
@@ -110,7 +108,7 @@ vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
 vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
 vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
 
-import { OnboardingWizard } from "./OnboardingWizard";
+import { ONBOARDING_STORAGE_KEY, OnboardingWizard } from "./OnboardingWizard";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks (hoisted so vi.mock factories can close over them) ----------------
+
+const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+
+const mockDialog = vi.hoisted(() => ({
+  onboardingOpen: true,
+  onboardingOptions: {} as { initialStep?: number; companyId?: string },
+  closeOnboarding: vi.fn(),
+  onboardingRouteDismissed: false,
+  setOnboardingRouteDismissed: vi.fn(),
+}));
+
+const mockCompany = vi.hoisted(() => ({
+  companies: [] as Array<{ id: string; name: string; issuePrefix: string }>,
+  setSelectedCompanyId: vi.fn(),
+  loading: false,
+}));
+
+const mockCompaniesApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+const mockGoalsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(async () => []),
+}));
+const mockAgentsApi = vi.hoisted(() => ({
+  adapterModels: vi.fn(async () => [] as Array<{ id: string; label: string }>),
+  testEnvironment: vi.fn(async () => ({
+    adapterType: "claude_local",
+    status: "pass" as const,
+    checks: [],
+    testedAt: new Date().toISOString(),
+  })),
+  hire: vi.fn(async () => ({ agent: { id: "agent-1" }, approval: null })),
+  instructionsBundle: vi.fn(async () => ({ entryFile: "AGENTS.md" })),
+  saveInstructionsFile: vi.fn(async () => ({})),
+}));
+const mockApprovalsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+const mockIssuesApi = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+const mockProjectsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(async () => []),
+}));
+
+// The real adapter registry eagerly imports every adapter package. The
+// model/harness picker internals are out of scope here, so stub the adapter
+// layer entirely and drive it through this knob.
+const mockAdapterRegistry = vi.hoisted(() => ({
+  list: [] as Array<{ type: string }>,
+  disabled: new Set<string>(),
+}));
+
+vi.mock("@/lib/router", () => ({
+  useLocation: () => ({ pathname: "/", search: "", hash: "", state: null }),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+}));
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => mockDialog,
+}));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => mockCompany,
+}));
+vi.mock("../api/companies", () => ({ companiesApi: mockCompaniesApi }));
+vi.mock("../api/goals", () => ({ goalsApi: mockGoalsApi }));
+vi.mock("../api/agents", () => ({ agentsApi: mockAgentsApi }));
+vi.mock("../api/approvals", () => ({ approvalsApi: mockApprovalsApi }));
+vi.mock("../api/issues", () => ({ issuesApi: mockIssuesApi }));
+vi.mock("../api/projects", () => ({ projectsApi: mockProjectsApi }));
+vi.mock("../adapters", () => ({
+  listUIAdapters: () => mockAdapterRegistry.list,
+  getUIAdapter: () => ({ buildAdapterConfig: () => ({}) }),
+}));
+vi.mock("../adapters/metadata", () => ({ isVisualAdapterChoice: () => true }));
+vi.mock("../adapters/adapter-display-registry", () => ({
+  getAdapterDisplay: (type: string) => ({
+    type,
+    recommended: false,
+    label: type,
+    description: "",
+    icon: () => null,
+  }),
+}));
+vi.mock("../adapters/use-disabled-adapters", () => ({
+  useDisabledAdaptersSync: () => mockAdapterRegistry.disabled,
+}));
+vi.mock("../adapters/use-adapter-capabilities", () => ({
+  useAdapterCapabilities: () => () => ({
+    supportsInstructionsBundle: false,
+    supportsSkills: false,
+    supportsLocalAgentJwt: false,
+    requiresMaterializedRuntimeSkills: false,
+    supportsModelProfiles: false,
+  }),
+}));
+// Animation / canvas-ish children that add nothing to the logic under test.
+vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
+vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
+vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
+
+import { OnboardingWizard } from "./OnboardingWizard";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+function render() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return { container, root, queryClient };
+}
+
+describe("OnboardingWizard restore-gate (stale localStorage across accounts)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockDialog.onboardingOpen = true;
+    mockDialog.onboardingOptions = {};
+    mockDialog.onboardingRouteDismissed = false;
+    mockCompany.companies = [];
+    mockCompany.loading = false;
+    mockAdapterRegistry.list = [];
+    mockAdapterRegistry.disabled = new Set<string>();
+    mockCompaniesApi.create.mockResolvedValue({
+      id: "created",
+      name: "Created Co",
+      issuePrefix: "CRE",
+    });
+    mockCompaniesApi.update.mockResolvedValue({
+      id: "c1",
+      name: "Acme Rockets",
+      issuePrefix: "PAP",
+    });
+    mockGoalsApi.create.mockResolvedValue({ id: "goal-1" });
+    mockGoalsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("re-syncs a restored draft once companies resolve asynchronously (companies start empty/loading)", async () => {
+    // Regression for the initializer-only restore bug: the inner wizard's
+    // ~20 useState(saved?.x ?? default) initializers only read `saved` on
+    // their very first render. useCompany() starts with companies=[] and
+    // loading=true and resolves later; if the inner component mounted before
+    // that resolution, restoreOnboardingState would see an empty companies
+    // list and the whole draft would lock to defaults forever, even after
+    // companies arrive. The fix defers mounting the inner wizard until
+    // companies settle.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 3,
+        companyName: "Saved Co",
+        agentName: "Ops Lead",
+        createdCompanyId: "c1",
+      }),
+    );
+    mockDialog.onboardingOptions = {};
+    mockCompany.companies = [];
+    mockCompany.loading = true;
+
+    const { container, root, queryClient } = render();
+    const renderTree = () =>
+      act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <OnboardingWizard />
+          </QueryClientProvider>,
+        );
+      });
+
+    await renderTree();
+    await flushReact();
+
+    // Nothing mounts yet: no premature guess, and the draft is not touched.
+    expect(container.textContent).toBe("");
+    expect(document.body.textContent).toBe("");
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).not.toBeNull();
+
+    // Companies resolve asynchronously, owning the saved company.
+    mockCompany.companies = [{ id: "c1", name: "Saved Co", issuePrefix: "SC" }];
+    mockCompany.loading = false;
+
+    await renderTree();
+    await flushReact();
+
+    // The draft is restored once companies settle: step 3 (Create your team
+    // lead) with the saved agent name in the input, not the defaults
+    // (step 0, "Chief of staff").
+    expect(document.body.textContent).toContain("Create your team lead");
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value).toBe("Ops Lead");
+    const currentStep = document.body.querySelector('[aria-current="step"]');
+    expect(currentStep?.getAttribute("aria-label")).toBe("Step 3");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("discards a saved draft for a company the signed-in account does not own, and wipes the stale blob", async () => {
+    // The actual vulnerability this fix closes: localStorage is per-origin,
+    // not per-account, so a browser that already onboarded "company-old" for
+    // a different account hands its id straight to a brand-new session.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 4,
+        companyName: "Someone Else's Co",
+        createdCompanyId: "company-old",
+      }),
+    );
+    mockCompany.companies = [{ id: "company-new", name: "My Co", issuePrefix: "MC" }];
+    mockCompany.loading = false;
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Falls back to the wizard's default first step, not the stale step 4
+    // draft for a company this account does not own.
+    expect(document.body.textContent).not.toContain("Someone Else's Co");
+    // The stale blob must not linger to confuse the next onboarding attempt.
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -94,6 +94,10 @@ vi.mock("../adapters/adapter-display-registry", () => ({
 }));
 vi.mock("../adapters/use-disabled-adapters", () => ({
   useDisabledAdaptersSync: () => mockAdapterRegistry.disabled,
+  // Added by #11371's adapter snap. A module mock replaces the whole module,
+  // so every export the component reaches for has to be here — omitting one
+  // makes it undefined and the call throws.
+  useAdapterRegistryLoaded: () => true,
 }));
 vi.mock("../adapters/use-adapter-capabilities", () => ({
   useAdapterCapabilities: () => () => ({

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -19,6 +19,7 @@ const mockCompany = vi.hoisted(() => ({
   companies: [] as Array<{ id: string; name: string; issuePrefix: string }>,
   setSelectedCompanyId: vi.fn(),
   loading: false,
+  error: null as Error | null,
 }));
 
 const mockCompaniesApi = vi.hoisted(() => ({
@@ -138,6 +139,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockDialog.onboardingRouteDismissed = false;
     mockCompany.companies = [];
     mockCompany.loading = false;
+    mockCompany.error = null;
     mockAdapterRegistry.list = [];
     mockAdapterRegistry.disabled = new Set<string>();
     mockCompaniesApi.create.mockResolvedValue({
@@ -253,6 +255,78 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     // The stale blob must not linger to confuse the next onboarding attempt.
     expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBeNull();
 
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("keeps a saved draft when the company query fails, instead of discarding it", async () => {
+    // React Query reports a failed list as `isLoading === false` with `data`
+    // defaulted to `[]`, which is indistinguishable from "settled, and this
+    // account owns nothing" — the verdict that wipes the blob. Deleting a
+    // customer's onboarding because their company request timed out is the one
+    // outcome here that cannot be undone.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 3,
+        companyName: "Saved Co",
+        agentName: "Ops Lead",
+        createdCompanyId: "c1",
+      }),
+    );
+    mockCompany.companies = [];
+    mockCompany.loading = false;
+    mockCompany.error = new Error("company list unavailable");
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Nothing mounts, so the persist effect cannot overwrite the draft either.
+    expect(document.body.textContent).toBe("");
+    const stillThere = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
+    expect(stillThere).not.toBeNull();
+    expect(JSON.parse(stillThere!).createdCompanyId).toBe("c1");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("renders instead of throwing when the browser denies storage access", async () => {
+    // Safari's private mode and blocked third-party contexts make getItem
+    // throw outright. This runs during render, so an escaping exception takes
+    // the whole app down rather than just losing a draft.
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new DOMException("The operation is insecure.", "SecurityError");
+      });
+    mockCompany.companies = [{ id: "c1", name: "My Co", issuePrefix: "MC" }];
+    mockCompany.loading = false;
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(getItem).toHaveBeenCalled();
+    // It mounted: the wizard is open with no draft, rather than the render
+    // throwing on the way in.
+    expect(document.body.textContent).not.toBe("");
+
+    getItem.mockRestore();
     await act(async () => {
       root.unmount();
     });

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -303,11 +303,16 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     // Safari's private mode and blocked third-party contexts make getItem
     // throw outright. This runs during render, so an escaping exception takes
     // the whole app down rather than just losing a draft.
-    const getItem = vi
-      .spyOn(Storage.prototype, "getItem")
-      .mockImplementation(() => {
-        throw new DOMException("The operation is insecure.", "SecurityError");
-      });
+    // A browser that refuses the read refuses the write too, so deny both —
+    // otherwise the cleanup effect's removeItem is never exercised.
+    const deny = () => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    };
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(deny);
+    const removeItem = vi
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(deny);
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(deny);
     mockCompany.companies = [{ id: "c1", name: "My Co", issuePrefix: "MC" }];
     mockCompany.loading = false;
 
@@ -327,6 +332,48 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     expect(document.body.textContent).not.toBe("");
 
     getItem.mockRestore();
+    removeItem.mockRestore();
+    setItem.mockRestore();
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("still opens when a background company refetch fails over a good cache", async () => {
+    // An error with companies in hand is a failed refetch over a cache that is
+    // still usable, not an unanswerable question. Treating it as undecidable
+    // would fail closed: onboarding would never appear for a customer whose
+    // company list is perfectly fine.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 3,
+        companyName: "Saved Co",
+        agentName: "Ops Lead",
+        createdCompanyId: "c1",
+      }),
+    );
+    mockCompany.companies = [{ id: "c1", name: "Saved Co", issuePrefix: "SC" }];
+    mockCompany.loading = false;
+    mockCompany.error = new Error("refetch failed");
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Mounted, and the owned draft was restored rather than withheld.
+    expect(document.body.textContent).toContain("Create your first agent");
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value).toBe("Ops Lead");
+
     await act(async () => {
       root.unmount();
     });

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -259,7 +259,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
       root.unmount();
     });
   });
-  it("keeps a saved draft when the company query fails, instead of discarding it", async () => {
+  it("opens, and keeps the draft, when the initial company query fails", async () => {
     // React Query reports a failed list as `isLoading === false` with `data`
     // defaulted to `[]`, which is indistinguishable from "settled, and this
     // account owns nothing" — the verdict that wipes the blob. Deleting a
@@ -288,11 +288,19 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     });
     await flushReact();
 
-    // Nothing mounts, so the persist effect cannot overwrite the draft either.
-    expect(document.body.textContent).toBe("");
-    const stillThere = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
-    expect(stillThere).not.toBeNull();
-    expect(JSON.parse(stillThere!).createdCompanyId).toBe("c1");
+    // It mounts: the companies query sets `retry: false`, and with no
+    // companies the dashboard's "Get Started" button opens onboarding — a gate
+    // that rendered nothing here would make that button dead.
+    expect(document.body.textContent).not.toBe("");
+    // The draft is not restored, because ownership cannot be verified...
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value ?? "").not.toBe("Ops Lead");
+    // ...and not deleted either. The wizard is open in this harness, so the
+    // persist effect does supersede it - the point is that the ownership check
+    // did not *discard* it. The closed case below is where it survives intact.
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).not.toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -416,6 +424,39 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     getItem.mockRestore();
     removeItem.mockRestore();
     setItem.mockRestore();
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("leaves the draft untouched when the company query fails and onboarding is closed", async () => {
+    // Mounting is safe for the draft precisely because the persist effect is
+    // gated on the wizard being open. A closed wizard writes nothing, so the
+    // blob survives for a later load that can actually verify ownership.
+    const draft = JSON.stringify({
+      step: 3,
+      companyName: "Saved Co",
+      agentName: "Ops Lead",
+      createdCompanyId: "c1",
+    });
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, draft);
+    mockDialog.onboardingOpen = false;
+    mockDialog.onboardingRouteDismissed = true;
+    mockCompany.companies = [];
+    mockCompany.loading = false;
+    mockCompany.error = new Error("company list unavailable");
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe(draft);
+
     await act(async () => {
       root.unmount();
     });

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -206,10 +206,10 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     await renderTree();
     await flushReact();
 
-    // The draft is restored once companies settle: step 3 (Create your team
-    // lead) with the saved agent name in the input, not the defaults
+    // The draft is restored once companies settle: step 3 (Create your first
+    // agent) with the saved agent name in the input, not the defaults
     // (step 0, "Chief of staff").
-    expect(document.body.textContent).toContain("Create your team lead");
+    expect(document.body.textContent).toContain("Create your first agent");
     const nameInput = document.body.querySelector(
       'input[placeholder="Chief of staff"]',
     ) as HTMLInputElement | null;

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -378,4 +378,46 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
       root.unmount();
     });
   });
+  it("closes without throwing when the browser denies storage access", async () => {
+    // `reset()` clears the draft and `handleClose` calls it, so the close
+    // button is a fourth storage call site. Guarding the read, the cleanup and
+    // the persist effect one at a time is how this one stayed unguarded while
+    // the others looked fixed.
+    const deny = () => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    };
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(deny);
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(deny);
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(deny);
+    mockCompany.companies = [{ id: "c1", name: "My Co", issuePrefix: "MC" }];
+    mockCompany.loading = false;
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const close = [...document.body.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("Close"),
+    );
+    expect(close).toBeDefined();
+    await act(async () => {
+      close!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockDialog.closeOnboarding).toHaveBeenCalled();
+
+    getItem.mockRestore();
+    removeItem.mockRestore();
+    setItem.mockRestore();
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -351,11 +351,14 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     });
   });
 
-  it("still opens when a background company refetch fails over a good cache", async () => {
-    // An error with companies in hand is a failed refetch over a cache that is
-    // still usable, not an unanswerable question. Treating it as undecidable
-    // would fail closed: onboarding would never appear for a customer whose
-    // company list is perfectly fine.
+  it("opens but does not restore when a refetch fails over a cached list", async () => {
+    // The companies cache is not account-scoped and survives sign-out, so a
+    // failed refetch after an account switch can leave the *previous*
+    // account's companies in hand. Trusting a non-empty list there would find
+    // the old company id in it and hand that draft to the new account — the
+    // leak this whole change closes, through a different door.
+    //
+    // So: mount (no dead end), do not restore, do not delete.
     window.localStorage.setItem(
       ONBOARDING_STORAGE_KEY,
       JSON.stringify({
@@ -379,12 +382,13 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     });
     await flushReact();
 
-    // Mounted, and the owned draft was restored rather than withheld.
-    expect(document.body.textContent).toContain("Create your first agent");
+    // Mounted rather than blank...
+    expect(document.body.textContent).not.toBe("");
+    // ...but the draft was not restored, because the list cannot be trusted.
     const nameInput = document.body.querySelector(
       'input[placeholder="Chief of staff"]',
     ) as HTMLInputElement | null;
-    expect(nameInput?.value).toBe("Ops Lead");
+    expect(nameInput?.value ?? "").not.toBe("Ops Lead");
 
     await act(async () => {
       root.unmount();
@@ -460,6 +464,50 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     await flushReact();
 
     expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe(draft);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("does not hand one account's draft to the next when a refetch fails after a switch", async () => {
+    // The attack path in full. Account A onboards and leaves a draft naming
+    // its company. A signs out — which does not clear the companies cache,
+    // because `useSignOut` invalidates only the session and health queries.
+    // B signs in and the companies refetch fails, so A's list is still in
+    // hand. A list that still contains A's company must not be read as proof
+    // that B owns it.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        // Step 3 so the agent-name input renders and can be asserted on —
+        // step 4 has no such field, which would make this pass for the wrong
+        // reason whether or not the draft was restored.
+        step: 3,
+        companyName: "Account A Co",
+        agentName: "A's Lead",
+        createdCompanyId: "company-a",
+      }),
+    );
+    mockCompany.companies = [{ id: "company-a", name: "Account A Co", issuePrefix: "AAC" }];
+    mockCompany.loading = false;
+    mockCompany.error = new Error("refetch failed for the new account");
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Account A's agent name must not appear in account B's wizard.
+    expect(document.body.textContent).not.toContain("A's Lead");
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value ?? "").not.toBe("A's Lead");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -117,6 +117,47 @@ Work in this order:
 4. On approval, execute only what they kept. Create exactly the checked options — hire the checked agents and create + delegate the checked follow-up tasks, each in its own task. Skip anything the user unchecked.
 
 Propose, don't decide. Keep it conversational.`;
+/**
+ * The onboarding draft in `localStorage`, via a browser that is allowed to say
+ * no.
+ *
+ * Storage access throws outright where a browser denies it — Safari's private
+ * mode, a blocked third-party context — and every call site here sits in a
+ * render, an effect, or a close handler, so an escaping exception takes down
+ * something the customer was using. Losing the ability to resume onboarding is
+ * a far smaller failure than the wizard tearing down mid-answer, or refusing
+ * to close.
+ *
+ * Routed through one object on purpose. Guarding these one at a time is how
+ * three of the four call sites ended up unguarded while the fourth looked
+ * fixed: the read, the stale-blob cleanup, the persist effect, and `reset()`
+ * all have the same failure and want the same answer.
+ */
+const onboardingDraftStorage = {
+  read(): string | null {
+    try {
+      return localStorage.getItem(ONBOARDING_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  },
+  write(value: string): void {
+    try {
+      localStorage.setItem(ONBOARDING_STORAGE_KEY, value);
+    } catch {
+      // Storage unavailable: the draft is simply not resumable this session.
+    }
+  },
+  clear(): void {
+    try {
+      localStorage.removeItem(ONBOARDING_STORAGE_KEY);
+    } catch {
+      // Nothing to do. A draft that cannot be cleared is re-rejected on the
+      // next load by the same ownership check that rejected it here.
+    }
+  },
+};
+
 const INCOMPLETE_ONBOARDING_STATE_MESSAGE =
   "Onboarding state is incomplete. Please restart onboarding and try again.";
 
@@ -135,17 +176,12 @@ export function OnboardingWizard() {
   // Parsed once (not re-parsed by the cleanup effect below) so the restored
   // value and the "should we wipe the blob" decision always agree.
   const rawBlob = useMemo(() => {
-    // `getItem` is inside the try, not just the parse. It throws outright when
-    // a browser denies storage access - Safari's private mode, a blocked
-    // third-party context - and this runs during render, so an escaping
-    // exception takes the whole app down. Onboarding without a restored draft
-    // is a working wizard; a render that throws is not.
+    const raw = onboardingDraftStorage.read();
+    if (!raw) return undefined;
     try {
-      const raw = localStorage.getItem(ONBOARDING_STORAGE_KEY);
-      if (!raw) return undefined;
       return JSON.parse(raw) as unknown;
     } catch {
-      return null; // unreadable or malformed: treated as stale below
+      return null; // malformed: treated as stale below
     }
   }, []);
 
@@ -177,15 +213,7 @@ export function OnboardingWizard() {
   // the next onboarding attempt (e.g. a different signed-in user).
   useEffect(() => {
     if (!staleStateDetected) return;
-    // Guarded for the same reason the read above is. A browser that refuses
-    // the read refuses the write, and clearing a blob is a convenience - it
-    // must not be the thing that takes the app down.
-    try {
-      localStorage.removeItem(ONBOARDING_STORAGE_KEY);
-    } catch {
-      // Nothing to do: the draft was already rejected, and it stays rejected
-      // on the next load because the same ownership check runs again.
-    }
+    onboardingDraftStorage.clear();
   }, [staleStateDetected]);
 
   // A saved blob exists but companies haven't settled yet: wait rather than
@@ -474,15 +502,7 @@ function OnboardingWizardInner({
       createdCompanyGoalId, createdProjectId, createdIssueRef,
       onboardingPath, growWorkflows, growPainPoints, growAutomate,
     };
-    // Guarded like the read and the clear. This effect runs on every keystroke
-    // in the wizard, so on a browser that denies storage it is the likeliest
-    // of the three to throw - and losing the ability to resume onboarding is a
-    // far smaller failure than the wizard tearing down mid-answer.
-    try {
-      localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state));
-    } catch {
-      // Storage unavailable: the draft simply is not resumable this session.
-    }
+    onboardingDraftStorage.write(JSON.stringify(state));
   }, [
     effectiveOnboardingOpen, step, companyName, companyGoal, missionPath, missionConfirmed,
     q1, q2, q3, q4, agentName, adapterType, cwd, model, command, args, url,
@@ -604,7 +624,7 @@ function OnboardingWizardInner({
   }, [filteredModels, adapterType]);
 
   function reset() {
-    localStorage.removeItem(ONBOARDING_STORAGE_KEY);
+    onboardingDraftStorage.clear();
     setStep(0);
     setOnboardingPath(null);
     setGrowWorkflows("");

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -31,6 +31,7 @@ import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { getAdapterDisplay } from "../adapters/adapter-display-registry";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { parseOnboardingGoalInput } from "../lib/onboarding-goal";
+import { restoreOnboardingState } from "../lib/onboarding-state";
 import { composeCeoInstructions } from "../lib/ceo-instructions";
 import {
   buildOnboardingIssuePayload,
@@ -117,16 +118,62 @@ Propose, don't decide. Keep it conversational.`;
 const INCOMPLETE_ONBOARDING_STATE_MESSAGE =
   "Onboarding state is incomplete. Please restart onboarding and try again.";
 
-function loadSavedState(): Record<string, unknown> | null {
-  try {
+/**
+ * Thin gate in front of {@link OnboardingWizardInner}. The inner component's
+ * ~20 `useState(saved?.x ?? default)` initializers only read `saved` on their
+ * very first render, so it must never mount before the restored draft is
+ * final, otherwise every field locks to its default and the draft is lost
+ * for good. restoreOnboardingState requires the SETTLED companies list (see
+ * its JSDoc), so when a saved blob exists we wait for `companiesLoading` to
+ * clear before computing `saved` and mounting the inner component at all.
+ */
+export function OnboardingWizard() {
+  const { companies, loading: companiesLoading } = useCompany();
+
+  // Parsed once (not re-parsed by the cleanup effect below) so the restored
+  // value and the "should we wipe the blob" decision always agree.
+  const rawBlob = useMemo(() => {
     const raw = localStorage.getItem(ONBOARDING_STORAGE_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch {
+    if (!raw) return undefined;
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return null; // malformed: treated as stale below, same as before
+    }
+  }, []);
+
+  const { saved, staleStateDetected } = useMemo(() => {
+    if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
+    // Companies not settled yet: restoreOnboardingState must not be called
+    // (see its CONTRACT). Not stale, just not decidable yet.
+    if (companiesLoading) return { saved: null, staleStateDetected: false };
+    if (rawBlob === null) return { saved: null, staleStateDetected: true };
+    const restored = restoreOnboardingState(rawBlob, companies);
+    return { saved: restored, staleStateDetected: restored === null };
+  }, [rawBlob, companiesLoading, companies]);
+
+  // A discarded/malformed state should not sit in storage waiting to confuse
+  // the next onboarding attempt (e.g. a different signed-in user).
+  useEffect(() => {
+    if (staleStateDetected) {
+      localStorage.removeItem(ONBOARDING_STORAGE_KEY);
+    }
+  }, [staleStateDetected]);
+
+  // A saved blob exists but companies haven't settled yet: wait rather than
+  // mount the inner wizard with a premature (and unrecoverable) guess.
+  if (rawBlob !== undefined && companiesLoading) {
     return null;
   }
+
+  return <OnboardingWizardInner saved={saved} />;
 }
 
-export function OnboardingWizard() {
+function OnboardingWizardInner({
+  saved,
+}: {
+  saved: Record<string, unknown> | null;
+}) {
   const {
     onboardingOpen,
     onboardingOptions,
@@ -184,9 +231,6 @@ export function OnboardingWizard() {
 
   const initialStep = effectiveOnboardingOptions.initialStep ?? 0;
   const existingCompanyId = effectiveOnboardingOptions.companyId;
-
-  // Restore saved state from localStorage (read once on mount)
-  const saved = useMemo(loadSavedState, []);
 
   const [step, setStep] = useState<Step>((saved?.step as Step) ?? initialStep);
   const [onboardingPath, setOnboardingPath] = useState<"create" | "grow" | null>((saved?.onboardingPath as "create" | "grow" | null) ?? null);

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -198,14 +198,25 @@ export function OnboardingWizard() {
   // list is fine. Only an error that leaves the list empty is undecidable.
   // Named for what it governs: whether the *draft* can be judged. It is not
   // the same question as whether to mount - see the gate below.
-  // A truthy check, not `!== null`. The context types this `Error | null`, but
-  // `undefined` reaches here in practice - any consumer that provides the
-  // company context without an `error` key, which several tests do - and
-  // `undefined !== null` would read a perfectly healthy load as a failure and
-  // discard the customer's draft. The distinction that matters is "is there an
-  // error", and only a truthy test asks that.
-  const ownershipUndecidable =
-    companiesLoading || (Boolean(companiesError) && companies.length === 0);
+  // Any error at all, not only one that left the list empty.
+  //
+  // The companies cache is not scoped to an account and survives sign-out -
+  // `useSignOut` invalidates only the session and health queries, and
+  // invalidation keeps serving the old data anyway. So after A signs out and B
+  // signs in, a *failed* refetch leaves A's companies in hand. Trusting a
+  // non-empty list there would find A's company id in it, call the draft
+  // owned, and hand A's onboarding to B - which is the exact leak this whole
+  // change exists to close, reached through a different door.
+  //
+  // The cost is small and recoverable: during a transient refetch failure the
+  // draft is not restored. It is not deleted either, and the next successful
+  // load restores it.
+  //
+  // A truthy check rather than `!== null`. The context types this
+  // `Error | null`, but `undefined` reaches here from any consumer that
+  // provides the company context without an `error` key, and `undefined !==
+  // null` would read a healthy load as a failure.
+  const ownershipUndecidable = companiesLoading || Boolean(companiesError);
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -149,13 +149,19 @@ export function OnboardingWizard() {
     }
   }, []);
 
-  // A failed company query is not an answer. React Query reports it as
-  // `isLoading === false` with `data` defaulted to an empty list, which reads
-  // exactly like "settled, and this account owns nothing" - and that verdict
-  // deletes the draft below. Discarding a customer's onboarding because their
-  // company request timed out is the one outcome here that cannot be undone,
-  // so an errored list is treated like a loading one: not decidable.
-  const companiesUndecided = companiesLoading || companiesError !== null;
+  // A failed company query is not an answer *when it left us with nothing*.
+  // React Query reports that as `isLoading === false` with `data` defaulted to
+  // an empty list, which reads exactly like "settled, and this account owns
+  // nothing" - and that verdict deletes the draft below. Discarding a
+  // customer's onboarding because their company request timed out is the one
+  // outcome here that cannot be undone.
+  //
+  // An error with companies still in hand is a different thing: a background
+  // refetch failed over a cache that is still good. Blocking on that would
+  // fail closed, and onboarding would simply never appear for a customer whose
+  // list is fine. Only an error that leaves the list empty is undecidable.
+  const companiesUndecided =
+    companiesLoading || (companiesError !== null && companies.length === 0);
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
@@ -170,8 +176,15 @@ export function OnboardingWizard() {
   // A discarded/malformed state should not sit in storage waiting to confuse
   // the next onboarding attempt (e.g. a different signed-in user).
   useEffect(() => {
-    if (staleStateDetected) {
+    if (!staleStateDetected) return;
+    // Guarded for the same reason the read above is. A browser that refuses
+    // the read refuses the write, and clearing a blob is a convenience - it
+    // must not be the thing that takes the app down.
+    try {
       localStorage.removeItem(ONBOARDING_STORAGE_KEY);
+    } catch {
+      // Nothing to do: the draft was already rejected, and it stays rejected
+      // on the next load because the same ownership check runs again.
     }
   }, [staleStateDetected]);
 
@@ -461,7 +474,15 @@ function OnboardingWizardInner({
       createdCompanyGoalId, createdProjectId, createdIssueRef,
       onboardingPath, growWorkflows, growPainPoints, growAutomate,
     };
-    localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state));
+    // Guarded like the read and the clear. This effect runs on every keystroke
+    // in the wizard, so on a browser that denies storage it is the likeliest
+    // of the three to throw - and losing the ability to resume onboarding is a
+    // far smaller failure than the wizard tearing down mid-answer.
+    try {
+      localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // Storage unavailable: the draft simply is not resumable this session.
+    }
   }, [
     effectiveOnboardingOpen, step, companyName, companyGoal, missionPath, missionConfirmed,
     q1, q2, q3, q4, agentName, adapterType, cwd, model, command, args, url,

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -130,29 +130,42 @@ const INCOMPLETE_ONBOARDING_STATE_MESSAGE =
  * clear before computing `saved` and mounting the inner component at all.
  */
 export function OnboardingWizard() {
-  const { companies, loading: companiesLoading } = useCompany();
+  const { companies, loading: companiesLoading, error: companiesError } = useCompany();
 
   // Parsed once (not re-parsed by the cleanup effect below) so the restored
   // value and the "should we wipe the blob" decision always agree.
   const rawBlob = useMemo(() => {
-    const raw = localStorage.getItem(ONBOARDING_STORAGE_KEY);
-    if (!raw) return undefined;
+    // `getItem` is inside the try, not just the parse. It throws outright when
+    // a browser denies storage access - Safari's private mode, a blocked
+    // third-party context - and this runs during render, so an escaping
+    // exception takes the whole app down. Onboarding without a restored draft
+    // is a working wizard; a render that throws is not.
     try {
+      const raw = localStorage.getItem(ONBOARDING_STORAGE_KEY);
+      if (!raw) return undefined;
       return JSON.parse(raw) as unknown;
     } catch {
-      return null; // malformed: treated as stale below, same as before
+      return null; // unreadable or malformed: treated as stale below
     }
   }, []);
+
+  // A failed company query is not an answer. React Query reports it as
+  // `isLoading === false` with `data` defaulted to an empty list, which reads
+  // exactly like "settled, and this account owns nothing" - and that verdict
+  // deletes the draft below. Discarding a customer's onboarding because their
+  // company request timed out is the one outcome here that cannot be undone,
+  // so an errored list is treated like a loading one: not decidable.
+  const companiesUndecided = companiesLoading || companiesError !== null;
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
     // Companies not settled yet: restoreOnboardingState must not be called
     // (see its CONTRACT). Not stale, just not decidable yet.
-    if (companiesLoading) return { saved: null, staleStateDetected: false };
+    if (companiesUndecided) return { saved: null, staleStateDetected: false };
     if (rawBlob === null) return { saved: null, staleStateDetected: true };
     const restored = restoreOnboardingState(rawBlob, companies);
     return { saved: restored, staleStateDetected: restored === null };
-  }, [rawBlob, companiesLoading, companies]);
+  }, [rawBlob, companiesUndecided, companies]);
 
   // A discarded/malformed state should not sit in storage waiting to confuse
   // the next onboarding attempt (e.g. a different signed-in user).
@@ -164,7 +177,14 @@ export function OnboardingWizard() {
 
   // A saved blob exists but companies haven't settled yet: wait rather than
   // mount the inner wizard with a premature (and unrecoverable) guess.
-  if (rawBlob !== undefined && companiesLoading) {
+  //
+  // Waiting is also what protects the blob while the answer is unknown.
+  // Mounting with `saved: null` would not merely show defaults - the persist
+  // effect inside writes the wizard's state back on every change, so it would
+  // overwrite the draft with those defaults within a render or two. Declining
+  // to mount is the only option here that leaves the draft intact for a later
+  // load that can actually decide.
+  if (rawBlob !== undefined && companiesUndecided) {
     return null;
   }
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -86,7 +86,9 @@ function buildMissionFromQuestionnaire(q1: string, q2: string, q3: string, q4: s
   return parts.join(" ");
 }
 
-const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+// Exported so tests write/read the exact key the component uses, instead of
+// duplicating the literal and silently drifting from it if it's ever renamed.
+export const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
 const DEFAULT_TASK_TITLE = "Paperclip onboarding";
 const DEFAULT_TASK_DESCRIPTION = `You are the Paperclip agent. This is your first task. Your job here is to
 understand what the user wants and turn it into a concrete plan — not to

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -198,8 +198,14 @@ export function OnboardingWizard() {
   // list is fine. Only an error that leaves the list empty is undecidable.
   // Named for what it governs: whether the *draft* can be judged. It is not
   // the same question as whether to mount - see the gate below.
+  // A truthy check, not `!== null`. The context types this `Error | null`, but
+  // `undefined` reaches here in practice - any consumer that provides the
+  // company context without an `error` key, which several tests do - and
+  // `undefined !== null` would read a perfectly healthy load as a failure and
+  // discard the customer's draft. The distinction that matters is "is there an
+  // error", and only a truthy test asks that.
   const ownershipUndecidable =
-    companiesLoading || (companiesError !== null && companies.length === 0);
+    companiesLoading || (Boolean(companiesError) && companies.length === 0);
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -196,18 +196,20 @@ export function OnboardingWizard() {
   // refetch failed over a cache that is still good. Blocking on that would
   // fail closed, and onboarding would simply never appear for a customer whose
   // list is fine. Only an error that leaves the list empty is undecidable.
-  const companiesUndecided =
+  // Named for what it governs: whether the *draft* can be judged. It is not
+  // the same question as whether to mount - see the gate below.
+  const ownershipUndecidable =
     companiesLoading || (companiesError !== null && companies.length === 0);
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
     // Companies not settled yet: restoreOnboardingState must not be called
     // (see its CONTRACT). Not stale, just not decidable yet.
-    if (companiesUndecided) return { saved: null, staleStateDetected: false };
+    if (ownershipUndecidable) return { saved: null, staleStateDetected: false };
     if (rawBlob === null) return { saved: null, staleStateDetected: true };
     const restored = restoreOnboardingState(rawBlob, companies);
     return { saved: restored, staleStateDetected: restored === null };
-  }, [rawBlob, companiesUndecided, companies]);
+  }, [rawBlob, ownershipUndecidable, companies]);
 
   // A discarded/malformed state should not sit in storage waiting to confuse
   // the next onboarding attempt (e.g. a different signed-in user).
@@ -216,16 +218,24 @@ export function OnboardingWizard() {
     onboardingDraftStorage.clear();
   }, [staleStateDetected]);
 
-  // A saved blob exists but companies haven't settled yet: wait rather than
-  // mount the inner wizard with a premature (and unrecoverable) guess.
+  // A saved blob exists and the company list is still in flight: wait rather
+  // than mount the inner wizard with a premature, and unrecoverable, guess at
+  // the draft.
   //
-  // Waiting is also what protects the blob while the answer is unknown.
-  // Mounting with `saved: null` would not merely show defaults - the persist
-  // effect inside writes the wizard's state back on every change, so it would
-  // overwrite the draft with those defaults within a render or two. Declining
-  // to mount is the only option here that leaves the draft intact for a later
-  // load that can actually decide.
-  if (rawBlob !== undefined && companiesUndecided) {
+  // Only while *loading*, not on error. An error with an empty list is still
+  // undecidable - nothing is restored and nothing is cleared, per the memo
+  // above - but withholding the wizard on top of that is a dead end, because
+  // the companies query sets `retry: false`. With no companies the dashboard
+  // offers a "Get Started" button that opens onboarding, and a gate that
+  // returned null here would make that button do nothing at all until a
+  // refetch happened to succeed.
+  //
+  // Mounting does not cost the draft. The persist effect that would overwrite
+  // it is itself gated on `effectiveOnboardingOpen`, so a mounted-but-closed
+  // wizard writes nothing, and the blob survives for a later load that can
+  // decide. If the wizard *is* open the customer is onboarding right now,
+  // which supersedes the draft anyway.
+  if (rawBlob !== undefined && companiesLoading) {
     return null;
   }
 

--- a/ui/src/lib/onboarding-state.test.ts
+++ b/ui/src/lib/onboarding-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { restoreOnboardingState } from "./onboarding-state";
+
+const companies = [{ id: "company-new" }];
+
+describe("restoreOnboardingState", () => {
+  it("returns null for unusable input", () => {
+    expect(restoreOnboardingState(null, companies)).toBeNull();
+    expect(restoreOnboardingState("nonsense", companies)).toBeNull();
+  });
+
+  it("discards state whose company the user does not own", () => {
+    const saved = { step: 4, companyName: "Old Co", createdCompanyId: "company-old" };
+    expect(restoreOnboardingState(saved, companies)).toBeNull();
+  });
+
+  it("keeps state for a company the user does own", () => {
+    const saved = { step: 4, companyName: "New Co", createdCompanyId: "company-new" };
+    expect(restoreOnboardingState(saved, companies)?.companyName).toBe("New Co");
+  });
+
+  it("keeps in-progress state that has no company yet", () => {
+    const saved = { step: 1, companyName: "Draft" };
+    expect(restoreOnboardingState(saved, companies)?.companyName).toBe("Draft");
+  });
+
+  it("discards a company id against an empty (settled) companies list", () => {
+    // Per the CONTRACT in the JSDoc, callers must only invoke this once
+    // companies have settled. An empty settled list legitimately means the
+    // account owns no companies, so a saved company id is discarded exactly
+    // like an unowned one.
+    const saved = { step: 4, createdCompanyId: "company-new" };
+    expect(restoreOnboardingState(saved, [])).toBeNull();
+  });
+});

--- a/ui/src/lib/onboarding-state.ts
+++ b/ui/src/lib/onboarding-state.ts
@@ -1,0 +1,31 @@
+/**
+ * localStorage is scoped per ORIGIN, not per account, so a browser that already
+ * ran onboarding will happily hand a previous company's id to a brand new
+ * session. Every downstream call then targets the wrong company: goals,
+ * agents, and issues get created there, and requests targeting the actual
+ * company fail with authorization errors.
+ *
+ * So restoring is an authorization decision, not a convenience. If the saved
+ * company is not one the signed-in user owns, the whole blob is discarded.
+ *
+ * CONTRACT: `companies` must be the caller's SETTLED companies list (its
+ * loading query/context has finished, e.g. `companiesLoading === false`).
+ * This function has no way to tell an empty-because-still-loading list apart
+ * from an empty-because-the-account-owns-nothing list, so it always treats
+ * an empty `companies` as "owns nothing" and discards a saved company id.
+ * Callers must not invoke this while companies are still loading, wait for
+ * the settled list first, or a legitimate draft gets discarded by mistake.
+ */
+export function restoreOnboardingState(
+  raw: unknown,
+  companies: Array<{ id: string }>,
+): Record<string, unknown> | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const saved = { ...(raw as Record<string, unknown>) };
+
+  const companyId = saved.createdCompanyId;
+  if (typeof companyId !== "string" || companyId === "") return saved;
+
+  return companies.some((c) => c.id === companyId) ? saved : null;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A person signs in to a company, and every agent, goal and task they create belongs to that company
> - Onboarding saves a draft to `localStorage` so a customer who closes the tab can pick up where they left off
> - But `localStorage` is scoped per browser origin, not per account, so the draft outlives the session that wrote it
> - A second account signing in on the same browser is handed the first account's company id, and every write the wizard makes then targets a company that account does not own
> - This pull request discards a saved draft whose company the signed-in account does not own, and waits for the company list to settle before deciding
> - The benefit is that a shared browser cannot leak one account's company into another account's onboarding

## Linked Issues or Issue Description

Lands the work from #9900, which had gone stale against `master`. No public issue exists. The problem follows.

**What happened?**

Onboarding persists a draft to `localStorage` under `paperclip-onboarding-state`, including `createdCompanyId`. That key is per origin, not per account. A browser that has already run onboarding hands the stored company id to the next session on the same origin, whoever is signed in.

Every downstream call in the wizard then targets that company: goals, agents and issues are created there, and requests fail with authorization errors when the account does not own it.

**Expected behavior**

A saved draft is restored only when the signed-in account owns the company it names. Otherwise the draft is discarded and the stale blob is removed.

**Steps to reproduce**

1. Sign in as account A and run onboarding far enough to create a company.
2. Sign out, and sign in as account B in the same browser.
3. Open onboarding. It restores account A's `createdCompanyId`.

**Paperclip version or commit**

`master` at `d95340b0b`.

## What Changed

Author: @stubbi. Their two commits are unchanged, with their authorship. The third commit is mine and is the rebase adaptation described below.

- `ui/src/lib/onboarding-state.ts` — new. `restoreOnboardingState` returns the saved draft only when the account owns the company it names.
- `ui/src/lib/onboarding-state.test.ts` — new. Covers ownership, absent company id, and malformed input.
- `ui/src/components/OnboardingWizard.tsx` — splits the component into a gate and `OnboardingWizardInner`, and exports `ONBOARDING_STORAGE_KEY`.
- `ui/src/components/OnboardingWizard.test.tsx` — new. Covers the deferred mount and the discard.

### Why the split into a gate

The inner component has around twenty `useState(saved?.x ?? default)` initializers, and an initializer runs only on the first render. If the inner component mounts before the restored draft is final, every field locks to its default and the draft is lost with no way back.

`restoreOnboardingState` needs the settled company list: it cannot tell an empty-because-loading list from an empty-because-the-account-owns-nothing list, and treats both as "owns nothing". So when a saved blob exists, the gate waits for `companiesLoading` to clear before computing `saved` and mounting the inner component at all.

### Rebase notes

The branch was 475 commits behind and conflicted. Two conflicts, both cosmetic:

1. `OnboardingWizard.tsx` — the `export` on `ONBOARDING_STORAGE_KEY` sat in a hunk whose surrounding context (`DEFAULT_TASK_TITLE`, `DEFAULT_TASK_DESCRIPTION`) `master` had rewritten. Kept master's copy, took the `export`.
2. `OnboardingWizard.test.tsx` — asserted on `"Create your team lead"`, which #11101 renamed to `"Create your first agent"`. Only the user-visible string moved; the gate reaches step 3 with the restored draft either way, and the test's other two assertions passed unchanged. This is the one commit of mine.

### Interaction with #11352

#11352 landed earlier today and reworked much of `OnboardingWizard.tsx`. Everything it changed lives in what this patch turns into `OnboardingWizardInner`, so the two compose. I checked the two ways that could have gone wrong:

- `companiesLoading` is React Query's `isLoading`, which is true only on a first load with no data. A background refetch cannot flip it back and unmount the wizard mid-flow.
- The dashboard auto-open added by #11352 fires only after the agent list and the mission lookup have settled, both of which are keyed on a company id that comes from the company query. So it cannot open the wizard inside the gate's `null` window.

## Verification

- `ui` typecheck is clean.
- The two new suites pass, and so do the four onboarding suites already on `master`.
- Full `ui` suite: **3939 pass**.

One failure remains, in `IssueProperties.test.tsx`. It is timezone-dependent, it reproduces on `master` without these changes, and it is in a file this change does not touch.

**Not done:** no manual two-account run in a real browser. The behaviour is covered by the component tests instead.

## Risks

Low, and bounded by the gate's own condition: it defers mounting only when a saved blob exists. A session with no saved draft — the common case — reaches the wizard exactly as before.

The failure mode if the ownership check were wrong in the other direction is a discarded draft, which costs the customer their in-progress onboarding but nothing that was already written to the server. The check errs that way deliberately: an empty company list reads as "owns nothing", which is why the gate waits for the list to settle first.

Revert the commits to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code, for the rebase, the conflict resolution and the verification. The two substantive commits are @stubbi's own work.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
