### PR TITLE
fix(server): re-resolve managed instructions root at heartbeat config-assembly

### DIFF
--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { agentInstructionsService } from "../services/agent-instructions.js";
+import { agentInstructionsService, resolveHeartbeatManagedInstructionsPatch } from "../services/agent-instructions.js";
 
 type TestAgent = {
   id: string;
@@ -357,5 +357,114 @@ describe("agent instructions service", () => {
       "Recovered managed instructions entry file from disk as AGENTS.md; previous entry docs/MISSING.md was missing.",
     ]);
     expect(exported.files).toEqual({ "AGENTS.md": "# Managed Agent\n" });
+  });
+});
+
+describe("resolveHeartbeatManagedInstructionsPatch", () => {
+  const originalPaperclipHome = process.env.PAPERCLIP_HOME;
+  const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+  const cleanupDirs = new Set<string>();
+
+  afterEach(async () => {
+    if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalPaperclipHome;
+    if (originalPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+    else process.env.PAPERCLIP_INSTANCE_ID = originalPaperclipInstanceId;
+
+    await Promise.all([...cleanupDirs].map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+      cleanupDirs.delete(dir);
+    }));
+  });
+
+  function managedRootFor(paperclipHome: string, instanceId: string) {
+    return path.join(
+      paperclipHome,
+      "instances",
+      instanceId,
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+  }
+
+  it("re-resolves the managed root when the instance root moved out from under a managed config (AGE-168 repro)", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-move-");
+    cleanupDirs.add(paperclipHome);
+
+    // Step 1: agent is configured in managed mode under instance root A.
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+    const rootA = managedRootFor(paperclipHome, "instance-a");
+    await fs.mkdir(rootA, { recursive: true });
+    await fs.writeFile(path.join(rootA, "AGENTS.md"), "# Instance A Agent\n", "utf8");
+
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: rootA,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(rootA, "AGENTS.md"),
+    });
+
+    // Sanity: with instance root A still current, nothing needs correcting.
+    await expect(resolveHeartbeatManagedInstructionsPatch(agent)).resolves.toEqual({});
+
+    // Step 2: the instance root is re-pointed to B (e.g. PAPERCLIP_INSTANCE_ID swap), and the real
+    // instructions file lives under the *current* resolveManagedInstructionsRoot(agent) for root B.
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-b";
+    const rootB = managedRootFor(paperclipHome, "instance-b");
+    cleanupDirs.add(rootB);
+    await fs.mkdir(rootB, { recursive: true });
+    await fs.writeFile(path.join(rootB, "AGENTS.md"), "# Instance B Agent\n", "utf8");
+
+    // The agent's persisted adapterConfig still points at stale root A.
+    const patch = await resolveHeartbeatManagedInstructionsPatch(agent);
+
+    expect(patch).toMatchObject({
+      instructionsRootPath: rootB,
+      instructionsFilePath: path.join(rootB, "AGENTS.md"),
+    });
+    expect((patch as { warnings: string[] }).warnings).toEqual([
+      `Recovered managed instructions from disk at ${rootB}; ignoring stale configured root ${rootA}.`,
+    ]);
+  });
+
+  it("returns {} for an external-mode config, even if it points at a nonexistent path", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-external-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+
+    const externalRoot = "/nonexistent/external/root";
+    const agent = makeAgent({
+      instructionsBundleMode: "external",
+      instructionsRootPath: externalRoot,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(externalRoot, "AGENTS.md"),
+    });
+
+    await expect(resolveHeartbeatManagedInstructionsPatch(agent)).resolves.toEqual({});
+  });
+
+  it("returns {} when the managed config is already correct", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-correct-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+
+    const rootA = managedRootFor(paperclipHome, "instance-a");
+    await fs.mkdir(rootA, { recursive: true });
+    await fs.writeFile(path.join(rootA, "AGENTS.md"), "# Instance A Agent\n", "utf8");
+
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: rootA,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(rootA, "AGENTS.md"),
+    });
+
+    await expect(resolveHeartbeatManagedInstructionsPatch(agent)).resolves.toEqual({});
   });
 });

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -425,10 +425,39 @@ describe("resolveHeartbeatManagedInstructionsPatch", () => {
     expect(patch).toMatchObject({
       instructionsRootPath: rootB,
       instructionsFilePath: path.join(rootB, "AGENTS.md"),
+      instructionsEntryFile: "AGENTS.md",
     });
     expect((patch as { warnings: string[] }).warnings).toEqual([
       `Recovered managed instructions from disk at ${rootB}; ignoring stale configured root ${rootA}.`,
     ]);
+  });
+
+  it("corrects a stale instructionsEntryFile too, not just the root (fingerprint resolution prefers entryFile over instructionsFilePath)", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-entry-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+
+    // The configured entry file (docs/MISSING.md) no longer exists on disk; only AGENTS.md does,
+    // so recovery must fall back to it as the recovered entry file.
+    const managedRoot = managedRootFor(paperclipHome, "instance-a");
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Recovered Agent\n", "utf8");
+
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: managedRoot,
+      instructionsEntryFile: "docs/MISSING.md",
+      instructionsFilePath: path.join(managedRoot, "docs", "MISSING.md"),
+    });
+
+    const patch = await resolveHeartbeatManagedInstructionsPatch(agent);
+
+    expect(patch).toMatchObject({
+      instructionsRootPath: managedRoot,
+      instructionsFilePath: path.join(managedRoot, "AGENTS.md"),
+      instructionsEntryFile: "AGENTS.md",
+    });
   });
 
   it("returns {} for an external-mode config, even if it points at a nonexistent path", async () => {

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-pi-local/server";
+import { resolveHeartbeatManagedInstructionsPatch } from "../services/agent-instructions.js";
 
 async function writeFakePiCommand(commandPath: string): Promise<void> {
   const script = `#!/usr/bin/env node
@@ -204,6 +205,139 @@ describe("pi_local execute", () => {
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("consumes a heartbeat-corrected config.instructionsFilePath end-to-end (AGE-168/AGE-484)", async () => {
+    // This proves resolveHeartbeatManagedInstructionsPatch's corrected instructionsFilePath
+    // actually reaches the injected system prompt in a real pi-local execute() run, not just
+    // that the resolver function returns the right value in isolation.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-instructions-patch-"));
+    const paperclipHome = path.join(root, "paperclip-home");
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "pi");
+    const systemPromptDumpPath = path.join(root, "captured-system-prompt.txt");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(paperclipHome, { recursive: true });
+
+    const captureSystemPromptScript = `#!/usr/bin/env node
+const fs = require("node:fs");
+if (process.argv.includes("--list-models")) {
+  console.log("provider  model");
+  console.log("google    gemini-3-flash-preview");
+  process.exit(0);
+}
+const flagIndex = process.argv.indexOf("--append-system-prompt");
+const systemPrompt = flagIndex >= 0 ? process.argv[flagIndex + 1] : "";
+fs.writeFileSync(${JSON.stringify(systemPromptDumpPath)}, systemPrompt);
+console.log(JSON.stringify({ type: "agent_start" }));
+console.log(JSON.stringify({ type: "turn_start" }));
+console.log(JSON.stringify({ type: "turn_end", message: { role: "assistant", content: "" }, toolResults: [] }));
+console.log(JSON.stringify({ type: "agent_end", messages: [] }));
+process.exit(0);
+`;
+    await fs.writeFile(commandPath, captureSystemPromptScript, "utf8");
+    await fs.chmod(commandPath, 0o755);
+
+    const previousHome = process.env.HOME;
+    const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    const previousPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+    process.env.HOME = root;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+
+    try {
+      const agent = {
+        id: "agent-instructions-patch",
+        companyId: "company-instructions-patch",
+        name: "Pi Agent",
+        adapterConfig: {} as Record<string, unknown>,
+      };
+
+      // Step 1: agent is configured in managed mode under instance root A.
+      process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+      const managedRootA = path.join(
+        paperclipHome,
+        "instances",
+        "instance-a",
+        "companies",
+        agent.companyId,
+        "agents",
+        agent.id,
+        "instructions",
+      );
+      await fs.mkdir(managedRootA, { recursive: true });
+      await fs.writeFile(path.join(managedRootA, "AGENTS.md"), "OLD STALE INSTRUCTIONS FROM ROOT A", "utf8");
+      agent.adapterConfig = {
+        instructionsBundleMode: "managed",
+        instructionsRootPath: managedRootA,
+        instructionsEntryFile: "AGENTS.md",
+        instructionsFilePath: path.join(managedRootA, "AGENTS.md"),
+      };
+
+      // Step 2: instance root is re-pointed to B; the real instructions file lives under the
+      // *current* managed root, not the stale root A recorded in adapterConfig.
+      process.env.PAPERCLIP_INSTANCE_ID = "instance-b";
+      const managedRootB = path.join(
+        paperclipHome,
+        "instances",
+        "instance-b",
+        "companies",
+        agent.companyId,
+        "agents",
+        agent.id,
+        "instructions",
+      );
+      await fs.mkdir(managedRootB, { recursive: true });
+      await fs.writeFile(path.join(managedRootB, "AGENTS.md"), "NEW MANAGED INSTRUCTIONS FROM ROOT B", "utf8");
+
+      const patch = await resolveHeartbeatManagedInstructionsPatch(agent);
+      expect(patch).toMatchObject({
+        instructionsRootPath: managedRootB,
+        instructionsFilePath: path.join(managedRootB, "AGENTS.md"),
+      });
+      if (!("instructionsFilePath" in patch)) throw new Error("expected a correction patch");
+
+      const result = await execute({
+        runId: "run-pi-instructions-patch",
+        agent: {
+          id: agent.id,
+          companyId: agent.companyId,
+          name: agent.name,
+          adapterType: "pi_local",
+          adapterConfig: agent.adapterConfig,
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "google/gemini-3-flash-preview",
+          promptTemplate: "Keep working.",
+          // Mirrors what heartbeat.ts applies to `config` before it reaches the adapter.
+          instructionsFilePath: patch.instructionsFilePath,
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      const capturedSystemPrompt = await fs.readFile(systemPromptDumpPath, "utf8");
+      expect(capturedSystemPrompt).toContain("NEW MANAGED INSTRUCTIONS FROM ROOT B");
+      expect(capturedSystemPrompt).not.toContain("OLD STALE INSTRUCTIONS FROM ROOT A");
+      expect(capturedSystemPrompt).toContain(`loaded from ${path.join(managedRootB, "AGENTS.md")}`);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+      if (previousPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -329,6 +329,51 @@ async function recoverManagedBundleState(agent: AgentLike, state: BundleState): 
   };
 }
 
+/**
+ * Re-derive the managed instructions root/entry-file for `agent` against the *current* process
+ * instance root (honoring `PAPERCLIP_HOME`/`PAPERCLIP_INSTANCE_ID` at call time), and report a
+ * config patch if the persisted `adapterConfig` disagrees with what is actually on disk.
+ *
+ * This exists so heartbeat config-assembly can correct a stale `instructionsRootPath`/
+ * `instructionsFilePath` pair *before* it is handed to an adapter (see heartbeat.ts, right after
+ * `parseObject(agent.adapterConfig)`). It intentionally reuses `deriveBundleState` +
+ * `recoverManagedBundleState` rather than reimplementing their on-disk recovery/precedence rules.
+ *
+ * Returns `{}` when:
+ * - the bundle is in `external` mode (external roots are never auto-corrected), or
+ * - the bundle is not in managed mode at all, or
+ * - the currently configured managed root/entry file already match what is on disk.
+ *
+ * Otherwise returns `{ instructionsRootPath, instructionsFilePath, warnings }` where `warnings`
+ * carries only the warning strings newly produced by this recovery pass (e.g. "Recovered managed
+ * instructions from disk ... ignoring stale configured root").
+ */
+export async function resolveHeartbeatManagedInstructionsPatch(
+  agent: AgentLike,
+): Promise<
+  | Record<string, never>
+  | { instructionsRootPath: string; instructionsFilePath: string; warnings: string[] }
+> {
+  const derived = deriveBundleState(agent);
+  const recovered = await recoverManagedBundleState(agent, derived);
+
+  // No correction was made (recoverManagedBundleState returns the exact same object by reference
+  // when the configured state already matches what's on disk, including the "nothing configured
+  // and nothing on disk" case).
+  if (recovered === derived) return {};
+
+  // Only managed-mode bundles are ever auto-corrected; `external` configs pass through untouched.
+  if (recovered.mode !== "managed" || !recovered.rootPath || !recovered.resolvedEntryPath) return {};
+
+  const newWarnings = recovered.warnings.filter((warning) => !derived.warnings.includes(warning));
+
+  return {
+    instructionsRootPath: recovered.rootPath,
+    instructionsFilePath: recovered.resolvedEntryPath,
+    warnings: newWarnings,
+  };
+}
+
 function toBundle(agent: AgentLike, state: BundleState, files: AgentInstructionsFileSummary[]): AgentInstructionsBundle {
   const nextFiles = [...files];
   if (state.legacyPromptTemplateActive && !nextFiles.some((file) => file.path === LEGACY_PROMPT_TEMPLATE_PATH)) {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -344,15 +344,25 @@ async function recoverManagedBundleState(agent: AgentLike, state: BundleState): 
  * - the bundle is not in managed mode at all, or
  * - the currently configured managed root/entry file already match what is on disk.
  *
- * Otherwise returns `{ instructionsRootPath, instructionsFilePath, warnings }` where `warnings`
- * carries only the warning strings newly produced by this recovery pass (e.g. "Recovered managed
- * instructions from disk ... ignoring stale configured root").
+ * Otherwise returns `{ instructionsRootPath, instructionsFilePath, instructionsEntryFile, warnings }`
+ * where `warnings` carries only the warning strings newly produced by this recovery pass (e.g.
+ * "Recovered managed instructions from disk ... ignoring stale configured root"). `entryFile` is
+ * included alongside the resolved file path because
+ * `resolveInstructionsConfigFingerprintMetadata` in heartbeat.ts resolves the session-freshness
+ * fingerprint path from `config.instructionsEntryFile` *in preference to* `config.instructionsFilePath`
+ * — leaving the stale entry file name in place would silently defeat the path correction for that
+ * fingerprint even though the adapter's own `instructionsFilePath` read is fixed.
  */
 export async function resolveHeartbeatManagedInstructionsPatch(
   agent: AgentLike,
 ): Promise<
   | Record<string, never>
-  | { instructionsRootPath: string; instructionsFilePath: string; warnings: string[] }
+  | {
+      instructionsRootPath: string;
+      instructionsFilePath: string;
+      instructionsEntryFile: string;
+      warnings: string[];
+    }
 > {
   const derived = deriveBundleState(agent);
   const recovered = await recoverManagedBundleState(agent, derived);
@@ -370,6 +380,7 @@ export async function resolveHeartbeatManagedInstructionsPatch(
   return {
     instructionsRootPath: recovered.rootPath,
     instructionsFilePath: recovered.resolvedEntryPath,
+    instructionsEntryFile: recovered.entryFile,
     warnings: newWarnings,
   };
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -80,6 +80,7 @@ import {
 // Re-exported because heartbeat's workspace surface exposed the scrubber before the
 // git-credentials module became its canonical home; existing importers keep working.
 export { scrubGitCredentialText };
+import { resolveHeartbeatManagedInstructionsPatch } from "./agent-instructions.js";
 import { publishLiveEvent } from "./live-events.js";
 import { normalizeResponsibleUserDenialCode } from "./responsible-user-denial-run-outcomes.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
@@ -14053,6 +14054,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         : null,
     });
     const config = parseObject(agent.adapterConfig);
+    const managedInstructionsPatch = await resolveHeartbeatManagedInstructionsPatch(agent);
+    if ("instructionsRootPath" in managedInstructionsPatch) {
+      logger.info(
+        {
+          event: "heartbeat_managed_instructions_root_corrected",
+          companyId: agent.companyId,
+          agentId: agent.id,
+          previousInstructionsRootPath: config.instructionsRootPath ?? null,
+          previousInstructionsFilePath: config.instructionsFilePath ?? null,
+          instructionsRootPath: managedInstructionsPatch.instructionsRootPath,
+          instructionsFilePath: managedInstructionsPatch.instructionsFilePath,
+          warnings: managedInstructionsPatch.warnings,
+        },
+        "Corrected stale managed instructions root at heartbeat config-assembly",
+      );
+      config.instructionsRootPath = managedInstructionsPatch.instructionsRootPath;
+      config.instructionsFilePath = managedInstructionsPatch.instructionsFilePath;
+    }
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14063,14 +14063,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agentId: agent.id,
           previousInstructionsRootPath: config.instructionsRootPath ?? null,
           previousInstructionsFilePath: config.instructionsFilePath ?? null,
+          previousInstructionsEntryFile: config.instructionsEntryFile ?? null,
           instructionsRootPath: managedInstructionsPatch.instructionsRootPath,
           instructionsFilePath: managedInstructionsPatch.instructionsFilePath,
+          instructionsEntryFile: managedInstructionsPatch.instructionsEntryFile,
           warnings: managedInstructionsPatch.warnings,
         },
         "Corrected stale managed instructions root at heartbeat config-assembly",
       );
       config.instructionsRootPath = managedInstructionsPatch.instructionsRootPath;
       config.instructionsFilePath = managedInstructionsPatch.instructionsFilePath;
+      // Session-freshness fingerprinting (resolveInstructionsConfigFingerprintMetadata below) prefers
+      // instructionsEntryFile over instructionsFilePath, so this must be corrected too or the
+      // fingerprint would keep resolving against the stale entry file name.
+      config.instructionsEntryFile = managedInstructionsPatch.instructionsEntryFile;
     }
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents can load role instructions from a "managed instructions bundle" stored under the Paperclip instance root
> - `server/services/agent-instructions.ts` already re-derives and self-heals that root on every read through the bundle HTTP API, but the heartbeat run-execution path never called that recovery logic
> - When the Paperclip instance root moves (for example a data-dir rename), the persisted `instructionsRootPath`/`instructionsFilePath` go stale, and every managed agent silently runs with the generic prompt template instead of its real instructions
> - This needs to be fixed once at the server choke point where `adapterConfig` enters the execution pipeline, not inside each of the 9 adapter packages, so the fix cannot be missed by a new adapter
> - This pull request adds a small exported helper in `agent-instructions.ts` that reuses the existing recovery logic, and calls it from `heartbeat.ts` right after the adapter config is parsed, correcting the config in place before it reaches any adapter
> - The benefit is that a moved instance root no longer orphans managed instructions at run time; the same self-healing that already worked for the bundle API now also protects live heartbeats, with a log line so the correction is operator-visible

## Linked Issues or Issue Description

Refs #11391 (item 2: "Managed instructions root persisted as a stale absolute path"). This PR implements exactly the "suggested fix" in that issue for item 2: re-resolve the managed root via the same recovery logic used by the bundle API, at the point where the adapter config is assembled, instead of trusting the persisted absolute string. Item 1 in that issue (silent read-failure surfacing) is a separate, already-open fix (#11396) and is out of scope here — this PR touches none of the files that PR touches.

- [x] I have searched the GitHub PR list for similar PRs (searched "instructions root", "managed instructions", "stale root" — found #11396, which addresses a different part of #11391 and does not overlap with these files).

## What Changed

- `server/src/services/agent-instructions.ts`: export a new `resolveHeartbeatManagedInstructionsPatch(agent)` that composes the existing (previously unexported) `deriveBundleState` + `recoverManagedBundleState` — no reimplementation of their on-disk recovery/precedence rules. Returns `{}` for `external`-mode configs and already-correct `managed` configs; otherwise returns `{ instructionsRootPath, instructionsFilePath, warnings }` reflecting the current on-disk managed root.
- `server/src/services/heartbeat.ts`: call the new function right after `const config = parseObject(agent.adapterConfig);` and apply the patch to `config` in place, before it flows into `workspaceManagedConfig` / `mergedConfig` / `resolvedConfig` / `runtimeConfig` and on to `adapter.execute()`. Log any correction via the existing pino `logger` with `agentId` / `companyId` / old and new paths.
- No changes to any adapter package. The fix sits entirely upstream of `adapter.execute()`, so it applies uniformly to all 9 local adapters without touching any of them.

## Verification

```
pnpm --filter @paperclipai/server typecheck
# exit 0

npx vitest run server/src/__tests__/agent-instructions-service.test.ts
# 11 passed — includes the repro: managed config recorded under instance root A,
# instance root re-pointed to B via PAPERCLIP_HOME/PAPERCLIP_INSTANCE_ID env swap,
# real instructions file placed under the *current* managed root for B, function
# returns the corrected root/path for B (not the stale one from A)

npx vitest run server/src/__tests__/pi-local-execute.test.ts
# 4 passed — new test proves execute() actually consumes a heartbeat-corrected
# config.instructionsFilePath end to end (the injected system prompt contains
# the instructions content from the corrected root, not the stale one)

npx vitest run server/src/__tests__/heartbeat-*.test.ts server/src/__tests__/agent-instructions-service.test.ts
# 45 test files, 620 tests passed — no regression for external-mode configs or
# already-correct managed configs
```

## Risks

- Low risk. The correction only fires when a managed-mode config's persisted root disagrees with what `recoverManagedBundleState` finds on disk (the same logic the bundle HTTP API already trusts). `external`-mode configs and already-correct `managed` configs pass through byte-identical — proven by dedicated tests.
- No schema or API change, no adapter package touched, no new dependency.
- Adds one `logger.info` call per heartbeat only in the (rare) correction case; no log volume increase in the steady state.

## Model Used

Claude (Anthropic), via the Paperclip `pi-local` adapter driving this agent session. Extended reasoning/tool-use mode (file read/edit/bash tools), no fixed context-window cap reported by the harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — not applicable; internal server config-assembly fix with no user-facing or operator-facing documentation surface.
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — verified with `gh pr checks 11519` at the time of this edit.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — confirmed via the Greptile Review comment: "Confidence Score: 5/5", no open P2s or follow-ups listed.
- [x] I will address all Greptile and reviewer comments before requesting merge
