### PR TITLE
fix(codex-local): set CODEX_SQLITE_HOME alongside CODEX_HOME

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -944,6 +944,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
     }
     env.CODEX_HOME = remoteCodexHome ?? effectiveCodexHome;
+    // Codex CLI splits runtime SQLite state (state_5.sqlite, logs_2.sqlite, etc.)
+    // into CODEX_SQLITE_HOME, separate from CODEX_HOME (config/auth/sessions).
+    // Without this, every codex_local agent on a host silently shares one
+    // SQLite state home instead of its own managed one, and concurrent agents
+    // collide with "failed to initialize sqlite state runtime". See #11398.
+    env.CODEX_SQLITE_HOME = remoteCodexHome ?? effectiveCodexHome;
     if (authToken) {
       env.PAPERCLIP_API_KEY = authToken;
     }


### PR DESCRIPTION
## Thinking Path

- Paperclip's `codex_local` adapter is meant to give each agent an isolated managed `CODEX_HOME` for config/auth/sessions.
- Codex CLI 0.147.0 also has a separate `CODEX_SQLITE_HOME` that controls where its runtime SQLite state (`state_5.sqlite`, `logs_2.sqlite`, `goals_1.sqlite`) actually lives.
- `execute.ts` only ever set `CODEX_HOME`, never `CODEX_SQLITE_HOME`, so that isolation silently didn't apply to SQLite state.
- Every `codex_local` agent on a host therefore shared one SQLite state home, and concurrent agents collided on it with `failed to initialize sqlite state runtime`.
- Confirmed this manually (isolated from Paperclip): setting `CODEX_HOME` alone does not relocate `state_5.sqlite`; setting both env vars to the same path does.
- The fix mirrors the existing `CODEX_HOME` assignment into `CODEX_SQLITE_HOME` at the same call site.

## What Changed

One line added at `packages/adapters/codex-local/src/server/execute.ts:886` (immediately after the existing `env.CODEX_HOME` assignment):

```ts
env.CODEX_SQLITE_HOME = remoteCodexHome ?? effectiveCodexHome;
```

Same value already computed and used on the line above — no new logic, no new inputs.

## Linked Issues or Issue Description

Fixes #11398. Full repro, evidence ruling out corruption/checksum-drift, and the manual before/after test are there.

## Verification

Confirmed manually, isolated from Paperclip entirely:

```
CODEX_HOME=<per-agent home> codex exec --json --skip-git-repo-check "say ok"
# -> per-agent state_5.sqlite untouched, writes to ~/.codex/ instead

CODEX_HOME=<per-agent home> CODEX_SQLITE_HOME=<per-agent home> codex exec --json --skip-git-repo-check "say ok"
# -> per-agent state_5.sqlite mtime updates; isolation confirmed
```

**Not done:** I have not run Paperclip's own test/CI suite or set up its dev environment — no `pnpm`/dev deps installed where I made this change. This is a minimal, single-line, same-value-reused change, but please treat CI as the actual verification, not me. Happy to add a regression test if pointed at the right fixture — `execute.remote.test.ts` looks like the relevant file (referenced in #8499) but I haven't run or extended it.

## Risks

Low. The new line only fires on the same branch that already sets `env.CODEX_HOME`, using the same already-resolved value. No new conditionals, no change to when/whether the managed-home path is taken. The scope note below covers what this PR deliberately does *not* touch.

## Scope note

This touches only the one confirmed call site. Other references to `CODEX_HOME` exist elsewhere (`quota.ts`, `codex-auth-reconciliation.ts`, `codex-device-login-service.ts`, `acpx-engine/execute.ts`) — I haven't audited whether those need the same treatment, and didn't want to guess beyond what the filed issue's repro actually covers.

(Note: an earlier push to this branch briefly included ~11 unrelated files from this fork's `master`, which had diverged from upstream. That's been force-fixed — this PR is now the single intended commit, rebuilt directly off upstream `master`.)

## Model Used

Claude (Anthropic), tool-using coding session with local shell execution, run on behalf of the repo owner after manually reproducing and confirming the fix.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [ ] I have searched GitHub for duplicate or related PRs (searched `codex_local`, `CODEX_SQLITE_HOME`, `codex-home sqlite` — found related-but-distinct adapter issues, nothing matching this exact gap)
- [x] I have linked the existing issue with `Fixes #11398`
- [ ] I have run tests locally (see Verification — explicitly not done, flagging rather than claiming)
- [ ] Greptile / reviewer comments addressed (in progress — this edit responds to the first round)