### PR TITLE
fix(runtime): terminate escaped descendant process trees

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -477,6 +477,56 @@ describe("runChildProcess", () => {
   });
 
   it.skipIf(process.platform === "win32")(
+    "kills a bash -lic descendant that escapes the run process group",
+    async () => {
+      let escapedPid: number | null = null;
+
+      try {
+        const escapedCommand = `exec ${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+          "setInterval(() => {}, 1000)",
+        )}`;
+        const result = await runChildProcess(
+          randomUUID(),
+          process.execPath,
+          [
+            "-e",
+            [
+              "const { spawn } = require('node:child_process');",
+              `const child = spawn('/bin/bash', ['-lic', ${JSON.stringify(escapedCommand)}], { detached: true, stdio: 'ignore' });`,
+              "process.stdout.write(String(child.pid));",
+              "setInterval(() => {}, 1000);",
+            ].join(" "),
+          ],
+          {
+            cwd: process.cwd(),
+            env: {},
+            timeoutSec: 1,
+            graceSec: 1,
+            onLog: async () => {},
+          },
+        );
+
+        escapedPid = Number.parseInt(result.stdout.trim(), 10);
+        expect(result.timedOut).toBe(true);
+        expect(Number.isInteger(escapedPid) && escapedPid > 0).toBe(true);
+        expect(await waitForPidExit(escapedPid!, 2_000)).toBe(true);
+      } finally {
+        if (escapedPid && isPidAlive(escapedPid)) {
+          try {
+            process.kill(-escapedPid, "SIGKILL");
+          } catch {
+            try {
+              process.kill(escapedPid, "SIGKILL");
+            } catch {
+              // Ignore cleanup races.
+            }
+          }
+        }
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
     "force-kills a child that ignores SIGTERM once the grace window elapses",
     async () => {
       // Residual hang case: a child that installs a SIGTERM handler which

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import os from "node:os";
@@ -55,6 +55,7 @@ interface RunningProcess {
   child: ChildProcess;
   graceSec: number;
   processGroupId: number | null;
+  retainedDescendantPids?: Set<number>;
 }
 
 interface SpawnTarget {
@@ -84,18 +85,105 @@ function resolveProcessGroupId(child: ChildProcess) {
   return typeof child.pid === "number" && child.pid > 0 ? child.pid : null;
 }
 
-// Exported so the direct-child fallback branch can be unit-tested directly.
-export function signalRunningProcess(
-  running: Pick<RunningProcess, "child" | "processGroupId">,
+function collectDescendantProcessIds(rootPid: number, retained: Set<number>) {
+  if (process.platform === "win32" || !Number.isInteger(rootPid) || rootPid <= 0) return;
+  let output = "";
+  try {
+    output = execFileSync("ps", ["-axo", "pid=,ppid="], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return;
+  }
+
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of output.split("\n")) {
+    const [pidText, parentPidText] = line.trim().split(/\s+/);
+    const pid = Number.parseInt(pidText ?? "", 10);
+    const parentPid = Number.parseInt(parentPidText ?? "", 10);
+    if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(parentPid) || parentPid < 0) continue;
+    const children = childrenByParent.get(parentPid) ?? [];
+    children.push(pid);
+    childrenByParent.set(parentPid, children);
+  }
+
+  const pending = [rootPid, ...retained];
+  const visited = new Set<number>();
+  while (pending.length > 0) {
+    const parentPid = pending.pop()!;
+    if (visited.has(parentPid)) continue;
+    visited.add(parentPid);
+    for (const childPid of childrenByParent.get(parentPid) ?? []) {
+      if (childPid === process.pid) continue;
+      retained.add(childPid);
+      pending.push(childPid);
+    }
+  }
+}
+
+export function signalProcessTree(
+  input: {
+    pid: number | null | undefined;
+    processGroupId: number | null | undefined;
+    retainedDescendantPids?: Set<number>;
+  },
   signal: NodeJS.Signals,
 ) {
-  if (process.platform !== "win32" && running.processGroupId && running.processGroupId > 0) {
+  const pid = input.pid ?? null;
+  const retained = input.retainedDescendantPids ?? new Set<number>();
+  if (pid === process.pid || input.processGroupId === process.pid) return retained;
+  if (typeof pid === "number" && pid > 0) collectDescendantProcessIds(pid, retained);
+
+  let groupSignaled = false;
+  if (
+    process.platform !== "win32" &&
+    typeof input.processGroupId === "number" &&
+    input.processGroupId > 0
+  ) {
     try {
-      process.kill(-running.processGroupId, signal);
-      return;
+      process.kill(-input.processGroupId, signal);
+      groupSignaled = true;
     } catch {
-      // Fall back to the direct child signal if group signaling fails.
+      // Fall back to direct PID signaling below.
     }
+  }
+
+  for (const descendantPid of Array.from(retained).reverse()) {
+    if (descendantPid === process.pid) continue;
+    try {
+      process.kill(descendantPid, signal);
+    } catch {
+      retained.delete(descendantPid);
+    }
+  }
+
+  if (!groupSignaled && typeof pid === "number" && pid > 0 && pid !== process.pid) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Ignore cleanup races.
+    }
+  }
+  return retained;
+}
+
+// Exported so the direct-child fallback branch can be unit-tested directly.
+export function signalRunningProcess(
+  running: Pick<RunningProcess, "child" | "processGroupId" | "retainedDescendantPids">,
+  signal: NodeJS.Signals,
+) {
+  const pid = running.child.pid ?? null;
+  if (pid || running.processGroupId) {
+    signalProcessTree(
+      {
+        pid,
+        processGroupId: running.processGroupId,
+        retainedDescendantPids: running.retainedDescendantPids,
+      },
+      signal,
+    );
+    if (running.processGroupId) return;
   }
   // Gate on real liveness: `child.killed` only means a signal was sent, not that
   // the process exited, so escalating on it would suppress a follow-up SIGKILL.
@@ -3356,7 +3444,13 @@ export async function runChildProcess(
             })
             : Promise.resolve();
 
-        runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
+        const retainedDescendantPids = new Set<number>();
+        runningProcesses.set(runId, {
+          child,
+          graceSec: opts.graceSec,
+          processGroupId,
+          retainedDescendantPids,
+        });
 
         let timedOut = false;
         let stdout = "";
@@ -3406,12 +3500,12 @@ export async function runChildProcess(
             if (terminalCleanupStarted || timedOut) return;
             terminalCleanupStarted = true;
             terminalCleanupSignal = "SIGTERM";
-            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            signalRunningProcess({ child, processGroupId, retainedDescendantPids }, "SIGTERM");
             terminalCleanupKillTimer = setTimeout(() => {
               terminalCleanupKillTimer = null;
               terminalCleanupSignal = "SIGKILL";
               terminalCleanupForceKilled = true;
-              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+              signalRunningProcess({ child, processGroupId, retainedDescendantPids }, "SIGKILL");
             }, Math.max(1, opts.graceSec) * 1000);
           }, graceMs);
         };
@@ -3421,9 +3515,9 @@ export async function runChildProcess(
             ? setTimeout(() => {
                 timedOut = true;
                 clearTerminalCleanupTimers();
-                signalRunningProcess({ child, processGroupId }, "SIGTERM");
+                signalRunningProcess({ child, processGroupId, retainedDescendantPids }, "SIGTERM");
                 setTimeout(() => {
-                  signalRunningProcess({ child, processGroupId }, "SIGKILL");
+                  signalRunningProcess({ child, processGroupId, retainedDescendantPids }, "SIGKILL");
                 }, Math.max(1, opts.graceSec) * 1000);
               }, opts.timeoutSec * 1000)
             : null;

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -357,7 +357,7 @@ afterEach(async () => {
   delete process.env.PAPERCLIP_INSTANCE_ID;
   delete process.env.PAPERCLIP_WORKTREES_DIR;
   delete process.env.DATABASE_URL;
-  await resetRuntimeServicesForTests();
+  await resetRuntimeServicesForTests({ terminateProcesses: true });
 });
 
 describe("sanitizeRuntimeServiceBaseEnv", () => {
@@ -5493,7 +5493,7 @@ describeEmbeddedPostgres("workspace runtime service control persistence", () => 
   });
 
   afterEach(async () => {
-    await resetRuntimeServicesForTests();
+    await resetRuntimeServicesForTests({ terminateProcesses: true });
     await db.delete(workspaceRuntimeServices);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { signalProcessTree } from "@paperclipai/adapter-utils/server-utils";
 
 const execFileAsync = promisify(execFile);
 
@@ -368,22 +369,23 @@ export async function terminateLocalService(
 ) {
   const signal = opts?.signal ?? "SIGTERM";
   const targetProcessGroup = process.platform !== "win32" && record.processGroupId && record.processGroupId > 0;
-  try {
-    if (targetProcessGroup) {
-      process.kill(-record.processGroupId!, signal);
-    } else {
-      process.kill(record.pid, signal);
-    }
-  } catch {
-    return;
-  }
+  const retainedDescendantPids = new Set<number>();
+  signalProcessTree(
+    {
+      pid: record.pid,
+      processGroupId: record.processGroupId,
+      retainedDescendantPids,
+    },
+    signal,
+  );
 
   const deadline = Date.now() + (opts?.forceAfterMs ?? 2_000);
   while (Date.now() < deadline) {
     const targetAlive = targetProcessGroup
       ? isProcessGroupAlive(record.processGroupId)
       : isPidAlive(record.pid);
-    if (!targetAlive) {
+    const descendantAlive = Array.from(retainedDescendantPids).some(isPidAlive);
+    if (!targetAlive && !descendantAlive) {
       return;
     }
     await delay(100);
@@ -392,16 +394,16 @@ export async function terminateLocalService(
   const stillAlive = targetProcessGroup
     ? isProcessGroupAlive(record.processGroupId)
     : isPidAlive(record.pid);
-  if (!stillAlive) return;
-  try {
-    if (targetProcessGroup) {
-      process.kill(-record.processGroupId!, "SIGKILL");
-    } else {
-      process.kill(record.pid, "SIGKILL");
-    }
-  } catch {
-    // Ignore cleanup races.
-  }
+  const descendantStillAlive = Array.from(retainedDescendantPids).some(isPidAlive);
+  if (!stillAlive && !descendantStillAlive) return;
+  signalProcessTree(
+    {
+      pid: record.pid,
+      processGroupId: record.processGroupId,
+      retainedDescendantPids,
+    },
+    "SIGKILL",
+  );
 }
 
 export async function readLocalServicePortOwner(port: number) {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -195,9 +195,28 @@ type ProcessOutputAccumulator = {
   finish(): ProcessOutputCapture;
 };
 
-export async function resetRuntimeServicesForTests() {
-  for (const record of runtimeServicesById.values()) {
+export async function resetRuntimeServicesForTests(options?: { terminateProcesses?: boolean }) {
+  const records = Array.from(runtimeServicesById.values());
+  for (const record of records) {
     clearIdleTimer(record);
+  }
+  if (options?.terminateProcesses) {
+    await Promise.all(
+      records.map(async (record) => {
+        if (record.child?.pid) {
+          await terminateLocalService({
+            pid: record.child.pid,
+            processGroupId: record.processGroupId ?? record.child.pid,
+          });
+        } else if (record.providerRef) {
+          const pid = Number.parseInt(record.providerRef, 10);
+          if (Number.isInteger(pid) && pid > 0) {
+            await terminateLocalService({ pid, processGroupId: record.processGroupId });
+          }
+        }
+        await removeLocalServiceRegistryRecord(record.serviceKey).catch(() => undefined);
+      }),
+    );
   }
   runtimeServicesById.clear();
   runtimeServicesByReuseKey.clear();


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent runs and must stop work when a run ends.
> - Local adapters start each run in a separate process group.
> - A descendant can create a new process group and escape group signals.
> - Escaped work can continue to use CPU and memory after its run ends.
> - Runtime-service test cleanup also cleared process records without stopping the processes.
> - This pull request records descendants before termination and retains them for force-stop escalation.
> - The benefit is complete run cleanup and leak-free runtime-service tests.

## Linked Issues or Issue Description

**What happened?**

A timed-out local adapter run only signaled its original process group. A descendant that started a new process group survived the run. Runtime-service tests could also leave detached HTTP fixtures alive after test teardown.

**Expected behavior**

Run termination must stop the full descendant process tree. Runtime-service test teardown must leave no detached fixture processes.

**Steps to reproduce**

1. Start a local run that launches a child through `bash -lic` in a new process group.
2. Let the run reach its timeout.
3. Check the escaped child PID.
4. Observe that the child remains alive without this change.

**Paperclip version or commit**

Reproduced from commit `072d5e9a9`.

## What Changed

- Snapshot the POSIX descendant tree before signaling a run.
- Retain escaped descendant PIDs across the SIGTERM to SIGKILL escalation.
- Apply the same tree termination to control-plane and runtime-service stops.
- Terminate registered runtime-service fixtures during test teardown.
- Add a regression test for a `bash -lic` child that escapes the run process group.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts`
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts`
- `pnpm test:run` completed all change-related suites. One unrelated serialized route test had a transient `socket hang up`; its isolated retry passed 7 of 7 tests.
- The PPID 1 runtime-fixture census stayed at zero across the full suite.

## Risks

- Process discovery uses the POSIX `ps` interface on termination paths. If `ps` is unavailable, the existing process-group and direct-child fallbacks still run.
- Retained PIDs exist only for the short termination grace window. This limits PID reuse exposure.
- Windows keeps the existing direct-child behavior because POSIX process groups are not available there.

> This is a defect fix. `ROADMAP.md` does not list this process-tree termination work. No public duplicate issue or pull request was found.

## Model Used

OpenAI GPT-5 Codex with repository tools, shell execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
