### PR TITLE
fix(auth): identify expired local run tokens

### DIFF
--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -1,7 +1,7 @@
 import { createHash, createHmac, randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agentApiKeys,
@@ -163,6 +163,7 @@ describe("agent auth middleware", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
     else process.env.PAPERCLIP_AGENT_JWT_SECRET = originalSecret;
     if (originalTtl === undefined) delete process.env.PAPERCLIP_AGENT_JWT_TTL_SECONDS;
@@ -195,6 +196,38 @@ describe("agent auth middleware", () => {
       onBehalfOfUserId: "user-claim",
       source: "agent_jwt",
     });
+  });
+
+  it("returns an expired_run_token error for an expired local agent JWT on every protected route", async () => {
+    process.env.PAPERCLIP_AGENT_JWT_TTL_SECONDS = "1";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: { id: runId, companyId, agentId, responsibleUserId: "user-claim" },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+
+    const app = createApp(db);
+    const readRes = await request(app)
+      .get(`/companies/${companyId}/issues/${issueId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId);
+    const writeRes = await request(app)
+      .patch(`/companies/${companyId}/issues/${issueId}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId)
+      .send({ title: "must not reach the route" });
+
+    for (const response of [readRes, writeRes]) {
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({ code: "expired_run_token" });
+    }
   });
 
   it("preserves signed skill_test JWT scope on the request actor", async () => {

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -160,7 +160,7 @@ export function createLocalAgentJwt(
   return `${signingInput}.${signature}`;
 }
 
-export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
+export function inspectLocalAgentJwt(token: string): { claims: LocalAgentJwtClaims; expired: boolean } | null {
   if (!token) return null;
   const config = jwtConfig();
   if (!config) return null;
@@ -222,7 +222,7 @@ export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
   const companyId = claimedCompanyId;
 
   const now = Math.floor(Date.now() / 1000);
-  if (exp < now) return null;
+  const expired = exp < now;
 
   const issuer = typeof claims.iss === "string" ? claims.iss : undefined;
   const audience = typeof claims.aud === "string" ? claims.aud : undefined;
@@ -239,17 +239,25 @@ export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
   if (instanceClaim && instanceClaim !== config.instanceId) return null;
 
   return {
-    sub,
-    company_id: companyId,
-    adapter_type: adapterType,
-    run_id: runId,
-    ...(responsibleUserClaim !== undefined ? { responsible_user_id: responsibleUserClaim } : {}),
-    ...(keyScopeClaim !== undefined ? { key_scope: keyScopeClaim } : {}),
-    iat,
-    exp,
-    ...(issuer ? { iss: issuer } : {}),
-    ...(audience ? { aud: audience } : {}),
-    ...(instanceClaim ? { instance_id: instanceClaim } : {}),
-    jti: typeof claims.jti === "string" ? claims.jti : undefined,
+    claims: {
+      sub,
+      company_id: companyId,
+      adapter_type: adapterType,
+      run_id: runId,
+      ...(responsibleUserClaim !== undefined ? { responsible_user_id: responsibleUserClaim } : {}),
+      ...(keyScopeClaim !== undefined ? { key_scope: keyScopeClaim } : {}),
+      iat,
+      exp,
+      ...(issuer ? { iss: issuer } : {}),
+      ...(audience ? { aud: audience } : {}),
+      ...(instanceClaim ? { instance_id: instanceClaim } : {}),
+      jti: typeof claims.jti === "string" ? claims.jti : undefined,
+    },
+    expired,
   };
+}
+
+export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
+  const inspection = inspectLocalAgentJwt(token);
+  return inspection && !inspection.expired ? inspection.claims : null;
 }

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -13,8 +13,8 @@ export function badRequest(message: string, details?: unknown) {
   return new HttpError(400, message, details);
 }
 
-export function unauthorized(message = "Unauthorized") {
-  return new HttpError(401, message);
+export function unauthorized(message = "Unauthorized", details?: unknown) {
+  return new HttpError(401, message, details);
 }
 
 export function forbidden(message = "Forbidden", details?: unknown) {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -12,7 +12,7 @@ import {
   heartbeatRuns,
   instanceUserRoles,
 } from "@paperclipai/db";
-import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
+import { inspectLocalAgentJwt } from "../agent-auth-jwt.js";
 import { isUuidLike, normalizeAgentApiKeyScope, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
@@ -46,7 +46,7 @@ function pruneCloudTenantWriteDebounce(
 }
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
-import { forbidden, unprocessable } from "../errors.js";
+import { forbidden, unauthorized, unprocessable } from "../errors.js";
 
 export { isCloudManagedInstance } from "../services/cloud-instance.js";
 
@@ -295,7 +295,12 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       .then((rows) => rows[0] ?? null);
 
     if (!key) {
-      const claims = verifyLocalAgentJwt(token);
+      const inspection = inspectLocalAgentJwt(token);
+      if (inspection?.expired) {
+        next(unauthorized("Agent run token has expired", { code: "expired_run_token" }));
+        return;
+      }
+      const claims = inspection?.claims ?? null;
       if (!claims) {
         next();
         return;


### PR DESCRIPTION
## Thinking Path

> - A local adapter calls the API with a signed run JWT.
> - A JWT can be correctly signed but expired.
> - The auth middleware previously treated that case like an unrecognized bearer token.
> - Protected routes then produced their ordinary authorization result instead of a stable token-expiry response.
> - This change preserves the authenticated inspection result only long enough to return a structured expiry error.
> - It never accepts, refreshes, or extends an expired token.

## Linked Issues or Issue Description

**What happened**

A local agent sends a signed run JWT after its `exp` time. Strict JWT verification rejects it. Middleware falls through as though the bearer token were unknown. The adapter cannot distinguish token expiry from other authorization failures.

**Expected behavior**

A signed expired local run JWT returns HTTP `401` with machine-readable code `expired_run_token`. Invalid, unsigned, foreign-instance, and absent bearer tokens retain existing behavior.

**Steps to reproduce**

1. Configure `PAPERCLIP_AGENT_JWT_TTL_SECONDS=1`.
2. Mint a local agent run JWT.
3. Advance time past expiry.
4. Call protected issue read and write routes with that token.
5. Before this change, the response has no token-expiry code.

**Deployment mode**

Self-hosted or local-agent JWT authentication.

## What Changed

- Add an authenticated local-JWT inspection result containing signed claims and expiry state.
- Keep `verifyLocalAgentJwt` strict for existing callers: expired tokens still fail verification.
- Return `401` and `expired_run_token` in middleware for a correctly signed expired run token.
- Permit the existing unauthorized error helper to pass structured details to the error handler.
- Add protected read/write regression coverage.

## Verification

- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-auth-jwt.test.ts src/__tests__/agent-auth-middleware.test.ts`
  - 25 tests passed.
- `git diff --check` passed.
- Repository CI typecheck, build, tests, E2E, Canary, Greptile, Superagent Security, and Snyk passed for the rebased strict-expiry head; this edit requests only a documentation-gate rerun.

## Risks

- Authentication code changes can affect agent API calls.
- This change only distinguishes already-signed expired local run tokens.
- It does not accept expired credentials, create a grace window, alter configured TTLs, add a refresh endpoint, or change database schema.

## Model Used

OpenAI Codex — `gpt-5.6-terra`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have searched the GitHub PR list for similar work and linked the related default-TTL PR below
- [x] I have either linked an issue or described the underlying issue inline
- [x] I have added regression tests
- [x] I have run focused local tests
- [x] I have considered the authentication risk

Related merged PR: https://github.com/paperclipai/paperclip/pull/10176
