### PR TITLE
fix(opencode): preserve worktree cwd and allow slow model discovery

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -392,6 +392,32 @@ describe("adapter skill snapshots", () => {
 });
 
 describe("runChildProcess", () => {
+  it("sets PWD to the resolved child working directory", async () => {
+    const childCwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-child-pwd-"));
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          "process.stdout.write(JSON.stringify({ cwd: process.cwd(), pwd: process.env.PWD }))",
+        ],
+        {
+          cwd: childCwd,
+          env: { PWD: "/stale/server/working-directory" },
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ cwd: childCwd, pwd: childCwd });
+    } finally {
+      await fs.rm(childCwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not arm a timeout when timeoutSec is 0", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3336,6 +3336,7 @@ export async function runChildProcess(
     })
       .then((target) => {
         const childEnv = { ...mergedEnv, ...target.env };
+        childEnv.PWD = target.cwd ?? opts.cwd;
         for (const [key, value] of Object.entries(childEnv)) {
           if (value === undefined) delete childEnv[key];
         }

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,5 +1,9 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  discoverOpenCodeModels,
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
   requireOpenCodeModelId,
@@ -17,6 +21,24 @@ describe("openCode models", () => {
     process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
     await expect(listOpenCodeModels()).resolves.toEqual([]);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "allows a model catalog cold start longer than 20 seconds",
+    async () => {
+      const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-models-"));
+      const command = path.join(fixtureDir, "slow-opencode");
+      await fs.writeFile(command, "#!/bin/sh\nsleep 21\nprintf 'openai/test-model\\n'\n", { mode: 0o755 });
+
+      try {
+        await expect(discoverOpenCodeModels({ command, cwd: fixtureDir })).resolves.toEqual([
+          { id: "openai/test-model", label: "openai/test-model" },
+        ]);
+      } finally {
+        await fs.rm(fixtureDir, { recursive: true, force: true });
+      }
+    },
+    70_000,
+  );
 
   it("rejects when model is missing", async () => {
     await expect(

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -9,7 +9,7 @@ import {
 import { isValidOpenCodeModelId } from "../index.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
-const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const MODELS_DISCOVERY_TIMEOUT_MS = 60_000;
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =


### PR DESCRIPTION
## Summary

- synchronize `PWD` with the resolved child working directory before spawning local adapter commands
- allow OpenCode model discovery up to 60 seconds during cold starts
- add regression coverage for both behaviors

## Root cause

Local adapter processes inherited a stale parent `PWD` even when spawned with a different `cwd`. Some CLIs use `PWD` when resolving workspace context, which could make simultaneous worktree runs operate against the wrong checkout. Separately, the fixed 20-second `opencode models` deadline was shorter than real provider catalog cold starts, causing healthy agents to fail environment setup.

## Impact

Worktree-backed agents now see a consistent current directory through both `cwd` and `PWD`, and slower OpenCode catalog discovery no longer produces a false setup failure.

## Validation

- targeted adapter test suite: 102 passed
- `@paperclipai/adapter-utils` typecheck and build
- `@paperclipai/adapter-opencode-local` typecheck and build
- exact release backport: 82 targeted tests passed and full monorepo build completed
- live OpenCode environment probe: 1,919 models discovered and hello execution passed
