### PR TITLE
fix(cli): require confirmation for instructions file deletes

### DIFF
--- a/cli/src/__tests__/agent-lifecycle.test.ts
+++ b/cli/src/__tests__/agent-lifecycle.test.ts
@@ -97,7 +97,7 @@ describe("agent lifecycle commands", () => {
     await run(["agent", "instructions-bundle:update", AGENT_ID, "--payload-json", JSON.stringify({ mode: "managed" })]);
     await run(["agent", "instructions-file:get", AGENT_ID, "--path", "AGENTS.md"]);
     await run(["agent", "instructions-file:put", AGENT_ID, "--path", "AGENTS.md", "--content", "hello"]);
-    await run(["agent", "instructions-file:delete", AGENT_ID, "--path", "AGENTS.md"]);
+    await run(["agent", "instructions-file:delete", AGENT_ID, "--path", "AGENTS.md", "--yes"]);
 
     expect(fetchMock.mock.calls.map((call) => [call[1]?.method ?? "GET", call[0]])).toEqual([
       ["PATCH", `http://localhost:3100/api/agents/${AGENT_ID}/permissions`],
@@ -117,6 +117,20 @@ describe("agent lifecycle commands", () => {
       ["PUT", `http://localhost:3100/api/agents/${AGENT_ID}/instructions-bundle/file`],
       ["DELETE", `http://localhost:3100/api/agents/${AGENT_ID}/instructions-bundle/file?path=AGENTS.md`],
     ]);
+  });
+
+  it("refuses to delete an instructions file without confirmation", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    await expect(run(["agent", "instructions-file:delete", AGENT_ID, "--path", "AGENTS.md"])).rejects.toThrow(
+      "exit:1",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -76,6 +76,7 @@ interface AgentSkillsSyncOptions extends BaseClientOptions {
 
 interface AgentInstructionsFileOptions extends BaseClientOptions {
   path: string;
+  yes?: boolean;
 }
 
 interface AgentInstructionsFilePutOptions extends BaseClientOptions {
@@ -711,8 +712,10 @@ export function registerAgentCommands(program: Command): void {
       .description("Delete an agent instructions file")
       .argument("<agentId>", "Agent ID")
       .requiredOption("--path <path>", "Bundle-relative file path")
+      .option("--yes", "Confirm deletion")
       .action(async (agentId: string, opts: AgentInstructionsFileOptions) => {
         try {
+          if (!opts.yes) throw new Error("Refusing to delete without --yes");
           const ctx = resolveCommandContext(opts);
           const query = new URLSearchParams({ path: opts.path });
           const result = await ctx.api.delete(`${apiPath`/api/agents/${agentId}/instructions-bundle/file`}?${query.toString()}`);

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -480,7 +480,7 @@ npx paperclipai agent instructions-bundle <agent-id>
 npx paperclipai agent instructions-bundle:update <agent-id> --payload-json '{"mode":"managed"}'
 npx paperclipai agent instructions-file:get <agent-id> --path AGENTS.md
 npx paperclipai agent instructions-file:put <agent-id> --path AGENTS.md --content-file ./AGENTS.md
-npx paperclipai agent instructions-file:delete <agent-id> --path AGENTS.md
+npx paperclipai agent instructions-file:delete <agent-id> --path AGENTS.md --yes
 ```
 
 Agent config, instructions, skills, project env, environment, secret, and workspace edits affect the next run. Active runs finish with the config they started with. When a saved session, reused workspace, or sandbox lease no longer matches the effective next-run config, Paperclip may start fresh execution and records non-sensitive freshness categories in run result JSON and workspace operation logs.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The CLI exposes board/operator controls for managing agent configuration and instructions.
> - Agent instructions files influence future agent behavior, so deleting one is a destructive configuration mutation.
> - Nearby destructive CLI commands already require explicit `--yes` confirmation before sending DELETE requests.
> - `agent instructions-file:delete` skipped that local confirmation guard and could delete a bundle file from a scripted or mistyped command.
> - This pull request aligns that command with the existing destructive-command safety convention.
> - The benefit is a small, predictable operator-safety guard with focused regression coverage.

## Linked Issues or Issue Description

Bug report:

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration.

### What happened?

`paperclipai agent instructions-file:delete` deleted an agent instructions bundle file without requiring explicit CLI confirmation.

### Expected behavior

Destructive CLI delete operations should require `--yes` before sending a DELETE request.

### Steps to reproduce

1. Run `npx paperclipai agent instructions-file:delete <agent-id> --path AGENTS.md`.
2. Observe that the CLI immediately issues `DELETE /api/agents/:agentId/instructions-bundle/file?path=AGENTS.md`.
3. No local confirmation guard blocks the destructive request.

### Paperclip version or commit

`fd472d02ba950519ca5eff75ed9fd55cf976f4c2`

### Deployment mode

Local dev (`pnpm dev`)

### Installation method

Built from source (`pnpm dev` / `pnpm build`)

### Agent adapter(s) involved

- [x] Not adapter-specific (core bug)

### Database mode

Not database-related

### Access context

Board (human operator)

### Node.js version

`v20.x`

### Operating system

macOS

### Relevant logs or output

```text
Current behavior is local CLI behavior: the command proceeds to the DELETE call without requiring `--yes`.
```

### Relevant config (if applicable)

None.

### Additional context

This command already sits next to other destructive CLI actions such as `agent delete`, which require explicit confirmation. Aligning the guard makes the CLI safety model consistent.

### Privacy checklist

- [x] I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.

## What Changed

- Added a `--yes` confirmation option to `agent instructions-file:delete`.
- Refuse the command locally before resolving API context or sending a DELETE request when confirmation is missing.
- Updated CLI parity coverage for confirmed and refused instructions-file deletion.
- Updated the CLI documentation example to include `--yes`.

## Verification

- `/Users/xinran/Downloads/dev/paperclip-pr-work/node_modules/.bin/vitest run cli/src/__tests__/agent-lifecycle.test.ts --config cli/vitest.config.ts` equivalent executed from the PR worktree using temporary dependency symlinks: 3 tests passed.
- `git diff --check`

## Risks

- Low risk: this only changes one destructive CLI command and matches existing `agent delete`, `issue delete`, and other delete-command confirmation behavior.
- Scripts that intentionally delete instructions files must add `--yes`, which is the intended explicit confirmation path.
- No database, API contract, or lockfile changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in Codex desktop with shell/tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
