### PR TITLE
fix(recovery): stop locking out a recovery action's return owner + misleading cross-issue error

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -198,7 +198,10 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
+  it("counts instead of failing closed when the persisted run has no source issue", async () => {
+    // A run with an empty contextSnapshot (no issueId/taskId at all) must be
+    // treated as a "no home issue" run, not refused outright: it still gets
+    // capped at CROSS_ISSUE_INFLUENCE_LIMIT writes, starting from zero.
     const fake = counterDb(0, { contextSnapshot: {} });
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
@@ -207,10 +210,45 @@ describe("cross-issue influence limit rollout", () => {
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
       kind: "update",
-    })).rejects.toMatchObject({
-      status: 403,
-      details: { code: "cross_issue_influence_run_context_required" },
+    })).resolves.toMatchObject({ allowed: true, count: 1, cap: CROSS_ISSUE_INFLUENCE_LIMIT });
+    expect(fake.inserted).toHaveLength(1);
+    expect((fake.inserted[0] as { action: string }).action).toBe("issue.cross_issue_influence_observed");
+  });
+
+  it("accepts a same-issue write from a bare heartbeat_timer run against its own checked-out issue", async () => {
+    // Reproduces the scheduler's exact contextSnapshot shape for a plain timer
+    // wake (services/heartbeat.js enqueueWakeup): no issueId, no taskId, just
+    // scheduler bookkeeping fields. The run has legitimately checked out
+    // targetIssueId before this write (checkoutRunId matches), so the write
+    // must succeed rather than 403 unconditionally.
+    const fake = counterDb(0, {
+      contextSnapshot: { source: "scheduler", reason: "interval_elapsed", timerClaimWasFirstHeartbeat: true },
     });
-    expect(fake.inserted).toEqual([]);
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueIdentifier: "TASK-482",
+      kind: "update",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({ allowed: true, mode: "enforce", count: 1, cap: CROSS_ISSUE_INFLUENCE_LIMIT });
+  });
+
+  it("still caps a no-source-issue run at the twenty-first write", async () => {
+    // Defense in depth: a homeless run does not get unlimited writes just
+    // because it has no recorded source issue. It hits the same 429 as any
+    // other cross-issue run once it exceeds the cap.
+    const fake = counterDb(CROSS_ISSUE_INFLUENCE_LIMIT, { contextSnapshot: {} });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({ allowed: false, mode: "enforce", count: CROSS_ISSUE_INFLUENCE_LIMIT + 1 });
   });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -118,6 +118,7 @@ import {
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   noticeMetadataReferencesRecoveryAction,
+  recoveryService,
 } from "../services/recovery/index.ts";
 import {
   UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
@@ -5891,6 +5892,60 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(commentMetadataRows(comments[0]).some((row) =>
       row.type === "agent_link" && row.label === "Recovery owner" && row.name === longRecoveryOwnerName.slice(0, 160),
     )).toBe(true);
+  });
+
+  // reconcileStrandedAssignedIssues checks hasActiveExecutionPath
+  // once near the top of its per-candidate loop, but the scan then does
+  // meaningful async work (recovery-action lookups, agent lookups, blocker
+  // reads) before it actually reassigns the issue. A legitimate new checkout
+  // landing in that window must not be stomped by a recovery takeover that was
+  // decided against stale evidence. escalateStrandedAssignedIssue re-verifies
+  // hasActiveExecutionPath immediately before touching anything; this proves
+  // that guard aborts the escalation instead of racing the live run.
+  it("does not escalate a stranded assigned issue when a fresh execution path appears after the recovery scan", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+      runErrorCode: "process_lost",
+    });
+
+    // Simulate the race: after reconcileStrandedAssignedIssues's initial
+    // hasActiveExecutionPath check passed (no live run yet), a fresh heartbeat
+    // run started on this same issue — e.g. the agent's next legitimate
+    // checkout — before the escalation actually commits.
+    const racingRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: racingRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      startedAt: new Date("2026-03-19T00:10:00.000Z"),
+    });
+
+    const issueBeforeEscalation = await db.select().from(issues).where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    const latestRun = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+
+    const recovery = recoveryService(db, { enqueueWakeup: async () => null });
+    const escalated = await recovery.escalateStrandedAssignedIssue({
+      issue: issueBeforeEscalation,
+      previousStatus: "todo",
+      latestRun: latestRun ?? null,
+    });
+
+    expect(escalated).toBeNull();
+
+    const issueAfter = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issueAfter?.status).toBe("todo");
+    expect(issueAfter?.assigneeAgentId).toBe(agentId);
+
+    const recoveryActions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(0);
   });
 
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1683,6 +1683,117 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  // A stranded_assigned_issue recovery reassigns the issue to a
+  // recovery owner, but names a returnOwnerAgentId (and/or previousOwnerAgentId)
+  // — the agent the work should come back to. That agent must never be treated
+  // as "another owner" of the recovery action they did not create.
+  it("allows the recovery action's return owner to resolve a status update even though someone else owns the recovery action", async () => {
+    // A stranded_assigned_issue recovery always leaves the source issue
+    // `blocked` with the recovery owner as its new assignee (see
+    // escalateStrandedAssignedIssue). The return owner named on that action
+    // must still be able to move it back to `todo`.
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId,
+      returnOwnerAgentId: peerAgentId,
+      previousOwnerAgentId: peerAgentId,
+    });
+
+    const res = await request(await createApp(peerActor())).patch(`/api/issues/${issueId}`).send({ status: "todo" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ status: "todo" }));
+  });
+
+  it("allows the recovery action's previous owner (not just the return owner) to resolve a status update", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId,
+      returnOwnerAgentId: null,
+      previousOwnerAgentId: peerAgentId,
+    });
+
+    const res = await request(await createApp(peerActor())).patch(`/api/issues/${issueId}`).send({ status: "todo" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ status: "todo" }));
+  });
+
+  it("lets the recovery action's return owner comment even when the cross-issue-influence run-cap check would otherwise fail closed", async () => {
+    // Simulates the AGE-471 failure mode: the run-cap guard rejects with the
+    // generic run-context error. The return owner posting on the very issue the
+    // recovery action is tracking must never be blocked by that guard — it is
+    // not a cross-issue write, and comments are never gated by recovery-action
+    // ownership in the first place.
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId,
+      returnOwnerAgentId: peerAgentId,
+      previousOwnerAgentId: peerAgentId,
+    });
+    mockObserveCrossIssueInfluence.mockRejectedValue(
+      Object.assign(new Error("run context required"), {
+        status: 403,
+        details: { code: "cross_issue_influence_run_context_required" },
+      }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Recording what happened on my own stranded issue." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Recording what happened on my own stranded issue.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockObserveCrossIssueInfluence).not.toHaveBeenCalled();
+  });
+
+  it("still runs the cross-issue run-cap check for a comment with no recovery return-path relationship", async () => {
+    // The bypass is scoped to the recovery action's named return/previous
+    // owner — it must not silently exempt every comment just because a
+    // recovery action happens to be active on the issue.
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId,
+      returnOwnerAgentId: ownerAgentId,
+      previousOwnerAgentId: ownerAgentId,
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Unrelated cross-issue comment." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockObserveCrossIssueInfluence).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targetIssueId: issueId }),
+    );
+  });
+
   it("rejects peer-agent recovery resolution on a board-owned source issue", async () => {
     mockIssueService.getById.mockResolvedValue(
       makeIssue({ status: "blocked", assigneeAgentId: null, assigneeUserId: "board-user" }),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2836,8 +2836,19 @@ export function issueRoutes(
     res: Response,
     issue: { id: string; identifier?: string | null; companyId: string },
     kind: CrossIssueInfluenceKind,
+    options: {
+      activeRecoveryAction?: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>> | null;
+    } = {},
   ) {
     if (req.actor.type !== "agent") return true;
+    // A recovery action's return/previous owner writing back to the very issue the
+    // recovery action is tracking is never "cross-issue" influence — it is the
+    // return path the recovery action itself names. Read+comment must never be
+    // blocked by recovery-action bookkeeping (only status/patch writes that would
+    // fight the recovery owner's disposition are gated, in assertRecoveryActionAuthority).
+    if (isRecoveryReturnPathAgent(options.activeRecoveryAction ?? null, req.actor.agentId ?? null)) {
+      return true;
+    }
     if (!req.actor.agentId || !req.actor.runId) throw crossIssueInfluenceRunContextError();
 
     // The counter transaction locks and validates the persisted run before it
@@ -5038,6 +5049,16 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (isDefaultOpenIssueWriteDecision(boundaryDecision)) return true;
+    // A recovery action's return/previous owner resuming the very issue the
+    // recovery action is tracking is not "another agent's issue" — it is
+    // exactly the return path the recovery action names. See
+    // isRecoveryReturnPathAgent.
+    const activeRecoveryActionForResume = await getActiveRecoveryActionBestEffort(
+      issue.companyId,
+      issue.id,
+      "issue_resume_intent",
+    );
+    if (isRecoveryReturnPathAgent(activeRecoveryActionForResume, actorAgentId)) return true;
 
     res.status(403).json({
       error: "Agent cannot request follow-up for another agent's issue",
@@ -5048,6 +5069,46 @@ export function issueRoutes(
       },
     });
     return false;
+  }
+
+  /**
+   * Best-effort recovery-action lookup for gates that only ever *widen* access
+   * (letting a recovery action's return/previous owner past the cross-issue
+   * run-cap check). A transient read failure here must never turn into a
+   * request failure — it just falls back to "no known recovery action", which
+   * is exactly today's behavior before this lookup existed.
+   */
+  async function getActiveRecoveryActionBestEffort(
+    companyId: string,
+    issueId: string,
+    trigger: string,
+  ) {
+    try {
+      return await recoveryActionsSvc.getActiveForIssue(companyId, issueId);
+    } catch (err) {
+      logger.warn({ err, issueId, trigger }, "failed to resolve active recovery action for return-owner write gate");
+      return null;
+    }
+  }
+
+  /**
+   * The recovery action names two agents besides its current owner: the agent
+   * who held the issue before the recovery takeover (`previousOwnerAgentId`) and
+   * the agent recovery intends to hand the issue back to once resolved
+   * (`returnOwnerAgentId`). Both are first-class parties to the recovery, not
+   * bystanders — they should never be treated as "another owner" for the
+   * purposes of resolving or commenting on their own stranded issue.
+   */
+  function isRecoveryReturnPathAgent(
+    activeRecoveryAction: Pick<
+      NonNullable<Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>>>,
+      "returnOwnerAgentId" | "previousOwnerAgentId"
+    > | null,
+    actorAgentId: string | null,
+  ) {
+    if (!activeRecoveryAction || !actorAgentId) return false;
+    return activeRecoveryAction.returnOwnerAgentId === actorAgentId ||
+      activeRecoveryAction.previousOwnerAgentId === actorAgentId;
   }
 
   async function assertRecoveryActionAuthority(
@@ -5073,6 +5134,11 @@ export function issueRoutes(
       return true;
     }
     if (activeRecoveryAction.ownerAgentId === actorAgentId) return true;
+    // The return/previous owner is who the recovery action itself says this work
+    // should come back to once resolved. Locking them out of their own return path
+    // is backwards: they are exactly who should be able to resume or hand the
+    // recovery back, not just the current recovery owner.
+    if (isRecoveryReturnPathAgent(activeRecoveryAction, actorAgentId)) return true;
     if (
       activeRecoveryAction.ownerAgentId &&
       await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, activeRecoveryAction.ownerAgentId)
@@ -9049,8 +9115,15 @@ export function issueRoutes(
       Array.isArray(req.body.blockedByIssueIds) ||
       req.body.executionPolicy !== undefined ||
       explicitMoveToTodoRequested;
-    const activeRecoveryActionBeforeUpdate = recoveryRelevantSourceMutationRequested
-      ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
+    // Also resolve the active recovery action when this update carries a
+    // comment, even if it isn't otherwise a recovery-relevant status/assignee
+    // mutation. The cross-issue-influence run-cap check right below needs to
+    // know the recovery action's return/previous owner so it never blocks a
+    // comment from either of them (see assertCrossIssueInfluenceWithinRunCap).
+    const activeRecoveryActionBeforeUpdate = recoveryRelevantSourceMutationRequested || !!commentBody
+      ? recoveryRelevantSourceMutationRequested
+        ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
+        : await getActiveRecoveryActionBestEffort(existing.companyId, existing.id, "issue_update.comment_only")
       : null;
     if (
       recoveryRelevantSourceMutationRequested &&
@@ -9126,11 +9199,15 @@ export function issueRoutes(
 
     if (
       isAgentWorkUpdate &&
-      !(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "update"))
+      !(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "update", {
+        activeRecoveryAction: activeRecoveryActionBeforeUpdate,
+      }))
     ) return;
     if (
       commentBody &&
-      !(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "comment"))
+      !(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "comment", {
+        activeRecoveryAction: activeRecoveryActionBeforeUpdate,
+      }))
     ) return;
 
     if (interruptRequested) {
@@ -11714,7 +11791,18 @@ export function issueRoutes(
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;
     }
-    if (!(await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "comment"))) return;
+    // Resolve the active recovery action so the run-cap check below can
+    // recognize the recovery action's return/previous owner and never block
+    // their comment on the issue the recovery action is tracking (plan: comments
+    // are never gated by recovery-action ownership, only status/patch writes are).
+    const activeRecoveryActionForComment = req.actor.type === "agent"
+      ? await getActiveRecoveryActionBestEffort(issue.companyId, issue.id, "issue_comment")
+      : null;
+    if (
+      !(await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "comment", {
+        activeRecoveryAction: activeRecoveryActionForComment,
+      }))
+    ) return;
     // Reopen the closed isolated workspace only after every access, resume-intent,
     // blocker, and run-cap gate passes. A rejected comment must not rebuild and
     // republish the workspace as active, because the issue stays terminal and the

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -109,11 +109,26 @@ export async function observeCrossIssueInfluence(
       throw crossIssueInfluenceRunContextError();
     }
 
+    // A run's source issue is the one it was scoped to at wake time (an explicit
+    // task id, or the comment/mention that woke it). A write back to that same
+    // issue is never cross-issue influence.
+    //
+    // A run can also have no recorded source issue at all: the plain
+    // `heartbeat_timer` scheduler wake (services/heartbeat.js `enqueueWakeup`)
+    // never sets `contextSnapshot.issueId`/`.taskId`, because the scheduler does
+    // not know which issue the agent will pick until its own inbox/checkout logic
+    // runs. That run is not exempt from the cap, but it must not be refused
+    // outright either — refusing it here blocks every write for the run's entire
+    // life, including writes to the issue it legitimately checked out on. Treat a
+    // missing source issue as "no home issue": every write for that run, starting
+    // with the first, counts against the same per-run cross-issue cap below.
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
-      sourceIssueId === input.targetIssueId ||
-      (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      sourceIssueId &&
+      (
+        sourceIssueId === input.targetIssueId ||
+        (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      )
     ) {
       return null;
     }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3315,6 +3315,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
 
+    // reconcileStrandedAssignedIssues checks hasActiveExecutionPath once per
+    // candidate near the top of its scan loop, but the scan itself walks every
+    // stranded candidate in the company before any one of them is escalated. A
+    // legitimate new checkout (or a queued wake) can land on this exact issue in
+    // that window — the agent that owns the issue is very much alive, just not
+    // yet visible when the scan read it. Re-verify immediately before creating a
+    // recovery action or reassigning anything, so a live run that started after
+    // the scan is never yanked out from under its agent.
+    if (await hasActiveExecutionPath(input.issue.companyId, input.issue.id)) {
+      logger.info(
+        { issueId: input.issue.id, companyId: input.issue.companyId },
+        "skipping stranded-issue escalation: an execution path appeared after the recovery scan",
+      );
+      return null;
+    }
+
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,


### PR DESCRIPTION
## What this fixes

A `stranded_assigned_issue` recovery action reassigns a source issue to a
recovery owner and records `returnOwnerAgentId`/`previousOwnerAgentId` — the
agent the work should come back to. That agent was still treated as
"another owner" by several write gates, and one unrelated guard produced a
misleading error on top of it:

1. **`assertRecoveryActionAuthority`** (PATCH status/assignee/blocker changes)
   only exempted the recovery action's current `ownerAgentId`, so the
   return/previous owner got `403 Agent cannot resolve another owner's
   recovery action` trying to resolve their own stranded issue.
2. **`assertExplicitResumeIntentAllowed`** (blocked/cancelled → active
   transitions) had the same gap, denying with `403 Agent cannot request
   follow-up for another agent's issue`.
3. **The cross-issue run-cap check** (`assertCrossIssueInfluenceWithinRunCap`)
   ran on the comment route and the PATCH comment path with no awareness of
   the recovery action, so a return/previous owner writing back to their own
   recovery-tracked issue could still be caught by an unrelated per-run
   rate-limit guard and get `403 cross_issue_influence_run_context_required`
   — a message that names a run-context problem, not the real cause.
4. Separately, that same rate-limit guard (`observeCrossIssueInfluence`)
   **failed closed for any run with no recorded source issue at all** — e.g.
   a plain `heartbeat_timer` scheduler wake, which does not know which issue
   the agent will pick until its own inbox/checkout logic runs. That refusal
   applied to *every* write the run ever made, including writes to the issue
   it legitimately checked out on.
5. **`reconcileStrandedAssignedIssues`** checks `hasActiveExecutionPath` once
   per candidate near the top of its scan loop, but the scan does further
   async work before actually escalating a given candidate. A legitimate new
   checkout landing in that window was never re-checked, so a live run could
   be stranded out from under its own agent based on stale evidence.

## Changes

- `server/src/services/cross-issue-influence-limit.ts`: a run with no
  recorded source issue is now treated as "no home issue" and counted
  against the same per-run cap, instead of being refused outright.
- `server/src/routes/issues.ts`: added `isRecoveryReturnPathAgent()` and used
  it in `assertRecoveryActionAuthority`, `assertExplicitResumeIntentAllowed`,
  and both cross-issue-run-cap call sites (PATCH + comment routes), so a
  recovery action's named return/previous owner is never locked out of
  writing to the issue the recovery action is tracking. The recovery-action
  lookup used only to widen comment access is best-effort (a transient read
  failure falls back to today's behavior rather than failing the request).
- `server/src/services/recovery/service.ts`: `escalateStrandedAssignedIssue`
  re-verifies `hasActiveExecutionPath` immediately before creating a recovery
  action or mutating the issue, aborting the escalation if a fresh execution
  path appeared since the scan.

## Tests

- `server/src/__tests__/cross-issue-influence-limit.test.ts`: red/green cases
  for the "no source issue" run (now counted, not refused) and a same-issue
  write from a bare scheduler-wake run.
- `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`:
  return/previous owner can resolve a blocked issue's status and comment even
  while the recovery action is owned by a different agent; a genuine
  third-party agent is still denied with the recovery-ownership error (not
  the cross-issue one); the bypass does not apply to agents unrelated to the
  recovery action.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: a fresh
  execution path appearing after the scan's own check aborts the escalation
  instead of stranding the live run (verified red without the fix, green
  with it).

All touched suites pass locally: `heartbeat-process-recovery.test.ts`,
`cross-issue-influence-limit.test.ts`, `issue-comment-reopen-routes.test.ts`,
`issue-agent-mutation-ownership-routes.test.ts`, `issue-recovery-actions.test.ts`,
and `services/recovery/*` (395 tests), plus a clean `tsc --noEmit` for the
`server` package.
