### PR TITLE
docs(kubernetes): fix agent-sandbox install manifest URL

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -44,7 +44,7 @@ The plugin supports two backend modes, selected via the `backend` config field:
 
 ### Migrating from `job` to `sandbox-cr`
 
-1. Install the agent-sandbox controller: `kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/install.yaml`
+1. Install the agent-sandbox controller: `kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml`
 2. Update your environment config to set `backend: "sandbox-cr"` (or remove `backend` since `sandbox-cr` is the default)
 3. New leases will use the Sandbox CR backend. Existing leases created with `job` mode continue to use job semantics until they are released.
 


### PR DESCRIPTION
The Kubernetes sandbox provider README tells users to run `kubectl apply -f .../agent-sandbox/releases/latest/download/install.yaml`, but the release has no `install.yaml` asset - the actual manifests are `sandbox.yaml`, `extensions.yaml`, and `sandbox-with-extensions.yaml`. The upstream agent-sandbox README uses `sandbox.yaml` for the base install, so this PR updates the URL accordingly (verified against the latest release assets).