### PR TITLE
fix(ui): keep the stored company when the company request fails

### DIFF
--- a/ui/src/context/CompanyContext.test.tsx
+++ b/ui/src/context/CompanyContext.test.tsx
@@ -137,6 +137,7 @@ describe("shouldClearStoredCompanySelection", () => {
       companies: [],
       isLoading: false,
       unauthorized: true,
+      errored: false,
     })).toBe(false);
   });
 
@@ -145,7 +146,22 @@ describe("shouldClearStoredCompanySelection", () => {
       companies: [],
       isLoading: false,
       unauthorized: false,
+      errored: false,
     })).toBe(true);
+  });
+
+  it("does not clear the stored company selection when the request failed", () => {
+    // `companiesListQueryOptions` sets `retry: false`, and a failure before any
+    // success leaves `data` undefined — which the provider defaults to an empty
+    // list. That is indistinguishable from "asked, and owns nothing", so
+    // without this a single failed request on a cold load would drop the
+    // customer's stored company.
+    expect(shouldClearStoredCompanySelection({
+      companies: [],
+      isLoading: false,
+      unauthorized: false,
+      errored: true,
+    })).toBe(false);
   });
 });
 
@@ -174,6 +190,30 @@ describe("CompanyProvider", () => {
     queryClient.clear();
     container.remove();
     vi.clearAllMocks();
+  });
+
+  it("keeps the stored company when the company request fails", async () => {
+    // The seam the predicate test above cannot reach: the provider defaults a
+    // failed request to an empty list, so the effect has to be told the
+    // request errored or it reads that as "asked, and owns nothing" and clears
+    // the customer's stored company.
+    localStorage.setItem("paperclip.selectedCompanyId", "company-a");
+    mockCompaniesApi.list.mockRejectedValue(new Error("companies unavailable"));
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CompanyProvider>
+            <Probe onSelectedCompanyId={() => {}} />
+          </CompanyProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(localStorage.getItem("paperclip.selectedCompanyId")).toBe("company-a");
   });
 
   it("does not expose a stale stored company id before companies load", async () => {

--- a/ui/src/context/CompanyContext.tsx
+++ b/ui/src/context/CompanyContext.tsx
@@ -67,7 +67,24 @@ export function shouldClearStoredCompanySelection(input: {
   companies: Array<Pick<Company, "id">>;
   isLoading: boolean;
   unauthorized: boolean;
+  /**
+   * Whether the company request failed. An error is not an answer, and this
+   * branch is destructive.
+   *
+   * `companiesListQueryOptions` sets `retry: false`, and a request that fails
+   * before ever succeeding leaves `data` undefined - which the provider
+   * defaults to `{ companies: [], unauthorized: false }`. That is
+   * indistinguishable from "this account was asked, and owns nothing", so a
+   * single failed request on a cold load would clear the customer's stored
+   * company and drop them onto whichever company sorts first next time.
+   *
+   * Not clearing costs nothing: a stored id that no longer resolves is
+   * ignored by {@link resolveBootstrapCompanySelection}, which checks it
+   * against the current list before using it.
+   */
+  errored: boolean;
 }) {
+  if (input.errored) return false;
   return !input.isLoading && !input.unauthorized && input.companies.length === 0;
 }
 
@@ -89,7 +106,12 @@ export function CompanyProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (isLoading) return;
     if (companies.length === 0) {
-      if (shouldClearStoredCompanySelection({ companies, isLoading: false, unauthorized: companyListUnauthorized })) {
+      if (shouldClearStoredCompanySelection({
+        companies,
+        isLoading: false,
+        unauthorized: companyListUnauthorized,
+        errored: error !== null,
+      })) {
         if (selectedCompanyId !== null) {
           setSelectedCompanyIdState(null);
         }
@@ -108,7 +130,7 @@ export function CompanyProvider({ children }: { children: ReactNode }) {
     setSelectedCompanyIdState(next);
     setSelectionSource("bootstrap");
     localStorage.setItem(STORAGE_KEY, next);
-  }, [companies, companyListUnauthorized, isLoading, selectedCompanyId, sidebarCompanies]);
+  }, [companies, companyListUnauthorized, error, isLoading, selectedCompanyId, sidebarCompanies]);
 
   const setSelectedCompanyId = useCallback((companyId: string, options?: CompanySelectionOptions) => {
     setSelectedCompanyIdState(companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A person can belong to several companies, so the app remembers which one they last had selected
> - That memory lives in `localStorage`, and `CompanyProvider` clears it when the account turns out to own no companies
> - But the company query sets `retry: false`, and a request that fails before ever succeeding leaves no data — which the provider defaults to an empty list
> - So a failed request is indistinguishable from a successful "you own nothing", and the destructive branch runs on it
> - This pull request tells that check whether the request failed, and refuses to clear when it did
> - The benefit is that a transient network failure no longer costs the customer their company selection

## Linked Issues or Issue Description

No public issue exists. The problem follows.

**What happened?**

`CompanyProvider` reads the company list with `companiesListQueryOptions`, which sets `retry: false`. On a failure before any success, `data` is undefined and the provider defaults it to `{ companies: [], unauthorized: false }`.

`shouldClearStoredCompanySelection` then sees a settled, authorized, empty list and returns true, so the effect calls `localStorage.removeItem`. The stored company is gone. `main.tsx` sets `refetchOnWindowFocus: true`, so a blip while the window regains focus during a cold load is enough.

**Expected behavior**

A failed company request leaves the stored selection alone. Only a successful, authorized, genuinely empty list clears it.

**Steps to reproduce**

1. Sign in and select a company other than the first alphabetically.
2. Reload with the company list request failing once (offline, or a 500).
3. `paperclip.selectedCompanyId` is removed. The next successful load selects whichever company sorts first.

**Paperclip version or commit**

`master` at `0023c5c4a`.

**Related pull requests**

Same failure family as #11382 and #11380: a request that could not answer being read as an answer. Those two closed it for the onboarding draft gate and for sign-out.

## What Changed

- `ui/src/context/CompanyContext.tsx` — `shouldClearStoredCompanySelection` takes `errored` and refuses to clear on it; the provider passes `error !== null`.
- `ui/src/context/CompanyContext.test.tsx` — one predicate case, one provider case, and the two existing predicate cases updated.

`errored` is required rather than optional on purpose. The compiler then made both existing call sites state their answer, rather than inheriting a default that happens to preserve today's behaviour.

### Scope, and a correction

I had described this file as carrying the same defect as the onboarding draft gate and the sign-out sweep. Re-reading it before changing anything, that was overstated.

Those two *trusted* a stale list to answer an authorization question — "does this account own this company?" — and a wrong answer handed one account's data to another. This file does not. `resolveBootstrapCompanySelection` checks both the stored id and the current selection for membership in the list it was given, so a stale list here produces a selection that self-corrects on the next resolve rather than a leak.

The failed-request branch is the part that is genuinely wrong, and it is the only part this changes. The transient re-decision during a background refetch is real but self-correcting, and gating on `isFetching` to suppress it would add churn for no behavioural gain, so it is deliberately left alone.

## Verification

- `ui` typecheck is clean.
- Full `ui` suite: **4016 pass**.

Tested at both levels, because the predicate alone would not have caught this. The provider is what defaults a failed request to an empty list, so the wiring is where the decision actually goes wrong — the same seam every defect in this area has lived in.

Fault-injected: removing `if (input.errored) return false;` fails both the predicate case and the provider case.

One failure remains, in `IssueProperties.test.tsx`. It is timezone-dependent, reproduces on `master`, and is in a file this change does not touch.

## Risks

Low, and in the safe direction. The change only ever *declines* to delete.

The cost of not clearing is a stored id that no longer resolves, which `resolveBootstrapCompanySelection` already ignores by checking it against the current list. The cost of clearing wrongly is the customer's selection, which cannot be recovered.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
