### PR TITLE
fix(routines): stop recording a covered delegation wait as a failed run

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -2593,4 +2593,92 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
 
     expect(run).toMatchObject({ source: "webhook", status: "issue_created" });
   });
+
+  async function seedDelegatingExecution(opts?: { withCoveredChild?: boolean }) {
+    const fixture = await seedFixture();
+    const { agentId, companyId, routine, svc } = fixture;
+    const run = await svc.runRoutine(routine.id, { source: "schedule" });
+    const executionIssueId = run.linkedIssueId!;
+
+    let childIssueId: string | null = null;
+    if (opts?.withCoveredChild) {
+      childIssueId = randomUUID();
+      const childRunId = randomUUID();
+      await db.insert(issues).values({
+        id: childIssueId,
+        companyId,
+        identifier: `${routine.title.slice(0, 3).toUpperCase()}-CHILD`,
+        title: "delegated child",
+        status: "in_progress",
+        priority: "medium",
+        parentId: executionIssueId,
+        assigneeAgentId: agentId,
+        originKind: "manual",
+      });
+      await db.insert(heartbeatRuns).values({
+        id: childRunId,
+        companyId,
+        agentId,
+        status: "running",
+        contextSnapshot: { issueId: childIssueId },
+      });
+      await db.update(issues).set({ executionRunId: childRunId }).where(eq(issues.id, childIssueId));
+    }
+
+    await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, executionIssueId));
+    return { ...fixture, childIssueId, executionIssueId, run };
+  }
+
+  const readRun = (runId: string) =>
+    db.select().from(routineRuns).where(eq(routineRuns.id, runId)).then((rows) => rows[0] ?? null);
+
+  it("keeps a delegating routine run in flight while the execution issue waits on a covered blocker", async () => {
+    const { childIssueId, executionIssueId, run, svc } = await seedDelegatingExecution({ withCoveredChild: true });
+
+    expect(await svc.syncRunStatusForIssue(executionIssueId)).toBeNull();
+    expect(await readRun(run.id)).toMatchObject({
+      status: "issue_created",
+      failureReason: null,
+      completedAt: null,
+    });
+
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, childIssueId!));
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, executionIssueId));
+    await svc.syncRunStatusForIssue(executionIssueId);
+
+    expect(await readRun(run.id)).toMatchObject({ status: "completed", failureReason: null });
+  });
+
+  it("fails a routine run when the execution issue is blocked with nothing driving the block", async () => {
+    const { executionIssueId, run, svc } = await seedDelegatingExecution();
+
+    await svc.syncRunStatusForIssue(executionIssueId);
+
+    const settled = await readRun(run.id);
+    expect(settled?.status).toBe("failed");
+    expect(settled?.failureReason).toContain("needs attention");
+  });
+
+  it("clears a stale failure reason when the execution issue later completes", async () => {
+    const { executionIssueId, run, svc } = await seedDelegatingExecution();
+    await svc.syncRunStatusForIssue(executionIssueId);
+    expect((await readRun(run.id))?.status).toBe("failed");
+
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, executionIssueId));
+    await svc.syncRunStatusForIssue(executionIssueId);
+
+    expect(await readRun(run.id)).toMatchObject({ status: "completed", failureReason: null });
+  });
+
+  it("still fails a routine run when the execution issue is cancelled", async () => {
+    const { executionIssueId, run, svc } = await seedDelegatingExecution({ withCoveredChild: true });
+    await db.update(issues).set({ status: "cancelled" }).where(eq(issues.id, executionIssueId));
+
+    await svc.syncRunStatusForIssue(executionIssueId);
+
+    expect(await readRun(run.id)).toMatchObject({
+      status: "failed",
+      failureReason: "Execution issue moved to cancelled",
+    });
+  });
 });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -29,6 +29,7 @@ import {
 import type {
   CreateRoutine,
   CreateRoutineTrigger,
+  IssueBlockerAttention,
   Routine,
   RoutineDetail,
   RoutineDescriptionDocument,
@@ -266,6 +267,18 @@ function nextResultText(status: string, issueId?: string | null) {
   if (status === "completed") return "Execution issue completed";
   if (status === "failed") return "Execution failed";
   return status;
+}
+
+function blockedExecutionFailureReason(attention: IssueBlockerAttention | null) {
+  const sample = attention?.sampleStalledBlockerIdentifier ?? attention?.sampleBlockerIdentifier ?? null;
+  const suffix = sample ? ` (${sample})` : "";
+  if (attention?.state === "stalled") {
+    return `Execution issue blocked on a stalled dependency${suffix}`;
+  }
+  if (attention?.state === "needs_attention") {
+    return `Execution issue blocked on a dependency that needs attention${suffix}`;
+  }
+  return "Execution issue moved to blocked";
 }
 
 function normalizeWebhookTimestampMs(rawTimestamp: string) {
@@ -3136,7 +3149,14 @@ export function routineService(
       const issue = await db
         .select({
           id: issues.id,
+          companyId: issues.companyId,
+          parentId: issues.parentId,
+          identifier: issues.identifier,
+          title: issues.title,
           status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          executionRunId: issues.executionRunId,
           originKind: issues.originKind,
           originRunId: issues.originRunId,
         })
@@ -3147,13 +3167,34 @@ export function routineService(
       if (issue.status === "done") {
         return finalizeRun(issue.originRunId, {
           status: "completed",
+          failureReason: null,
           completedAt: new Date(),
         });
       }
-      if (issue.status === "blocked" || issue.status === "cancelled") {
+      if (issue.status === "cancelled") {
         return finalizeRun(issue.originRunId, {
           status: "failed",
-          failureReason: `Execution issue moved to ${issue.status}`,
+          failureReason: "Execution issue moved to cancelled",
+          completedAt: new Date(),
+        });
+      }
+      if (issue.status === "blocked") {
+        // A routine that delegates work parks its execution issue in `blocked`
+        // on purpose while the delegated issues run. That wait is the routine
+        // working as designed, so it must not be recorded as a run failure —
+        // otherwise every delegating routine reports a structural failure and
+        // real failures drown in it. Only a block that nobody is driving
+        // (`needs_attention` / `stalled`, which also covers a blocked issue
+        // with no live blocker at all) settles the run as failed; a covered
+        // wait leaves the run in flight so it can settle when the execution
+        // issue finally reaches `done` or `cancelled`.
+        const attention = await issueSvc
+          .listBlockerAttention(issue.companyId, [issue])
+          .then((map) => map.get(issue.id) ?? null);
+        if (attention?.state === "covered") return null;
+        return finalizeRun(issue.originRunId, {
+          status: "failed",
+          failureReason: blockedExecutionFailureReason(attention),
           completedAt: new Date(),
         });
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Routines fire on a schedule and track each fire as a `routine_runs` row linked to one execution issue
> - Some routines delegate: the execution issue opens child issues, hands them to other agents, and waits in `blocked` until they land
> - `syncRunStatusForIssue` settled any `blocked` execution issue as a failed run, so that designed wait was recorded as a failure
> - Every delegating routine therefore reported a failure on every fire, and real routine failures hid inside that noise
> - This pull request reads `blockerAttention` for the execution issue and keeps a covered wait in flight instead of failing it
> - The benefit is that `routine_runs.status` again separates routines that are waiting by design from routines that are actually broken

## Linked Issues or Issue Description

Refs #9689 — that pull request keeps the current "blocked means failed" classification and adds recovery of the transient failure state afterwards. This pull request changes the classification itself, so the two overlap in `syncRunStatusForIssue`. If #9689 lands first, this change rebases on top of it and its two assertions of `failureReason: "Execution issue moved to blocked"` need the new covered/attention split.

**What happened?**

A monthly routine opens two child issues, delegates them, and parks its execution issue in `blocked` until both are done. The routine description states that wait. Both fires of that routine recorded:

```
routine_runs.status         = "failed"
routine_runs.failure_reason = "Execution issue moved to blocked"
```

Both fires actually succeeded. The delegated children reached `done` and the execution issue reached `done`.

The failure is also durable. When the execution issue later reached `done`, `finalizeRun` wrote `status = "completed"` but left `failure_reason` untouched. The stored rows now read `completed` with a failure reason attached, which is self-contradictory.

**Expected behavior**

A `blocked` execution issue that waits on live delegated work is the routine working as designed. It must not settle the run as failed. The run must stay in flight and settle when the execution issue reaches a terminal state.

A `blocked` execution issue that nobody is driving must still settle the run as failed, because that is a real routine failure. `blockerAttention.state` already draws that line: `covered` means an active waiting path exists, while `needs_attention` and `stalled` mean the wait needs a human. A blocked issue with no live blocker at all already reports `needs_attention`, so an empty-blocker zombie still fails.

A run that settles as `completed` must not keep an earlier failure reason.

**Steps to reproduce**

1. Create a routine whose execution issue opens a child issue and delegates it to another agent.
2. Let the child issue start. It now has a running heartbeat run, so the parent's `blockerAttention.state` is `covered`.
3. Move the execution issue to `blocked` to wait for the child.
4. Read the linked `routine_runs` row. Before this change it reads `status = "failed"`, `failure_reason = "Execution issue moved to blocked"`.
5. Complete the child, then move the execution issue to `done`.
6. Read the row again. It reads `status = "completed"` with the failure reason still set.

**Paperclip version or commit**

`master` at e52b8a343.

**Deployment mode**

Local single-instance server with embedded PostgreSQL.

## What Changed

- `syncRunStatusForIssue` splits the old `blocked || cancelled` branch. `cancelled` still settles the run as failed with an explicit reason.
- The `blocked` branch loads `blockerAttention` through `issueService.listBlockerAttention` for the execution issue. State `covered` returns without settling the run, so the run stays `issue_created` and settles later.
- Any other blocked state settles the run as failed. `blockedExecutionFailureReason` names the state and a sample blocker, so the run row says which dependency needs attention instead of only "moved to blocked".
- The `done` branch writes `failureReason: null` next to `status: "completed"`, so a recovered run no longer keeps a stale failure string.
- Four regression tests in `routines-service.test.ts` cover: a covered delegation wait staying in flight and later completing; a driverless block still failing; a stale failure reason cleared on completion; and `cancelled` still failing.

## Verification

```
pnpm --filter @paperclipai/server typecheck
pnpm --filter @paperclipai/server exec vitest run src/__tests__/routines-service.test.ts
```

Both pass. The full file is 65 tests, 65 passed, including the four new ones. The first new test fails on `master` because `syncRunStatusForIssue` returns the settled failed run instead of `null`.

## Risks

- Behavioral shift for operators who read `routine_runs`: a delegating routine now shows an in-flight run for the whole delegation window instead of a failed run. That is the intent, but dashboards that count in-flight runs will see longer-lived rows.
- The blocked state is evaluated once, at the moment the issue moves to `blocked`. If a covered wait later stalls, no issue status change fires and the run is not re-evaluated, so it stays in flight. The blocked-issue attention surface already reports that stall on its own channel, so the stall is not lost, but it does not appear as a run failure.
- The block branch now runs a blocker-graph query on each execution-issue status change. `listBlockerAttention` is bounded by depth and node caps and is already used on issue list paths.
- No schema change and no migration.

## Model Used

Claude (Anthropic), `claude-opus-5`, extended thinking enabled, run through the Claude Agent SDK with file editing and shell tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
