### PR TITLE
fix(onboarding): verify draft ownership against a list fetched this session

### DIFF
--- a/ui/src/components/OnboardingWizard.adapters.test.tsx
+++ b/ui/src/components/OnboardingWizard.adapters.test.tsx
@@ -43,6 +43,14 @@ vi.mock("../context/DialogContext", () => ({
 vi.mock("../context/CompanyContext", () => ({
   useCompany: () => mockCompany,
 }));
+// The restore gate fetches the company list itself to verify draft ownership,
+// rather than trusting the shared cache, so this module now needs stubbing
+// here. An empty list is fine: the drafts in this file carry no
+// `createdCompanyId`, so there is no ownership question — but the fetch has to
+// succeed for the gate to treat the draft as decidable at all.
+vi.mock("../api/companies", () => ({
+  companiesApi: { create: vi.fn(), list: vi.fn().mockResolvedValue([]) },
+}));
 vi.mock("../adapters", () => ({
   listUIAdapters: () => mockAdapterRegistry.list,
   getUIAdapter: () => ({ buildAdapterConfig: () => ({}) }),

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -118,6 +118,7 @@ vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
 vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
 
 import { ApiError } from "../api/client";
+import { queryKeys } from "../lib/queryKeys";
 import { ONBOARDING_STORAGE_KEY, OnboardingWizard } from "./OnboardingWizard";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -618,6 +619,111 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     await flushReact();
 
     expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("does not restore against data retained from a failed post-mount refetch", async () => {
+    // The gate's weak point if it only asks "was there a fetch after mount,
+    // and is there data". React Query keeps the last successful `data` when a
+    // refetch fails — so after an account switch the retained value is the
+    // *previous* account's list, and accepting it restores their draft.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 3,
+        companyName: "Account A Co",
+        agentName: "A's Lead",
+        createdCompanyId: "company-a",
+      }),
+    );
+    const { root, queryClient } = render();
+    // A's list, already in the cache from their session.
+    queryClient.setQueryData(queryKeys.companies.all, {
+      companies: [{ id: "company-a", name: "Account A Co", issuePrefix: "AAC" }],
+      unauthorized: false,
+    });
+    // B's session: the refetch fails, so A's data is retained.
+    mockCompaniesApi.list.mockRejectedValue(new Error("refetch failed"));
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Mounted, so this observes the real thing rather than an empty document.
+    expect(document.body.textContent).not.toBe("");
+    expect(document.body.textContent).not.toContain("A's Lead");
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value ?? "").not.toBe("A's Lead");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("does not mount undecided over a warm cache, which would overwrite the draft", async () => {
+    // The customer's own draft, their own companies already cached, and a
+    // refetch in flight. `isLoading` is false whenever retained data exists,
+    // so a gate keyed on it would mount the wizard while ownership was still
+    // undecidable — and with the wizard open, the persist effect writes the
+    // wizard's state back on every change, overwriting their draft with
+    // defaults before the answer arrives.
+    const draft = JSON.stringify({
+      step: 3,
+      companyName: "Saved Co",
+      agentName: "Ops Lead",
+      createdCompanyId: "c1",
+    });
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, draft);
+    const { root, queryClient } = render();
+    queryClient.setQueryData(queryKeys.companies.all, {
+      companies: [{ id: "c1", name: "Saved Co", issuePrefix: "SC" }],
+      unauthorized: false,
+    });
+    mockCompaniesApi.list.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Nothing mounted, so nothing could have written over the draft.
+    expect(document.body.textContent).toBe("");
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe(draft);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("clears an unreadable draft without waiting on the company endpoint", async () => {
+    // Junk is junk whoever owns what, so judging it must not queue behind a
+    // request that cannot change the answer — nor issue one at all.
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, "{not json");
+    const { root, queryClient } = render();
+    mockCompaniesApi.list.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBeNull();
+    expect(mockCompaniesApi.list).not.toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -25,6 +25,10 @@ const mockCompany = vi.hoisted(() => ({
 const mockCompaniesApi = vi.hoisted(() => ({
   create: vi.fn(),
   update: vi.fn(),
+  // The gate fetches the list itself now, rather than reading the shared
+  // cache, so ownership cases are driven from here. `mockCompany.companies`
+  // below still feeds the *inner* wizard, which is a different question.
+  list: vi.fn(),
 }));
 const mockGoalsApi = vi.hoisted(() => ({
   create: vi.fn(),
@@ -113,6 +117,7 @@ vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
 vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
 vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
 
+import { ApiError } from "../api/client";
 import { ONBOARDING_STORAGE_KEY, OnboardingWizard } from "./OnboardingWizard";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -144,6 +149,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockCompany.companies = [];
     mockCompany.loading = false;
     mockCompany.error = null;
+    mockCompaniesApi.list.mockResolvedValue([]);
     mockAdapterRegistry.list = [];
     mockAdapterRegistry.disabled = new Set<string>();
     mockCompaniesApi.create.mockResolvedValue({
@@ -186,6 +192,15 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockDialog.onboardingOptions = {};
     mockCompany.companies = [];
     mockCompany.loading = true;
+    // Deferred rather than swapped later: the gate's fetch fires on the first
+    // render, so replacing the mock afterwards would never reach it.
+    let resolveList: (companies: Array<{ id: string; name: string; issuePrefix: string }>) => void =
+      () => {};
+    mockCompaniesApi.list.mockReturnValue(
+      new Promise<Array<{ id: string; name: string; issuePrefix: string }>>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
 
     const { container, root, queryClient } = render();
     const renderTree = () =>
@@ -208,6 +223,9 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     // Companies resolve asynchronously, owning the saved company.
     mockCompany.companies = [{ id: "c1", name: "Saved Co", issuePrefix: "SC" }];
     mockCompany.loading = false;
+    await act(async () => {
+      resolveList([{ id: "c1", name: "Saved Co", issuePrefix: "SC" }]);
+    });
 
     await renderTree();
     await flushReact();
@@ -242,6 +260,9 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     );
     mockCompany.companies = [{ id: "company-new", name: "My Co", issuePrefix: "MC" }];
     mockCompany.loading = false;
+    mockCompaniesApi.list.mockResolvedValue([
+      { id: "company-new", name: "My Co", issuePrefix: "MC" },
+    ]);
 
     const { root, queryClient } = render();
     await act(async () => {
@@ -281,6 +302,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockCompany.companies = [];
     mockCompany.loading = false;
     mockCompany.error = new Error("company list unavailable");
+    mockCompaniesApi.list.mockRejectedValue(new Error("company list unavailable"));
 
     const { root, queryClient } = render();
     await act(async () => {
@@ -371,6 +393,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockCompany.companies = [{ id: "c1", name: "Saved Co", issuePrefix: "SC" }];
     mockCompany.loading = false;
     mockCompany.error = new Error("refetch failed");
+    mockCompaniesApi.list.mockRejectedValue(new Error("refetch failed"));
 
     const { root, queryClient } = render();
     await act(async () => {
@@ -452,6 +475,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockCompany.companies = [];
     mockCompany.loading = false;
     mockCompany.error = new Error("company list unavailable");
+    mockCompaniesApi.list.mockRejectedValue(new Error("company list unavailable"));
 
     const { root, queryClient } = render();
     await act(async () => {
@@ -491,6 +515,7 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     mockCompany.companies = [{ id: "company-a", name: "Account A Co", issuePrefix: "AAC" }];
     mockCompany.loading = false;
     mockCompany.error = new Error("refetch failed for the new account");
+    mockCompaniesApi.list.mockRejectedValue(new Error("refetch failed for the new account"));
 
     const { root, queryClient } = render();
     await act(async () => {
@@ -508,6 +533,91 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
       'input[placeholder="Chief of staff"]',
     ) as HTMLInputElement | null;
     expect(nameInput?.value ?? "").not.toBe("A's Lead");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  it("does not judge ownership against a warm cache that never refetched", async () => {
+    // The door this whole change exists to shut, and the one the previous
+    // version missed. `main.tsx` sets `staleTime: 30_000`, so for thirty
+    // seconds after a sign-in the company list is served straight from cache
+    // with no request — and `Auth.tsx` invalidates on sign-in but invalidation
+    // keeps serving the old data while refetching. Either way account A's
+    // companies arrive with *no loading state and no error*, so a gate keyed
+    // on "not loading, no error" reads them as authoritative.
+    //
+    // Here the context reports exactly that healthy-looking stale state, and
+    // the fetch for this session has not answered. A's draft must not be
+    // restored on the strength of A's cached list.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        step: 3,
+        companyName: "Account A Co",
+        agentName: "A's Lead",
+        createdCompanyId: "company-a",
+      }),
+    );
+    // The shared cache still holds A's list, and looks entirely healthy.
+    mockCompany.companies = [{ id: "company-a", name: "Account A Co", issuePrefix: "AAC" }];
+    mockCompany.loading = false;
+    mockCompany.error = null;
+    // The list fetched for *this* session answers with B's companies, which
+    // do not include A's. Note the fetch must actually complete: leaving it
+    // pending would keep the wizard unmounted and the assertion below would
+    // hold for the wrong reason.
+    mockCompaniesApi.list.mockResolvedValue([
+      { id: "company-b", name: "Account B Co", issuePrefix: "BBC" },
+    ]);
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    // Mounted — so this is a real observation, not an unmounted false pass.
+    expect(document.body.textContent).not.toBe("");
+    expect(document.body.textContent).not.toContain("A's Lead");
+    const nameInput = document.body.querySelector(
+      'input[placeholder="Chief of staff"]',
+    ) as HTMLInputElement | null;
+    expect(nameInput?.value ?? "").not.toBe("A's Lead");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("does not delete a draft when the company list comes back unauthorized", async () => {
+    // `companiesListQueryOptions` folds 401/403 into
+    // `{ companies: [], unauthorized: true }` rather than throwing, so an auth
+    // blip arrives as a successful fetch of an empty list — which reads as
+    // "this account owns nothing" and would delete the draft.
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({ step: 3, companyName: "Saved Co", createdCompanyId: "c1" }),
+    );
+    mockCompaniesApi.list.mockRejectedValue(
+      new ApiError("forbidden", 403, null),
+    );
+
+    const { root, queryClient } = render();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingWizard />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).not.toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -212,29 +212,49 @@ export function OnboardingWizard() {
   const companiesQuery = useQuery({
     ...companiesListQueryOptions,
     staleTime: 0,
-    // Only a saved draft poses the question. Without one there is nothing to
-    // authorize, and this must not add a request to every wizard mount.
-    enabled: rawBlob !== undefined,
+    // Only a *parseable* saved draft poses the question. Without one there is
+    // nothing to authorize, and this must not add a request to every wizard
+    // mount - nor make the cleanup of unreadable junk wait on an endpoint that
+    // has no bearing on whether it is junk.
+    enabled: rawBlob !== undefined && rawBlob !== null,
   });
 
-  // Decidable only with a list fetched since this component mounted, that
-  // actually arrived, and that the server was willing to give us. A 401 or 403
-  // is folded into `{ companies: [], unauthorized: true }` by
-  // `companiesListQueryOptions` rather than thrown, so without this last check
-  // an auth blip would read as "this account owns nothing" and delete the
+  // Decidable only with a list that succeeded, was fetched since this
+  // component mounted, actually arrived, and that the server was willing to
+  // give us.
+  //
+  // `isSuccess` is what ties the answer to this session. React Query keeps the
+  // last good `data` when a refetch fails, so after an account switch the
+  // retained value is the *previous* account's list - but a failed refetch
+  // flips status to error, so `isSuccess` rejects it. Combined with
+  // `staleTime: 0`, which makes every mount refetch, and the mount gate below
+  // holding while that is in flight, a success here is always this session's.
+  //
+  // `isFetchedAfterMount` looks like it belongs here too and does not: it is
+  // true after a *failed* refetch as well, so it never rejects anything
+  // `isSuccess` has not already rejected. Left out rather than kept as
+  // decoration - no test could distinguish it, which is how a guard rots.
+  //
+  // The `unauthorized` check is the last one: `companiesListQueryOptions`
+  // folds 401 and 403 into `{ companies: [], unauthorized: true }` rather than
+  // throwing, so an auth blip arrives as a *successful* fetch of an empty list
+  // and would otherwise read as "this account owns nothing" and delete the
   // draft.
   const ownershipDecidable =
-    companiesQuery.isFetchedAfterMount &&
+    companiesQuery.isSuccess &&
     companiesQuery.data !== undefined &&
     !companiesQuery.data.unauthorized;
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
+    // Unreadable, so junk regardless of who owns what. Judged before the
+    // ownership check rather than after it, so clearing it does not wait on a
+    // company request that cannot change the answer.
+    if (rawBlob === null) return { saved: null, staleStateDetected: true };
     // Not decidable yet, or not decidable at all. Either way: restore nothing,
     // delete nothing. A draft withheld is recoverable on the next load; a
     // draft deleted, or one handed to the wrong account, is not.
     if (!ownershipDecidable) return { saved: null, staleStateDetected: false };
-    if (rawBlob === null) return { saved: null, staleStateDetected: true };
     const restored = restoreOnboardingState(rawBlob, companiesQuery.data!.companies);
     return { saved: restored, staleStateDetected: restored === null };
   }, [rawBlob, ownershipDecidable, companiesQuery.data]);
@@ -251,7 +271,13 @@ export function OnboardingWizard() {
   // guess at the draft. Its ~20 `useState(saved?.x ?? default)` initializers
   // only read `saved` once.
   //
-  // While *in flight*, not on failure. The companies query sets `retry: false`,
+  // `isFetching`, not `isLoading`. `isLoading` is false whenever the cache
+  // holds retained data, so a refetch over a warm cache would mount the wizard
+  // while ownership was still undecidable - and with the wizard open, the
+  // persist effect would overwrite the customer's own draft with defaults
+  // before the answer arrived. `isFetching` covers the refetch too.
+  //
+  // While in flight, not on failure. The companies query sets `retry: false`,
   // so a failed fetch stays failed; and with no companies the dashboard offers
   // a "Get Started" button wired to onboarding, which a gate that returned null
   // here would make do nothing at all.
@@ -260,7 +286,7 @@ export function OnboardingWizard() {
   // it is itself gated on `effectiveOnboardingOpen`, so a mounted-but-closed
   // wizard writes nothing. If the wizard is open the customer is onboarding
   // right now, which supersedes the draft anyway.
-  if (rawBlob !== undefined && companiesQuery.isLoading) {
+  if (rawBlob !== undefined && companiesQuery.isFetching) {
     return null;
   }
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
+import { companiesListQueryOptions } from "../api/companies-query";
 import { goalsApi } from "../api/goals";
 import { agentsApi } from "../api/agents";
 import { approvalsApi } from "../api/approvals";
@@ -171,7 +172,8 @@ const INCOMPLETE_ONBOARDING_STATE_MESSAGE =
  * clear before computing `saved` and mounting the inner component at all.
  */
 export function OnboardingWizard() {
-  const { companies, loading: companiesLoading, error: companiesError } = useCompany();
+  // Deliberately does not call `useCompany()`. The list it exposes is the
+  // shared cache, which is what this gate must not trust - see below.
 
   // Parsed once (not re-parsed by the cleanup effect below) so the restored
   // value and the "should we wipe the blob" decision always agree.
@@ -185,48 +187,57 @@ export function OnboardingWizard() {
     }
   }, []);
 
-  // A failed company query is not an answer *when it left us with nothing*.
-  // React Query reports that as `isLoading === false` with `data` defaulted to
-  // an empty list, which reads exactly like "settled, and this account owns
-  // nothing" - and that verdict deletes the draft below. Discarding a
-  // customer's onboarding because their company request timed out is the one
-  // outcome here that cannot be undone.
+  // Whether this account owns the company the draft names is an authorization
+  // question, and the shared company cache cannot answer it.
   //
-  // An error with companies still in hand is a different thing: a background
-  // refetch failed over a cache that is still good. Blocking on that would
-  // fail closed, and onboarding would simply never appear for a customer whose
-  // list is fine. Only an error that leaves the list empty is undecidable.
-  // Named for what it governs: whether the *draft* can be judged. It is not
-  // the same question as whether to mount - see the gate below.
-  // Any error at all, not only one that left the list empty.
+  // `main.tsx` sets `staleTime: 30_000` for every query, so for thirty seconds
+  // after a sign-in a mounted observer of the company list serves whatever is
+  // cached with no request at all. `Auth.tsx` invalidates the list on sign-in,
+  // but invalidation keeps serving the old data while it refetches. Neither
+  // shows up as loading and neither shows up as an error, so the previous
+  // account's companies arrive looking perfectly healthy - and a check that
+  // trusts "not loading, no error" finds the old company id in them and hands
+  // one account's onboarding draft to the next.
   //
-  // The companies cache is not scoped to an account and survives sign-out -
-  // `useSignOut` invalidates only the session and health queries, and
-  // invalidation keeps serving the old data anyway. So after A signs out and B
-  // signs in, a *failed* refetch leaves A's companies in hand. Trusting a
-  // non-empty list there would find A's company id in it, call the draft
-  // owned, and hand A's onboarding to B - which is the exact leak this whole
-  // change exists to close, reached through a different door.
+  // Sign-out does not help: `useSignOut` never clears the company cache, and
+  // on the self-hosted path there is no document reload to clear it either.
+  // Even once that is fixed, an account change can skip the button entirely -
+  // a session lapsing server-side, a second account signing in on a warm tab.
   //
-  // The cost is small and recoverable: during a transient refetch failure the
-  // draft is not restored. It is not deleted either, and the next successful
-  // load restores it.
-  //
-  // A truthy check rather than `!== null`. The context types this
-  // `Error | null`, but `undefined` reaches here from any consumer that
-  // provides the company context without an `error` key, and `undefined !==
-  // null` would read a healthy load as a failure.
-  const ownershipUndecidable = companiesLoading || Boolean(companiesError);
+  // So this asks for a list fetched *for this mount*, rather than reading the
+  // one in hand. `isFetchedAfterMount` is the part that matters; `staleTime: 0`
+  // is what makes that reachable while the shared entry is still fresh. It
+  // shares the query key, so the result populates the same cache entry the
+  // rest of the app reads.
+  const companiesQuery = useQuery({
+    ...companiesListQueryOptions,
+    staleTime: 0,
+    // Only a saved draft poses the question. Without one there is nothing to
+    // authorize, and this must not add a request to every wizard mount.
+    enabled: rawBlob !== undefined,
+  });
+
+  // Decidable only with a list fetched since this component mounted, that
+  // actually arrived, and that the server was willing to give us. A 401 or 403
+  // is folded into `{ companies: [], unauthorized: true }` by
+  // `companiesListQueryOptions` rather than thrown, so without this last check
+  // an auth blip would read as "this account owns nothing" and delete the
+  // draft.
+  const ownershipDecidable =
+    companiesQuery.isFetchedAfterMount &&
+    companiesQuery.data !== undefined &&
+    !companiesQuery.data.unauthorized;
 
   const { saved, staleStateDetected } = useMemo(() => {
     if (rawBlob === undefined) return { saved: null, staleStateDetected: false };
-    // Companies not settled yet: restoreOnboardingState must not be called
-    // (see its CONTRACT). Not stale, just not decidable yet.
-    if (ownershipUndecidable) return { saved: null, staleStateDetected: false };
+    // Not decidable yet, or not decidable at all. Either way: restore nothing,
+    // delete nothing. A draft withheld is recoverable on the next load; a
+    // draft deleted, or one handed to the wrong account, is not.
+    if (!ownershipDecidable) return { saved: null, staleStateDetected: false };
     if (rawBlob === null) return { saved: null, staleStateDetected: true };
-    const restored = restoreOnboardingState(rawBlob, companies);
+    const restored = restoreOnboardingState(rawBlob, companiesQuery.data!.companies);
     return { saved: restored, staleStateDetected: restored === null };
-  }, [rawBlob, ownershipUndecidable, companies]);
+  }, [rawBlob, ownershipDecidable, companiesQuery.data]);
 
   // A discarded/malformed state should not sit in storage waiting to confuse
   // the next onboarding attempt (e.g. a different signed-in user).
@@ -235,24 +246,21 @@ export function OnboardingWizard() {
     onboardingDraftStorage.clear();
   }, [staleStateDetected]);
 
-  // A saved blob exists and the company list is still in flight: wait rather
-  // than mount the inner wizard with a premature, and unrecoverable, guess at
-  // the draft.
+  // A saved blob exists and the verification fetch is still in flight: wait,
+  // rather than mount the inner wizard with a premature and unrecoverable
+  // guess at the draft. Its ~20 `useState(saved?.x ?? default)` initializers
+  // only read `saved` once.
   //
-  // Only while *loading*, not on error. An error with an empty list is still
-  // undecidable - nothing is restored and nothing is cleared, per the memo
-  // above - but withholding the wizard on top of that is a dead end, because
-  // the companies query sets `retry: false`. With no companies the dashboard
-  // offers a "Get Started" button that opens onboarding, and a gate that
-  // returned null here would make that button do nothing at all until a
-  // refetch happened to succeed.
+  // While *in flight*, not on failure. The companies query sets `retry: false`,
+  // so a failed fetch stays failed; and with no companies the dashboard offers
+  // a "Get Started" button wired to onboarding, which a gate that returned null
+  // here would make do nothing at all.
   //
   // Mounting does not cost the draft. The persist effect that would overwrite
   // it is itself gated on `effectiveOnboardingOpen`, so a mounted-but-closed
-  // wizard writes nothing, and the blob survives for a later load that can
-  // decide. If the wizard *is* open the customer is onboarding right now,
-  // which supersedes the draft anyway.
-  if (rawBlob !== undefined && companiesLoading) {
+  // wizard writes nothing. If the wizard is open the customer is onboarding
+  // right now, which supersedes the draft anyway.
+  if (rawBlob !== undefined && companiesQuery.isLoading) {
     return null;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Everything a person creates belongs to a company, and which companies they can see is an authorization fact the server owns
> - Onboarding saves a draft to `localStorage`, which is scoped per browser origin rather than per account, so #11370 made the wizard check that the signed-in account owns the company a saved draft names
> - That check reads the shared company list, and the shared list is a cache: for thirty seconds after a sign-in it is served without a request, and an invalidation keeps serving the old data while it refetches
> - So the previous account's companies arrive looking healthy — no loading, no error — and a check that trusts them restores that account's draft for whoever signed in next
> - This pull request judges ownership against a list fetched for the current mount instead of the one in hand
> - The benefit is that an authorization check stops depending on cache freshness, which nothing in the app currently guarantees

## Linked Issues or Issue Description

Corrects #11370, which I merged earlier today. No public issue exists. The problem follows.

**What happened?**

#11370 added an ownership check so a saved onboarding draft is restored only when the signed-in account owns the company it names. It judged ownership from `useCompany()`, treating the list as authoritative whenever it was not loading and had no error.

The company list is a cache, and neither condition detects a stale one:

- `main.tsx:41` sets `staleTime: 30_000` for all queries, so a mounted observer is served the cached list for thirty seconds after a sign-in with no request at all.
- `Auth.tsx:58` invalidates the list on sign-in, but `invalidateQueries` keeps serving the old data while it refetches, and `isLoading` stays false throughout.

`useSignOut` never clears that cache, and the self-hosted path does not reload the document, so a sign-out leaves it warm.

**Expected behavior**

A draft is restored only when a company list fetched for the current session says the account owns it.

**Steps to reproduce**

1. On a self-hosted instance, sign in as account A and run onboarding far enough to create a company. A draft is saved naming it.
2. Sign out. The page does not reload and the company cache is not cleared.
3. Sign in as account B in the same tab.
4. Onboarding restores account A's draft.

**Paperclip version or commit**

`master` at `35a9b987`.

## What Changed

- `ui/src/components/OnboardingWizard.tsx` — the restore gate fetches the company list itself, with `staleTime: 0`, and decides only once `isFetchedAfterMount` is true. It no longer reads `useCompany()`.
- `ui/src/components/OnboardingWizard.test.tsx` — ownership cases now drive the fetch rather than the context; two new cases.
- `ui/src/components/OnboardingWizard.adapters.test.tsx` — stubs `companiesApi` now that the gate fetches.

### Why fetching, rather than a better staleness check

There is no flag on the cached value that says which account it belongs to. `isFetchedAfterMount` is the only signal that ties the data to this mount, and `staleTime: 0` is what makes such a fetch happen while the shared entry is still fresh. It uses the same query key, so it populates the same cache entry rather than adding a parallel one, and it is `enabled` only when a saved draft exists — without one there is nothing to authorize and no request is made.

### An auth blip no longer deletes a draft

`companiesListQueryOptions` folds 401 and 403 into `{ companies: [], unauthorized: true }` rather than throwing. Those arrived as a successful fetch of an empty list, which reads as "this account owns nothing" — and that verdict deletes the blob. `unauthorized` is now undecidable: nothing restored, nothing deleted.

### What is unchanged

The mount gate still holds only while the fetch is in flight, never on failure, so the dead end fixed in #11370 stays fixed: with no companies the dashboard's "Get Started" button still opens a working wizard.

## Verification

- `ui` typecheck is clean.
- Full `ui` suite: **3960 pass**.
- Every case was checked against the specific clause it guards, not just run green.

| Case | Fails without |
| --- | --- |
| Warm cache holding another account's list, no error | the `isFetchedAfterMount` check |
| Unauthorized list | the `unauthorized` check |
| Unowned draft | the ownership check itself |
| Failed fetch | the decidability gate |

The warm-cache case first passed against the code it was meant to catch: a pending fetch left the wizard unmounted, so "the draft was not restored" held for the wrong reason. It now resolves the fetch with a different account's companies and asserts against a mounted wizard.

One failure remains, in `IssueProperties.test.tsx`. It is timezone-dependent, it reproduces on `master` without these changes, and it is in a file this change does not touch.

**Not done:** no manual two-account run in a browser.

## Risks

Low, and lower than what it replaces. The failure direction is a draft withheld until the next load, which is recoverable; the direction it removes is a draft handed to the wrong account, which is not.

It adds one request, on mounts where a saved draft exists, to a query key the app already uses.

**This does not close the class.** The stale cache is still there for every other consumer — `CompanyContext`'s auto-select effect (`CompanyContext.tsx:89-111`) writes a company id to `localStorage` from whatever list is cached, with the same exposure. Sign-out cleanup is being handled separately, and cannot close it either: an account change can skip the button entirely, via a server-side session lapse or a second account signing in on a warm tab.

Credit where due: found by a sibling session working on the same cache from `InviteLanding`. Its warning that `resetQueries` keeps the query object — and can leave `isFetchedAfterMount` false for existing observers — matters directly here, since this fix depends on that flag.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
