### PR TITLE
test(workspace-runtime): lock the readiness probe timeout against regression

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3919,6 +3919,66 @@ describe("ensureRuntimeServicesForRun", () => {
     }
   });
 
+  it("fails readiness at the configured timeout when the service accepts connections but never responds", async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-hung-"));
+    const workspace = buildWorkspace(workspaceRoot);
+    const runId = "run-paperclip-hung-readiness";
+    // Accepts the TCP connection and the request, then never writes a response.
+    // The child stays alive and healthy, so the spawn-error race arm never
+    // settles; only the readiness deadline can end the wait.
+    const serviceCommand =
+      "node -e \"require('node:http').createServer(() => {}).listen(Number(process.env.PORT), '127.0.0.1')\"";
+
+    const startedAt = Date.now();
+    try {
+      await expect(
+        ensureRuntimeServicesForRun({
+          runId,
+          agent: {
+            id: "agent-1",
+            name: "Codex Coder",
+            companyId: "company-1",
+          },
+          issue: null,
+          workspace,
+          config: {
+            workspaceRuntime: {
+              services: [
+                {
+                  name: "hung-service",
+                  command: serviceCommand,
+                  cwd: ".",
+                  port: { type: "auto" },
+                  readiness: {
+                    type: "http",
+                    urlTemplate: "http://127.0.0.1:{{port}}",
+                    timeoutSec: 1,
+                    intervalMs: 100,
+                  },
+                  expose: {
+                    type: "url",
+                    urlTemplate: "http://127.0.0.1:{{port}}",
+                  },
+                  lifecycle: "shared",
+                  stopPolicy: {
+                    type: "manual",
+                  },
+                },
+              ],
+            },
+          },
+          adapterEnv: {},
+        }),
+      ).rejects.toThrow(/Readiness check failed for http:\/\/127\.0\.0\.1:\d+/);
+      // The point of the test: the wait ends at the deadline instead of hanging
+      // on a single unbounded probe. Generous headroom over the 1s timeout so
+      // this asserts "bounded", not a specific scheduling latency.
+      expect(Date.now() - startedAt).toBeLessThan(4000);
+    } finally {
+      await releaseRuntimeServicesForRun(runId);
+    }
+  });
+
   it("uses explicit readiness URL when exposed URL is not the local probe address", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-explicit-readiness-"));
     const workspace = buildWorkspace(workspaceRoot);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - An agent run can start workspace runtime services, and the run waits for each service's HTTP readiness check before proceeding
> - The readiness probe originally called `fetch()` with no signal, so a service that accepted the connection and never responded parked the wait forever — the deadline was never re-read and the cleanup path never ran
> - #11525 fixed this on `master` with `RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS`, bounding each probe so the loop always reaches its deadline
> - That fix landed without a test for the hung-service failure mode — nothing in `workspace-runtime.test.ts` references the new constant or exercises a service that never answers
> - This pull request adds that regression test, and nothing else
> - The benefit is that the probe bound cannot be silently lost in a future refactor of the readiness loop

## Linked Issues or Issue Description

This PR originally fixed the unbounded readiness probe itself. While it was open, #11525 landed an equivalent (and better-parameterised) fix on `master`, so the source change here is superseded and has been dropped. What remains is the piece #11525 did not include: a regression test for the failure mode.

The underlying problem, for context: `waitForRuntimeServiceReadiness` polls an HTTP readiness URL in a loop bounded by a deadline. Node's `fetch` has no default timeout, so before #11525 a service that completed the TCP handshake and then never responded parked the `await` forever. The readiness promise races only against a spawn-error promise, and a hung-but-alive child never rejects it, so the catch branch that terminates the child and marks the service record stopped never ran — an orphaned process and a row stuck in `starting`.

## What Changed

- `server/src/__tests__/workspace-runtime.test.ts`: one new test, `fails readiness at the configured timeout when the service accepts connections but never responds`. It starts a real HTTP server that accepts requests and never writes a response, gives readiness a 1 second budget, and asserts through the production entry point (`ensureRuntimeServicesForRun`) that readiness rejects and that the wait stayed bounded.

No source files are changed.

## Verification

```sh
cd server
npx vitest run src/__tests__/workspace-runtime.test.ts -t "never responds"
```

Run on Node 22.22.3: passes in 1.25s against current `master`.

The test is a genuine lock on the #11525 behavior: on any revision before #11525 (for example this PR's own original base), the same test hangs until vitest kills it at the 5s test timeout, because the probe had no bound.

Note for reviewers: this suite needs Node 22 locally. On Node 24 the spawned probe servers do not become reachable and readiness tests fail with `fetch failed` on `master` as well.

## Risks

None to runtime — the diff is a single added test. The test spawns a real HTTP server on an auto-assigned port and gives generous headroom (asserts the wait ends within 4s of a 1s budget), so it should not be timing-flaky on loaded runners.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5`, used via Claude Code with extended thinking and tool use (repository search, file editing, and local test execution). The test was produced with model assistance and verified locally against `master` as described in Verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — #11525 supersedes the original source change and is linked
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — none applicable to a test-only change
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — to be confirmed after CI runs
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — to be confirmed after review
- [x] I will address all Greptile and reviewer comments before requesting merge
