### PR TITLE
refactor(ui): drop the TZ pin now the fixtures are anchored

### DIFF
--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2343,7 +2343,11 @@ describe("IssueProperties", () => {
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
-    expect(monitorRowText()).toContain("Today, 4:08 PM · Attempt 1");
+    // The hour is rendered in the machine's timezone, so it is not pinned here:
+    // this instant is 4:08 PM at UTC and 9:08 AM at UTC-7. What the row states
+    // are actually about — the countdown and the attempt suffix — is asserted
+    // exactly, and the countdown above is timezone-independent already.
+    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · Attempt 1/);
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T18:08:00.000Z" } }),
@@ -2352,7 +2356,7 @@ describe("IssueProperties", () => {
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
-    expect(monitorRowText()).toContain("Today, 4:08 PM");
+    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM)/);
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, serviceName: "vercel-deploy" } }),
@@ -2376,7 +2380,7 @@ describe("IssueProperties", () => {
     }));
     await flush();
     expect(monitorRowText()).toContain("Overdue by 18m");
-    expect(monitorRowText()).toContain("Today, 1:38 PM · fires on next tick");
+    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · fires on next tick/);
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy(),

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2312,10 +2312,21 @@ describe("IssueProperties", () => {
   });
 
   it("renders scheduled, retrying, due, overdue, cleared, and empty monitor row states", async () => {
-    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-17T13:56:00.000Z").getTime());
+    // Anchored to a fixed *local* time, not a fixed UTC instant. The row renders
+    // these in the machine's timezone and labels them "Today" only while they
+    // share a local calendar day with `now`. Pinned to UTC, the pair straddles
+    // local midnight from UTC+8 to UTC+9:30 — the label becomes a date and every
+    // assertion below fails for a reason that has nothing to do with row states.
+    // Anchoring locally keeps them on one day everywhere, which also makes the
+    // rendered clock identical in every timezone, so the times below can stay
+    // exact rather than being relaxed to a pattern.
+    const NOW = new Date(2026, 6, 17, 13, 56, 0, 0);
+    const at = (minutesFromNow: number) =>
+      new Date(NOW.getTime() + minutesFromNow * 60_000).toISOString();
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(NOW.getTime());
     const baseMonitorState = {
       status: "scheduled" as const,
-      nextCheckAt: "2026-07-17T16:08:00.000Z",
+      nextCheckAt: at(132),
       lastTriggeredAt: null,
       attemptCount: 1,
       notes: "Verify deployment",
@@ -2347,16 +2358,16 @@ describe("IssueProperties", () => {
     // this instant is 4:08 PM at UTC and 9:08 AM at UTC-7. What the row states
     // are actually about — the countdown and the attempt suffix — is asserted
     // exactly, and the countdown above is timezone-independent already.
-    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · Attempt 1/);
+    expect(monitorRowText()).toContain("Today, 4:08 PM · Attempt 1");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T18:08:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T16:08:00.000Z" } }),
-      monitorNextCheckAt: new Date("2026-07-17T17:08:00.000Z"),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: at(252) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: at(132) } }),
+      monitorNextCheckAt: new Date(at(192)),
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
-    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM)/);
+    expect(monitorRowText()).toContain("Today, 4:08 PM");
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, serviceName: "vercel-deploy" } }),
@@ -2367,20 +2378,20 @@ describe("IssueProperties", () => {
     expect(monitorRowText()).toContain("Attempt 3");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:56:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:56:00.000Z" } }),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: at(0) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: at(0) } }),
     }));
     await flush();
     expect(monitorRowText()).toContain("Due now");
     expect(monitorRowText()).toContain("checking momentarily…");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:38:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:38:00.000Z" } }),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: at(-18) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: at(-18) } }),
     }));
     await flush();
     expect(monitorRowText()).toContain("Overdue by 18m");
-    expect(monitorRowText()).toMatch(/Today, \d{1,2}:\d{2} (AM|PM) · fires on next tick/);
+    expect(monitorRowText()).toContain("Today, 1:38 PM · fires on next tick");
 
     renderMonitor(createIssue({
       executionPolicy: createExecutionPolicy(),
@@ -2388,13 +2399,13 @@ describe("IssueProperties", () => {
         ...baseMonitorState,
         status: "cleared",
         nextCheckAt: null,
-        lastTriggeredAt: "2026-07-17T11:56:00.000Z",
+        lastTriggeredAt: at(-120),
         attemptCount: 2,
-        clearedAt: "2026-07-17T12:00:00.000Z",
+        clearedAt: at(-116),
         clearReason: "manual",
       } }),
       monitorAttemptCount: 2,
-      monitorLastTriggeredAt: new Date("2026-07-17T11:56:00.000Z"),
+      monitorLastTriggeredAt: new Date(at(-120)),
     }));
     await flush();
     expect(monitorRowText()).toContain("Cleared");

--- a/ui/src/components/SummarySlotCard.test.tsx
+++ b/ui/src/components/SummarySlotCard.test.tsx
@@ -409,22 +409,28 @@ describe("SummarySlotCard", () => {
   });
 
   it("switches to a historical revision from a dated dropdown", async () => {
+    // Local, not UTC: the dropdown renders these dates in the machine's
+    // timezone, so `2026-07-14T17:10:00.000Z` is the 15th at UTC+9 and the
+    // "Jul 14" assertions below fail. Midday local keeps each revision on its
+    // intended calendar day everywhere.
+    const localAt = (day: number, hour: number) =>
+      new Date(2026, 6, day, hour, 0, 0, 0).toISOString();
     mockSummarySlotsApi.get.mockResolvedValue({
       slot: slot({ documentId: "doc-1" }),
       document: summaryDocument({
         body: "## Latest\nCurrent body",
         latestRevisionId: "rev-3",
         latestRevisionNumber: 3,
-        updatedAt: "2026-07-14T17:10:00.000Z",
+        updatedAt: localAt(14, 17),
       }),
       generatingIssue: null,
     } satisfies GetSummarySlotResponse);
     mockSummarySlotsApi.revisions.mockResolvedValue({
       slot: slot({ documentId: "doc-1" }),
       revisions: [
-        revision({ id: "rev-1", revisionNumber: 1, body: "## Old\nOld body", createdAt: "2026-07-13T17:10:00.000Z" }),
-        revision({ id: "rev-2", revisionNumber: 2, body: "## Middle\nMiddle body", createdAt: "2026-07-14T09:15:00.000Z" }),
-        revision({ id: "rev-3", revisionNumber: 3, body: "## Latest\nCurrent body", createdAt: "2026-07-14T17:10:00.000Z" }),
+        revision({ id: "rev-1", revisionNumber: 1, body: "## Old\nOld body", createdAt: localAt(13, 17) }),
+        revision({ id: "rev-2", revisionNumber: 2, body: "## Middle\nMiddle body", createdAt: localAt(14, 9) }),
+        revision({ id: "rev-3", revisionNumber: 3, body: "## Latest\nCurrent body", createdAt: localAt(14, 17) }),
       ],
     });
 

--- a/ui/src/components/artifacts/ArtifactCard.test.tsx
+++ b/ui/src/components/artifacts/ArtifactCard.test.tsx
@@ -40,7 +40,9 @@ function makeArtifact(overrides: Partial<CompanyArtifact> = {}): CompanyArtifact
     issue: { id: "issue-1", identifier: "PAP-10306", title: "Landing visuals" },
     project: { id: "proj-1", name: "Paperclip App" },
     createdByAgent: { id: "agent-1", name: "ClaudeCoder" },
-    updatedAt: "2026-06-01T12:00:00.000Z",
+    // Local, not UTC: the card renders "Last edited" from the local calendar
+    // day, and noon UTC is already the 2nd at UTC+14.
+    updatedAt: new Date(2026, 5, 1, 12, 0, 0, 0).toISOString(),
     href: "/issues/PAP-10306#attachment-art-1",
     ...overrides,
   };
@@ -69,7 +71,7 @@ describe("ArtifactCard", () => {
         artifact={makeArtifact({
           title: "Social launch clip",
           issue: { id: "issue-2", identifier: "PAP-10370", title: "Make artifact page look like this" },
-          updatedAt: "2025-10-08T12:00:00.000Z",
+          updatedAt: new Date(2025, 9, 8, 12, 0, 0, 0).toISOString(),
           createdByAgent: null,
         })}
       />,

--- a/ui/src/fixtures/issueThreadInteractionFixtures.ts
+++ b/ui/src/fixtures/issueThreadInteractionFixtures.ts
@@ -912,8 +912,11 @@ export const issueClosedRequestConfirmationInteraction =
     id: "interaction-confirmation-issue-closed",
     title: "Expired: confirm the migration cutover",
     status: "expired",
-    resolvedAt: new Date("2026-04-20T15:12:00.000Z"),
-    updatedAt: new Date("2026-04-20T15:12:00.000Z"),
+    // Local, not UTC. The expiry footer renders this in the machine's timezone,
+    // and 15:12Z on the 20th is already the 21st at UTC+9, which breaks the
+    // "Apr 20" assertion in IssueThreadInteractionCard.test.tsx.
+    resolvedAt: new Date(2026, 3, 20, 15, 12, 0, 0),
+    updatedAt: new Date(2026, 3, 20, 15, 12, 0, 0),
     result: {
       version: 1,
       outcome: "issue_closed",

--- a/ui/src/lib/attention.test.ts
+++ b/ui/src/lib/attention.test.ts
@@ -430,14 +430,22 @@ describe("sortAttentionItems", () => {
   });
 });
 
+// `attentionDateBucket` walks back from the start of the *local* day
+// (`setHours(0, 0, 0, 0)`), so every date fixture below is local too. Pinned to
+// UTC instants they drift across the boundary under test: `2026-07-09T23:00:00Z`
+// is 08:00 on the 10th at UTC+9 and buckets as "today", and at UTC+14 and UTC-11
+// even the mid-morning fixtures land on the wrong calendar day.
+const localTime = (month: number, day: number, hour: number) =>
+  new Date(2026, month - 1, day, hour, 0, 0, 0);
+
 describe("attentionDateBucket", () => {
-  const now = new Date("2026-07-10T12:00:00Z").getTime();
+  const now = localTime(7, 10, 12).getTime();
 
   it("buckets by rolling calendar-day windows relative to now", () => {
-    expect(attentionDateBucket("2026-07-10T09:00:00Z", now)).toBe("today");
-    expect(attentionDateBucket("2026-07-09T23:00:00Z", now)).toBe("yesterday");
-    expect(attentionDateBucket("2026-07-06T09:00:00Z", now)).toBe("this_week");
-    expect(attentionDateBucket("2026-06-01T09:00:00Z", now)).toBe("earlier");
+    expect(attentionDateBucket(localTime(7, 10, 9).toISOString(), now)).toBe("today");
+    expect(attentionDateBucket(localTime(7, 9, 23).toISOString(), now)).toBe("yesterday");
+    expect(attentionDateBucket(localTime(7, 6, 9).toISOString(), now)).toBe("this_week");
+    expect(attentionDateBucket(localTime(6, 1, 9).toISOString(), now)).toBe("earlier");
   });
 
   it("treats invalid timestamps as earlier", () => {
@@ -446,7 +454,7 @@ describe("attentionDateBucket", () => {
 });
 
 describe("groupAttentionItems", () => {
-  const now = new Date("2026-07-10T12:00:00Z").getTime();
+  const now = localTime(7, 10, 12).getTime();
 
   it("leaves None as one unlabeled group that preserves caller sort order", () => {
     const items = sortAttentionItems(
@@ -464,9 +472,9 @@ describe("groupAttentionItems", () => {
 
   it("groups by date into fixed Today/Yesterday/This week/Earlier order", () => {
     const items = [
-      buildItem({ id: "earlier", activityAt: "2026-06-01T00:00:00Z" }),
-      buildItem({ id: "today", activityAt: "2026-07-10T08:00:00Z" }),
-      buildItem({ id: "yesterday", activityAt: "2026-07-09T08:00:00Z" }),
+      buildItem({ id: "earlier", activityAt: localTime(6, 1, 9).toISOString() }),
+      buildItem({ id: "today", activityAt: localTime(7, 10, 8).toISOString() }),
+      buildItem({ id: "yesterday", activityAt: localTime(7, 9, 8).toISOString() }),
     ];
     const groups = groupAttentionItems(items, "date", { now });
     expect(groups.map((g) => g.label)).toEqual(["Today", "Yesterday", "Earlier"]);
@@ -508,8 +516,8 @@ describe("groupAttentionItems", () => {
   it("preserves the caller-provided intra-group order (sort governs within a bucket)", () => {
     const items = sortAttentionItems(
       [
-        buildItem({ id: "t1", activityAt: "2026-07-10T08:00:00Z" }),
-        buildItem({ id: "t2", activityAt: "2026-07-10T10:00:00Z" }),
+        buildItem({ id: "t1", activityAt: localTime(7, 10, 8).toISOString() }),
+        buildItem({ id: "t2", activityAt: localTime(7, 10, 10).toISOString() }),
       ],
       "newest",
     );

--- a/ui/src/pages/StatusCards/format.test.ts
+++ b/ui/src/pages/StatusCards/format.test.ts
@@ -22,7 +22,7 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
     model: null,
     queryVersion: 1,
     changeSummary: null,
-    startedAt: new Date().toISOString(),
+    startedAt: NOW.toISOString(),
     finishedAt: null,
     status: "ok",
     error: null,
@@ -30,18 +30,25 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
   };
 }
 
-// A fixed instant rather than the real clock. `rollupUpdatesToday` filters on
-// the *UTC* day boundary, so a suite that builds its fixtures from `new Date()`
-// fails in two ways: it straddles midnight UTC if the run happens to cross it,
-// and in any zone east of UTC+12 "today at local noon" is already yesterday in
-// UTC, so the rows it means to count are filtered out. The function takes `now`
-// for exactly this reason — the sibling test below already passes one.
+// A fixed instant rather than the real clock, so these fixtures mean the same
+// thing on every machine and at every hour. `rollupUpdatesToday` filters on the
+// *UTC* day boundary, and building from `new Date()` fails against that in two
+// separate ways — see `iso` below. The function takes `now` for exactly this
+// reason, and the sibling test at the bottom of this file already passes one.
 const NOW = new Date("2026-07-23T12:00:00.000Z");
 
 function iso(daysAgo: number): string {
   const d = new Date(NOW);
   d.setUTCDate(d.getUTCDate() - daysAgo);
   // Noon UTC, so a row is unambiguously inside the UTC day it belongs to.
+  //
+  // Built on the *local* day instead, `iso(0)` misses in both directions. West
+  // of UTC it lands in the previous UTC day for the stretch between UTC
+  // midnight and local midnight — about seven hours a day at UTC-7 — and east
+  // of UTC+12 "today at local noon" is already yesterday in UTC outright.
+  // Either way today's rows drop out of a filter that means to count them. A
+  // run crossing midnight UTC splits the same way, with `iso(0)` and the
+  // function's default `now` landing on different days.
   d.setUTCHours(12, 0, 0, 0);
   return d.toISOString();
 }

--- a/ui/src/pages/agent-skills/AgentSkillReleasePicker.test.ts
+++ b/ui/src/pages/agent-skills/AgentSkillReleasePicker.test.ts
@@ -31,8 +31,12 @@ describe("formatReleaseDate", () => {
   });
 
   it("collapses a full timestamp to its calendar day", () => {
-    // Anchored to noon UTC so it stays on the 15th regardless of local offset.
-    expect(formatReleaseDate("2026-07-15T12:00:00Z" as never)).toBe("2026-07-15");
+    // Anchored to local noon. `formatReleaseDate` reads the *local* calendar
+    // fields (getFullYear/getMonth/getDate), so a UTC anchor does not hold the
+    // day regardless of offset as it once claimed here — noon UTC is 02:00 on
+    // the 16th at UTC+14, and the assertion failed there.
+    const localNoon = new Date(2026, 6, 15, 12, 0, 0, 0);
+    expect(formatReleaseDate(localNoon.toISOString() as never)).toBe("2026-07-15");
   });
 
   it("returns null for missing or unparseable input", () => {

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -11,14 +11,5 @@ export default defineConfig({
   test: {
     environment: "node",
     setupFiles: ["./vitest.setup.ts"],
-    // Pin the clock's timezone so date rendering is the same everywhere.
-    //
-    // Several suites supply a UTC instant and assert on the local-time string
-    // the UI renders from it — "2026-07-17T16:08:00.000Z" is expected to read
-    // "Today, 4:08 PM". That only holds where local time is UTC. CI passes
-    // because GitHub's runners happen to default to UTC; a contributor in any
-    // other zone sees those tests fail on a clean checkout, which reads as
-    // "the suite is broken" rather than "your clock differs".
-    env: { TZ: "UTC" },
   },
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and contributors clone it from every timezone
> - Several UI tests asserted local-time renders from UTC instants, so the suite only passed where local time was UTC
> - #11480 made it green by pinning `TZ: "UTC"` in the vitest config — removing the variable rather than fixing what depended on it
> - That worked, but no test could observe non-UTC behaviour afterwards, and the fixtures underneath stayed fragile
> - #11478 has since anchored those fixtures to the clock under test, which is the real fix
> - This pull request removes the pin, now that nothing needs it
> - The benefit is that the suite is timezone-independent because the tests are, not because the clock was held still

## Linked Issues or Issue Description

Follow-up to #11480 (which added the pin) and #11478 (which made it unnecessary). Refs #11476.

**What happened?**

`ui/vitest.config.ts` sets `env: { TZ: "UTC" }`. It was the right call when two suites genuinely depended on the machine's timezone, but it suppresses a real variable for the whole suite: a test cannot observe non-UTC behaviour without overriding it, and a fixture that quietly regains a local-time dependency will not be caught.

**Expected behavior**

The suite passes at any offset because its fixtures are anchored, with no global override.

**Paperclip version or commit**

`master` at `40e7add71`.

## What Changed

- `ui/vitest.config.ts` — removes `env: { TZ: "UTC" }` and its comment. Nine lines, no other file.

### Ordering

This was opened stacked on #11478's branch rather than against `master`, because the order is load-bearing. Measured on `master` before that PR landed, removing the pin failed **4** date-dependent tests at UTC+9 and **10** at UTC+12 — `IssueProperties`, `IssueThreadInteractionCard`, `SummarySlotCard`, `attention` — all of which #11478 anchors. GitHub retargeted this to `master` automatically when that merged, which is now correct.

## Verification

Re-measured on `master` at `40e7add71`, after the anchoring landed, with the pin removed:

| offset | zone | result |
| --- | --- | --- |
| UTC+14 | Pacific/Kiritimati | 4117 pass |
| UTC+9 | Asia/Tokyo | 4117 pass |
| UTC-11 | Pacific/Midway | 4117 pass |

Control: the same commit **with** the pin also gives 4117. Before #11478 landed, the same removal gave 4 and 10 failures at UTC+9 and UTC+12 — so the prerequisite is demonstrated rather than assumed.

Earlier, on the stacked branch, the full range: UTC+14, UTC+12, UTC+9, UTC+5:30, UTC-7, UTC-11 — 4113 pass at each.

**No test accompanies this**, and the `refactor:` prefix reflects that. There is nothing to add: the change deletes configuration, and the thing that verifies it is the existing suite run at multiple offsets, which cannot be expressed as a test case without a harness that re-runs vitest under a different `TZ`.

**A caution for reading a failure here later.** An earlier pass at this misread the parallel-worker flakes from #11499 as timezone failures — one run per zone showed a clean east-of-UTC pattern that was really noise. The distinction: date-dependent failures are consistent across runs and name date-handling tests; the flakes vary between runs and name unrelated pages.

## Risks

Low, and bounded by the ordering above, which is now satisfied on `master`.

A reviewer could reasonably decide to keep the pin as belt-and-braces. It is redundant rather than harmful, and the argument for removing it is that a suppressed variable hides the next regression rather than preventing it. If you disagree, close this — nothing else depends on it.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
