### PR TITLE
test(ui): wait for conditions in the last four fixed-turn loops

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -43,17 +43,18 @@ vi.mock("@/lib/router", () => ({
   useParams: () => ({}),
 }));
 
-async function flushReact() {
-  await Promise.resolve();
-  await new Promise((resolve) => window.setTimeout(resolve, 0));
-}
-
+/**
+ * Waits on the condition, not on a fixed number of turns. A hand-rolled retry
+ * loop is ample on an idle machine and not when the suite runs many workers in
+ * parallel: it gives up after N turns and reports a failure on behaviour that
+ * works. `vi.waitFor` retries against a time budget, so a loaded worker gets
+ * more turns instead.
+ *
+ * Same replacement as #11499 and #11521, which fixed the shorter-budget
+ * instances of this in the routing tests.
+ */
 async function waitForText(container: HTMLElement, text: string) {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    if (container.textContent?.includes(text)) return;
-    await flushReact();
-  }
-  expect(container.textContent).toContain(text);
+  await vi.waitFor(() => expect(container.textContent).toContain(text));
 }
 
 function renderGate(container: HTMLElement) {

--- a/ui/src/components/WorkspaceFileBrowser.test.tsx
+++ b/ui/src/components/WorkspaceFileBrowser.test.tsx
@@ -16,18 +16,21 @@ function act(callback: () => void | Promise<void>) {
   return result;
 }
 
+/**
+ * Waits on the condition, not on a fixed number of turns. A hand-rolled retry
+ * loop is ample on an idle machine and not when the suite runs many workers in
+ * parallel: it gives up after N turns and reports a failure on behaviour that
+ * works. `vi.waitFor` retries against a time budget, so a loaded worker gets
+ * more turns instead.
+ *
+ * Same replacement as #11499 and #11521, which fixed the shorter-budget
+ * instances of this in the routing tests.
+ *
+ * This was a reimplementation of `vi.waitFor` down to rethrowing the last
+ * error, differing only in bounding on turns rather than on time.
+ */
 async function waitForExpectation(assertion: () => void) {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => window.setTimeout(resolve, 0));
-    }
-  }
-  throw lastError;
+  await vi.waitFor(assertion);
 }
 
 const useQueryMock = vi.fn();

--- a/ui/src/components/WorkspaceFileMarkdownBody.availability.test.tsx
+++ b/ui/src/components/WorkspaceFileMarkdownBody.availability.test.tsx
@@ -44,18 +44,21 @@ function act(callback: () => void) {
   flushSync(callback);
 }
 
+/**
+ * Waits on the condition, not on a fixed number of turns. A hand-rolled retry
+ * loop is ample on an idle machine and not when the suite runs many workers in
+ * parallel: it gives up after N turns and reports a failure on behaviour that
+ * works. `vi.waitFor` retries against a time budget, so a loaded worker gets
+ * more turns instead.
+ *
+ * Same replacement as #11499 and #11521, which fixed the shorter-budget
+ * instances of this in the routing tests.
+ *
+ * This was a reimplementation of `vi.waitFor` down to rethrowing the last
+ * error, differing only in bounding on turns rather than on time.
+ */
 async function waitForExpectation(assertion: () => void) {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => window.setTimeout(resolve, 0));
-    }
-  }
-  throw lastError;
+  await vi.waitFor(assertion);
 }
 
 function resource(overrides: Partial<ResolvedWorkspaceResource> = {}): ResolvedWorkspaceResource {

--- a/ui/src/pages/SkillStudio.test.tsx
+++ b/ui/src/pages/SkillStudio.test.tsx
@@ -150,23 +150,21 @@ async function act(callback: () => void | Promise<void>) {
   await result;
 }
 
-async function flushReact() {
-  await Promise.resolve();
-  await new Promise((resolve) => window.setTimeout(resolve, 0));
-}
-
+/**
+ * Waits on the condition, not on a fixed number of turns. A hand-rolled retry
+ * loop is ample on an idle machine and not when the suite runs many workers in
+ * parallel: it gives up after N turns and reports a failure on behaviour that
+ * works. `vi.waitFor` retries against a time budget, so a loaded worker gets
+ * more turns instead.
+ *
+ * Same replacement as #11499 and #11521, which fixed the shorter-budget
+ * instances of this in the routing tests.
+ *
+ * This was a reimplementation of `vi.waitFor` down to rethrowing the last
+ * error, differing only in bounding on turns rather than on time.
+ */
 async function waitFor(assertion: () => void) {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 25; attempt += 1) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      lastError = error;
-      await flushReact();
-    }
-  }
-  throw lastError;
+  await vi.waitFor(assertion);
 }
 
 async function renderStudio() {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and its UI suite runs many workers in parallel
> - Tests that wait a fixed number of event-loop turns before asserting are fine on an idle machine and fail on a loaded one
> - #11499 and #11521 replaced that pattern in three routing tests, where the budgets were three and five turns
> - Grepping the suite found four more with budgets of 20 to 30 turns — rarer, and one of them failed earlier today
> - So the same fix applies, and the pattern can be removed from the suite entirely
> - This pull request replaces all four with `vi.waitFor`
> - The benefit is fewer failures that look like broken features and are really a busy machine

## Linked Issues or Issue Description

Refs #11484. Completes the pattern started in #11499 and #11521.

**What happened?**

Four helpers retried an assertion a fixed number of turns, then gave up:

| file | budget |
| --- | --- |
| `App.test.tsx:52` | 20 turns |
| `WorkspaceFileBrowser.test.tsx:21` | 20 turns |
| `WorkspaceFileMarkdownBody.availability.test.tsx:49` | 30 turns |
| `SkillStudio.test.tsx:160` | 25 turns |

Under parallel workers the value sometimes lands later than that, and the test reports a failure on behaviour that works. `SkillStudio` was among the failures observed earlier today.

**Expected behavior**

The tests wait for the condition, bounded by time rather than by turns.

**Paperclip version or commit**

`master` at `65907aa41`.

## What Changed

- All four helpers now call `vi.waitFor`.
- Two `flushReact` helpers became dead with the loops that used them, and are removed.

Three of the four were **reimplementations of `vi.waitFor`** down to rethrowing the last error, differing only in bounding on turns instead of time. The fourth was the text variant.

## Verification

**On the mechanism, not on a green run.** These budgets are large enough that passing proves nothing — the whole point is that they pass until the machine is loaded. A throwaway probe drove a 30-turn loop and `vi.waitFor` against a value landing at turn 60:

| helper | result |
| --- | --- |
| 30-turn loop | **throws** |
| `vi.waitFor` | reaches it |

So this is not a lateral move from one arbitrary bound to another. The probe was deleted rather than committed.

`ui` typecheck clean. The four files pass. Full suite passes two of three runs.

### The class is not closed, and my sweep was too narrow

The third run failed on `AgentToolsTab > autosaves installed apps for the current agent`, which this PR does not touch. It holds **two other shapes of the same bug** that a grep for `attempt < N` does not find:

- a fixed-cycle helper — `flushReact(cycles = 4)` in `AgentToolsTab.test.tsx:41`
- fixed-duration sleeps — `setTimeout(resolve, 300)` and similar, in `AgentToolsTab`, `CompanyContext`, `AgentConfigForm.render`, `Artifacts`, `Search`, `ImportFromVaultDialog`

I said after #11521 that four instances remained. That was the count for one spelling of the pattern, not for the class. Worth stating plainly rather than letting this PR read as the end of it.

## Risks

None. Test-only, and `vi.waitFor` has a bounded budget, so genuinely broken behaviour still fails rather than hanging.

Revert the commit to restore.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking enabled. Tool use enabled: file read and edit, shell for typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I have updated relevant documentation to reflect my changes
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
