### PR TITLE
test(ui): make the suite independent of the machine timezone

### DIFF
--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2343,7 +2343,11 @@ describe("IssueProperties", () => {
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
-    expect(monitorRowText()).toContain("Today, 4:08 PM · Attempt 1");
+    // The hour is rendered in the machine's timezone, so it is not pinned here:
+    // this instant is 4:08 PM at UTC and 9:08 AM at UTC-7. What the row states
+    // are actually about — the countdown and the attempt suffix — is asserted
+    // exactly, and the countdown above is timezone-independent already.
+    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · Attempt 1/);
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T18:08:00.000Z" } }),
@@ -2352,7 +2356,7 @@ describe("IssueProperties", () => {
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
-    expect(monitorRowText()).toContain("Today, 4:08 PM");
+    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM)/);
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, serviceName: "vercel-deploy" } }),
@@ -2376,7 +2380,7 @@ describe("IssueProperties", () => {
     }));
     await flush();
     expect(monitorRowText()).toContain("Overdue by 18m");
-    expect(monitorRowText()).toContain("Today, 1:38 PM · fires on next tick");
+    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · fires on next tick/);
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy(),

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2312,10 +2312,21 @@ describe("IssueProperties", () => {
   });
 
   it("renders scheduled, retrying, due, overdue, cleared, and empty monitor row states", async () => {
-    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-17T13:56:00.000Z").getTime());
+    // Anchored to a fixed *local* time, not a fixed UTC instant. The row renders
+    // these in the machine's timezone and labels them "Today" only while they
+    // share a local calendar day with `now`. Pinned to UTC, the pair straddles
+    // local midnight from UTC+8 to UTC+9:30 — the label becomes a date and every
+    // assertion below fails for a reason that has nothing to do with row states.
+    // Anchoring locally keeps them on one day everywhere, which also makes the
+    // rendered clock identical in every timezone, so the times below can stay
+    // exact rather than being relaxed to a pattern.
+    const NOW = new Date(2026, 6, 17, 13, 56, 0, 0);
+    const at = (minutesFromNow: number) =>
+      new Date(NOW.getTime() + minutesFromNow * 60_000).toISOString();
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(NOW.getTime());
     const baseMonitorState = {
       status: "scheduled" as const,
-      nextCheckAt: "2026-07-17T16:08:00.000Z",
+      nextCheckAt: at(132),
       lastTriggeredAt: null,
       attemptCount: 1,
       notes: "Verify deployment",
@@ -2347,16 +2358,16 @@ describe("IssueProperties", () => {
     // this instant is 4:08 PM at UTC and 9:08 AM at UTC-7. What the row states
     // are actually about — the countdown and the attempt suffix — is asserted
     // exactly, and the countdown above is timezone-independent already.
-    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · Attempt 1/);
+    expect(monitorRowText()).toContain("Today, 4:08 PM · Attempt 1");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T18:08:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T16:08:00.000Z" } }),
-      monitorNextCheckAt: new Date("2026-07-17T17:08:00.000Z"),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: at(252) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: at(132) } }),
+      monitorNextCheckAt: new Date(at(192)),
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
-    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM)/);
+    expect(monitorRowText()).toContain("Today, 4:08 PM");
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, serviceName: "vercel-deploy" } }),
@@ -2367,20 +2378,20 @@ describe("IssueProperties", () => {
     expect(monitorRowText()).toContain("Attempt 3");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:56:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:56:00.000Z" } }),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: at(0) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: at(0) } }),
     }));
     await flush();
     expect(monitorRowText()).toContain("Due now");
     expect(monitorRowText()).toContain("checking momentarily…");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:38:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:38:00.000Z" } }),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: at(-18) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: at(-18) } }),
     }));
     await flush();
     expect(monitorRowText()).toContain("Overdue by 18m");
-    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · fires on next tick/);
+    expect(monitorRowText()).toContain("Today, 1:38 PM · fires on next tick");
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy(),
@@ -2388,13 +2399,13 @@ describe("IssueProperties", () => {
         ...baseMonitorState,
         status: "cleared",
         nextCheckAt: null,
-        lastTriggeredAt: "2026-07-17T11:56:00.000Z",
+        lastTriggeredAt: at(-120),
         attemptCount: 2,
-        clearedAt: "2026-07-17T12:00:00.000Z",
+        clearedAt: at(-116),
         clearReason: "manual",
       } }),
       monitorAttemptCount: 2,
-      monitorLastTriggeredAt: new Date("2026-07-17T11:56:00.000Z"),
+      monitorLastTriggeredAt: new Date(at(-120)),
     }));
     await flush();
     expect(monitorRowText()).toContain("Cleared");

--- a/ui/src/components/SummarySlotCard.test.tsx
+++ b/ui/src/components/SummarySlotCard.test.tsx
@@ -409,22 +409,28 @@ describe("SummarySlotCard", () => {
   });
 
   it("switches to a historical revision from a dated dropdown", async () => {
+    // Local, not UTC: the dropdown renders these dates in the machine's
+    // timezone, so `2026-07-14T17:10:00.000Z` is the 15th at UTC+9 and the
+    // "Jul 14" assertions below fail. Midday local keeps each revision on its
+    // intended calendar day everywhere.
+    const localAt = (day: number, hour: number) =>
+      new Date(2026, 6, day, hour, 0, 0, 0).toISOString();
     mockSummarySlotsApi.get.mockResolvedValue({
       slot: slot({ documentId: "doc-1" }),
       document: summaryDocument({
         body: "## Latest\nCurrent body",
         latestRevisionId: "rev-3",
         latestRevisionNumber: 3,
-        updatedAt: "2026-07-14T17:10:00.000Z",
+        updatedAt: localAt(14, 17),
       }),
       generatingIssue: null,
     } satisfies GetSummarySlotResponse);
     mockSummarySlotsApi.revisions.mockResolvedValue({
       slot: slot({ documentId: "doc-1" }),
       revisions: [
-        revision({ id: "rev-1", revisionNumber: 1, body: "## Old\nOld body", createdAt: "2026-07-13T17:10:00.000Z" }),
-        revision({ id: "rev-2", revisionNumber: 2, body: "## Middle\nMiddle body", createdAt: "2026-07-14T09:15:00.000Z" }),
-        revision({ id: "rev-3", revisionNumber: 3, body: "## Latest\nCurrent body", createdAt: "2026-07-14T17:10:00.000Z" }),
+        revision({ id: "rev-1", revisionNumber: 1, body: "## Old\nOld body", createdAt: localAt(13, 17) }),
+        revision({ id: "rev-2", revisionNumber: 2, body: "## Middle\nMiddle body", createdAt: localAt(14, 9) }),
+        revision({ id: "rev-3", revisionNumber: 3, body: "## Latest\nCurrent body", createdAt: localAt(14, 17) }),
       ],
     });
 

--- a/ui/src/components/artifacts/ArtifactCard.test.tsx
+++ b/ui/src/components/artifacts/ArtifactCard.test.tsx
@@ -40,7 +40,9 @@ function makeArtifact(overrides: Partial<CompanyArtifact> = {}): CompanyArtifact
     issue: { id: "issue-1", identifier: "PAP-10306", title: "Landing visuals" },
     project: { id: "proj-1", name: "Paperclip App" },
     createdByAgent: { id: "agent-1", name: "ClaudeCoder" },
-    updatedAt: "2026-06-01T12:00:00.000Z",
+    // Local, not UTC: the card renders "Last edited" from the local calendar
+    // day, and noon UTC is already the 2nd at UTC+14.
+    updatedAt: new Date(2026, 5, 1, 12, 0, 0, 0).toISOString(),
     href: "/issues/PAP-10306#attachment-art-1",
     ...overrides,
   };
@@ -69,7 +71,7 @@ describe("ArtifactCard", () => {
         artifact={makeArtifact({
           title: "Social launch clip",
           issue: { id: "issue-2", identifier: "PAP-10370", title: "Make artifact page look like this" },
-          updatedAt: "2025-10-08T12:00:00.000Z",
+          updatedAt: new Date(2025, 9, 8, 12, 0, 0, 0).toISOString(),
           createdByAgent: null,
         })}
       />,

--- a/ui/src/fixtures/issueThreadInteractionFixtures.ts
+++ b/ui/src/fixtures/issueThreadInteractionFixtures.ts
@@ -912,8 +912,11 @@ export const issueClosedRequestConfirmationInteraction =
     id: "interaction-confirmation-issue-closed",
     title: "Expired: confirm the migration cutover",
     status: "expired",
-    resolvedAt: new Date("2026-04-20T15:12:00.000Z"),
-    updatedAt: new Date("2026-04-20T15:12:00.000Z"),
+    // Local, not UTC. The expiry footer renders this in the machine's timezone,
+    // and 15:12Z on the 20th is already the 21st at UTC+9, which breaks the
+    // "Apr 20" assertion in IssueThreadInteractionCard.test.tsx.
+    resolvedAt: new Date(2026, 3, 20, 15, 12, 0, 0),
+    updatedAt: new Date(2026, 3, 20, 15, 12, 0, 0),
     result: {
       version: 1,
       outcome: "issue_closed",

--- a/ui/src/lib/attention.test.ts
+++ b/ui/src/lib/attention.test.ts
@@ -430,14 +430,22 @@ describe("sortAttentionItems", () => {
   });
 });
 
+// `attentionDateBucket` walks back from the start of the *local* day
+// (`setHours(0, 0, 0, 0)`), so every date fixture below is local too. Pinned to
+// UTC instants they drift across the boundary under test: `2026-07-09T23:00:00Z`
+// is 08:00 on the 10th at UTC+9 and buckets as "today", and at UTC+14 and UTC-11
+// even the mid-morning fixtures land on the wrong calendar day.
+const localTime = (month: number, day: number, hour: number) =>
+  new Date(2026, month - 1, day, hour, 0, 0, 0);
+
 describe("attentionDateBucket", () => {
-  const now = new Date("2026-07-10T12:00:00Z").getTime();
+  const now = localTime(7, 10, 12).getTime();
 
   it("buckets by rolling calendar-day windows relative to now", () => {
-    expect(attentionDateBucket("2026-07-10T09:00:00Z", now)).toBe("today");
-    expect(attentionDateBucket("2026-07-09T23:00:00Z", now)).toBe("yesterday");
-    expect(attentionDateBucket("2026-07-06T09:00:00Z", now)).toBe("this_week");
-    expect(attentionDateBucket("2026-06-01T09:00:00Z", now)).toBe("earlier");
+    expect(attentionDateBucket(localTime(7, 10, 9).toISOString(), now)).toBe("today");
+    expect(attentionDateBucket(localTime(7, 9, 23).toISOString(), now)).toBe("yesterday");
+    expect(attentionDateBucket(localTime(7, 6, 9).toISOString(), now)).toBe("this_week");
+    expect(attentionDateBucket(localTime(6, 1, 9).toISOString(), now)).toBe("earlier");
   });
 
   it("treats invalid timestamps as earlier", () => {
@@ -446,7 +454,7 @@ describe("attentionDateBucket", () => {
 });
 
 describe("groupAttentionItems", () => {
-  const now = new Date("2026-07-10T12:00:00Z").getTime();
+  const now = localTime(7, 10, 12).getTime();
 
   it("leaves None as one unlabeled group that preserves caller sort order", () => {
     const items = sortAttentionItems(
@@ -464,9 +472,9 @@ describe("groupAttentionItems", () => {
 
   it("groups by date into fixed Today/Yesterday/This week/Earlier order", () => {
     const items = [
-      buildItem({ id: "earlier", activityAt: "2026-06-01T00:00:00Z" }),
-      buildItem({ id: "today", activityAt: "2026-07-10T08:00:00Z" }),
-      buildItem({ id: "yesterday", activityAt: "2026-07-09T08:00:00Z" }),
+      buildItem({ id: "earlier", activityAt: localTime(6, 1, 9).toISOString() }),
+      buildItem({ id: "today", activityAt: localTime(7, 10, 8).toISOString() }),
+      buildItem({ id: "yesterday", activityAt: localTime(7, 9, 8).toISOString() }),
     ];
     const groups = groupAttentionItems(items, "date", { now });
     expect(groups.map((g) => g.label)).toEqual(["Today", "Yesterday", "Earlier"]);
@@ -508,8 +516,8 @@ describe("groupAttentionItems", () => {
   it("preserves the caller-provided intra-group order (sort governs within a bucket)", () => {
     const items = sortAttentionItems(
       [
-        buildItem({ id: "t1", activityAt: "2026-07-10T08:00:00Z" }),
-        buildItem({ id: "t2", activityAt: "2026-07-10T10:00:00Z" }),
+        buildItem({ id: "t1", activityAt: localTime(7, 10, 8).toISOString() }),
+        buildItem({ id: "t2", activityAt: localTime(7, 10, 10).toISOString() }),
       ],
       "newest",
     );

--- a/ui/src/pages/StatusCards/format.test.ts
+++ b/ui/src/pages/StatusCards/format.test.ts
@@ -22,7 +22,7 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
     model: null,
     queryVersion: 1,
     changeSummary: null,
-    startedAt: new Date().toISOString(),
+    startedAt: NOW.toISOString(),
     finishedAt: null,
     status: "ok",
     error: null,
@@ -30,18 +30,25 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
   };
 }
 
-// A fixed instant rather than the real clock. `rollupUpdatesToday` filters on
-// the *UTC* day boundary, so a suite that builds its fixtures from `new Date()`
-// fails in two ways: it straddles midnight UTC if the run happens to cross it,
-// and in any zone east of UTC+12 "today at local noon" is already yesterday in
-// UTC, so the rows it means to count are filtered out. The function takes `now`
-// for exactly this reason — the sibling test below already passes one.
+// A fixed instant rather than the real clock, so these fixtures mean the same
+// thing on every machine and at every hour. `rollupUpdatesToday` filters on the
+// *UTC* day boundary, and building from `new Date()` fails against that in two
+// separate ways — see `iso` below. The function takes `now` for exactly this
+// reason, and the sibling test at the bottom of this file already passes one.
 const NOW = new Date("2026-07-23T12:00:00.000Z");
 
 function iso(daysAgo: number): string {
   const d = new Date(NOW);
   d.setUTCDate(d.getUTCDate() - daysAgo);
   // Noon UTC, so a row is unambiguously inside the UTC day it belongs to.
+  //
+  // Built on the *local* day instead, `iso(0)` misses in both directions. West
+  // of UTC it lands in the previous UTC day for the stretch between UTC
+  // midnight and local midnight — about seven hours a day at UTC-7 — and east
+  // of UTC+12 "today at local noon" is already yesterday in UTC outright.
+  // Either way today's rows drop out of a filter that means to count them. A
+  // run crossing midnight UTC splits the same way, with `iso(0)` and the
+  // function's default `now` landing on different days.
   d.setUTCHours(12, 0, 0, 0);
   return d.toISOString();
 }

--- a/ui/src/pages/agent-skills/AgentSkillReleasePicker.test.ts
+++ b/ui/src/pages/agent-skills/AgentSkillReleasePicker.test.ts
@@ -31,8 +31,12 @@ describe("formatReleaseDate", () => {
   });
 
   it("collapses a full timestamp to its calendar day", () => {
-    // Anchored to noon UTC so it stays on the 15th regardless of local offset.
-    expect(formatReleaseDate("2026-07-15T12:00:00Z" as never)).toBe("2026-07-15");
+    // Anchored to local noon. `formatReleaseDate` reads the *local* calendar
+    // fields (getFullYear/getMonth/getDate), so a UTC anchor does not hold the
+    // day regardless of offset as it once claimed here — noon UTC is 02:00 on
+    // the 16th at UTC+14, and the assertion failed there.
+    const localNoon = new Date(2026, 6, 15, 12, 0, 0, 0);
+    expect(formatReleaseDate(localNoon.toISOString() as never)).toBe("2026-07-15");
   });
 
   it("returns null for missing or unparseable input", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Contributors change the UI and run the `ui` vitest suite to check they have not broken anything
> - That signal only works if a failure means the change was wrong, and two tests failed on the machine's timezone instead
> - CI sets `TZ=UTC`, so the project never saw them, while anyone developing outside UTC met a red suite on their first run
> - A red suite that has nothing to do with your change costs time to dismiss and trains people to ignore failures
> - This pull request removes the timezone assumption from every test that carried one
> - The benefit is that a failing `ui` suite means something again, wherever it is run

## Linked Issues or Issue Description

Fixes: #11476

## What Changed

Seven files, one rule: **anchor each fixture to the clock the code under test actually reads.**

| File | Code under test reads | Fixture now |
| --- | --- | --- |
| `components/IssueProperties.test.tsx` | local (renders + labels "Today") | local |
| `pages/StatusCards/format.test.ts` | UTC day (`setUTCHours`) | UTC, with an explicit `now` |
| `lib/attention.test.ts` | local day (`setHours`) | local |
| `components/SummarySlotCard.test.tsx` | local (dated dropdown) | local |
| `fixtures/issueThreadInteractionFixtures.ts` | local (expiry footer) | local |
| `pages/agent-skills/AgentSkillReleasePicker.test.ts` | local (`getFullYear`/`getMonth`/`getDate`) | local |
| `components/artifacts/ArtifactCard.test.tsx` | local ("Last edited") | local |

`format.test.ts` is the only one anchored to UTC, because it is the only one whose code deliberately works on the UTC day — that boundary matches the server-side daily token cap.

### The two failed for different reasons

**A local-time surface pinned to UTC instants.** `IssueProperties.test.tsx` asserted `"Today, 4:08 PM · Attempt 1"` against fixtures written as fixed UTC strings. The row renders those in the machine's timezone, so the string only appeared at offset 0; at UTC-7 the row reads `9:08 AM` and the case failed on every run, at any hour. The `Today` label has the same problem one level up — it holds only while the scheduled time shares a local calendar day with `now`.

Both follow from anchoring a local-time surface to UTC. Anchoring the fixtures to a fixed local time instead fixes both at once: the pair cannot straddle local midnight, and the rendered clock is the same in every timezone, so `"Today, 4:08 PM · Attempt 1"` is exactly right everywhere and stays asserted verbatim.

**Local-day fixtures against a UTC-day filter, failed in a daily window.** `rollupUpdatesToday` filters on the UTC calendar day, deliberately, to match the server-side daily token cap:

```ts
const startOfDay = new Date(now);
startOfDay.setUTCHours(0, 0, 0, 0);
```

The `iso()` helper built its timestamps at local noon, and its comment described the filter it was feeding as "the local-day filter" — so the helper and the function disagreed about which day boundary applied. Once UTC has rolled over and local has not, `iso(0)` lands in the *previous* UTC day and today's rows are filtered out, so `updateCount` is 0 rather than 1. At UTC-7 that window runs from about 17:00 to local midnight — roughly seven hours a day, not a midnight edge.

Fixtures are now built on the same boundary the function uses, from a fixed instant that is also passed as `now`. That removes the dependency on the current time rather than moving it, and it is the pattern the neighbouring test in the same file already used (`"uses the UTC day boundary used by the server token cap"`).

### Why not pin `TZ=UTC` in the vitest config

It would turn both green in one line, and hide the class. The second case is a real local-versus-UTC mismatch that is worth correcting on its own; pinning the timezone would leave the misleading comment in place and the next fixture would be written the same way.

## Verification

Both files, across ten offsets from UTC-11 to UTC+14:

| TZ | Offset | Result |
| --- | --- | --- |
| `Pacific/Midway` | UTC-11 | 64 passed |
| `America/Los_Angeles` | UTC-7 | 64 passed |
| `UTC` | 0 | 64 passed |
| `Asia/Kolkata` | UTC+5:30 | 64 passed |
| `Asia/Kathmandu` | UTC+5:45 | 64 passed |
| `Asia/Shanghai` | UTC+8 | 64 passed |
| `Asia/Tokyo` | UTC+9 | 64 passed |
| `Australia/Adelaide` | UTC+9:30 | 64 passed |
| `Pacific/Auckland` | UTC+12 | 64 passed |
| `Pacific/Kiritimati` | UTC+14 | 64 passed |

### A correction to the first version of this PR

The first commit relaxed the monitor assertions to a pattern and I reported the case fixed. It was not: the row labels a time `Today` only while it shares a local calendar day with `now`, and with fixed UTC instants that pair straddles local midnight from UTC+8 to UTC+9:30, so the label becomes a date and the assertions still failed. My matrix — UTC, UTC-7, UTC+5:30, UTC+5:45, UTC+12 — stepped over the failing band, which is exactly the shape of verification that reports a fix it has not tested.

Greptile caught it. The second commit anchors the fixtures to a fixed *local* time instead, which keeps `now` and every scheduled time on one calendar day everywhere. That also makes the rendered clock identical in every timezone, so the relaxed assertions are **restored to exact strings** — the precision given up in the first commit was a symptom of anchoring to the wrong clock, not a necessary trade. The risk noted below about losing timestamp precision no longer applies.

Full `ui` suite, every zone tried:

| TZ | Offset | Suite |
| --- | --- | --- |
| `Pacific/Midway` | UTC-11 | 4015 passed |
| `America/Los_Angeles` | UTC-7 | 4015 passed |
| `UTC` | 0 | 4015 passed |
| `Asia/Kathmandu` | UTC+5:45 | 4015 passed |
| `Asia/Tokyo` | UTC+9 | 4015 passed |
| `Pacific/Kiritimati` | UTC+14 | 4015 passed |

`tsc -b` clean.

### Scope grew twice, both times for the same reason

#11476 named two tests. Fixing those and running the full suite at UTC+9 surfaced three more; fixing those and running at UTC+14 surfaced two more still (`AgentSkillReleasePicker.test.ts`, `ArtifactCard.test.tsx`). Each round was found by widening the offset, not by reading more code.

That is the actual lesson of this PR, and one of the fixtures says so out loud. `AgentSkillReleasePicker.test.ts` carried the comment *"Anchored to noon UTC so it stays on the 15th regardless of local offset"* — a claim that is false at UTC+14, written by someone reasoning about offsets rather than running them. The first revision of this PR made the identical mistake with the identical confidence.

### Not fixed here: one genuinely flaky test

`src/components/task-chat/TaskMessageScroller.test.tsx` — "plays the exit animation before unmounting when motion is enabled" — failed once in a full run at `Asia/Tokyo`. It is **not** timezone-dependent: it passes 3/3 in isolation at both `Asia/Tokyo` and `UTC`. It is an animation-timing flake that surfaces under parallel load, a different problem from this PR, and left alone rather than folded in.

Before this change, on the same machine, the suite was `1 failed | 63 passed` at UTC-7 and `64 passed` at `TZ=UTC` — timezone as the only variable.

**One honest gap in the verification.** Every failure here reproduces on demand and was re-run against the fix, except one. The `format.test.ts` failure only occurs while the UTC date is ahead of the local date, and no timezone is in that state at the hour I am writing this; I observed it live at 23:41 PDT earlier and traced the mechanism above, but could not re-trigger it on demand to watch the fix flip it. The fix does not rest on that: the case now takes its `now` explicitly and builds fixtures from it, so there is no clock left for it to depend on.

## Risks

Low, and confined to test code — no runtime behavior changes.

No precision is given up. An earlier revision of this PR relaxed the monitor-row assertions to a pattern; local anchoring made that unnecessary and they are back to exact strings.

The narrower residual: `IssueProperties.test.tsx` lines 1515-1517 still pin the minute of three timestamps against a UTC-anchored fixture. They pass in every zone tried, including UTC+5:45 — the fixture and the assertion happen to agree — so they are left alone rather than changed on speculation. The minute there is load-bearing (it is what distinguishes Created from Started from Completed), so any change to them needs more care than the mechanical anchoring in this PR.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and multi-timezone test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
