### PR TITLE
fix(codex-local): fail fast when the selected model_provider's env_key is unset

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -716,6 +716,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const preparedRuntimeConfig = await prepareCodexRuntimeConfig({
     env: envConfigStrings,
     codexHome: configuredCodexHome ? null : effectiveCodexHome,
+    externalCodexHome: configuredCodexHome,
+    executionTargetIsRemote,
   });
   // Curated allowlist dir staged for the remote `home` asset (see below). Held
   // here so the outer `finally` can remove it on every exit path (teardown and

--- a/packages/adapters/codex-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/codex-local/src/server/runtime-config.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { prepareCodexRuntimeConfig } from "./runtime-config.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prepareCodexRuntimeConfig, readSelectedProviderEnvKey } from "./runtime-config.js";
 
 const cleanupPaths = new Set<string>();
 
@@ -40,6 +40,11 @@ const BIFROST_PROVIDERS = {
   model_provider: "bifrost",
 };
 
+// The selected provider declares env_key "OPENAI_API_KEY", and prepare fails fast
+// when that variable is unset. Pass it explicitly rather than relying on the
+// host shell, so these tests do not depend on the machine they run on.
+const PROVIDER_KEY_ENV = { OPENAI_API_KEY: "sk-test-provider-key" };
+
 describe("prepareCodexRuntimeConfig", () => {
   it("is a no-op when PAPERCLIP_CODEX_PROVIDERS is unset", async () => {
     const home = await makeCodexHome("model = \"gpt-5.1-codex\"\n");
@@ -62,7 +67,7 @@ describe("prepareCodexRuntimeConfig", () => {
   it("merges providers + model_provider into a fresh config.toml and cleans it up", async () => {
     const home = await makeCodexHome();
     const prepared = await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
 
@@ -88,7 +93,7 @@ describe("prepareCodexRuntimeConfig", () => {
     ].join("\n");
     const home = await makeCodexHome(original);
     const prepared = await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
 
@@ -126,7 +131,7 @@ describe("prepareCodexRuntimeConfig", () => {
     ].join("\n");
     const home = await makeCodexHome(original);
     const prepared = await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
 
@@ -214,7 +219,7 @@ describe("prepareCodexRuntimeConfig", () => {
     const home = await makeCodexHome();
     process.env.PAPERCLIP_CODEX_PROVIDERS = JSON.stringify(BIFROST_PROVIDERS);
     try {
-      const prepared = await prepareCodexRuntimeConfig({ env: {}, codexHome: home });
+      const prepared = await prepareCodexRuntimeConfig({ env: { ...PROVIDER_KEY_ENV }, codexHome: home });
       const content = await readConfigToml(home);
       expect(content).toContain("[model_providers.bifrost]");
       await prepared.cleanup();
@@ -264,6 +269,7 @@ describe("prepareCodexRuntimeConfig", () => {
     const home = await makeCodexHome();
     const prepared = await prepareCodexRuntimeConfig({
       env: {
+        ...PROVIDER_KEY_ENV,
         PAPERCLIP_CODEX_PROVIDERS: JSON.stringify({
           providers: {
             bad: "http://gateway.example/v1",
@@ -315,7 +321,7 @@ describe("prepareCodexRuntimeConfig", () => {
     // Simulate a crash: the merge excises the user's same-name provider
     // section (the managed definition must win), and cleanup() never runs.
     await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
     expect(await readConfigToml(home)).toContain('env_key = "OPENAI_API_KEY"');
@@ -330,7 +336,7 @@ describe("prepareCodexRuntimeConfig", () => {
   it("removes the pre-run backup on cleanup", async () => {
     const home = await makeCodexHome('approval_policy = "never"\n');
     const prepared = await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
     const backupPath = path.join(home, "config.toml.paperclip-backup");
@@ -355,7 +361,7 @@ describe("prepareCodexRuntimeConfig", () => {
   it("self-heals stale managed blocks when the env is no longer set", async () => {
     const home = await makeCodexHome();
     const crashed = await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
     // Simulate a crash: cleanup never runs, the managed blocks persist.
@@ -373,12 +379,13 @@ describe("prepareCodexRuntimeConfig", () => {
   it("re-running with changed providers replaces the previous managed blocks", async () => {
     const home = await makeCodexHome("approval_policy = \"never\"\n");
     const first = await prepareCodexRuntimeConfig({
-      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
+      env: { ...PROVIDER_KEY_ENV, PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(BIFROST_PROVIDERS) },
       codexHome: home,
     });
     void first; // simulate crash: no cleanup
     const second = await prepareCodexRuntimeConfig({
       env: {
+        ...PROVIDER_KEY_ENV,
         PAPERCLIP_CODEX_PROVIDERS: JSON.stringify({
           providers: { gw2: { base_url: "http://gw2.example/v1", env_key: "OPENAI_API_KEY" } },
           model_provider: "gw2",
@@ -412,5 +419,277 @@ describe("prepareCodexRuntimeConfig", () => {
     );
     const content = await readConfigToml(home);
     expect(content).toBe("model = \"gpt-5.1-codex\"\n");
+  });
+});
+
+// A provider's `env_key` names the env var codex reads the bearer key from at
+// request time. When it is unset, codex dies on its first model refresh with
+// "Missing environment variable: `X`" -- naming neither the config file nor the
+// setting that selected the provider. These cover the pre-flight check that
+// turns that into an actionable adapter error.
+describe("selected model_provider env_key readiness", () => {
+  // Deliberately not OPENAI_API_KEY: a var that can be set in a developer's
+  // shell would make these tests pass or fail depending on the machine.
+  const GATEWAY_KEY = "PAPERCLIP_TEST_GATEWAY_KEY";
+  const GATEWAY_PROVIDERS = {
+    providers: {
+      gw: { base_url: "http://gw.example/v1", env_key: GATEWAY_KEY, wire_api: "responses" },
+    },
+    model_provider: "gw",
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("fails fast, naming the provider, the env var, and the config file", async () => {
+    const home = await makeCodexHome("model = \"gpt-5.1-codex\"\n");
+
+    await expect(
+      prepareCodexRuntimeConfig({
+        env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS) },
+        codexHome: home,
+      }),
+    ).rejects.toThrow(
+      // The raw codex error names only the env var; this one has to be traceable.
+      new RegExp(
+        `model_provider "gw".*env_key "${GATEWAY_KEY}".*${path.join(home, "config.toml")}`,
+        "s",
+      ),
+    );
+  });
+
+  it("leaves the home untouched when it fails: no partial merge, no backup file", async () => {
+    const original = 'model = "gpt-5.1-codex"\n';
+    const home = await makeCodexHome(original);
+
+    await expect(
+      prepareCodexRuntimeConfig({
+        env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS) },
+        codexHome: home,
+      }),
+    ).rejects.toThrow(GATEWAY_KEY);
+
+    // The throw happens before any write, so there is no cleanup() to call and
+    // nothing for the next run's self-heal to undo.
+    expect(await readConfigToml(home)).toBe(original);
+    await expect(
+      fs.access(path.join(home, "config.toml.paperclip-backup")),
+    ).rejects.toThrow();
+  });
+
+  it("passes when the env var comes from the adapter config env", async () => {
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: {
+        PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS),
+        [GATEWAY_KEY]: "sk-gateway",
+      },
+      codexHome: home,
+    });
+
+    expect(prepared.notes.some((n) => n.startsWith("Warning:"))).toBe(false);
+    expect(await readConfigToml(home)).toContain("[model_providers.gw]");
+    await prepared.cleanup();
+  });
+
+  it("passes when the env var comes from the host process env", async () => {
+    vi.stubEnv(GATEWAY_KEY, "sk-from-host");
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS) },
+      codexHome: home,
+    });
+
+    expect(await readConfigToml(home)).toContain("[model_providers.gw]");
+    await prepared.cleanup();
+  });
+
+  it("treats a whitespace-only value as unset", async () => {
+    // codex would send it verbatim as the bearer token and the provider would
+    // reject it -- the same broken run with a less obvious symptom.
+    const home = await makeCodexHome();
+    await expect(
+      prepareCodexRuntimeConfig({
+        env: {
+          PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS),
+          [GATEWAY_KEY]: "   ",
+        },
+        codexHome: home,
+      }),
+    ).rejects.toThrow(GATEWAY_KEY);
+  });
+
+  it("catches a selection inherited from the base config, not just from PAPERCLIP_CODEX_PROVIDERS", async () => {
+    // PAPERCLIP_CODEX_PROVIDERS defines the provider but selects nothing, so the
+    // base config's root key survives the merge and is the effective selection.
+    // Checking `parsed.modelProvider` instead of the merged file would miss this.
+    const home = await makeCodexHome('model_provider = "gw"\n');
+
+    await expect(
+      prepareCodexRuntimeConfig({
+        env: {
+          PAPERCLIP_CODEX_PROVIDERS: JSON.stringify({ providers: GATEWAY_PROVIDERS.providers }),
+        },
+        codexHome: home,
+      }),
+    ).rejects.toThrow(GATEWAY_KEY);
+  });
+
+  it("does not fire when nothing selects the provider", async () => {
+    // An unselected [model_providers.*] table is inert, so its env_key is not
+    // required. Firing here would break every merge that only defines providers.
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: {
+        PAPERCLIP_CODEX_PROVIDERS: JSON.stringify({ providers: GATEWAY_PROVIDERS.providers }),
+      },
+      codexHome: home,
+    });
+
+    expect(prepared.notes.some((n) => n.startsWith("Warning:"))).toBe(false);
+    expect(await readConfigToml(home)).toContain("[model_providers.gw]");
+    await prepared.cleanup();
+  });
+
+  it("warns instead of failing when the run targets a remote execution host", async () => {
+    // The control plane's process.env is not the remote process's environment,
+    // so a missing value here is not proof the run will fail.
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS) },
+      codexHome: home,
+      executionTargetIsRemote: true,
+    });
+
+    const warning = prepared.notes.find((n) => n.startsWith("Warning:"));
+    expect(warning).toContain(GATEWAY_KEY);
+    expect(warning).toContain("remote execution host");
+    // The merge still happens; only the hard failure is withheld.
+    expect(await readConfigToml(home)).toContain("[model_providers.gw]");
+    await prepared.cleanup();
+  });
+
+  it("warns but never fails or rewrites a user-managed CODEX_HOME", async () => {
+    const original = [
+      'model_provider = "omlx"',
+      "",
+      "[model_providers.omlx]",
+      'base_url = "http://127.0.0.1:8080/v1"',
+      `env_key = "${GATEWAY_KEY}"`,
+      "",
+    ].join("\n");
+    const home = await makeCodexHome(original);
+
+    const prepared = await prepareCodexRuntimeConfig({
+      env: {},
+      codexHome: null,
+      externalCodexHome: home,
+    });
+
+    const warning = prepared.notes.find((n) => n.startsWith("Warning:"));
+    expect(warning).toContain('model_provider "omlx"');
+    expect(warning).toContain(GATEWAY_KEY);
+    expect(warning).toContain("user-managed");
+    // Read-only: the user's file is byte-for-byte untouched.
+    expect(await readConfigToml(home)).toBe(original);
+    await prepared.cleanup();
+  });
+
+  it("does not warn about a user-managed CODEX_HOME whose env var is set", async () => {
+    const home = await makeCodexHome(
+      ['model_provider = "omlx"', "[model_providers.omlx]", `env_key = "${GATEWAY_KEY}"`, ""].join(
+        "\n",
+      ),
+    );
+    const prepared = await prepareCodexRuntimeConfig({
+      env: { [GATEWAY_KEY]: "sk-local" },
+      codexHome: null,
+      externalCodexHome: home,
+    });
+
+    expect(prepared.notes.some((n) => n.startsWith("Warning:"))).toBe(false);
+    await prepared.cleanup();
+  });
+
+  it("does not warn about a user-managed CODEX_HOME with no config.toml", async () => {
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: {},
+      codexHome: null,
+      externalCodexHome: home,
+    });
+
+    expect(prepared.notes).toEqual([]);
+    await prepared.cleanup();
+  });
+});
+
+describe("readSelectedProviderEnvKey", () => {
+  it("reads the root selection and the matching provider's env_key", () => {
+    expect(
+      readSelectedProviderEnvKey(
+        [
+          'model_provider = "gw"  # selected by paperclip',
+          "",
+          "[model_providers.other]",
+          'env_key = "OTHER_KEY"',
+          "",
+          "[model_providers.gw]",
+          "env_key = 'GW_KEY'",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual({ modelProvider: "gw", envKey: "GW_KEY" });
+  });
+
+  it("ignores a model_provider key that lives inside a table", () => {
+    // [profiles.dev].model_provider is a different key; only the root-level one
+    // selects the provider codex actually dials.
+    expect(
+      readSelectedProviderEnvKey(
+        ["[profiles.dev]", 'model_provider = "gw"', "", "[model_providers.gw]", 'env_key = "GW_KEY"'].join(
+          "\n",
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores env_key in a subtable of the selected provider", () => {
+    // [model_providers.gw.http_headers] is header data, not the provider's own key.
+    expect(
+      readSelectedProviderEnvKey(
+        [
+          'model_provider = "gw"',
+          "[model_providers.gw]",
+          'base_url = "http://gw.example/v1"',
+          "[model_providers.gw.http_headers]",
+          'env_key = "NOT_THE_PROVIDER_KEY"',
+        ].join("\n"),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the selected provider declares no env_key", () => {
+    // A keyless local gateway is a legitimate config; there is nothing to check.
+    expect(
+      readSelectedProviderEnvKey(
+        ['model_provider = "gw"', "[model_providers.gw]", 'base_url = "http://gw.example/v1"'].join(
+          "\n",
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not match env_key nested in an inline table on another key", () => {
+    expect(
+      readSelectedProviderEnvKey(
+        [
+          'model_provider = "gw"',
+          "[model_providers.gw]",
+          'http_headers = { env_key = "DECOY" }',
+        ].join("\n"),
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/adapters/codex-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/codex-local/src/server/runtime-config.test.ts
@@ -570,7 +570,7 @@ describe("selected model_provider env_key readiness", () => {
     await prepared.cleanup();
   });
 
-  it("warns but never fails or rewrites a user-managed CODEX_HOME", async () => {
+  it("warns but never fails or rewrites an explicitly configured CODEX_HOME", async () => {
     const original = [
       'model_provider = "omlx"',
       "",
@@ -590,13 +590,13 @@ describe("selected model_provider env_key readiness", () => {
     const warning = prepared.notes.find((n) => n.startsWith("Warning:"));
     expect(warning).toContain('model_provider "omlx"');
     expect(warning).toContain(GATEWAY_KEY);
-    expect(warning).toContain("user-managed");
+    expect(warning).toContain("does not merge model providers");
     // Read-only: the user's file is byte-for-byte untouched.
     expect(await readConfigToml(home)).toBe(original);
     await prepared.cleanup();
   });
 
-  it("does not warn about a user-managed CODEX_HOME whose env var is set", async () => {
+  it("does not warn about an explicitly configured CODEX_HOME whose env var is set", async () => {
     const home = await makeCodexHome(
       ['model_provider = "omlx"', "[model_providers.omlx]", `env_key = "${GATEWAY_KEY}"`, ""].join(
         "\n",
@@ -612,7 +612,7 @@ describe("selected model_provider env_key readiness", () => {
     await prepared.cleanup();
   });
 
-  it("does not warn about a user-managed CODEX_HOME with no config.toml", async () => {
+  it("does not warn about an explicitly configured CODEX_HOME with no config.toml", async () => {
     const home = await makeCodexHome();
     const prepared = await prepareCodexRuntimeConfig({
       env: {},

--- a/packages/adapters/codex-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/codex-local/src/server/runtime-config.test.ts
@@ -429,8 +429,10 @@ describe("prepareCodexRuntimeConfig", () => {
 // turns that into an actionable adapter error.
 describe("selected model_provider env_key readiness", () => {
   // Deliberately not OPENAI_API_KEY: a var that can be set in a developer's
-  // shell would make these tests pass or fail depending on the machine.
-  const GATEWAY_KEY = "PAPERCLIP_TEST_GATEWAY_KEY";
+  // shell would make these tests pass or fail depending on the machine. Also
+  // deliberately not PAPERCLIP_*-prefixed -- that prefix is stripped from the
+  // inherited env before codex is spawned, which is its own case below.
+  const GATEWAY_KEY = "CODEX_TEST_GATEWAY_KEY";
   const GATEWAY_PROVIDERS = {
     providers: {
       gw: { base_url: "http://gw.example/v1", env_key: GATEWAY_KEY, wire_api: "responses" },
@@ -568,6 +570,64 @@ describe("selected model_provider env_key readiness", () => {
     // The merge still happens; only the hard failure is withheld.
     expect(await readConfigToml(home)).toContain("[model_providers.gw]");
     await prepared.cleanup();
+  });
+
+  it("still warns for a remote target when only the control plane's process env has the key", async () => {
+    // The regression this whole distinction exists for. The control plane's
+    // environment does not cross the ssh/sandbox transport -- only the explicit
+    // env record does -- so crediting process.env here would silently pass a run
+    // that dies inside codex on the remote host. Reading it as "already set"
+    // withholds the one warning that would have explained the failure.
+    vi.stubEnv(GATEWAY_KEY, "sk-control-plane-only");
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: { PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS) },
+      codexHome: home,
+      executionTargetIsRemote: true,
+    });
+
+    const warning = prepared.notes.find((n) => n.startsWith("Warning:"));
+    expect(warning).toContain(GATEWAY_KEY);
+    expect(warning).toContain("does not cross the transport");
+    await prepared.cleanup();
+  });
+
+  it("does not warn for a remote target when the adapter config env carries the key", async () => {
+    // The adapter config env IS forwarded across the transport, so it is the one
+    // source that settles the question for a remote run.
+    const home = await makeCodexHome();
+    const prepared = await prepareCodexRuntimeConfig({
+      env: {
+        PAPERCLIP_CODEX_PROVIDERS: JSON.stringify(GATEWAY_PROVIDERS),
+        [GATEWAY_KEY]: "sk-gateway",
+      },
+      codexHome: home,
+      executionTargetIsRemote: true,
+    });
+
+    expect(prepared.notes.some((n) => n.startsWith("Warning:"))).toBe(false);
+    await prepared.cleanup();
+  });
+
+  it("fails fast when a PAPERCLIP_-prefixed env_key is satisfied only by the host process env", async () => {
+    // sanitizeInheritedPaperclipEnv strips PAPERCLIP_* from the inherited env
+    // before codex is spawned, so a value visible here never reaches the child.
+    // Treating it as set would pass the check on a run guaranteed to fail.
+    const prefixedKey = "PAPERCLIP_TEST_GATEWAY_KEY";
+    vi.stubEnv(prefixedKey, "sk-stripped-before-spawn");
+    const home = await makeCodexHome();
+
+    await expect(
+      prepareCodexRuntimeConfig({
+        env: {
+          PAPERCLIP_CODEX_PROVIDERS: JSON.stringify({
+            providers: { gw: { base_url: "http://gw.example/v1", env_key: prefixedKey } },
+            model_provider: "gw",
+          }),
+        },
+        codexHome: home,
+      }),
+    ).rejects.toThrow(prefixedKey);
   });
 
   it("warns but never fails or rewrites an explicitly configured CODEX_HOME", async () => {

--- a/packages/adapters/codex-local/src/server/runtime-config.ts
+++ b/packages/adapters/codex-local/src/server/runtime-config.ts
@@ -304,6 +304,98 @@ async function readFileOrNull(filePath: string): Promise<string | null> {
   return fs.readFile(filePath, "utf8").catch(() => null);
 }
 
+export type CodexProviderEnvKeySelection = {
+  /** Value of the root-level `model_provider` key. */
+  modelProvider: string;
+  /** `env_key` declared by that provider's `[model_providers.<id>]` table. */
+  envKey: string;
+};
+
+// A quoted scalar assignment on its own line: `key = "value"` or `key = 'value'`,
+// with an optional trailing comment. Deliberately narrow -- anything else (inline
+// tables, multi-line strings) yields no selection, which disables the check
+// rather than guessing.
+const ROOT_MODEL_PROVIDER_RE = /^\s*model_provider\s*=\s*(?:"([^"]*)"|'([^']*)')\s*(?:#.*)?$/;
+const ENV_KEY_RE = /^\s*env_key\s*=\s*(?:"([^"]*)"|'([^']*)')\s*(?:#.*)?$/;
+
+function readQuotedAssignment(line: string, pattern: RegExp): string | null {
+  const match = pattern.exec(line);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? "").trim();
+  return value.length > 0 ? value : null;
+}
+
+// Best-effort read of the *effective* provider selection from config.toml text:
+// the root-level `model_provider`, plus the `env_key` its [model_providers.<id>]
+// table declares. Codex reads that env var at request time and aborts the run
+// when it is unset, so the pair is exactly what a pre-flight check needs.
+//
+// Deliberately a text scan rather than a real TOML parse: the merge code above
+// already reasons about this file line-by-line, the adapter carries no TOML
+// dependency, and every consumer of this function treats "no selection found"
+// as "nothing to check". A parse this narrow can only under-report.
+export function readSelectedProviderEnvKey(content: string): CodexProviderEnvKeySelection | null {
+  const lines = content.split("\n");
+  // TOML root-level keys must precede the first table header, so the search for
+  // `model_provider` stops there; a `model_provider` inside a table is a
+  // different key entirely (e.g. [profiles.x]) and must not be picked up.
+  let modelProvider: string | null = null;
+  for (const line of lines) {
+    if (parseTableHeaderPath(line) !== null) break;
+    modelProvider = readQuotedAssignment(line, ROOT_MODEL_PROVIDER_RE);
+    if (modelProvider !== null) break;
+  }
+  if (modelProvider === null) return null;
+
+  let inSelectedTable = false;
+  for (const line of lines) {
+    const headerPath = parseTableHeaderPath(line);
+    if (headerPath !== null) {
+      // Exactly [model_providers.<id>] -- a subtable such as
+      // [model_providers.<id>.http_headers] does not carry the provider's env_key.
+      inSelectedTable =
+        headerPath.length === 2 &&
+        headerPath[0] === "model_providers" &&
+        headerPath[1] === modelProvider;
+      continue;
+    }
+    if (!inSelectedTable) continue;
+    const envKey = readQuotedAssignment(line, ENV_KEY_RE);
+    if (envKey !== null) return { modelProvider, envKey };
+  }
+  return null;
+}
+
+// The selected provider's env_key when it resolves to nothing in the run env,
+// else null. An env var set to whitespace is treated as unset: codex sends it as
+// the bearer token and the provider rejects it, which is the same broken run
+// with a less obvious symptom.
+function findUnsetProviderEnvKey(
+  content: string,
+  resolveEnv: (name: string) => string | undefined,
+): CodexProviderEnvKeySelection | null {
+  const selection = readSelectedProviderEnvKey(content);
+  if (selection === null) return null;
+  const value = resolveEnv(selection.envKey);
+  return value === undefined || value.trim().length === 0 ? selection : null;
+}
+
+// Codex's own failure here is `Missing environment variable: \`X\``, which names
+// neither the config file the selection came from nor the setting that put it
+// there. Name all three.
+function describeUnsetProviderEnvKey(
+  selection: CodexProviderEnvKeySelection,
+  configTomlPath: string,
+): string {
+  return (
+    `Codex model_provider "${selection.modelProvider}" declares env_key "${selection.envKey}" in ` +
+    `"${configTomlPath}", but ${selection.envKey} is unset or empty in this run's environment. ` +
+    `Codex would fail with "Missing environment variable: \`${selection.envKey}\`". ` +
+    `Set ${selection.envKey} in the agent's adapter config env (or bind it as a secret), ` +
+    `or select a provider that does not need it via PAPERCLIP_CODEX_PROVIDERS.`
+  );
+}
+
 // Pre-run backup of the original config.toml, written before the merged file.
 // If a run dies without reaching cleanup() (a setup throw between prepare and
 // execution, SIGKILL, ...), the next prepare restores the original from this
@@ -336,6 +428,19 @@ function configTomlBackupPath(configTomlPath: string): string {
 export async function prepareCodexRuntimeConfig(input: {
   env: Record<string, string>;
   codexHome: string | null;
+  /**
+   * The user-supplied `env.CODEX_HOME` when there is one (`codexHome` is null in
+   * that case). Read-only: its config.toml is inspected for diagnostics and
+   * never seeded, merged, or rewritten.
+   */
+  externalCodexHome?: string | null;
+  /**
+   * True when the codex process will run on a remote execution target. The
+   * control plane's `process.env` is not that process's environment, so the
+   * selected-provider env_key check degrades to a warning instead of failing
+   * a run whose env we cannot actually see.
+   */
+  executionTargetIsRemote?: boolean;
 }): Promise<PreparedCodexRuntimeConfig> {
   const resolveEnv = (name: string): string | undefined => input.env[name] ?? process.env[name];
   const notes: string[] = [];
@@ -344,6 +449,23 @@ export async function prepareCodexRuntimeConfig(input: {
     resolveEnv,
     notes,
   );
+
+  // A user-managed home is never seeded or rewritten, but its config can still
+  // select a provider whose env_key is unset. Reading it is free and warning
+  // beats letting codex die on its first model refresh -- but this file is the
+  // user's, so a warning is as far as it goes.
+  if (input.externalCodexHome) {
+    const externalConfigTomlPath = path.join(input.externalCodexHome, "config.toml");
+    const externalConfig = await readFileOrNull(externalConfigTomlPath);
+    const unset =
+      externalConfig === null ? null : findUnsetProviderEnvKey(externalConfig, resolveEnv);
+    if (unset) {
+      notes.push(
+        `Warning: ${describeUnsetProviderEnvKey(unset, externalConfigTomlPath)} ` +
+          `This home is user-managed, so Paperclip is leaving it as-is.`,
+      );
+    }
+  }
 
   if (!parsed) {
     // Self-heal state left behind by a crashed run (cleanup() never ran).
@@ -405,11 +527,32 @@ export async function prepareCodexRuntimeConfig(input: {
     providerNames,
     parsed.modelProvider !== null,
   );
+  const merged = buildMergedConfigToml(base, parsed);
+
+  // The selection can come from either side of the merge -- PAPERCLIP_CODEX_PROVIDERS'
+  // own `model_provider`, or a root key already in the base config -- so the check
+  // runs against the merged result rather than the parsed input. A run whose
+  // selected provider names an unset env_key is guaranteed to die inside codex;
+  // fail here, where the error can name the provider, the env var, and the file.
+  // Nothing has been written yet, so a throw leaves the home exactly as it was.
+  const unsetEnvKey = findUnsetProviderEnvKey(merged, resolveEnv);
+  if (unsetEnvKey) {
+    if (input.executionTargetIsRemote) {
+      notes.push(
+        `Warning: ${describeUnsetProviderEnvKey(unsetEnvKey, configTomlPath)} ` +
+          `This run targets a remote execution host whose environment Paperclip cannot read, ` +
+          `so this is a warning rather than a hard failure.`,
+      );
+    } else {
+      throw new Error(describeUnsetProviderEnvKey(unsetEnvKey, configTomlPath));
+    }
+  }
+
   await fs.mkdir(input.codexHome, { recursive: true });
   // Persist the original BEFORE writing the merged file so a run that never
   // reaches cleanup() can be restored by the next prepare.
   await fs.writeFile(backupPath, original ?? "", "utf8");
-  await fs.writeFile(configTomlPath, buildMergedConfigToml(base, parsed), "utf8");
+  await fs.writeFile(configTomlPath, merged, "utf8");
 
   return {
     notes: [

--- a/packages/adapters/codex-local/src/server/runtime-config.ts
+++ b/packages/adapters/codex-local/src/server/runtime-config.ts
@@ -429,9 +429,9 @@ export async function prepareCodexRuntimeConfig(input: {
   env: Record<string, string>;
   codexHome: string | null;
   /**
-   * The user-supplied `env.CODEX_HOME` when there is one (`codexHome` is null in
-   * that case). Read-only: its config.toml is inspected for diagnostics and
-   * never seeded, merged, or rewritten.
+   * The explicitly configured `env.CODEX_HOME` when there is one (`codexHome` is
+   * null in that case). Read-only: its config.toml is inspected for diagnostics
+   * and never seeded, merged, or rewritten.
    */
   externalCodexHome?: string | null;
   /**
@@ -450,10 +450,10 @@ export async function prepareCodexRuntimeConfig(input: {
     notes,
   );
 
-  // A user-managed home is never seeded or rewritten, but its config can still
-  // select a provider whose env_key is unset. Reading it is free and warning
-  // beats letting codex die on its first model refresh -- but this file is the
-  // user's, so a warning is as far as it goes.
+  // An explicitly configured CODEX_HOME is never merged into or rewritten, but
+  // its config can still select a provider whose env_key is unset. Reading it is
+  // free and warning beats letting codex die on its first model refresh -- but
+  // the merge is off for this home, so a warning is as far as it goes.
   if (input.externalCodexHome) {
     const externalConfigTomlPath = path.join(input.externalCodexHome, "config.toml");
     const externalConfig = await readFileOrNull(externalConfigTomlPath);
@@ -462,7 +462,8 @@ export async function prepareCodexRuntimeConfig(input: {
     if (unset) {
       notes.push(
         `Warning: ${describeUnsetProviderEnvKey(unset, externalConfigTomlPath)} ` +
-          `This home is user-managed, so Paperclip is leaving it as-is.`,
+          `Paperclip does not merge model providers into an explicitly configured CODEX_HOME, ` +
+          `so it is leaving this file as-is.`,
       );
     }
   }

--- a/packages/adapters/codex-local/src/server/runtime-config.ts
+++ b/packages/adapters/codex-local/src/server/runtime-config.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { sanitizeInheritedPaperclipEnv } from "@paperclipai/adapter-utils/server-utils";
 
 type PreparedCodexRuntimeConfig = {
   notes: string[];
@@ -442,7 +443,30 @@ export async function prepareCodexRuntimeConfig(input: {
    */
   executionTargetIsRemote?: boolean;
 }): Promise<PreparedCodexRuntimeConfig> {
+  // Two different questions, two resolvers -- conflating them is what makes the
+  // pre-flight check lie.
+  //
+  // `resolveEnv` answers "what should this {env:VAR} placeholder expand to?".
+  // The expansion is baked into config.toml here on the control plane and
+  // travels with the file, so the control plane's own process.env is a
+  // legitimate source even for a run that executes elsewhere.
   const resolveEnv = (name: string): string | undefined => input.env[name] ?? process.env[name];
+  // `resolveRunEnv` answers the narrower question the env_key check needs:
+  // "will the codex process itself see a value for this variable?". The spawned
+  // child's environment is `sanitizeInheritedPaperclipEnv(process.env)` with the
+  // adapter config env layered on top (runChildProcess in adapter-utils) -- note
+  // the sanitize step, which drops PAPERCLIP_*, so a provider whose env_key uses
+  // that prefix is NOT satisfied by the host process env.
+  //
+  // A remote target inherits none of it: only the explicit env record crosses
+  // the transport (sanitizeRemoteExecutionEnv + buildSshSpawnTarget), so the
+  // control plane's process.env is not evidence of anything. Its own login
+  // profile may still supply the value and we cannot read it from here, which is
+  // why a miss on a remote target warns rather than fails.
+  const inheritedEnv: NodeJS.ProcessEnv = input.executionTargetIsRemote
+    ? {}
+    : sanitizeInheritedPaperclipEnv(process.env);
+  const resolveRunEnv = (name: string): string | undefined => input.env[name] ?? inheritedEnv[name];
   const notes: string[] = [];
   const parsed = parseCodexProvidersConfig(
     input.env.PAPERCLIP_CODEX_PROVIDERS ?? process.env.PAPERCLIP_CODEX_PROVIDERS,
@@ -458,7 +482,7 @@ export async function prepareCodexRuntimeConfig(input: {
     const externalConfigTomlPath = path.join(input.externalCodexHome, "config.toml");
     const externalConfig = await readFileOrNull(externalConfigTomlPath);
     const unset =
-      externalConfig === null ? null : findUnsetProviderEnvKey(externalConfig, resolveEnv);
+      externalConfig === null ? null : findUnsetProviderEnvKey(externalConfig, resolveRunEnv);
     if (unset) {
       notes.push(
         `Warning: ${describeUnsetProviderEnvKey(unset, externalConfigTomlPath)} ` +
@@ -536,13 +560,15 @@ export async function prepareCodexRuntimeConfig(input: {
   // selected provider names an unset env_key is guaranteed to die inside codex;
   // fail here, where the error can name the provider, the env var, and the file.
   // Nothing has been written yet, so a throw leaves the home exactly as it was.
-  const unsetEnvKey = findUnsetProviderEnvKey(merged, resolveEnv);
+  const unsetEnvKey = findUnsetProviderEnvKey(merged, resolveRunEnv);
   if (unsetEnvKey) {
     if (input.executionTargetIsRemote) {
       notes.push(
         `Warning: ${describeUnsetProviderEnvKey(unsetEnvKey, configTomlPath)} ` +
-          `This run targets a remote execution host whose environment Paperclip cannot read, ` +
-          `so this is a warning rather than a hard failure.`,
+          `This run targets a remote execution host: the control plane's own environment does ` +
+          `not cross the transport, so ${unsetEnvKey.envKey} has to come from the adapter config ` +
+          `env or from the remote host's own login profile -- which Paperclip cannot read from ` +
+          `here, so this is a warning rather than a hard failure.`,
       );
     } else {
       throw new Error(describeUnsetProviderEnvKey(unsetEnvKey, configTomlPath));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `codex_local` adapter can point an agent at a custom OpenAI-compatible endpoint through `PAPERCLIP_CODEX_PROVIDERS`, which becomes a `[model_providers.<id>]` table in the managed `CODEX_HOME`'s `config.toml`
> - That table declares an `env_key`: the environment variable codex reads the provider's bearer key from at request time
> - If the selected provider's `env_key` is not set, every run dies inside codex with `Missing environment variable: SOME_KEY` -- an error naming neither the config file nor the setting that selected the provider
> - The adapter already validates that `model_provider` names a provider that exists, so the neighbouring misconfiguration gets a clear message and this one does not
> - This pull request checks the selected provider's `env_key` before dispatch and fails with an error naming the provider, the variable, and the file
> - The benefit is that configuring a gateway wrong tells you what to fix, instead of looking like a runtime failure

## Linked Issues or Issue Description

Refs #11442

Related PRs:

- #11437 (open) -- `fix(codex): never inherit the host's model/provider pin into a managed Codex home`. Same failure signature, different cause: that one stops a *host* pin from leaking into a managed home. This one covers what that sanitizer cannot reach -- a provider selected on purpose whose key is missing, and a user-supplied `CODEX_HOME`. The two do not touch the same files and land independently.
- #7919 (merged) -- added `PAPERCLIP_CODEX_PROVIDERS`.

## What Changed

`packages/adapters/codex-local/src/server/runtime-config.ts`:

- Added `readSelectedProviderEnvKey(content)`. It reads the *effective* selection back out of `config.toml` text: the root-level `model_provider`, plus the `env_key` declared by that provider's `[model_providers.<id>]` table.
- `prepareCodexRuntimeConfig` runs that against the **merged** config and throws when the named variable is unset or empty in the run env. The error names the provider id, the variable, and the config path.
- The check runs **before** the backup and merged files are written, so a rejected run leaves the home byte-for-byte unchanged -- no partial merge and no `.paperclip-backup` for the next run's self-heal to undo.
- New optional input `externalCodexHome`: when the adapter config supplies its own `env.CODEX_HOME`, that home's `config.toml` is read and the same condition is surfaced as a warning. Read-only -- the file is never seeded, merged, or rewritten.
- New optional input `executionTargetIsRemote`: on a remote target the check degrades to a warning.
- The readiness check resolves values through `resolveRunEnv`, which is deliberately **not** the resolver used for `{env:VAR}` placeholder expansion. See "Review follow-ups" below.

`packages/adapters/codex-local/src/server/execute.ts` passes the two new inputs.

Deliberate choices worth review:

- **Checked against the merged file, not the parsed input.** The selection can also come from a root `model_provider` already in the base config, which survives the merge when `PAPERCLIP_CODEX_PROVIDERS` sets no selector of its own. Keying off `parsed.modelProvider` would miss that; there is a test for it.
- **Remote targets warn, they do not fail.** For a remote execution target the control plane's `process.env` is not the codex process's environment, in either direction: a variable present on the host is not forwarded unless it is in `config.env`, and one that is ambient on the remote host is invisible from here. A hard failure on evidence that weak would be a new failure mode, not a diagnostic.
- **A text scan, not a TOML parse.** The adapter carries no TOML dependency and the surrounding merge code already reasons about this file line-by-line. The patterns only match a quoted scalar on its own line, so anything unusual yields "no selection found", which disables the check. It can under-report; it cannot invent a failure.
- **Whitespace counts as unset.** Codex would send it verbatim as the bearer token and the provider would reject it -- the same broken run with a less obvious symptom.
- **`evaluateCodexCredentialReadiness` was left alone.** #11442 floats folding this into the pre-dispatch readiness gate. It does not fit without cost: `ready` is currently a single boolean whose only consumer reports `reason: "codex_credentials_missing"` with `requiredEnvKeys: ["OPENAI_API_KEY"]`, so this condition would need a new reason code and a wider `ConfigurationIncompleteFailure` payload. The adapter-side throw already produces an actionable error. Happy to do it as a follow-up if you would rather have the blocker before dispatch.

No user-facing doc change: `PAPERCLIP_CODEX_PROVIDERS` is not documented in `src/index.ts` on `master` (that doc block is part of #11437), so the inline comments remain the reference, consistent with the surrounding code.

## Verification

```
npx vitest run packages/adapters/codex-local
npx vitest run server/src/__tests__/codex-local-execute.test.ts
npx tsc --noEmit   # in packages/adapters/codex-local
```

336 pass / 1 skipped in `packages/adapters/codex-local` (up from 318; 18 new), 16 pass in the server execute suite, typecheck clean.

Nine pre-existing tests in `runtime-config.test.ts` had to be updated. They configured `model_provider = "bifrost"` with `env_key = "OPENAI_API_KEY"` and never set `OPENAI_API_KEY`, which is exactly the state this PR rejects. They now pass the key explicitly through the run env rather than inheriting it from the host shell, which also makes them independent of the machine they run on -- previously they would have passed or failed depending on whether the developer had `OPENAI_API_KEY` exported.

Every new test was mutation-tested. 12 mutations were applied one at a time and all 12 were caught: check disabled, throw downgraded to a note, remote branch removed, whitespace treated as set, check keyed on the parsed selector instead of the merged file, root-region scan not stopped at the first table header, subtable accepted as the provider's own table, check moved after the writes, external-home block deleted, external-home warning turned into a throw, `env_key` pattern unanchored, and the external-home resolver narrowed to `process.env`.

## Review follow-ups

**Greptile P1, `runtime-config.ts:445` -- credential environment mismatch.** Valid, and the underlying mistake was wider than the report. The check resolved through `input.env[name] ?? process.env[name]`, i.e. the control plane's own environment, which is not the environment codex runs in:

- **Remote targets.** The control plane's `process.env` does not cross the transport at all -- only the explicit env record does (`sanitizeRemoteExecutionEnv` -> `buildSshSpawnTarget` for ssh; `environmentRuntime.execute` for sandbox). A key present only on the control plane read as "set", so the check passed *and withheld the warning* on a run that then died inside codex. The `executionTargetIsRemote` branch only covered the case where the key was missing everywhere, which is the case that needed it least.
- **Locally.** The child inherits `sanitizeInheritedPaperclipEnv(process.env)`, which strips `PAPERCLIP_*`. A provider whose `env_key` uses that prefix read as "set" here but never reaches the child. The previous revision's own test used `PAPERCLIP_TEST_GATEWAY_KEY` as its host-env fixture, so it was asserting exactly the wrong thing.

The fix splits the two questions that were being conflated:

| resolver | question | control plane `process.env`? |
|---|---|---|
| `resolveEnv` | what should this `{env:VAR}` placeholder expand to? | **yes** -- the expansion is baked into `config.toml` here and travels with the file |
| `resolveRunEnv` | will the codex process itself see a value? | **no** on a remote target; locally, only via `sanitizeInheritedPaperclipEnv` |

`resolveRunEnv` is composed from the same helper the spawner uses, so it cannot drift from `runChildProcess`. Both `findUnsetProviderEnvKey` call sites (merged config, and the read-only external `CODEX_HOME`) now use it, and the remote warning says where the value actually has to come from.

**Whitespace half of the same comment.** Already handled: `findUnsetProviderEnvKey` trims, and a whitespace value in `config.env` genuinely does override an inherited one on the way to the child, so failing fast on it is correct rather than a false positive. Covered by the existing "treats a whitespace-only value as unset" test.

Three new tests, each mutation-tested against the specific revert that would reintroduce the bug:

- *"still warns for a remote target when only the control plane's process env has the key"* -- the P1 itself. Dies when `resolveRunEnv` credits `process.env` on a remote target.
- *"does not warn for a remote target when the adapter config env carries the key"* -- the other side, so the fix cannot degrade into warning on every remote run.
- *"fails fast when a `PAPERCLIP_`-prefixed env_key is satisfied only by the host process env"* -- dies when the resolver reads raw `process.env` instead of the sanitized copy.

**Category safeguard (follow-up, not this PR).** The class is *a pre-flight check modeling an environment it does not own, and drifting from the code that actually builds it.* The durable form is a shared `adapter-utils` resolver -- "will the spawned process see `NAME`?" -- exported next to `runChildProcess` and reused by every adapter that pre-flights an env var. Not built here: codex-local is its only consumer today, and a shared abstraction with one caller is the wrong shape to commit to. What this PR does instead is the cheap version of the same idea -- import `sanitizeInheritedPaperclipEnv` rather than restate it -- so the drift that caused the local half of this bug cannot recur silently.

## Risks

- **Runs that were already broken now fail earlier and louder.** A managed home whose selected provider names an unset variable is rejected at prepare instead of dying inside codex. That is the point, but it does move the failure from `codex` to the adapter, so anyone reading logs for the old string will see a different one.
- **The base-config path can fail a run over a file Paperclip did not write.** If the managed home's `config.toml` carries a root `model_provider` from somewhere else, that selection is now enforced. #11437 stops the main source of those pins from being seeded in the first place; the two changes agree.
- **A false positive would block a working run.** The text scan is deliberately narrow to keep that unlikely, and the two cases where the environment genuinely cannot be verified -- remote targets and user-supplied homes -- warn instead. The residual case was the *inverse* -- a key visible in `process.env` here that never reaches codex -- and Greptile found two of them; both are closed below.

## Category safeguard

The instance fix is a test that configures a provider with an unset `env_key` and asserts the adapter fails with a message naming the variable and the config file, rather than letting the raw codex error through.

The class is wider: *Paperclip writes a config file for a subprocess, and the subprocess rejects it with an error that cannot be traced back to what Paperclip wrote.* `readSelectedProviderEnvKey` is the seam for that -- reading the generated artifact back and validating it before handing it over, instead of trusting the inputs that produced it. The ordering matters as much as the check: validate the fully merged artifact, and do it before the first write, so a rejection leaves nothing to clean up. Both are asserted here (the base-config-inherited selection test, and the no-partial-merge test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), Anthropic, run through Claude Code with extended thinking, tool use, and code execution. Sub-tasks (the test-fixture update and the 12-mutation test-quality pass) were delegated to Claude Sonnet 4.5 (`claude-sonnet-4-5`) subagents. All output was reviewed and verified by the author.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (searched the PR list for `env_key codex model_provider` and `PAPERCLIP_CODEX_PROVIDERS`; the only hits are #11437 and #7919, both linked above — neither covers this check)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (see the note under "What Changed" — `PAPERCLIP_CODEX_PROVIDERS` has no user-facing doc block on `master`, so the inline comments are the reference)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

