### PR TITLE
test(issues): cover cancel across the idle issue write boundary

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1592,6 +1592,45 @@ describe("agent issue mutation checkout ownership", () => {
     },
   );
 
+  // The default-open write rule lets a visible agent cancel another agent's issue while
+  // that issue is still idle. The grant comes from the idle status and from issue
+  // visibility. It does not come from the identity of the issue creator, so this test
+  // sets no creator. Locked in here so a later change does not narrow the rule silently.
+  it("allows a peer agent to cancel an idle issue assigned to another agent", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "duplicate of an existing issue" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "cancelled" }),
+    );
+  });
+
+  // This is the other half of the same boundary. After the assignee starts its run, the
+  // peer agent loses the cancel path and must use a comment instead. The suite covered
+  // the run lock with a title edit only, so pin it with the cancel payload as well.
+  it("refuses a peer agent's cancel once the assignee's run has started", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "duplicate of an existing issue" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents change each other's issues through the agent issue PATCH route, which asks `assertAgentIssueMutationAllowed` for a decision
> - #10804 made writes on visible issues default-open, so an agent can now write to an issue that a different agent owns while that issue is idle
> - The same gate keeps one wall: after the assignee starts its run, the route returns 409 `issue_write_assignee_run_lock` and sends the other agent to comments
> - The test suite pinned that boundary with a title edit only, so the cancel payload was never asserted on either side of the wall
> - A cancel is the higher-consequence write here, because it ends another agent's work, and a later change to the idle rule could move it in either direction with no test failure
> - This pull request adds two characterization tests for the cancel payload, one on each side of the run lock
> - The benefit is that the current cancel boundary is now executable behavior instead of an assumption

## Linked Issues or Issue Description

No public issue exists for this gap, so the enhancement fields are below.

**What existing behavior does this improve?**

Test coverage of the agent issue PATCH authorization boundary. The behavior of the route does not change.

**Subsystem affected**

`server/src/routes/issues.ts` — agent issue mutation authorization. Test file: `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`.

**Current behavior**

`assertAgentIssueMutationAllowed` allows a peer agent to write to an idle issue that another agent owns, and it refuses the same actor with 409 `issue_write_assignee_run_lock` once the issue is `in_progress`. The suite asserts this boundary with a title edit. No test sends a `status: "cancelled"` payload across it, so the cancel case rests on the generic write test.

**Proposed behavior**

Assert the cancel payload directly on both sides of the run lock. Keep route behavior as it is.

**Reason and benefit**

Cancel ends another agent's work, so it is the write with the highest consequence on this boundary. A future change to the idle default-open rule should have to state its intent about cancel. Today such a change can pass the suite either way.

**Breaking changes**

None. The change is test-only.

**Additional context**

Related work on the same gate, checked for overlap before this PR:

- #10804 — merged, introduced `allowVisibleIssueWrite` and the default-open rule these tests characterize
- #11271 — open, applies `allowVisibleIssueWrite` to recovery action resolution
- #11350 — open, changes terminal dispositions out of `blocked`

None of these add cancel-payload coverage for the idle boundary, and this PR changes no source file, so it does not conflict with them.

## What Changed

- Added a test that a peer agent can cancel an idle issue assigned to another agent, and that the update reaches the service with `status: "cancelled"`.
- Added a test that the same actor gets 409 `issue_write_assignee_run_lock` after the assignee run starts, and that no update reaches the service.

## Verification

```
npx vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
# Test Files 1 passed (1)
# Tests 78 passed (78)   (76 on master, plus the 2 tests added here)
```

Both tests were also confirmed to describe the real rule and not a stricter one. `assertAgentIssueMutationAllowed` and `decideIssueAccess` read the assignee, the status, and issue visibility. Neither reads `createdByAgentId`, so the tests set no creator on the fixture.

## Risks

Low risk. The change adds two tests to one file and changes no source file.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, with tool use for repository search, test runs, and git operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — not applicable, this PR adds tests only and changes no documented behavior
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — confirmed on `3d8541f`: every required check passed (Build, Typecheck + Release Registry, General tests, Verify serialized server suites, e2e, policy, security). Storybook visual regression reports `skipping` because the diff touches no stories.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — confirmed on `3d8541f`: Greptile scored 5/5 and left no inline comments, recommendations, or follow-ups.
- [x] I will address all Greptile and reviewer comments before requesting merge

