### PR TITLE
fix(claude): add 1M context model options

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -17,13 +17,24 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `cwd` | string | Yes | Working directory for the agent process (absolute path; created automatically if missing when permissions allow) |
-| `model` | string | No | Claude model to use (e.g. `claude-opus-4-6`) |
+| `model` | string | No | Claude model to use (e.g. `claude-opus-4-6` or `claude-opus-4-6[1m]`) |
 | `promptTemplate` | string | No | Prompt used for all runs |
 | `env` | object | No | Environment variables (supports secret refs) |
 | `timeoutSec` | number | No | Process timeout (0 = no timeout) |
 | `graceSec` | number | No | Grace period before force-kill |
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
+
+### Extended context models
+
+Paperclip lists Claude Code's supported `[1m]` model variants in the model
+picker. Select one of these variants when the execution target or LLM gateway
+requires an explicit 1 million token context window. Paperclip passes the model
+ID to Claude Code without changing the suffix.
+
+Availability depends on the model, account plan, and provider. Claude Code or
+the configured gateway can reject the request when extended context is not
+available. Use the environment test after you select a `[1m]` model.
 
 ## Prompt Templates
 

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -7,13 +7,20 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @anthropic-ai/claude-code
 
 export const models = [
   { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+  { id: "claude-opus-4-8[1m]", label: "Claude Opus 4.8 (1M context)" },
   { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+  { id: "claude-sonnet-5[1m]", label: "Claude Sonnet 5 (1M context)" },
   { id: "claude-fable-5", label: "Claude Fable 5" },
+  { id: "claude-fable-5[1m]", label: "Claude Fable 5 (1M context)" },
   { id: "claude-mythos-5", label: "Claude Mythos 5" },
   { id: "claude-opus-5", label: "Claude Opus 5" },
+  { id: "claude-opus-5[1m]", label: "Claude Opus 5 (1M context)" },
   { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
+  { id: "claude-opus-4-7[1m]", label: "Claude Opus 4.7 (1M context)" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+  { id: "claude-opus-4-6[1m]", label: "Claude Opus 4.6 (1M context)" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-sonnet-4-6[1m]", label: "Claude Sonnet 4.6 (1M context)" },
   { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
 ];
@@ -39,7 +46,7 @@ Core fields:
 - engine (string, optional): execution engine. Leave unset/auto to use ACP when prerequisites pass and fall back to the Claude Code CLI with diagnostics. Use "cli" to pin the CLI lane or "acp" to require ACP.
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file injected at runtime
-- model (string, optional): Claude model id
+- model (string, optional): Claude model id. Paperclip lists Claude Code's supported \`[1m]\` variants for models with an extended 1M context window (for example, \`claude-opus-4-8[1m]\`).
 - effort (string, optional): reasoning effort passed via --effort (low|medium|high)
 - chrome (boolean, optional): pass --chrome when running Claude
 - promptTemplate (string, optional): run prompt template

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -70,6 +70,15 @@ describe("adapter model listing", () => {
     expect(models.some((model) => model.id === "claude-mythos-5")).toBe(true);
     // Opus 5 is a current GA flagship and must be offered even when live discovery is unavailable.
     expect(models.some((model) => model.id === "claude-opus-5")).toBe(true);
+    expect(models).toEqual(expect.arrayContaining([
+      { id: "claude-fable-5[1m]", label: "Claude Fable 5 (1M context)" },
+      { id: "claude-sonnet-5[1m]", label: "Claude Sonnet 5 (1M context)" },
+      { id: "claude-opus-5[1m]", label: "Claude Opus 5 (1M context)" },
+      { id: "claude-opus-4-8[1m]", label: "Claude Opus 4.8 (1M context)" },
+      { id: "claude-opus-4-7[1m]", label: "Claude Opus 4.7 (1M context)" },
+      { id: "claude-opus-4-6[1m]", label: "Claude Opus 4.6 (1M context)" },
+      { id: "claude-sonnet-4-6[1m]", label: "Claude Sonnet 4.6 (1M context)" },
+    ]));
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source app that manages AI agents for work.
> - The Claude Code adapter supplies model options to the agent configuration form.
> - Claude Code supports an explicit `[1m]` suffix for extended-context model selection.
> - The Paperclip fallback model list did not include these variants.
> - Paperclip therefore passed a base model ID when a gateway required the explicit suffix.
> - The environment probe then failed before the agent could start.
> - This pull request adds the supported variants and documents their use.
> - The benefit is a working model selection path for accounts and gateways that require the 1M selector.

## Linked Issues or Issue Description

No public issue or pull request matched this problem.

**What happened?**

The Claude Code adapter model picker only listed base model IDs. Some Claude Code execution targets require the explicit `[1m]` suffix. Paperclip passed the selected base model through `--model`, so the environment probe received an HTTP 400 response from the target.

**Expected behavior**

Paperclip should list the supported Claude Code `[1m]` variants. Paperclip should preserve the selected model ID when it starts Claude Code.

**Steps to reproduce**

1. Configure Claude Code with an execution target that requires the explicit 1M selector.
2. Select the base version of a supported model in Paperclip.
3. Run the adapter environment test.
4. Observe an HTTP 400 response from the target.
5. Enter the same model ID with `[1m]`.
6. Observe that the probe succeeds.

**Paperclip version or commit**

`a8d118a` on `master` before this change.

**Deployment mode**

Local trusted deployment built from source.

**Agent adapter(s) involved**

Claude Code (`claude_local`).

## What Changed

- Added supported `[1m]` entries to the Claude Code fallback model list.
- Added assertions for the extended-context model IDs and labels.
- Documented model suffix behavior, availability limits, and environment testing.

## Verification

- `pnpm exec vitest run server/src/__tests__/adapter-models.test.ts` passed with 17 tests.
- `pnpm --filter @paperclipai/adapter-claude-local typecheck` passed.
- `pnpm -r typecheck` passed for all workspace projects.
- `pnpm build` passed.
- A manual Claude Code probe failed with the base model and passed with the same model plus `[1m]`.
- The full server test run found existing failures outside this change. A focused rerun reported 17 failures and 184 passes across five unrelated workspace, skill, cleanup, and branch-containment test files. Most failures were caused by macOS `/var` and `/private/var` path differences. The Claude adapter model test passed separately.

## Risks

- Low risk. This change only adds selectable model IDs, tests, and documentation.
- A provider, account, or plan can reject a `[1m]` model when extended context is not available.
- The environment test remains the validation point for each installation.

> I checked `ROADMAP.md`. This adapter compatibility fix does not duplicate planned core work.

## Model Used

- OpenAI Codex with model ID `gpt-5`. The model used agentic coding mode, tool use, and code execution. The runtime did not expose its context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
