### PR TITLE
fix: restrict dev tsx loader to repo-local plugins (Windows external plugin workers)

### DIFF
--- a/server/src/__tests__/plugin-tsx-loader-condition.test.ts
+++ b/server/src/__tests__/plugin-tsx-loader-condition.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { isRepoLocalPluginPath, REPO_ROOT } from "../services/plugin-loader.js";
+
+describe("isRepoLocalPluginPath", () => {
+  it("returns true for a package inside the repository", () => {
+    const pkgPath = path.join(REPO_ROOT, "packages", "plugins", "examples", "plugin-hello-world-example");
+    expect(isRepoLocalPluginPath(pkgPath)).toBe(true);
+  });
+
+  it("returns true when the package path equals the repository root", () => {
+    expect(isRepoLocalPluginPath(REPO_ROOT)).toBe(true);
+  });
+
+  it("returns false for a package outside the repository", () => {
+    const outside = path.join(REPO_ROOT, "..", "external-plugin");
+    expect(isRepoLocalPluginPath(outside)).toBe(false);
+  });
+
+  it("returns false for a sibling directory that merely shares the repo name prefix", () => {
+    const sibling = path.join(path.dirname(REPO_ROOT), path.basename(REPO_ROOT) + "-external");
+    expect(isRepoLocalPluginPath(sibling)).toBe(false);
+  });
+
+  it("returns false for null and undefined", () => {
+    expect(isRepoLocalPluginPath(null)).toBe(false);
+    expect(isRepoLocalPluginPath(undefined)).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isRepoLocalPluginPath("")).toBe(false);
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -703,6 +703,19 @@ function isPathWithin(root: string, target: string): boolean {
   return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
+/**
+ * True when a plugin package path is inside this repository.
+ *
+ * The dev tsx loader is only applied to repo-local packages, because
+ * external plugins ship prebuilt JS and tsx's `--import` loader crashes
+ * on Windows when the worker entry is an absolute drive-letter path
+ * (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol 'e:').
+ */
+export function isRepoLocalPluginPath(packagePath: string | null | undefined): boolean {
+  if (!packagePath) return false;
+  return isPathWithin(REPO_ROOT, path.resolve(packagePath));
+}
+
 export function isRepoBundledPluginPath(
   packageRoot: string,
   options: { repoRoot?: string } = {},
@@ -2295,18 +2308,16 @@ export function pluginLoader(
       // entry as a raw drive-letter path (e.g. `E:\plugins\dist\worker.js`)
       // and fails with ERR_UNSUPPORTED_ESM_URL_SCHEME (protocol 'e:').
       // External plugins ship prebuilt JS and do not need the tsx loader.
-      const PLUGIN_REPO_ROOT = path.resolve(__dirname, "../../..");
       const resolvedPkgPath = activePlugin.packagePath
         ? path.resolve(activePlugin.packagePath)
         : null;
-      const isRepoLocalPlugin =
+      if (
         resolvedPkgPath !== null &&
-        (resolvedPkgPath === PLUGIN_REPO_ROOT ||
-          resolvedPkgPath.startsWith(PLUGIN_REPO_ROOT + path.sep));
-      if (isRepoLocalPlugin && existsSync(DEV_TSX_LOADER_PATH)) {
+        isRepoLocalPluginPath(resolvedPkgPath) &&
+        existsSync(DEV_TSX_LOADER_PATH)
+      ) {
         workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];
       }
-
       await workerManager.startWorker(pluginId, workerOptions);
       registered.worker = true;
 

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -2287,10 +2287,23 @@ export function pluginLoader(
         proactiveCompanyScopes: configRows.map((row) => row.companyId),
       };
 
-      // Repo-local plugin installs can resolve workspace TS sources at runtime
-      // (for example @paperclipai/shared exports). Run those workers through
-      // the tsx loader so first-party example plugins work in development.
-      if (activePlugin.packagePath && existsSync(DEV_TSX_LOADER_PATH)) {
+      // The tsx loader is only needed for repo-local packages that may
+      // import workspace TypeScript sources (e.g. @paperclipai/shared)
+      // at runtime. Restricting it to packages inside this repo also fixes
+      // a Windows crash for external local-path plugin installs: with
+      // `--import <tsx-loader>`, Node's ESM loader receives the worker
+      // entry as a raw drive-letter path (e.g. `E:\plugins\dist\worker.js`)
+      // and fails with ERR_UNSUPPORTED_ESM_URL_SCHEME (protocol 'e:').
+      // External plugins ship prebuilt JS and do not need the tsx loader.
+      const PLUGIN_REPO_ROOT = path.resolve(__dirname, "../../..");
+      const resolvedPkgPath = activePlugin.packagePath
+        ? path.resolve(activePlugin.packagePath)
+        : null;
+      const isRepoLocalPlugin =
+        resolvedPkgPath !== null &&
+        (resolvedPkgPath === PLUGIN_REPO_ROOT ||
+          resolvedPkgPath.startsWith(PLUGIN_REPO_ROOT + path.sep));
+      if (isRepoLocalPlugin && existsSync(DEV_TSX_LOADER_PATH)) {
         workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - It orchestrates agents through a control plane: server, React UI, and an extensible plugin system
> - Plugins declare a worker entrypoint; the server spawns it via child_process.fork
> - In development, the server adds `--import <tsx-loader>` so repo-local example plugins can resolve workspace TypeScript sources at runtime
> - The current condition adds the tsx loader whenever a plugin has a packagePath, including external local-path installs
> - On Windows, running the worker with `--import` routes the main entry through Node's ESM loader, which receives the absolute drive-letter path (`E:\...`) as a raw specifier and fails with `ERR_UNSUPPORTED_ESM_URL_SCHEME (protocol 'e:')`
> - This makes every external local-path plugin unusable on Windows in dev mode
> - This pull request restricts the tsx loader to packages that live inside this repository
> - The benefit is that external plugins (which ship prebuilt JS) start on Windows, while repo-local example plugins keep working

## What happened?

External local-path plugin workers crash on Windows in dev mode. Installing a plugin from a local path outside this repository (for example `paperclipai plugin install E:/some-plugin`) leaves the plugin in `error` status. The worker process exits immediately with:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'e:'
```

The root cause is in `plugin-loader.ts`: it adds `execArgv = ["--import", DEV_TSX_LOADER_PATH]` whenever `activePlugin.packagePath` is set. With `--import`, Node routes the main entry through the ESM loader, which receives the raw Windows drive-letter path (protocol `e:`) and throws. The tsx loader is only needed for repo-local packages that import workspace TypeScript sources.

## Expected behavior

External local-path plugins (which ship prebuilt JS) should activate successfully on Windows in dev mode, without the tsx loader. Repo-local example plugins should keep running through the tsx loader exactly as before.

## Steps to reproduce

1. On Windows, run the Paperclip dev server (`pnpm dev:once`)
2. Install any plugin from a local path outside this repository (e.g. `paperclipai plugin install E:/some-plugin`)
3. Observe the plugin status is `error` with `ERR_UNSUPPORTED_ESM_URL_SCHEME` in the worker stderr

## Paperclip version or commit

`cd50149` (master, 2026-08-15)

## Deployment mode

- Local dev (pnpm dev)

## Installation method

- Built from source (pnpm dev / pnpm build)

## What Changed

- Restrict the dev tsx loader to packages whose resolved path is inside this repository (new exported helper `isRepoLocalPluginPath`, reusing the existing `isPathWithin` / `REPO_ROOT`)
- External local-path plugins (prebuilt JS) now spawn with a plain `node` fork and start correctly on Windows
- Repo-local example plugins keep the tsx loader and their workspace-source behavior is unchanged
- Add unit tests for `isRepoLocalPluginPath` covering in-repo, out-of-repo, repo-root, sibling-prefix, and empty/null cases

## Verification

- New unit tests: `pnpm vitest run server/src/__tests__/plugin-tsx-loader-condition.test.ts` (6 tests, all pass)
- Windows dev server: install an external plugin from a local path → status becomes `ready`, UI bundle serves at `/_plugins/:id/ui/index.js`
- Repo-local example plugin (e.g. `packages/plugins/examples/plugin-hello-world-example`) still loads its worker through the tsx loader
- Linux/macOS behavior is unchanged (the condition is narrower, never wider)

## Risks

- Low risk. The change only narrows an existing condition: the tsx loader now applies to repo-local packages only. No behavior change for npm-installed plugins (no packagePath) or repo-local plugins.
- `isRepoLocalPluginPath` is derived from `REPO_ROOT` (`server/src/services` → repo root); if the server is ever moved out of this layout, the boundary check would need updating. A comment documents the assumption.

## Model Used

- Provider: DeepSeek
- Model: deepseek-v4-flash (used via the DeepSeek Harness coding environment)
- Capabilities: code generation, tool use, file editing; no image input
- The change was authored with AI assistance and verified end-to-end on a Windows dev instance before opening this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
