### PR TITLE
fix(security): redact sensitive fields in config-read API responses (extracted from #10284)

### DIFF
--- a/packages/mcp-server/src/format.ts
+++ b/packages/mcp-server/src/format.ts
@@ -4,12 +4,50 @@ type McpTextResponse = {
   content: Array<{ type: "text"; text: string }>;
 };
 
+const SENSITIVE_FIELD_NAMES = new Set([
+  "token",
+  "authtoken",
+  "deviceprivatekeypem",
+  "apikey",
+  "secret",
+  "password",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redactSensitiveFields(value: unknown): unknown {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveFields(item));
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (SENSITIVE_FIELD_NAMES.has(key.toLowerCase())) {
+      redacted[key] = "***REDACTED***";
+    } else {
+      redacted[key] = redactSensitiveFields(fieldValue);
+    }
+  }
+  return redacted;
+}
+
 export function formatTextResponse(value: unknown): McpTextResponse {
+  const redacted = redactSensitiveFields(value);
   return {
     content: [
       {
         type: "text",
-        text: typeof value === "string" ? value : JSON.stringify(value, null, 2),
+        text: typeof redacted === "string" ? redacted : JSON.stringify(redacted, null, 2),
       },
     ],
   };

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -397,4 +397,60 @@ describe("paperclip MCP tools", () => {
 
     expect(response.content[0]?.text).toContain("must not contain '..'");
   });
+
+  it("redacts sensitive fields in list agents response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse([
+        {
+          id: "agent-1",
+          name: "Test Agent",
+          token: "secret-token-123",
+          authToken: "auth-secret-456",
+          devicePrivateKeyPem: "-----BEGIN PRIVATE KEY-----...",
+          config: {
+            apiKey: "api-secret-789",
+            publicData: "public-value",
+          },
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipListAgents");
+    const response = await tool.execute({ companyId: "11111111-1111-1111-1111-111111111111" });
+
+    const text = response.content[0]?.text || "";
+    expect(text).toContain("Test Agent");
+    expect(text).toContain("public-value");
+    expect(text).toContain("***REDACTED***");
+    expect(text).not.toContain("secret-token-123");
+    expect(text).not.toContain("auth-secret-456");
+    expect(text).not.toContain("-----BEGIN PRIVATE KEY-----");
+    expect(text).not.toContain("api-secret-789");
+  });
+
+  it("redacts sensitive fields in get agent response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        id: "agent-1",
+        name: "Test Agent",
+        token: "secret-token-xyz",
+        nested: {
+          password: "password-secret",
+          publicInfo: "visible",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipGetAgent");
+    const response = await tool.execute({ agentId: "agent-1" });
+
+    const text = response.content[0]?.text || "";
+    expect(text).toContain("Test Agent");
+    expect(text).toContain("visible");
+    expect(text).toContain("***REDACTED***");
+    expect(text).not.toContain("secret-token-xyz");
+    expect(text).not.toContain("password-secret");
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The MCP server exposes a config-read API surface that returns configuration objects to clients
> - Config objects can contain credential material (`token`, `authToken`, `devicePrivateKeyPem`, `apiKey`, `secret`, `password`) which must never reach the client in plaintext
> - PR #10284 bundled ~5,080 lines of unrelated changes (routines-goals integration, memory-plane-observer, goal/routine validators, contextforge/linear-sync plugins) alongside a genuine security redaction, so Greptile/SNYK failed it and it conflicted
> - This pull request extracts ONLY the redaction as a single-purpose, reviewable change
> - The benefit is that secrets are recursively redacted in the config-read API response path while the larger #10284 feature work can land separately

## Linked Issues or Issue Description

Refs #10284 — the redaction extracted from that bundle. No standalone public issue exists.

**What happened?** The `config-read` API response path could return configuration objects containing credential material (tokens, keys, secrets, passwords) unredacted to the client.

**Expected behavior:** Sensitive fields are recursively redacted (`***REDACTED***`) before the response reaches the client.

**Steps to reproduce:**
1. Issue a config-read request against a configuration containing a `token` or `apiKey` field.
2. Observe the plaintext credential in the response payload.

## What Changed

- Adds `redactSensitiveFields` to `packages/mcp-server/src/format.ts` (`formatTextResponse`), recursively redacting `token`, `authToken`, `devicePrivateKeyPem`, `apiKey`, `secret`, `password` to `***REDACTED***` in the config-read API response path.
- Adds 2 tests asserting redaction across nested structures.
- Scope is deliberately limited to the redaction; the unrelated #10284 feature work is intentionally excluded.

## Verification

- `pnpm -r --filter @paperclipai/mcp-server typecheck` green.
- New tests pass.
- Branch rebased on current `origin/master`; no migration or schema changes.

## Risks

- Security surface: this touches where secrets could leak in API responses — review the field list against the actual config schema before merge.
- This does NOT close #10284; the original bundle remains for the feature work to land separately.

## Model Used

Prepared by Aegis (Hermes Agent, GLM family via Ollama Cloud); rebase and verification via poolside/laguna-s-2.1. Tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge