### PR TITLE
fix(runtime): reap and sweep orphaned queued heartbeat runs (MAD-891)

### DIFF
--- a/server/src/__tests__/heartbeat-run-liveness.test.ts
+++ b/server/src/__tests__/heartbeat-run-liveness.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RUN_LEASE_TTL_MS,
+  isAbandonedHeartbeatRun,
+  type HeartbeatRunLivenessRow,
+} from "../services/heartbeat-run-liveness.js";
+
+const NOW = new Date("2026-08-07T12:00:00.000Z");
+
+function run(overrides: Partial<HeartbeatRunLivenessRow> = {}): HeartbeatRunLivenessRow {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    status: "running",
+    processPid: null,
+    processGroupId: null,
+    processStartedAt: null,
+    lastOutputAt: null,
+    startedAt: null,
+    updatedAt: null,
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+function ago(ms: number) {
+  return new Date(NOW.getTime() - ms);
+}
+
+describe("isAbandonedHeartbeatRun (MAD-622)", () => {
+  it("treats a process-less run silent past the lease as abandoned", () => {
+    expect(
+      isAbandonedHeartbeatRun(run({ lastOutputAt: ago(DEFAULT_RUN_LEASE_TTL_MS + 1000) }), { now: NOW }),
+    ).toBe(true);
+  });
+
+  it("leaves a recently active run alone", () => {
+    expect(
+      isAbandonedHeartbeatRun(run({ lastOutputAt: ago(60_000) }), { now: NOW }),
+    ).toBe(false);
+  });
+
+  it("leaves a run with a live process alone even past the lease", () => {
+    // process.pid is by definition alive while this test runs.
+    expect(
+      isAbandonedHeartbeatRun(
+        run({ processPid: process.pid, lastOutputAt: ago(DEFAULT_RUN_LEASE_TTL_MS * 10) }),
+        { now: NOW },
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to startedAt, then updatedAt, for the lease clock", () => {
+    expect(
+      isAbandonedHeartbeatRun(run({ startedAt: ago(DEFAULT_RUN_LEASE_TTL_MS + 1) }), { now: NOW }),
+    ).toBe(true);
+    expect(
+      isAbandonedHeartbeatRun(run({ updatedAt: ago(DEFAULT_RUN_LEASE_TTL_MS + 1) }), { now: NOW }),
+    ).toBe(true);
+    expect(
+      isAbandonedHeartbeatRun(run({ updatedAt: ago(1000) }), { now: NOW }),
+    ).toBe(false);
+  });
+
+  it("fails closed when there is no timestamp to reason about", () => {
+    expect(isAbandonedHeartbeatRun(run(), { now: NOW })).toBe(false);
+  });
+
+  it("honours an explicit ttl override", () => {
+    expect(
+      isAbandonedHeartbeatRun(run({ lastOutputAt: ago(5_000) }), { now: NOW, ttlMs: 1_000 }),
+    ).toBe(true);
+  });
+});
+
+describe("never-started queued runs (MAD-891)", () => {
+  const orphan = (overrides: Partial<HeartbeatRunLivenessRow> = {}) =>
+    run({ status: "queued", startedAt: null, lastOutputAt: null, ...overrides });
+
+  it("reaps a queued run that never started and is past the lease", () => {
+    expect(
+      isAbandonedHeartbeatRun(orphan({ createdAt: ago(DEFAULT_RUN_LEASE_TTL_MS + 1) }), { now: NOW }),
+    ).toBe(true);
+  });
+
+  it("leaves a freshly queued run alone", () => {
+    expect(
+      isAbandonedHeartbeatRun(orphan({ createdAt: ago(60_000) }), { now: NOW }),
+    ).toBe(false);
+  });
+
+  // The regression the ticket called out: `updatedAt` is bookkeeping, not
+  // liveness. A stale queued run whose row keeps getting re-stamped would renew
+  // its lease forever and make the reaper a no-op for exactly this case.
+  it("ignores a bumped updatedAt and keeps the lease clock on createdAt", () => {
+    expect(
+      isAbandonedHeartbeatRun(
+        orphan({ createdAt: ago(DEFAULT_RUN_LEASE_TTL_MS + 1), updatedAt: ago(1_000) }),
+        { now: NOW },
+      ),
+    ).toBe(true);
+  });
+
+  // A run that did start is measured by its own activity, not by enqueue time.
+  it("does not use createdAt once the run has started", () => {
+    expect(
+      isAbandonedHeartbeatRun(
+        run({ createdAt: ago(DEFAULT_RUN_LEASE_TTL_MS * 10), startedAt: ago(1_000) }),
+        { now: NOW },
+      ),
+    ).toBe(false);
+  });
+});

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -541,4 +541,117 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       executionRunId: currentRunId,
     });
   });
+
+  // MAD-891: the wedge that stranded MAD-741/868/875/878/879. A retry run was
+  // promoted `scheduled_retry` -> `queued`, its dispatch failed, and the row
+  // stayed `queued` with `startedAt = null` forever. That status is neither
+  // terminal nor missing, so the lock reaper could not release it and every
+  // mutation on the issue 409'd with `Issue run ownership conflict`.
+  it("releases an execution lock held by a queued run that never started", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const orphanRunId = randomUUID();
+    const issueId = randomUUID();
+    const longPast = new Date(Date.now() - 60 * 60 * 1000);
+
+    await db.insert(heartbeatRuns).values({
+      id: orphanRunId,
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "manual",
+      // The orphan signature: promoted to `queued`, never claimed, no process.
+      startedAt: null,
+      finishedAt: null,
+      processPid: null,
+      processGroupId: null,
+      createdAt: longPast,
+      // Bumped well after createdAt — the lease must not be renewed by it.
+      updatedAt: new Date(),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Orphaned queued run holds the lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: orphanRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: longPast,
+    });
+    await db.update(heartbeatRuns)
+      .set({ contextSnapshot: { issueId } })
+      .where(eq(heartbeatRuns.id, currentRunId));
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Recovered from orphaned queued run" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const row = await db
+      .select({
+        title: issues.title,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      title: "Recovered from orphaned queued run",
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+  });
+
+  // Guard the other direction: a queued run inside its lease is a legitimate
+  // waiter, and its lock must still be honoured.
+  it("keeps the lock for a recently queued run that has not started yet", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const queuedRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(heartbeatRuns).values({
+      id: queuedRunId,
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "manual",
+      startedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Recently queued run still owns the lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: queuedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+    await db.update(heartbeatRuns)
+      .set({ contextSnapshot: { issueId } })
+      .where(eq(heartbeatRuns.id, currentRunId));
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Should not steal the lock" });
+
+    expect(res.status).toBe(409);
+
+    const row = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row?.executionRunId).toBe(queuedRunId);
+  });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1159,6 +1159,13 @@ export async function startServer(): Promise<StartedServer> {
           logger.warn({ ...scanned }, "startup active-run output watchdog created review work");
         }
 
+        // MAD-891: must run before the stale-lock sweeper — it makes orphaned
+        // queued runs terminal, which is what lets the lock sweeper release them.
+        const orphanedQueued = await heartbeat.sweepOrphanedQueuedRuns();
+        if (orphanedQueued.failed > 0 || orphanedQueued.dispatched > 0) {
+          logger.warn({ ...orphanedQueued }, "startup orphaned queued-run sweeper resolved stranded runs");
+        }
+
         const swept = await heartbeat.sweepStaleIssueLocks();
         if (swept.cleared > 0) {
           logger.warn({ ...swept }, "startup stale-lock sweeper cleared issue locks");
@@ -1368,6 +1375,14 @@ export async function startServer(): Promise<StartedServer> {
               const scanned = await heartbeat.scanSilentActiveRuns();
               if (scanned.created > 0 || scanned.escalated > 0) {
                 logger.warn({ ...scanned }, "periodic active-run output watchdog created review work");
+              }
+            })
+            .then(async () => {
+              // MAD-891: ordered before the stale-lock sweeper on purpose — it
+              // makes orphaned queued runs terminal so their locks become reapable.
+              const orphanedQueued = await heartbeat.sweepOrphanedQueuedRuns();
+              if (orphanedQueued.failed > 0 || orphanedQueued.dispatched > 0) {
+                logger.warn({ ...orphanedQueued }, "periodic orphaned queued-run sweeper resolved stranded runs");
               }
             })
             .then(async () => {

--- a/server/src/services/heartbeat-run-liveness.ts
+++ b/server/src/services/heartbeat-run-liveness.ts
@@ -1,0 +1,111 @@
+// MAD-622: lease/TTL liveness for heartbeat runs that hold issue locks.
+//
+// Issue lock reaping used to be status-driven only: a run row had to be
+// terminal (or missing) before `checkoutRunId` / `executionRunId` could be
+// cleared. A run whose *process* dies without its DB row ever transitioning —
+// API restart mid-run, host crash, model session limit — is neither terminal
+// nor missing, so its lock was held forever and the issue was stranded.
+//
+// This module adds the second liveness axis: a non-terminal run is treated as
+// dead when it has no live process AND has been silent past a TTL. Both
+// conditions are required. The pid probe alone is not enough (pid reuse, and
+// runs that legitimately have no local process); the TTL alone is not enough
+// (a healthy long-running turn can be quiet for minutes).
+//
+// On pid reuse (see MAD-375): a recycled pid makes `isPidAlive` report a run as
+// alive when it is not. That error direction is the safe one here — it delays a
+// reap rather than reaping a live run's lock, and letting two runs mutate one
+// issue concurrently is strictly worse than a stuck lock. Every ambiguous case
+// below therefore resolves to "still alive".
+
+import { runningProcesses } from "../adapters/utils.js";
+import { isPidAlive, isProcessGroupAlive } from "./local-service-supervisor.js";
+
+/**
+ * How long a non-terminal, process-less run may stay silent before its issue
+ * lock is considered abandoned. Deliberately generous: reaping too early is a
+ * correctness bug, reaping late is an availability annoyance.
+ */
+export const DEFAULT_RUN_LEASE_TTL_MS = 15 * 60 * 1000;
+
+export type HeartbeatRunLivenessRow = {
+  id: string;
+  status: string;
+  processPid: number | null;
+  processGroupId: number | null;
+  processStartedAt: Date | null;
+  lastOutputAt: Date | null;
+  startedAt: Date | null;
+  updatedAt: Date | null;
+  createdAt: Date | null;
+};
+
+function hasLiveProcess(run: HeartbeatRunLivenessRow): boolean {
+  // An in-memory handle is the strongest signal available: this server process
+  // is still supervising the run, so it is alive regardless of what the row says.
+  if (runningProcesses.get(run.id)) return true;
+
+  const pid = run.processPid;
+  const processGroupId = run.processGroupId;
+  if (typeof pid !== "number" && typeof processGroupId !== "number") {
+    // No process metadata at all. We cannot probe; fall back to the TTL alone.
+    return false;
+  }
+
+  return (
+    (typeof pid === "number" && isPidAlive(pid)) ||
+    (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId))
+  );
+}
+
+function lastActivityAt(run: HeartbeatRunLivenessRow): Date | null {
+  if (run.lastOutputAt) return run.lastOutputAt;
+  if (run.startedAt) return run.startedAt;
+
+  // MAD-891: a run that never started (`queued` with `startedAt = null`) has no
+  // execution activity to measure. `updatedAt` is *bookkeeping*, not liveness —
+  // any unrelated row write (retry promotion, wakeup linkage, a status re-stamp)
+  // pushes it forward and would silently renew the lease of a run that is doing
+  // nothing at all, making the reaper a no-op for exactly the orphan case it
+  // exists to catch. Key the lease off `createdAt` for never-started runs so the
+  // clock starts when the run was enqueued and only ever moves forward once.
+  if (!run.startedAt) return run.createdAt ?? run.updatedAt ?? null;
+
+  return run.updatedAt ?? null;
+}
+
+/**
+ * True when a non-terminal run is demonstrably dead and its lease has expired,
+ * so any issue lock it holds may be reaped.
+ *
+ * Callers must still handle the terminal/missing cases themselves — this
+ * function speaks only to the "row says running but nothing is running" case.
+ */
+export function isAbandonedHeartbeatRun(
+  run: HeartbeatRunLivenessRow,
+  options: { now?: Date; ttlMs?: number } = {},
+): boolean {
+  const now = options.now ?? new Date();
+  const ttlMs = options.ttlMs ?? DEFAULT_RUN_LEASE_TTL_MS;
+
+  if (hasLiveProcess(run)) return false;
+
+  const activityAt = lastActivityAt(run);
+  // No timestamp to reason about → fail closed and leave the lock alone.
+  if (!activityAt) return false;
+
+  return now.getTime() - activityAt.getTime() >= ttlMs;
+}
+
+/** Column selection matching {@link HeartbeatRunLivenessRow}. */
+export const HEARTBEAT_RUN_LIVENESS_COLUMNS = [
+  "id",
+  "status",
+  "processPid",
+  "processGroupId",
+  "processStartedAt",
+  "lastOutputAt",
+  "startedAt",
+  "updatedAt",
+  "createdAt",
+] as const;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -81,6 +81,7 @@ import {
 // git-credentials module became its canonical home; existing importers keep working.
 export { scrubGitCredentialText };
 import { publishLiveEvent } from "./live-events.js";
+import { DEFAULT_RUN_LEASE_TTL_MS } from "./heartbeat-run-liveness.js";
 import { normalizeResponsibleUserDenialCode } from "./responsible-user-denial-run-outcomes.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, listAdapterModelProfiles, runningProcesses } from "../adapters/index.js";
@@ -357,6 +358,12 @@ const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_AGENT_MESSAGE_KEY = "paperclipAgentMessage";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+/**
+ * MAD-891: a run that sat in `queued` past its lease without ever starting and
+ * could not be dispatched. Distinct from `process_lost` (which had a process)
+ * and from the `claimQueuedRun` cancel codes (which are modelled refusals).
+ */
+export const ORPHANED_DISPATCH_ERROR_CODE = "dispatch_orphaned";
 // The reaper sweeps at most this many pending_cleanup leases per tick.
 const PENDING_CLEANUP_SWEEP_PAGE_SIZE = 20;
 // The reaper stops retrying a pending_cleanup lease after this many attempts.
@@ -13586,6 +13593,126 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
   }
 
+  /**
+   * MAD-891: backstop for runs stranded in `queued` with `startedAt = null`.
+   *
+   * `resumeQueuedRuns` -> `startNextQueuedRunForAgent` -> `claimQueuedRun` is the
+   * dispatcher, and every *known* refusal inside it is terminal (cancel + lock
+   * release). But a dispatch that fails for an unmodelled reason — the failure
+   * storm on 2026-08-16, a throw between promotion and claim, a scheduling
+   * suppression window that outlives the run — leaves the row `queued` forever.
+   * That state is owned by nothing: `promoteDueScheduledRetries` only selects
+   * `scheduled_retry`, `reapOrphanedRuns` deliberately skips `queued`, and the
+   * lock reaper cannot release a run that is neither terminal nor missing. Every
+   * mutation on the issue then 409s with `Issue run ownership conflict`.
+   *
+   * This sweep resolves such runs one way or the other: dispatch it if the agent
+   * can take it now, otherwise fail it with a distinct `dispatch_orphaned` code
+   * so it becomes terminal and the MAD-622 reaper releases its issue lock. Rows
+   * are never deleted.
+   *
+   * A run merely *waiting its turn* behind a busy agent is not an orphan, so the
+   * fail path is skipped whenever the agent has no free concurrency slot.
+   */
+  async function sweepOrphanedQueuedRuns(opts?: { orphanTtlMs?: number; now?: Date }) {
+    const orphanTtlMs = opts?.orphanTtlMs ?? DEFAULT_RUN_LEASE_TTL_MS;
+    const now = opts?.now ?? new Date();
+    if ((await getSchedulingSuppression()).suppressed) {
+      return { dispatched: 0, failed: 0, runIds: [] as string[] };
+    }
+    const cutoff = await getWorktreeExecutionCutoff();
+
+    const candidates = await db
+      .select({ run: heartbeatRuns })
+      .from(heartbeatRuns)
+      .innerJoin(companies, eq(companies.id, heartbeatRuns.companyId))
+      .where(and(
+        eq(heartbeatRuns.status, "queued"),
+        isNull(heartbeatRuns.startedAt),
+        eq(companies.status, "active"),
+        lte(heartbeatRuns.createdAt, new Date(now.getTime() - orphanTtlMs)),
+        cutoff ? gte(heartbeatRuns.createdAt, cutoff) : undefined,
+      ))
+      .orderBy(asc(heartbeatRuns.createdAt))
+      .limit(50);
+
+    let dispatched = 0;
+    const failedRunIds: string[] = [];
+    const nudgedAgentIds = new Set<string>();
+
+    for (const { run: candidate } of candidates) {
+      // Something in this process is already driving it; not an orphan.
+      if (runningProcesses.has(candidate.id) || activeRunExecutions.has(candidate.id)) continue;
+
+      // Try the normal dispatcher first — a stalled queue that can simply be
+      // drained should be drained, not failed. One nudge per agent per sweep
+      // drains that agent's whole queue, so don't re-nudge for each candidate.
+      if (!nudgedAgentIds.has(candidate.agentId)) {
+        nudgedAgentIds.add(candidate.agentId);
+        await startNextQueuedRunForAgent(candidate.agentId);
+      }
+
+      const current = await getRun(candidate.id);
+      if (!current) continue;
+      if (current.status !== "queued") {
+        dispatched += 1;
+        continue;
+      }
+
+      const agent = await getAgent(current.agentId);
+      if (!agent) continue; // claimQueuedRun cancels agent-less runs on its own.
+
+      // Legitimately queued behind the agent's own concurrency limit.
+      const policy = parseHeartbeatPolicy(agent);
+      const runningCount = await countRunningRunsForAgent(current.agentId);
+      if (policy.maxConcurrentRuns - runningCount <= 0) continue;
+
+      const reason =
+        `Failed because the run stayed queued for over ${Math.round(orphanTtlMs / 60_000)} minutes `
+        + "without ever starting and could not be dispatched";
+      // Compare-and-set on `queued`: a dispatcher that claims this run between
+      // the check above and here must win, so we never fail a live run.
+      const transition = await setRunStatusFromLive(current.id, "failed", ["queued"], {
+        finishedAt: now,
+        error: reason,
+        errorCode: ORPHANED_DISPATCH_ERROR_CODE,
+        resultJson: {
+          ...parseObject(current.resultJson),
+          stopReason: ORPHANED_DISPATCH_ERROR_CODE,
+        },
+      });
+      if (!transition.updated || !transition.run) continue;
+      const failed = transition.run;
+
+      await setWakeupStatus(failed.wakeupRequestId, "failed", { finishedAt: now, error: reason });
+      // Terminal now, so this releases the issue execution lock the orphan held.
+      await releaseIssueExecutionAndPromote(failed);
+
+      await appendRunEvent(failed, await nextRunEventSeq(failed.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "error",
+        message: reason,
+        payload: {
+          orphanTtlMs,
+          queuedAt: failed.createdAt ? new Date(failed.createdAt).toISOString() : null,
+          scheduledRetryReason: failed.scheduledRetryReason,
+          scheduledRetryAttempt: failed.scheduledRetryAttempt,
+        },
+      });
+
+      failedRunIds.push(failed.id);
+    }
+
+    if (failedRunIds.length > 0) {
+      logger.warn(
+        { failedCount: failedRunIds.length, runIds: failedRunIds, dispatched },
+        "failed orphaned queued heartbeat runs that never started",
+      );
+    }
+    return { dispatched, failed: failedRunIds.length, runIds: failedRunIds };
+  }
+
   async function reconcileStrandedAssignedIssues() {
     return recovery.reconcileStrandedAssignedIssues({ issueCreatedAtGte: await getWorktreeExecutionCutoff() });
   }
@@ -19251,6 +19378,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     retryScheduledRetryNow,
 
     resumeQueuedRuns,
+    sweepOrphanedQueuedRuns,
 
     scheduleBoundedRetry: async (
       runId: string,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -131,6 +131,10 @@ import {
 } from "./activity-log.js";
 import { buildIssueChanges } from "./issue-change-receipt.js";
 import { issueThreadInteractionAttentionAgentAllowed } from "./issue-thread-interaction-resolution.js";
+import {
+  isAbandonedHeartbeatRun,
+  type HeartbeatRunLivenessRow,
+} from "./heartbeat-run-liveness.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -776,6 +780,19 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 }
 
 export const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "interrupted", "failed", "cancelled", "timed_out"]);
+// Columns every lock-reaping path needs to decide whether a non-terminal run is
+// actually still alive (MAD-622).
+const HEARTBEAT_RUN_LIVENESS_SELECTION = {
+  id: heartbeatRuns.id,
+  status: heartbeatRuns.status,
+  processPid: heartbeatRuns.processPid,
+  processGroupId: heartbeatRuns.processGroupId,
+  processStartedAt: heartbeatRuns.processStartedAt,
+  lastOutputAt: heartbeatRuns.lastOutputAt,
+  startedAt: heartbeatRuns.startedAt,
+  updatedAt: heartbeatRuns.updatedAt,
+  createdAt: heartbeatRuns.createdAt,
+} as const;
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
 
@@ -1133,18 +1150,24 @@ async function listPendingFinalizeBlockerIssueIds(
  * Whether a heartbeat run has reached a terminal state or no longer exists.
  * A terminal/missing run can make no further progress on its execution
  * workspace, so callers must not wait on it to advance an in-flight operation.
+ *
+ * MAD-622: a run whose *process* died without its row ever transitioning is
+ * neither terminal nor missing, yet it can make no further progress either. Such
+ * an abandoned run (no live process, silent past its lease) counts as terminal
+ * here so it stops blocking gates and holding issue locks forever.
  */
 export async function heartbeatRunIsTerminalOrMissing(
   dbOrTx: Pick<Db, "select">,
   runId: string,
 ): Promise<boolean> {
   const run = await dbOrTx
-    .select({ status: heartbeatRuns.status })
+    .select(HEARTBEAT_RUN_LIVENESS_SELECTION)
     .from(heartbeatRuns)
     .where(eq(heartbeatRuns.id, runId))
-    .then((rows: Array<{ status: string }>) => rows[0] ?? null);
+    .then((rows: HeartbeatRunLivenessRow[]) => rows[0] ?? null);
   if (!run) return true;
-  return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+  if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+  return isAbandonedHeartbeatRun(run);
 }
 
 /**
@@ -5258,11 +5281,19 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select(HEARTBEAT_RUN_LIVENESS_SELECTION)
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.executionRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      // MAD-622: terminal, missing, or abandoned (dead process past its lease)
+      // all mean the run holds no real claim on the execution lock.
+      if (
+        run &&
+        !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status) &&
+        !isAbandonedHeartbeatRun(run)
+      ) {
+        return false;
+      }
 
       const updated = await tx
         .update(issues)
@@ -5306,22 +5337,32 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.checkoutRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select(HEARTBEAT_RUN_LIVENESS_SELECTION)
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.checkoutRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      // MAD-622: abandoned runs (dead process past the lease) count as stale
+      // alongside terminal and missing ones.
+      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status) && !isAbandonedHeartbeatRun(run)) {
+        return false;
+      }
 
       if (issue.executionRunId && issue.executionRunId !== issue.checkoutRunId) {
         await tx.execute(
           sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
         );
         const executionRun = await tx
-          .select({ status: heartbeatRuns.status })
+          .select(HEARTBEAT_RUN_LIVENESS_SELECTION)
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, issue.executionRunId))
           .then((rows) => rows[0] ?? null);
-        if (executionRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)) return false;
+        if (
+          executionRun &&
+          !TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status) &&
+          !isAbandonedHeartbeatRun(executionRun)
+        ) {
+          return false;
+        }
       }
 
       const updated = await tx


### PR DESCRIPTION
Fixes the wedge diagnosed in MAD-889/MAD-891: a heartbeat run stuck in `status = 'queued'` with `startedAt = null` is owned by nothing — no dispatcher re-examines it, and no reaper releases the issue execution lock it holds. Every mutation on the affected issue then 409s with `Issue run ownership conflict`. Observed live on five issues after a `claude_transient_upstream` failure storm.

## A. Land the MAD-622 lease reaper (and correct it)

`heartbeat-run-liveness.ts` (`isAbandonedHeartbeatRun`, `DEFAULT_RUN_LEASE_TTL_MS`) existed only as uncommitted working-tree changes and shipped in neither runtime. Committed here, folded into the shared `heartbeatRunIsTerminalOrMissing` helper rather than duplicated per call site, so every lock-reaping path picks it up.

**The `updatedAt` concern was real.** `lastActivityAt()` fell back to `updatedAt`, which is bookkeeping, not liveness — retry promotion, wakeup linkage and status re-stamps all push it forward, so a run doing nothing would renew its lease indefinitely and the reaper would be a no-op for exactly this case. For a run that never started, the lease clock now keys off `createdAt`. Regression test: `ignores a bumped updatedAt and keeps the lease clock on createdAt`.

## B. Sweep orphaned queued runs

New `sweepOrphanedQueuedRuns` in `heartbeat.ts`: selects `queued` + `startedAt IS NULL` + `createdAt` past the lease. For each it **nudges the real dispatcher first** — a drainable queue should be drained, not failed. Only if the run is still `queued` afterwards is it failed with a distinct `dispatch_orphaned` error code, via a compare-and-set on `queued` so a dispatcher winning the race is never clobbered. No rows are deleted. Wired into the startup and periodic recovery chains, ordered before `sweepStaleIssueLocks` so the lock is reaped in the same tick. Runs whose agent has no free concurrency slot are skipped — a run waiting its turn is a legitimate waiter, not an orphan.

## C. Lock-at-enqueue — no change needed

`claimQueuedRun` already stamps `executionRunId` / `executionLockedAt` lazily at claim time. The stale `executionLockedAt` seen live came from the prior attempt's row, not an enqueue-time stamp. No blast radius to assess.

One correction to the original diagnosis: a queued-run dispatcher *does* exist (`resumeQueuedRuns` → `startNextQueuedRunForAgent` → `claimQueuedRun`), and every modelled refusal inside it is already terminal. The wedge is the *unmodelled* dispatch failure — hence a backstop sweep rather than a replacement.

## Verification

- `npx vitest run src/__tests__/heartbeat-run-liveness.test.ts` — 10 passed
- `npx vitest run src/__tests__/issue-stale-execution-lock-routes.test.ts` — 13 passed
- Typecheck clean

Includes the specific orphan-case coverage required by the ticket: a `queued` run, `startedAt = null`, no pid, past the TTL → lock released and the run reaches a terminal status.

Opened from a fork: `mmdgn` has READ-only permission on this repo, so a direct branch push 403s.
