### PR TITLE
fix(issues): say whether a counted blocker came from blockedBy or a child

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -951,6 +951,7 @@ export type {
   IssueSubtreeDiagnosticEdge,
   IssueSubtreeDiagnosticsResponse,
   IssueBlockerAttention,
+  IssueBlockerAttentionEdgeKind,
   IssueBlockerAttentionReason,
   IssueBlockerAttentionState,
   IssueReviewAttention,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -604,6 +604,7 @@ export type {
   IssueSubtreeDiagnosticEdge,
   IssueSubtreeDiagnosticsResponse,
   IssueBlockerAttention,
+  IssueBlockerAttentionEdgeKind,
   IssueBlockerAttentionReason,
   IssueBlockerAttentionState,
   IssueReviewAttention,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -396,6 +396,14 @@ export type IssueBlockerAttentionReason =
   | "attention_required"
   | null;
 
+/**
+ * How a counted blocker reaches the blocked issue. `blocked_by` is an explicit
+ * `blocks` relation and appears in the issue's `blockedBy` list. `child` is an
+ * open child issue, which the blocker graph also treats as a wait but which
+ * never appears in `blockedBy`.
+ */
+export type IssueBlockerAttentionEdgeKind = "blocked_by" | "child";
+
 export interface IssueBlockerAttention {
   state: IssueBlockerAttentionState;
   reason: IssueBlockerAttentionReason;
@@ -403,8 +411,14 @@ export interface IssueBlockerAttention {
   coveredBlockerCount: number;
   stalledBlockerCount: number;
   attentionBlockerCount: number;
+  /** Counted blockers that come from an explicit `blocks` relation. */
+  dependencyBlockerCount?: number;
+  /** Counted blockers that are open child issues rather than `blockedBy` entries. */
+  childBlockerCount?: number;
   pendingFinalizeBlockerIssueIds?: string[];
   sampleBlockerIdentifier: string | null;
+  /** Which edge the sampled blocker was reached through. */
+  sampleBlockerEdgeKind?: IssueBlockerAttentionEdgeKind | null;
   sampleStalledBlockerIdentifier: string | null;
   /** True when a blocker or one of its open descendants is actively progressing. */
   blockingTreeLive?: boolean;

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -411,13 +411,18 @@ export interface IssueBlockerAttention {
   coveredBlockerCount: number;
   stalledBlockerCount: number;
   attentionBlockerCount: number;
-  /** Counted blockers that come from an explicit `blocks` relation. */
+  /** Top-level blockers of this issue that come from an explicit `blocks` relation. */
   dependencyBlockerCount?: number;
-  /** Counted blockers that are open child issues rather than `blockedBy` entries. */
+  /** Top-level blockers of this issue that are open child issues rather than `blockedBy` entries. */
   childBlockerCount?: number;
   pendingFinalizeBlockerIssueIds?: string[];
   sampleBlockerIdentifier: string | null;
-  /** Which edge the sampled blocker was reached through. */
+  /**
+   * The edge that reaches `sampleBlockerIdentifier`. The sample can sit deeper
+   * in the chain than the counted top-level blockers, so this describes the
+   * sampled issue's own incoming edge and does not have to agree with
+   * `dependencyBlockerCount` / `childBlockerCount`.
+   */
   sampleBlockerEdgeKind?: IssueBlockerAttentionEdgeKind | null;
   sampleStalledBlockerIdentifier: string | null;
   /** True when a blocker or one of its open descendants is actively progressing. */

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -371,6 +371,40 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("labels a sampled descendant with its own edge kind, not the top-level one", async () => {
+    // The sample can come from deeper in the chain than the counted top-level
+    // blockers. Reporting the root edge kind for it would claim a descendant is
+    // in `blockedBy` when it is not.
+    const { companyId, agentId } = await createCompany("PBG");
+    const parentId = await insertIssue({ companyId, identifier: "PBG-1", title: "Parent", status: "blocked" });
+    const dependencyId = await insertIssue({
+      companyId,
+      identifier: "PBG-2",
+      title: "Explicit dependency, itself blocked",
+      status: "blocked",
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBG-3",
+      title: "Open child of the dependency",
+      status: "todo",
+      parentId: dependencyId,
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: dependencyId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      unresolvedBlockerCount: 1,
+      dependencyBlockerCount: 1,
+      childBlockerCount: 0,
+      sampleBlockerIdentifier: "PBG-3",
+      sampleBlockerEdgeKind: "child",
+    });
+  });
+
   it("covers recursive blocker chains when the downstream leaf has active work", async () => {
     const { companyId, agentId } = await createCompany("PBR");
     const parentId = await insertIssue({ companyId, identifier: "PBR-1", title: "Parent", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -298,6 +298,79 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe("PBD-4");
   });
 
+  it("reports that a sampled blocker came from a child issue rather than blockedBy", async () => {
+    // Regression: an issue whose explicit blockers are all done, but which still
+    // has one open child, reported unresolvedBlockerCount 1 and sampled that
+    // child. The child never appears in `blockedBy`, so the two payloads read as
+    // a contradiction. The counts are correct — the payload must say which edge
+    // they came from.
+    const { companyId, agentId } = await createCompany("PBE");
+    const parentId = await insertIssue({ companyId, identifier: "PBE-1", title: "Delegating parent", status: "blocked" });
+    const doneBlockerOneId = await insertIssue({
+      companyId,
+      identifier: "PBE-2",
+      title: "Delegated work one",
+      status: "done",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    const doneBlockerTwoId = await insertIssue({
+      companyId,
+      identifier: "PBE-3",
+      title: "Delegated work two",
+      status: "done",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBE-4",
+      title: "Leftover child, not a blocker",
+      status: "todo",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: doneBlockerOneId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: doneBlockerTwoId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      unresolvedBlockerCount: 1,
+      dependencyBlockerCount: 0,
+      childBlockerCount: 1,
+      sampleBlockerIdentifier: "PBE-4",
+      sampleBlockerEdgeKind: "child",
+    });
+  });
+
+  it("reports a blocker that is both an open child and an explicit dependency as blocked_by", async () => {
+    const { companyId, agentId } = await createCompany("PBF");
+    const parentId = await insertIssue({ companyId, identifier: "PBF-1", title: "Parent", status: "blocked" });
+    const childBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBF-2",
+      title: "Delegated child that also blocks",
+      status: "todo",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: childBlockerId, blockedIssueId: parentId });
+    await activeRun({ companyId, agentId, issueId: childBlockerId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      unresolvedBlockerCount: 1,
+      dependencyBlockerCount: 1,
+      childBlockerCount: 0,
+      sampleBlockerIdentifier: "PBF-2",
+      sampleBlockerEdgeKind: "blocked_by",
+    });
+  });
+
   it("covers recursive blocker chains when the downstream leaf has active work", async () => {
     const { companyId, agentId } = await createCompany("PBR");
     const parentId = await insertIssue({ companyId, identifier: "PBR-1", title: "Parent", status: "blocked" });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2591,64 +2591,77 @@ async function listIssueBlockerAttentionMap(
     covered: boolean;
     stalled: boolean;
     sampleBlockerIdentifier: string | null;
+    /**
+     * The edge that reaches `sampleBlockerIdentifier`. A sample taken from
+     * further down the chain carries that node's own incoming edge kind, not
+     * the top-level one, so the kind always describes the sampled issue.
+     */
+    sampleBlockerEdgeKind: IssueBlockerAttentionEdgeKind;
     sampleStalledBlockerIdentifier: string | null;
     terminalBlockerIssueId?: string | null;
   };
   const classifyPath = (
     nodeId: string,
     seen: Set<string>,
+    edgeKind: IssueBlockerAttentionEdgeKind,
   ): PathClassification => {
     const sample = blockerSampleIdentifier(nodesById.get(nodeId));
     if (truncated || seen.has(nodeId)) {
-      return { covered: false, stalled: false, sampleBlockerIdentifier: sample, sampleStalledBlockerIdentifier: null };
+      return {
+        covered: false,
+        stalled: false,
+        sampleBlockerIdentifier: sample,
+        sampleBlockerEdgeKind: edgeKind,
+        sampleStalledBlockerIdentifier: null,
+      };
     }
     const node = nodesById.get(nodeId);
     if (!node || node.companyId !== companyId) {
-      return { covered: false, stalled: false, sampleBlockerIdentifier: nodeId, sampleStalledBlockerIdentifier: null };
+      return {
+        covered: false,
+        stalled: false,
+        sampleBlockerIdentifier: nodeId,
+        sampleBlockerEdgeKind: edgeKind,
+        sampleStalledBlockerIdentifier: null,
+      };
     }
     const nodeSample = blockerSampleIdentifier(node);
+    const selfSample = {
+      sampleBlockerIdentifier: nodeSample,
+      sampleBlockerEdgeKind: edgeKind,
+      sampleStalledBlockerIdentifier: null,
+    } as const;
     if (node.status === "done" && !pendingFinalizeBlockerIssueIds.has(node.id)) {
-      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+      return { covered: true, stalled: false, ...selfSample };
     }
     if (explicitWaitingIssueIds.has(node.id)) {
-      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+      return { covered: true, stalled: false, ...selfSample };
     }
     if (node.assigneeUserId && node.status !== "cancelled") {
-      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+      return { covered: true, stalled: false, ...selfSample };
     }
     if (node.status === "in_review") {
       const hasWaitingPath = activeIssueIds.has(node.id) || Boolean(node.assigneeUserId);
       if (hasWaitingPath) {
-        return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+        return { covered: true, stalled: false, ...selfSample };
       }
       return {
         covered: false,
         stalled: true,
         sampleBlockerIdentifier: nodeSample,
+        sampleBlockerEdgeKind: edgeKind,
         sampleStalledBlockerIdentifier: nodeSample,
         terminalBlockerIssueId: node.id,
       };
     }
     if (activeIssueIds.has(node.id)) {
-      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+      return { covered: true, stalled: false, ...selfSample };
     }
     if (node.status === "cancelled") {
-      return {
-        covered: false,
-        stalled: false,
-        sampleBlockerIdentifier: nodeSample,
-        sampleStalledBlockerIdentifier: null,
-        terminalBlockerIssueId: node.id,
-      };
+      return { covered: false, stalled: false, ...selfSample, terminalBlockerIssueId: node.id };
     }
     if (node.status === "backlog" && node.assigneeAgentId) {
-      return {
-        covered: false,
-        stalled: false,
-        sampleBlockerIdentifier: nodeSample,
-        sampleStalledBlockerIdentifier: null,
-        terminalBlockerIssueId: node.id,
-      };
+      return { covered: false, stalled: false, ...selfSample, terminalBlockerIssueId: node.id };
     }
 
     const downstream = (edgesByIssueId.get(node.id) ?? []).filter((edge) => {
@@ -2658,7 +2671,7 @@ async function listIssueBlockerAttentionMap(
     if (downstream.length > 0) {
       const nextSeen = new Set(seen);
       nextSeen.add(nodeId);
-      const classified = downstream.map((edge) => classifyPath(edge.blockerIssueId, nextSeen));
+      const classified = downstream.map((edge) => classifyPath(edge.blockerIssueId, nextSeen, edge.kind));
       const stalledChild = classified.find((result) => result.stalled || result.sampleStalledBlockerIdentifier);
       const sampleStalled = stalledChild?.sampleStalledBlockerIdentifier ?? null;
       const hardAttention = classified.find((result) =>
@@ -2669,6 +2682,7 @@ async function listIssueBlockerAttentionMap(
           covered: false,
           stalled: false,
           sampleBlockerIdentifier: hardAttention.sampleBlockerIdentifier,
+          sampleBlockerEdgeKind: hardAttention.sampleBlockerEdgeKind,
           sampleStalledBlockerIdentifier: sampleStalled,
           terminalBlockerIssueId: hardAttention.terminalBlockerIssueId ?? null,
         };
@@ -2679,14 +2693,17 @@ async function listIssueBlockerAttentionMap(
           covered: false,
           stalled: true,
           sampleBlockerIdentifier: stalledEntry.sampleBlockerIdentifier,
+          sampleBlockerEdgeKind: stalledEntry.sampleBlockerEdgeKind,
           sampleStalledBlockerIdentifier: sampleStalled,
           terminalBlockerIssueId: stalledEntry.terminalBlockerIssueId ?? null,
         };
       }
+      const firstDownstream = classified[0]?.sampleBlockerIdentifier ? classified[0] : null;
       return {
         covered: true,
         stalled: false,
-        sampleBlockerIdentifier: classified[0]?.sampleBlockerIdentifier ?? nodeSample,
+        sampleBlockerIdentifier: firstDownstream?.sampleBlockerIdentifier ?? nodeSample,
+        sampleBlockerEdgeKind: firstDownstream?.sampleBlockerEdgeKind ?? edgeKind,
         sampleStalledBlockerIdentifier: null,
       };
     }
@@ -2694,23 +2711,11 @@ async function listIssueBlockerAttentionMap(
     if (node.assigneeAgentId) {
       const assignee = agentsById.get(node.assigneeAgentId);
       if (!assignee || assignee.companyId !== companyId || !BLOCKER_ATTENTION_INVOKABLE_AGENT_STATUSES.has(assignee.status)) {
-        return {
-          covered: false,
-          stalled: false,
-          sampleBlockerIdentifier: nodeSample,
-          sampleStalledBlockerIdentifier: null,
-          terminalBlockerIssueId: node.id,
-        };
+        return { covered: false, stalled: false, ...selfSample, terminalBlockerIssueId: node.id };
       }
     }
 
-    return {
-      covered: false,
-      stalled: false,
-      sampleBlockerIdentifier: nodeSample,
-      sampleStalledBlockerIdentifier: null,
-      terminalBlockerIssueId: node.id,
-    };
+    return { covered: false, stalled: false, ...selfSample, terminalBlockerIssueId: node.id };
   };
 
   const pathHasLiveWork = (nodeId: string, seen: Set<string>): boolean => {
@@ -2752,7 +2757,7 @@ async function listIssueBlockerAttentionMap(
 
     const classified = topLevelEdges.map((edge) => ({
       edge,
-      result: classifyPath(edge.blockerIssueId, new Set([root.id])),
+      result: classifyPath(edge.blockerIssueId, new Set([root.id]), edge.kind),
     }));
     const coveredBlockerCount = classified.filter((entry) => entry.result.covered).length;
     const stalledBlockerCount = classified.filter((entry) => entry.result.stalled).length;
@@ -2799,7 +2804,14 @@ async function listIssueBlockerAttentionMap(
         .map((edge) => edge.blockerIssueId)
         .filter((blockerIssueId) => pendingFinalizeBlockerIssueIds.has(blockerIssueId)),
       sampleBlockerIdentifier: sampleEntry?.result.sampleBlockerIdentifier ?? blockerSampleIdentifier(sampleNode),
-      sampleBlockerEdgeKind: sampleEntry?.edge.kind ?? null,
+      // The sample can come from deeper in the chain, so take the kind the
+      // classifier reported for that node. Only fall back to the top-level
+      // edge when the sample itself falls back to the top-level node.
+      sampleBlockerEdgeKind: sampleEntry
+        ? (sampleEntry.result.sampleBlockerIdentifier
+          ? sampleEntry.result.sampleBlockerEdgeKind
+          : sampleEntry.edge.kind)
+        : null,
       sampleStalledBlockerIdentifier:
         stalledEntry?.result.sampleStalledBlockerIdentifier ?? sampleStalledFromChain ?? null,
       blockingTreeLive: topLevelEdges.some((edge) => pathHasLiveWork(edge.blockerIssueId, new Set([root.id]))),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -44,6 +44,7 @@ import type {
   IssueCommentMetadata,
   IssueCommentPresentation,
   IssueBlockerAttention,
+  IssueBlockerAttentionEdgeKind,
   IssueReviewAttention,
   IssueReviewAttentionPath,
   IssueBlockedInboxAttention,
@@ -1948,6 +1949,7 @@ type IssueBlockerAttentionInputNode =
 type IssueBlockerAttentionEdge = {
   issueId: string;
   blockerIssueId: string;
+  kind: IssueBlockerAttentionEdgeKind;
 };
 type IssueBlockerAttentionQueryRow = IssueBlockerAttentionNode & {
   issueId: string | null;
@@ -2090,8 +2092,11 @@ function createIssueBlockerAttention(input: Partial<IssueBlockerAttention> = {})
     coveredBlockerCount: input.coveredBlockerCount ?? 0,
     stalledBlockerCount: input.stalledBlockerCount ?? 0,
     attentionBlockerCount: input.attentionBlockerCount ?? 0,
+    dependencyBlockerCount: input.dependencyBlockerCount ?? 0,
+    childBlockerCount: input.childBlockerCount ?? 0,
     pendingFinalizeBlockerIssueIds: input.pendingFinalizeBlockerIssueIds ?? [],
     sampleBlockerIdentifier: input.sampleBlockerIdentifier ?? null,
+    sampleBlockerEdgeKind: input.sampleBlockerEdgeKind ?? null,
     sampleStalledBlockerIdentifier: input.sampleStalledBlockerIdentifier ?? null,
     blockingTreeLive: input.blockingTreeLive ?? false,
     terminalBlockerIssueId: input.terminalBlockerIssueId ?? null,
@@ -2108,10 +2113,17 @@ function appendBlockerAttentionEdges(
 ) {
   for (const row of rows) {
     const existing = edgesByIssueId.get(row.issueId) ?? [];
-    if (!existing.some((edge) => edge.blockerIssueId === row.blockerIssueId)) {
-      existing.push(row);
-      edgesByIssueId.set(row.issueId, existing);
+    const duplicate = existing.find((edge) => edge.blockerIssueId === row.blockerIssueId);
+    if (duplicate) {
+      // An issue can be both an open child and an explicit blocker. Report the
+      // explicit dependency, because that is the edge a caller can also see in
+      // `blockedBy`. This runs on either merge order, so the reported kind does
+      // not depend on which query returned the row first.
+      if (row.kind === "blocked_by") duplicate.kind = "blocked_by";
+      continue;
     }
+    existing.push(row);
+    edgesByIssueId.set(row.issueId, existing);
   }
 }
 
@@ -2416,10 +2428,10 @@ async function listIssueBlockerAttentionMap(
       appendBlockerAttentionEdges(edgesByIssueId, [
         ...unresolvedExplicitBlockerRows
           .filter((row): row is IssueBlockerAttentionQueryRow & { issueId: string } => row.issueId !== null)
-          .map((row) => ({ issueId: row.issueId, blockerIssueId: row.blockerIssueId })),
+          .map((row) => ({ issueId: row.issueId, blockerIssueId: row.blockerIssueId, kind: "blocked_by" as const })),
         ...childRows
           .filter((row): row is IssueBlockerAttentionQueryRow & { issueId: string } => row.issueId !== null)
-          .map((row) => ({ issueId: row.issueId, blockerIssueId: row.blockerIssueId })),
+          .map((row) => ({ issueId: row.issueId, blockerIssueId: row.blockerIssueId, kind: "child" as const })),
       ]);
 
       for (const row of [...unresolvedExplicitBlockerRows, ...childRows]) {
@@ -2781,10 +2793,13 @@ async function listIssueBlockerAttentionMap(
       coveredBlockerCount,
       stalledBlockerCount,
       attentionBlockerCount,
+      dependencyBlockerCount: topLevelEdges.filter((edge) => edge.kind === "blocked_by").length,
+      childBlockerCount: topLevelEdges.filter((edge) => edge.kind === "child").length,
       pendingFinalizeBlockerIssueIds: topLevelEdges
         .map((edge) => edge.blockerIssueId)
         .filter((blockerIssueId) => pendingFinalizeBlockerIssueIds.has(blockerIssueId)),
       sampleBlockerIdentifier: sampleEntry?.result.sampleBlockerIdentifier ?? blockerSampleIdentifier(sampleNode),
+      sampleBlockerEdgeKind: sampleEntry?.edge.kind ?? null,
       sampleStalledBlockerIdentifier:
         stalledEntry?.result.sampleStalledBlockerIdentifier ?? sampleStalledFromChain ?? null,
       blockingTreeLive: topLevelEdges.some((edge) => pathHasLiveWork(edge.blockerIssueId, new Set([root.id]))),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A blocked issue carries a `blockerAttention` summary that says whether the wait is covered, stalled, or needs a human
> - `listIssueBlockerAttentionMap` builds that summary from two kinds of edge: explicit `blocks` relations, and open child issues
> - The API returns only the explicit relations as `blockedBy`, so the child edges are counted but invisible to the caller
> - An operator who compares `blockerAttention` with `blockedBy` sees a contradiction and cannot tell which field to trust
> - This pull request keeps the graph semantics and labels the source of every counted blocker
> - The benefit is that a reader can reconcile the two fields instead of guessing which one is wrong

## Linked Issues or Issue Description

Refs #8251 — that pull request reports the same mismatch and fixes it from the other side: it widens the blocker **summaries** so `blockedBy` also projects active direct-child edges. It has been open since 2026-06-18 with no code change since, and it is `CONFLICTING` against current `master`, so its green checks are stale. This pull request takes the other option and leaves `blockedBy` alone.

Two reasons to prefer labelling over widening, offered for the reviewer rather than as a claim that #8251 is wrong:

- `blockedBy` is the read side of the writable `blockedByIssueIds` field. A caller that reads `blockedBy` and writes the ids back is a normal round trip, and if child-derived entries appear in that read, the round trip silently promotes a parent/child link into an explicit `blocks` relation.
- Callers still cannot tell an explicit dependency from a child wait after the widening, because both arrive in one list. The mismatch goes away, but the distinction that made the counts confusing is still not expressed.

If maintainers prefer #8251's direction, the `kind` labelling here still composes with it: keep `dependencyBlockerCount` / `childBlockerCount` / `sampleBlockerEdgeKind` and drop nothing.

**What happened?**

A blocked issue reported `blockerAttention` counts that do not match its own `blockedBy` list.

```
blockedBy = [ A (done), B (done) ]
blockerAttention = {
  state: "needs_attention",
  unresolvedBlockerCount: 1,
  attentionBlockerCount: 1,
  sampleBlockerIdentifier: "C"
}
```

`C` is not in `blockedBy`. Reading `C` back shows `blocks: []`, so by the relation graph it blocks nothing.

The counts are not wrong. `C` is an open **child** of the blocked issue, and `listIssueBlockerAttentionMap` treats an open child as a wait on purpose — a parent that delegates to children and waits is covered by that path, and a regression test already depends on it. Both explicit blockers were `done`, so the child was the only live edge left, and it became the whole summary.

The problem is that the payload merges the two edge kinds into one count and one sample and never says which kind it used. `blockedBy` exposes only one of the two kinds, so the two fields disagree with no way to reconcile them. A reader can misdiagnose a healthy wait as a zombie, or miss a wait that has really stopped.

**Expected behavior**

`blockerAttention` should keep counting open children, because that wait is real. It should also state where each counted blocker came from, so a caller can line the summary up against `blockedBy` and see that the difference is child edges rather than a corrupt graph.

**Steps to reproduce**

1. Create issue P and move it to `blocked`.
2. Create child issues A and B under P, and add explicit `blocks` relations from A and B to P.
3. Create child issue C under P. Do not give it any `blocks` relation.
4. Move A and B to `done`. Leave C open and assigned, with no active run.
5. Read P. `blockedBy` lists only A and B, both `done`, while `blockerAttention` reports `unresolvedBlockerCount: 1` and samples C.

**Paperclip version or commit**

`master` at e52b8a343.

**Deployment mode**

Local single-instance server with embedded PostgreSQL.

## What Changed

- `IssueBlockerAttentionEdge` carries a `kind` of `blocked_by` or `child`, set where the explicit-blocker rows and the child rows are merged.
- `appendBlockerAttentionEdges` upgrades a duplicate edge to `blocked_by`, so an issue that is both an open child and an explicit dependency reports the edge a caller can also see in `blockedBy`. The upgrade applies on either merge order.
- `IssueBlockerAttention` gains three optional fields: `dependencyBlockerCount`, `childBlockerCount`, and `sampleBlockerEdgeKind`. `dependencyBlockerCount + childBlockerCount` equals the existing `unresolvedBlockerCount`.
- The new `IssueBlockerAttentionEdgeKind` type is exported from `@paperclipai/shared`, and the type carries doc comments that state the two edge kinds and which of them `blockedBy` shows.
- Two regression tests in `issue-blocker-attention.test.ts`: the reported shape reports `childBlockerCount: 1` with `sampleBlockerEdgeKind: "child"`, and a blocker that is both an open child and an explicit dependency reports `blocked_by`.

## Verification

```
pnpm typecheck
pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-blocker-attention.test.ts
```

Both pass. The attention test file is 26 tests, 26 passed, including the two new ones. Root `pnpm typecheck` covers `server`, `ui`, `cli`, and the plugin packages.

## Risks

- Low risk. No state classification changes, so `state`, `reason`, `unresolvedBlockerCount`, `coveredBlockerCount`, `stalledBlockerCount`, and `attentionBlockerCount` keep their current values. The existing 24 attention tests pass unchanged.
- The three new fields are optional, so existing clients that do not read them are unaffected.
- No schema change and no migration.

## Model Used

Claude (Anthropic), `claude-opus-5`, extended thinking enabled, run through the Claude Agent SDK with file editing and shell tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
