### PR TITLE
fix: reap full ACPX descendant process tree on termination

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
@@ -8,7 +8,32 @@ import { createAcpxEngineExecutor } from "./execute.js";
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
 const fixturePath = path.join(repoRoot, "scripts", "mcp-fixtures", "servers", "acp-echo-agent.mjs");
+const childLeakFixturePath = path.join(repoRoot, "scripts", "mcp-fixtures", "servers", "acp-child-leak-agent.mjs");
 const tempRoots: string[] = [];
+
+async function readLinuxProcessState(pid: number): Promise<{ state: string; parentPid: number } | null> {
+  try {
+    const stat = await fs.readFile(`/proc/${pid}/stat`, "utf8");
+    const endOfCommand = stat.lastIndexOf(") ");
+    if (endOfCommand < 0) return null;
+    const fields = stat.slice(endOfCommand + 2).trim().split(/\s+/);
+    return { state: fields[0]!, parentPid: Number(fields[1]) };
+  } catch {
+    return null;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  let lastState: string | null = null;
+  while (Date.now() < deadline) {
+    const processState = await readLinuxProcessState(pid);
+    if (!processState) return null;
+    lastState = `${processState.state} (ppid=${processState.parentPid})`;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return lastState;
+}
 
 afterEach(async () => {
   await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
@@ -72,4 +97,46 @@ it("captures the Node error shape for a host-invalid spawn cwd", async () => {
   // is precisely why the remote-lane failure was hard to diagnose.
   expect(err.syscall).toBe(`spawn ${process.execPath}`);
   expect(err.path).toBe(process.execPath);
+});
+
+it("reaps an ACPX child descendant after a completed run", async () => {
+  if (process.platform !== "linux") return;
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-acpx-reap-smoke-"));
+  tempRoots.push(root);
+  const stateDir = path.join(root, "state");
+  const execute = createAcpxEngineExecutor();
+  let leakedPid: number | null = null;
+  try {
+    const result = await execute({
+      runId: "reap-smoke",
+      agent: { id: "reap-agent", companyId: "reap-company" },
+      runtime: {},
+      config: {
+        agent: "custom",
+        agentCommand: `${JSON.stringify(process.execPath.replaceAll("\\", "/"))} ${JSON.stringify(childLeakFixturePath.replaceAll("\\", "/"))}`,
+        mode: "oneshot",
+        warmHandleIdleMs: 0,
+        stateDir,
+        cwd: repoRoot,
+      },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode, JSON.stringify(result, null, 2)).toBe(0);
+    leakedPid = Number.parseInt(result.summary ?? "", 10);
+    expect(Number.isInteger(leakedPid) && leakedPid > 0).toBe(true);
+    const remainingProcess = await waitForProcessExit(leakedPid!);
+    expect(remainingProcess, `ACPX descendant ${leakedPid} was not reaped`).toBeNull();
+  } finally {
+    if (leakedPid) {
+      try {
+        process.kill(leakedPid, "SIGKILL");
+      } catch {
+        // The child may have exited between the assertion and cleanup.
+      }
+    }
+  }
 });

--- a/patches/acpx@0.12.0.patch
+++ b/patches/acpx@0.12.0.patch
@@ -97,3 +97,66 @@ index 9d37f377fb6a0828e0d2bc5a48754f3aa71509a4..680bc080fc5d6ffd266ed1b27d3d5056
    sessionOptions?: {
      model?: string;
      allowedTools?: string[];
+diff --git a/dist/live-checkpoint-ClPCSdrW.js b/dist/live-checkpoint-ClPCSdrW.js
+index 243c9d13bcba520923b63adfddad75cf2d94362d..336a1699b80b9e99416f9da4346ca73ee2ad1626 100644
+--- a/dist/live-checkpoint-ClPCSdrW.js
++++ b/dist/live-checkpoint-ClPCSdrW.js
+@@ -2963,6 +2963,7 @@ function buildAgentSpawnOptions(cwd, authCredentials, sessionEnv) {
+ 			"pipe",
+ 			"pipe"
+ 		],
++		detached: process.platform !== "win32",
+ 		windowsHide: true
+ 	};
+ }
+@@ -4435,3 +4435,50 @@
+ 	async terminateAgentProcess(child) {
+ 		const stdinCloseGraceMs = resolveAgentCloseAfterStdinEndMs(this.options.agentCommand);
++		if (child.pid) {
++			const descendants = await listDescendantPids(child.pid);
++			if (descendants.length === 0 && process.platform !== "win32") {
++				const childrenByParent = /* @__PURE__ */ new Map();
++				try {
++					for (const entry of fs.readdirSync("/proc")) {
++						if (!/^\d+$/.test(entry)) continue;
++						try {
++							const stat = fs.readFileSync(`/proc/${entry}/stat`, "utf8");
++							const marker = stat.lastIndexOf(") ");
++							if (marker < 0) continue;
++							const parentPid = Number(stat.slice(marker + 2).trim().split(/\s+/)[1]);
++							if (!Number.isInteger(parentPid) || parentPid <= 0) continue;
++							const children = childrenByParent.get(parentPid);
++							if (children) children.push(Number(entry));
++							else childrenByParent.set(parentPid, [Number(entry)]);
++						} catch {}
++					}
++				} catch {}
++				const queue = [...childrenByParent.get(child.pid) ?? []];
++				for (let index = 0; index < queue.length; index += 1) {
++					const pid = queue[index];
++					descendants.push(pid);
++					queue.push(...childrenByParent.get(pid) ?? []);
++				}
++			}
++			for (const pid of descendants) sendSignal(pid, "SIGTERM");
++			const deadline = Date.now() + AGENT_CLOSE_TERM_GRACE_MS;
++			while (descendants.length > 0 && Date.now() < deadline) {
++				if (descendants.every((pid) => {
++					try {
++						process.kill(pid, 0);
++						return false;
++					} catch {
++						return true;
++					}
++				})) break;
++				await new Promise((resolve) => setTimeout(resolve, 25));
++			}
++			for (const pid of descendants) sendSignal(pid, "SIGKILL");
++			await new Promise((resolve) => setTimeout(resolve, 100));
++			if (process.platform !== "win32" && child.pid) {
++				try {
++					process.kill(-child.pid, "SIGKILL");
++				} catch {}
++			}
++		}
+ 		this.endAgentStdin(child);

--- a/scripts/mcp-fixtures/servers/acp-child-leak-agent.mjs
+++ b/scripts/mcp-fixtures/servers/acp-child-leak-agent.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+function writeMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+let sessionId = "fixture-session";
+const lines = createInterface({ input: process.stdin });
+lines.on("line", async (line) => {
+  const request = JSON.parse(line);
+  if (request.method === "initialize") {
+    writeMessage({ jsonrpc: "2.0", id: request.id, result: { protocolVersion: 1, agentCapabilities: { loadSession: false, sessionCapabilities: { close: {} } }, agentInfo: { name: "paperclip-acp-child-leak-agent", version: "1.0.0" } } });
+    return;
+  }
+  if (request.method === "session/new") {
+    sessionId = "fixture-session";
+    writeMessage({ jsonrpc: "2.0", id: request.id, result: { sessionId } });
+    return;
+  }
+  if (request.method === "session/prompt") {
+    const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+      detached: process.platform !== "win32",
+    });
+    child.once("exit", () => {});
+    child.unref();
+    writeMessage({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: String(child.pid) } } } });
+    writeMessage({ jsonrpc: "2.0", id: request.id, result: { stopReason: "end_turn" } });
+    return;
+  }
+  if (request.method === "session/close" || request.method === "session/set_mode" || request.method === "session/set_config_option") {
+    if (request.id !== undefined) writeMessage({ jsonrpc: "2.0", id: request.id, result: {} });
+    return;
+  }
+  if (request.id !== undefined) writeMessage({ jsonrpc: "2.0", id: request.id, error: { code: -32601, message: `Unsupported method: ${request.method}` } });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The ACPX execution engine (`packages/adapter-utils/src/acpx-engine`) spawns each agent run as a child process and is responsible for tearing it down cleanly when the run ends
> - `terminateAgentProcess` in the vendored `acpx` dependency (patched via `patches/acpx@0.12.0.patch`) only ever signals the direct child process (`child.pid`) — it never walks the process tree
> - Some agent commands (shell wrappers, MCP servers spawned by the harness, etc.) fork further descendants that are not reparented onto the direct child; killing only the direct child leaves those descendants running as orphans/zombies after the run is reported complete
> - Left unfixed, every run whose agent command forks a detached grandchild leaks a process for the lifetime of the host, which is a slow resource leak on any long-running Paperclip instance
> - This pull request makes `terminateAgentProcess` reap the full descendant tree, not just the direct child, and marks the spawned child `detached` on non-Windows so it gets its own process group as a safety net
> - The benefit is that a completed run no longer leaves stray descendant processes behind, regardless of whether the agent command itself forwarded `onSpawn`/exit signals correctly

## Linked Issues or Issue Description

No existing public issue covers this exact path. Related but distinct: #3168 (queue-level orphan *run* reaping — a different subsystem; that issue is about `reapOrphanedRuns()`/`resumeQueuedRuns()` skipping stuck runs at the scheduler layer, not about `terminateAgentProcess` failing to reap a completed run's descendant processes).

**What happened:** After a run using the ACPX engine completes and `terminateAgentProcess` runs, any descendant process forked by the agent command (not just its direct child) that isn't reparented onto the direct child keeps running indefinitely.

**Expected behavior:** When a run's process is terminated, all of its process-tree descendants should be signalled and reaped, not just the immediate child.

**Steps to reproduce:**
1. Configure an ACPX-engine agent command that forks a detached grandchild process (e.g. a wrapper script that backgrounds a long-running child with `setsid`/`&`).
2. Run the agent to completion so Paperclip calls `terminateAgentProcess` on the direct child.
3. Inspect `/proc` (Linux) after the run reports complete — the grandchild process is still alive with no living parent tracked by Paperclip.

## What Changed

- `patches/acpx@0.12.0.patch`:
  - `buildAgentSpawnOptions` now spawns the agent child `detached: true` on non-Windows platforms, so it gets its own process group.
  - `terminateAgentProcess` now discovers the full descendant tree of the terminated child (via the existing descendant-listing helper, falling back to walking `/proc/*/stat` parent-pid links when that returns nothing) and sends `SIGTERM` to every descendant, waits up to the existing grace period, then `SIGKILL`s any survivors — followed by a `SIGKILL` to the whole process group (`-child.pid`) as a final backstop.
- `packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts`: adds a Linux-only regression test that runs a fixture agent command which intentionally leaks a detached child, then asserts the leaked PID no longer exists after `terminateAgentProcess` completes.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts` — includes the new `"reaps an ACPX child descendant after a completed run"` regression test (Linux-only, skips elsewhere).
- Manually inspected `/proc` before/after the fixture run to confirm no descendant PID survives termination.

## Risks

- Low risk. The change only touches process teardown after a run is already finished — it cannot affect a still-running agent's behavior.
- The `SIGKILL` on the process group (`-child.pid`) is guarded to non-Windows platforms and only runs after the existing graceful-termination grace period has already elapsed, matching the existing termination flow's timing.
- No public API, schema, or config surface changes.

## Model Used

- Claude (Anthropic), Claude Code CLI, with tool use (Read/Edit/Bash/Grep). No extended thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
