### PR TITLE
SCR-168: guard routine/trigger lookups against non-UUID ids

### DIFF
--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -358,6 +358,38 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
     );
   }, 15_000);
 
+  it("returns 404 for routine and trigger endpoints with non-UUID ids instead of crashing the uuid query", async () => {
+    const { companyId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const malformedId = "1188e836";
+
+    const patchRes = await request(app)
+      .patch(`/api/routines/${malformedId}`)
+      .send({ title: "SCR-131 finalize clone (delta pass + bootloader + verify)" });
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(404);
+    expect(patchRes.body.error).toBe("Routine not found");
+
+    const getRes = await request(app).get(`/api/routines/${malformedId}`);
+    expect(getRes.status).toBe(404);
+    expect(getRes.body.error).toBe("Routine not found");
+
+    const revisionsRes = await request(app).get(`/api/routines/${malformedId}/revisions`);
+    expect(revisionsRes.status).toBe(404);
+
+    const triggerPatchRes = await request(app)
+      .patch(`/api/routine-triggers/${malformedId}`)
+      .send({ enabled: true });
+    expect(triggerPatchRes.status, JSON.stringify(triggerPatchRes.body)).toBe(404);
+    expect(triggerPatchRes.body.error).toBe("Routine trigger not found");
+  }, 15_000);
+
   it("runs routines with variable inputs and interpolates the execution issue description", async () => {
     const { companyId, agentId, projectId, userId } = await seedFixture();
     const app = await createApp({

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -272,6 +272,14 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(allRoutines.map((entry) => entry.id)).toEqual(expect.arrayContaining([routine.id, otherRoutine.id]));
   });
 
+  it("returns null for routine and trigger lookups with non-UUID ids instead of crashing the uuid query", async () => {
+    const { svc } = await seedFixture();
+
+    await expect(svc.get("1188e836")).resolves.toBeNull();
+    await expect(svc.getDetail("1188e836")).resolves.toBeNull();
+    await expect(svc.getTrigger("1188e836")).resolves.toBeNull();
+  });
+
   it("does not reveal folders owned by another company", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const otherCompanyId = randomUUID();

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -49,6 +49,7 @@ import {
   getBuiltinRoutineVariableValues,
   extractRoutineVariableNames,
   interpolateRoutineTemplate,
+  isUuidLike,
   isValidRoutineDateString,
   normalizeAgentUrlKey,
   pluginOperationIssueOriginKind,
@@ -638,10 +639,12 @@ export function routineService(
   });
 
   async function getRoutineById(id: string) {
+    const normalizedId = id.trim();
+    if (!isUuidLike(normalizedId)) return null;
     return db
       .select()
       .from(routines)
-      .where(eq(routines.id, id))
+      .where(eq(routines.id, normalizedId))
       .then((rows) => rows[0] ?? null);
   }
 
@@ -722,10 +725,12 @@ export function routineService(
   }
 
   async function getTriggerById(id: string) {
+    const normalizedId = id.trim();
+    if (!isUuidLike(normalizedId)) return null;
     return db
       .select()
       .from(routineTriggers)
-      .where(eq(routineTriggers.id, id))
+      .where(eq(routineTriggers.id, normalizedId))
       .then((rows) => rows[0] ?? null);
   }
 


### PR DESCRIPTION
## Summary

`getRoutineById` and `getTriggerById` ran an `eq()` against a uuid column with arbitrary input, so a malformed id like `1188e836` crashed the Postgres uuid cast and turned `PATCH /api/routines/{id}` into an HTTP 500.

This trims and validates the id with `isUuidLike` before querying, returning null for non-UUID ids so the route 404s (Routine not found / Routine trigger not found) instead of crashing.

## Root cause

Original SCR-168: `PATCH /api/routines/1188e836` (short, non-UUID id) returned HTTP 500 while full-UUID ids worked. The uuid column comparison in Postgres throws when the input is not a valid uuid, and the service had no guard.

## Changes

- `server/src/services/routines.ts`: guard `getRoutineById` and `getTriggerById` with `isUuidLike` + trim.
- `server/src/__tests__/routines-service.test.ts`: service-level regression test asserting null lookups.
- `server/src/__tests__/routines-e2e.test.ts`: route-level regression test asserting 404 responses for routine and trigger endpoints with non-UUID ids.

## Verification

- `vitest run src/__tests__/routines-service.test.ts` — 57 passed
- `vitest run src/__tests__/routines-e2e.test.ts` — 5 passed
- `tsc --noEmit` in server — clean
