### PR TITLE
fix(onboarding): choose the launcher's step from the company's mission too

### DIFF
--- a/ui/src/App.onboarding-launcher.test.tsx
+++ b/ui/src/App.onboarding-launcher.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ONBOARDING_AGENT_STEP,
+  ONBOARDING_MISSION_STEP,
+} from "./lib/onboarding-route";
+
+/**
+ * The third way into onboarding for a company that already exists: the "Add
+ * Agent" card on `/{prefix}/onboarding`, shown once the wizard is dismissed.
+ *
+ * The route resolver and the dashboard both choose the step from whether the
+ * company already has its mission. This button hardcoded the mission step, so
+ * the one entry point whose own copy says "add another agent" was the one that
+ * stopped to ask for the mission again.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// jsdom's CSS parser rejects the custom-property marker rule stitches inserts
+// (`--sxs{--sxs:N}`), pulled into <App>'s eager import graph transitively via
+// @codesandbox/sandpack-react. Substitute a benign, valid rule on parse failure
+// so stitches' index bookkeeping stays intact and the module graph evaluates.
+vi.hoisted(() => {
+  const sheetProto = window.CSSStyleSheet.prototype as unknown as {
+    insertRule: (rule: string, index?: number) => number;
+    __papLauncherPatched?: boolean;
+  };
+  if (!sheetProto.__papLauncherPatched) {
+    const original = sheetProto.insertRule;
+    sheetProto.insertRule = function patched(this: CSSStyleSheet, rule: string, index?: number) {
+      try {
+        return original.call(this, rule, index);
+      } catch {
+        try {
+          return original.call(this, ".pap-launcher-noop{}", index);
+        } catch {
+          return this.cssRules?.length ?? 0;
+        }
+      }
+    };
+    sheetProto.__papLauncherPatched = true;
+  }
+});
+
+const routeState = vi.hoisted(() => ({ companyPrefix: "PC1" as string | undefined }));
+const dialogState = vi.hoisted(() => ({
+  onboardingOpen: false,
+  onboardingRouteDismissed: true,
+  openOnboarding: vi.fn(),
+}));
+const mockGoalsApi = vi.hoisted(() => ({ list: vi.fn() }));
+
+vi.mock("@/lib/router", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ companyPrefix: routeState.companyPrefix }),
+    useActiveCompanyPrefix: () => routeState.companyPrefix ?? null,
+  };
+});
+
+vi.mock("./context/CompanyContext", () => ({
+  useCompany: () => ({
+    companies: [{ id: "company-1", name: "Acme", issuePrefix: "PC1" }],
+    selectedCompanyId: "company-1",
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("./context/DialogContext", () => ({
+  useDialogActions: () => ({ openOnboarding: dialogState.openOnboarding }),
+  useDialogState: () => ({
+    onboardingOpen: dialogState.onboardingOpen,
+    onboardingRouteDismissed: dialogState.onboardingRouteDismissed,
+  }),
+}));
+
+vi.mock("./api/goals", () => ({ goalsApi: mockGoalsApi }));
+
+const { OnboardingRoutePage } = await import("./App");
+
+const COMPANY_GOAL = {
+  id: "goal-1",
+  companyId: "company-1",
+  title: "Scale the marketplace",
+  description: null,
+  level: "company",
+  status: "active",
+  parentId: null,
+  ownerAgentId: null,
+  createdAt: new Date("2026-03-02T00:00:00Z"),
+  updatedAt: new Date("2026-03-02T00:00:00Z"),
+};
+
+describe("the onboarding launcher's Add Agent button", () => {
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+  let root: Root | null = null;
+
+  async function render() {
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <OnboardingRoutePage />
+        </QueryClientProvider>,
+      );
+    });
+  }
+
+  async function settle(ticks = 12) {
+    for (let i = 0; i < ticks; i++) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+
+  function addAgentButton(): HTMLButtonElement {
+    const button = [...container.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("Add Agent"),
+    );
+    // Asserted rather than optional-chained: a lookup that silently matches
+    // nothing turns the click below into a no-op and the test into decoration.
+    expect(button).toBeDefined();
+    return button!;
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    routeState.companyPrefix = "PC1";
+    dialogState.onboardingOpen = false;
+    dialogState.onboardingRouteDismissed = true;
+    mockGoalsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    root = null;
+    queryClient.clear();
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("opens on the agent step for a company that already has its mission", async () => {
+    mockGoalsApi.list.mockResolvedValue([COMPANY_GOAL]);
+    await render();
+    await settle();
+
+    await act(async () => {
+      addAgentButton().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(dialogState.openOnboarding).toHaveBeenCalledWith({
+      initialStep: ONBOARDING_AGENT_STEP,
+      companyId: "company-1",
+    });
+  });
+
+  it("still asks for the mission when the company has none", async () => {
+    mockGoalsApi.list.mockResolvedValue([]);
+    await render();
+    await settle();
+
+    await act(async () => {
+      addAgentButton().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(dialogState.openOnboarding).toHaveBeenCalledWith({
+      initialStep: ONBOARDING_MISSION_STEP,
+      companyId: "company-1",
+    });
+  });
+
+  it("asks for the mission when the lookup fails, rather than skipping it", async () => {
+    // Same fail-open rule the other two entry points follow: an unknown
+    // mission costs the step, which the customer can answer. Confirming it now
+    // updates the company's existing goal rather than adding a second one.
+    mockGoalsApi.list.mockRejectedValue(new Error("goals unavailable"));
+    await render();
+    await settle();
+
+    await act(async () => {
+      addAgentButton().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(dialogState.openOnboarding).toHaveBeenCalledWith({
+      initialStep: ONBOARDING_MISSION_STEP,
+      companyId: "company-1",
+    });
+  });
+
+  it("opens with no company when the prefix matches none", async () => {
+    routeState.companyPrefix = "NOPE";
+    await render();
+    await settle();
+
+    const start = [...container.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("Start Onboarding"),
+    );
+    expect(start).toBeDefined();
+    await act(async () => {
+      start!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(dialogState.openOnboarding).toHaveBeenCalledWith();
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -93,8 +93,10 @@ import { useDialogActions, useDialogState } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
 import {
   isOnboardingWizardActive,
+  onboardingStepForCompany,
   shouldRedirectCompanylessRouteToOnboarding,
 } from "./lib/onboarding-route";
+import { useCompanyMission } from "./hooks/useCompanyMission";
 import { normalizeRememberedInstanceSettingsPath } from "./lib/instance-settings";
 
 function boardRoutes() {
@@ -393,11 +395,18 @@ function legacyToolsRedirectTarget(tab?: string) {
   return `/apps/advanced/${tab}`;
 }
 
-function OnboardingRoutePage() {
+export function OnboardingRoutePage() {
   const { companies } = useCompany();
   const { openOnboarding } = useDialogActions();
   const { onboardingOpen, onboardingRouteDismissed } = useDialogState();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
+  const matchedCompany = companyPrefix
+    ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase()) ?? null
+    : null;
+  // Which step this company belongs on, by the same rule the route resolver
+  // and the dashboard already use. Resolved above the early return below,
+  // because a hook cannot be called after it.
+  const { hasMission } = useCompanyMission(matchedCompany?.id ?? null);
 
   // The OnboardingWizard auto-opens on this route (and can also be opened
   // explicitly). While it is showing it covers the whole screen, so the
@@ -407,9 +416,6 @@ function OnboardingRoutePage() {
   if (isOnboardingWizardActive({ onboardingOpen, routeDismissed: onboardingRouteDismissed })) {
     return null;
   }
-  const matchedCompany = companyPrefix
-    ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase()) ?? null
-    : null;
 
   const title = matchedCompany
     ? `Add another agent to ${matchedCompany.name}`
@@ -431,7 +437,16 @@ function OnboardingRoutePage() {
           <Button
             onClick={() =>
               matchedCompany
-                ? openOnboarding({ initialStep: 2, companyId: matchedCompany.id })
+                ? openOnboarding({
+                    // "Add another agent" to a company that already has its
+                    // mission must not stop to ask for the mission again. An
+                    // unsettled or failed lookup reads as "no mission" and
+                    // costs the step, which the customer can pass - and the
+                    // mission step now updates the existing goal rather than
+                    // adding a second one.
+                    initialStep: onboardingStepForCompany(hasMission),
+                    companyId: matchedCompany.id,
+                  })
                 : openOnboarding()
             }
           >


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A company's mission is collected once, and onboarding should never ask for it twice
> - Three things can open onboarding for a company that already exists: the `/{prefix}/onboarding` route, the dashboard's auto-open, and the "Add Agent" card on that route once the wizard is dismissed
> - The first two choose their step from whether the company already has its mission; the third hardcoded the mission step
> - So the entry point whose own copy reads "Add another agent to X" was the one that stopped to ask X for the mission it already had
> - This pull request has it choose the step the same way as the other two
> - The benefit is that all three doors into onboarding agree about what the company has already answered

## Linked Issues or Issue Description

No public issue exists. The problem follows.

**What happened?**

`App.tsx` opened the wizard with `initialStep: 2` for any matched company, regardless of that company's mission. #11352 and #11416 made the route and dashboard paths mission-aware; this one was missed.

**Expected behavior**

A company that already has its mission opens on the agent step from every entry point.

**Steps to reproduce**

1. Open `/{prefix}/onboarding` for a company that has a mission.
2. Dismiss the wizard. The launcher card appears.
3. Press "Add Agent". It opens on "Define your mission".

**Paperclip version or commit**

`master` at `6542ad1f4`.

**Related pull requests**

Last unported piece of #11259, which can close once this lands. #11352 introduced the mission-aware step; #11416 ported the rest.

## What Changed

- `ui/src/App.tsx` — the launcher's button calls `onboardingStepForCompany` instead of hardcoding the mission step. `matchedCompany` moves above the early return, because a hook cannot be called after it. `OnboardingRoutePage` is exported for the test.
- `ui/src/App.onboarding-launcher.test.tsx` — new, 4 cases.

### Why exported rather than driven through `<App>`

The existing App tests render the real route table, which is the right shape for testing routing. This is a question about one button's argument, and that harness costs a full route tree and the stitches/jsdom workaround to answer it. Exporting the page keeps the test to the seam it is about. The workaround is still needed — `<App>`'s import graph pulls in sandpack either way — and is copied from `App.activity-routing.test.tsx`.

### Fail-open, unchanged

An unsettled or failed goal lookup reads as "no mission" and costs the mission step, which the customer can answer. That is the rule the other two callers already follow, and it is safe here because #11416 made confirming the mission update the company's existing goal rather than adding a second one.

## Verification

- `ui` typecheck is clean.
- 4 new cases pass; full `ui` suite **4010 pass**.

Fault-injected: reverting the button to `initialStep: 2` fails the first case. The button lookup asserts it matched something before clicking, because a lookup that silently matches nothing turns the click into a no-op — which is how a test on this branch passed against unfixed code yesterday.

One failure remains, in `IssueProperties.test.tsx`. It is timezone-dependent, reproduces on `master`, and is in a file this change does not touch.

## Risks

Very low. One argument at one call site, and the step it now produces is the one the other two entry points already produce for the same company.

The export of `OnboardingRoutePage` widens the module's surface slightly. It is not referenced outside `App.tsx` and its test.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
