### PR TITLE
test(ui): assert auth health invalidation call

### DIFF
--- a/ui/src/pages/Auth.test.tsx
+++ b/ui/src/pages/Auth.test.tsx
@@ -217,6 +217,7 @@ describe("AuthPage", () => {
 
   it("invalidates anonymous health metadata after sign-in", async () => {
     const { root, queryClient } = await mount();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
     queryClient.setQueryData(queryKeys.health, {
       status: "ok",
       deploymentMode: "authenticated",
@@ -247,7 +248,7 @@ describe("AuthPage", () => {
       email: "jane@example.com",
       password: "supersecret",
     });
-    expect(queryClient.getQueryState(queryKeys.health)?.isInvalidated).toBe(true);
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.health });
 
     await act(async () => {
       root.unmount();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected subsystem is the authenticated UI flow in `ui/src/pages/Auth.tsx` and its `AuthPage` test.
> - The test previously checked a React Query health state after sign-in.
> - That state assertion depends on asynchronous query timing and can fail even when the sign-in invalidation call is correct.
> - The test should observe the behavior that the sign-in flow owns: invalidation of the health query.
> - This pull request updates the test to spy on `invalidateQueries` and assert the expected health-query key.
> - The benefit is a deterministic regression test that preserves coverage of the existing sign-in behavior.

## Linked Issues or Issue Description

**Problem:** The `AuthPage` test asserted that the health query became invalidated through observable React Query state. That assertion was timing-sensitive and did not directly verify the call made by the sign-in flow.

**Expected behavior:** Signing in invalidates the health query using the existing query key.

**Scope:** This pull request changes only the UI test assertion. It does not change production authentication behavior.

## What Changed

- Spy on the test-local query client's `invalidateQueries` method before sign-in.
- Assert that sign-in invalidates the health query with the expected query key.
- Remove the timing-sensitive invalidated-state assertion.

## Verification

- The isolated `AuthPage` test passed.
- The full UI suite passed: 438 files and 3,688 tests.
- UI typecheck passed.
- GitHub CI passed for build, typecheck, general tests, serialized server suites, E2E tests, and security checks.

## Risks

Low risk. The change is test-only and does not modify production code, authentication behavior, query configuration, or runtime data. The remaining risk is limited to the test failing to detect a future change in the invalidation call shape, which the explicit query-key assertion covers.

## Model Used

OpenAI Codex GPT 5.6 Luna, with repository inspection, GitHub Actions log analysis, and local test verification. The model used tool-assisted code analysis and execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented the risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

This PR is submitted from the `tiangao88/paperclip` fork. No branch or commit was pushed to the upstream repository.
