### PR TITLE
fix(mcp): reject unsupported GET streams

### DIFF
--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -178,6 +178,32 @@ describe("openapi routes", () => {
     });
     expect(res.body.paths["/api/health"].get.security).toEqual([]);
     expect(res.body.paths["/mcp/gateways/{gatewayPublicId}"].post.security).toEqual([]);
+    expect(res.body.paths["/mcp/gateways/{gatewayPublicId}"].get).toMatchObject({
+      summary: "Reject unsupported MCP GET streams by public id",
+      responses: {
+        405: {
+          headers: {
+            Allow: {
+              schema: { type: "string", example: "POST" },
+            },
+          },
+        },
+      },
+    });
+    expect(res.body.paths["/mcp/gateways/{gatewayPublicId}"].get.responses["200"]).toBeUndefined();
+    expect(res.body.paths["/api/tool-gateway/gateways/{gatewayId}/mcp"].get).toMatchObject({
+      summary: "Reject unsupported MCP GET streams by gateway id",
+      responses: {
+        405: {
+          headers: {
+            Allow: {
+              schema: { type: "string", example: "POST" },
+            },
+          },
+        },
+      },
+    });
+    expect(res.body.paths["/api/tool-gateway/gateways/{gatewayId}/mcp"].get.responses["200"]).toBeUndefined();
     expect(res.body.paths["/api/mcp/gateways/{gatewayPublicId}"]).toBeUndefined();
     expect(res.body.paths["/api/companies"].post.responses["201"]).toBeDefined();
     expect(res.body.paths["/api/companies"].post.requestBody.content["application/json"].schema).toMatchObject({

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -578,6 +578,18 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
       expect(token.tokenPrefix).toMatch(/^pcgw_[a-f0-9]{8}$/);
 
       const app = createGatewayRouteApp(db, gateway);
+      const publicGet = await request(app)
+        .get(`/mcp/gateways/${created.gatewayPublicId}`)
+        .expect(405);
+      expect(publicGet.headers.allow).toBe("POST");
+      expect(publicGet.text).toBe("");
+
+      const internalGet = await request(app)
+        .get(`/api/tool-gateway/gateways/${created.id}/mcp`)
+        .expect(405);
+      expect(internalGet.headers.allow).toBe("POST");
+      expect(internalGet.text).toBe("");
+
       const listed = await request(app)
         .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
         .set("authorization", `Bearer ${token.token}`)

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -520,6 +520,15 @@ const responses = {
     description: "Not found",
     content: { "application/json": { schema: ErrorSchema } },
   },
+  methodNotAllowed: {
+    description: "GET is not supported for this Streamable HTTP MCP endpoint; use POST",
+    headers: {
+      Allow: {
+        description: "Supported HTTP methods",
+        schema: { type: "string", example: "POST" },
+      },
+    },
+  },
   conflict: {
     description: "Conflict",
     content: { "application/json": { schema: ErrorSchema } },
@@ -7475,7 +7484,8 @@ registerCurrentRoute({
   method: "get",
   path: "/mcp/gateways/{gatewayPublicId}",
   tags: ["tool-gateway"],
-  summary: "Describe a public MCP gateway endpoint",
+  summary: "Reject unsupported MCP GET streams by public id",
+  responses: { 405: r.methodNotAllowed },
 });
 
 registerCurrentRoute({
@@ -7534,7 +7544,8 @@ registerCurrentRoute({
   method: "get",
   path: "/api/tool-gateway/gateways/{gatewayId}/mcp",
   tags: ["tool-gateway"],
-  summary: "Describe a named MCP gateway endpoint",
+  summary: "Reject unsupported MCP GET streams by gateway id",
+  responses: { 405: r.methodNotAllowed },
 });
 
 registerCurrentRoute({

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -158,15 +158,14 @@ async function handleMcpGatewayProtocol(
   }
 }
 
+function rejectUnsupportedMcpGet(_req: Request, res: Response) {
+  res.setHeader("Allow", "POST");
+  res.status(405).end();
+}
+
 export function mcpGatewayProtocolRoutes(toolGateway: ToolGatewayService) {
   const router = Router();
-  router.get("/mcp/gateways/:gatewayPublicId", async (req, res) => {
-    res.json({
-      transport: "streamable_http",
-      endpoint: `/mcp/gateways/${req.params.gatewayPublicId}`,
-      authentication: "bearer",
-    });
-  });
+  router.get("/mcp/gateways/:gatewayPublicId", rejectUnsupportedMcpGet);
   router.post("/mcp/gateways/:gatewayPublicId", async (req, res) => {
     await handleMcpGatewayProtocol(req, res, toolGateway, { gatewayPublicId: req.params.gatewayPublicId });
   });
@@ -372,13 +371,7 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
     }
   });
 
-  router.get("/tool-gateway/gateways/:gatewayId/mcp", async (req, res) => {
-    res.json({
-      transport: "streamable_http",
-      endpoint: `/api/tool-gateway/gateways/${req.params.gatewayId}/mcp`,
-      authentication: "bearer",
-    });
-  });
+  router.get("/tool-gateway/gateways/:gatewayId/mcp", rejectUnsupportedMcpGet);
 
   router.post("/tool-gateway/gateways/:gatewayId/mcp", async (req, res) => {
     await handleMcpGatewayProtocol(req, res, toolGateway, { gatewayId: req.params.gatewayId });


### PR DESCRIPTION
## Thinking Path

> - Paperclip gives agents governed access to MCP tools.
> - The tool gateway exposes Streamable HTTP endpoints.
> - These endpoints do not provide a server-initiated SSE stream.
> - They returned a JSON descriptor with HTTP 200 for a GET request.
> - MCP clients can treat that response as a failed stream and retry it.
> - This pull request returns the required method error instead.
> - The change stops the retry loop and keeps POST as the only data path.

## Linked Issues or Issue Description

**What happened?**

The two named tool-gateway MCP endpoints returned a JSON descriptor with HTTP 200 for `GET`. They did not return an SSE stream. A Streamable HTTP client can retry the invalid stream response.

**Expected behavior**

An endpoint that does not provide an SSE stream must return HTTP 405 for `GET`. The response must include `Allow: POST`.

**Steps to reproduce**

1. Create a named tool gateway on commit `b38d6ddb811b3ff3145ff5df60174eb9e7313fe6`.
2. Send `GET` to its public or internal MCP endpoint.
3. Observe HTTP 200 with JSON instead of HTTP 405.

**Paperclip version or commit**

`b38d6ddb811b3ff3145ff5df60174eb9e7313fe6`

**Deployment mode**

This bug is not deployment-specific.

The MCP 2025-03-26 Streamable HTTP transport requires either an SSE response or HTTP 405 for this GET request. I searched open and closed Paperclip issues and pull requests for `Method Not Allowed`, `streamable HTTP`, and tool-gateway GET behavior. I found no duplicate. Issues #10346 and pull requests #10341 and #9750 concern MCP attachment or outgoing client initialization. They do not change this server GET behavior.

## What Changed

- Return HTTP 405 from both named tool-gateway MCP GET routes.
- Add the required `Allow: POST` header.
- Return an empty body so the endpoint no longer publishes a non-stream descriptor.
- Add regression checks for the public and internal route forms.

## Verification

- `pnpm exec vitest run server/src/__tests__/tool-gateway.test.ts` — 51 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Low risk. MCP messages already use POST.
- A caller that used the GET response as a discovery document will now receive the protocol-defined method error. The response `Allow` header identifies the supported method.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with the `gpt-5` model, high reasoning, tool use, and code execution. The client does not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
