### PR TITLE
feat(plugin-sdk): concurrent event dispatch and host-call faults in the test harness

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -1649,6 +1649,8 @@ The test harness provides:
 - ability to simulate `executeTool` calls as if coming from an agent run
 - in-memory state and entity stores for assertions
 - configurable capability sets for testing capability denial paths
+- concurrent event delivery that matches the host event bus, so that read-modify-write races against `ctx.state` reproduce in tests instead of being hidden by a strictly serialized harness
+- host-call fault injection, so that a test can make one `ctx` call throw before its effect, throw after its effect, or park while another call proceeds
 
 Example usage:
 

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -73,6 +73,39 @@ import type {
   PluginPerformActionContext,
 } from "./protocol.js";
 
+/**
+ * How `emit` dispatches to matching handlers. See `TestHarnessOptions.eventDispatch`.
+ */
+export type TestHarnessEventDispatch = "sequential" | "concurrent";
+
+/** One host call intercepted through `ctx`. See `TestHarnessOptions.hostCallInterceptor`. */
+export interface TestHarnessHostCall {
+  /** Dotted path of the intercepted host call, e.g. `"issues.update"`. */
+  path: string;
+  args: unknown[];
+  /** Monotonic sequence number across every host call on this harness. */
+  seq: number;
+}
+
+/**
+ * Wraps a host call. Call `proceed()` to run the real in-memory implementation.
+ * Throwing without calling it models a host call that failed before its effect
+ * landed; awaiting it and then throwing models an effect that landed but was
+ * never acknowledged.
+ */
+export type TestHarnessHostCallInterceptor = (
+  call: TestHarnessHostCall,
+  proceed: () => Promise<unknown>,
+) => Promise<unknown>;
+
+/** Handle returned by `harness.faults.parkOn(...)`. */
+export interface TestHarnessParkHandle {
+  /** Resolves once the parked call has actually been entered. */
+  reached: Promise<void>;
+  /** Let the parked call proceed. */
+  release: () => void;
+}
+
 export interface TestHarnessOptions {
   /** Plugin manifest used to seed capability checks and metadata. */
   manifest: PaperclipPluginManifestV1;
@@ -80,6 +113,22 @@ export interface TestHarnessOptions {
   capabilities?: PluginCapability[];
   /** Initial config returned by `ctx.config.get(companyId)`. */
   config?: Record<string, unknown>;
+  /**
+   * How `emit` dispatches to matching handlers.
+   *
+   * - `"sequential"` (default) awaits each handler before starting the next.
+   * - `"concurrent"` starts every matching handler and awaits them together,
+   *   mirroring the production event bus, which fans out with `Promise.all`
+   *   and whose worker bridge dispatches `onEvent` without awaiting it. Under
+   *   this mode handlers interleave at every `await`, so read-modify-write
+   *   races against `ctx.state` are reproducible in tests.
+   */
+  eventDispatch?: TestHarnessEventDispatch;
+  /**
+   * Intercept every host call made through `ctx` (any `ctx.<namespace>.<method>(...)`).
+   * Runs outermost around the queued-fault layer registered via `harness.faults`.
+   */
+  hostCallInterceptor?: TestHarnessHostCallInterceptor;
 }
 
 export interface TestHarnessLogEntry {
@@ -123,7 +172,21 @@ export interface TestHarness {
   }): void;
   setConfig(config: Record<string, unknown>): void;
   /** Dispatch a host or plugin event to registered handlers. */
-  emit(eventType: PluginEventType | `plugin.${string}`, payload: unknown, base?: Partial<PluginEvent>): Promise<void>;
+  emit(
+    eventType: PluginEventType | `plugin.${string}`,
+    payload: unknown,
+    base?: Partial<PluginEvent>,
+    options?: { dispatch?: TestHarnessEventDispatch },
+  ): Promise<void>;
+  /**
+   * Deliver several events whose handlers interleave with each other, as the
+   * production bus does when two events arrive close together.
+   */
+  emitConcurrent(events: Array<{
+    eventType: PluginEventType | `plugin.${string}`;
+    payload: unknown;
+    base?: Partial<PluginEvent>;
+  }>): Promise<void>;
   /** Execute a previously-registered scheduled job handler. */
   runJob(jobKey: string, partial?: Partial<PluginJobContext>): Promise<void>;
   /** Invoke a `ctx.data.register(...)` handler by key. */
@@ -146,6 +209,19 @@ export interface TestHarness {
   telemetry: Array<{ eventName: string; dimensions?: Record<string, string | number | boolean> }>;
   dbQueries: Array<{ sql: string; params?: unknown[] }>;
   dbExecutes: Array<{ sql: string; params?: unknown[] }>;
+  /** Ordered log of every host call made through `ctx`. */
+  hostCalls: TestHarnessHostCall[];
+  /** Ergonomic fault injection for host calls made through `ctx`. See `TestHarnessOptions.hostCallInterceptor` for the general-purpose escape hatch. */
+  faults: {
+    /** Fail the next matching call to `path`. */
+    throwOn(path: string, error: Error, options?: { when?: (args: unknown[]) => boolean; times?: number }): void;
+    /** Run the real effect for the next matching call, then throw. */
+    throwAfterOn(path: string, error: Error, options?: { when?: (args: unknown[]) => boolean; times?: number }): void;
+    /** Park the next matching call until the returned handle is released. */
+    parkOn(path: string, options?: { when?: (args: unknown[]) => boolean }): TestHarnessParkHandle;
+    /** Drop all queued faults. */
+    clear(): void;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -2513,8 +2589,200 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     tracer: NOOP_PLUGIN_TRACER,
   };
 
+  // ---------------------------------------------------------------------------
+  // Host call interception: every function reachable on `ctx` is routed through
+  // `interceptCall` so tests can record calls (`hostCalls`) and inject faults
+  // (`harness.faults`) without the harness hand-enumerating ~30 namespaces.
+  // ---------------------------------------------------------------------------
+
+  const hostCalls: TestHarness["hostCalls"] = [];
+  let hostCallSeq = 0;
+
+  type QueuedFault = {
+    kind: "throw" | "throwAfter" | "park";
+    error?: Error;
+    when?: (args: unknown[]) => boolean;
+    timesRemaining: number;
+    onReached?: () => void;
+    released?: Promise<void>;
+  };
+  const faultsByPath = new Map<string, QueuedFault[]>();
+
+  function queueFault(path: string, fault: QueuedFault) {
+    const queue = faultsByPath.get(path) ?? [];
+    queue.push(fault);
+    faultsByPath.set(path, queue);
+  }
+
+  /** Consume (FIFO, per path) the first queued fault whose `when` accepts `args`, if any. */
+  function takeMatchingFault(path: string, args: unknown[]): QueuedFault | undefined {
+    const queue = faultsByPath.get(path);
+    if (!queue) return undefined;
+    const index = queue.findIndex((fault) => !fault.when || fault.when(args));
+    if (index === -1) return undefined;
+    const fault = queue[index];
+    fault.timesRemaining -= 1;
+    if (fault.timesRemaining <= 0) queue.splice(index, 1);
+    return fault;
+  }
+
+  /**
+   * True if any value reachable from `value` (without crossing arrays) exposes
+   * a function — i.e. `value` is a namespace of host calls (like `ctx.issues`
+   * or `ctx.issues.documents`) rather than a plain data value (like
+   * `ctx.manifest`). Used to decide what the ctx proxy should recurse into.
+   */
+  function isHostNamespace(value: unknown, seen: Set<unknown> = new Set()): boolean {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+    if (seen.has(value)) return false;
+    seen.add(value);
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (typeof nested === "function") return true;
+      if (isHostNamespace(nested, seen)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Wrap one host method. Every call is logged to `hostCalls` regardless of
+   * whether anything is intercepting it. The wrapper only becomes async (a
+   * `Promise`-returning function) when a fault or `hostCallInterceptor` is
+   * actually in play for this specific call — otherwise it forwards the real
+   * return value untouched. That keeps synchronous host methods (e.g.
+   * `ctx.events.on`, which returns an unsubscribe function synchronously)
+   * working exactly as before for the common case where no test in the suite
+   * uses fault injection.
+   */
+  function interceptCall(fn: (...args: unknown[]) => unknown, thisArg: unknown, path: string) {
+    return (...args: unknown[]) => {
+      const call: TestHarnessHostCall = { path, args, seq: hostCallSeq++ };
+      hostCalls.push(call);
+
+      const fault = takeMatchingFault(path, args);
+      const userInterceptor = options.hostCallInterceptor;
+      if (!fault && !userInterceptor) {
+        return fn.apply(thisArg, args);
+      }
+
+      const proceed = async (): Promise<unknown> => {
+        if (!fault) return fn.apply(thisArg, args);
+        if (fault.kind === "throw") throw fault.error;
+        if (fault.kind === "throwAfter") {
+          await fn.apply(thisArg, args);
+          throw fault.error;
+        }
+        // fault.kind === "park": announce we've been entered, then wait to be released.
+        fault.onReached?.();
+        await fault.released;
+        return fn.apply(thisArg, args);
+      };
+
+      return userInterceptor ? userInterceptor(call, proceed) : proceed();
+    };
+  }
+
+  /**
+   * Recursively wrap a ctx namespace in a `Proxy` so every function it exposes
+   * — at any depth — is routed through `interceptCall`. Non-function
+   * properties (e.g. `ctx.manifest`, `ctx.db.namespace`) pass through
+   * untouched and keep their identity, since `isHostNamespace` only recurses
+   * into values that actually expose functions.
+   */
+  function wrapNamespace<T extends object>(target: T, path: string): T {
+    const wrapperCache = new Map<string, { source: unknown; wrapped: unknown }>();
+    return new Proxy(target, {
+      get(obj, prop, receiver) {
+        const value = Reflect.get(obj, prop, receiver);
+        if (typeof prop !== "string") return value;
+
+        // Wrappers are memoized so that repeated reads are reference-stable
+        // (`ctx.issues === ctx.issues`, `ctx.issues.update === ctx.issues.update`),
+        // which keeps `toBe`/`vi.spyOn` assertions and the `isHostNamespace`
+        // scan below from being re-done on every property access. The cached
+        // entry records the value it wrapped, so reassigning a method through
+        // the proxy still re-wraps rather than returning a stale wrapper.
+        const cached = wrapperCache.get(prop);
+        if (cached && cached.source === value) return cached.wrapped;
+
+        const childPath = path ? `${path}.${prop}` : prop;
+        if (typeof value === "function") {
+          const wrapped = interceptCall(value as (...args: unknown[]) => unknown, obj, childPath);
+          wrapperCache.set(prop, { source: value, wrapped });
+          return wrapped;
+        }
+        if (isHostNamespace(value)) {
+          const wrapped = wrapNamespace(value as object, childPath);
+          wrapperCache.set(prop, { source: value, wrapped });
+          return wrapped;
+        }
+        // Plain data (e.g. `ctx.manifest`) is passed through live and uncached.
+        return value;
+      },
+    }) as T;
+  }
+
+  const wrappedCtx = wrapNamespace(ctx, "");
+
+  const faults: TestHarness["faults"] = {
+    throwOn(path, error, faultOptions) {
+      queueFault(path, { kind: "throw", error, when: faultOptions?.when, timesRemaining: faultOptions?.times ?? 1 });
+    },
+    throwAfterOn(path, error, faultOptions) {
+      queueFault(path, { kind: "throwAfter", error, when: faultOptions?.when, timesRemaining: faultOptions?.times ?? 1 });
+    },
+    parkOn(path, faultOptions) {
+      let resolveReached!: () => void;
+      const reached = new Promise<void>((resolve) => {
+        resolveReached = resolve;
+      });
+      let resolveReleased!: () => void;
+      const released = new Promise<void>((resolve) => {
+        resolveReleased = resolve;
+      });
+      queueFault(path, {
+        kind: "park",
+        when: faultOptions?.when,
+        timesRemaining: 1,
+        onReached: () => resolveReached(),
+        released,
+      });
+      return { reached, release: () => resolveReleased() };
+    },
+    clear() {
+      faultsByPath.clear();
+    },
+  };
+
+  /** Build a fully-populated event envelope from `emit`/`emitConcurrent` inputs. */
+  function buildEvent(eventType: PluginEventType | `plugin.${string}`, payload: unknown, base?: Partial<PluginEvent>): PluginEvent {
+    return {
+      eventId: base?.eventId ?? randomUUID(),
+      eventType,
+      companyId: base?.companyId ?? "test-company",
+      occurredAt: base?.occurredAt ?? new Date().toISOString(),
+      actorId: base?.actorId,
+      actorType: base?.actorType,
+      entityId: base?.entityId,
+      entityType: base?.entityType,
+      payload,
+    };
+  }
+
+  /** Registered handlers whose name/filter match `event`, in registration order. */
+  function matchingHandlers(event: PluginEvent): EventRegistration[] {
+    return events.filter((handler) => {
+      const exactMatch = handler.name === event.eventType;
+      const wildcardPluginAll = handler.name === "plugin.*" && String(event.eventType).startsWith("plugin.");
+      const wildcardPluginOne = String(handler.name).endsWith(".*")
+        && String(event.eventType).startsWith(String(handler.name).slice(0, -1));
+      if (!exactMatch && !wildcardPluginAll && !wildcardPluginOne) return false;
+      return allowsEvent(handler.filter, event);
+    });
+  }
+
   const harness: TestHarness = {
-    ctx,
+    ctx: wrappedCtx,
     seed(input) {
       for (const row of input.companies ?? []) companies.set(row.id, row);
       for (const row of input.projects ?? []) projects.set(row.id, row);
@@ -2560,28 +2828,24 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     setConfig(config) {
       currentConfig = { ...config };
     },
-    async emit(eventType, payload, base) {
-      const event: PluginEvent = {
-        eventId: base?.eventId ?? randomUUID(),
-        eventType,
-        companyId: base?.companyId ?? "test-company",
-        occurredAt: base?.occurredAt ?? new Date().toISOString(),
-        actorId: base?.actorId,
-        actorType: base?.actorType,
-        entityId: base?.entityId,
-        entityType: base?.entityType,
-        payload,
-      };
-
-      for (const handler of events) {
-        const exactMatch = handler.name === event.eventType;
-        const wildcardPluginAll = handler.name === "plugin.*" && String(event.eventType).startsWith("plugin.");
-        const wildcardPluginOne = String(handler.name).endsWith(".*")
-          && String(event.eventType).startsWith(String(handler.name).slice(0, -1));
-        if (!exactMatch && !wildcardPluginAll && !wildcardPluginOne) continue;
-        if (!allowsEvent(handler.filter, event)) continue;
-        await handler.fn(event);
+    async emit(eventType, payload, base, callOptions) {
+      const event = buildEvent(eventType, payload, base);
+      const dispatch = callOptions?.dispatch ?? options.eventDispatch ?? "sequential";
+      const handlers = matchingHandlers(event);
+      if (dispatch === "concurrent") {
+        await Promise.all(handlers.map((handler) => handler.fn(event)));
+      } else {
+        for (const handler of handlers) {
+          await handler.fn(event);
+        }
       }
+    },
+    async emitConcurrent(eventInputs) {
+      const dispatches = eventInputs.flatMap(({ eventType, payload, base }) => {
+        const event = buildEvent(eventType, payload, base);
+        return matchingHandlers(event).map((handler) => handler.fn(event));
+      });
+      await Promise.all(dispatches);
     },
     async runJob(jobKey, partial = {}) {
       const handler = jobs.get(jobKey);
@@ -2633,6 +2897,8 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     telemetry,
     dbQueries,
     dbExecutes,
+    hostCalls,
+    faults,
   };
 
   return harness;

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -125,8 +125,14 @@ export interface TestHarnessOptions {
    */
   eventDispatch?: TestHarnessEventDispatch;
   /**
-   * Intercept every host call made through `ctx` (any `ctx.<namespace>.<method>(...)`).
-   * Runs outermost around the queued-fault layer registered via `harness.faults`.
+   * Intercept the asynchronous host calls made through `ctx` (any
+   * `ctx.<namespace>.<method>(...)` declared `async`). Runs outermost around
+   * the queued-fault layer registered via `harness.faults`.
+   *
+   * The synchronous parts of `ctx` are not intercepted, because interception
+   * is promise-based and those callers rely on a synchronous return value.
+   * `ctx.events.on`, for example, returns an unsubscribe callback directly.
+   * Such calls are still recorded in `harness.hostCalls`.
    */
   hostCallInterceptor?: TestHarnessHostCallInterceptor;
 }
@@ -544,6 +550,12 @@ function isInCompany<T extends { companyId: string | null | undefined }>(
 ): record is T {
   return Boolean(record && record.companyId === companyId);
 }
+
+/**
+ * Constructor of `async function`, used to tell the asynchronous host calls on
+ * `ctx` apart from its synchronous registration APIs. See `interceptCall`.
+ */
+const ASYNC_FUNCTION_CTOR = Object.getPrototypeOf(async () => {}).constructor as FunctionConstructor;
 
 /**
  * Create an in-memory host harness for plugin worker tests.
@@ -2646,21 +2658,26 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
 
   /**
    * Wrap one host method. Every call is logged to `hostCalls` regardless of
-   * whether anything is intercepting it. The wrapper only becomes async (a
-   * `Promise`-returning function) when a fault or `hostCallInterceptor` is
-   * actually in play for this specific call — otherwise it forwards the real
-   * return value untouched. That keeps synchronous host methods (e.g.
-   * `ctx.events.on`, which returns an unsubscribe function synchronously)
-   * working exactly as before for the common case where no test in the suite
-   * uses fault injection.
+   * whether anything is intercepting it.
+   *
+   * Only `async` methods are ever routed through the fault/interceptor
+   * pipeline, because that pipeline is inherently promise-returning. The
+   * synchronous parts of `ctx` are registration and observation APIs —
+   * `ctx.events.on`, the `register` methods, `ctx.streams.open/emit/close`,
+   * `ctx.logger.*` — not host round trips, and callers depend on their
+   * synchronous return values. `ctx.events.on` in particular returns an
+   * unsubscribe callback that plugin cleanup code invokes directly, so
+   * turning it into a `Promise` would break real plugins. Those methods are
+   * still recorded in `hostCalls`; they are simply never faulted.
    */
   function interceptCall(fn: (...args: unknown[]) => unknown, thisArg: unknown, path: string) {
+    const isAsyncHostCall = fn instanceof ASYNC_FUNCTION_CTOR;
     return (...args: unknown[]) => {
       const call: TestHarnessHostCall = { path, args, seq: hostCallSeq++ };
       hostCalls.push(call);
 
-      const fault = takeMatchingFault(path, args);
-      const userInterceptor = options.hostCallInterceptor;
+      const fault = isAsyncHostCall ? takeMatchingFault(path, args) : undefined;
+      const userInterceptor = isAsyncHostCall ? options.hostCallInterceptor : undefined;
       if (!fault && !userInterceptor) {
         return fn.apply(thisArg, args);
       }

--- a/packages/plugins/sdk/tests/testing-concurrency.test.ts
+++ b/packages/plugins/sdk/tests/testing-concurrency.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestHarness } from "../src/testing.js";
+import type { PaperclipPluginManifestV1 } from "../src/types.js";
+
+const manifest = {
+  id: "paperclip.test-concurrency",
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Test Concurrency",
+  description: "Test plugin",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [],
+  entrypoints: {},
+} satisfies PaperclipPluginManifestV1;
+
+// ---------------------------------------------------------------------------
+// The headline case: production plugin event delivery is concurrent (the
+// event bus fans out with `Promise.all`, and the worker bridge dispatches
+// `onEvent` without awaiting it), but a harness whose `emit` always awaits
+// each handler in a strict sequence is strictly MORE serialized than
+// production and can never reproduce a read-modify-write race. These two
+// tests are the whole point of this change: the same racy handler passes
+// under the harness's old (default) behavior and fails once the harness is
+// told to deliver events the way production does.
+// ---------------------------------------------------------------------------
+
+describe("createTestHarness event dispatch reproduces production races", () => {
+  const raceManifest = {
+    ...manifest,
+    capabilities: ["events.subscribe", "plugin.state.read", "plugin.state.write"],
+  } satisfies PaperclipPluginManifestV1;
+
+  const counterKey = { scopeKind: "company" as const, scopeId: "company-1", stateKey: "counter" };
+
+  /** A handler with a classic lost-update bug: it reads `ctx.state`, awaits, then writes back a value derived from the stale read. */
+  function registerCounterHandler(harness: ReturnType<typeof createTestHarness>) {
+    harness.ctx.events.on("issue.created", async () => {
+      const current = (await harness.ctx.state.get(counterKey)) as number | null;
+      // Yield to the microtask queue between the read and the write. This is
+      // exactly the window where a second, concurrently-dispatched handler
+      // can interleave and clobber this handler's update.
+      await Promise.resolve();
+      await harness.ctx.state.set(counterKey, (current ?? 0) + 1);
+    });
+  }
+
+  it("sequential emit() (the default) fully serializes each event, hiding the race — false confidence", async () => {
+    const harness = createTestHarness({ manifest: raceManifest });
+    registerCounterHandler(harness);
+
+    await harness.emit("issue.created", { issueId: "issue-1" });
+    await harness.emit("issue.created", { issueId: "issue-2" });
+
+    expect(harness.getState(counterKey)).toBe(2);
+  });
+
+  it("emitConcurrent delivers both events at once, reproducing the lost update", async () => {
+    const harness = createTestHarness({ manifest: raceManifest });
+    registerCounterHandler(harness);
+
+    await harness.emitConcurrent([
+      { eventType: "issue.created", payload: { issueId: "issue-1" } },
+      { eventType: "issue.created", payload: { issueId: "issue-2" } },
+    ]);
+
+    // Both handlers read the counter as 0 before either writes it back, so
+    // the second write clobbers the first.
+    expect(harness.getState(counterKey)).toBe(1);
+  });
+
+  it("eventDispatch: 'concurrent' interleaves multiple handlers registered on the same event", async () => {
+    const harness = createTestHarness({
+      manifest: raceManifest,
+      eventDispatch: "concurrent",
+    });
+    const order: string[] = [];
+    harness.ctx.events.on("issue.created", async () => {
+      order.push("a:start");
+      await Promise.resolve();
+      order.push("a:end");
+    });
+    harness.ctx.events.on("issue.created", async () => {
+      order.push("b:start");
+      await Promise.resolve();
+      order.push("b:end");
+    });
+
+    await harness.emit("issue.created", {});
+
+    expect(order).toEqual(["a:start", "b:start", "a:end", "b:end"]);
+  });
+
+  it("emitConcurrent interleaves handlers across two different event types", async () => {
+    const harness = createTestHarness({ manifest: raceManifest });
+    const order: string[] = [];
+
+    harness.ctx.events.on("issue.created", async () => {
+      order.push("created:start");
+      await Promise.resolve();
+      order.push("created:end");
+    });
+    harness.ctx.events.on("issue.updated", async () => {
+      order.push("updated:start");
+      await Promise.resolve();
+      order.push("updated:end");
+    });
+
+    await harness.emitConcurrent([
+      { eventType: "issue.created", payload: {} },
+      { eventType: "issue.updated", payload: {} },
+    ]);
+
+    // Both handlers start before either finishes.
+    expect(order).toEqual(["created:start", "updated:start", "created:end", "updated:end"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Host call interception / fault injection
+// ---------------------------------------------------------------------------
+
+describe("createTestHarness host call faults", () => {
+  const faultManifest = {
+    ...manifest,
+    capabilities: ["issues.create", "issues.update", "issues.read"],
+  } satisfies PaperclipPluginManifestV1;
+
+  it("faults.throwOn fails the call before its effect lands", async () => {
+    const harness = createTestHarness({ manifest: faultManifest });
+    const issue = await harness.ctx.issues.create({ companyId: "company-1", title: "Original" });
+
+    harness.faults.throwOn("issues.update", new Error("host unavailable"));
+
+    await expect(
+      harness.ctx.issues.update(issue.id, { title: "Renamed" }, "company-1"),
+    ).rejects.toThrow("host unavailable");
+
+    const stored = await harness.ctx.issues.get(issue.id, "company-1");
+    expect(stored?.title).toBe("Original");
+  });
+
+  it("faults.throwAfterOn fails the call after its effect has already landed", async () => {
+    const harness = createTestHarness({ manifest: faultManifest });
+    const issue = await harness.ctx.issues.create({ companyId: "company-1", title: "Original" });
+
+    harness.faults.throwAfterOn("issues.update", new Error("ack lost"));
+
+    await expect(
+      harness.ctx.issues.update(issue.id, { title: "Renamed" }, "company-1"),
+    ).rejects.toThrow("ack lost");
+
+    const stored = await harness.ctx.issues.get(issue.id, "company-1");
+    expect(stored?.title).toBe("Renamed");
+  });
+
+  it("faults.parkOn produces a deterministic interleaving between two calls", async () => {
+    const harness = createTestHarness({ manifest: faultManifest });
+    const issue = await harness.ctx.issues.create({ companyId: "company-1", title: "Original" });
+
+    const handle = harness.faults.parkOn("issues.update");
+    const order: string[] = [];
+
+    const parked = harness.ctx.issues.update(issue.id, { title: "Parked" }, "company-1").then(() => {
+      order.push("parked");
+    });
+
+    await handle.reached;
+    // The parked call has been entered but its real effect hasn't run yet, so
+    // a second, independent call can be observed completing first.
+    await harness.ctx.issues.update(issue.id, { title: "Second" }, "company-1");
+    order.push("second");
+    expect(order).toEqual(["second"]);
+
+    handle.release();
+    await parked;
+
+    expect(order).toEqual(["second", "parked"]);
+    expect(harness.hostCalls.map((call) => call.path)).toEqual(["issues.create", "issues.update", "issues.update"]);
+  });
+
+  it("hostCalls records path, args, and seq for every ctx call in order", async () => {
+    const harness = createTestHarness({ manifest: faultManifest });
+    await harness.ctx.issues.create({ companyId: "company-1", title: "A" });
+    await harness.ctx.issues.create({ companyId: "company-1", title: "B" });
+
+    expect(harness.hostCalls).toHaveLength(2);
+    expect(harness.hostCalls[0]).toMatchObject({ path: "issues.create", seq: 0 });
+    expect(harness.hostCalls[0].args).toEqual([{ companyId: "company-1", title: "A" }]);
+    expect(harness.hostCalls[1]).toMatchObject({ path: "issues.create", seq: 1 });
+    expect(harness.hostCalls[1].args).toEqual([{ companyId: "company-1", title: "B" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard: with no new options passed, behavior is unchanged.
+// ---------------------------------------------------------------------------
+
+describe("createTestHarness host call interception is transparent by default", () => {
+  const plainManifest = {
+    ...manifest,
+    capabilities: ["events.subscribe"],
+  } satisfies PaperclipPluginManifestV1;
+
+  it("does not change ctx.manifest identity or synchronous return values when no options are passed", () => {
+    const harness = createTestHarness({ manifest: plainManifest });
+
+    expect(harness.ctx.manifest).toBe(plainManifest);
+
+    const unsubscribe = harness.ctx.events.on("issue.created", async () => {});
+    expect(typeof unsubscribe).toBe("function");
+    unsubscribe();
+  });
+
+  it("returns reference-stable namespaces and methods so spies and toBe assertions work", () => {
+    const harness = createTestHarness({ manifest: plainManifest });
+
+    expect(harness.ctx.issues).toBe(harness.ctx.issues);
+    expect(harness.ctx.issues.update).toBe(harness.ctx.issues.update);
+    expect(harness.ctx.state.set).toBe(harness.ctx.state.set);
+  });
+
+  it("keeps default sequential emit() behavior unchanged for multiple handlers on one event", async () => {
+    const harness = createTestHarness({ manifest: plainManifest });
+    const order: string[] = [];
+
+    harness.ctx.events.on("issue.created", async () => {
+      order.push("first:start");
+      await Promise.resolve();
+      order.push("first:end");
+    });
+    harness.ctx.events.on("issue.created", async () => {
+      order.push("second:start");
+      await Promise.resolve();
+      order.push("second:end");
+    });
+
+    await harness.emit("issue.created", {});
+
+    expect(order).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+  });
+});

--- a/packages/plugins/sdk/tests/testing-concurrency.test.ts
+++ b/packages/plugins/sdk/tests/testing-concurrency.test.ts
@@ -213,6 +213,32 @@ describe("createTestHarness host call interception is transparent by default", (
     unsubscribe();
   });
 
+  it("keeps synchronous ctx methods synchronous even when an interceptor is configured", async () => {
+    const seen: string[] = [];
+    const harness = createTestHarness({
+      manifest: { ...plainManifest, capabilities: ["events.subscribe", "issues.read"] },
+      hostCallInterceptor: async (call, proceed) => {
+        seen.push(call.path);
+        return proceed();
+      },
+    });
+
+    // `ctx.events.on` returns an unsubscribe callback synchronously. Plugin
+    // cleanup code calls it directly, so it must never become a Promise.
+    const unsubscribe = harness.ctx.events.on("issue.created", async () => {});
+    expect(typeof unsubscribe).toBe("function");
+    expect(unsubscribe).not.toBeInstanceOf(Promise);
+    expect(() => unsubscribe()).not.toThrow();
+
+    // Asynchronous host calls are still intercepted.
+    await harness.ctx.issues.get("missing", "company-1");
+    expect(seen).toContain("issues.get");
+
+    // The synchronous call is recorded, it is just not routed through the interceptor.
+    expect(harness.hostCalls.map((call) => call.path)).toContain("events.on");
+    expect(seen).not.toContain("events.on");
+  });
+
   it("returns reference-stable namespaces and methods so spies and toBe assertions work", () => {
     const harness = createTestHarness({ manifest: plainManifest });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins extend Paperclip. The plugin SDK gives authors `createTestHarness()` to test a plugin without a live host.
> - The production event path is concurrent. `plugin-event-bus.ts` fans out to subscribers with `Promise.all`. `worker-rpc-host.ts` dispatches each `onEvent` handler without awaiting it. Two events interleave at every `await` inside a handler.
> - The harness `emit` awaited each handler in a loop. The harness was more serialized than production.
> - A read-modify-write race against `ctx.state` therefore failed in production but passed in the harness. This is the worst failure mode for a test tool, because it gives false confidence about the bug class that is hardest to find by inspection.
> - The harness also had no way to make a host call fail. `TestHarnessOptions` accepted only `manifest`, `capabilities` and `config`. The only failure lever was to omit a capability.
> - This pull request makes the harness able to reproduce concurrent delivery, and adds host-call fault injection.
> - The benefit is that plugin authors can write a test for a lost update or a partial failure, and that test now fails when the bug is present.

## Linked Issues or Issue Description

Refs #11393

That issue covers the design gap in full: plugin event delivery is concurrent, but the SDK has no mutual-exclusion primitive. This pull request fixes the test-harness half of it, so the resulting race is at least reproducible in a test. It does not add the primitive itself, so it does not close the issue.

I searched the repository for `createTestHarness`, `test harness concurrent`, `plugin state compare-and-swap` and `plugin mutex lock`, and found no duplicate or in-flight pull requests.

The inline description below follows `.github/ISSUE_TEMPLATE/enhancement.yml`.

**What is the current behavior?**

`createTestHarness().emit(...)` dispatches to matching event handlers in a `for` loop and awaits each handler before it starts the next. Handlers cannot interleave. `TestHarnessOptions` accepts only `manifest`, `capabilities` and `config`, and the harness `ctx` is a fixed object literal with no stub hooks. A test cannot make `issues.update` or `state.set` throw.

**What is the desired behavior?**

The harness must be able to deliver events the way the host does, so that a racy handler fails the test. The harness must also be able to fail an individual host call, so that a test can cover partial-failure paths.

**Why is this valuable?**

Plugin event delivery is concurrent and unserialized end to end:

- `server/src/services/plugin-event-bus.ts` calls subscribers concurrently and awaits them with `Promise.all`.
- `packages/plugins/sdk/src/worker-rpc-host.ts` dispatches `onEvent` without awaiting the returned promise.

A plugin that reads `ctx.state`, awaits, and then writes a value derived from the stale read has a lost-update bug. The harness could not show that bug. The new test file demonstrates the difference directly: the same handler produces `2` under sequential dispatch and `1` under concurrent dispatch.

## What Changed

- Added `TestHarnessEventDispatch` (`"sequential" | "concurrent"`) and the `TestHarnessOptions.eventDispatch` option.
- Added an `options` parameter to `emit(...)` for a per-call `dispatch` override.
- Added `emitConcurrent([...])`. It delivers several events whose handlers interleave with each other.
- Added `TestHarnessOptions.hostCallInterceptor`, plus the `TestHarnessHostCall`, `TestHarnessHostCallInterceptor` and `TestHarnessParkHandle` types. The interceptor wraps any `ctx.<namespace>.<method>(...)` call. It can throw before the effect, throw after the effect, or park the call.
- Added `harness.hostCalls`, an ordered log of every host call, with `path`, `args` and `seq`.
- Added `harness.faults` with `throwOn`, `throwAfterOn`, `parkOn` and `clear`. This is an ergonomic layer over the interceptor.
- Extracted `buildEvent()` and `matchingHandlers()` from the old `emit` body. Both `emit` and `emitConcurrent` use them, so the matching rules stay in one place.
- The `ctx` interception uses a recursive `Proxy`. It covers namespaces at any depth and needs no hand-written list of namespaces. Wrappers are memoized, so `ctx.issues === ctx.issues` and `ctx.issues.update === ctx.issues.update` stay true.

The default dispatch stays `"sequential"`. Existing tests keep their meaning.

## Verification

```
pnpm --filter @paperclipai/plugin-sdk typecheck     # passes
cd packages/plugins/sdk && npx vitest run           # 7 files, 55 tests, all pass
```

The new file is `packages/plugins/sdk/tests/testing-concurrency.test.ts`. Its first two tests are the point of the change. One asserts that the default sequential dispatch hides a lost update. The other asserts that `emitConcurrent` reproduces it.

I also rebuilt the SDK and ran the downstream users of `createTestHarness`, to confirm the proxied `ctx` is transparent:

```
pnpm --filter @paperclipai/plugin-sdk build
pnpm --filter @paperclipai/plugin-llm-wiki test        # 101 tests pass
pnpm --filter @paperclipai/plugin-workspace-diff test  # 26 tests pass
cd server && npx vitest run src/__tests__/plugin-sdk-testing.test.ts                  # 8 tests pass
cd server && npx vitest run src/__tests__/plugin-sdk-orchestration-contract.test.ts   # 5 tests pass
```

## Risks

Low risk. The change is limited to `packages/plugins/sdk`. It touches test tooling only, and it adds no production code path.

The one behavior change for existing callers is that `harness.ctx` is now a `Proxy` instead of the raw object literal. Three properties of the proxy keep this safe:

- A method call returns the underlying value unchanged when no fault and no interceptor apply. Synchronous methods such as `ctx.events.on` still return synchronously.
- Plain data such as `ctx.manifest` passes through by reference and is not wrapped.
- Wrappers are memoized against the value they wrapped, so reference equality holds and a reassigned method is re-wrapped rather than served stale.

All new options default to the old behavior. A caller that passes no new option gets the previous result.

## Model Used

Claude Opus 5 (`claude-opus-5`), running in Claude Code with extended thinking and tool use. The model read the relevant host and SDK sources to confirm the concurrency claims, designed the API, and wrote the implementation and tests. A human reviewed the diff, found and fixed the proxy reference-stability defect, and ran the verification commands above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
