### PR TITLE
test(ui): wait for the route, not three turns, in the cases-routing test

### DIFF
--- a/ui/src/App.cases-routing.test.tsx
+++ b/ui/src/App.cases-routing.test.tsx
@@ -100,12 +100,19 @@ async function renderAppAt(container: HTMLElement, path: string) {
   return root;
 }
 
+/**
+ * Waits on the condition, not on a fixed number of turns. The previous version
+ * yielded at most three macrotasks before asserting, which is ample on an idle
+ * machine and not when the suite is running many workers in parallel — the
+ * container was still empty and the assertion failed on a route that resolves
+ * perfectly well. `vi.waitFor` retries against a time budget instead, so a
+ * loaded worker gets more turns rather than a failure.
+ *
+ * The same fix #11499 applied to the sibling `App.activity-routing.test.tsx`,
+ * which had the identical loop with five turns instead of three.
+ */
 async function waitForRoute(container: HTMLElement, text: string) {
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    if (container.textContent?.includes(text)) return;
-    await new Promise((resolve) => window.setTimeout(resolve, 0));
-  }
-  expect(container.textContent).toContain(text);
+  await vi.waitFor(() => expect(container.textContent).toContain(text));
 }
 
 describe("App Cases routing (PAP-13002)", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and its UI suite runs many workers in parallel
> - Some tests waited a fixed number of event-loop turns before asserting, which is enough on an idle machine and not on a loaded one
> - #11499 replaced that pattern in three tests, and its merge note named a fourth it had not included
> - `App.cases-routing.test.tsx` carries the identical helper its sibling had, with three turns instead of five
> - So it fails the same way, on a route that resolves perfectly well, whenever the worker is busy
> - This pull request applies the same one-line replacement
> - The benefit is one less failure that looks like a broken feature and is really a busy machine

## Linked Issues or Issue Description

Refs #11484. Follow-up to #11499, which named this instance in its merge commit without including it.

**What happened?**

`App.cases-routing.test.tsx:103-109` waited at most three macrotasks for the route to render, then asserted. Under parallel workers the container is sometimes still empty at that point, and the test fails reporting that a working route did not resolve.

It was one of the failures I observed while verifying #11499 — appearing in one of three full-suite runs, alongside two other unrelated tests in the same family.

**Expected behavior**

The test waits for the route to appear, not for a fixed number of turns.

**Paperclip version or commit**

`master` at `e07d605df`.

## What Changed

- `ui/src/App.cases-routing.test.tsx` — `waitForRoute` now uses `vi.waitFor`. The two sibling helpers are byte-identical again.

## Verification

**On the mechanism, not on a green run** — the old loop passes in isolation too, which is exactly what made this a flake rather than a failure. Running the file eight times proves nothing about it.

So a throwaway probe drove both helpers against a container whose text lands after ten macrotasks, simulating a loaded worker:

| helper | result |
| --- | --- |
| three-turn loop | **throws** |
| `vi.waitFor` | resolves |

That is the condition CI creates, and it discriminates between the two versions. The probe was deleted rather than committed — it tests a test helper, and its job was to answer one question.

Full `ui` suite passes three consecutive times with no failure in any file. Worth being precise about what that does and does not show: the other instances of this class that appeared during #11499's verification (`TaskChatComposer`, `RequestCollapsedSidebar`) did not recur here, so they are **rarer, not fixed**. This PR closes one named instance, not the class.

## Risks

None. Test-only, and `vi.waitFor` has a bounded budget, so a genuinely broken route still fails rather than hanging.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I have updated relevant documentation to reflect my changes
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
