### PR TITLE
test(adapter-utils): make the next sandbox flake diagnosable

### DIFF
--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -214,7 +214,11 @@ describe("sandbox adapter execution targets", () => {
       `proxy stderr=${JSON.stringify(result.stderr)}`,
     ];
     const walk = async (dir: string, depth: number): Promise<void> => {
-      if (depth > 3) return;
+      // Deep enough to reach the queue frames, which are the point. They sit
+      // at process-sessions/<id>/stdin/<seq>.json — depth 4 from the runtime
+      // root — so a cap of 3 listed the `stdin/` directory and stopped, making
+      // "the queue is empty" and "the walk never looked" print identically.
+      if (depth > 5) return;
       let entries;
       try {
         entries = await readdir(dir, { withFileTypes: true });

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -148,7 +148,22 @@ describe("sandbox adapter execution targets", () => {
     throw new Error(message);
   }
 
-  async function runProxyWithInput(command: string, input: string): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  type ProxyRunResult = {
+    stdout: string;
+    stderr: string;
+    code: number | null;
+    /**
+     * How long the exchange took. The bridge and the proxy both run on 5s
+     * budgets, which is generous locally and tight on a CI runner sharing a
+     * box with 19 other lanes. A run that returns fast and empty is a
+     * different fault from one that nearly hit the ceiling, and the numbers
+     * are the only way to tell them apart after the fact.
+     */
+    elapsedMs: number;
+  };
+
+  async function runProxyWithInput(command: string, input: string): Promise<ProxyRunResult> {
+    const startedAt = performance.now();
     const child = spawn(command, [], { stdio: ["pipe", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
@@ -175,7 +190,61 @@ describe("sandbox adapter execution targets", () => {
         resolve(exitCode);
       });
     });
-    return { stdout, stderr, code };
+    return { stdout, stderr, code, elapsedMs: Math.round(performance.now() - startedAt) };
+  }
+
+  /**
+   * A failure report for a proxy exchange, attached to the assertions below.
+   *
+   * `execution-target-sandbox` has failed twice in CI and never once in a few
+   * hundred local runs, so the next occurrence has to carry its own evidence -
+   * a second unreproducible failure teaches nothing. The observed signature was
+   * an empty stdout with exit code 0, meaning the child exited cleanly having
+   * produced nothing, which is what a lost stdin frame looks like from here.
+   *
+   * The runtime tree is the part that discriminates. The stdin queue files are
+   * written by the host and deleted by the wrapper once parsed, so what remains
+   * says whether the frame was never written, written and never consumed, or
+   * consumed normally and the reply lost on the way back.
+   */
+  async function describeProxyRun(result: ProxyRunResult, runtimeRootDir: string): Promise<string> {
+    const lines = [
+      `proxy exit=${result.code} elapsedMs=${result.elapsedMs}`,
+      `proxy stdout=${JSON.stringify(result.stdout)}`,
+      `proxy stderr=${JSON.stringify(result.stderr)}`,
+    ];
+    const walk = async (dir: string, depth: number): Promise<void> => {
+      if (depth > 3) return;
+      let entries;
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch (error) {
+        lines.push(`${"  ".repeat(depth)}<unreadable ${dir}: ${(error as Error).message}>`);
+        return;
+      }
+      for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          lines.push(`${"  ".repeat(depth)}${entry.name}/`);
+          await walk(full, depth + 1);
+          continue;
+        }
+        // Small files are the queue and event frames, and their contents are
+        // the point. Anything larger is a child script or a log; the size is
+        // enough to say it exists.
+        let detail = "";
+        try {
+          const raw = await readFile(full, "utf8");
+          detail = raw.length <= 400 ? ` ${JSON.stringify(raw)}` : ` <${raw.length}B>`;
+        } catch (error) {
+          detail = ` <unreadable: ${(error as Error).message}>`;
+        }
+        lines.push(`${"  ".repeat(depth)}${entry.name}${detail}`);
+      }
+    };
+    lines.push(`runtime tree under ${runtimeRootDir}:`);
+    await walk(runtimeRootDir, 1);
+    return lines.join("\n");
   }
 
   function combinedStream(
@@ -729,9 +798,10 @@ describe("sandbox adapter execution targets", () => {
 
     try {
       const result = await runProxyWithInput(bridge!.agentCommand, "hello\n");
-      expect(result.code).toBe(0);
-      expect(result.stdout).toBe("out:hello\n");
-      expect(result.stderr).toBe("err:hello\n");
+      const report = await describeProxyRun(result, path.posix.join(rootDir, ".paperclip-runtime", "acpx"));
+      expect(result.code, report).toBe(0);
+      expect(result.stdout, report).toBe("out:hello\n");
+      expect(result.stderr, report).toBe("err:hello\n");
     } finally {
       await bridge?.stop();
     }
@@ -1026,9 +1096,10 @@ describe("sandbox adapter execution targets", () => {
 
       try {
         const result = await runProxyWithInput(bridge!.agentCommand, "hello\n");
-        expect(result.code).toBe(0);
-        expect(result.stdout).toBe("out:hello\n");
-        expect(result.stderr).toBe("err:hello\n");
+        const report = await describeProxyRun(result, path.posix.join(rootDir, ".paperclip-runtime", "acpx"));
+        expect(result.code, report).toBe(0);
+        expect(result.stdout, report).toBe("out:hello\n");
+        expect(result.stderr, report).toBe("err:hello\n");
       } finally {
         await bridge?.stop();
       }
@@ -1087,8 +1158,9 @@ describe("sandbox adapter execution targets", () => {
         // frame flows, so it is observable as soon as the handle resolves.
         expect(spanNames).toContain("sandbox.agentProcess");
         const result = await runProxyWithInput(bridge!.agentCommand, "hello\n");
-        expect(result.code).toBe(0);
-        expect(result.stdout).toBe("out:hello\n");
+        const report = await describeProxyRun(result, path.posix.join(rootDir, ".paperclip-runtime", "acpx"));
+        expect(result.code, report).toBe(0);
+        expect(result.stdout, report).toBe("out:hello\n");
       } finally {
         await bridge?.stop();
       }
@@ -1480,7 +1552,10 @@ describe("sandbox adapter execution targets", () => {
         // Round-trip one input so a stdin-delivery control exec runs and gets
         // recorded before the assertions below.
         const result = await runProxyWithInput(bridge!.agentCommand, "hello\n");
-        expect(result.stdout).toBe("out:hello\n");
+        expect(
+          result.stdout,
+          await describeProxyRun(result, path.posix.join(rootDir, ".paperclip-runtime", "acpx")),
+        ).toBe("out:hello\n");
 
         // Exactly one exec runs on the persistent session: the long-lived agent
         // command. It streams its output through the session log stream, so it


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run through execution targets, and the sandbox target proxies a long-lived child process over a local session bridge
> - `execution-target-sandbox` covers that bridge with real subprocesses, real sockets and a real stdin queue
> - It has failed twice in CI and never once locally, so each failure so far has produced a puzzle rather than a cause
> - A flaky test that cannot be diagnosed after the fact will keep costing a re-run and teaching nothing
> - This pull request does not fix the flake — it makes the next occurrence carry the evidence needed to fix it
> - The benefit is that the third failure is the last one, instead of another unreproducible report

## Linked Issues or Issue Description

No public issue exists. The problem follows.

**What happened?**

`packages/adapter-utils/src/execution-target-sandbox.test.ts` failed twice in CI during recent work:

```
AssertionError: expected '' to be 'out:hello\n'
```

The proxy exited **0** with **empty** stdout — the child exited cleanly having produced nothing.

**Expected behavior**

Either the test is reliable, or its failure explains itself.

**Steps to reproduce**

None known. It does not reproduce locally: 10 consecutive full-suite runs and several hundred iterations of the individual test all pass. Both CI failures were on runners executing 20 lanes in parallel.

**Paperclip version or commit**

`master` at `add65ba4a`.

## What Changed

- `packages/adapter-utils/src/execution-target-sandbox.test.ts` — `runProxyWithInput` records elapsed time; a new `describeProxyRun` builds a failure report; it is attached to all four round-trip exchanges.

No production code changes. No timeout changes.

### Three mechanisms ruled out, not assumed

| hypothesis | why it is not the cause |
| --- | --- |
| Helper resolves on `exit` rather than `close`, truncating output | A 200-iteration probe produced 0 truncations. The failure was *empty*, not partial |
| Wrapper reports exit before stdout drains | It already listens on `close`, with a comment saying exactly why |
| Frame writes race each other | The stream wrapper's `writeEvent` is synchronous and sequence-numbered |

### What the report captures, and why each part

Two candidates remain, and **the runtime tree separates them**: a stdin queue file still present means the host wrote the frame and the wrapper never consumed it; an empty queue with no output means it was consumed and the reply was lost coming back.

Alongside that: both proxy streams, the exit code, and the elapsed time. The last matters because the bridge and proxy run on 5s budgets — generous locally, tight on a runner sharing a box with 19 other lanes — and a fast empty return is a different fault from one that nearly hit the ceiling.

### Why not just raise the timeouts

That would probably make the symptom go away, which is the reason not to do it blind. If there is a real ordering bug in the bridge, a longer budget hides it and the fault resurfaces later somewhere less observable.

## Verification

- `adapter-utils` typecheck is clean.
- 44 pass, stable over five consecutive runs.

**The instrumentation was verified by forcing a failure and reading what it prints**, rather than trusting that it would print something useful. A healthy exchange reports:

```
proxy exit=0 elapsedMs=330
proxy stdout="out:hello\n"
proxy stderr=""
runtime tree under …/.paperclip-runtime/acpx:
  process-sessions/
    <session-id>/
      stdin/
    paperclip-process-session-remote-stream.mjs <7049B>
```

`elapsedMs=330` against a 5000ms budget, and a drained `stdin/` queue. That is the control the failing case will be read against.

**A correction to an earlier revision of this PR.** The first version capped the tree walk at depth 3, which listed `stdin/` and stopped — so the queue frames one level below were never printed, and "the queue is empty" and "the walk never looked" produced identical output. Caught in review.

I had verified that version by forcing a failure and reading the report, and still missed it, because I checked that it printed *something* rather than that it printed the thing that discriminates. Re-verified by planting a frame in the queue: before the fix the report omits it, after the fix it prints `000000000007.json "{"probe":true}"`.

## Risks

None to production. Test-only, and the report is built solely on the failure path.

The tree walk is depth-capped at 5 and inlines only files of 400 bytes or less, so a failure cannot dump a large log into CI output.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
