### PR TITLE
test(ui): wait for conditions, not durations, in three flaky tests

### DIFF
--- a/ui/src/App.activity-routing.test.tsx
+++ b/ui/src/App.activity-routing.test.tsx
@@ -111,12 +111,16 @@ function renderAppAt(container: HTMLElement, path: string) {
   return root;
 }
 
+/**
+ * Waits on the condition, not on a fixed number of turns. The previous version
+ * yielded at most five macrotasks before asserting, which is ample on an idle
+ * machine and not when the suite is running many workers in parallel — the
+ * container was still empty and the assertion failed on a route that resolves
+ * perfectly well. `vi.waitFor` retries against a time budget instead, so a
+ * loaded worker gets more turns rather than a failure.
+ */
 async function waitForRoute(container: HTMLElement, text: string) {
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    if (container.textContent?.includes(text)) return;
-    await new Promise((resolve) => window.setTimeout(resolve, 0));
-  }
-  expect(container.textContent).toContain(text);
+  await vi.waitFor(() => expect(container.textContent).toContain(text));
 }
 
 describe("App Activity routing (PAP-16302)", () => {

--- a/ui/src/components/DocumentAnnotationPopover.test.tsx
+++ b/ui/src/components/DocumentAnnotationPopover.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 
-import { createRef } from "react";
+import { act, createRef } from "react";
 import { createRoot } from "react-dom/client";
 import type { DocumentAnnotationThreadWithComments } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DocumentAnnotationPopover } from "./DocumentAnnotationPopover";
+
+// Required for `act` to flush passive effects rather than warn.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mutations = vi.hoisted(() => ({
   create: vi.fn(),
@@ -88,7 +91,16 @@ describe("DocumentAnnotationPopover", () => {
       ...overrides,
     };
     props.containerRef.current = container;
-    root.render(<DocumentAnnotationPopover {...props} />);
+    // `act`, so the passive effects are flushed before this returns. Waiting on
+    // the popover element alone is not enough: the element is in the DOM as
+    // soon as React commits, while the effect that registers the document-level
+    // keydown/pointerdown listeners runs afterwards. A test that dispatches in
+    // that gap loses the event outright — and a lost event cannot be recovered
+    // by retrying the assertion, which is why this is fixed here and not at the
+    // call site.
+    await act(async () => {
+      root.render(<DocumentAnnotationPopover {...props} />);
+    });
     await vi.waitFor(() => expect(container.querySelector('[data-testid="document-annotation-popover"]')).not.toBeNull());
     return { onClose };
   };
@@ -114,10 +126,14 @@ describe("DocumentAnnotationPopover", () => {
 
   it("dismisses on Escape and outside pointer down", async () => {
     const first = await render();
+    // What makes the dispatch safe is `render` flushing effects, not the waits
+    // below: an event fired before the listener exists is gone, and no amount of
+    // retrying an assertion brings it back. These waits cover the smaller race
+    // that remains — the handler running before React commits the state change.
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    expect(first.onClose).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(first.onClose).toHaveBeenCalledTimes(1));
     document.body.dispatchEvent(new Event("pointerdown", { bubbles: true }));
-    expect(first.onClose).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(first.onClose).toHaveBeenCalledTimes(2));
   });
 
   it("replies to and resolves a focused thread", async () => {

--- a/ui/src/components/task-chat/TaskMessageScroller.test.tsx
+++ b/ui/src/components/task-chat/TaskMessageScroller.test.tsx
@@ -56,6 +56,20 @@ describe("TaskMessageScroller", () => {
     return container.querySelector<HTMLButtonElement>(PILL_SELECTOR);
   }
 
+  /**
+   * Wait for the pill to reach a state, rather than for a fixed number of turns.
+   * `flushEvents` yields exactly one macrotask, which is enough on an idle
+   * machine and not when the suite runs many workers in parallel — React
+   * flushes continuous-priority updates asynchronously, so the DOM read can
+   * land before the state does. Sites that dereference `pill()!` turn that into
+   * a hard failure rather than a retry.
+   */
+  async function waitForPill(present: boolean): Promise<void> {
+    await vi.waitFor(() =>
+      present ? expect(pill()).not.toBeNull() : expect(pill()).toBeNull(),
+    );
+  }
+
   /** Set scrollTop and fire a scroll event, like a user or the browser would. */
   async function scrollTo(el: HTMLElement, top: number) {
     el.scrollTop = top;
@@ -101,6 +115,7 @@ describe("TaskMessageScroller", () => {
     const el = scroller();
     fakeGeometry(el);
     await scrollTo(el, 600); // bottom: 1000 - 600 - 400 = 0 → pinned
+    await waitForPill(false); // pinned state settled before content grows
     render(2);
     expect(el.scrollTop).toBe(1000);
     expect(pill()).toBeNull();
@@ -111,6 +126,7 @@ describe("TaskMessageScroller", () => {
     const el = scroller();
     fakeGeometry(el);
     await scrollTo(el, 100); // 500px from bottom → unpinned
+    await waitForPill(true);
     const btn = pill();
     expect(btn).not.toBeNull();
     expect(btn!.className).toContain("tc-scroll-pill-in");
@@ -139,6 +155,7 @@ describe("TaskMessageScroller", () => {
     el.scrollTo = scrollToSpy as unknown as typeof el.scrollTo;
 
     await scrollTo(el, 100);
+    await waitForPill(true);
     const btn = pill()!;
     btn.click();
     await flushEvents();
@@ -167,6 +184,7 @@ describe("TaskMessageScroller", () => {
     el.scrollTo = vi.fn() as unknown as typeof el.scrollTo;
 
     await scrollTo(el, 100);
+    await waitForPill(true);
     pill()!.click();
     await flushEvents();
     await dispatch(el, new Event("wheel", { bubbles: true }));
@@ -190,20 +208,20 @@ describe("TaskMessageScroller", () => {
     const el = scroller();
     fakeGeometry(el);
     await scrollTo(el, 100);
-    expect(pill()!.className).toContain("tc-scroll-pill-in");
+    await vi.waitFor(() => expect(pill()?.className).toContain("tc-scroll-pill-in"));
 
     // Scrolling back to the bottom starts the exit animation but keeps the
     // pill mounted until animationend.
     await scrollTo(el, 600);
+    await vi.waitFor(() => expect(pill()?.className).toContain("tc-scroll-pill-out"));
     const exiting = pill();
     expect(exiting).not.toBeNull();
-    expect(exiting!.className).toContain("tc-scroll-pill-out");
 
     // jsdom has no window.AnimationEvent, so React's vendor-prefix detection
     // maps onAnimationEnd to "webkitAnimationEnd" here (real browsers get the
     // unprefixed event).
     await dispatch(exiting!, new Event("webkitAnimationEnd", { bubbles: true }));
-    expect(pill()).toBeNull();
+    await waitForPill(false);
   });
 
   it("unmounts immediately on hide under prefers-reduced-motion", async () => {
@@ -215,8 +233,8 @@ describe("TaskMessageScroller", () => {
     const el = scroller();
     fakeGeometry(el);
     await scrollTo(el, 100);
-    expect(pill()).not.toBeNull();
+    await waitForPill(true);
     await scrollTo(el, 600);
-    expect(pill()).toBeNull(); // no animationend needed
+    await waitForPill(false); // no animationend needed
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Contributors run the `ui` vitest suite to check a change has not broken anything
> - That signal is only worth reading if a failure means the change was wrong
> - Three tests failed intermittently on full-suite runs and passed alone, so a red run had to be re-run before it could be believed
> - A suite that is wrong one run in four teaches people to re-run rather than investigate, which is how a real regression gets waved through
> - This pull request makes each of the three wait for the condition it needs instead of a fixed number of turns
> - The benefit is that a red `ui` run is evidence again

## Linked Issues or Issue Description

Refs: #11484

## What Changed

- `ui/src/App.activity-routing.test.tsx` — `waitForRoute` uses `vi.waitFor` instead of a hand-rolled five-attempt loop.
- `ui/src/components/task-chat/TaskMessageScroller.test.tsx` — a `waitForPill` helper; assertions and `pill()!` dereferences wait for the pill state rather than a single macrotask.
- `ui/src/components/DocumentAnnotationPopover.test.tsx` — `render` flushes passive effects with `act` before returning.

### Two of the three are the same fix

`App.activity-routing.test.tsx` polled at most five macrotasks before asserting:

```ts
for (let attempt = 0; attempt < 5; attempt += 1) {
  if (container.textContent?.includes(text)) return;
  await new Promise((resolve) => window.setTimeout(resolve, 0));
}
expect(container.textContent).toContain(text);
```

Under load it ran out of attempts and failed with `expected '' to contain 'ACTIVITY_PAGE@/PAP/activity?mode=agents'` — an empty container on a route that resolves perfectly well.

`TaskMessageScroller.test.tsx` had the same shape in a different disguise: `flushEvents()` yields exactly one macrotask, and scroll is a continuous-priority event, so React flushes the resulting update asynchronously. The file's own comment says as much; one macrotask is simply not a guarantee that the flush has happened. Several sites then wrote `pill()!`, which turns a miss into a crash instead of a retry, so those wait first.

### The third needed a different fix, and the obvious one would not have worked

The reflex is to wrap the failing assertion in `vi.waitFor`. That does not fix `DocumentAnnotationPopover.test.tsx`. Its dismissal listeners are registered in an effect, and `render` awaited only the popover element — which is in the DOM as soon as React commits, while passive effects run afterwards. A test that dispatches `Escape` in that gap loses the event outright, and **a lost event cannot be recovered by retrying an assertion**: `vi.waitFor` retries the expectation, not the dispatch. It would have converted a fast failure into a slow one.

So `render` flushes effects with `act` before returning. The waits added at the call site cover only the smaller remaining race — the handler running before React commits the state change — and the comment there says which one does the real work.

### Why not raise the budgets

Bumping the attempt count from 5 to 50, or setting a longer timeout, would make all three fail less often without making any of them correct. The threshold just moves to the next slower runner.

## Verification

Six consecutive full-suite runs, `TZ=UTC`: **4103 passed** every time, no failures of any kind.

Each of the three also passes repeatedly in isolation (3-4 runs each).

`tsc -b` clean.

**What that does and does not establish.** The baseline was roughly one full run in four failing with at least one of these three. Six clean runs is consistent with the fix and is *not* proof: at a 25% per-run failure rate, six clean runs happen by chance about 18% of the time. Read this as "the mechanism is identified and addressed, and the suite has been stable since", not as a demonstrated absence.

The one part that is not statistical is `DocumentAnnotationPopover`: the effect-flush gap is a structural fact about when React runs passive effects, not a timing coincidence, and `act` closes it.

**I could not reproduce the flakes on demand**, which is worth recording for whoever revisits this. `TaskMessageScroller` passed 12/12 in isolation while ten CPU-burner processes saturated the machine — raw contention does not do it. What surfaced these was the full suite's parallel worker scheduling, so reproduction means running the whole suite repeatedly, not hammering one file.

## Risks

Low, and confined to test code — no runtime behavior changes.

The real risk is the opposite of a regression: `vi.waitFor` retries until a timeout, so a test that genuinely breaks now takes its full budget to fail instead of failing immediately. That is the intended trade — a slow honest failure beats a fast wrong one — but it does mean a broken assertion in these files reports more slowly than before.

Waiting on an *absence* (`waitForPill(false)`) remains weak in principle: it passes as soon as the pill is gone, and cannot prove it will not reappear later. That weakness predates this change and is not made worse by it.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck, repeated full-suite runs, and load-testing under CPU saturation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
