### PR TITLE
fix(ui): clear account-scoped query caches on sign-out

### DIFF
--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -496,11 +496,15 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
   });
   it("does not hand one account's draft to the next when a refetch fails after a switch", async () => {
     // The attack path in full. Account A onboards and leaves a draft naming
-    // its company. A signs out — which does not clear the companies cache,
-    // because `useSignOut` invalidates only the session and health queries.
-    // B signs in and the companies refetch fails, so A's list is still in
+    // its company. The account then changes without this component's company
+    // cache being cleared, and the refetch fails, so A's list is still in
     // hand. A list that still contains A's company must not be read as proof
     // that B owns it.
+    //
+    // `useSignOut` now resets account-scoped caches, which closes the
+    // sign-out-button route into this state (see its own regression test). The
+    // gate is asserted here independently of that: it must hold for any route
+    // that leaves a stale list behind, not only the one that has been fixed.
     window.localStorage.setItem(
       ONBOARDING_STORAGE_KEY,
       JSON.stringify({

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -205,10 +205,15 @@ export function OnboardingWizard() {
   // trusts "not loading, no error" finds the old company id in them and hands
   // one account's onboarding draft to the next.
   //
-  // Sign-out does not help: `useSignOut` never clears the company cache, and
-  // on the self-hosted path there is no document reload to clear it either.
-  // Even once that is fixed, an account change can skip the button entirely -
-  // a session lapsing server-side, a second account signing in on a warm tab.
+  // Sign-out is no longer the hole it was: `useSignOut` now resets every
+  // account-scoped cache entry rather than invalidating two of them, so the
+  // ordinary A-signs-out-then-B-signs-in path does not leave A's companies in
+  // hand.
+  //
+  // That covers the button, not the question. An account can change without
+  // it - a session lapsing server-side, a second account signing in on a warm
+  // tab, a caller supplying the company context from somewhere else - so this
+  // gate stays independent of that fix rather than deferring to it.
   //
   // So this asks for a list fetched *for this mount*, rather than reading the
   // one in hand. `isFetchedAfterMount` is the part that matters; `staleTime: 0`

--- a/ui/src/hooks/useSignOut.test.tsx
+++ b/ui/src/hooks/useSignOut.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
+import { act } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { queryKeys } from "@/lib/queryKeys";
-import { useSignOut } from "./useSignOut";
+import { isAccountScopedQueryKey, useSignOut } from "./useSignOut";
 
 const mockAuthApi = vi.hoisted(() => ({ signOut: vi.fn() }));
 const mockNavigateTopLevel = vi.hoisted(() => vi.fn());
@@ -75,13 +76,22 @@ describe("useSignOut", () => {
     flushSync(() => root.unmount());
   });
 
-  it("keeps self-hosted sign-out pending until the local request finishes, then invalidates caches", async () => {
+  it("keeps self-hosted sign-out pending until the local request finishes, then clears account caches", async () => {
     let resolveSignOut: (() => void) | undefined;
     mockAuthApi.signOut.mockImplementation(() => new Promise<void>((resolve) => {
       resolveSignOut = resolve;
     }));
     queryClient.setQueryData(queryKeys.health, { status: "ok", deploymentMode: "authenticated" });
     queryClient.setQueryData(queryKeys.auth.session, { session: { id: "session-1" } });
+    queryClient.setQueryData(queryKeys.companies.all, {
+      companies: [{ id: "company-a", name: "Account A Co" }],
+      unauthorized: false,
+    });
+    queryClient.setQueryData(queryKeys.access.currentBoardAccess, {
+      isInstanceAdmin: false,
+      companyIds: ["company-a"],
+    });
+    queryClient.setQueryData(queryKeys.issues.list("company-a"), [{ id: "issue-a" }]);
     const onSignedOut = vi.fn();
     const root = renderHarness(onSignedOut);
 
@@ -97,16 +107,101 @@ describe("useSignOut", () => {
 
     expect(captured?.error).toBeNull();
     expect(onSignedOut).toHaveBeenCalledOnce();
-    expect(queryClient.getQueryState(queryKeys.auth.session)?.isInvalidated).toBe(true);
+
+    // Account-scoped entries are gone outright, not merely marked stale. An
+    // invalidated entry keeps serving its old value until a refetch succeeds,
+    // which is the leak this guards.
+    expect(queryClient.getQueryData(queryKeys.auth.session)).toBeUndefined();
+    expect(queryClient.getQueryData(queryKeys.companies.all)).toBeUndefined();
+    expect(queryClient.getQueryData(queryKeys.access.currentBoardAccess)).toBeUndefined();
+    expect(queryClient.getQueryData(queryKeys.issues.list("company-a"))).toBeUndefined();
+
+    // Health describes the instance, not the account, and several observers
+    // read it with `enabled: false`. It is refreshed in place.
+    expect(queryClient.getQueryData(queryKeys.health)).toEqual({
+      status: "ok",
+      deploymentMode: "authenticated",
+    });
     expect(queryClient.getQueryState(queryKeys.health)?.isInvalidated).toBe(true);
 
     flushSync(() => root.unmount());
   });
 
-  it("exposes a stable error without closing chrome or invalidating caches", async () => {
+  it("leaves the previous account nothing to read when the next account's refetch fails", async () => {
+    // The end-to-end shape of the leak. Account A's company list is in cache,
+    // A signs out, B signs in, and B's companies request fails.
+    // `companiesListQueryOptions` sets `retry: false`, so that single failure
+    // is final — and under `invalidateQueries` the observer would still be
+    // holding A's list, which consumers read as "this account owns these
+    // companies".
+    mockAuthApi.signOut.mockResolvedValue(undefined);
+    queryClient.setQueryData(queryKeys.health, { status: "ok", deploymentMode: "authenticated" });
+
+    const companiesQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        companies: [{ id: "company-a", name: "Account A Co" }],
+        unauthorized: false,
+      })
+      .mockRejectedValue(new Error("refetch failed for the new account"));
+
+    // A live observer, standing in for CompanyProvider — which sits above the
+    // router and stays mounted across the whole sign-out/sign-in cycle, so it
+    // never gets a fresh mount to clear it.
+    let observed: unknown = "unset";
+    function CompaniesObserver() {
+      const { data } = useQuery({
+        queryKey: queryKeys.companies.all,
+        queryFn: companiesQueryFn,
+        retry: false,
+      });
+      observed = data;
+      return null;
+    }
+
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Harness />
+          <CompaniesObserver />
+        </QueryClientProvider>,
+      );
+    });
+
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(observed).toEqual({
+          companies: [{ id: "company-a", name: "Account A Co" }],
+          unauthorized: false,
+        }),
+      );
+    });
+
+    await act(async () => {
+      captured?.mutate();
+      // The sign-out resolves, its cache reset fires, and the refetch that
+      // reset kicks off is the one that fails.
+      await vi.waitFor(() => expect(captured?.isSuccess).toBe(true));
+      await vi.waitFor(() => expect(companiesQueryFn).toHaveBeenCalledTimes(2));
+    });
+
+    expect(queryClient.getQueryData(queryKeys.companies.all)).toBeUndefined();
+    expect(observed).toBeUndefined();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("exposes a stable error without closing chrome or clearing caches", async () => {
     mockAuthApi.signOut.mockRejectedValue(new Error("Sign-out request failed"));
     queryClient.setQueryData(queryKeys.health, { status: "ok", deploymentMode: "authenticated" });
     queryClient.setQueryData(queryKeys.auth.session, { session: { id: "session-1" } });
+    queryClient.setQueryData(queryKeys.companies.all, {
+      companies: [{ id: "company-a", name: "Account A Co" }],
+      unauthorized: false,
+    });
     const onSignedOut = vi.fn();
     const root = renderHarness(onSignedOut);
 
@@ -115,9 +210,62 @@ describe("useSignOut", () => {
     await vi.waitFor(() => expect(captured?.error?.message).toBe("Sign-out request failed"));
     expect(captured?.isPending).toBe(false);
     expect(onSignedOut).not.toHaveBeenCalled();
+    // The account is still signed in, so its caches must survive intact —
+    // a failed sign-out must not blank the app the user is still using.
+    expect(queryClient.getQueryData(queryKeys.auth.session)).toEqual({ session: { id: "session-1" } });
+    expect(queryClient.getQueryData(queryKeys.companies.all)).toEqual({
+      companies: [{ id: "company-a", name: "Account A Co" }],
+      unauthorized: false,
+    });
     expect(queryClient.getQueryState(queryKeys.auth.session)?.isInvalidated).toBe(false);
     expect(queryClient.getQueryState(queryKeys.health)?.isInvalidated).toBe(false);
 
     flushSync(() => root.unmount());
+  });
+
+  it("leaves the Cloud cache to the document reload rather than clearing it locally", async () => {
+    // The Cloud path never reaches onSuccess's clearing branch: it hands off to
+    // a top-level navigation, and the resulting document load builds a new
+    // QueryClient from scratch. Clearing here would only blank the UI during
+    // the frames before that navigation commits.
+    queryClient.setQueryData(queryKeys.health, {
+      status: "ok",
+      cloud: {
+        managed: true,
+        managedBy: "paperclip-cloud",
+        stackSlug: "acme",
+        cloudBaseUrl: "https://cloud.example.test",
+      },
+    });
+    queryClient.setQueryData(queryKeys.companies.all, {
+      companies: [{ id: "company-a", name: "Account A Co" }],
+      unauthorized: false,
+    });
+    const root = renderHarness();
+
+    flushSync(() => captured?.mutate());
+
+    await vi.waitFor(() => expect(mockNavigateTopLevel).toHaveBeenCalledOnce());
+    expect(queryClient.getQueryData(queryKeys.companies.all)).toEqual({
+      companies: [{ id: "company-a", name: "Account A Co" }],
+      unauthorized: false,
+    });
+
+    flushSync(() => root.unmount());
+  });
+});
+
+describe("isAccountScopedQueryKey", () => {
+  it("keeps only the instance-scoped health entry", () => {
+    expect(isAccountScopedQueryKey(queryKeys.health)).toBe(false);
+  });
+
+  it("treats every other key root as account-scoped, including ones added later", () => {
+    expect(isAccountScopedQueryKey(queryKeys.companies.all)).toBe(true);
+    expect(isAccountScopedQueryKey(queryKeys.auth.session)).toBe(true);
+    expect(isAccountScopedQueryKey(queryKeys.access.currentBoardAccess)).toBe(true);
+    expect(isAccountScopedQueryKey(queryKeys.issues.list("company-a"))).toBe(true);
+    expect(isAccountScopedQueryKey(queryKeys.secrets.list("company-a"))).toBe(true);
+    expect(isAccountScopedQueryKey(["some-key-nobody-has-written-yet"])).toBe(true);
   });
 });

--- a/ui/src/hooks/useSignOut.ts
+++ b/ui/src/hooks/useSignOut.ts
@@ -6,6 +6,27 @@ import { useCloudInstance } from "./useCloudInstance";
 
 const CLOUD_SIGN_OUT_PATH = "/cloud/logout";
 
+/**
+ * Query-key roots that describe the *instance* rather than the account that was
+ * signed in, and so are allowed to outlive a sign-out.
+ *
+ * `health` is the only one. It carries deployment mode, bootstrap state and
+ * Cloud metadata — nothing account-scoped — and `useCloudInstance` observes it
+ * with `enabled: false`, deliberately leaving the fetch to CloudAccessGate.
+ * Dropping the entry would strand every such observer on `null` until the gate
+ * happened to refetch, flipping Cloud instances into their self-hosted
+ * rendering mid-sign-out. It is refreshed in place instead.
+ *
+ * Everything *not* listed here is treated as account-scoped and cleared. That
+ * direction is the point: a query key added later is account-scoped unless
+ * someone deliberately says otherwise, so forgetting this file fails closed.
+ */
+const INSTANCE_SCOPED_QUERY_ROOTS: readonly unknown[] = [queryKeys.health[0]];
+
+export function isAccountScopedQueryKey(queryKey: readonly unknown[]): boolean {
+  return !INSTANCE_SCOPED_QUERY_ROOTS.includes(queryKey[0]);
+}
+
 interface UseSignOutOptions {
   onSignedOut?: () => void;
 }
@@ -14,8 +35,10 @@ interface UseSignOutOptions {
  * Owns the app-wide sign-out decision.
  *
  * Cloud-managed tenants must enter the harness-owned logout sequence without
- * first clearing the tenant session. Authenticated self-hosted instances keep
- * the local API flow and invalidate the auth-dependent caches afterward.
+ * first clearing the tenant session; that path is a top-level navigation, so
+ * the document reload it triggers builds a new QueryClient and there is nothing
+ * left here to clear. Authenticated self-hosted instances keep the local API
+ * flow and drop the account-scoped caches afterward.
  */
 export function useSignOut({ onSignedOut }: UseSignOutOptions = {}) {
   const cloud = useCloudInstance();
@@ -36,10 +59,34 @@ export function useSignOut({ onSignedOut }: UseSignOutOptions = {}) {
       if (target === "cloud") return;
 
       onSignedOut?.();
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.auth.session }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.health }),
-      ]);
+
+      // Drop every account-scoped cache entry, rather than invalidating a
+      // couple of them. `invalidateQueries` only marks an entry stale and goes
+      // on serving the old value until a refetch succeeds — and the companies
+      // query sets `retry: false`, so a single failed request is enough to
+      // leave the previous account's company list readable for the whole of
+      // the *next* account's session. Consumers that read a non-empty list as
+      // authoritative (company auto-selection, the invite-landing "already a
+      // member" check, the board-access gate) would then act on it.
+      //
+      // `resetQueries` rather than `removeQueries`: removal empties the cache
+      // but does not notify the observers already subscribed to those entries,
+      // so a mounted `useQuery` keeps returning its last result until some
+      // unrelated re-render happens to rebuild the query. That is not a corner
+      // case here — CompanyProvider sits above the router and stays mounted
+      // across the whole sign-out/sign-in cycle. Reset notifies them, so the
+      // old data is gone from the cache *and* from everything reading it.
+      //
+      // Not awaited: the refetches this kicks off are expected to 401 now that
+      // the session is gone, and the sign-out button should not sit pending
+      // while they fail.
+      void queryClient.resetQueries({
+        predicate: (query) => isAccountScopedQueryKey(query.queryKey),
+      });
+
+      // Instance-scoped, so refreshed in place rather than dropped — see
+      // INSTANCE_SCOPED_QUERY_ROOTS.
+      await queryClient.invalidateQueries({ queryKey: queryKeys.health });
     },
   });
 }

--- a/ui/src/pages/InstanceGeneralSettings.test.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.test.tsx
@@ -101,17 +101,27 @@ describe("InstanceGeneralSettings sign-out", () => {
     expect(mockAuthApi.signOut).not.toHaveBeenCalled();
   });
 
-  it("keeps authenticated self-hosted sign-out local and invalidates auth caches", async () => {
+  it("keeps authenticated self-hosted sign-out local and drops the account caches", async () => {
     const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
     await renderPage(SELF_HOSTED_HEALTH);
+    queryClient.setQueryData(queryKeys.auth.session, { session: { id: "session-1" } });
+    queryClient.setQueryData(queryKeys.companies.all, {
+      companies: [{ id: "company-a", name: "Account A Co" }],
+      unauthorized: false,
+    });
 
     flushSync(() => signOutButton()?.click());
 
     await vi.waitFor(() => expect(mockAuthApi.signOut).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: queryKeys.auth.session,
-    }));
+    // Account-scoped entries are cleared outright, not marked stale — a stale
+    // entry keeps serving the previous account's data until a refetch succeeds.
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryData(queryKeys.auth.session)).toBeUndefined(),
+    );
+    expect(queryClient.getQueryData(queryKeys.companies.all)).toBeUndefined();
+    // Health describes the instance, so it is refreshed rather than dropped.
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.health });
+    expect(queryClient.getQueryData(queryKeys.health)).toEqual(SELF_HOSTED_HEALTH);
     expect(mockNavigateTopLevel).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Everything a person creates belongs to a company, and which companies a person can see is an authorization fact the server owns
> - The UI keeps that company list in a React Query cache entry, `["companies"]`, that carries no account identity
> - Sign-out is the moment that cache stops describing the person at the keyboard, but the self-hosted path only marked two unrelated keys stale and left the company list untouched
> - Invalidation also keeps serving the old value until a refetch succeeds, and the companies query sets `retry: false`, so one failed request pins the previous account's list in place
> - This pull request drops every account-scoped cache entry on sign-out, against a small allowlist of entries that describe the instance instead of the account
> - The benefit is that consumers reading the company list stop inheriting the previous account's answer

## Linked Issues or Issue Description

No public issue exists. Refs #11370, #11382. The problem follows.

**What happened?**

`useSignOut` invalidated only `queryKeys.auth.session` and `queryKeys.health` on the self-hosted path. Two things follow:

- The companies query (`queryKeys.companies.all`) was never touched, so the previous account's company list stayed in the cache across a sign-out.
- `invalidateQueries` marks data stale but keeps serving it, so even the two keys it did touch stayed readable until a refetch succeeded.

`CompanyProvider` sits above the router in `ui/src/main.tsx`, so it stays mounted across the whole sign-out and sign-in cycle and never gets a fresh mount to clear it. `companiesListQueryOptions` sets `retry: false`, so a single failed refetch sticks for the rest of the next account's session.

Consumers that would then act on the previous account's list:

- `resolveBootstrapCompanySelection` (`ui/src/context/CompanyContext.tsx`) auto-selects `selectableCompanies[0]`, putting account B on account A's company and rendering A's company name in the sidebar and breadcrumbs.
- `CloudAccessGate` gates on `boardAccessQuery.data.companyIds.length`, so a stale `access.currentBoardAccess` entry admits B on A's memberships.
- `InviteLanding` reads a cached list as proof of membership in two places.

**Expected behavior**

After a sign-out, no cache entry describing the previous account remains readable.

**Steps to reproduce**

1. On a self-hosted instance in `authenticated` mode, sign in as account A and let the company list load.
2. Sign out. The document does not reload.
3. Sign in as account B in the same tab, with the companies request failing once.
4. `useCompany()` still returns account A's companies.

**Paperclip version or commit**

`master` at `2a4b4bc63`.

## What Changed

- `ui/src/hooks/useSignOut.ts` — the self-hosted path resets every account-scoped cache entry instead of invalidating two keys. Adds `isAccountScopedQueryKey`, tested against an `INSTANCE_SCOPED_QUERY_ROOTS` allowlist that holds `health` alone.
- `ui/src/hooks/useSignOut.test.tsx` — regression coverage for sign-out followed by a failed refetch, plus cases for the allowlist, a failed sign-out, and the Cloud path.
- `ui/src/pages/InstanceGeneralSettings.test.tsx` — asserted the old mechanism (`invalidateQueries` called with the session key); now asserts the outcome.
- `ui/src/components/OnboardingWizard.tsx`, `ui/src/components/OnboardingWizard.test.tsx` — comments only. They stated that sign-out invalidates just two keys, which is no longer true.

### Why the allowlist is default-deny

A query key added to `queryKeys` later is treated as account-scoped unless someone deliberately adds it to the allowlist, so forgetting this file fails closed.

`health` is refreshed in place rather than dropped. It carries deployment mode, bootstrap state and Cloud metadata, nothing account-scoped, and `useCloudInstance` observes it with `enabled: false` because `CloudAccessGate` owns the fetch. Dropping the entry would strand those observers on `null` and flip Cloud instances into their self-hosted rendering mid-sign-out.

### Why `resetQueries` and not `removeQueries`

`removeQueries` empties the cache but does not notify observers already subscribed to those entries, because `#updateQuery` only runs on `setOptions` and `onSubscribe`. A probe against the installed query-core (5.101.4) confirms it: after the sweep `getQueryData` returns `undefined` while the mounted observer keeps returning the old data and never refetches. Since `CompanyProvider` never unmounts here, that is the common case, not a corner one.

A sibling change (#11382, and the invite-landing work) depends on `isFetchedAfterMount`, and warns that `resetQueries` rewinds the update counters that flag is derived from. That warning is correct, and I measured its reach:

| Observer | After the sweep |
| --- | --- |
| Binds while the cache is **warm**, survives the sweep | `isFetchedAfterMount: false` — stranded |
| Same, across two sweeps | `false` — stays stranded |
| Binds while the cache is **cold**, survives the sweep | `true` |
| Mounts fresh **after** the sweep | `true` |

It cannot reach the sign-out sweep. The sweep resets `auth.session` too, so `CloudAccessGate` renders `<Navigate to="/auth">` on the next render and unmounts every component holding such a gate; they remount fresh on re-entry, which is the safe row. The strand also fails closed — a false `isFetchedAfterMount` makes those gates withhold a membership verdict rather than grant one, the opposite of the leak this fixes.

### Cloud path

Unaffected. `navigateTopLevel` is `window.location.assign`, a real document load that builds a new `QueryClient`, and it returns before the clearing branch. A test pins that the Cloud path leaves the cache alone.

## Verification

- `pnpm vitest run` in `ui`: 3957 passed, 1 failed.
- `pnpm tsc -b`: clean.
- The two changed tests were confirmed to fail against the old implementation: session data survives, and the companies query is never touched (1 call instead of 2).
- The `removeQueries` and `isFetchedAfterMount` claims above were measured with a throwaway probe against query-core 5.101.4, not reasoned about. The probe was deleted after it answered.

The one failure is `IssueProperties.test.tsx`, "renders scheduled, retrying, due, overdue…", which expects `4:08 PM` and gets `9:08 AM`. It is timezone-dependent, it reproduces on `master` without these changes, and it is in a file this change does not touch.

**Not done:** no manual two-account run in a browser. The sign-out button renders only in `authenticated` deployment mode and the bug needs two accounts, so a local dev instance cannot exercise the path.

## Risks

Low. The change widens what a sign-out clears, and the failure direction is an extra refetch after signing in rather than data held past its account.

The one behavioral shift worth naming: queries that were previously left alone across a sign-out now refetch. Those requests are expected to 401 now that the session is gone, so the sweep is deliberately not awaited and the sign-out button does not sit pending while they fail.

**This does not close the class.** An account can change without the sign-out button: a session that lapses server-side, or a second account signing in on a warm tab. #11382 and the invite-landing work handle those at the point of use, and remain necessary.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck, test runs, and the query-core probe.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
