### PR TITLE
feat: add idempotencyKey to POST /api/companies/:companyId/approvals

### DIFF
--- a/packages/db/src/migrations/0219_approvals_idempotency_key.sql
+++ b/packages/db/src/migrations/0219_approvals_idempotency_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "approvals" ADD COLUMN "idempotency_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "approvals_company_idempotency_key_idx" ON "approvals" ("company_id","idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1520,6 +1520,13 @@
       "when": 1786711898729,
       "tag": "0218_mushy_jack_murdock",
       "breakpoints": true
+    },
+    {
+      "idx": 219,
+      "version": "7",
+      "when": 1786941219026,
+      "tag": "0219_approvals_idempotency_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/approvals.ts
+++ b/packages/db/src/schema/approvals.ts
@@ -1,4 +1,5 @@
-import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
 
@@ -15,6 +16,7 @@ export const approvals = pgTable(
     decisionNote: text("decision_note"),
     decidedByUserId: text("decided_by_user_id"),
     decidedAt: timestamp("decided_at", { withTimezone: true }),
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -24,5 +26,8 @@ export const approvals = pgTable(
       table.status,
       table.type,
     ),
+    companyIdempotencyKeyIdx: uniqueIndex("approvals_company_idempotency_key_idx")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
   }),
 );

--- a/packages/shared/src/validators/approval.ts
+++ b/packages/shared/src/validators/approval.ts
@@ -7,6 +7,7 @@ export const createApprovalSchema = z.object({
   requestedByAgentId: z.string().uuid().optional().nullable(),
   payload: z.record(z.string(), z.unknown()),
   issueIds: z.array(z.string().uuid()).optional(),
+  idempotencyKey: z.string().min(1).max(255).optional().nullable(),
 });
 
 export type CreateApproval = z.infer<typeof createApprovalSchema>;

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -6,6 +6,7 @@ const mockApprovalService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
   create: vi.fn(),
+  createIdempotent: vi.fn(),
   approve: vi.fn(),
   reject: vi.fn(),
   requestRevision: vi.fn(),
@@ -121,6 +122,7 @@ describe("approval routes idempotent retries", () => {
     mockApprovalService.list.mockReset();
     mockApprovalService.getById.mockReset();
     mockApprovalService.create.mockReset();
+    mockApprovalService.createIdempotent.mockReset();
     mockApprovalService.approve.mockReset();
     mockApprovalService.reject.mockReset();
     mockApprovalService.requestRevision.mockReset();
@@ -323,7 +325,7 @@ describe("approval routes idempotent retries", () => {
   });
 
   it("lets agents create generic issue-linked board approval requests", async () => {
-    mockApprovalService.create.mockResolvedValue({
+    const approval = {
       id: "approval-1",
       companyId: "company-1",
       type: "request_board_approval",
@@ -334,9 +336,11 @@ describe("approval routes idempotent retries", () => {
       decisionNote: null,
       decidedByUserId: null,
       decidedAt: null,
+      idempotencyKey: null,
       createdAt: new Date("2026-04-06T00:00:00.000Z"),
       updatedAt: new Date("2026-04-06T00:00:00.000Z"),
-    });
+    };
+    mockApprovalService.createIdempotent.mockResolvedValue({ approval, created: true });
 
     const res = await request(await createAgentApp())
       .post("/api/companies/company-1/approvals")
@@ -346,7 +350,7 @@ describe("approval routes idempotent retries", () => {
         payload: { title: "Approve hosting spend" },
       });
 
-    expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
     expect(res.body).toMatchObject({
       companyId: "company-1",
       type: "request_board_approval",
@@ -371,6 +375,101 @@ describe("approval routes idempotent retries", () => {
     );
   });
 
+  it("returns 200 with the existing approval when idempotencyKey matches", async () => {
+    const existingApproval = {
+      id: "approval-dup",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      idempotencyKey: "card:INU-123:inu-care/inu-fe:42:abc",
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    };
+    mockApprovalService.createIdempotent.mockResolvedValue({ approval: existingApproval, created: false });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        payload: { title: "Approve spend" },
+        idempotencyKey: "card:INU-123:inu-care/inu-fe:42:abc",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.id).toBe("approval-dup");
+    expect(mockIssueApprovalService.linkManyForApproval).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("returns 201 and creates a new approval when idempotencyKey is new", async () => {
+    const newApproval = {
+      id: "approval-new",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      idempotencyKey: "card:INU-456:inu-care/inu-fe:55:def",
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    };
+    mockApprovalService.createIdempotent.mockResolvedValue({ approval: newApproval, created: true });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        payload: { title: "Approve spend" },
+        idempotencyKey: "card:INU-456:inu-care/inu-fe:55:def",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.id).toBe("approval-new");
+    expect(mockLogActivity).toHaveBeenCalledOnce();
+  });
+
+  it("works without idempotencyKey for backward compatibility", async () => {
+    const approval = {
+      id: "approval-back",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "No key" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      idempotencyKey: null,
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    };
+    mockApprovalService.createIdempotent.mockResolvedValue({ approval, created: true });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        payload: { title: "No key" },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockApprovalService.createIdempotent).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ idempotencyKey: undefined }),
+    );
+  });
+
   it("blocks status-only recovery runs from creating approvals", async () => {
     const res = await request(await createAgentApp({
       contextSnapshot: {
@@ -389,6 +488,7 @@ describe("approval routes idempotent retries", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toContain("Cheap status-only recovery runs cannot create or modify approvals");
+    expect(mockApprovalService.createIdempotent).not.toHaveBeenCalled();
     expect(mockApprovalService.create).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.linkManyForApproval).not.toHaveBeenCalled();
   });

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -167,3 +167,84 @@ describe("approvalService.findOpenHireApprovalForAgent", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("approvalService.createIdempotent", () => {
+  const pendingApproval = {
+    id: "approval-1",
+    companyId: "company-1",
+    type: "request_board_approval",
+    status: "pending",
+    payload: {},
+    requestedByAgentId: null,
+    idempotencyKey: "key-abc",
+  };
+
+  function makeInsertDb(existingRow: typeof pendingApproval | null, insertedRow: typeof pendingApproval | null) {
+    const selectWhere = vi.fn().mockResolvedValue(existingRow ? [existingRow] : []);
+    const db = {
+      select: vi.fn(() => ({ from: vi.fn(() => ({ where: selectWhere })) })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve(insertedRow ? [insertedRow] : [])),
+          })),
+        })),
+      })),
+    };
+    return { db, selectWhere };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentService.activatePendingApproval.mockResolvedValue({ agent: { id: "agent-1" }, activated: true });
+    mockAgentService.create.mockResolvedValue({ id: "agent-1" });
+  });
+
+  it("creates a new approval and returns created:true when no key is provided", async () => {
+    const row = { ...pendingApproval, idempotencyKey: null };
+    const { db } = makeInsertDb(null, row);
+
+    const svc = approvalService(db as any);
+    const result = await svc.createIdempotent("company-1", { ...row, companyId: undefined } as any);
+
+    expect(result.created).toBe(true);
+    expect(result.approval.id).toBe("approval-1");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing approval with created:false when key already exists", async () => {
+    const { db } = makeInsertDb(pendingApproval, null);
+
+    const svc = approvalService(db as any);
+    const result = await svc.createIdempotent("company-1", pendingApproval as any);
+
+    expect(result.created).toBe(false);
+    expect(result.approval.id).toBe("approval-1");
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("creates and returns created:true when key is new", async () => {
+    const { db } = makeInsertDb(null, pendingApproval);
+
+    const svc = approvalService(db as any);
+    const result = await svc.createIdempotent("company-1", pendingApproval as any);
+
+    expect(result.created).toBe(true);
+    expect(result.approval.id).toBe("approval-1");
+    expect(db.insert).toHaveBeenCalledOnce();
+  });
+
+  it("handles the race condition: insert returns nothing but the row is found on re-select", async () => {
+    const { db, selectWhere } = makeInsertDb(null, null);
+    // Second select (after failed insert) returns the winner row
+    selectWhere.mockResolvedValueOnce([]).mockResolvedValue([pendingApproval]);
+
+    const svc = approvalService(db as any);
+    const result = await svc.createIdempotent("company-1", pendingApproval as any);
+
+    expect(result.created).toBe(false);
+    expect(result.approval.id).toBe("approval-1");
+    expect(db.insert).toHaveBeenCalledOnce();
+    expect(selectWhere).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -242,7 +242,7 @@ export function approvalRoutes(
         : approvalInput.payload;
 
     const actor = getActorInfo(req);
-    const approval = await svc.create(companyId, {
+    const { approval, created } = await svc.createIdempotent(companyId, {
       ...approvalInput,
       payload: normalizedPayload,
       requestedByUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -255,25 +255,27 @@ export function approvalRoutes(
       updatedAt: new Date(),
     });
 
-    if (uniqueIssueIds.length > 0) {
-      await issueApprovalsSvc.linkManyForApproval(approval.id, uniqueIssueIds, {
+    if (created) {
+      if (uniqueIssueIds.length > 0) {
+        await issueApprovalsSvc.linkManyForApproval(approval.id, uniqueIssueIds, {
+          agentId: actor.agentId,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        });
+      }
+
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
         agentId: actor.agentId,
-        userId: actor.actorType === "user" ? actor.actorId : null,
+        action: "approval.created",
+        entityType: "approval",
+        entityId: approval.id,
+        details: { type: approval.type, issueIds: uniqueIssueIds },
       });
     }
 
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "approval.created",
-      entityType: "approval",
-      entityId: approval.id,
-      details: { type: approval.type, issueIds: uniqueIssueIds },
-    });
-
-    res.status(201).json(redactApprovalPayload(approval));
+    res.status(created ? 201 : 200).json(redactApprovalPayload(approval));
   });
 
   router.get("/approvals/:id/issues", async (req, res) => {

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -114,6 +114,37 @@ export function approvalService(db: Db) {
       return rows[0] ?? null;
     },
 
+    createIdempotent: async (
+      companyId: string,
+      data: Omit<typeof approvals.$inferInsert, "companyId">,
+    ): Promise<{ approval: typeof approvals.$inferSelect; created: boolean }> => {
+      if (data.idempotencyKey) {
+        const existing = await db
+          .select()
+          .from(approvals)
+          .where(and(eq(approvals.companyId, companyId), eq(approvals.idempotencyKey, data.idempotencyKey)))
+          .then((rows) => rows[0] ?? null);
+        if (existing) return { approval: existing, created: false };
+      }
+      const approval = await db
+        .insert(approvals)
+        .values({ ...data, companyId })
+        .onConflictDoNothing()
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (approval) return { approval, created: true };
+      // Race: another concurrent insert with the same idempotencyKey won
+      if (data.idempotencyKey) {
+        const winner = await db
+          .select()
+          .from(approvals)
+          .where(and(eq(approvals.companyId, companyId), eq(approvals.idempotencyKey, data.idempotencyKey)))
+          .then((rows) => rows[0] ?? null);
+        if (winner) return { approval: winner, created: false };
+      }
+      throw unprocessable("Failed to create approval due to a conflict");
+    },
+
     create: (companyId: string, data: Omit<typeof approvals.$inferInsert, "companyId">) =>
       db
         .insert(approvals)


### PR DESCRIPTION
## Problem

Two concurrent agent heartbeats posting to `POST /api/companies/:companyId/approvals` with identical payloads both received a new approval ID — no server-side dedup. The check-before-create pattern is a racy read-before-write that does not prevent concurrent creates.

## Solution

Add an optional `idempotencyKey` field to the approvals endpoint. When provided, duplicate requests within the same company return the original approval (200) instead of creating a new one (201).

## Changes

- **DB migration 0219:** add nullable `idempotency_key` column + partial unique index `(company_id, idempotency_key) WHERE NOT NULL`
- **Shared validator:** extend `createApprovalSchema` with optional `idempotencyKey`
- **Service:** add `createIdempotent` — pre-checks key, uses `onConflictDoNothing`, falls back to re-select on race condition
- **Route:** use `createIdempotent`; skip side-effects and return 200 on duplicate; return 201 on new creation
- **Tests:** update route mock, add idempotency and backward-compat test cases; add service-level unit tests for `createIdempotent`

## Backward compatibility

Fully backward-compatible: `idempotencyKey` is optional. Existing callers without the field continue to get 201 with a new approval.

## Related

Fixes duplicate-handoff race condition tracked in INUA-5613.