### PR TITLE
fix(server): keep comment after-cursor exclusive at microsecond precision

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2371,6 +2371,137 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(comments.map((comment) => comment.id)).toEqual([latestCommentId]);
   });
 
+  it("keeps the ascending comment cursor exclusive for microsecond-precision anchors", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const sameMillisecondLaterCommentId = randomUUID();
+    const anchorCommentId = randomUUID();
+    const latestCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Paged comments issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-03-26T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:00:00.000Z"),
+      },
+      {
+        id: sameMillisecondLaterCommentId,
+        companyId,
+        issueId,
+        body: "Same-millisecond later comment",
+        createdAt: sql`'2026-03-26T11:00:00.123999+00'::timestamptz`,
+        updatedAt: sql`'2026-03-26T11:00:00.123999+00'::timestamptz`,
+      },
+      {
+        id: anchorCommentId,
+        companyId,
+        issueId,
+        body: "Anchor comment",
+        createdAt: sql`'2026-03-26T11:00:00.123456+00'::timestamptz`,
+        updatedAt: sql`'2026-03-26T11:00:00.123456+00'::timestamptz`,
+      },
+      {
+        id: latestCommentId,
+        companyId,
+        issueId,
+        body: "Latest comment",
+        createdAt: new Date("2026-03-26T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T12:00:00.000Z"),
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      afterCommentId: anchorCommentId,
+      order: "asc",
+      limit: 50,
+    });
+
+    expect(comments.map((comment) => comment.id)).toEqual([
+      sameMillisecondLaterCommentId,
+      latestCommentId,
+    ]);
+  });
+
+  it("keeps the descending comment cursor from dropping same-millisecond comments", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const sameMillisecondEarlierCommentId = randomUUID();
+    const anchorCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Paged comments issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-03-26T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:00:00.000Z"),
+      },
+      {
+        id: sameMillisecondEarlierCommentId,
+        companyId,
+        issueId,
+        body: "Same-millisecond earlier comment",
+        createdAt: sql`'2026-03-26T11:00:00.123100+00'::timestamptz`,
+        updatedAt: sql`'2026-03-26T11:00:00.123100+00'::timestamptz`,
+      },
+      {
+        id: anchorCommentId,
+        companyId,
+        issueId,
+        body: "Anchor comment",
+        createdAt: sql`'2026-03-26T11:00:00.123999+00'::timestamptz`,
+        updatedAt: sql`'2026-03-26T11:00:00.123999+00'::timestamptz`,
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      afterCommentId: anchorCommentId,
+      order: "desc",
+      limit: 50,
+    });
+
+    expect(comments.map((comment) => comment.id)).toEqual([
+      sameMillisecondEarlierCommentId,
+      firstCommentId,
+    ]);
+  });
+
   it("lists user comments when derived run attribution scans a timestamp window", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gt, gte, inArray, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, like, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -8482,36 +8482,24 @@ export function issueService(db: Db) {
 
       const conditions = [eq(issueComments.issueId, issueId)];
       if (afterCommentId) {
-        const anchor = await db
-          .select({
-            id: issueComments.id,
-            createdAt: issueComments.createdAt,
-          })
+        // Keyset cursor with exclusive `(createdAt, id)` tuple semantics.
+        // The anchor comparison must stay inside SQL: Postgres keeps
+        // timestamptz at microsecond precision while a JS Date only carries
+        // milliseconds, so re-binding the anchor createdAt through JS
+        // truncates it and makes `created_at > anchor` true for the anchor
+        // row itself (re-delivering the boundary comment on every poll) and
+        // drops same-millisecond neighbours in descending order. The scalar
+        // subquery is evaluated once and keeps full precision; a missing
+        // anchor compares to NULL, so no rows return, matching the old
+        // `return []` behaviour.
+        const anchorCreatedAt = db
+          .select({ createdAt: issueComments.createdAt })
           .from(issueComments)
-          .where(and(eq(issueComments.issueId, issueId), eq(issueComments.id, afterCommentId)))
-          .then((rows) => rows[0] ?? null);
-
-        if (!anchor) return [];
-        const anchorCreatedAt =
-          anchor.createdAt instanceof Date
-            ? anchor.createdAt
-            : new Date(String(anchor.createdAt));
+          .where(and(eq(issueComments.issueId, issueId), eq(issueComments.id, afterCommentId)));
         conditions.push(
           order === "asc"
-            ? or(
-                gt(issueComments.createdAt, anchorCreatedAt),
-                and(
-                  eq(issueComments.createdAt, anchorCreatedAt),
-                  gt(issueComments.id, anchor.id),
-                ),
-              )!
-            : or(
-                lt(issueComments.createdAt, anchorCreatedAt),
-                and(
-                  eq(issueComments.createdAt, anchorCreatedAt),
-                  lt(issueComments.id, anchor.id),
-                ),
-              )!,
+            ? sql`(${issueComments.createdAt}, ${issueComments.id}) > ((${anchorCreatedAt}), ${afterCommentId})`
+            : sql`(${issueComments.createdAt}, ${issueComments.id}) < ((${anchorCreatedAt}), ${afterCommentId})`,
         );
       }
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -74,7 +74,7 @@ If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling
 Use comments incrementally:
 
 - if `PAPERCLIP_WAKE_COMMENT_ID` is set, fetch that exact comment first with `GET /api/issues/{issueId}/comments/{commentId}`
-- if you already know the thread and only need updates, use `GET /api/issues/{issueId}/comments?after={last-seen-comment-id}&order=asc`
+- if you already know the thread and only need updates, use `GET /api/issues/{issueId}/comments?after={last-seen-comment-id}&order=asc` — the cursor is exclusive: the response contains only comments that sort strictly after the cursor, so the boundary comment is never re-delivered
 - use the full `GET /api/issues/{issueId}/comments` route only when cold-starting or when incremental isn't enough
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents read issue threads incrementally with `GET /api/issues/:id/comments?after={id}&order=asc`.
> - The cursor must be exclusive: the call returns only comments that are newer than the anchor.
> - Postgres stores `timestamptz` with microsecond precision. A JavaScript `Date` only carries milliseconds.
> - `listComments` read the anchor `createdAt` into a JS `Date` and bound it back into the `created_at > anchor` comparison.
> - The bound value lost the microseconds. The comparison then stayed true for the anchor row itself, so ascending polls returned the boundary comment again on every call.
> - The same truncation made descending polls drop comments that shared a millisecond with the anchor.
> - This pull request moves the anchor comparison into SQL as a `(created_at, id)` row comparison against a scalar subquery, so the anchor keeps full precision.
> - The benefit is that incremental comment reads stay exact: no re-delivered boundary comment and no dropped same-millisecond neighbours.

## Linked Issues or Issue Description

**What happened?**

`GET /api/issues/{issueId}/comments?after={commentId}&order=asc` returned the boundary comment itself as the first element. Any client that polls with `after` as an exclusive cursor re-processes the boundary item on every poll. A bridge client in our deployment re-posted the same comment to an external channel on every 15 second poll because of this.

**Expected behavior**

`after={id}` returns only comments that sort strictly after the anchor in `(created_at, id)` order, for both `order=asc` and `order=desc`.

**Steps to reproduce**

1. Find an issue with at least two comments that were created through the normal API (real clock timestamps carry microseconds).
2. Pick any comment id as the anchor.
3. Call `GET /api/issues/{issueId}/comments?after={anchorId}&order=asc`.
4. The response starts with the anchor comment itself.

The bug is data-dependent: rows whose `created_at` microseconds are all zero compare correctly. Rows written by `now()` almost always carry nonzero microseconds, so the failure is near-deterministic in practice. Existing tests inserted whole-second timestamps, which is why this stayed hidden.

**Paperclip version or commit**

Observed on `paperclipai@2026.722.0`. The comparison code is the same on current `master` as of commit `0023c5c4a`.

**Deployment mode**

Local (`local_trusted`), embedded Postgres.

Related prior work: #3787 and #1252 fixed a 500 on `Date` binding for this same cursor; #5220 (commit `d58a862`) coerced the anchor to a `Date` for the driver. Those fixes kept the JS-side anchor value, so the millisecond truncation remained. #1788 is an older open attempt at the 500 path and does not address precision.

## What Changed

- `server/src/services/issues.ts` — `listComments` now builds the exclusive cursor as a SQL row comparison `(created_at, id) > ((scalar subquery), anchorId)` (or `<` for descending) instead of re-binding a JS `Date` anchor. The anchor subquery is evaluated once; a missing anchor compares to `NULL`, so no rows return, which matches the old early `return []`.
- Removed the now-unused `lt` import.
- `server/src/__tests__/issues-service.test.ts` — two regression tests insert anchors with microsecond precision (`'...T11:00:00.123456+00'::timestamptz`): one proves ascending order excludes the anchor and still returns a later comment that shares its millisecond; one proves descending order no longer drops an earlier comment that shares the anchor's millisecond.

## Verification

```bash
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/issues-service.test.ts -t "cursor"
# → 2 passed with this change

# Same command with the service change stashed:
# → 2 failed (ascending returns 3 rows including the anchor;
#    descending returns 1 row and drops the same-millisecond comment)

pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/issues-service.test.ts
# → 120 passed

pnpm --filter @paperclipai/server exec tsc --noEmit
# → error count identical to a clean checkout (139 pre-existing
#   unbuilt-workspace module errors, none in the touched files)
```

Live instance check before the fix: the same anchor returned the boundary comment for `order=asc` and did not for `order=desc`, which matches the truncation mechanism (a `>=`/`>` typo would be inclusive in both directions).

## Risks

- Low risk. The change is internal to one query builder in `listComments`; no schema, migration, or API contract change.
- Clients that worked around the inclusive behaviour by skipping the first element will now receive a truly exclusive list. Such clients would drop a real comment instead, but the documented contract in the agent skill already states exclusive semantics (`comments?after={last-seen-comment-id}` delta reads), so this change aligns behaviour with the contract.
- Row-value comparisons can use the existing `(company_id, issue_id, created_at)` index through the same OR-expansion the previous form produced.

## Model Used

GLM-5.2 (Z.ai), exact model id `zai-coding-plan/glm-5.2`, 200K context, tool-using coding mode, no extended thinking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

