### PR TITLE
fix(costs): price credit-billed lanes off tokens, not discounted cache reads

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -83,6 +83,16 @@ export type {
   RuntimeStatusUpdate,
 } from "./runtime-progress.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export {
+  DEFAULT_TOKEN_RATE_CARD,
+  TOKEN_RATE_CARD_ENV_KEY,
+  applyTokenRateCard,
+  lookupTokenRateCardEntry,
+  priceUsageWithRateCard,
+  resolveTokenRateCard,
+  totalBilledTokens,
+} from "./token-rate-card.js";
+export type { AppliedTokenRateCard, TokenRateCardEntry } from "./token-rate-card.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/token-rate-card.test.ts
+++ b/packages/adapter-utils/src/token-rate-card.test.ts
@@ -108,6 +108,31 @@ describe("token rate card", () => {
     ).toBeCloseTo(10, 10);
   });
 
+  it("drops an empty or provider-only multiplier key instead of matching every model", () => {
+    const env = {
+      [TOKEN_RATE_CARD_ENV_KEY]: JSON.stringify({
+        "github-copilot": {
+          usdPerThousandTokens: 0.01,
+          billingType: "credits",
+          // "", " ", and "provider/" all normalize to an empty key. Stored as
+          // a multiplier, an empty prefix would match every model id.
+          modelMultipliers: { "": 5, " ": 5, "provider/": 5, "claude-opus": 2 },
+        },
+      }),
+    };
+    const usage = { inputTokens: 500_000, cachedInputTokens: 500_000, outputTokens: 0 };
+
+    // Unrelated model: no multiplier should apply (would be 50 if the empty
+    // key matched).
+    expect(
+      applyTokenRateCard({ biller: "github-copilot", model: "gpt-5.4", usage, env }).costUsd,
+    ).toBeCloseTo(10, 10);
+    // The real "claude-opus" multiplier still applies normally.
+    expect(
+      applyTokenRateCard({ biller: "github-copilot", model: "claude-opus-4.5", usage, env }).costUsd,
+    ).toBeCloseTo(20, 10);
+  });
+
   it("lets an operator zero-price a lane that is not actually billed", () => {
     const env = {
       [TOKEN_RATE_CARD_ENV_KEY]: JSON.stringify({

--- a/packages/adapter-utils/src/token-rate-card.test.ts
+++ b/packages/adapter-utils/src/token-rate-card.test.ts
@@ -133,6 +133,21 @@ describe("token rate card", () => {
     }
   });
 
+  it("rejects an override with an unsupported billingType instead of degrading to unknown", () => {
+    const env = {
+      [TOKEN_RATE_CARD_ENV_KEY]: JSON.stringify({
+        "github-copilot": { usdPerThousandTokens: 0.02, billingType: "credit" },
+      }),
+    };
+    const entry = lookupTokenRateCardEntry("github-copilot", env);
+    // Falls back to the built-in entry rather than adopting the typo'd
+    // override: a malformed billingType override must not silently degrade
+    // the biller to "unknown" the way the CLI-reported path did before this
+    // rate card existed.
+    expect(entry?.usdPerThousandTokens).toBe(0.0092);
+    expect(entry?.billingType).toBe("credits");
+  });
+
   it("matches the biller case-insensitively", () => {
     expect(lookupTokenRateCardEntry("GitHub-Copilot")?.billingType).toBe("credits");
     expect(lookupTokenRateCardEntry("  ")).toBeNull();

--- a/packages/adapter-utils/src/token-rate-card.test.ts
+++ b/packages/adapter-utils/src/token-rate-card.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_TOKEN_RATE_CARD,
+  TOKEN_RATE_CARD_ENV_KEY,
+  applyTokenRateCard,
+  lookupTokenRateCardEntry,
+  priceUsageWithRateCard,
+} from "./token-rate-card.js";
+
+describe("token rate card", () => {
+  it("bills cached input at the same rate as input for github-copilot", () => {
+    const entry = DEFAULT_TOKEN_RATE_CARD["github-copilot"]!;
+    const cachedOnly = priceUsageWithRateCard(entry, {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 1_000_000,
+    });
+    const inputOnly = priceUsageWithRateCard(entry, {
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    });
+    expect(cachedOnly).toBeCloseTo(inputOnly, 10);
+    expect(cachedOnly).toBeCloseTo(9.2, 10);
+  });
+
+  it("prices a cache-heavy workload at the full credit rate, not the API rate", () => {
+    // Shape of a long-running agent workload: ~99.3% of tokens are cache reads.
+    // An API-shaped price table with a 10x cache-read discount prices the same
+    // volume an order of magnitude lower, which is the bug this card fixes.
+    const priced = applyTokenRateCard({
+      biller: "github-copilot",
+      model: "github-copilot/claude-opus-4.5",
+      usage: {
+        inputTokens: 22_000,
+        cachedInputTokens: 9_930_000,
+        outputTokens: 48_000,
+      },
+      reportedCostUsd: 7.5,
+    });
+
+    expect(priced.pricingSource).toBe("rate_card");
+    expect(priced.billingType).toBe("credits");
+    // 10,000,000 tokens at $0.0092 per 1,000 tokens.
+    expect(priced.costUsd).toBeCloseTo(92, 6);
+  });
+
+  it("leaves billers without a rate card entry priced by the adapter", () => {
+    const priced = applyTokenRateCard({
+      biller: "anthropic",
+      model: "claude-sonnet-4.5",
+      usage: { inputTokens: 1_000, cachedInputTokens: 500_000, outputTokens: 2_000 },
+      reportedCostUsd: 1.23,
+      reportedBillingType: "metered_api",
+    });
+    expect(priced).toEqual({
+      costUsd: 1.23,
+      billingType: "metered_api",
+      pricingSource: "adapter",
+    });
+  });
+
+  it("reports no cost rather than zero when an unpriced lane reports nothing", () => {
+    const priced = applyTokenRateCard({
+      biller: "opencode",
+      usage: { inputTokens: 10, outputTokens: 10 },
+      reportedCostUsd: null,
+    });
+    expect(priced.costUsd).toBeNull();
+    expect(priced.billingType).toBe("unknown");
+  });
+
+  it("prices a zero-token run at zero without touching the reported cost source", () => {
+    const priced = applyTokenRateCard({
+      biller: "github-copilot",
+      usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0 },
+      reportedCostUsd: 4.2,
+    });
+    expect(priced.costUsd).toBe(0);
+    expect(priced.pricingSource).toBe("rate_card");
+  });
+
+  it("applies a per-model multiplier by longest matching prefix", () => {
+    const env = {
+      [TOKEN_RATE_CARD_ENV_KEY]: JSON.stringify({
+        "github-copilot": {
+          usdPerThousandTokens: 0.01,
+          billingType: "credits",
+          modelMultipliers: { "claude-opus": 2, "claude-opus-4.5": 3, "claude-sonnet": 0.5 },
+        },
+      }),
+    };
+    const usage = { inputTokens: 500_000, cachedInputTokens: 500_000, outputTokens: 0 };
+
+    expect(
+      applyTokenRateCard({ biller: "github-copilot", model: "github-copilot/claude-opus-4.5", usage, env })
+        .costUsd,
+    ).toBeCloseTo(30, 10);
+    expect(
+      applyTokenRateCard({ biller: "github-copilot", model: "claude-opus-4.6", usage, env }).costUsd,
+    ).toBeCloseTo(20, 10);
+    expect(
+      applyTokenRateCard({ biller: "github-copilot", model: "claude-sonnet-4.5", usage, env }).costUsd,
+    ).toBeCloseTo(5, 10);
+    expect(
+      applyTokenRateCard({ biller: "github-copilot", model: "gpt-5.4", usage, env }).costUsd,
+    ).toBeCloseTo(10, 10);
+  });
+
+  it("lets an operator zero-price a lane that is not actually billed", () => {
+    const env = {
+      [TOKEN_RATE_CARD_ENV_KEY]: JSON.stringify({
+        google: { usdPerThousandTokens: 0, billingType: "fixed", note: "AI Studio free tier" },
+      }),
+    };
+    const priced = applyTokenRateCard({
+      biller: "google",
+      model: "google/gemini-3.7-flash",
+      usage: { inputTokens: 1_000_000, cachedInputTokens: 5_000_000, outputTokens: 100_000 },
+      reportedCostUsd: 0.11,
+      env,
+    });
+    expect(priced.costUsd).toBe(0);
+    expect(priced.billingType).toBe("fixed");
+    expect(priced.rateCardNote).toBe("AI Studio free tier");
+  });
+
+  it("ignores malformed override JSON instead of failing the run", () => {
+    for (const raw of ["not json", "[]", '{"github-copilot":{"usdPerThousandTokens":"free"}}', '{"":{}}']) {
+      const entry = lookupTokenRateCardEntry("github-copilot", { [TOKEN_RATE_CARD_ENV_KEY]: raw });
+      expect(entry?.usdPerThousandTokens).toBe(0.0092);
+    }
+  });
+
+  it("matches the biller case-insensitively", () => {
+    expect(lookupTokenRateCardEntry("GitHub-Copilot")?.billingType).toBe("credits");
+    expect(lookupTokenRateCardEntry("  ")).toBeNull();
+    expect(lookupTokenRateCardEntry(null)).toBeNull();
+  });
+});

--- a/packages/adapter-utils/src/token-rate-card.ts
+++ b/packages/adapter-utils/src/token-rate-card.ts
@@ -1,0 +1,211 @@
+/**
+ * Biller-level token rate card.
+ *
+ * Some billers do not sell tokens at API list prices. GitHub Copilot bills
+ * agent traffic against *premium credits*: every token — input, cached input,
+ * and output — consumes the same credit budget, and a cache read is **not**
+ * discounted.
+ *
+ * Coding CLIs report a `costUsd` computed from an API-shaped price table
+ * (input / output / cacheRead, with cacheRead typically at ~10% of input).
+ * Passing that number through understates a credit-billed lane by roughly the
+ * inverse of the cache-read discount times the cached share of volume. On a
+ * long-running agent workload where cache reads are ~99% of tokens, that is an
+ * order-of-magnitude error — measured at 12.3x against a real Copilot org bill.
+ *
+ * So for these billers Paperclip re-prices the run from token counts instead of
+ * trusting the CLI's cost field.
+ */
+
+import type { AdapterBillingType, UsageSummary } from "./types.js";
+
+/** Env var carrying operator overrides, merged over {@link DEFAULT_TOKEN_RATE_CARD}. */
+export const TOKEN_RATE_CARD_ENV_KEY = "PAPERCLIP_TOKEN_RATE_CARD_JSON";
+
+export interface TokenRateCardEntry {
+  /**
+   * USD charged per 1,000 tokens, applied uniformly to input, cached input and
+   * output. A blended rate is intentional: credit-metered billers do not expose
+   * a per-token-class price.
+   */
+  usdPerThousandTokens: number;
+  /** Billing type stamped on the cost event for this biller. */
+  billingType: AdapterBillingType;
+  /**
+   * Optional per-model multipliers on {@link usdPerThousandTokens}, keyed by the
+   * model id with any `provider/` prefix stripped. Matching is case-insensitive
+   * and longest-prefix, so `"claude-opus"` covers `claude-opus-4.5`.
+   *
+   * Empty by default: GitHub does not publish a per-model token multiplier for
+   * credit-metered usage, and a guessed split is worse than a blended rate that
+   * reconciles in aggregate.
+   */
+  modelMultipliers?: Record<string, number>;
+  /** Why this entry exists. Surfaced in the priced result for auditability. */
+  note?: string;
+}
+
+/**
+ * Built-in entries. Only billers whose *published* billing model diverges from
+ * token list pricing belong here — anything else keeps the CLI-reported cost.
+ */
+export const DEFAULT_TOKEN_RATE_CARD: Readonly<Record<string, TokenRateCardEntry>> = Object.freeze({
+  "github-copilot": {
+    // ~1 premium credit per ~1,000 tokens at $0.01 per credit. Cross-checked
+    // against metered credits vs token volume on a real org bill: 1,087 tokens
+    // per credit, i.e. a realized $0.0092 per 1,000 tokens.
+    usdPerThousandTokens: 0.0092,
+    billingType: "credits",
+    note: "GitHub Copilot premium credits: cache reads are billed at full rate, not discounted.",
+  },
+});
+
+function normalizeBillerKey(biller: string | null | undefined): string | null {
+  const trimmed = typeof biller === "string" ? biller.trim().toLowerCase() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeModelKey(model: string | null | undefined): string {
+  const trimmed = typeof model === "string" ? model.trim().toLowerCase() : "";
+  if (trimmed.length === 0) return "";
+  const slash = trimmed.lastIndexOf("/");
+  return slash >= 0 ? trimmed.slice(slash + 1) : trimmed;
+}
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function parseEntry(value: unknown): TokenRateCardEntry | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (!isFiniteNonNegative(raw.usdPerThousandTokens)) return null;
+  const multipliers: Record<string, number> = {};
+  if (raw.modelMultipliers && typeof raw.modelMultipliers === "object") {
+    for (const [model, multiplier] of Object.entries(raw.modelMultipliers as Record<string, unknown>)) {
+      if (isFiniteNonNegative(multiplier)) multipliers[normalizeModelKey(model)] = multiplier;
+    }
+  }
+  return {
+    usdPerThousandTokens: raw.usdPerThousandTokens,
+    billingType: typeof raw.billingType === "string" ? (raw.billingType as AdapterBillingType) : "credits",
+    ...(Object.keys(multipliers).length > 0 ? { modelMultipliers: multipliers } : {}),
+    ...(typeof raw.note === "string" && raw.note.trim().length > 0 ? { note: raw.note.trim() } : {}),
+  };
+}
+
+/**
+ * Reads operator overrides from the runtime env. The value is a JSON object
+ * keyed by biller, e.g.:
+ *
+ * ```json
+ * {"google":{"usdPerThousandTokens":0,"billingType":"fixed","note":"AI Studio free tier"}}
+ * ```
+ *
+ * Overrides replace a built-in entry for the same biller. Malformed JSON or
+ * malformed entries are ignored rather than failing the run: a bad rate card
+ * must never take an agent offline.
+ */
+export function resolveTokenRateCard(
+  env: Record<string, string | undefined> = {},
+): Record<string, TokenRateCardEntry> {
+  const card: Record<string, TokenRateCardEntry> = { ...DEFAULT_TOKEN_RATE_CARD };
+  const raw = env[TOKEN_RATE_CARD_ENV_KEY];
+  if (typeof raw !== "string" || raw.trim().length === 0) return card;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return card;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return card;
+  for (const [biller, value] of Object.entries(parsed as Record<string, unknown>)) {
+    const key = normalizeBillerKey(biller);
+    if (!key) continue;
+    const entry = parseEntry(value);
+    if (entry) card[key] = entry;
+  }
+  return card;
+}
+
+export function lookupTokenRateCardEntry(
+  biller: string | null | undefined,
+  env: Record<string, string | undefined> = {},
+): TokenRateCardEntry | null {
+  const key = normalizeBillerKey(biller);
+  if (!key) return null;
+  return resolveTokenRateCard(env)[key] ?? null;
+}
+
+function resolveModelMultiplier(entry: TokenRateCardEntry, model: string | null | undefined): number {
+  const multipliers = entry.modelMultipliers;
+  if (!multipliers) return 1;
+  const key = normalizeModelKey(model);
+  if (!key) return 1;
+  const exact = multipliers[key];
+  if (isFiniteNonNegative(exact)) return exact;
+  let best: { prefix: string; multiplier: number } | null = null;
+  for (const [prefix, multiplier] of Object.entries(multipliers)) {
+    if (!key.startsWith(prefix)) continue;
+    if (!best || prefix.length > best.prefix.length) best = { prefix, multiplier };
+  }
+  return best?.multiplier ?? 1;
+}
+
+export function totalBilledTokens(usage: UsageSummary | null | undefined): number {
+  if (!usage) return 0;
+  const input = isFiniteNonNegative(usage.inputTokens) ? usage.inputTokens : 0;
+  const cached = isFiniteNonNegative(usage.cachedInputTokens) ? (usage.cachedInputTokens ?? 0) : 0;
+  const output = isFiniteNonNegative(usage.outputTokens) ? usage.outputTokens : 0;
+  return input + cached + output;
+}
+
+/** Price a run's token usage with a rate card entry. Cached input is NOT discounted. */
+export function priceUsageWithRateCard(
+  entry: TokenRateCardEntry,
+  usage: UsageSummary | null | undefined,
+  model?: string | null,
+): number {
+  const tokens = totalBilledTokens(usage);
+  if (tokens <= 0) return 0;
+  const rate = entry.usdPerThousandTokens * resolveModelMultiplier(entry, model);
+  return (tokens / 1000) * rate;
+}
+
+export interface AppliedTokenRateCard {
+  costUsd: number | null;
+  billingType: AdapterBillingType;
+  /** `"rate_card"` when Paperclip re-priced the run, `"adapter"` when the CLI's cost stands. */
+  pricingSource: "rate_card" | "adapter";
+  rateCardNote?: string;
+}
+
+/**
+ * Decides the cost and billing type recorded for a run.
+ *
+ * When the biller has a rate card entry, the CLI-reported cost is replaced by
+ * the token-derived price and the entry's billing type is stamped. Otherwise
+ * the reported cost and billing type pass through untouched.
+ */
+export function applyTokenRateCard(input: {
+  biller: string | null | undefined;
+  model?: string | null;
+  usage?: UsageSummary | null;
+  reportedCostUsd?: number | null;
+  reportedBillingType?: AdapterBillingType | null;
+  env?: Record<string, string | undefined>;
+}): AppliedTokenRateCard {
+  const fallback: AppliedTokenRateCard = {
+    costUsd: isFiniteNonNegative(input.reportedCostUsd) ? input.reportedCostUsd : null,
+    billingType: input.reportedBillingType ?? "unknown",
+    pricingSource: "adapter",
+  };
+  const entry = lookupTokenRateCardEntry(input.biller, input.env ?? {});
+  if (!entry) return fallback;
+  return {
+    costUsd: priceUsageWithRateCard(entry, input.usage, input.model),
+    billingType: entry.billingType,
+    pricingSource: "rate_card",
+    ...(entry.note ? { rateCardNote: entry.note } : {}),
+  };
+}

--- a/packages/adapter-utils/src/token-rate-card.ts
+++ b/packages/adapter-utils/src/token-rate-card.ts
@@ -104,7 +104,11 @@ function parseEntry(value: unknown): TokenRateCardEntry | null {
   const multipliers: Record<string, number> = {};
   if (raw.modelMultipliers && typeof raw.modelMultipliers === "object") {
     for (const [model, multiplier] of Object.entries(raw.modelMultipliers as Record<string, unknown>)) {
-      if (isFiniteNonNegative(multiplier)) multipliers[normalizeModelKey(model)] = multiplier;
+      // An empty, whitespace-only, or provider-only key (e.g. "provider/")
+      // normalizes to "", and every model id starts with "" -- storing it
+      // would silently apply the multiplier to every model for this biller.
+      const key = normalizeModelKey(model);
+      if (key && isFiniteNonNegative(multiplier)) multipliers[key] = multiplier;
     }
   }
   return {

--- a/packages/adapter-utils/src/token-rate-card.ts
+++ b/packages/adapter-utils/src/token-rate-card.ts
@@ -76,10 +76,31 @@ function isFiniteNonNegative(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
+/** The full {@link AdapterBillingType} union, used to validate operator overrides. */
+const KNOWN_BILLING_TYPES: ReadonlySet<AdapterBillingType> = new Set([
+  "api",
+  "subscription",
+  "metered_api",
+  "subscription_included",
+  "subscription_overage",
+  "credits",
+  "fixed",
+  "unknown",
+]);
+
+function isKnownBillingType(value: unknown): value is AdapterBillingType {
+  return typeof value === "string" && KNOWN_BILLING_TYPES.has(value as AdapterBillingType);
+}
+
 function parseEntry(value: unknown): TokenRateCardEntry | null {
   if (!value || typeof value !== "object") return null;
   const raw = value as Record<string, unknown>;
   if (!isFiniteNonNegative(raw.usdPerThousandTokens)) return null;
+  // An operator override with an unsupported billingType (typo, unknown
+  // value) must not silently replace a valid built-in entry: that would
+  // reintroduce the `unknown` billing-type misclassification this rate card
+  // exists to fix. Reject the whole entry so the built-in falls through.
+  if (raw.billingType !== undefined && !isKnownBillingType(raw.billingType)) return null;
   const multipliers: Record<string, number> = {};
   if (raw.modelMultipliers && typeof raw.modelMultipliers === "object") {
     for (const [model, multiplier] of Object.entries(raw.modelMultipliers as Record<string, unknown>)) {
@@ -88,7 +109,7 @@ function parseEntry(value: unknown): TokenRateCardEntry | null {
   }
   return {
     usdPerThousandTokens: raw.usdPerThousandTokens,
-    billingType: typeof raw.billingType === "string" ? (raw.billingType as AdapterBillingType) : "credits",
+    billingType: isKnownBillingType(raw.billingType) ? raw.billingType : "credits",
     ...(Object.keys(multipliers).length > 0 ? { modelMultipliers: multipliers } : {}),
     ...(typeof raw.note === "string" && raw.note.trim().length > 0 ? { note: raw.note.trim() } : {}),
   };

--- a/packages/adapters/AUTHORING.md
+++ b/packages/adapters/AUTHORING.md
@@ -68,3 +68,45 @@ above) so the opt-in shows up in code review.
 
 For the architecture-level write-up of cross-run persistence, see
 [`docs/guides/board-operator/execution-workspaces-and-runtime-services.md`](../../docs/guides/board-operator/execution-workspaces-and-runtime-services.md#cross-run-persistence-no-remote-git-contract).
+
+## Credit-billed lanes: do not trust the CLI's cost field
+
+Coding CLIs report `costUsd` from an API-shaped price table: separate input,
+output, and *discounted* cache-read rates. Some billers do not sell tokens that
+way. GitHub Copilot meters agent traffic against premium credits, where a cache
+read costs exactly as much as a fresh input token.
+
+Reconciled against a real Copilot org bill, passing the CLI number through
+understated that lane by **12.3x**, because ~99% of a long-running agent
+workload's tokens are cache reads.
+
+So an adapter that can route through such a biller must run its result through
+[`applyTokenRateCard`](../adapter-utils/src/token-rate-card.ts) instead of
+forwarding `costUsd` and hard-coding `billingType: "unknown"`:
+
+```ts
+const priced = applyTokenRateCard({
+  biller,
+  model,
+  usage,
+  reportedCostUsd: parsed.usage.costUsd,
+  env: runtimeEnv,
+});
+// → { costUsd, billingType, pricingSource }
+```
+
+Billers with no rate-card entry keep the adapter-reported cost and billing type,
+so this is safe to apply unconditionally. Operators can add or override entries
+per deployment with `PAPERCLIP_TOKEN_RATE_CARD_JSON`, which is also how a lane
+that is genuinely not billed (a free tier) gets priced at `$0` instead of
+carrying a shadow price:
+
+```sh
+PAPERCLIP_TOKEN_RATE_CARD_JSON='{"google":{"usdPerThousandTokens":0,"billingType":"fixed","note":"AI Studio free tier"}}'
+```
+
+Known limitation: the built-in `github-copilot` rate is *blended*. GitHub does
+not publish a per-model token multiplier for credit-metered usage, so the total
+reconciles while the split between models (Opus vs Sonnet) is approximate. When
+a real multiplier is known, add it to `modelMultipliers` rather than forking the
+rate.

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  applyTokenRateCard,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -671,25 +676,37 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderrLine ||
         `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
       const modelId = model || null;
+      const usage = {
+        inputTokens: attempt.parsed.usage.inputTokens,
+        outputTokens: attempt.parsed.usage.outputTokens,
+        cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
+      };
+      const openCodeProvider = parseModelProvider(modelId);
+      const biller = resolveOpenCodeBiller(runtimeEnv, openCodeProvider);
+      // Same credit-billing correction as pi-local: OpenCode can route through
+      // GitHub Copilot, where cache reads are not discounted.
+      const priced = applyTokenRateCard({
+        biller,
+        model: modelId,
+        usage,
+        reportedCostUsd: attempt.parsed.costUsd,
+        env: runtimeEnv,
+      });
 
       return {
         exitCode: synthesizedExitCode,
         signal: attempt.proc.signal,
         timedOut: false,
         errorMessage: (synthesizedExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
-        usage: {
-          inputTokens: attempt.parsed.usage.inputTokens,
-          outputTokens: attempt.parsed.usage.outputTokens,
-          cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
-        },
+        usage,
         sessionId: resolvedSessionId,
         sessionParams: resolvedSessionParams,
         sessionDisplayId: resolvedSessionId,
-        provider: parseModelProvider(modelId),
-        biller: resolveOpenCodeBiller(runtimeEnv, parseModelProvider(modelId)),
+        provider: openCodeProvider,
+        biller,
         model: modelId,
-        billingType: "unknown",
-        costUsd: attempt.parsed.costUsd,
+        billingType: priced.billingType,
+        costUsd: priced.costUsd,
         resultJson: {
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  applyTokenRateCard,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -762,6 +767,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           }
         : null;
 
+      const usage = {
+        inputTokens: attempt.parsed.usage.inputTokens,
+        outputTokens: attempt.parsed.usage.outputTokens,
+        cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
+      };
+      const biller = resolvePiBiller(runtimeEnv, provider);
+      // Credit-billed lanes (GitHub Copilot) do not discount cache reads, so the
+      // CLI's API-priced cost is re-derived from token counts. Everything else
+      // keeps the cost Pi reported.
+      const priced = applyTokenRateCard({
+        biller,
+        model,
+        usage,
+        reportedCostUsd: attempt.parsed.usage.costUsd,
+        env: runtimeEnv,
+      });
+
       const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
       const parsedError = attempt.parsed.errors.find((error) => error.trim().length > 0) ?? "";
@@ -773,19 +795,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         signal: attempt.proc.signal,
         timedOut: false,
         errorMessage: (effectiveExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
-        usage: {
-          inputTokens: attempt.parsed.usage.inputTokens,
-          outputTokens: attempt.parsed.usage.outputTokens,
-          cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
-        },
+        usage,
         sessionId: resolvedSessionId,
         sessionParams: resolvedSessionParams,
         sessionDisplayId: resolvedSessionId,
         provider: provider,
-        biller: resolvePiBiller(runtimeEnv, provider),
+        biller,
         model: model,
-        billingType: "unknown",
-        costUsd: attempt.parsed.usage.costUsd,
+        billingType: priced.billingType,
+        costUsd: priced.costUsd,
         resultJson: {
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -46,7 +46,88 @@ process.exit(0);
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeUsagePiCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+if (process.argv.includes("--list-models")) {
+  console.log("provider  model");
+  console.log("github-copilot  claude-opus-4.5");
+  process.exit(0);
+}
+console.log(JSON.stringify({ type: "agent_start" }));
+console.log(JSON.stringify({ type: "turn_start" }));
+console.log(JSON.stringify({
+  type: "turn_end",
+  message: {
+    role: "assistant",
+    content: "done",
+    usage: {
+      input: 1000,
+      output: 4000,
+      cacheRead: 995000,
+      // What Pi computes off an API-shaped price table: the cache read is
+      // discounted 10x, which is exactly the assumption GitHub does not honor.
+      cost: { total: 0.6025 }
+    }
+  },
+  toolResults: []
+}));
+console.log(JSON.stringify({ type: "agent_end", messages: [] }));
+process.exit(0);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 describe("pi_local execute", () => {
+  it("prices the github-copilot lane off tokens, with no cache-read discount", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-credits-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "pi");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeUsagePiCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-pi-copilot-credits",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Pi Agent",
+          adapterType: "pi_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "github-copilot/claude-opus-4.5",
+          promptTemplate: "Keep working.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.biller).toBe("github-copilot");
+      expect(result.billingType).toBe("credits");
+      expect(result.usage?.cachedInputTokens).toBe(995_000);
+      // 1,000,000 tokens at $0.0092/1k, cache reads billed at full rate.
+      expect(result.costUsd).toBeCloseTo(9.2, 6);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("fails the run when Pi exhausts automatic retries despite exiting 0", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-execute-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The cost ledger (`cost_events`, `/api/costs/*`) is how an operator sees what those agents spend
> - Local adapters fill that ledger with the `costUsd` the coding CLI reports, and CLIs compute it from an API-shaped price table: separate input, output, and heavily discounted cache-read rates
> - GitHub Copilot does not bill that way. It meters agent traffic against premium credits, and a cache read consumes exactly as much credit as a fresh input token
> - A long-running agent workload is roughly 99% cache reads, so the discount is applied to almost the whole volume. Reconciled against a real Copilot org bill, the lane was understated by 12.3x
> - This pull request adds a biller-keyed token rate card and re-prices credit-billed lanes from token counts instead of trusting the CLI's cost field
> - The benefit is that the operator's most expensive lane stops reading an order of magnitude cheap, and prompt caching stops looking like a saving where it is actually a cost multiplier

## Linked Issues or Issue Description

**What happened:** the cost ledger reports GitHub Copilot spend roughly 12x lower than GitHub bills. Every `cost_events` row on that lane also carries `billing_type: unknown`.

**Steps to reproduce:** run a `pi_local` (or `opencode_local`) agent against a `github-copilot/*` model until prompt caching is warm, then compare `GET /api/companies/:id/costs/by-biller` for the lane with the premium-credit usage on the GitHub organization billing page for the same window.

**Expected behavior:** the ledger total tracks the credits GitHub actually meters, because Copilot bills every token — cached or not — at the same credit rate.

**Actual behavior:** the adapter forwards the CLI's `costUsd`, which prices a cache read at ~10% of an input token. With cache reads at ~99% of volume the ledger reads about 12x low, and the lane is stamped `unknown` instead of `credits`.

**Environment:** any deployment routing `pi_local` or `opencode_local` through GitHub Copilot.

## What Changed

- Add `packages/adapter-utils/src/token-rate-card.ts`: a biller-keyed rate card that re-prices a run from token counts, applying one rate to input, cached input, and output.
- Ship one built-in entry, `github-copilot`, at $0.0092 per 1,000 tokens (≈1 premium credit per ~1,000 tokens at $0.01 per credit) with `billingType: "credits"`.
- Support optional per-model multipliers with longest-prefix matching, so a published per-model credit multiplier can be dropped in later without forking the rate.
- Support `PAPERCLIP_TOKEN_RATE_CARD_JSON` operator overrides, which is also how a lane that is genuinely not billed (a free tier) gets priced at $0 instead of carrying a shadow price. Malformed overrides are ignored, never fatal.
- Apply the card in `pi-local` and `opencode-local`. Both previously hard-coded `billingType: "unknown"` and forwarded the CLI cost.
- Document the contract in `packages/adapters/AUTHORING.md`.

Billers with no entry keep the adapter-reported cost and billing type, so nothing else changes. Existing rows are not rewritten: the token counts in them are real, only the dollar label was wrong, and this fixes it forward.

## Verification

```sh
npx vitest run packages/adapter-utils/src/token-rate-card.test.ts server/src/__tests__/pi-local-execute.test.ts
# Test Files  2 passed (2)
#      Tests  13 passed (13)
```

- `packages/adapter-utils/src/token-rate-card.test.ts` asserts a cache read costs the same as an input token, that a cache-heavy 10M-token workload prices at $92.00 instead of the CLI's API-shaped number, that unlisted billers pass through untouched, that per-model multipliers resolve by longest prefix, and that malformed override JSON falls back to the built-in entry.
- `server/src/__tests__/pi-local-execute.test.ts` drives the real `pi_local` `execute()` against a fake Pi CLI that emits 995,000 cache-read tokens and a discounted `cost.total` of $0.6025. The run now returns `billingType: "credits"` and `costUsd: 9.20`.
- Typecheck: `packages/adapter-utils`, `packages/adapters/pi-local`, `packages/adapters/opencode-local` all clean.

## Risks

- The Copilot rate is **blended**. GitHub does not publish a per-model token multiplier for credit-metered usage, so the lane total reconciles while the split between models (Opus vs Sonnet) is approximate. A correct total with a fuzzy split is strictly better than the previous 12x-wrong total; `modelMultipliers` is the seam for fixing the split.
- Deployments on that lane will see reported cost jump by about an order of magnitude. That is the correction, not a regression, but it can trip budget thresholds that were tuned against the understated number.
- The rate is anchored to observed credit metering. If GitHub changes its credit conversion, the built-in entry goes stale; `PAPERCLIP_TOKEN_RATE_CARD_JSON` lets an operator correct it without a release.

## Model Used

Anthropic Claude (Sonnet class) via the `pi` coding agent, running as a Paperclip agent with tool use and shell execution. Extended reasoning enabled; all code, tests, and verification output in this PR were produced and executed in that session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — verified with `gh pr checks 11421` at the time of this edit.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — confirmed via the Greptile Review comment: "Confidence Score: 5/5", no open P2s or follow-ups listed.
- [x] I will address all Greptile and reviewer comments before requesting merge

Related: #11420 also touches `pi-local` billing type. See my comment there — that PR classifies `github-copilot` as `subscription`, which the server maps to `subscription_included` and zeroes the cost. This PR's rate card must win for that biller.

