### PR TITLE
fix(ui): theme the onboarding wizard decorative panel instead of hardcoding dark

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -2155,7 +2155,7 @@ function OnboardingWizardInner({
               name + mission steps) */}
           <div
             className={cn(
-              "hidden md:block overflow-hidden bg-(--hex-1d1d1d) transition-(--tp-width-opacity) duration-500 ease-in-out",
+              "hidden md:block overflow-hidden bg-muted text-muted-foreground transition-(--tp-width-opacity) duration-500 ease-in-out",
               step === 1 || step === 2 ? "w-1/2 opacity-100" : "w-0 opacity-0"
             )}
           >

--- a/ui/src/components/OnboardingWizardTheme.test.tsx
+++ b/ui/src/components/OnboardingWizardTheme.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The onboarding wizard's decorative right-hand panel (which renders the
+// ASCII paperclip illustration) must follow the active shadcn theme instead of
+// hardcoding a dark surface. Otherwise a light/cream deployer theme (set via
+// the PAPERCLIP_DEFAULT_THEME bootstrap) renders a jarring cream form next to a
+// solid dark panel. The illustration glyphs already use `text-muted-foreground`,
+// so the panel must sit on the paired `bg-muted` surface to read as an
+// intentional ink-on-surface texture in every theme.
+//
+// Asserting against the source keeps this guard cheap: the panel className is a
+// static string literal, and the full wizard dialog is too heavy to mount here.
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe("OnboardingWizard decorative panel theming", () => {
+  const source = readFileSync(
+    path.join(here, "OnboardingWizard.tsx"),
+    "utf8"
+  );
+
+  it("does not hardcode a dark decorative panel background", () => {
+    expect(source).not.toContain("bg-[#1d1d1d]");
+    expect(source).not.toMatch(/bg-\[#[0-9a-fA-F]{3,8}\]/);
+  });
+
+  it("themes the decorative panel with shadcn surface tokens", () => {
+    expect(source).toContain("bg-muted text-muted-foreground");
+  });
+});

--- a/ui/src/components/OnboardingWizardTheme.test.tsx
+++ b/ui/src/components/OnboardingWizardTheme.test.tsx
@@ -29,6 +29,16 @@ describe("OnboardingWizard decorative panel theming", () => {
   });
 
   it("themes the decorative panel with shadcn surface tokens", () => {
-    expect(source).toContain("bg-muted text-muted-foreground");
+    // Anchor to the wrapper around <AsciiArtAnimation /> so the guard checks
+    // the decorative panel itself (the same tokens appear elsewhere in the
+    // wizard), then assert each token independently so a class reorder or a
+    // utility inserted between them cannot false-fail the test. `[^<>]`
+    // keeps the match from spanning across other JSX elements.
+    const panel = source.match(
+      /className=\{cn\(([^<>]*)\)\}\s*>\s*<AsciiArtAnimation\s*\/>/
+    );
+    expect(panel).not.toBeNull();
+    expect(panel?.[1]).toMatch(/\bbg-muted\b(?!-)/);
+    expect(panel?.[1]).toMatch(/\btext-muted-foreground\b/);
   });
 });

--- a/ui/src/components/OnboardingWizardTheme.test.tsx
+++ b/ui/src/components/OnboardingWizardTheme.test.tsx
@@ -24,8 +24,14 @@ describe("OnboardingWizard decorative panel theming", () => {
   );
 
   it("does not hardcode a dark decorative panel background", () => {
-    expect(source).not.toContain("bg-[#1d1d1d]");
-    expect(source).not.toMatch(/bg-\[#[0-9a-fA-F]{3,8}\]/);
+    // Both spellings of a hardcoded surface. The bracket form is what this
+    // guard was written against; master has since migrated the codebase to the
+    // CSS-variable form, and a check that knows only the old spelling passes
+    // whether or not the panel is themed - it did exactly that until this
+    // widened it.
+    expect(source).not.toMatch(
+      /bg-(?:\[#[0-9a-fA-F]{3,8}\]|\(--hex-[0-9a-fA-F]{3,8}\))/
+    );
   });
 
   it("themes the decorative panel with shadcn surface tokens", () => {

--- a/ui/src/components/OnboardingWizardTheme.test.tsx
+++ b/ui/src/components/OnboardingWizardTheme.test.tsx
@@ -23,15 +23,34 @@ describe("OnboardingWizard decorative panel theming", () => {
     "utf8"
   );
 
-  it("does not hardcode a dark decorative panel background", () => {
-    // Both spellings of a hardcoded surface. The bracket form is what this
-    // guard was written against; master has since migrated the codebase to the
-    // CSS-variable form, and a check that knows only the old spelling passes
-    // whether or not the panel is themed - it did exactly that until this
-    // widened it.
-    expect(source).not.toMatch(
-      /bg-(?:\[#[0-9a-fA-F]{3,8}\]|\(--hex-[0-9a-fA-F]{3,8}\))/
+  /**
+   * The className expression on the wrapper around <AsciiArtAnimation />.
+   * Anchoring here keeps both guards on the decorative panel itself - the same
+   * tokens appear elsewhere in the wizard. `[^<>]` stops the match spanning
+   * into other JSX elements.
+   */
+  function panelClassNames(): string | null {
+    return (
+      source.match(/className=\{cn\(([^<>]*)\)\}\s*>\s*<AsciiArtAnimation\s*\/>/)?.[1] ??
+      null
     );
+  }
+
+  it("gives the decorative panel no background but the muted token", () => {
+    // Scoped to the panel, not the file. A file-wide scan would fail this
+    // case for a hardcoded colour anywhere else in the wizard, reporting a
+    // panel regression that had not happened.
+    //
+    // Asserted as the complete set of `bg-` classes rather than a list of
+    // spellings to forbid. The previous version scanned for `bg-[#rrggbb]`
+    // alone, and passed unchanged once master migrated this class to
+    // `bg-(--hex-1d1d1d)` - so it guarded nothing at all for a while. A named
+    // colour like `bg-black` or `bg-zinc-900` would have slipped through the
+    // same way. Naming what is allowed cannot rot like that.
+    const panel = panelClassNames();
+    expect(panel).not.toBeNull();
+    const backgrounds = panel!.match(/\bbg-[^\s"'`,]+/g) ?? [];
+    expect(backgrounds).toEqual(["bg-muted"]);
   });
 
   it("themes the decorative panel with shadcn surface tokens", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The app ships a light theme and a dark theme, and follows the operating system unless the customer picks one
> - Onboarding is the first screen a new customer sees, and its right-hand half is a decorative panel holding the ASCII paperclip illustration
> - That panel hardcoded a near-black surface, so it stayed dark whatever the theme said
> - In light mode the customer meets the product as a pale form sitting beside a solid black rectangle, on the one screen that is supposed to introduce it
> - This pull request paints the panel with the same muted surface tokens as the rest of the app
> - The benefit is that the first screen looks deliberate in both themes, and follows any future theme without another fix

## Linked Issues or Issue Description

Lands the work from #8982. No public issue exists. The problem follows.

**What happened?**

The onboarding wizard's decorative right-hand panel used a hardcoded dark background. `ThemeContext` supports `"light" | "dark"` and follows `prefers-color-scheme`, so in light mode the panel stayed near-black against a light form.

The illustration glyphs inside it already use `text-muted-foreground`, so the panel was the only part not following the theme.

**Expected behavior**

The panel uses the paired `bg-muted` surface, so the illustration reads as ink on a surface in either theme.

**Steps to reproduce**

1. Set the app to light mode.
2. Open onboarding and go to step 1 or 2, where the panel is visible.
3. The left half is light and the right half is near-black.

**Paperclip version or commit**

`master` at `a53cc8819`.

## What Changed

Author: @stubbi. Their two commits are unchanged, with their authorship. The third is mine and is the rebase adaptation below.

- `ui/src/components/OnboardingWizard.tsx` — the decorative panel uses `bg-muted text-muted-foreground` instead of a hardcoded surface. One line.
- `ui/src/components/OnboardingWizardTheme.test.tsx` — new. Asserts against the source, since the panel's className is a static literal and mounting the full wizard dialog to check a background is disproportionate.

### Rebase notes

One conflict, on the changed line itself. This branch replaced `bg-(--hex-1d1d1d)` with the muted tokens, while `master` had separately moved `transition-[width,opacity]` to `transition-(--tp-width-opacity)`. Kept master's transition and this branch's colours.

### One assertion had stopped guarding anything

The suite has two cases. The first checked `bg-[#1d1d1d]` and the bracket-hex form generally — but `master` migrated that class to the CSS-variable spelling `bg-(--hex-1d1d1d)` while this branch was open, and neither pattern matches it. So it passed whether or not the panel was themed.

It now matches both spellings. Found by reverting the fix on the rebased branch: the second case failed and the first stayed green.

## Verification

- `ui` typecheck is clean.
- Both theme cases pass, and both fail when the panel is reverted to a hardcoded surface — where before, only one did.
- `--muted` is defined in both themes in `index.css` (light `oklch(0.97 0 0)`, dark `oklch(0.269 0 0)`), so the panel follows the theme rather than staying near-black.
- Full `ui` suite: **3958 pass**.

One failure remains, in `IssueProperties.test.tsx`. It is timezone-dependent, it reproduces on `master` without these changes, and it is in a file this change does not touch.

**Not done:** no screenshot comparison. The change is one class on a decorative panel, and the token pair is asserted in the test.

## Risks

Very low. One className on a decorative element, with no behaviour attached and no other consumer.

Worth naming that the original motivation cited `PAPERCLIP_DEFAULT_THEME`, a deployer setting that does not exist in this codebase. The fix stands on its own here regardless: Paperclip ships a real light theme with an OS-following default, and the panel was ignoring it.

Revert the commits to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code, for the rebase, the widened assertion and the verification. The two substantive commits are @stubbi's own work.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
