### PR TITLE
fix(github-fetch): bound GitHub requests and response bodies at the boundary

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -28,6 +28,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_HIDDEN_SETTINGS` | (unset) | Comma-separated settings surfaces to hide from the UI and floor at the API, for operators hosting Paperclip for others (managed cloud, internal shared server). See [Hiding settings surfaces](#hiding-settings-surfaces). |
 | `PAPERCLIP_SETTING_DEFAULTS` | (unset) | JSON object replacing the schema default of selected instance settings, for hosting operators. See [Operator setting defaults](#operator-setting-defaults). |
 | `PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS` | `30000` | Timeout for each GitHub / GitHub Enterprise request (skill imports, company exports). Raise it for slow GitHub Enterprise instances. |
+| `PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES` | `10485760` | Maximum size of a single GitHub / GitHub Enterprise response body. Raise it if a legitimate import exceeds 10 MiB. |
 
 Daytona connectivity for `paperclip_runner` uses authenticated provider
 WebSocket ingress and follows the instance experimental setting

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -27,6 +27,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_RUNNER_REMOTE_PROVIDER_PACK_PATH` | (unset) | Host-local path to the immutable provider pack built by `pnpm --filter @paperclipai/paperclip-runner build:provider-pack`. The pack includes its target-built Node 24.11 runtime, locked production dependencies, OpenCode proxy/executable, and ACPX sidecar. Remote OpenCode and ACPX fail closed without it. A preinstalled pack is accepted only when its complete digested manifest matches this build-owned pack; otherwise Paperclip stages this pack into the sandbox. |
 | `PAPERCLIP_HIDDEN_SETTINGS` | (unset) | Comma-separated settings surfaces to hide from the UI and floor at the API, for operators hosting Paperclip for others (managed cloud, internal shared server). See [Hiding settings surfaces](#hiding-settings-surfaces). |
 | `PAPERCLIP_SETTING_DEFAULTS` | (unset) | JSON object replacing the schema default of selected instance settings, for hosting operators. See [Operator setting defaults](#operator-setting-defaults). |
+| `PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS` | `30000` | Timeout for each GitHub / GitHub Enterprise request (skill imports, company exports). Raise it for slow GitHub Enterprise instances. |
 
 Daytona connectivity for `paperclip_runner` uses authenticated provider
 WebSocket ingress and follows the instance experimental setting

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -19,6 +19,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS` | `30000` | Timeout for each GitHub / GitHub Enterprise request (skill imports, company exports). Raise it for slow GitHub Enterprise instances. |
 
 ## Secrets
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -20,6 +20,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
 | `PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS` | `30000` | Timeout for each GitHub / GitHub Enterprise request (skill imports, company exports). Raise it for slow GitHub Enterprise instances. |
+| `PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES` | `10485760` | Maximum size of a single GitHub / GitHub Enterprise response body. Raise it if a legitimate import exceeds 10 MiB. |
 
 ## Secrets
 

--- a/server/src/services/company-portability-github-ref-fallback.test.ts
+++ b/server/src/services/company-portability-github-ref-fallback.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { companyPortabilityService } from "./company-portability.js";
+
+// The master fallback in resolveSource must fire when the ref is genuinely
+// absent (raw.githubusercontent answers 404) and must NOT fire when the request
+// failed for a transport reason — a timeout, an oversized body, an unreachable
+// host. Retrying a different ref cannot fix those, and doing so both hides the
+// original cause and doubles the work a wedged host can extract.
+
+const SOURCE = {
+  type: "github" as const,
+  url: "https://github.com/acme/company-package/tree/main/pkg",
+};
+
+const TARGET = { mode: "new_company" as const, newCompanyName: "Acme" };
+
+const COMPANY_MD = "---\nname: Acme\n---\n\n# Acme\n";
+
+const originalFetch = globalThis.fetch;
+
+function textResponse(body: string) {
+  return new Response(body, { status: 200, headers: { "content-type": "text/plain" } });
+}
+
+function notFound() {
+  return new Response("404: Not Found", { status: 404 });
+}
+
+let requested: string[];
+
+beforeEach(() => {
+  requested = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("resolveSource GitHub ref fallback", () => {
+  it("falls back to master when the main ref is absent", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url.includes("/main/")) return notFound();
+      if (url.includes("/master/") && url.endsWith("COMPANY.md")) return textResponse(COMPANY_MD);
+      // Everything else the manifest build asks for is optional.
+      return notFound();
+    }) as typeof fetch;
+
+    const portability = companyPortabilityService({} as never);
+    const preview = await portability.previewImport({ source: SOURCE, target: TARGET } as never);
+
+    expect(preview.warnings).toContain("GitHub ref main not found; falling back to master.");
+    expect(requested.some((url) => url.includes("/main/"))).toBe(true);
+    expect(requested.some((url) => url.includes("/master/"))).toBe(true);
+  });
+
+  it("does not retry master when the main request fails for a transport reason", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      // Stands in for a timeout / unreachable host: ghFetch maps this to its 422.
+      throw new Error("socket hang up");
+    }) as typeof fetch;
+
+    const portability = companyPortabilityService({} as never);
+
+    await expect(
+      portability.previewImport({ source: SOURCE, target: TARGET } as never),
+    ).rejects.toThrow(/Could not connect to/);
+
+    // The transport failure must surface as itself, not be relabelled a missing
+    // ref and retried against master.
+    expect(requested.every((url) => !url.includes("/master/"))).toBe(true);
+  });
+});

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -72,7 +72,14 @@ import { requireOpenCodeModelId } from "@paperclipai/adapter-opencode-local/serv
 import { findServerAdapter } from "../adapters/index.js";
 import { formatAttachmentSize, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { forbidden, notFound, unprocessable } from "../errors.js";
-import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
+import {
+  ghFetch,
+  gitHubApiBase,
+  readGitHubResponseBytes,
+  readGitHubResponseJson,
+  readGitHubResponseText,
+  resolveRawGitHubUrl,
+} from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
 import { accessService } from "./access.js";
 import { agentService } from "./agents.js";
@@ -2883,7 +2890,7 @@ async function fetchText(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.text();
+  return readGitHubResponseText(response, url);
 }
 
 async function fetchOptionalText(url: string) {
@@ -2892,7 +2899,7 @@ async function fetchOptionalText(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.text();
+  return readGitHubResponseText(response, url);
 }
 
 async function fetchBinary(url: string) {
@@ -2900,7 +2907,7 @@ async function fetchBinary(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return Buffer.from(await response.arrayBuffer());
+  return readGitHubResponseBytes(response, url);
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -2912,7 +2919,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.json() as Promise<T>;
+  return readGitHubResponseJson<T>(response, url);
 }
 
 function dedupeEnvInputs(values: CompanyPortabilityManifest["envInputs"]) {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3757,21 +3757,21 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     const companyRelativePath = parsed.companyPath === "COMPANY.md"
       ? [parsed.basePath, "COMPANY.md"].filter(Boolean).join("/")
       : parsed.companyPath;
-    let companyMarkdown: string | null = null;
-    try {
+    // A missing ref is reported by fetchOptionalText as null (its 404 case), not
+    // as a throw, so key the master fallback off that. Keying it off a thrown
+    // error instead meant it never fired for an absent ref, while every real
+    // transport failure — a timeout, a response over the size limit, an
+    // unreachable host — was relabelled "ref main not found" and retried against
+    // master, which cannot fix it and hides the original cause.
+    let companyMarkdown = await fetchOptionalText(
+      resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, companyRelativePath),
+    );
+    if (companyMarkdown === null && ref === "main") {
+      ref = "master";
+      warnings.push("GitHub ref main not found; falling back to master.");
       companyMarkdown = await fetchOptionalText(
         resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, companyRelativePath),
       );
-    } catch (err) {
-      if (ref === "main") {
-        ref = "master";
-        warnings.push("GitHub ref main not found; falling back to master.");
-        companyMarkdown = await fetchOptionalText(
-          resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, companyRelativePath),
-        );
-      } else {
-        throw err;
-      }
     }
     if (!companyMarkdown) {
       throw unprocessable("GitHub company package is missing COMPANY.md");

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3661,21 +3661,21 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     const companyRelativePath = parsed.companyPath === "COMPANY.md"
       ? [parsed.basePath, "COMPANY.md"].filter(Boolean).join("/")
       : parsed.companyPath;
-    let companyMarkdown: string | null = null;
-    try {
+    // A missing ref is reported by fetchOptionalText as null (its 404 case), not
+    // as a throw, so key the master fallback off that. Keying it off a thrown
+    // error instead meant it never fired for an absent ref, while every real
+    // transport failure — a timeout, a response over the size limit, an
+    // unreachable host — was relabelled "ref main not found" and retried against
+    // master, which cannot fix it and hides the original cause.
+    let companyMarkdown = await fetchOptionalText(
+      resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, companyRelativePath),
+    );
+    if (companyMarkdown === null && ref === "main") {
+      ref = "master";
+      warnings.push("GitHub ref main not found; falling back to master.");
       companyMarkdown = await fetchOptionalText(
         resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, companyRelativePath),
       );
-    } catch (err) {
-      if (ref === "main") {
-        ref = "master";
-        warnings.push("GitHub ref main not found; falling back to master.");
-        companyMarkdown = await fetchOptionalText(
-          resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, companyRelativePath),
-        );
-      } else {
-        throw err;
-      }
     }
     if (!companyMarkdown) {
       throw unprocessable("GitHub company package is missing COMPANY.md");

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -72,7 +72,14 @@ import { requireOpenCodeModelId } from "@paperclipai/adapter-opencode-local/serv
 import { findServerAdapter } from "../adapters/index.js";
 import { normalizeIssueAttachmentMaxBytes } from "../attachment-types.js";
 import { forbidden, notFound, unprocessable } from "../errors.js";
-import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
+import {
+  ghFetch,
+  gitHubApiBase,
+  readGitHubResponseBytes,
+  readGitHubResponseJson,
+  readGitHubResponseText,
+  resolveRawGitHubUrl,
+} from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
 import { accessService } from "./access.js";
 import { agentService } from "./agents.js";
@@ -2811,7 +2818,7 @@ async function fetchText(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.text();
+  return readGitHubResponseText(response, url);
 }
 
 async function fetchOptionalText(url: string) {
@@ -2820,7 +2827,7 @@ async function fetchOptionalText(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.text();
+  return readGitHubResponseText(response, url);
 }
 
 async function fetchBinary(url: string) {
@@ -2828,7 +2835,7 @@ async function fetchBinary(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return Buffer.from(await response.arrayBuffer());
+  return readGitHubResponseBytes(response, url);
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -2840,7 +2847,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.json() as Promise<T>;
+  return readGitHubResponseJson<T>(response, url);
 }
 
 function dedupeEnvInputs(values: CompanyPortabilityManifest["envInputs"]) {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -102,7 +102,13 @@ import {
 } from "@paperclipai/shared";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
-import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
+import {
+  ghFetch,
+  gitHubApiBase,
+  readGitHubResponseJson,
+  readGitHubResponseText,
+  resolveRawGitHubUrl,
+} from "./github-fetch.js";
 import { agentService } from "./agents.js";
 import { issueDocumentSelect, mapIssueDocumentRow } from "./documents.js";
 import { toIssueWorkProduct } from "./work-products.js";
@@ -726,7 +732,7 @@ async function fetchText(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.text();
+  return readGitHubResponseText(response, url);
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -738,7 +744,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.json() as Promise<T>;
+  return readGitHubResponseJson<T>(response, url);
 }
 
 

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -102,7 +102,13 @@ import {
 } from "@paperclipai/shared";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
-import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
+import {
+  ghFetch,
+  gitHubApiBase,
+  readGitHubResponseJson,
+  readGitHubResponseText,
+  resolveRawGitHubUrl,
+} from "./github-fetch.js";
 import { agentService } from "./agents.js";
 import { issueDocumentSelect, mapIssueDocumentRow } from "./documents.js";
 import { toIssueWorkProduct } from "./work-products.js";
@@ -709,7 +715,7 @@ async function fetchText(url: string) {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.text();
+  return readGitHubResponseText(response, url);
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -721,7 +727,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
-  return response.json() as Promise<T>;
+  return readGitHubResponseJson<T>(response, url);
 }
 
 

--- a/server/src/services/github-fetch.test.ts
+++ b/server/src/services/github-fetch.test.ts
@@ -1,7 +1,12 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { ghFetch } from "./github-fetch.js";
+import {
+  ghFetch,
+  readGitHubResponseBytes,
+  readGitHubResponseJson,
+  readGitHubResponseText,
+} from "./github-fetch.js";
 
 // A server that accepts the connection and the request, then never writes a
 // response. `fetch` has no default timeout, so without a bound in ghFetch the
@@ -13,6 +18,23 @@ let hungUrl: string;
 // the normal path.
 let okServer: http.Server;
 let okUrl: string;
+
+let jsonServer: http.Server;
+let jsonUrl: string;
+
+// Answers with an accurate content-length larger than the test limit, so the
+// declared-size check can refuse it before reading the body.
+let sizedServer: http.Server;
+let sizedUrl: string;
+
+// Streams chunked output with no content-length until the client disconnects.
+// Only the running byte total can stop a read from this server.
+let floodServer: http.Server;
+let floodUrl: string;
+
+// Sends headers and one chunk, then stops writing without ending the response.
+let stalledBodyServer: http.Server;
+let stalledBodyUrl: string;
 
 function listen(server: http.Server): Promise<string> {
   return new Promise((resolve) => {
@@ -35,15 +57,51 @@ beforeAll(async () => {
   hungUrl = await listen(hungServer);
   okServer = http.createServer((_req, res) => res.end("ok"));
   okUrl = await listen(okServer);
+  jsonServer = http.createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ ok: true }));
+  });
+  jsonUrl = await listen(jsonServer);
+  sizedServer = http.createServer((_req, res) => res.end(Buffer.alloc(1000, 0x61)));
+  sizedUrl = await listen(sizedServer);
+  floodServer = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "application/octet-stream" });
+    const chunk = Buffer.alloc(64 * 1024, 0x61);
+    let stopped = false;
+    const stop = () => { stopped = true; };
+    res.on("close", stop);
+    res.on("error", stop);
+    const pump = () => {
+      if (stopped || res.writableEnded) return;
+      if (!res.write(chunk)) {
+        res.once("drain", pump);
+        return;
+      }
+      setImmediate(pump);
+    };
+    pump();
+  });
+  floodUrl = await listen(floodServer);
+  stalledBodyServer = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.write("partial");
+    // Deliberately never end the response.
+  });
+  stalledBodyUrl = await listen(stalledBodyServer);
 });
 
 afterAll(async () => {
   await close(hungServer);
   await close(okServer);
+  await close(jsonServer);
+  await close(sizedServer);
+  await close(floodServer);
+  await close(stalledBodyServer);
 });
 
 afterEach(() => {
   delete process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS;
+  delete process.env.PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES;
 });
 
 describe("ghFetch", () => {
@@ -65,6 +123,47 @@ describe("ghFetch", () => {
 
     expect(response.ok).toBe(true);
     await expect(response.text()).resolves.toBe("ok");
+  });
+
+  it("reads a normal body through the capped readers", async () => {
+    process.env.PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES = "1048576";
+
+    await expect(readGitHubResponseText(await ghFetch(okUrl), okUrl)).resolves.toBe("ok");
+    await expect(readGitHubResponseBytes(await ghFetch(okUrl), okUrl)).resolves.toEqual(Buffer.from("ok"));
+    await expect(readGitHubResponseJson(await ghFetch(jsonUrl), jsonUrl)).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects a body whose declared content-length exceeds the limit", async () => {
+    process.env.PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES = "100";
+
+    // 1000 bytes with an accurate content-length: refused before the body is read.
+    await expect(
+      readGitHubResponseBytes(await ghFetch(sizedUrl), sizedUrl),
+    ).rejects.toThrow(/exceeds the 100 byte limit/);
+  });
+
+  it("stops a body that streams past the limit without declaring a content-length", async () => {
+    process.env.PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES = "100";
+
+    // The chunked server streams until the client disconnects, so nothing but
+    // the running total can stop this read.
+    await expect(
+      readGitHubResponseBytes(await ghFetch(floodUrl), floodUrl),
+    ).rejects.toThrow(/exceeds the 100 byte limit/);
+  });
+
+  it("reports a mid-body stall as a connection error, not a raw abort", async () => {
+    // ghFetch resolves once headers arrive, so this timeout fires during the
+    // body read — outside ghFetch's own try/catch.
+    process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS = "300";
+    process.env.PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES = "1048576";
+
+    const response = await ghFetch(stalledBodyUrl);
+    expect(response.ok).toBe(true);
+
+    await expect(readGitHubResponseText(response, stalledBodyUrl)).rejects.toThrow(
+      /Could not read the response from 127\.0\.0\.1/,
+    );
   });
 
   it("honors a caller-supplied abort signal", async () => {

--- a/server/src/services/github-fetch.test.ts
+++ b/server/src/services/github-fetch.test.ts
@@ -1,0 +1,80 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ghFetch } from "./github-fetch.js";
+
+// A server that accepts the connection and the request, then never writes a
+// response. `fetch` has no default timeout, so without a bound in ghFetch the
+// request never settles.
+let hungServer: http.Server;
+let hungUrl: string;
+
+// A server that answers immediately, to confirm the timeout does not disturb
+// the normal path.
+let okServer: http.Server;
+let okUrl: string;
+
+function listen(server: http.Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${port}/`);
+    });
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.closeAllConnections?.();
+    server.close(() => resolve());
+  });
+}
+
+beforeAll(async () => {
+  hungServer = http.createServer(() => {});
+  hungUrl = await listen(hungServer);
+  okServer = http.createServer((_req, res) => res.end("ok"));
+  okUrl = await listen(okServer);
+});
+
+afterAll(async () => {
+  await close(hungServer);
+  await close(okServer);
+});
+
+afterEach(() => {
+  delete process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS;
+});
+
+describe("ghFetch", () => {
+  it("gives up on a host that accepts the connection but never responds", async () => {
+    process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS = "250";
+
+    const startedAt = Date.now();
+    await expect(ghFetch(hungUrl)).rejects.toThrow(/Could not connect to 127\.0\.0\.1/);
+    // The point of the test: the call ends on its own instead of hanging.
+    // Generous headroom over the 250ms bound so this asserts "bounded", not a
+    // specific scheduling latency.
+    expect(Date.now() - startedAt).toBeLessThan(4000);
+  });
+
+  it("still returns a response when the host answers", async () => {
+    process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS = "5000";
+
+    const response = await ghFetch(okUrl);
+
+    expect(response.ok).toBe(true);
+    await expect(response.text()).resolves.toBe("ok");
+  });
+
+  it("honors a caller-supplied abort signal", async () => {
+    // Long request timeout, so only the caller's signal can end this call.
+    process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS = "60000";
+
+    const startedAt = Date.now();
+    await expect(
+      ghFetch(hungUrl, { signal: AbortSignal.timeout(250) }),
+    ).rejects.toThrow(/Could not connect to 127\.0\.0\.1/);
+    expect(Date.now() - startedAt).toBeLessThan(4000);
+  });
+});

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -16,9 +16,23 @@ export function resolveRawGitHubUrl(hostname: string, owner: string, repo: strin
     : `https://${hostname}/raw/${owner}/${repo}/${ref}/${p}`;
 }
 
+const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+function requestTimeoutMs() {
+  const parsed = Number.parseInt(process.env.PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GITHUB_REQUEST_TIMEOUT_MS;
+}
+
 export async function ghFetch(url: string, init?: RequestInit): Promise<Response> {
+  // `fetch` has no default timeout. The host here comes from a user-supplied
+  // repository URL, so a GitHub Enterprise instance that accepts the connection
+  // and then never responds would block this call — and the request handler
+  // waiting on it — indefinitely. Bound every request, and keep honouring a
+  // caller-supplied signal so existing cancellation still works.
+  const timeout = AbortSignal.timeout(requestTimeoutMs());
+  const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout;
   try {
-    return await fetch(url, init);
+    return await fetch(url, { ...init, signal });
   } catch {
     throw unprocessable(`Could not connect to ${new URL(url).hostname} — ensure the URL points to a GitHub or GitHub Enterprise instance`);
   }

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -1,4 +1,4 @@
-import { unprocessable } from "../errors.js";
+import { HttpError, unprocessable } from "../errors.js";
 
 export function isGitHubDotCom(hostname: string) {
   const h = hostname.toLowerCase();
@@ -36,4 +36,72 @@ export async function ghFetch(url: string, init?: RequestInit): Promise<Response
   } catch {
     throw unprocessable(`Could not connect to ${new URL(url).hostname} — ensure the URL points to a GitHub or GitHub Enterprise instance`);
   }
+}
+
+// Generous next to the 1 MiB per-file ceiling skill imports already enforce
+// (MAX_CATALOG_FILE_BYTES), and above a large recursive repo-tree listing,
+// while still bounding what one response can allocate.
+const DEFAULT_GITHUB_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+function maxResponseBytes() {
+  const parsed = Number.parseInt(process.env.PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GITHUB_MAX_RESPONSE_BYTES;
+}
+
+function tooLarge(url: string, limit: number) {
+  return unprocessable(`Response from ${new URL(url).hostname} exceeds the ${limit} byte limit for GitHub requests`);
+}
+
+/**
+ * Read a GitHub response body with a size ceiling.
+ *
+ * The host is user-supplied, so an unbounded read lets one response allocate
+ * without limit. `response.arrayBuffer()` cannot help — it has already buffered
+ * everything by the time its result could be measured — so this streams and
+ * stops as soon as the running total crosses the limit.
+ */
+export async function readGitHubResponseBytes(response: Response, url: string): Promise<Buffer> {
+  const limit = maxResponseBytes();
+
+  // Trust `content-length` only to reject early; a hostile host can understate
+  // or omit it, so the streaming total below remains the real enforcement.
+  const declared = Number.parseInt(response.headers.get("content-length") ?? "", 10);
+  if (Number.isFinite(declared) && declared > limit) {
+    await response.body?.cancel();
+    throw tooLarge(url, limit);
+  }
+
+  // ghFetch returns as soon as the headers arrive, but its request timeout stays
+  // armed for the body. A host that sends headers and then stalls mid-stream
+  // aborts the read here, outside ghFetch's own try, so translate that into the
+  // same error the wrapper raises instead of leaking a raw AbortError.
+  try {
+    if (!response.body) return Buffer.from(await response.arrayBuffer());
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel();
+        throw tooLarge(url, limit);
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks);
+  } catch (err) {
+    if (err instanceof HttpError) throw err;
+    throw unprocessable(`Could not read the response from ${new URL(url).hostname} — the connection ended before the body was complete`);
+  }
+}
+
+export async function readGitHubResponseText(response: Response, url: string): Promise<string> {
+  return (await readGitHubResponseBytes(response, url)).toString("utf8");
+}
+
+export async function readGitHubResponseJson<T>(response: Response, url: string): Promise<T> {
+  return JSON.parse(await readGitHubResponseText(response, url)) as T;
 }

--- a/server/src/services/skills-catalog.ts
+++ b/server/src/services/skills-catalog.ts
@@ -12,7 +12,7 @@ import type {
 } from "@paperclipai/shared";
 import { HttpError, conflict, notFound, unprocessable } from "../errors.js";
 import { logger } from "../middleware/logger.js";
-import { ghFetch, resolveRawGitHubUrl } from "./github-fetch.js";
+import { ghFetch, readGitHubResponseBytes, resolveRawGitHubUrl } from "./github-fetch.js";
 import { normalizePortablePath } from "./portable-path.js";
 
 interface CatalogManifestFile {
@@ -224,7 +224,7 @@ async function fetchCatalogSourceFile(
   if (!response.ok) {
     throw unprocessable(`Failed to fetch pinned catalog file ${sourcePath} from ${source.owner}/${source.repo}@${source.commit}: HTTP ${response.status}`);
   }
-  return Buffer.from(await response.arrayBuffer());
+  return readGitHubResponseBytes(response, url);
 }
 
 async function readCatalogFileBytes(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Companies can install skills and import company data from a GitHub or GitHub Enterprise repository. `ghFetch` in `server/src/services/github-fetch.ts` is the single wrapper for every GitHub request the server makes
> - The host is not trusted input. It comes from a user-supplied repository URL through `new URL(...).hostname`, and `gitHubApiBase` builds `https://<host>/api/v3` for any non-`github.com` hostname, with no allowlist
> - `ghFetch` called `fetch()` with no signal. Node's `fetch` has no default timeout, so a host that accepts the TCP connection and then never responds blocks the call forever
> - All seven call sites run inside request handling and none of them passes a signal, so one wedged host parks a request handler indefinitely
> - The response bodies were unbounded too. Every caller read them with `response.text()`, `response.json()` or `Buffer.from(await response.arrayBuffer())`, so a host could return a body of any size and the server would buffer all of it
> - This pull request bounds every GitHub request in time with `AbortSignal.timeout`, and bounds every response body in size by streaming it through readers that stop at a ceiling
> - The benefit is that a hostile or broken GitHub Enterprise host can neither hold a request handler open nor make the server allocate without limit

## Linked Issues or Issue Description

No existing issue — describing the problem here, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

Related PR: #9871 (`feat: inject GITHUB_TOKEN auth header in ghFetch`) is open and changes the same function and the same two files, for a different reason (auth header injection). It is not a duplicate of this change and neither supersedes the other, but they will conflict textually. This PR adds its tests at `server/src/services/github-fetch.test.ts`, the same path #9871 uses, so whichever lands first the other resolves into one test file rather than leaving two test files for one module. Happy to rebase on top of #9871 if maintainers prefer to take that one first.

**What happened?**

Two related problems at the same trust boundary.

First, `ghFetch` issues every GitHub and GitHub Enterprise request with no timeout. A host that completes the TCP handshake and then never sends a response makes the request hang for as long as the connection stays open. The affected call sites are `fetchText`, `fetchOptionalText`, `fetchBinary` and `fetchJson` in `server/src/services/company-portability.ts`, `fetchText` and `fetchJson` in `server/src/services/company-skills.ts`, and the raw file read in `server/src/services/skills-catalog.ts`. None of them passes an abort signal, and none of them applies its own time bound.

Second, none of those callers bounds the size of the response body. `fetchText`, `fetchOptionalText` and `fetchJson` read it with `response.text()` / `response.json()`, and `fetchBinary` in `company-portability.ts` and the catalog read in `skills-catalog.ts` use `Buffer.from(await response.arrayBuffer())`. A host that returns an unbounded body makes the server buffer all of it. Measuring the result afterwards cannot help, because `arrayBuffer()` has already allocated everything by the time its length is available.

The hostname reaches `ghFetch` from a user-supplied repository URL. `parseGitHubRepoUrl` takes `new URL(value).hostname`, and `gitHubApiBase` maps any hostname other than `github.com` to `https://<hostname>/api/v3`. There is no allowlist, so any reachable host can be pointed at.

**Expected behavior**

A GitHub request fails after a bounded time, and a GitHub response body is refused once it passes a size ceiling. Both surface as the wrapper's existing 422, not as a raw abort error.

**Steps to reproduce**

1. Start a server that listens and never answers, for example `node -e "require('node:http').createServer(() => {}).listen(3000,'127.0.0.1')"`.
2. Call any code path that reads a skill or company export from a repository on that host.
3. The request never returns. The added test reproduces this as a hang.
4. For the size half, point a caller at a host that streams a body without a `content-length`. The read continues until memory is exhausted. The added test reproduces this too: with the cap removed it hangs until the test timeout.

**Paperclip version or commit**

`master` at 6d0adbfb.

**Deployment mode**

Not deployment-specific — the code path runs wherever skills or company data are read from GitHub.

## What Changed

- `server/src/services/github-fetch.ts`: `ghFetch` now bounds every request with `AbortSignal.timeout`. The default is 30s, overridable with `PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS`, parsed with the same positive-integer rule used for the `PAPERCLIP_MCP_GATEWAY_*_MS` settings. A caller-supplied `init.signal` is still honoured by composing both with `AbortSignal.any`.
- `server/src/services/github-fetch.ts`: added `readGitHubResponseBytes`, `readGitHubResponseText` and `readGitHubResponseJson`. They reject early when `content-length` declares more than the ceiling, then stream the body and stop as soon as the running total crosses it, so an omitted or understated length is still bounded. The ceiling defaults to 10 MiB and is overridable with `PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES`.
- `server/src/services/github-fetch.ts`: the readers translate a body-read abort into the wrapper's existing 422. `ghFetch` returns once the headers arrive, so its timeout can fire during the body read, outside `ghFetch`'s own `try`. Without this the caller saw a raw `The operation was aborted due to timeout`. This is the issue Greptile raised on the first revision of this PR.
- `server/src/services/company-skills.ts`, `server/src/services/company-portability.ts`, `server/src/services/skills-catalog.ts`: all seven body reads now go through the capped readers. No `response.text()`, `response.json()` or `response.arrayBuffer()` call on a `ghFetch` response remains in these files.
- `server/src/services/company-portability.ts`: `resolveSource` now keys its `main` → `master` fallback off `companyMarkdown === null` instead of off a thrown error. `fetchOptionalText` reports a missing file as `null`, so an absent `main` ref never reached the old `catch` — the fallback could not do the job it was named for. What did reach it was every transport failure, which was relabelled "GitHub ref main not found" and retried against `master`, hiding the original cause and doubling the work a wedged host could extract. This is the second half of Greptile's P1 on this PR.
- `server/src/services/github-fetch.test.ts`: new test file, 7 tests.
- `server/src/services/company-portability-github-ref-fallback.test.ts`: new test file, 2 tests, covering both directions of the fallback.
- `docs/deploy/environment-variables.md`: documented both new variables in the Server Configuration table.

## Verification

```sh
cd server
npx vitest run src/services/github-fetch.test.ts
```

Run on Node 24.16.0 (the repo now requires Node 24), re-verified after rebasing onto current master (8c8934044). Three of the seven tests are genuine red/green; each was confirmed to fail with only its own guard removed:

| Test | Without the fix | With the fix |
|---|---|---|
| `gives up on a host that accepts the connection but never responds` | hangs, killed by vitest at 5009ms | rejects, suite passes |
| `rejects a body whose declared content-length exceeds the limit` | resolves in 8ms, no rejection | rejects with the limit message |
| `stops a body that streams past the limit without declaring a content-length` | hangs to the 8s test timeout — `arrayBuffer()` on an unbounded stream never returns | rejects with the limit message |
| `reports a mid-body stall as a connection error, not a raw abort` | throws `The operation was aborted due to timeout` | throws the wrapper's 422 |

All 7 tests pass in 1.08s.

The portability fallback is covered separately, and both of its tests fail on the previous logic:

```sh
npx vitest run src/services/company-portability-github-ref-fallback.test.ts
```

| Test | On the old logic | With the fix |
|---|---|---|
| `falls back to master when the main ref is absent` | fails — the old `catch` never ran for an absent ref, because `fetchOptionalText` returns `null` rather than throwing | passes; the warning is emitted and `master` is requested |
| `does not retry master when the main request fails for a transport reason` | fails — the transport error was relabelled a missing ref and `master` was fetched | passes; the 422 surfaces and `master` is never requested |

The remaining three tests — `still returns a response when the host answers`, `reads a normal body through the capped readers`, and `honors a caller-supplied abort signal` — pass with and without the change. They are regression guards for the normal path and for existing cancellation, not evidence of a bug.

Consumers of `ghFetch`, compared against this PR's own first revision (the timeout commit alone) so the size-cap change is isolated:

```sh
npx vitest run src/__tests__/company-portability.test.ts src/__tests__/company-portability-routes.test.ts \
  src/__tests__/company-portability-import-batching.test.ts src/__tests__/company-skills.test.ts \
  src/__tests__/company-skills-service.test.ts src/__tests__/company-skills-catalog-service.test.ts \
  src/__tests__/skills-catalog-service.test.ts src/services/github-fetch.test.ts
```

- before the size-cap commit: `11 failed | 209 passed | 1 skipped (221)`
- after: `11 failed | 213 passed | 1 skipped (225)`

The portability suites are green in full, including the two new tests:

```sh
npx vitest run src/services/company-portability-github-ref-fallback.test.ts src/services/github-fetch.test.ts \
  src/__tests__/company-portability.test.ts src/__tests__/company-portability-routes.test.ts \
  src/__tests__/company-portability-import-batching.test.ts
# Test Files 5 passed (5) | Tests 133 passed | 1 skipped (134)
```

The same 11 tests fail either way. They are project-workspace skill-folder tests that do not touch GitHub, and they fail locally on `master` too. The delta is the 4 added tests, all passing.

`tsc --noEmit -p server/tsconfig.json` reports the same 139 pre-existing errors as clean `master`, none in the four files changed here. They are all unresolved `@paperclipai/plugin-sdk` imports caused by workspace packages not being built locally.

## Risks

Low risk. Neither change alters a function signature, and both failure modes surface as the 422 the wrapper already raised.

Two behavioral changes worth naming:

- A GitHub request that legitimately takes longer than 30s now fails. `PAPERCLIP_GITHUB_REQUEST_TIMEOUT_MS` raises the bound without a code change.
- A `main` ref that fails for a transport reason no longer silently retries `master`. An import that previously appeared to succeed via that accidental retry will now report the transport error instead. That is the intended correction — the retry was masking a real failure — but it is a visible behavior change.
- A GitHub response body larger than 10 MiB is now refused. `PAPERCLIP_GITHUB_MAX_RESPONSE_BYTES` raises the ceiling. 10 MiB was chosen to sit well above both the 1 MiB per-file limit skill imports already enforce (`MAX_CATALOG_FILE_BYTES` in `company-skills.ts`) and a large recursive repo-tree listing, so a working setup should not hit it. A tighter default would be easy to argue for and easy to change.

`AbortSignal.any` requires Node 20+, which matches the `engines` field in `package.json`.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5`, used via Claude Code with extended thinking and tool use (repository search, file editing, and local test execution). The fix and the tests were produced with model assistance and verified locally by running the test suites and typechecker as described in Verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — both new variables are documented in `docs/deploy/environment-variables.md`
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — to be confirmed after CI runs
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — to be confirmed after review
- [x] I will address all Greptile and reviewer comments before requesting merge

