### PR TITLE
fix(issues,routines): let the company reclaim work owned by a terminated agent

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -967,6 +967,8 @@ Server behavior:
 2. if updated row count is 0, return `409` with current owner/status
 3. successful checkout sets `assignee_agent_id`, `status = in_progress`, and `started_at`
 
+A terminated agent can never run again, so work it still holds is unowned. Before the checkout update, the server clears an assignee that points at a terminated agent when `checkout_run_id` and `execution_run_id` are both null. The issue authorization boundary applies the same rule, so any agent in the company can also update such an issue. The same rule applies to routines: an agent that is not the assignee may manage a routine whose assignee agent is terminated.
+
 `POST /issues/:issueId/admin/force-release` is an operator recovery endpoint for stale harness locks. It requires board access to the issue company, clears checkout and execution run lock fields, and may clear the agent assignee when `clearAssignee=true` is passed. The route must write an `issue.admin_force_release` activity log entry containing the previous checkout and execution run IDs.
 
 ## 10.5 Projects

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -129,6 +129,8 @@ const mockAccessService = vi.hoisted(() => ({
   canUser: vi.fn(),
 }));
 
+const mockIsTerminatedAgentId = vi.hoisted(() => vi.fn());
+
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockTrackRoutineCreated = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
@@ -151,6 +153,10 @@ function registerModuleMocks() {
 
   vi.doMock("../services/routines.js", () => ({
     routineService: () => mockRoutineService,
+  }));
+
+  vi.doMock("../services/terminated-assignee.js", () => ({
+    isTerminatedAgentId: mockIsTerminatedAgentId,
   }));
 
   vi.doMock("../services/activity-log.js", () => ({
@@ -190,6 +196,7 @@ describe("routine routes", () => {
     vi.doUnmock("../services/index.js");
     vi.doUnmock("../services/activity-log.js");
     vi.doUnmock("../services/routines.js");
+    vi.doUnmock("../services/terminated-assignee.js");
     vi.doUnmock("../routes/routines.js");
     vi.doUnmock("../routes/authz.js");
     vi.doUnmock("../middleware/index.js");
@@ -215,6 +222,7 @@ describe("routine routes", () => {
       status: "issue_created",
     });
     mockAccessService.canUser.mockResolvedValue(false);
+    mockIsTerminatedAgentId.mockResolvedValue(false);
     mockLogActivity.mockResolvedValue(undefined);
     mockRoutineService.getDescriptionDocument.mockResolvedValue({
       id: "99999999-9999-4999-8999-999999999999",
@@ -470,6 +478,20 @@ describe("routine routes", () => {
 
     expect(res.status).toBe(403);
     expect(mockRoutineService.listRevisions).not.toHaveBeenCalled();
+  });
+
+  it("lets any company agent read revisions when the assigned agent is terminated", async () => {
+    mockIsTerminatedAgentId.mockResolvedValue(true);
+    const app = await createApp({
+      type: "agent",
+      agentId: otherAgentId,
+      companyId,
+    });
+
+    const res = await request(app).get(`/api/routines/${routineId}/revisions`);
+
+    expect(res.status).toBe(200);
+    expect(mockRoutineService.listRevisions).toHaveBeenCalledWith(routineId);
   });
 
   it("restores routine revisions with existing routine-management permissions", async () => {

--- a/server/src/__tests__/terminated-assignee-reclaim.test.ts
+++ b/server/src/__tests__/terminated-assignee-reclaim.test.ts
@@ -1,0 +1,294 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  heartbeatRuns,
+  issues,
+  routines,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { routineRoutes } from "../routes/routines.js";
+import { agentService } from "../services/agents.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres terminated-assignee reclaim tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+/**
+ * Regression coverage for the "terminated agent parks work forever" hole:
+ * an issue or routine still pointing at a terminated agent answered
+ * `403 Issue is outside this actor's authorization boundary` on PATCH and
+ * `409 Issue checkout conflict` on checkout (with `checkoutRunId` and
+ * `executionRunId` both null), so nobody in the company could reclaim it.
+ */
+describeEmbeddedPostgres("reclaiming work owned by a terminated agent", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const boardUserId = "board-user-terminated-assignee";
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-terminated-assignee-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+    tempDb = null;
+  });
+
+  function boardActor(companyId: string) {
+    return {
+      type: "board",
+      userId: boardUserId,
+      companyIds: [companyId],
+      memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+  }
+
+  function createApp(actor: Record<string, unknown>) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any, { taskWatchdogEnqueueWakeup: null }));
+    app.use("/api", routineRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: `Terminated assignee ${companyId}`,
+      issuePrefix: `T${randomUUID().replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: boardUserId,
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: boardUserId,
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(companyId: string, name: string) {
+    const id = randomUUID();
+    await db.insert(agents).values({
+      id,
+      companyId,
+      name,
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return id;
+  }
+
+  async function seedIssue(companyId: string, overrides: Partial<typeof issues.$inferInsert> = {}) {
+    const id = randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title: overrides.title ?? "Work parked by a terminated agent",
+      status: overrides.status ?? "todo",
+      priority: "medium",
+      assigneeAgentId: overrides.assigneeAgentId,
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    return id;
+  }
+
+  async function seedRunningRun(companyId: string, agentId: string, sourceIssueId?: string) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      contextSnapshot: sourceIssueId ? { issueId: sourceIssueId } : {},
+    });
+    return runId;
+  }
+
+  /** Company with a terminated agent plus a live agent that should be able to reclaim its work. */
+  async function seedTerminatedOwner() {
+    const companyId = await seedCompany();
+    const deadAgentId = await seedAgent(companyId, "Terminated VP of Engineering");
+    const liveAgentId = await seedAgent(companyId, "Software Engineer");
+    return { companyId, deadAgentId, liveAgentId };
+  }
+
+  it("lets another agent check out an issue whose assignee was terminated", async () => {
+    const { companyId, deadAgentId, liveAgentId } = await seedTerminatedOwner();
+    const issueId = await seedIssue(companyId, { assigneeAgentId: deadAgentId, status: "todo" });
+    await agentService(db).terminate(deadAgentId);
+
+    const runId = await seedRunningRun(companyId, liveAgentId);
+    const app = createApp({
+      type: "agent",
+      agentId: liveAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: liveAgentId, expectedStatuses: ["todo", "backlog", "blocked", "in_review"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.assigneeAgentId).toBe(liveAgentId);
+    expect(res.body.status).toBe("in_progress");
+  });
+
+  it("lets another agent mutate an in_progress issue left behind by a terminated assignee", async () => {
+    const { companyId, deadAgentId, liveAgentId } = await seedTerminatedOwner();
+    // Mirrors the stuck production row: in_progress, but no run holds it.
+    const issueId = await seedIssue(companyId, { assigneeAgentId: deadAgentId, status: "in_progress" });
+    await agentService(db).terminate(deadAgentId);
+
+    // The reclaiming agent acts from its own checked-out task, so the run has a
+    // source issue and the cross-issue influence cap can attribute the write.
+    const sourceIssueId = await seedIssue(companyId, {
+      title: "Reclaim the parked task",
+      assigneeAgentId: liveAgentId,
+      status: "in_progress",
+    });
+    const runId = await seedRunningRun(companyId, liveAgentId, sourceIssueId);
+    const app = createApp({
+      type: "agent",
+      agentId: liveAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: liveAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.assigneeAgentId).toBe(liveAgentId);
+  });
+
+  it("keeps another agent's live issue protected", async () => {
+    const { companyId, deadAgentId, liveAgentId } = await seedTerminatedOwner();
+    const issueId = await seedIssue(companyId, { assigneeAgentId: deadAgentId, status: "in_progress" });
+    const ownerRunId = await seedRunningRun(companyId, deadAgentId);
+    await db.update(issues).set({ checkoutRunId: ownerRunId, executionRunId: ownerRunId }).where(eq(issues.id, issueId));
+
+    const runId = await seedRunningRun(companyId, liveAgentId);
+    const app = createApp({
+      type: "agent",
+      agentId: liveAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: liveAgentId, expectedStatuses: ["todo", "in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    const [row] = await db.select({ assigneeAgentId: issues.assigneeAgentId }).from(issues).where(eq(issues.id, issueId));
+    expect(row?.assigneeAgentId).toBe(deadAgentId);
+  });
+
+  it("lets another agent take over a routine owned by a terminated agent", async () => {
+    const { companyId, deadAgentId, liveAgentId } = await seedTerminatedOwner();
+    const boardApp = createApp(boardActor(companyId));
+    const created = await request(boardApp)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({ title: "Weekly Sentry review", assigneeAgentId: deadAgentId });
+    expect(created.status, JSON.stringify(created.body)).toBe(201);
+    const routineId = created.body.id as string;
+
+    await agentService(db).terminate(deadAgentId);
+
+    const runId = await seedRunningRun(companyId, liveAgentId);
+    const agentApp = createApp({
+      type: "agent",
+      agentId: liveAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const paused = await request(agentApp).patch(`/api/routines/${routineId}`).send({ status: "paused" });
+    expect(paused.status, JSON.stringify(paused.body)).toBe(200);
+
+    const reassigned = await request(agentApp)
+      .patch(`/api/routines/${routineId}`)
+      .send({ assigneeAgentId: liveAgentId });
+    expect(reassigned.status, JSON.stringify(reassigned.body)).toBe(200);
+
+    const [row] = await db
+      .select({ assigneeAgentId: routines.assigneeAgentId, status: routines.status })
+      .from(routines)
+      .where(eq(routines.id, routineId));
+    expect(row?.assigneeAgentId).toBe(liveAgentId);
+    expect(row?.status).toBe("paused");
+  });
+
+  it("still refuses routine management when the assignee is alive", async () => {
+    const { companyId, deadAgentId, liveAgentId } = await seedTerminatedOwner();
+    const boardApp = createApp(boardActor(companyId));
+    const created = await request(boardApp)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({ title: "Weekly Sentry review", assigneeAgentId: deadAgentId });
+    expect(created.status, JSON.stringify(created.body)).toBe(201);
+
+    const runId = await seedRunningRun(companyId, liveAgentId);
+    const agentApp = createApp({
+      type: "agent",
+      agentId: liveAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(agentApp)
+      .patch(`/api/routines/${created.body.id}`)
+      .send({ status: "paused" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agents can only manage routines assigned to themselves");
+  });
+});

--- a/server/src/__tests__/terminated-assignee-reclaim.test.ts
+++ b/server/src/__tests__/terminated-assignee-reclaim.test.ts
@@ -2,8 +2,9 @@ import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
 import { eq } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  activityLog,
   agents,
   companies,
   companyMemberships,
@@ -24,6 +25,21 @@ import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compa
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+// Assigning an issue wakes the new assignee. The wake starts a background run
+// that outlives this file and then writes to the embedded Postgres after the
+// database stops, which fails the whole test file with an unhandled error. This
+// suite checks ownership rules, not wake delivery, so make the wake a no-op.
+vi.mock("../services/heartbeat.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/heartbeat.js")>("../services/heartbeat.js");
+  return {
+    ...actual,
+    heartbeatService: (...args: Parameters<typeof actual.heartbeatService>) => ({
+      ...actual.heartbeatService(...args),
+      wakeup: async () => null,
+    }),
+  };
+});
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -175,6 +191,15 @@ describeEmbeddedPostgres("reclaiming work owned by a terminated agent", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.assigneeAgentId).toBe(liveAgentId);
     expect(res.body.status).toBe("in_progress");
+
+    // The release of the dead assignee is an ownership change with no actor
+    // request behind it, so it must leave an audit trail.
+    const [audit] = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.terminated_assignee_released"));
+    expect(audit?.action).toBe("issue.terminated_assignee_released");
+    expect((audit?.details as Record<string, unknown>)?.previousAssigneeAgentId).toBe(deadAgentId);
   });
 
   it("lets another agent mutate an in_progress issue left behind by a terminated assignee", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3921,6 +3921,16 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  /**
+   * True when the issue's assignee row is a terminated agent. Terminated agents
+   * can never run again, so anything they still hold has to stay reclaimable.
+   */
+  async function assigneeAgentIsTerminated(assigneeAgentId: string | null | undefined) {
+    if (!assigneeAgentId) return false;
+    const assignee = await agentsSvc.getById(assigneeAgentId);
+    return assignee?.status === "terminated";
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -3971,6 +3981,12 @@ export function issueRoutes(
       return denyIssueWrite(req, res, issue, issueWriteDenialCodeForDecision(boundaryDecision));
     }
     if (issue.assigneeAgentId === null) {
+      return true;
+    }
+    // A terminated agent has no live run and can never resume, so its issues are
+    // unowned in practice. Without this the assignee run lock below freezes every
+    // issue the terminated agent held, with no supported path back.
+    if (issue.assigneeAgentId !== actorAgentId && (await assigneeAgentIsTerminated(issue.assigneeAgentId))) {
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3921,16 +3921,6 @@ export function issueRoutes(
     return decision.allowed;
   }
 
-  /**
-   * True when the issue's assignee row is a terminated agent. Terminated agents
-   * can never run again, so anything they still hold has to stay reclaimable.
-   */
-  async function assigneeAgentIsTerminated(assigneeAgentId: string | null | undefined) {
-    if (!assigneeAgentId) return false;
-    const assignee = await agentsSvc.getById(assigneeAgentId);
-    return assignee?.status === "terminated";
-  }
-
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -3984,9 +3974,10 @@ export function issueRoutes(
       return true;
     }
     // A terminated agent has no live run and can never resume, so its issues are
-    // unowned in practice. Without this the assignee run lock below freezes every
-    // issue the terminated agent held, with no supported path back.
-    if (issue.assigneeAgentId !== actorAgentId && (await assigneeAgentIsTerminated(issue.assigneeAgentId))) {
+    // unowned in practice. The authorization service reports that with its own
+    // reason. Without this the assignee run lock below freezes every issue the
+    // terminated agent held, with no supported path back.
+    if (boundaryDecision.reason === "allow_terminated_assignee") {
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -15,6 +15,7 @@ import { trackRoutineCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
 import { accessService, documentAnnotationService, logActivity, routineService } from "../services/index.js";
 import { assertCompanyAccess, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
+import { isTerminatedAgentId } from "../services/terminated-assignee.js";
 import { forbidden, unauthorized } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
@@ -112,7 +113,12 @@ export function routineRoutes(
     if (req.actor.type === "board") return routine;
     if (req.actor.type !== "agent" || !req.actor.agentId) throw unauthorized();
     if (routine.assigneeAgentId !== req.actor.agentId) {
-      throw forbidden("Agents can only manage routines assigned to themselves");
+      // A routine owned by a terminated agent keeps firing and minting issues
+      // nobody can pick up. The dead owner holds no real claim, so any agent in
+      // the company may take it over, pause it, or retarget it.
+      if (!(await isTerminatedAgentId(db, routine.assigneeAgentId))) {
+        throw forbidden("Agents can only manage routines assigned to themselves");
+      }
     }
     return routine;
   }

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -717,6 +717,17 @@ export function authorizationService(db: Db) {
       .then((rows) => rows[0] ?? null);
   }
 
+  /**
+   * A terminated agent can never run again, so an issue still pointing at one
+   * is unowned in practice. Without this, one termination freezes every issue
+   * that agent held: no peer, and not even its former manager, can write to it.
+   */
+  async function assigneeAgentIsTerminated(agentId: string | null | undefined) {
+    if (!agentId) return false;
+    const assignee = await loadAgent(agentId);
+    return assignee?.status === "terminated";
+  }
+
   async function loadProject(projectId: string): Promise<ProjectAuthorizationRow | null> {
     return db
       .select({
@@ -2153,6 +2164,13 @@ export function authorizationService(db: Db) {
           action: input.action,
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
+        });
+      }
+      if (await assigneeAgentIsTerminated(resource.assigneeAgentId)) {
+        return allow({
+          action: input.action,
+          reason: "allow_company_agent",
+          explanation: "Allowed because the issue assignee agent is terminated, so the issue is unowned.",
         });
       }
       if (

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -111,6 +111,7 @@ export type AuthorizationDecision = {
     | "allow_visible_issue_write"
     | "allow_self"
     | "allow_company_agent"
+    | "allow_terminated_assignee"
     | "allow_company_member"
     | "allow_simple_company_member"
     | "allow_manager_chain"
@@ -2169,7 +2170,7 @@ export function authorizationService(db: Db) {
       if (await assigneeAgentIsTerminated(resource.assigneeAgentId)) {
         return allow({
           action: input.action,
-          reason: "allow_company_agent",
+          reason: "allow_terminated_assignee",
           explanation: "Allowed because the issue assignee agent is terminated, so the issue is unowned.",
         });
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5312,6 +5312,11 @@ export function issueService(db: Db) {
   // run this after clearExecutionRunIfTerminal/clearCheckoutRunIfTerminal, so a
   // stale lock left by the terminated agent is already gone by this point.
   async function releaseTerminatedAssignee(issueId: string): Promise<boolean> {
+    const before = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
     const released = await db
       .update(issues)
       .set({ assigneeAgentId: null, updatedAt: new Date() })
@@ -5323,9 +5328,24 @@ export function issueService(db: Db) {
           sql`exists (select 1 from ${agents} where ${agents.id} = ${issues.assigneeAgentId} and ${agents.status} = 'terminated')`,
         ),
       )
-      .returning({ id: issues.id })
+      .returning({ id: issues.id, companyId: issues.companyId })
       .then((rows) => rows[0] ?? null);
-    return Boolean(released);
+    if (!released) return false;
+    // Ownership changes here without an actor request, so record why. An operator
+    // who sees an issue lose its assignee must be able to read the reason.
+    await logActivity(db, {
+      companyId: released.companyId,
+      actorType: "system",
+      actorId: "issue_service",
+      action: "issue.terminated_assignee_released",
+      entityType: "issue",
+      entityId: released.id,
+      details: {
+        previousAssigneeAgentId: before?.assigneeAgentId ?? null,
+        reason: "assignee_agent_terminated",
+      },
+    });
+    return true;
   }
 
   async function addStopRelayCommentIfNeeded(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5305,6 +5305,29 @@ export function issueService(db: Db) {
     });
   }
 
+  // A terminated agent can never run again, so an issue still pointing at one is
+  // unowned in practice — but the checkout guard below only accepts a null
+  // assignee, so the row stays frozen forever. Release the dead assignee when no
+  // run holds the issue, which lets the normal checkout path claim it. Callers
+  // run this after clearExecutionRunIfTerminal/clearCheckoutRunIfTerminal, so a
+  // stale lock left by the terminated agent is already gone by this point.
+  async function releaseTerminatedAssignee(issueId: string): Promise<boolean> {
+    const released = await db
+      .update(issues)
+      .set({ assigneeAgentId: null, updatedAt: new Date() })
+      .where(
+        and(
+          eq(issues.id, issueId),
+          isNull(issues.checkoutRunId),
+          isNull(issues.executionRunId),
+          sql`exists (select 1 from ${agents} where ${agents.id} = ${issues.assigneeAgentId} and ${agents.status} = 'terminated')`,
+        ),
+      )
+      .returning({ id: issues.id })
+      .then((rows) => rows[0] ?? null);
+    return Boolean(released);
+  }
+
   async function addStopRelayCommentIfNeeded(
     child: typeof issues.$inferSelect,
     dbOrTx: any = db,
@@ -8003,6 +8026,7 @@ export function issueService(db: Db) {
 
       await clearExecutionRunIfTerminal(id);
       await clearCheckoutRunIfTerminal(id);
+      await releaseTerminatedAssignee(id);
 
       const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
       const readiness = dependencyReadiness.get(id);

--- a/server/src/services/terminated-assignee.ts
+++ b/server/src/services/terminated-assignee.ts
@@ -1,0 +1,19 @@
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents } from "@paperclipai/db";
+
+/**
+ * A terminated agent can never run again: its API keys are revoked and it can
+ * never be assigned new work. Anything it still owns — issues, routines — is
+ * therefore unowned in practice, and must stay reclaimable by the rest of the
+ * company instead of being frozen forever behind an ownership check.
+ */
+export async function isTerminatedAgentId(db: Db, agentId: string | null | undefined): Promise<boolean> {
+  if (!agentId) return false;
+  const row = await db
+    .select({ status: agents.status })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .then((rows) => rows[0] ?? null);
+  return row?.status === "terminated";
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent lifecycle and issue/routine ownership are two parts of that app
> - An agent can be terminated while it still holds open issues and active routines
> - The ownership guards compare assignee identity only. They do not ask if the assignee can still run
> - So one termination freezes every issue and routine that agent held, and no agent in the company can take the work back
> - This pull request treats a terminated assignee as unowned in the checkout guard, the issue authorization boundary, and the routine management guard
> - The benefit is that stuck work becomes reclaimable by normal agent flows, and a routine owned by a dead agent can be paused or moved

## Linked Issues or Issue Description

Refs #10508 — "Issues assigned to a terminated agent become fully immutable".

Related PR: #10861 releases open issues at termination time. This pull request is complementary. It repairs rows that are already stuck, including agents terminated before that change, and it also closes the routine hole.

**What happened?**

An issue assigned to a terminated agent is unreclaimable by every agent in the company. There is no supported path back. A routine owned by a terminated agent keeps firing and creates issues that nobody can pick up.

**Steps to reproduce**

1. Assign an open issue to an agent and give that agent a schedule routine.
2. Terminate the agent.
3. As a different agent in the same company, send `PATCH /api/issues/{id}` with a new `assigneeAgentId`.
4. As that same agent, send `POST /api/issues/{id}/checkout`.
5. As that same agent, send `PATCH /api/routines/{id}` with `{"status":"paused"}`.

**Actual behavior**

```
PATCH /api/issues/{id}   {"assigneeAgentId": ...}
  -> 403 {"error":"Issue is outside this actor's authorization boundary"}

POST /api/issues/{id}/checkout
  -> 409 {"error":"Issue checkout conflict",
          "details":{"assigneeAgentId":"<terminated-agent>","checkoutRunId":null,"executionRunId":null}}

PATCH /api/routines/{id}   {"status":"paused"}
  -> 403 {"error":"Agents can only manage routines assigned to themselves"}
```

`checkoutRunId` and `executionRunId` are both null. No run holds the issue. The 409 is only "the assignee is a different agent". The boundary check does not consider that this agent can never run again. The manager agent gets the same two answers.

**Expected behavior**

A terminated agent holds no live claim. Another agent in the company can check the issue out, can update it, and can manage the routine.

## What Changed

- `server/src/services/authorization.ts`: allow a company agent to act on an issue when the assignee agent is terminated. The decision carries the new reason `allow_terminated_assignee`.
- `server/src/routes/issues.ts`: skip the assignee run lock in the agent issue-mutation guard when the boundary decision reports that reason. The route adds no lookup of its own.
- `server/src/services/issues.ts`: on checkout, release a terminated assignee when `checkoutRunId` and `executionRunId` are both null. The normal checkout path then claims the issue. The release writes an `issue.terminated_assignee_released` activity entry that names the previous assignee.
- `server/src/routes/routines.ts`: allow any agent in the company to manage a routine whose assignee is terminated. A routine with a live assignee stays protected.
- `server/src/services/terminated-assignee.ts`: new small helper that reads the assignee agent status.
- `server/src/__tests__/terminated-assignee-reclaim.test.ts`: new regression suite against embedded Postgres.
- `server/src/__tests__/routines-routes.test.ts`: mock the new helper and add a case for the terminated-assignee read path.
- `doc/SPEC-implementation.md`: record the rule in the atomic checkout contract.

## Verification

```
$ cd server && npx vitest run src/__tests__/terminated-assignee-reclaim.test.ts src/__tests__/routines-routes.test.ts
 Test Files  2 passed (2)
      Tests  21 passed (21)
```

The new suite terminates an agent that holds an open issue and an active routine, then proves another agent can reclaim both:

- checkout of a `todo` issue owned by a terminated agent returns 200 and the new assignee.
- `PATCH` of an `in_progress` issue left by a terminated assignee returns 200.
- an issue held by a live run still returns 409 and keeps its assignee.
- the automatic release writes an `issue.terminated_assignee_released` activity row that names the previous assignee.
- `PATCH /api/routines/{id}` by a non-assignee agent returns 200 for pause and for reassign after the owner is terminated.
- `PATCH /api/routines/{id}` still returns 403 while the assignee is alive.

Regression suites that cover the touched guards:

```
$ npx vitest run src/__tests__/authorization-service.test.ts src/__tests__/routines-routes.test.ts src/__tests__/issues-checkout-wakeup.test.ts
 Test Files  3 passed (3)
      Tests  80 passed (80)

$ npx vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/issue-stale-execution-lock-routes.test.ts src/__tests__/attention-service.test.ts
 Test Files  3 passed (3)
      Tests  111 passed (111)
```

`npx tsc -p server/tsconfig.json --noEmit` reports no error in the changed files. The repository has pre-existing errors in `server/src/routes/plugins.ts` from an unbuilt `@paperclipai/plugin-sdk`; those are not touched here.

## Risks

Low to medium risk, and the blast radius is limited to agents whose status is `terminated`.

- The change widens who can write to an issue. It only widens it when the assignee agent is terminated, which is a terminal state that no agent can leave.
- Checkout still refuses to steal an issue that a run holds. The release is guarded by `checkoutRunId is null and executionRunId is null` in the same statement, so a live lock is never broken.
- The routine guard now costs one extra agent lookup on each non-assignee call. The lookup runs only after the identity check fails.
- No schema change and no migration. The rollback is a revert of this commit.

## Model Used

Anthropic Claude, `claude-opus-5`, accessed through GitHub Copilot. High reasoning mode. Tool use for file read/edit, shell command execution, and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
