### PR TITLE
test(ui): make the suite pass outside UTC

### DIFF
--- a/ui/src/pages/StatusCards/format.test.ts
+++ b/ui/src/pages/StatusCards/format.test.ts
@@ -30,11 +30,19 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
   };
 }
 
+// A fixed instant rather than the real clock. `rollupUpdatesToday` filters on
+// the *UTC* day boundary, so a suite that builds its fixtures from `new Date()`
+// fails in two ways: it straddles midnight UTC if the run happens to cross it,
+// and in any zone east of UTC+12 "today at local noon" is already yesterday in
+// UTC, so the rows it means to count are filtered out. The function takes `now`
+// for exactly this reason — the sibling test below already passes one.
+const NOW = new Date("2026-07-23T12:00:00.000Z");
+
 function iso(daysAgo: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - daysAgo);
-  // Noon avoids DST/midnight edge cases in the local-day filter.
-  d.setHours(12, 0, 0, 0);
+  const d = new Date(NOW);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  // Noon UTC, so a row is unambiguously inside the UTC day it belongs to.
+  d.setUTCHours(12, 0, 0, 0);
   return d.toISOString();
 }
 
@@ -61,7 +69,7 @@ describe("rollupUpdatesToday", () => {
       // yesterday + last week — must not be counted as "today"
       update({ kind: "full", inputTokens: 9999, outputTokens: 9999, costCents: 99, startedAt: iso(1) }),
       update({ kind: "incremental", inputTokens: 9999, outputTokens: 9999, costCents: 99, startedAt: iso(7) }),
-    ]);
+    ], NOW);
     // Only today's full rebuild counts as an update (compile excluded).
     expect(rollup.updateCount).toBe(1);
     // Today's tokens/cost include today's compile but not older days.

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -11,5 +11,14 @@ export default defineConfig({
   test: {
     environment: "node",
     setupFiles: ["./vitest.setup.ts"],
+    // Pin the clock's timezone so date rendering is the same everywhere.
+    //
+    // Several suites supply a UTC instant and assert on the local-time string
+    // the UI renders from it — "2026-07-17T16:08:00.000Z" is expected to read
+    // "Today, 4:08 PM". That only holds where local time is UTC. CI passes
+    // because GitHub's runners happen to default to UTC; a contributor in any
+    // other zone sees those tests fail on a clean checkout, which reads as
+    // "the suite is broken" rather than "your clock differs".
+    env: { TZ: "UTC" },
   },
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - It is open source, so the first thing a new contributor does is clone it and run the tests
> - The `ui` suite passes in CI, because GitHub's runners default to UTC
> - It fails on a clean checkout in any other timezone, and has done for as long as those tests have existed
> - A suite that is red on arrival reads as "this project is broken", not "your clock differs from the CI runner's"
> - This pull request pins the test timezone and fixes a test that was wrong about which day boundary it was using
> - The benefit is that `pnpm vitest run` is green for everyone, not only for people in UTC

## Linked Issues or Issue Description

No public issue exists. The problem follows.

**What happened?**

Two `ui` tests fail outside UTC:

- `IssueProperties.test.tsx` — *"renders scheduled, retrying, due, overdue, cleared, and empty monitor row states"*
- `StatusCards/format.test.ts` — *"only counts updates started today and drops older ledger rows"*

Nothing reported it because CI runs in UTC.

**Expected behavior**

The suite passes regardless of the machine's timezone or the time of day.

**Steps to reproduce**

```
TZ=Pacific/Auckland pnpm --filter @paperclipai/ui vitest run
```

**Paperclip version or commit**

`master` at `e384d0a2b`.

## What Changed

- `ui/vitest.config.ts` — `env: { TZ: "UTC" }`.
- `ui/src/pages/StatusCards/format.test.ts` — fixtures built from a fixed instant, passed to the function as `now`.

### Two independent causes

**`IssueProperties` asserts local time from a UTC instant.** It supplies `2026-07-17T16:08:00.000Z` and expects the row to read `Today, 4:08 PM`. True only where local time is UTC.

Pinned rather than rewritten. Those assertions are about what a person sees, and `"Today, 4:08 PM"` is worth more to a reader than an expectation computed from the same formatter the component uses — which would pass whatever the formatter did.

**`StatusCards/format` was wrong in two ways at once**, and the pin only hides one, so it is fixed directly. `rollupUpdatesToday` filters on the **UTC** day boundary, while the test built fixtures from local noon on the real clock:

- East of UTC+12, "today at local noon" is already yesterday in UTC, so the rows the test means to count are filtered out.
- Any run crossing midnight UTC sees `iso(0)` and the function's default `now` land on different days. That is what failed mid-session yesterday, and no timezone pin would prevent it.

Fixtures now derive from a fixed instant, and the test passes it as `now`. The parameter exists for exactly this, and the sibling test in the same file already used it.

## Verification

- `ui` typecheck is clean.
- Full `ui` suite: **4017 pass, 0 fail** — in UTC, `Pacific/Auckland` and `Asia/Kolkata`.

That is the first fully green run of this suite in a long session of work on it.

Each fix was confirmed load-bearing by removing it with `TZ=Pacific/Auckland`:

| state | result |
| --- | --- |
| pin removed | `IssueProperties` fails |
| pin removed, `StatusCards` fixed | `StatusCards` passes |
| pin removed, `StatusCards` reverted | `StatusCards` fails |

The middle row is the one that matters: the `StatusCards` fix stands on its own rather than riding on the pin.

## Risks

Low. The pin makes explicit what every date assertion in the suite already assumed, so no test changes meaning — confirmed by the whole suite passing unchanged apart from the two failures it fixes.

It does mean a test written from now on cannot observe a non-UTC local zone without overriding `TZ` itself. That is the right default: a test that depends on the runner's zone is the bug this fixes.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
