### PR TITLE
feat(secrets): allow binding proposals from agent source paths

### DIFF
--- a/server/src/__tests__/secret-proposals-routes.test.ts
+++ b/server/src/__tests__/secret-proposals-routes.test.ts
@@ -593,6 +593,10 @@ describeEmbeddedPostgres("secret proposal routes", () => {
       definitionId: definition.id,
       value: "personal-report-source-secret",
     });
+    await secrets.createCurrentUserSecretValue(fixture.companyId, "user-2", {
+      definitionId: definition.id,
+      value: "second-user-report-secret",
+    });
     await agentService(db).update(fixture.agentId, {
       adapterConfig: {
         "access.personal_report_source": {
@@ -649,6 +653,18 @@ describeEmbeddedPostgres("secret proposal routes", () => {
         configPath: "access.personal_alias",
       },
     )).resolves.toMatchObject({ value: "personal-report-source-secret" });
+    await expect(secrets.resolveUserSecretValue(
+      fixture.companyId,
+      {
+        definitionKey: definition.key,
+        responsibleUserId: "user-2",
+      },
+      {
+        consumerType: "agent",
+        consumerId: reportAgentId,
+        configPath: "access.personal_alias",
+      },
+    )).resolves.toMatchObject({ value: "second-user-report-secret" });
   });
 
   it("returns 404 when sourceConfigPath is missing or belongs to another agent", async () => {

--- a/server/src/__tests__/secret-proposals-routes.test.ts
+++ b/server/src/__tests__/secret-proposals-routes.test.ts
@@ -533,6 +533,53 @@ describeEmbeddedPostgres("secret proposal routes", () => {
     expect(proposal.body).toMatchObject({ secretId: userSecret.id, target: { id: fixture.agentId } });
   });
 
+  it("rejects rebinding a user-scoped source secret to a report", async () => {
+    const fixture = await seedRun();
+    const reportAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: reportAgentId,
+      companyId: fixture.companyId,
+      name: "Report",
+      role: "engineer",
+      reportsTo: fixture.agentId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      permissions: {},
+      status: "idle",
+    });
+    const secrets = secretService(db);
+    const definition = await secrets.createUserSecretDefinition(fixture.companyId, {
+      key: "personal_report_source_token",
+      name: "Personal report source token",
+      provider: "local_encrypted",
+    });
+    const userSecret = await secrets.createCurrentUserSecretValue(fixture.companyId, "user-1", {
+      definitionId: definition.id,
+      value: "personal-report-source-secret",
+    });
+    await db.insert(companySecretBindings).values({
+      companyId: fixture.companyId,
+      secretId: userSecret.id,
+      targetType: "agent",
+      targetId: fixture.agentId,
+      configPath: "access.personal_report_source",
+    });
+
+    const proposal = await request(createAgentApp(fixture))
+      .post("/api/agents/me/secret-proposals")
+      .send({
+        kind: "binding",
+        sourceConfigPath: "access.personal_report_source",
+        targetAgentId: reportAgentId,
+        configPath: "access.personal_alias",
+        justification: "Attempt to pass a personal credential to a report",
+      });
+
+    expect(proposal.status).toBe(422);
+    expect(proposal.body.error).toBe("User-scoped source secrets may be rebound only to the proposing agent");
+    expect(await db.select().from(companySecretProposals)).toHaveLength(0);
+  });
+
   it("returns 404 when sourceConfigPath is missing or belongs to another agent", async () => {
     const fixture = await seedRun();
     const otherAgentId = randomUUID();

--- a/server/src/__tests__/secret-proposals-routes.test.ts
+++ b/server/src/__tests__/secret-proposals-routes.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import express from "express";
 import request from "supertest";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -19,6 +19,7 @@ import {
   heartbeatRuns,
   issueComments,
   issues,
+  userSecretDeclarations,
   userSecretDefinitions,
 } from "@paperclipai/db";
 import { conflict } from "../errors.js";
@@ -27,6 +28,7 @@ import { secretRoutes } from "../routes/secrets.js";
 import { awsSecretsManagerProvider } from "../secrets/aws-secrets-manager-provider.js";
 import type { IssueAssignmentWakeupDeps } from "../services/issue-assignment-wakeup.js";
 import { issueService } from "../services/issues.js";
+import { agentService } from "../services/agents.js";
 import { createSecretProposalsService } from "../services/secret-proposals.js";
 import { secretService } from "../services/secrets.js";
 import {
@@ -59,6 +61,7 @@ describeEmbeddedPostgres("secret proposal routes", () => {
     await db.delete(companySecretBindings);
     await db.delete(companySecretVersions);
     await db.delete(companySecrets);
+    await db.delete(userSecretDeclarations);
     await db.delete(userSecretDefinitions);
     await db.delete(companySecretProviderConfigs);
     await db.delete(issues);
@@ -100,6 +103,7 @@ describeEmbeddedPostgres("secret proposal routes", () => {
       companyId,
       agentId,
       status: "running",
+      responsibleUserId: "user-1",
       contextSnapshot: { issueId },
     });
     await db.insert(issues).values({
@@ -108,6 +112,7 @@ describeEmbeddedPostgres("secret proposal routes", () => {
       title: "Needs credential",
       identifier: "SEC-1",
       status: "in_progress",
+      responsibleUserId: "user-1",
       executionRunId: heartbeatRunId,
     });
     return { companyId, agentId, heartbeatRunId, issueId };
@@ -512,12 +517,16 @@ describeEmbeddedPostgres("secret proposal routes", () => {
       definitionId: definition.id,
       value: "personal-source-secret",
     });
-    await db.insert(companySecretBindings).values({
-      companyId: fixture.companyId,
-      secretId: userSecret.id,
-      targetType: "agent",
-      targetId: fixture.agentId,
-      configPath: "access.personal_source",
+    await agentService(db).update(fixture.agentId, {
+      adapterConfig: {
+        "access.personal_source": {
+          type: "user_secret_ref",
+          key: definition.key,
+          version: "latest",
+          required: true,
+          allowMissingOverride: false,
+        },
+      },
     });
 
     const proposal = await request(createAgentApp(fixture))
@@ -531,9 +540,36 @@ describeEmbeddedPostgres("secret proposal routes", () => {
 
     expect(proposal.status).toBe(201);
     expect(proposal.body).toMatchObject({ secretId: userSecret.id, target: { id: fixture.agentId } });
+
+    const approved = await request(createBoardApp(fixture))
+      .post(`/api/companies/${fixture.companyId}/secret-proposals/${proposal.body.id}/approve`)
+      .send({});
+
+    expect(approved.status).toBe(200);
+    const updatedAgent = await agentService(db).getById(fixture.agentId);
+    expect(updatedAgent?.adapterConfig).toMatchObject({
+      "access.personal_alias": {
+        type: "user_secret_ref",
+        key: definition.key,
+        version: "latest",
+        required: true,
+        allowMissingOverride: false,
+      },
+    });
+    expect(await db.select().from(userSecretDeclarations).where(eq(userSecretDeclarations.targetId, fixture.agentId)))
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          userSecretDefinitionId: definition.id,
+          configPath: "access.personal_source",
+        }),
+        expect.objectContaining({
+          userSecretDefinitionId: definition.id,
+          configPath: "access.personal_alias",
+        }),
+      ]));
   });
 
-  it("rejects rebinding a user-scoped source secret to a report", async () => {
+  it("preserves user-secret declaration semantics when rebinding a source secret to a report", async () => {
     const fixture = await seedRun();
     const reportAgentId = randomUUID();
     await db.insert(agents).values({
@@ -557,12 +593,16 @@ describeEmbeddedPostgres("secret proposal routes", () => {
       definitionId: definition.id,
       value: "personal-report-source-secret",
     });
-    await db.insert(companySecretBindings).values({
-      companyId: fixture.companyId,
-      secretId: userSecret.id,
-      targetType: "agent",
-      targetId: fixture.agentId,
-      configPath: "access.personal_report_source",
+    await agentService(db).update(fixture.agentId, {
+      adapterConfig: {
+        "access.personal_report_source": {
+          type: "user_secret_ref",
+          key: definition.key,
+          version: "latest",
+          required: true,
+          allowMissingOverride: false,
+        },
+      },
     });
 
     const proposal = await request(createAgentApp(fixture))
@@ -575,9 +615,40 @@ describeEmbeddedPostgres("secret proposal routes", () => {
         justification: "Attempt to pass a personal credential to a report",
       });
 
-    expect(proposal.status).toBe(422);
-    expect(proposal.body.error).toBe("User-scoped source secrets may be rebound only to the proposing agent");
-    expect(await db.select().from(companySecretProposals)).toHaveLength(0);
+    expect(proposal.status).toBe(201);
+    expect(proposal.body).toMatchObject({ secretId: userSecret.id, target: { id: reportAgentId } });
+
+    const approved = await request(createBoardApp(fixture))
+      .post(`/api/companies/${fixture.companyId}/secret-proposals/${proposal.body.id}/approve`)
+      .send({});
+
+    expect(approved.status).toBe(200);
+    const report = await agentService(db).getById(reportAgentId);
+    expect(report?.adapterConfig).toMatchObject({
+      "access.personal_alias": {
+        type: "user_secret_ref",
+        key: definition.key,
+        version: "latest",
+        required: true,
+        allowMissingOverride: false,
+      },
+    });
+    expect(await db.select().from(userSecretDeclarations).where(and(
+      eq(userSecretDeclarations.targetId, reportAgentId),
+      eq(userSecretDeclarations.configPath, "access.personal_alias"),
+    ))).toEqual([expect.objectContaining({ userSecretDefinitionId: definition.id })]);
+    await expect(secrets.resolveUserSecretValue(
+      fixture.companyId,
+      {
+        definitionKey: definition.key,
+        responsibleUserId: "user-1",
+      },
+      {
+        consumerType: "agent",
+        consumerId: reportAgentId,
+        configPath: "access.personal_alias",
+      },
+    )).resolves.toMatchObject({ value: "personal-report-source-secret" });
   });
 
   it("returns 404 when sourceConfigPath is missing or belongs to another agent", async () => {

--- a/server/src/__tests__/secret-proposals-routes.test.ts
+++ b/server/src/__tests__/secret-proposals-routes.test.ts
@@ -19,6 +19,7 @@ import {
   heartbeatRuns,
   issueComments,
   issues,
+  userSecretDefinitions,
 } from "@paperclipai/db";
 import { conflict } from "../errors.js";
 import { errorHandler } from "../middleware/error-handler.js";
@@ -58,6 +59,7 @@ describeEmbeddedPostgres("secret proposal routes", () => {
     await db.delete(companySecretBindings);
     await db.delete(companySecretVersions);
     await db.delete(companySecrets);
+    await db.delete(userSecretDefinitions);
     await db.delete(companySecretProviderConfigs);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
@@ -418,6 +420,171 @@ describeEmbeddedPostgres("secret proposal routes", () => {
     ]);
   });
 
+  it("proposes and approves a binding by resolving the proposer's own sourceConfigPath", async () => {
+    const fixture = await seedRun();
+    const sourceSecret = await secretService(db).create(fixture.companyId, {
+      name: "dev/source-path/token",
+      key: "SOURCE_PATH_TOKEN",
+      provider: "local_encrypted",
+      value: "source-path-secret",
+    });
+    await secretService(db).createBinding({
+      companyId: fixture.companyId,
+      secretId: sourceSecret.id,
+      targetType: "agent",
+      targetId: fixture.agentId,
+      configPath: "access.existing_source",
+    });
+
+    const proposal = await request(createAgentApp(fixture))
+      .post("/api/agents/me/secret-proposals")
+      .send({
+        kind: "binding",
+        sourceConfigPath: "access.existing_source",
+        configPath: "access.new_alias",
+        justification: "Reuse the credential under the task-specific alias",
+      });
+
+    expect(proposal.status).toBe(201);
+    expect(proposal.body).toMatchObject({
+      kind: "binding",
+      secretId: sourceSecret.id,
+      configPath: "access.new_alias",
+      target: { id: fixture.agentId },
+    });
+    expect(await db.select().from(companySecretProposals).where(eq(companySecretProposals.id, proposal.body.id)))
+      .toEqual([expect.objectContaining({ secretId: sourceSecret.id, targetId: fixture.agentId })]);
+
+    const approved = await request(createBoardApp(fixture))
+      .post(`/api/companies/${fixture.companyId}/secret-proposals/${proposal.body.id}/approve`)
+      .send({});
+
+    expect(approved.status).toBe(200);
+    expect(await db.select().from(companySecretBindings)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        secretId: sourceSecret.id,
+        targetId: fixture.agentId,
+        configPath: "access.new_alias",
+      }),
+    ]));
+  });
+
+  it("rejects binding proposals that provide both secretId and sourceConfigPath", async () => {
+    const fixture = await seedRun();
+    const sourceSecret = await secretService(db).create(fixture.companyId, {
+      name: "dev/mutual-exclusion/token",
+      key: "MUTUAL_EXCLUSION_TOKEN",
+      provider: "local_encrypted",
+      value: "mutual-exclusion-secret",
+    });
+    await secretService(db).createBinding({
+      companyId: fixture.companyId,
+      secretId: sourceSecret.id,
+      targetType: "agent",
+      targetId: fixture.agentId,
+      configPath: "access.mutual_exclusion_source",
+    });
+
+    const response = await request(createAgentApp(fixture))
+      .post("/api/agents/me/secret-proposals")
+      .send({
+        kind: "binding",
+        secretId: sourceSecret.id,
+        sourceConfigPath: "access.mutual_exclusion_source",
+        configPath: "access.new_alias",
+        justification: "This request is intentionally ambiguous",
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatch(/exactly one of secretId, sourceConfigPath, or secretProposalId/);
+    expect(await db.select().from(companySecretProposals)).toHaveLength(0);
+  });
+
+  it("accepts a user-scoped source secret only through the proposer's existing binding", async () => {
+    const fixture = await seedRun();
+    const secrets = secretService(db);
+    const definition = await secrets.createUserSecretDefinition(fixture.companyId, {
+      key: "personal_source_token",
+      name: "Personal source token",
+      provider: "local_encrypted",
+    });
+    const userSecret = await secrets.createCurrentUserSecretValue(fixture.companyId, "user-1", {
+      definitionId: definition.id,
+      value: "personal-source-secret",
+    });
+    await db.insert(companySecretBindings).values({
+      companyId: fixture.companyId,
+      secretId: userSecret.id,
+      targetType: "agent",
+      targetId: fixture.agentId,
+      configPath: "access.personal_source",
+    });
+
+    const proposal = await request(createAgentApp(fixture))
+      .post("/api/agents/me/secret-proposals")
+      .send({
+        kind: "binding",
+        sourceConfigPath: "access.personal_source",
+        configPath: "access.personal_alias",
+        justification: "Reuse the already-bound user credential",
+      });
+
+    expect(proposal.status).toBe(201);
+    expect(proposal.body).toMatchObject({ secretId: userSecret.id, target: { id: fixture.agentId } });
+  });
+
+  it("returns 404 when sourceConfigPath is missing or belongs to another agent", async () => {
+    const fixture = await seedRun();
+    const otherAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId: fixture.companyId,
+      name: "Other agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      permissions: {},
+      status: "idle",
+    });
+    const otherSecret = await secretService(db).create(fixture.companyId, {
+      name: "dev/other-agent/token",
+      key: "OTHER_AGENT_TOKEN",
+      provider: "local_encrypted",
+      value: "other-agent-secret",
+    });
+    await secretService(db).createBinding({
+      companyId: fixture.companyId,
+      secretId: otherSecret.id,
+      targetType: "agent",
+      targetId: otherAgentId,
+      configPath: "access.other_agent_only",
+    });
+    const agentApp = createAgentApp(fixture);
+
+    const missing = await request(agentApp)
+      .post("/api/agents/me/secret-proposals")
+      .send({
+        kind: "binding",
+        sourceConfigPath: "access.does_not_exist",
+        configPath: "access.new_alias",
+        justification: "Try an unresolved source",
+      });
+    const crossAgent = await request(agentApp)
+      .post("/api/agents/me/secret-proposals")
+      .send({
+        kind: "binding",
+        sourceConfigPath: "access.other_agent_only",
+        configPath: "access.new_alias",
+        justification: "Try another agent's source",
+      });
+
+    expect(missing.status).toBe(404);
+    expect(crossAgent.status).toBe(404);
+    expect(missing.body.error).toBe("Source secret binding not found");
+    expect(crossAgent.body.error).toBe("Source secret binding not found");
+    expect(await db.select().from(companySecretProposals)).toHaveLength(0);
+  });
+
   it("serializes proposal quotas and exposes bounded list pagination", async () => {
     const fixture = await seedRun();
     const liveSecret = await secretService(db).create(fixture.companyId, {
@@ -426,6 +593,13 @@ describeEmbeddedPostgres("secret proposal routes", () => {
       provider: "local_encrypted",
       value: "quota-source-secret",
     });
+    await secretService(db).createBinding({
+      companyId: fixture.companyId,
+      secretId: liveSecret.id,
+      targetType: "agent",
+      targetId: fixture.agentId,
+      configPath: "access.quota_source",
+    });
     const agentApp = createAgentApp(fixture);
 
     const responses = await Promise.all(Array.from({ length: 21 }, (_, index) =>
@@ -433,7 +607,7 @@ describeEmbeddedPostgres("secret proposal routes", () => {
         .post("/api/agents/me/secret-proposals")
         .send({
           kind: "binding",
-          secretId: liveSecret.id,
+          sourceConfigPath: "access.quota_source",
           configPath: `env.QUOTA_${index}`,
           justification: "Exercise the concurrent proposal cap",
         })));

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -74,6 +74,48 @@ describe("secret routes", () => {
     mockLogActivity.mockReset();
   });
 
+  it("returns an opaque secretRef in agent secret metadata without internal binding details", async () => {
+    const secretId = "11111111-1111-4111-8111-111111111111";
+    mockSecretService.listAgentSecretAccess.mockResolvedValue([{
+      secretId,
+      bindingId: "22222222-2222-4222-8222-222222222222",
+      configPath: "env.OPENAI_API_KEY",
+      key: "openai_api_key",
+      name: "OpenAI API key",
+      description: "Used for model access",
+      delivery: "env",
+      projectionClass: "unclassified",
+      latestVersion: 3,
+      versionSelector: "latest",
+      resolvedVersion: 3,
+    }]);
+
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "44444444-4444-4444-8444-444444444444",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_jwt",
+      keyScope: { kind: "standard" },
+    })).get("/api/agents/me/secrets");
+
+    expect(res.status).toBe(200);
+    expect(res.body.secrets).toEqual([{
+      secretRef: secretId,
+      key: "openai_api_key",
+      name: "OpenAI API key",
+      description: "Used for model access",
+      delivery: "env",
+      projectionClass: "unclassified",
+      latestVersion: 3,
+      versionSelector: "latest",
+      resolvedVersion: 3,
+    }]);
+    expect(res.body.secrets[0]).not.toHaveProperty("secretId");
+    expect(res.body.secrets[0]).not.toHaveProperty("bindingId");
+    expect(res.body.secrets[0]).not.toHaveProperty("configPath");
+  });
+
   it("returns provider health checks for board callers with company access", async () => {
     mockSecretService.checkProviders.mockResolvedValue([
       {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -1687,6 +1687,7 @@ registry.registerPath({
 
 const AgentSecretListResponseSchema = z.object({
   secrets: z.array(z.object({
+    secretRef: z.string().uuid(),
     key: z.string(),
     name: z.string(),
     description: z.string().nullable(),
@@ -1709,12 +1710,24 @@ const createAgentSecretProposalSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("binding"),
     secretId: z.string().uuid().optional(),
+    sourceConfigPath: z.string().min(1).optional(),
     secretProposalId: z.string().uuid().optional(),
     targetAgentId: z.string().uuid().optional(),
     configPath: z.string().min(1),
     justification: z.string().min(1),
   }),
-]);
+]).superRefine((value, ctx) => {
+  if (
+    value.kind === "binding"
+    && [value.secretId, value.sourceConfigPath, value.secretProposalId]
+      .filter((reference) => Boolean(reference)).length !== 1
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide exactly one of secretId, sourceConfigPath, or secretProposalId",
+    });
+  }
+});
 
 const approveSecretProposalSchema = z.object({
   cascade: z.boolean().optional(),

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -257,7 +257,8 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
         })
       : body.kind === "binding"
         ? await proposals.createBinding({ companyId: context.companyId, heartbeatRunId: context.heartbeatRunId }, {
-            secretId: body.secretId, secretProposalId: body.secretProposalId, targetAgentId: body.targetAgentId,
+            secretId: body.secretId, sourceConfigPath: body.sourceConfigPath,
+            secretProposalId: body.secretProposalId, targetAgentId: body.targetAgentId,
             configPath: body.configPath, justification: body.justification, bindingTargetPolicy: "self_and_reports",
           })
         : (() => { throw unprocessable("kind must be secret or binding"); })();
@@ -348,7 +349,10 @@ export function secretRoutes(db: Db, deps: SecretRoutesDeps = {}) {
       details: { count: secrets.length },
     });
     res.json({
-      secrets: secrets.map(({ secretId: _secretId, bindingId: _bindingId, configPath: _configPath, ...secret }) => secret),
+      secrets: secrets.map(({ secretId, bindingId: _bindingId, configPath: _configPath, ...secret }) => ({
+        ...secret,
+        secretRef: secretId,
+      })),
     });
   });
 

--- a/server/src/services/secret-proposals.ts
+++ b/server/src/services/secret-proposals.ts
@@ -266,6 +266,9 @@ export function createSecretProposalsService(db: Db) {
       ) {
         throw notFound("Secret not found");
       }
+      if (sourceBindingAllowsUserSecret && targetAgentId !== run.agentId) {
+        throw unprocessable("User-scoped source secrets may be rebound only to the proposing agent");
+      }
     }
     return createWithinQuota(
       { companyId: context.companyId, agentId: run.agentId, runId: run.id, issueId: originIssueId },

--- a/server/src/services/secret-proposals.ts
+++ b/server/src/services/secret-proposals.ts
@@ -7,6 +7,8 @@ import {
   companySecrets,
   heartbeatRuns,
   issues,
+  userSecretDeclarations,
+  userSecretDefinitions,
 } from "@paperclipai/db";
 import type { SecretProvider } from "@paperclipai/shared";
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
@@ -250,8 +252,29 @@ export function createSecretProposalsService(db: Db) {
           eq(companySecretBindings.configPath, input.sourceConfigPath),
         ))
         .then((rows) => rows[0] ?? null);
-      if (!sourceBinding) throw notFound("Source secret binding not found");
-      resolvedSecretId = sourceBinding.secretId;
+      if (sourceBinding) {
+        resolvedSecretId = sourceBinding.secretId;
+      } else if (run.responsibleUserId) {
+        const sourceDeclaration = await db
+          .select({ secretId: companySecrets.id })
+          .from(userSecretDeclarations)
+          .innerJoin(companySecrets, and(
+            eq(companySecrets.companyId, context.companyId),
+            eq(companySecrets.scope, "user"),
+            eq(companySecrets.ownerUserId, run.responsibleUserId),
+            eq(companySecrets.userSecretDefinitionId, userSecretDeclarations.userSecretDefinitionId),
+            eq(companySecrets.status, "active"),
+          ))
+          .where(and(
+            eq(userSecretDeclarations.companyId, context.companyId),
+            eq(userSecretDeclarations.targetType, "agent"),
+            eq(userSecretDeclarations.targetId, run.agentId),
+            eq(userSecretDeclarations.configPath, input.sourceConfigPath),
+          ))
+          .then((rows) => rows[0] ?? null);
+        resolvedSecretId = sourceDeclaration?.secretId ?? null;
+      }
+      if (!resolvedSecretId) throw notFound("Source secret binding not found");
     }
     if (resolvedSecretId) {
       const secret = await db.select().from(companySecrets).where(and(
@@ -265,9 +288,6 @@ export function createSecretProposalsService(db: Db) {
         || (secret.scope !== "company" && !sourceBindingAllowsUserSecret)
       ) {
         throw notFound("Secret not found");
-      }
-      if (sourceBindingAllowsUserSecret && targetAgentId !== run.agentId) {
-        throw unprocessable("User-scoped source secrets may be rebound only to the proposing agent");
       }
     }
     return createWithinQuota(
@@ -481,14 +501,37 @@ export function createSecretProposalsService(db: Db) {
     return updated;
   }
 
-  async function applyBindingApproval(txDb: Db, proposal: Proposal, secretId: string, resolvedByUserId: string) {
+  async function applyBindingApproval(
+    txDb: Db,
+    proposal: Proposal,
+    secret: typeof companySecrets.$inferSelect,
+    resolvedByUserId: string,
+  ) {
     if (!proposal.targetId || !proposal.configPath) throw conflict("Binding proposal is incomplete");
     const agentSvc = agentService(txDb);
     const target = await agentSvc.getById(proposal.targetId);
     if (!target || target.companyId !== proposal.companyId) throw notFound("Target agent not found");
     const adapterConfig = { ...asRecord(target.adapterConfig) };
     const [namespace, key] = proposal.configPath.split(".", 2);
-    const binding = { type: "secret_ref", secretId, version: "latest" };
+    const userSecretDefinition = secret.scope === "user" && secret.userSecretDefinitionId
+      ? await txDb.select({ key: userSecretDefinitions.key }).from(userSecretDefinitions).where(and(
+          eq(userSecretDefinitions.id, secret.userSecretDefinitionId),
+          eq(userSecretDefinitions.companyId, proposal.companyId),
+          eq(userSecretDefinitions.status, "active"),
+        )).then((rows) => rows[0] ?? null)
+      : null;
+    if (secret.scope === "user" && !userSecretDefinition) {
+      throw conflict("Binding proposal user secret definition is not active");
+    }
+    const binding = userSecretDefinition
+      ? {
+          type: "user_secret_ref",
+          key: userSecretDefinition.key,
+          version: "latest",
+          required: true,
+          allowMissingOverride: false,
+        }
+      : { type: "secret_ref", secretId: secret.id, version: "latest" };
     if (namespace === "env") {
       const env = { ...asRecord(adapterConfig.env) };
       const existing = env[key];
@@ -561,9 +604,9 @@ export function createSecretProposalsService(db: Db) {
       if (!secretId) throw conflict("Binding proposal has no approved secret");
       const liveSecret = await secretService(txDb).getById(secretId);
       if (!liveSecret || liveSecret.companyId !== companyId || liveSecret.status !== "active") {
-        throw conflict("Binding proposal secret is not an active company secret");
+        throw conflict("Binding proposal secret is not active");
       }
-      await applyBindingApproval(txDb, proposal, secretId, input.resolvedByUserId);
+      await applyBindingApproval(txDb, proposal, liveSecret, input.resolvedByUserId);
       return markApproved(txDb, proposal, {
         resolvedByUserId: input.resolvedByUserId,
         appliedBindingConfigPath: proposal.configPath,

--- a/server/src/services/secret-proposals.ts
+++ b/server/src/services/secret-proposals.ts
@@ -1,8 +1,15 @@
 import { and, count, desc, eq, gte, lte, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, companySecretProposals, companySecrets, heartbeatRuns, issues } from "@paperclipai/db";
+import {
+  agents,
+  companySecretBindings,
+  companySecretProposals,
+  companySecrets,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
 import type { SecretProvider } from "@paperclipai/shared";
-import { conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
+import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { getSecretProvider } from "../secrets/provider-registry.js";
 import { agentService } from "./agents.js";
 import { logActivity } from "./activity-log.js";
@@ -204,16 +211,24 @@ export function createSecretProposalsService(db: Db) {
 
   async function createBinding(context: Pick<ProposalRunContext, "companyId" | "heartbeatRunId">, input: {
     secretId?: string | null;
+    sourceConfigPath?: string | null;
     secretProposalId?: string | null;
     targetAgentId?: string | null;
     configPath: string;
     justification: string;
     bindingTargetPolicy: "self_and_reports";
   }) {
-    if (Boolean(input.secretId) === Boolean(input.secretProposalId)) {
-      throw unprocessable("Binding proposals require exactly one of secretId or secretProposalId");
+    const referenceCount = [input.secretId, input.sourceConfigPath, input.secretProposalId]
+      .filter((value) => Boolean(value)).length;
+    if (referenceCount !== 1) {
+      throw badRequest(
+        "Binding proposals require exactly one of secretId, sourceConfigPath, or secretProposalId",
+      );
     }
     if (!CONFIG_PATH_RE.test(input.configPath)) throw unprocessable("configPath must use env.<KEY> or access.<ALIAS>");
+    if (input.sourceConfigPath && !CONFIG_PATH_RE.test(input.sourceConfigPath)) {
+      throw unprocessable("sourceConfigPath must use env.<KEY> or access.<ALIAS>");
+    }
     if (!input.justification.trim()) throw unprocessable("Justification is required");
     const { run, originIssueId } = await loadRunContext(db, context);
     const targetAgentId = input.targetAgentId ?? run.agentId;
@@ -224,12 +239,33 @@ export function createSecretProposalsService(db: Db) {
     if (!bindingTargetAllowed(run.agentId, targetAgentId, targetAncestors)) {
       throw forbidden("Binding proposals may target only the proposing agent or its reports");
     }
-    if (input.secretId) {
+    let resolvedSecretId = input.secretId ?? null;
+    if (input.sourceConfigPath) {
+      const sourceBinding = await db.select({ secretId: companySecretBindings.secretId })
+        .from(companySecretBindings)
+        .where(and(
+          eq(companySecretBindings.companyId, context.companyId),
+          eq(companySecretBindings.targetType, "agent"),
+          eq(companySecretBindings.targetId, run.agentId),
+          eq(companySecretBindings.configPath, input.sourceConfigPath),
+        ))
+        .then((rows) => rows[0] ?? null);
+      if (!sourceBinding) throw notFound("Source secret binding not found");
+      resolvedSecretId = sourceBinding.secretId;
+    }
+    if (resolvedSecretId) {
       const secret = await db.select().from(companySecrets).where(and(
-        eq(companySecrets.id, input.secretId),
+        eq(companySecrets.id, resolvedSecretId),
         eq(companySecrets.companyId, context.companyId),
       )).then((rows) => rows[0] ?? null);
-      if (!secret || secret.scope !== "company" || secret.status === "deleted") throw notFound("Secret not found");
+      const sourceBindingAllowsUserSecret = Boolean(input.sourceConfigPath) && secret?.scope === "user";
+      if (
+        !secret
+        || secret.status === "deleted"
+        || (secret.scope !== "company" && !sourceBindingAllowsUserSecret)
+      ) {
+        throw notFound("Secret not found");
+      }
     }
     return createWithinQuota(
       { companyId: context.companyId, agentId: run.agentId, runId: run.id, issueId: originIssueId },
@@ -250,7 +286,7 @@ export function createSecretProposalsService(db: Db) {
           companyId: context.companyId,
           kind: "binding",
           justification: input.justification.trim(),
-          secretId: input.secretId ?? null,
+          secretId: resolvedSecretId,
           secretProposalId: input.secretProposalId ?? null,
           targetType: "agent",
           targetId: targetAgentId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The secrets subsystem gives agents scoped secret bindings without exposing secret values.
> - The existing proposal API requires an agent to know a secret identifier before it can request another binding.
> - An agent already has enough authority when the secret is bound to that same agent.
> - The server must resolve the source binding in the proposing agent's scope and preserve the existing approval workflow.
> - This pull request adds source-path resolution and an opaque secret handle to agent secret listings.
> - The benefit is a one-call rebind request without new secret disclosure or cross-agent access.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

This improves `POST /api/agents/me/secret-proposals` binding proposals and `GET /api/agents/me/secrets` discovery.

**Subsystem affected**

`server/` — REST API and orchestration services.

**Current behavior**

An agent must provide `secretId` to propose a new binding. The agent secret listing removes that identifier and has no stable opaque handle. An agent cannot request a second binding from one of its existing config paths in one call.

**Proposed behavior**

A binding proposal can provide exactly one of `secretId`, `secretProposalId`, or `sourceConfigPath`. The server resolves `sourceConfigPath` only from a binding owned by the proposing agent. Agent secret listing rows include `secretRef` as an opaque handle. Existing values and fingerprints remain hidden.

**Reason and benefit**

Agents can request a safe alias for a secret they already receive. The approval workflow, quotas, expiry, and target-agent rules remain unchanged.

**Breaking changes**

None. The new request and response fields are additive.

## What Changed

- Resolve binding proposals from an existing company binding or responsible-user declaration on the proposing agent.
- Reject ambiguous source inputs and missing or cross-agent source paths.
- Return `secretRef` in agent secret listing rows without exposing values or fingerprints.
- Document the additive API fields in OpenAPI.
- Cover company-scoped and user-scoped sources, isolation, validation, and quota behavior with route tests.

## Verification

- `pnpm -r typecheck`
- `cd server && pnpm exec vitest run --config vitest.config.ts src/__tests__/secret-proposals-routes.test.ts src/__tests__/secrets-routes.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`
- `pnpm test:run` completed 339 server files and 458 UI files. One unrelated CLI AWS-doctor test saw inherited static AWS credentials. The isolated test passed after those two variables were removed: `env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY pnpm exec vitest run src/__tests__/secrets.test.ts -t "passes AWS doctor checks when non-secret provider config is present"` from `cli/`.

## Risks

- A source path could cross an agent boundary if its lookup loses the target type and target ID filters. Tests use the same path on two agents and require a not-found response.
- `secretRef` is an identifier, not a capability. Every route that accepts it must continue to authorize the caller.
- User-scoped secrets remain eligible only when an existing declaration proves that the proposing agent already receives that credential type. Approved aliases stay as `user_secret_ref` declarations and resolve the current run's responsible-user value.
- No database migration is required.

> This change does not overlap with an item in `ROADMAP.md`. A GitHub search found no duplicate or closely related pull request or issue.

## Model Used

OpenAI Codex with model ID `gpt-5` produced this change. The runtime did not expose its context-window size. Reasoning, tool use, code execution, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
