### PR TITLE
fix(heartbeat): allow managed MCP for Claude local

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3338,7 +3338,7 @@ function createAdapterRuntimeMcpAccess(
   });
 }
 
-const MANAGED_MCP_LOCAL_ADAPTERS = new Set(["codex_local"]);
+const MANAGED_MCP_LOCAL_ADAPTERS = new Set(["codex_local", "claude_local"]);
 
 function adapterSupportsManagedMcpConfig(adapterType: string): boolean {
   return MANAGED_MCP_LOCAL_ADAPTERS.has(adapterType);


### PR DESCRIPTION
## Summary
- allow claude_local heartbeats to receive Paperclip-managed MCP gateway config
- preserve existing codex_local behavior

## Verification
- git diff --check
- targeted test not run: this clean worktree has no installed vitest dependency