### PR TITLE
fix(server): count instead of refuse a run with no recorded source issue

### DIFF
--- a/server/src/__tests__/cross-issue-influence-checkout-route-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-checkout-route-postgres.test.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres cross-issue-influence checkout route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/**
+ * Route-level proof for a bare `heartbeat_timer` run (no recorded source
+ * issue in `contextSnapshot`) writing to the issue it actually checked out
+ * through the real `/checkout` route, then the real `/comments` route — not
+ * `observeCrossIssueInfluence` called directly with a hand-built fake db and
+ * an asserted-away checkout state. The unit test in
+ * cross-issue-influence-limit.test.ts proves the counter math; this proves
+ * checkout ownership and the checkout-to-write route integration actually
+ * hold end to end. See the Greptile review on PR #11500.
+ */
+describeEmbeddedPostgres("cross-issue influence cap for a source-less run (checkout + comment routes)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cross-issue-checkout-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    const cleanups = [
+      () => db.delete(activityLog),
+      () => db.delete(heartbeatRuns),
+      () => db.delete(issues),
+      () => db.delete(companyMemberships),
+      () => db.delete(agents),
+      () => db.delete(companies),
+    ];
+    for (const cleanup of cleanups) await cleanup().catch(() => undefined);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function app(actor: Record<string, unknown>) {
+    const testApp = express();
+    testApp.use(express.json());
+    testApp.use((req, _res, next) => {
+      (req as any).actor = actor;
+      next();
+    });
+    testApp.use("/api", issueRoutes(db, {} as any, {}));
+    testApp.use(errorHandler);
+    return testApp;
+  }
+
+  function agentActor(companyId: string, agentId: string, runId: string) {
+    return { type: "agent", source: "agent_key", companyId, agentId, runId };
+  }
+
+  async function seedCompanyAndAgent(prefix: string) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: `${prefix} Company`,
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: `${prefix} Resolver`,
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: `${prefix.toLowerCase()}-operator`,
+      status: "active",
+      membershipRole: "operator",
+    });
+    return { companyId, agentId };
+  }
+
+  async function seedUnassignedIssue(companyId: string, prefix: string) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: `${prefix}-1`,
+      title: `${prefix} issue`,
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: null,
+    });
+    return issueId;
+  }
+
+  /**
+   * The plain `heartbeat_timer` scheduler wake shape (services/heartbeat.js
+   * `enqueueWakeup`): no `issueId`/`taskId` at all, because the scheduler does
+   * not know which issue the agent will pick until its own inbox/checkout
+   * logic runs.
+   */
+  async function seedSourcelessRun(companyId: string, agentId: string) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "heartbeat_timer",
+      status: "running",
+      contextSnapshot: { source: "scheduler", reason: "interval_elapsed" },
+    });
+    return runId;
+  }
+
+  async function countInfluenceRows(companyId: string, runId: string, action: string) {
+    const rows = await db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.companyId, companyId),
+        eq(activityLog.runId, runId),
+        eq(activityLog.action, action),
+      ));
+    return rows.length;
+  }
+
+  it("allows a source-less run to comment on the issue it actually checked out through the real checkout route", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent("SLS");
+    const issueId = await seedUnassignedIssue(companyId, "SLS");
+    const runId = await seedSourcelessRun(companyId, agentId);
+    const client = request(app(agentActor(companyId, agentId, runId)));
+
+    // Real checkout: the run has no recorded source issue, so this is the
+    // only place its ownership of `issueId` is ever established.
+    const checkoutRes = await client
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo"] });
+    expect(checkoutRes.status, JSON.stringify(checkoutRes.body)).toBe(200);
+
+    const [checkedOut] = await db
+      .select({ checkoutRunId: issues.checkoutRunId, assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(checkedOut).toMatchObject({ checkoutRunId: runId, assigneeAgentId: agentId });
+
+    // Real write against the checked-out issue, through the real comments
+    // route — not a direct service call.
+    const commentRes = await client
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Picked this up from the inbox." });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    expect(await countInfluenceRows(companyId, runId, "issue.cross_issue_influence_observed")).toBe(1);
+    expect(await countInfluenceRows(companyId, runId, "issue.cross_issue_influence_cap_rejected")).toBe(0);
+  }, 30_000);
+});

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -198,7 +198,10 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
+  it("counts instead of failing closed when the persisted run has no source issue", async () => {
+    // A run with an empty contextSnapshot (no issueId/taskId at all) must be
+    // treated as a "no home issue" run, not refused outright: it still gets
+    // capped at CROSS_ISSUE_INFLUENCE_LIMIT writes, starting from zero.
     const fake = counterDb(0, { contextSnapshot: {} });
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
@@ -207,10 +210,45 @@ describe("cross-issue influence limit rollout", () => {
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
       kind: "update",
-    })).rejects.toMatchObject({
-      status: 403,
-      details: { code: "cross_issue_influence_run_context_required" },
+    })).resolves.toMatchObject({ allowed: true, count: 1, cap: CROSS_ISSUE_INFLUENCE_LIMIT });
+    expect(fake.inserted).toHaveLength(1);
+    expect((fake.inserted[0] as { action: string }).action).toBe("issue.cross_issue_influence_observed");
+  });
+
+  it("accepts a same-issue write from a bare heartbeat_timer run against its own checked-out issue", async () => {
+    // Reproduces the scheduler's exact contextSnapshot shape for a plain timer
+    // wake (services/heartbeat.js enqueueWakeup): no issueId, no taskId, just
+    // scheduler bookkeeping fields. The run has legitimately checked out
+    // targetIssueId before this write (checkoutRunId matches), so the write
+    // must succeed rather than 403 unconditionally.
+    const fake = counterDb(0, {
+      contextSnapshot: { source: "scheduler", reason: "interval_elapsed", timerClaimWasFirstHeartbeat: true },
     });
-    expect(fake.inserted).toEqual([]);
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueIdentifier: "TASK-482",
+      kind: "update",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({ allowed: true, mode: "enforce", count: 1, cap: CROSS_ISSUE_INFLUENCE_LIMIT });
+  });
+
+  it("still caps a no-source-issue run at the twenty-first write", async () => {
+    // Defense in depth: a homeless run does not get unlimited writes just
+    // because it has no recorded source issue. It hits the same 429 as any
+    // other cross-issue run once it exceeds the cap.
+    const fake = counterDb(CROSS_ISSUE_INFLUENCE_LIMIT, { contextSnapshot: {} });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({ allowed: false, mode: "enforce", count: CROSS_ISSUE_INFLUENCE_LIMIT + 1 });
   });
 });

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -109,11 +109,26 @@ export async function observeCrossIssueInfluence(
       throw crossIssueInfluenceRunContextError();
     }
 
+    // A run's source issue is the one it was scoped to at wake time (an explicit
+    // task id, or the comment/mention that woke it). A write back to that same
+    // issue is never cross-issue influence.
+    //
+    // A run can also have no recorded source issue at all: the plain
+    // `heartbeat_timer` scheduler wake (services/heartbeat.js `enqueueWakeup`)
+    // never sets `contextSnapshot.issueId`/`.taskId`, because the scheduler does
+    // not know which issue the agent will pick until its own inbox/checkout logic
+    // runs. That run is not exempt from the cap, but it must not be refused
+    // outright either — refusing it here blocks every write for the run's entire
+    // life, including writes to the issue it legitimately checked out on. Treat a
+    // missing source issue as "no home issue": every write for that run, starting
+    // with the first, counts against the same per-run cross-issue cap below.
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
-      sourceIssueId === input.targetIssueId ||
-      (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      sourceIssueId &&
+      (
+        sourceIssueId === input.targetIssueId ||
+        (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      )
     ) {
       return null;
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Cross-issue influence containment refuses a heartbeat run's issue write when the run has no recorded "source issue" in `heartbeat_runs.contextSnapshot`
> - The plain `heartbeat_timer` scheduler wake never sets `contextSnapshot.issueId`/`.taskId` at all, because the scheduler enqueues the run before the agent's own inbox/checkout logic has picked an issue
> - `observeCrossIssueInfluence` throws unconditionally in that case, so every plain timer heartbeat is refused on every write — including a write to the issue it legitimately checked out on
> - This pull request stops treating a missing source issue as an error: it now counts against the existing per-run cap instead, the same way a genuine cross-issue write does
> - The benefit is that a bare timer heartbeat can finish its own checked-out work without being silently locked out of every write for the run's entire life

## Linked Issues or Issue Description

No public issue exists for this specific defect. Related/duplicate PRs already open against the same root cause, from a different angle (see "Duplicate/related PRs" below): #11211, #11232, #11466.

**What happened?**

A heartbeat run created from a plain `heartbeat_timer` scheduler wake (no `issueId`/`taskId` in `contextSnapshot`) checks out an issue successfully, then is refused on every subsequent `PATCH /api/issues/:id` or `POST /api/issues/:id/comments` against that same issue with `403 cross_issue_influence_run_context_required` — even though the run has a valid `X-Paperclip-Run-Id` header and is genuinely checked out on the target issue.

`observeCrossIssueInfluence` (`server/src/services/cross-issue-influence-limit.ts`) reads the run's source issue from the persisted `contextSnapshot`, and throws unconditionally when none is recorded:

```ts
const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
```

The scheduler that creates `heartbeat_timer` runs (`services/heartbeat.js`, the periodic `enqueueWakeup(agent.id, { reason: "heartbeat_timer", contextSnapshot: { source: "scheduler", reason: "interval_elapsed", now, timerClaimWasFirstHeartbeat } })` call) never sets `issueId`/`taskId` — the scheduler does not know which issue the agent will work on until the agent's own inbox-lite/checkout logic runs, well after the run row is created. So `sourceIssueId` is always `null` for this wake reason, and the throw fires unconditionally, for every issue the run tries to write to, including its own checked-out issue.

**Expected behavior**

A run with no recorded source issue should not be refused outright. It should be treated as a "no home issue" run and capped the same way a genuine cross-issue write is: up to `CROSS_ISSUE_INFLUENCE_LIMIT` (20) writes, starting from zero, then `429 cross_issue_influence_cap_exceeded`.

**Steps to reproduce**

1. Create a heartbeat run with `contextSnapshot: { source: "scheduler", reason: "interval_elapsed" }` (no `issueId`/`taskId`) — the exact shape the scheduler's `heartbeat_timer` wake produces.
2. As that run, check out an assigned `todo`/`in_progress` issue with `POST /api/issues/:id/checkout`. This succeeds — checkout does not read or write `contextSnapshot`.
3. As the same run, call `PATCH /api/issues/:id` or `POST /api/issues/:id/comments` against that same issue.
4. Observe `403 cross_issue_influence_run_context_required` on `master`, unconditionally, regardless of which issue is targeted.

**Paperclip version or commit**

`master` at `fd472d0` and earlier (present since `CROSS_ISSUE_INFLUENCE_ENFORCE_AT`, 2026-08-11).

**Deployment mode**

Affects all modes. Reproduced on a self-hosted `local_trusted` instance with an agent API key + run id, so `req.actor.type === "agent"` and the check applies.

## Duplicate/related PRs

Three other open PRs already fix the same underlying scenario at the **checkout** layer, by writing `contextSnapshot.issueId` back onto the run when it checks out an issue: #11211, #11232, #11466. Any of them would also fix this reproduction, since it goes through checkout.

This PR fixes the same problem at the **cap-evaluation** layer instead (`observeCrossIssueInfluence` itself), which has two properties none of the checkout-side PRs have:

- It does not depend on checkout writing back `contextSnapshot` correctly, so it also covers any other route or future wake path that never checks out at all.
- It is strictly smaller: one function, no new service module, no new route wiring.

These are not mutually exclusive. Landing this PR *and* one of the checkout-side PRs is fine — the checkout-side fix would mean most `heartbeat_timer` runs adopt a real source issue and never hit the "no source issue" branch at all, while this PR is the fail-safe for the runs that don't.

## What Changed

- `server/src/services/cross-issue-influence-limit.ts`: `observeCrossIssueInfluence` no longer throws when the persisted run has no recorded `sourceIssueId`. It now falls through to the existing per-run counter and cap logic, exactly like a genuine cross-issue write, starting from a prior count of zero.
- `server/src/__tests__/cross-issue-influence-limit.test.ts`:
  - Replaced the test that asserted the old fail-closed behavior with one asserting the run now counts (`allowed: true, count: 1`) instead of throwing.
  - Added a repro test using the exact `heartbeat_timer` scheduler `contextSnapshot` shape (`{ source: "scheduler", reason: "interval_elapsed", timerClaimWasFirstHeartbeat: true }`), asserting the write succeeds.
  - Added a test proving a no-source-issue run still hits the existing cap and its `429` behavior on its 21st write — the cap intent is preserved, not removed.
- No route, schema, or migration changes. The route call site (`assertCrossIssueInfluenceWithinRunCap` in `server/src/routes/issues.ts`) is unchanged; it already delegates the "should this be refused" decision entirely to `observeCrossIssueInfluence`.

## Verification

```sh
npx vitest run \
  server/src/__tests__/cross-issue-influence-limit.test.ts \
  server/src/__tests__/cross-issue-influence-limit-postgres.test.ts \
  server/src/__tests__/issue-comment-reopen-routes.test.ts \
  server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
```

Result on this branch: 4 files passed, 182 tests passed. The last two files exercise the route-level 403/429 paths against a mocked `observeCrossIssueInfluence` and are unaffected, confirming this change is fully contained to the service function.

```sh
pnpm --filter @paperclipai/server typecheck
```

Result: exit 0, no errors.

To confirm by hand, repeat the reproduction steps above. At step 3/4 the write is now accepted (`200`), and the activity log records `issue.cross_issue_influence_observed` with `count: 1`.

## Risks

Low risk.

- The change only widens acceptance for the one case that previously always failed (`sourceIssueId === null`). Every other branch (same-issue bypass, cross-issue cap-and-count, malformed run id, run/agent/company mismatch) is untouched — see the unchanged `it.each` fail-closed tests for missing/wrong-agent/wrong-company runs in the test file.
- A "no home issue" run is not granted unlimited writes: it is capped at `CROSS_ISSUE_INFLUENCE_LIMIT` (20) exactly like any other cross-issue run, so the cap's blast-radius intent is preserved.
- No schema or migration changes.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), via the Pi coding agent harness. Standard reasoning, with tool use for repository search, file editing, running the test suite, and typechecking in an isolated git worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — not applicable; internal server authorization/recovery-logic fix with no user-facing or operator-facing documentation surface.
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — verified with `gh pr checks 11500`: every required build/test gate passes; only the Greptile gate (tracked separately below) is red.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — currently 4/5. Open finding: a non-blocking test-coverage gap in the claimed checkout-to-write regression scenario. Not yet fixed; tracked as follow-up branch work, not a description issue.
- [x] I will address all Greptile and reviewer comments before requesting merge


