### PR TITLE
feat(server): surface issueless-wake reuse-binding skips in wake diagnostics

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -17,7 +17,9 @@ import {
   buildEffectiveRunWorkspaceConfigMetadata,
   buildWorkspaceConfigFreshnessOperation,
   deriveTaskKeyWithHeartbeatFallback,
+  evaluateIssuelessWakeReuseBindingDiagnostic,
   extractWakeCommentIds,
+  ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES,
   formatRuntimeWorkspaceWarningLog,
   mergeExecutionWorkspaceMetadataForPersistence,
   mergeCoalescedContextSnapshot,
@@ -45,6 +47,7 @@ import {
   shouldResetTaskSessionForWake,
   scrubGitCredentialText,
   buildAnchorFallbackWorkspaceNotes,
+  type IssuelessWakeReuseBindingCandidate,
   type ResolvedWorkspaceForRun,
 } from "../services/heartbeat.ts";
 import type { TrustPresetResolution } from "../services/trust-preset-resolver.ts";
@@ -2909,5 +2912,101 @@ describe("reconcileReusedExecutionWorkspaceProjectWorkspaceId", () => {
     expect(
       reconcileReusedExecutionWorkspaceProjectWorkspaceId(undefined, "resolved-workspace"),
     ).toBe("resolved-workspace");
+  });
+});
+
+describe("evaluateIssuelessWakeReuseBindingDiagnostic", () => {
+  function buildBoundIssue(index: number): IssuelessWakeReuseBindingCandidate {
+    return {
+      issueId: `issue-${index}`,
+      issueIdentifier: `PAP-${index}`,
+      executionWorkspaceId: `execution-workspace-${index}`,
+    };
+  }
+
+  function buildDiagnosticInput(
+    overrides: Partial<Parameters<typeof evaluateIssuelessWakeReuseBindingDiagnostic>[0]> = {},
+  ): Parameters<typeof evaluateIssuelessWakeReuseBindingDiagnostic>[0] {
+    return {
+      issueId: null,
+      wakeSource: "on_demand",
+      resolvedWorkspaceSource: "agent_home",
+      workspaceStrategyType: "adapter_managed",
+      boundIssues: [buildBoundIssue(1)],
+      ...overrides,
+    };
+  }
+
+  it("emits a row naming the bound issue for a bare non-timer issueless wake without touching the resolved workspace", () => {
+    const resolvedWorkspace = buildResolvedWorkspace({ source: "agent_home", projectId: null, workspaceId: null });
+    const resolvedWorkspaceBefore = structuredClone(resolvedWorkspace);
+    const input = buildDiagnosticInput({ resolvedWorkspaceSource: resolvedWorkspace.source });
+    Object.freeze(input);
+    Object.freeze(input.boundIssues);
+    Object.freeze(input.boundIssues[0]);
+
+    expect(evaluateIssuelessWakeReuseBindingDiagnostic(input)).toEqual([
+      {
+        issueId: "issue-1",
+        issueIdentifier: "PAP-1",
+        executionWorkspaceId: "execution-workspace-1",
+      },
+    ]);
+    expect(resolvedWorkspace).toEqual(resolvedWorkspaceBefore);
+  });
+
+  it("emits one row per bound issue when the agent holds several live bindings", () => {
+    expect(
+      evaluateIssuelessWakeReuseBindingDiagnostic(
+        buildDiagnosticInput({ boundIssues: [buildBoundIssue(1), buildBoundIssue(2)] }),
+      ).map((row) => row.issueId),
+    ).toEqual(["issue-1", "issue-2"]);
+  });
+
+  it("caps the emitted rows at the diagnostic maximum", () => {
+    const boundIssues = Array.from(
+      { length: ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES + 2 },
+      (_, index) => buildBoundIssue(index + 1),
+    );
+    expect(
+      evaluateIssuelessWakeReuseBindingDiagnostic(buildDiagnosticInput({ boundIssues })),
+    ).toHaveLength(ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES);
+  });
+
+  it("emits nothing for a timer wake with the same live bindings", () => {
+    expect(
+      evaluateIssuelessWakeReuseBindingDiagnostic(
+        buildDiagnosticInput({
+          wakeSource: "timer",
+          boundIssues: [buildBoundIssue(1), buildBoundIssue(2)],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("emits nothing when the agent has no live bound issues", () => {
+    expect(
+      evaluateIssuelessWakeReuseBindingDiagnostic(buildDiagnosticInput({ boundIssues: [] })),
+    ).toEqual([]);
+  });
+
+  it("emits nothing for an issue-bound wake even when other live bindings exist", () => {
+    expect(
+      evaluateIssuelessWakeReuseBindingDiagnostic(
+        buildDiagnosticInput({
+          issueId: "issue-9",
+          resolvedWorkspaceSource: "project_primary",
+          boundIssues: [buildBoundIssue(1)],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("emits nothing when the run resolved to an isolated git worktree strategy", () => {
+    expect(
+      evaluateIssuelessWakeReuseBindingDiagnostic(
+        buildDiagnosticInput({ workspaceStrategyType: "git_worktree" }),
+      ),
+    ).toEqual([]);
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4347,6 +4347,94 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
   };
 }
 
+/**
+ * Action string for the issueless-wake reuse-binding diagnostic. Must stay in sync with
+ * ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS in issues.ts so the rows surface in the
+ * GET /api/issues/{id}/diagnostics/wakes endpoint.
+ */
+export const ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_ACTION =
+  "heartbeat.issueless_wake_reuse_binding_skipped";
+/** Bounds the activity writes per wake so a large backlog cannot fan out unbounded rows. */
+export const ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES = 5;
+
+export type IssuelessWakeReuseBindingCandidate = {
+  issueId: string;
+  issueIdentifier: string | null;
+  executionWorkspaceId: string;
+};
+
+/**
+ * Observability-only gate for issue #11455. A wake with no issue id resolves to a shared or
+ * agent-home workspace by design and never consults the persisted reuse_existing bindings of
+ * the agent's in-flight issues; that resolution behaviour is intentional and unchanged. This
+ * decides whether the skip is worth surfacing: only a non-timer issueless wake that resolved
+ * to a non-isolated workspace while live bound candidates exist produces rows, capped at
+ * ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES. Pure decision, no side effects.
+ */
+export function evaluateIssuelessWakeReuseBindingDiagnostic(input: {
+  issueId: string | null;
+  wakeSource: string | null;
+  resolvedWorkspaceSource: ResolvedWorkspaceForRun["source"];
+  workspaceStrategyType: string | null;
+  boundIssues: IssuelessWakeReuseBindingCandidate[];
+}): IssuelessWakeReuseBindingCandidate[] {
+  if (input.issueId) return [];
+  if (input.wakeSource === "timer") return [];
+  if (input.workspaceStrategyType === "git_worktree") return [];
+  if (
+    input.resolvedWorkspaceSource !== "project_primary" &&
+    input.resolvedWorkspaceSource !== "task_session" &&
+    input.resolvedWorkspaceSource !== "agent_home"
+  ) {
+    return [];
+  }
+  return input.boundIssues.slice(0, ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES);
+}
+
+/**
+ * The agent's in-flight (non-terminal, non-hidden) issues that carry a live reuse_existing
+ * binding: executionWorkspacePreference is reuse_existing and the bound execution workspace
+ * row exists and is not archived. Candidate source for the issueless-wake diagnostic above.
+ */
+export async function listAgentIssuesWithLiveReuseBindings(
+  db: Db,
+  companyId: string,
+  agentId: string,
+  limit: number,
+): Promise<IssuelessWakeReuseBindingCandidate[]> {
+  const rows = await db
+    .select({
+      issueId: issues.id,
+      issueIdentifier: issues.identifier,
+      executionWorkspaceId: issues.executionWorkspaceId,
+    })
+    .from(issues)
+    .innerJoin(
+      executionWorkspaces,
+      and(
+        eq(executionWorkspaces.id, issues.executionWorkspaceId),
+        eq(executionWorkspaces.companyId, issues.companyId),
+        ne(executionWorkspaces.status, "archived"),
+      ),
+    )
+    .where(
+      and(
+        eq(issues.companyId, companyId),
+        eq(issues.assigneeAgentId, agentId),
+        notInArray(issues.status, ["done", "cancelled"]),
+        isNull(issues.hiddenAt),
+        eq(issues.executionWorkspacePreference, "reuse_existing"),
+      ),
+    )
+    .orderBy(asc(issues.createdAt))
+    .limit(limit);
+  return rows.flatMap((row) =>
+    row.executionWorkspaceId
+      ? [{ issueId: row.issueId, issueIdentifier: row.issueIdentifier, executionWorkspaceId: row.executionWorkspaceId }]
+      : [],
+  );
+}
+
 export function resolveExecutionWorkspaceReuseProvisioningPolicy(input: {
   requestedShouldReuseExisting: boolean;
   workspaceConfigFreshness: ExecutionWorkspaceConfigFreshnessDecision;
@@ -14418,6 +14506,57 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       requestedExecutionWorkspaceMode,
       hostExecutionWorkspaceConfig,
     );
+    // Observability only (issue #11455): a non-timer wake with no issue id resolves through
+    // the shared or agent-home path by design and never reads the persisted reuse_existing
+    // bindings of the agent's in-flight issues. Surface that skip as wake-diagnostics
+    // activity rows. Resolution itself is intentionally unchanged, and a diagnostic failure
+    // never fails the run.
+    if (!issueId) {
+      try {
+        const issuelessWakeSource = readNonEmptyString(context.wakeSource);
+        if (issuelessWakeSource !== "timer") {
+          const issuelessWakeBoundIssues = await listAgentIssuesWithLiveReuseBindings(
+            db,
+            agent.companyId,
+            agent.id,
+            ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_MAX_ISSUES,
+          );
+          const issuelessWakeDiagnosticCandidates = evaluateIssuelessWakeReuseBindingDiagnostic({
+            issueId,
+            wakeSource: issuelessWakeSource,
+            resolvedWorkspaceSource: resolvedWorkspace.source,
+            workspaceStrategyType: latestWorkspaceStrategyType,
+            boundIssues: issuelessWakeBoundIssues,
+          });
+          for (const candidate of issuelessWakeDiagnosticCandidates) {
+            await logActivity(db, {
+              companyId: agent.companyId,
+              actorType: "system",
+              actorId: "system",
+              agentId: agent.id,
+              runId: run.id,
+              action: ISSUELESS_WAKE_REUSE_BINDING_DIAGNOSTIC_ACTION,
+              entityType: "issue",
+              entityId: candidate.issueId,
+              details: {
+                issueId: candidate.issueId,
+                issueIdentifier: candidate.issueIdentifier,
+                executionWorkspaceId: candidate.executionWorkspaceId,
+                resolvedWorkspaceSource: resolvedWorkspace.source,
+                resolvedWorkspaceStrategyType: latestWorkspaceStrategyType,
+                requestedExecutionWorkspaceMode,
+                wakeSource: issuelessWakeSource,
+              },
+            });
+          }
+        }
+      } catch (error) {
+        logger.warn(
+          { err: error, runId: run.id, agentId: agent.id },
+          "Failed to emit issueless-wake reuse-binding diagnostic activity; run continues",
+        );
+      }
+    }
     const selectedEnvironmentConfigForFingerprint = parseObject(selectedEnvironmentForConfig?.config);
     const workspaceEnvironmentFingerprint = selectedEnvironmentForConfig
       ? {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -161,7 +161,13 @@ export const ISSUE_CREATE_IDEMPOTENCY_KEY_RETENTION_DAYS = 7;
 const ISSUE_CREATE_IDEMPOTENCY_KEY_RETENTION_MS = ISSUE_CREATE_IDEMPOTENCY_KEY_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 const ISSUE_CREATE_IDEMPOTENCY_KEY_CLEANUP_BATCH_SIZE = 500;
 const DELETED_ISSUE_COMMENT_BODY = "";
-const ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS = ["issue.tree_hold_wakeup_deferred"] as const;
+const ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS = [
+  "issue.tree_hold_wakeup_deferred",
+  // Emitted by heartbeat executeRun when a non-timer wake with no issue id resolves to a
+  // non-isolated workspace while the agent still holds issues with live reuse_existing
+  // bindings. Observability only; resolution is unchanged.
+  "heartbeat.issueless_wake_reuse_binding_skipped",
+] as const;
 
 function wakeRequestTargetsIssue(issueId: string) {
   return sql`(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run through heartbeat wakes. The execution workspace subsystem gives each issue its own git worktree when the project policy asks for an isolated workspace
> - A wake carries an issue id, or it does not. When it does not, `executeRun` never loads the issue context, so it never reads the persisted `executionWorkspaceId` and `executionWorkspacePreference` of the agent's in flight issues. The run resolves to a shared or agent home workspace
> - That resolution is correct for timer wakes. Timer wakes have no issue by design
> - The gap is the silence. If the agent then works on one of those issues, it works in a shared checkout, and no record says that an expected isolated workspace was not used. An operator sees a normal successful run
> - This pull request adds one activity row when that situation happens. It does not change any resolution result
> - The benefit is that operators and maintainers can see the skip in the existing wake diagnostics endpoint, and triage on related reports has real data

## Linked Issues or Issue Description

- Refs #11455 (the general case, filed with the source lines and a reproduction)
- Refs #3364 (`retry_failed_run` wakeups can lose issue context, the narrowest filed trigger of the same gate, still open)
- Related prior art, searched and reviewed: closed PR #3446 (an attempt to fix #3364 by changing resolution), #7584 (no task heartbeats), #6275 (isolated workspace demoted at checkout), #10497 (preference rewritten after realization)

This pull request does not fix #3364 or #11455. It makes the condition visible.

## What Changed

- `server/src/services/heartbeat.ts`: added a pure decision function `evaluateIssuelessWakeReuseBindingDiagnostic`, a query helper `listAgentIssuesWithLiveReuseBindings`, and one guarded block in `executeRun` that emits the diagnostic. The block runs after workspace resolution and only reads its outputs
- `server/src/services/issues.ts`: added the new action to `ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS` so the row appears in `GET /api/issues/{id}/diagnostics/wakes`
- `server/src/__tests__/heartbeat-workspace-session.test.ts`: added 7 tests for the decision function

The diagnostic fires only when all of these are true:

1. The run has no issue id
2. The wake source is not `timer`
3. The resolved workspace strategy is not `git_worktree`
4. The agent has at least one non terminal issue with `executionWorkspacePreference = 'reuse_existing'` and a live `executionWorkspaceId`

The write is capped at 5 issues per wake. The whole block is inside a try and catch. A diagnostic failure logs a warning and never fails the run.

## Verification

- `npx vitest run server/src/__tests__/heartbeat-workspace-session.test.ts`: 1 file passed, 145 tests passed (138 existing, 7 new)
- `pnpm --filter @paperclipai/server typecheck`: passed with no errors
- The repository has no lint script or ESLint configuration, so there is no lint step to run

The new tests include two negative cases. One proves that a `timer` wake emits nothing with the same bindings in place. This protects the intentional behaviour of timer wakes. The other proves that an agent with no reuse bindings emits nothing.

Limitation, stated plainly: `heartbeat-workspace-session.test.ts` is a pure unit test file with no database harness, so it does not run `executeRun` end to end. The new tests cover the decision function. The wiring of the guarded block is covered by the typecheck only. I did not run the full monorepo suite or the UI suites.

## Risks

- Low. No resolution output changes. The diagnostic is additive and read only with respect to workspace selection
- The block adds one database query per issueless non timer wake for agents that reach it. The query is bounded and runs only after the cheap guards fail to exit early
- New rows appear in the activity log for affected wakes. The 5 issue cap bounds the write per wake
- The action name is new. Consumers that enumerate wake diagnostics actions will see an additional value

## Model Used

Claude Fable 5, model id `claude-fable-5`, 1M token context window. The model performed the source reconnaissance, wrote the diff, and wrote the tests, under human direction and review. The reproduction evidence in #11455 came from a self hosted instance on version 2026.722.0.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user facing documentation change applies; the diagnostic appears in an existing endpoint)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI on this pull request)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
