### PR TITLE
feat(runtime): managed Tailscale HTTPS lifecycle, durable runtime leases, and bounded control recovery

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -648,6 +648,22 @@ For project execution worktrees, Paperclip can also run a project-defined provis
 
 Heavier setup that is only needed by a managed runtime service can use `workspaceStrategy.runtimeProvisionCommand`. Paperclip runs this command lazily before spawning the first service in a start batch, serializes concurrent provisioning for the same workspace, and records the attempt as `workspace_runtime_provision`. The command receives the same workspace environment as `provisionCommand` and should be idempotent because later service-start batches invoke it again.
 
+Managed runtime control actions (`start`, `stop`, `restart`, and job `run`) are mutually exclusive per execution workspace. An overlapping control is rejected with `409 workspace_runtime_control_in_progress` instead of racing the active operation, and authorization is still checked first, so the conflict never widens who may control a workspace.
+
+Every managed control reaches a terminal operation state. Each one stamps the owning server process and pid on its `workspace_operations` row and heartbeats while it runs, and each one carries a wall-clock ceiling (30 minutes for lifecycle controls, 4 hours for workspace jobs) so a hung provider or listener fails the operation rather than leaving it active. When a start fails part-way, Paperclip tears the workspace's runtime services down through the ordinary stop path and records a stopped desired state, so the lane is retryable and a startup reconcile will not resurrect a service that never came up.
+
+Recovery of stranded controls is bounded and cannot steal a live operation. A `running` control is only terminalized when its owning process is gone, when the owning request in this process no longer exists, or after 60 seconds without a heartbeat; the terminalizing write is a compare-and-swap on `updated_at`, so an owner that heartbeats concurrently keeps its operation. Recovery runs on server startup and before each managed control, appends reconciliation evidence to the workspace-operation log, and stays inside the requested workspace's scope.
+
+Readiness probes and port allocation are bounded for the same reason. Each HTTP readiness probe is aborted after at most 5 seconds (never past the service's readiness budget), so a foreign listener that accepts a connection but never answers cannot park a start forever. Auto-allocated loopback ports are reserved in-process for the duration of a start and re-checked for a live owner, and a configured port already claimed by another in-flight start fails that start terminally — so two isolated workspaces asking for the same app/HMR pair either get distinct healthy ports or one fails cleanly and retryably.
+
+Beyond that in-flight guard, `start`, `stop`, and `restart` also take a durable exclusivity lease on the execution workspace (`execution_workspace_runtime_leases`). The lease is keyed by execution workspace and owned by the controlling issue (or, when a run has no issue in scope, by the run or agent), so it survives across calls, heartbeats, and server processes. The owning issue can keep operating; a different issue or run is rejected with `409 workspace_runtime_lease_conflict` before any workspace operation is recorded and before any runtime service is touched. Board/operator actions bypass the lease entirely and never take the lane away from an agent.
+
+Lease recovery is bounded and explicit. Another issue may reclaim the lane once the owner becomes ineligible — the owning issue reaches a terminal status, is hidden, or is deleted; the owning run reaches a terminal status — or once the lease's 30-minute TTL elapses without the owner touching it. Archiving the execution workspace releases the lease outright. Conflict responses carry the owning issue/run ids and the lease expiry so an operator can tell who holds the lane.
+
+For Tailscale HTTPS exposure, readiness includes stable listener-ownership checks for every requested loopback port (the app and, when configured, its Vite HMR companion). Each listener must belong to the spawned managed process group; an unrelated listener that races onto either reserved port fails the start closed before the broker is asked to expose it.
+
+In Vite middleware mode, Paperclip gives HMR a dedicated HTTP server bound to the managed runtime's loopback host. The browser still derives the HMR hostname from the public HTTPS page, so listener containment does not break remote hot reload.
+
 ## App-Shipped Skills Catalog
 
 The Paperclip app ships a curated catalog of company skills out of the box. The

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -90,6 +90,7 @@ const tailscaleAuthFlagNames = new Set([
 let tailscaleAuth = false;
 let bindMode: BindMode | null = null;
 let bindHost: string | null = null;
+const managedRuntimeExposure = process.env.PAPERCLIP_MANAGED_RUNTIME_EXPOSURE === "tailscale_https";
 const forwardedArgs: string[] = [];
 
 for (let index = 0; index < cliArgs.length; index += 1) {
@@ -133,6 +134,10 @@ if (!bindMode && process.env.npm_config_bind && BIND_MODES.includes(process.env.
 if (!bindHost && process.env.npm_config_bind_host) {
   bindHost = process.env.npm_config_bind_host;
 }
+if (managedRuntimeExposure) {
+  bindMode = "custom";
+  bindHost = "127.0.0.1";
+}
 if (bindMode === "custom" && !bindHost) {
   console.error("[paperclip] --bind custom requires --bind-host <host>");
   process.exit(1);
@@ -174,7 +179,7 @@ if (tailscaleAuth || bindMode) {
   } else {
     env.PAPERCLIP_DEPLOYMENT_MODE = "authenticated";
     env.PAPERCLIP_DEPLOYMENT_EXPOSURE = "private";
-    env.PAPERCLIP_AUTH_BASE_URL_MODE = "auto";
+    env.PAPERCLIP_AUTH_BASE_URL_MODE = managedRuntimeExposure ? "explicit" : "auto";
     console.log(
       `[paperclip] dev mode: authenticated/private (bind=${effectiveBind}${bindHost ? `:${bindHost}` : ""})`,
     );

--- a/server/src/__tests__/app-hmr-port.test.ts
+++ b/server/src/__tests__/app-hmr-port.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { resolveViteHmrHost, resolveViteHmrPort } from "../app.ts";
+import { createServer } from "node:http";
+import {
+  listenViteHmrServer,
+  resolveViteHmrHost,
+  resolveViteHmrPort,
+  resolveViteHmrProtocol,
+} from "../app.ts";
 
 describe("resolveViteHmrPort", () => {
   it("uses serverPort + 10000 when the result stays in range", () => {
@@ -24,8 +30,30 @@ describe("resolveViteHmrHost", () => {
     expect(resolveViteHmrHost("::")).toBeUndefined();
   });
 
-  it("keeps concrete bind hosts", () => {
-    expect(resolveViteHmrHost("127.0.0.1")).toBe("127.0.0.1");
+  it("uses the browser hostname for loopback while keeping non-loopback concrete hosts", () => {
+    expect(resolveViteHmrHost("127.0.0.1")).toBeUndefined();
+    expect(resolveViteHmrHost("localhost")).toBeUndefined();
     expect(resolveViteHmrHost("paperclip-dev")).toBe("paperclip-dev");
+  });
+});
+
+describe("resolveViteHmrProtocol", () => {
+  it("selects secure WebSockets for HTTPS branch runtimes", () => {
+    expect(resolveViteHmrProtocol("wss")).toBe("wss");
+    expect(resolveViteHmrProtocol(undefined)).toBeUndefined();
+    expect(() => resolveViteHmrProtocol("https")).toThrow(/ws or wss/);
+  });
+});
+
+describe("listenViteHmrServer", () => {
+  it("binds the dedicated middleware-mode HMR listener to loopback", async () => {
+    const server = createServer();
+    await listenViteHmrServer(server, 0, "127.0.0.1");
+
+    expect(server.address()).toMatchObject({ address: "127.0.0.1" });
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
   });
 });

--- a/server/src/__tests__/board-mutation-guard.test.ts
+++ b/server/src/__tests__/board-mutation-guard.test.ts
@@ -90,13 +90,14 @@ describe("boardMutationGuard", () => {
     expect([200, 204]).toContain(res.status);
   });
 
-  it("allows board mutations when x-forwarded-host matches origin", async () => {
+  it("allows HTTPS branch-runtime mutations when forwarded MagicDNS host and non-standard port match", async () => {
     const app = createApp("board");
     const res = await request(app)
       .post("/mutate")
       .set("Host", "127.0.0.1")
-      .set("X-Forwarded-Host", "10.90.10.20:3443")
-      .set("Origin", "https://10.90.10.20:3443")
+      .set("X-Forwarded-Host", "branch-runner.tail123.ts.net:42000")
+      .set("X-Forwarded-Proto", "https")
+      .set("Origin", "https://branch-runner.tail123.ts.net:42000")
       .send({ ok: true });
     expect([200, 204]).toContain(res.status);
   });

--- a/server/src/__tests__/execution-workspace-runtime-control-conflict.test.ts
+++ b/server/src/__tests__/execution-workspace-runtime-control-conflict.test.ts
@@ -1,0 +1,286 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+const mockWorkspaceOperationService = vi.hoisted(() => ({
+  assertRuntimeControlAvailable: vi.fn(),
+  createRecorder: vi.fn(),
+  reconcileStaleRuntimeControlOperations: vi.fn(),
+}));
+const mockAccessService = vi.hoisted(() => ({ decide: vi.fn() }));
+const mockEnvironmentService = vi.hoisted(() => ({ getById: vi.fn() }));
+const mockSecretService = vi.hoisted(() => ({ normalizeEnvBindingsForPersistence: vi.fn() }));
+const mockProjectService = vi.hoisted(() => ({ getById: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+const mockAssertCanManageExecutionWorkspaceRuntimeServices = vi.hoisted(() => vi.fn());
+const mockAssertCanManageProjectWorkspaceRuntimeServices = vi.hoisted(() => vi.fn());
+const mockStartRuntimeServices = vi.hoisted(() => vi.fn());
+const mockStopRuntimeServicesForExecutionWorkspace = vi.hoisted(() => vi.fn());
+const mockEnsurePersistedExecutionWorkspaceAvailable = vi.hoisted(() => vi.fn());
+const mockBuildWorkspaceRuntimeDesiredStatePatch = vi.hoisted(() => vi.fn());
+// The integrated control path also takes the durable runtime-control lease (PAP-17205). This
+// suite covers the in-flight guard and failed-start reconciliation, so the lease always grants;
+// `execution-workspace-runtime-lease-route.test.ts` exercises the lease itself against a real db.
+const mockClaimRuntimeLease = vi.hoisted(() => vi.fn(async () => null));
+const mockReleaseRuntimeLease = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../telemetry.js", () => ({ getTelemetryClient: mockGetTelemetryClient }));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  environmentService: () => mockEnvironmentService,
+  executionWorkspaceService: () => mockExecutionWorkspaceService,
+  heartbeatService: () => mockHeartbeatService,
+  logActivity: mockLogActivity,
+  projectService: () => mockProjectService,
+  secretService: () => mockSecretService,
+  workspaceOperationService: () => mockWorkspaceOperationService,
+  workspaceRuntimeLeaseService: () => ({
+    claim: mockClaimRuntimeLease,
+    release: mockReleaseRuntimeLease,
+  }),
+  LEASED_WORKSPACE_RUNTIME_ACTIONS: ["start", "stop", "restart"],
+}));
+
+vi.mock("../services/workspace-runtime.js", () => ({
+  buildWorkspaceRuntimeDesiredStatePatch: mockBuildWorkspaceRuntimeDesiredStatePatch,
+  cleanupExecutionWorkspaceArtifacts: vi.fn(),
+  ensurePersistedExecutionWorkspaceAvailable: mockEnsurePersistedExecutionWorkspaceAvailable,
+  listConfiguredRuntimeServiceEntries: vi.fn(() => []),
+  runWorkspaceJobForControl: vi.fn(),
+  startRuntimeServicesForWorkspaceControl: mockStartRuntimeServices,
+  stopRuntimeServicesForExecutionWorkspace: mockStopRuntimeServicesForExecutionWorkspace,
+  stopRuntimeServicesForProjectWorkspace: vi.fn(),
+}));
+
+vi.mock("../routes/workspace-runtime-service-authz.js", () => ({
+  assertCanManageExecutionWorkspaceRuntimeServices: mockAssertCanManageExecutionWorkspaceRuntimeServices,
+  assertCanManageProjectWorkspaceRuntimeServices: mockAssertCanManageProjectWorkspaceRuntimeServices,
+}));
+
+const executionWorkspaceId = "33333333-3333-4333-8333-333333333333";
+
+function buildExecutionWorkspace(overrides: Record<string, unknown> = {}) {
+  return {
+    id: executionWorkspaceId,
+    companyId: "company-1",
+    // Left unset so the handler does not need a real `db` for project/policy lookups; the
+    // runtime config below is what the control path actually reads.
+    projectId: null,
+    projectWorkspaceId: null,
+    sourceIssueId: null,
+    mode: "isolated_workspace",
+    strategyType: "git_worktree",
+    name: "Lane A",
+    status: "active",
+    cwd: "/tmp/lane-a",
+    repoUrl: null,
+    baseRef: "main",
+    branchName: "canary/lane-a",
+    providerType: "git_worktree",
+    providerRef: null,
+    derivedFromExecutionWorkspaceId: null,
+    lastUsedAt: new Date(),
+    openedAt: new Date(),
+    closedAt: null,
+    cleanupEligibleAt: null,
+    cleanupReason: null,
+    config: {
+      workspaceRuntime: {
+        services: [{ name: "app", command: "pnpm dev", port: { type: "fixed", value: 42003 } }],
+      },
+      desiredState: "running",
+    },
+    metadata: null,
+    runtimeServices: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+async function createApp() {
+  const [{ executionWorkspaceRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/execution-workspaces.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "run-1",
+    };
+    next();
+  });
+  app.use("/api", executionWorkspaceRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+/**
+ * Route-level guarantees for PAP-17249: the competing lane in the PAP-17207 report must get a
+ * stable 409 while a control is genuinely live, and a start that fails must leave the workspace
+ * stopped and retryable instead of "desired running" with residue.
+ */
+describe.sequential("execution workspace runtime control conflict and failure reconciliation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      action: "runtime:manage",
+      reason: "allow_test",
+      explanation: "Allowed by test mock.",
+    });
+    mockExecutionWorkspaceService.getById.mockResolvedValue(buildExecutionWorkspace());
+    mockExecutionWorkspaceService.update.mockResolvedValue(buildExecutionWorkspace());
+    mockAssertCanManageExecutionWorkspaceRuntimeServices.mockResolvedValue(undefined);
+    mockWorkspaceOperationService.assertRuntimeControlAvailable.mockResolvedValue(undefined);
+    mockBuildWorkspaceRuntimeDesiredStatePatch.mockReturnValue({
+      desiredState: "stopped",
+      serviceStates: { app: "stopped" },
+    });
+    mockEnsurePersistedExecutionWorkspaceAvailable.mockResolvedValue({
+      cwd: "/tmp/lane-a",
+      projectId: "project-1",
+      workspaceId: null,
+      branchName: "canary/lane-a",
+      worktreePath: "/tmp/lane-a",
+      repoUrl: null,
+      repoRef: "main",
+    });
+    mockStopRuntimeServicesForExecutionWorkspace.mockResolvedValue(undefined);
+    mockWorkspaceOperationService.createRecorder.mockReturnValue({
+      attachExecutionWorkspaceId: vi.fn(),
+      recordOperation: async (input: any) => {
+        // Mirror the real recorder: a throwing `run` becomes a terminal failed operation and
+        // the error still propagates to the caller.
+        try {
+          await input.run();
+        } catch (error) {
+          (error as any).recordedOperationStatus = "failed";
+          throw error;
+        }
+        return { id: "operation-1", status: "succeeded" };
+      },
+    });
+  });
+
+  it("returns a stable 409 while a managed control is genuinely live", async () => {
+    const { conflict } = await import("../errors.js");
+    mockWorkspaceOperationService.assertRuntimeControlAvailable.mockRejectedValue(
+      conflict("A managed runtime control operation is already in progress for this execution workspace.", {
+        code: "workspace_runtime_control_in_progress",
+        executionWorkspaceId,
+        activeAction: "start",
+        requestedAction: "stop",
+        activeOperationId: "operation-live",
+        remediation: "Wait for the active operation to reach a terminal state before retrying.",
+      }),
+    );
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/stop`)
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.details ?? res.body).toMatchObject({
+      code: "workspace_runtime_control_in_progress",
+      activeAction: "start",
+      requestedAction: "stop",
+    });
+    // The conflict is decided before any runtime mutation happens.
+    expect(mockStopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalled();
+    expect(mockStartRuntimeServices).not.toHaveBeenCalled();
+  });
+
+  it("checks authorization before recovering or claiming the workspace", async () => {
+    const { forbidden } = await import("../errors.js");
+    mockAssertCanManageExecutionWorkspaceRuntimeServices.mockRejectedValue(
+      forbidden("Missing permission to manage workspace runtime services"),
+    );
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(mockWorkspaceOperationService.assertRuntimeControlAvailable).not.toHaveBeenCalled();
+  });
+
+  it("tears down residue and records a stopped desired state when a start fails", async () => {
+    mockStartRuntimeServices.mockRejectedValue(
+      new Error(
+        'Runtime service "app" could not start because port 42003 is already in use by pid 4242 (cwd: /tmp/lane-b)',
+      ),
+    );
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .send({});
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    // No exposure/listener residue: the failed lane is stopped through the ordinary teardown.
+    expect(mockStopRuntimeServicesForExecutionWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ executionWorkspaceId, workspaceCwd: "/tmp/lane-a" }),
+    );
+    // ...and the workspace is no longer recorded as wanting to run, so it is retryable and a
+    // startup reconcile will not resurrect a lane that never came up.
+    expect(mockBuildWorkspaceRuntimeDesiredStatePatch).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "stop" }),
+    );
+    expect(mockExecutionWorkspaceService.update).toHaveBeenCalledWith(
+      executionWorkspaceId,
+      expect.objectContaining({ metadata: expect.anything() }),
+    );
+  });
+
+  it("reconciles once when the operation's own time budget fails a start that never settles", async () => {
+    const { WorkspaceOperationTimeoutError } = await import("../services/workspace-operations.js");
+    // The recorder's ceiling fires outside `run`, so only the outer handler can reconcile.
+    mockWorkspaceOperationService.createRecorder.mockReturnValue({
+      attachExecutionWorkspaceId: vi.fn(),
+      recordOperation: async () => {
+        throw new WorkspaceOperationTimeoutError(1_000, "start");
+      },
+    });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .send({});
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(mockStopRuntimeServicesForExecutionWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockBuildWorkspaceRuntimeDesiredStatePatch).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "stop" }),
+    );
+  });
+
+  it("leaves a successful start's desired state untouched by the failure path", async () => {
+    mockStartRuntimeServices.mockResolvedValue([{ id: "runtime-1" }]);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .send({});
+
+    expect(res.status).toBeLessThan(400);
+    expect(mockStopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalled();
+    expect(mockBuildWorkspaceRuntimeDesiredStatePatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "stop" }),
+    );
+  });
+});

--- a/server/src/__tests__/execution-workspace-runtime-lease-route.test.ts
+++ b/server/src/__tests__/execution-workspace-runtime-lease-route.test.ts
@@ -1,0 +1,351 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  executionWorkspaceRuntimeLeases,
+  executionWorkspaces,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+const mockAccessService = vi.hoisted(() => ({ decide: vi.fn(async () => ({ allowed: true })) }));
+const mockRecordOperation = vi.hoisted(() => vi.fn());
+const mockReconcileStaleRuntimeControlOperations = vi.hoisted(() => vi.fn(async () => ({ reconciled: 0, operationIds: [] })));
+// The control path recovers stranded operations and then refuses only a genuinely live one
+// (PAP-17249). This suite is about the durable lease, so availability always resolves.
+const mockAssertRuntimeControlAvailable = vi.hoisted(() => vi.fn(async () => undefined));
+const mockWorkspaceOperationService = vi.hoisted(() => ({
+  createRecorder: vi.fn(() => ({
+    attachExecutionWorkspaceId: vi.fn(),
+    recordOperation: mockRecordOperation,
+  })),
+  assertRuntimeControlAvailable: mockAssertRuntimeControlAvailable,
+  reconcileStaleRuntimeControlOperations: mockReconcileStaleRuntimeControlOperations,
+  listForExecutionWorkspace: vi.fn(async () => []),
+}));
+const mockStartRuntimeServices = vi.hoisted(() => vi.fn(async () => []));
+const mockStopRuntimeServices = vi.hoisted(() => vi.fn(async () => undefined));
+const mockAssertCanManage = vi.hoisted(() => vi.fn());
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", async () => {
+  const leases = await import("../services/workspace-runtime-leases.js");
+  return {
+    accessService: () => mockAccessService,
+    executionWorkspaceService: () => mockExecutionWorkspaceService,
+    heartbeatService: () => ({}),
+    logActivity: mockLogActivity,
+    workspaceOperationService: () => mockWorkspaceOperationService,
+    workspaceRuntimeLeaseService: leases.workspaceRuntimeLeaseService,
+    LEASED_WORKSPACE_RUNTIME_ACTIONS: leases.LEASED_WORKSPACE_RUNTIME_ACTIONS,
+  };
+});
+
+vi.mock("../services/environment-runtime.js", () => ({
+  environmentRuntimeService: () => ({ destroyReusableSandboxLeases: vi.fn() }),
+}));
+
+vi.mock("../services/workspace-runtime.js", () => ({
+  buildWorkspaceRuntimeDesiredStatePatch: () => ({ desiredState: "running", serviceStates: null }),
+  cleanupExecutionWorkspaceArtifacts: vi.fn(),
+  ensurePersistedExecutionWorkspaceAvailable: vi.fn(async () => ({ cwd: "/tmp/lease-route-workspace" })),
+  listConfiguredRuntimeServiceEntries: () => [],
+  runWorkspaceJobForControl: vi.fn(),
+  startRuntimeServicesForWorkspaceControl: mockStartRuntimeServices,
+  stopRuntimeServicesForExecutionWorkspace: mockStopRuntimeServices,
+}));
+
+vi.mock("../routes/workspace-runtime-service-authz.js", () => ({
+  assertCanManageExecutionWorkspaceRuntimeServices: mockAssertCanManage,
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping runtime lease route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("execution workspace runtime control lease enforcement", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId = "";
+  let projectId = "";
+  let executionWorkspaceId = "";
+  let agentId = "";
+  let canaryIssueId = "";
+  let competingIssueId = "";
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-runtime-lease-route-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockAccessService.decide.mockResolvedValue({ allowed: true } as never);
+    mockReconcileStaleRuntimeControlOperations.mockResolvedValue({ reconciled: 0, operationIds: [] } as never);
+    mockStartRuntimeServices.mockResolvedValue([] as never);
+    // Owner identity is read per-request from a header so concurrent requests cannot
+    // observe each other's authorization mock.
+    mockAssertCanManage.mockImplementation(async (_db: unknown, req: { get: (name: string) => string | undefined }) => ({
+      actorType: "agent",
+      agentId,
+      runId: null,
+      issueId: req.get("x-test-owner-issue") ?? null,
+    }));
+    mockRecordOperation.mockImplementation(async (input: { run: () => Promise<unknown> }) => {
+      await input.run();
+      return { id: randomUUID(), status: "succeeded" };
+    });
+
+    companyId = randomUUID();
+    projectId = randomUUID();
+    executionWorkspaceId = randomUUID();
+    agentId = randomUUID();
+    canaryIssueId = randomUUID();
+    competingIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Runtime lease route",
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({ id: projectId, companyId, name: "Lane", status: "in_progress" });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "git_worktree",
+      name: "Shared canary workspace",
+      status: "active",
+      cwd: "/tmp/lease-route-workspace",
+    });
+    await db.insert(agents).values({ id: agentId, companyId, name: "Engineer", role: "engineer" });
+    await db.insert(issues).values([
+      {
+        id: canaryIssueId,
+        companyId,
+        projectId,
+        executionWorkspaceId,
+        title: "HTTPS canary",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: competingIssueId,
+        companyId,
+        projectId,
+        executionWorkspaceId,
+        title: "Unrelated shared-workspace work",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: executionWorkspaceId,
+      companyId,
+      projectId: null,
+      projectWorkspaceId: null,
+      sourceIssueId: null,
+      mode: "shared_workspace",
+      strategyType: "git_worktree",
+      name: "Shared canary workspace",
+      status: "active",
+      cwd: "/tmp/lease-route-workspace",
+      repoUrl: null,
+      baseRef: "main",
+      branchName: null,
+      providerType: "git_worktree",
+      providerRef: null,
+      config: { workspaceRuntime: { command: "pnpm dev" } },
+      metadata: null,
+      runtimeServices: [],
+    } as never);
+    mockExecutionWorkspaceService.update.mockResolvedValue({ id: executionWorkspaceId } as never);
+  });
+
+  afterEach(async () => {
+    await db.delete(executionWorkspaceRuntimeLeases);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  async function createApp() {
+    const [{ executionWorkspaceRoutes }, { errorHandler }] = await Promise.all([
+      import("../routes/execution-workspaces.js"),
+      import("../middleware/index.js"),
+    ]);
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "agent",
+        agentId,
+        companyId,
+        source: "agent_key",
+        runId: null,
+      };
+      next();
+    });
+    app.use("/api", executionWorkspaceRoutes(db as never));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("lets the lease owner start and restart, and blocks a sequential competing issue without mutating anything", async () => {
+    const app = await createApp();
+
+    const started = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .set("x-test-owner-issue", canaryIssueId)
+      .send({});
+    expect(started.status).toBe(200);
+    expect(mockStartRuntimeServices).toHaveBeenCalledTimes(1);
+
+    const restarted = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/restart`)
+      .set("x-test-owner-issue", canaryIssueId)
+      .send({});
+    expect(restarted.status).toBe(200);
+    expect(mockStartRuntimeServices).toHaveBeenCalledTimes(2);
+
+    mockRecordOperation.mockClear();
+    mockStartRuntimeServices.mockClear();
+    mockStopRuntimeServices.mockClear();
+    mockReconcileStaleRuntimeControlOperations.mockClear();
+
+    const blocked = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .set("x-test-owner-issue", competingIssueId)
+      .send({});
+
+    expect(blocked.status).toBe(409);
+    expect(blocked.body.code).toBe("workspace_runtime_lease_conflict");
+    expect(blocked.body.details).toMatchObject({
+      ownerIssueId: canaryIssueId,
+      requestedAction: "start",
+    });
+    expect(typeof blocked.body.remediation).toBe("string");
+
+    // No workspace operation, no runtime-service mutation, no reconciliation side effect.
+    expect(mockRecordOperation).not.toHaveBeenCalled();
+    expect(mockStartRuntimeServices).not.toHaveBeenCalled();
+    expect(mockStopRuntimeServices).not.toHaveBeenCalled();
+    expect(mockReconcileStaleRuntimeControlOperations).not.toHaveBeenCalled();
+
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ownerIssueId).toBe(canaryIssueId);
+  });
+
+  it("blocks a competing issue that races the owner concurrently", async () => {
+    const app = await createApp();
+
+    const ownerStart = request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .set("x-test-owner-issue", canaryIssueId)
+      .send({});
+    const competingStart = request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/stop`)
+      .set("x-test-owner-issue", competingIssueId)
+      .send({});
+
+    const [ownerRes, competingRes] = await Promise.all([ownerStart, competingStart]);
+
+    expect(ownerRes.status).toBe(200);
+    expect(competingRes.status).toBe(409);
+    expect(competingRes.body.code).toMatch(
+      /workspace_runtime_lease_conflict|workspace_runtime_control_in_progress/,
+    );
+    expect(mockStopRuntimeServices).not.toHaveBeenCalled();
+
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ownerIssueId).toBe(canaryIssueId);
+  });
+
+  it("lets a teardown issue take the lane once the canary issue is terminal", async () => {
+    const app = await createApp();
+
+    expect((await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .set("x-test-owner-issue", canaryIssueId)
+      .send({})).status).toBe(200);
+
+    const { eq } = await import("drizzle-orm");
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, canaryIssueId));
+
+    const teardown = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/stop`)
+      .set("x-test-owner-issue", competingIssueId)
+      .send({});
+
+    expect(teardown.status).toBe(200);
+    expect(mockStopRuntimeServices).toHaveBeenCalledTimes(1);
+
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ownerIssueId).toBe(competingIssueId);
+  });
+
+  it("leaves board actors unleased and unblocked", async () => {
+    const [{ executionWorkspaceRoutes }, { errorHandler }] = await Promise.all([
+      import("../routes/execution-workspaces.js"),
+      import("../middleware/index.js"),
+    ]);
+    mockAssertCanManage.mockResolvedValue({
+      actorType: "board",
+      agentId: null,
+      runId: null,
+      issueId: null,
+    } as never);
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "board-1",
+        companyIds: [companyId],
+        source: "session",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", executionWorkspaceRoutes(db as never));
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post(`/api/execution-workspaces/${executionWorkspaceId}/runtime-services/start`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(await db.select().from(executionWorkspaceRuntimeLeases)).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -21,6 +21,12 @@ const mockWorkspaceOperationService = vi.hoisted(() => ({
   createRecorder: vi.fn(),
 }));
 
+const mockWorkspaceRuntimeLeaseService = vi.hoisted(() => ({
+  claim: vi.fn(async () => ({ outcome: "created", ownerKey: "issue:issue-1", lease: null, reclaimedFrom: null })),
+  release: vi.fn(async () => ({ released: false, ownerKey: null })),
+  get: vi.fn(async () => null),
+}));
+
 const mockHeartbeatService = vi.hoisted(() => ({
   wakeup: vi.fn(),
 }));
@@ -40,6 +46,8 @@ vi.mock("../services/index.js", () => ({
   heartbeatService: () => mockHeartbeatService,
   logActivity: mockLogActivity,
   workspaceOperationService: () => mockWorkspaceOperationService,
+  workspaceRuntimeLeaseService: () => mockWorkspaceRuntimeLeaseService,
+  LEASED_WORKSPACE_RUNTIME_ACTIONS: ["start", "stop", "restart"],
 }));
 
 vi.mock("../services/environment-runtime.js", () => ({

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -3948,6 +3948,186 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     });
   });
 
+  it("serializes the verified HTTPS URL as canonical and never falls back to the HTTP backend", async () => {
+    // PAP-17158: the UI's workspace/project/issue launch links read `url` off the
+    // serialized runtime service. Two things have to hold for a managed HTTPS
+    // runtime: once exposure is `ready` the canonical `url` is the HTTPS public
+    // URL, and while exposure is *not* ready the canonical `url` stays null even
+    // though the row still knows its loopback `backendUrl`. Serializing that
+    // backend URL would put `http://…` back into a launch link, which is exactly
+    // the fail-closed contract this feature exists to enforce.
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const readyWorkspaceId = randomUUID();
+    const provisioningWorkspaceId = randomUUID();
+    const readyServiceId = randomUUID();
+    const provisioningServiceId = randomUUID();
+    const hostname = "paperclip-dev.tail29c1aa.ts.net";
+    const httpsUrl = `https://${hostname}:42010`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "HTTPS URL serialization",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      isPrimary: true,
+      cwd: "/tmp/https-url-serialization",
+      metadata: {
+        runtimeConfig: {
+          workspaceRuntime: { services: [{ name: "paperclip-dev", command: "pnpm dev" }] },
+          desiredState: "running",
+        },
+      },
+    });
+    await db.insert(executionWorkspaces).values([
+      {
+        id: readyWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        mode: "dedicated_worktree",
+        strategyType: "git_worktree",
+        name: "Exposed workspace",
+        status: "idle",
+        providerType: "local_fs",
+        cwd: "/tmp/https-url-serialization/ready",
+      },
+      {
+        id: provisioningWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        mode: "dedicated_worktree",
+        strategyType: "git_worktree",
+        name: "Provisioning workspace",
+        status: "idle",
+        providerType: "local_fs",
+        cwd: "/tmp/https-url-serialization/provisioning",
+      },
+    ]);
+    await db.insert(workspaceRuntimeServices).values([
+      {
+        id: readyServiceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        executionWorkspaceId: readyWorkspaceId,
+        scopeType: "execution_workspace",
+        scopeId: readyWorkspaceId,
+        serviceName: "paperclip-dev",
+        status: "running",
+        lifecycle: "shared",
+        reuseKey: "ready-dev",
+        command: "pnpm dev",
+        cwd: "/tmp/https-url-serialization/ready",
+        port: 42_010,
+        url: httpsUrl,
+        // The loopback backend is still recorded; it must never be serialized.
+        backendUrl: "http://127.0.0.1:42010",
+        provider: "local_process",
+        healthStatus: "healthy",
+        exposure: {
+          provider: "tailscale_https",
+          state: "ready",
+          publicUrl: httpsUrl,
+          hostname,
+          listeners: [
+            { purpose: "app", publicPort: 42_010, targetPort: 42_010 },
+            { purpose: "vite_hmr", publicPort: 52_010, targetPort: 52_010 },
+          ],
+          brokerRef: "broker-ref-1",
+          lastError: null,
+          updatedAt: "2026-08-12T10:00:00.000Z",
+        },
+        updatedAt: new Date("2026-08-12T10:00:00.000Z"),
+      },
+      {
+        id: provisioningServiceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        executionWorkspaceId: provisioningWorkspaceId,
+        scopeType: "execution_workspace",
+        scopeId: provisioningWorkspaceId,
+        serviceName: "paperclip-dev",
+        status: "running",
+        lifecycle: "shared",
+        reuseKey: "provisioning-dev",
+        command: "pnpm dev",
+        cwd: "/tmp/https-url-serialization/provisioning",
+        port: 42_020,
+        url: null,
+        backendUrl: "http://127.0.0.1:42020",
+        provider: "local_process",
+        healthStatus: "healthy",
+        exposure: {
+          provider: "tailscale_https",
+          state: "pending",
+          publicUrl: null,
+          hostname,
+          listeners: [],
+          brokerRef: null,
+          lastError: null,
+          updatedAt: "2026-08-12T10:00:00.000Z",
+        },
+        updatedAt: new Date("2026-08-12T10:00:00.000Z"),
+      },
+    ]);
+
+    const workspaces = await svc.list(companyId);
+    const readyService = workspaces
+      .find((workspace) => workspace.id === readyWorkspaceId)
+      ?.runtimeServices.find((service) => service.id === readyServiceId);
+    expect(readyService).toMatchObject({
+      url: httpsUrl,
+      port: 42_010,
+      exposure: { provider: "tailscale_https", state: "ready", publicUrl: httpsUrl, hostname },
+    });
+    // Lease handles are server-private and must never reach a serialized DTO.
+    expect(readyService).not.toHaveProperty("exposureHandle");
+
+    const provisioningService = workspaces
+      .find((workspace) => workspace.id === provisioningWorkspaceId)
+      ?.runtimeServices.find((service) => service.id === provisioningServiceId);
+    expect(provisioningService?.url).toBeNull();
+    expect(provisioningService?.exposure).toMatchObject({ state: "pending", publicUrl: null });
+    expect(JSON.stringify(provisioningService)).not.toContain("http://127.0.0.1:42020");
+
+    // The overview feeds the workspace list launch links.
+    const overview = await svc.listOverview(companyId, { limit: 10, offset: 0 });
+    const readyItem = overview.items.find((item) => item.workspaceId === readyWorkspaceId);
+    expect(readyItem?.primaryService).toMatchObject({
+      id: readyServiceId,
+      status: "running",
+      url: httpsUrl,
+      exposure: { state: "ready", publicUrl: httpsUrl },
+    });
+    expect(new URL(readyItem!.primaryService!.url!).protocol).toBe("https:");
+
+    const provisioningItem = overview.items.find((item) => item.workspaceId === provisioningWorkspaceId);
+    expect(provisioningItem?.primaryService).toMatchObject({
+      id: provisioningServiceId,
+      status: "running",
+      url: null,
+      exposure: { state: "pending" },
+    });
+    expect(JSON.stringify(provisioningItem)).not.toContain("http://127.0.0.1:42020");
+  }, 30_000);
+
   it("returns a bounded company-scoped workspace overview with service and linked issue summaries", async () => {
     const companyId = randomUUID();
     const otherCompanyId = randomUUID();

--- a/server/src/__tests__/setup-supertest.ts
+++ b/server/src/__tests__/setup-supertest.ts
@@ -30,6 +30,14 @@ if (!process.env.CODEX_HOME) {
   process.env.CODEX_HOME = codexHome;
 }
 
+// The automatic Tailscale HTTPS default (PAP-17158) probes for a real host
+// broker socket, so leaving it enabled would make every test that starts a
+// service named `paperclip-dev` behave differently on a broker-capable host
+// than on CI. Tests that exercise the default opt in explicitly.
+if (!process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS) {
+  process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = "off";
+}
+
 if (!SupertestTest.prototype.__paperclipLoopbackPatched) {
   SupertestTest.prototype.serverAddress = function serverAddress(app, path) {
     const addr = app.address();

--- a/server/src/__tests__/workspace-operations-reconciliation.test.ts
+++ b/server/src/__tests__/workspace-operations-reconciliation.test.ts
@@ -1,0 +1,207 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  createDb,
+  executionWorkspaces,
+  projects,
+  workspaceOperations,
+} from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { getWorkspaceOperationLogStore } from "../services/workspace-operation-log-store.js";
+import {
+  RUNTIME_CONTROL_STALE_AFTER_MS,
+  resetWorkspaceRuntimeControlLocksForTests,
+  runExclusiveWorkspaceRuntimeControl,
+  workspaceOperationService,
+} from "../services/workspace-operations.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+describe("workspace runtime control serialization", () => {
+  afterEach(() => {
+    resetWorkspaceRuntimeControlLocksForTests();
+  });
+
+  it("deterministically rejects an overlapping control operation and releases the claim", async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = runExclusiveWorkspaceRuntimeControl({
+      executionWorkspaceId: "workspace-1",
+      action: "start",
+      run: async () => {
+        await firstGate;
+        return "started";
+      },
+    });
+
+    await expect(runExclusiveWorkspaceRuntimeControl({
+      executionWorkspaceId: "workspace-1",
+      action: "restart",
+      run: async () => "restarted",
+    })).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "workspace_runtime_control_in_progress",
+        activeAction: "start",
+        requestedAction: "restart",
+      },
+    });
+
+    releaseFirst();
+    await expect(first).resolves.toBe("started");
+    await expect(runExclusiveWorkspaceRuntimeControl({
+      executionWorkspaceId: "workspace-1",
+      action: "stop",
+      run: async () => "stopped",
+    })).resolves.toBe("stopped");
+  });
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping workspace-operation reconciliation tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("workspace operation reconciliation", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let logRoot = "";
+  let previousLogRoot: string | undefined;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-operation-reconcile-");
+    db = createDb(tempDb.connectionString);
+    logRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-workspace-operation-logs-"));
+    previousLogRoot = process.env.WORKSPACE_OPERATION_LOG_BASE_PATH;
+    process.env.WORKSPACE_OPERATION_LOG_BASE_PATH = logRoot;
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(workspaceOperations);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    if (previousLogRoot === undefined) delete process.env.WORKSPACE_OPERATION_LOG_BASE_PATH;
+    else process.env.WORKSPACE_OPERATION_LOG_BASE_PATH = previousLogRoot;
+    await fs.rm(logRoot, { recursive: true, force: true });
+    await tempDb?.cleanup();
+  });
+
+  it("terminalizes an orphaned runtime start with an inspectable reconciliation log", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const staleOperationId = randomUUID();
+    const unrelatedOperationId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Workspace operation reconciliation",
+      issuePrefix: `W${companyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Runtime reconciliation",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Reconciliation workspace",
+      status: "active",
+      cwd: "/tmp/reconciliation-workspace",
+    });
+
+    const logHandle = await getWorkspaceOperationLogStore().begin({
+      companyId,
+      operationId: staleOperationId,
+    });
+    await db.insert(workspaceOperations).values([
+      {
+        id: staleOperationId,
+        companyId,
+        executionWorkspaceId,
+        phase: "workspace_provision",
+        command: "workspace command start",
+        cwd: "/tmp/reconciliation-workspace",
+        status: "running",
+        logStore: logHandle.store,
+        logRef: logHandle.logRef,
+        metadata: { action: "start", executionWorkspaceId },
+      },
+      {
+        id: unrelatedOperationId,
+        companyId,
+        executionWorkspaceId,
+        phase: "workspace_provision",
+        command: "bash ./scripts/provision-worktree.sh",
+        cwd: "/tmp/reconciliation-workspace",
+        status: "running",
+        metadata: { created: true },
+      },
+    ]);
+
+    const service = workspaceOperationService(db);
+
+    // Recovery is bounded and cannot steal a live operation (PAP-17249): a `running` control
+    // that has signalled recently is left alone even when it carries no ownership stamp, which
+    // is the shape a control recorded by a pre-stamp build has.
+    await expect(service.reconcileStaleRuntimeControlOperations(executionWorkspaceId)).resolves.toEqual({
+      reconciled: 0,
+      operationIds: [],
+    });
+    expect((await service.getById(staleOperationId))?.status).toBe("running");
+
+    // Once it has gone quiet for longer than the staleness window, it is terminalized.
+    await expect(
+      service.reconcileStaleRuntimeControlOperations(executionWorkspaceId, {
+        now: new Date(Date.now() + RUNTIME_CONTROL_STALE_AFTER_MS + 5_000),
+      }),
+    ).resolves.toEqual({
+      reconciled: 1,
+      operationIds: [staleOperationId],
+    });
+
+    const stale = await service.getById(staleOperationId);
+    expect(stale).toMatchObject({
+      status: "failed",
+      metadata: {
+        action: "start",
+        reconciled: true,
+        reconciliationReason: "orphaned_runtime_control",
+      },
+    });
+    expect(stale?.finishedAt).toBeInstanceOf(Date);
+    expect(stale?.stderrExcerpt).toContain("no live owner has reported progress");
+    expect((await service.readLog(staleOperationId)).content).toContain(
+      "no live owner has reported progress",
+    );
+
+    const unrelated = await db
+      .select({ status: workspaceOperations.status })
+      .from(workspaceOperations)
+      .where(eq(workspaceOperations.id, unrelatedOperationId))
+      .then((rows) => rows[0]);
+    expect(unrelated?.status).toBe("running");
+  });
+});

--- a/server/src/__tests__/workspace-runtime-control-recovery.test.ts
+++ b/server/src/__tests__/workspace-runtime-control-recovery.test.ts
@@ -1,0 +1,519 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  createDb,
+  executionWorkspaces,
+  projects,
+  workspaceOperations,
+} from "@paperclipai/db";
+import { and, eq } from "drizzle-orm";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  RUNTIME_CONTROL_STALE_AFTER_MS,
+  WorkspaceOperationTimeoutError,
+  resetWorkspaceRuntimeControlStateForTests,
+  workspaceOperationService,
+  workspaceRuntimeControlOwnerIdForTests,
+} from "../services/workspace-operations.js";
+import { getWorkspaceOperationLogStore } from "../services/workspace-operation-log-store.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping runtime-control recovery tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/**
+ * Regression coverage for PAP-17249. The adverse report on PAP-17207 left an execution
+ * workspace with a `running` managed start that no owner was driving, so every managed
+ * cleanup was rejected with `409 workspace_runtime_control_in_progress` forever.
+ *
+ * These cases run against real Postgres because the recovery guarantee is a
+ * compare-and-swap over `workspace_operations`, not an in-process lock.
+ */
+describeEmbeddedPostgres("managed runtime-control operation recovery", () => {
+  let db!: ReturnType<typeof createDb>;
+  let stopDb: (() => Promise<void>) | null = null;
+  let logRoot = "";
+  let previousLogRoot: string | undefined;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-runtime-control-recovery-");
+    stopDb = started.cleanup;
+    db = createDb(started.connectionString);
+    logRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-control-logs-"));
+    previousLogRoot = process.env.WORKSPACE_OPERATION_LOG_BASE_PATH;
+    process.env.WORKSPACE_OPERATION_LOG_BASE_PATH = logRoot;
+  }, 60_000);
+
+  afterEach(async () => {
+    resetWorkspaceRuntimeControlStateForTests();
+    await db.delete(workspaceOperations);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    if (previousLogRoot === undefined) delete process.env.WORKSPACE_OPERATION_LOG_BASE_PATH;
+    else process.env.WORKSPACE_OPERATION_LOG_BASE_PATH = previousLogRoot;
+    await fs.rm(logRoot, { recursive: true, force: true });
+    if (stopDb) await stopDb();
+  });
+
+  async function seedWorkspace() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Runtime control recovery",
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Runtime control recovery",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Lane A",
+      status: "active",
+      cwd: "/tmp/runtime-control-lane-a",
+    });
+    return { companyId, projectId, executionWorkspaceId };
+  }
+
+  /** Wait for a managed control to have actually persisted its claim row. */
+  async function waitForRunningOperation(executionWorkspaceId: string) {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const row = await db
+        .select({ id: workspaceOperations.id })
+        .from(workspaceOperations)
+        .where(
+          and(
+            eq(workspaceOperations.executionWorkspaceId, executionWorkspaceId),
+            eq(workspaceOperations.status, "running"),
+          ),
+        )
+        .then((rows) => rows[0]);
+      if (row) return row.id;
+      await delay(20);
+    }
+    throw new Error("timed out waiting for the managed control operation row");
+  }
+
+  /** Insert a `running` start the way an abandoned request or dead server process leaves one. */
+  async function seedRunningStart(input: {
+    companyId: string;
+    executionWorkspaceId: string;
+    owner?: { ownerId: string; pid: number; heartbeatAt: Date };
+    withLog?: boolean;
+    startedAt?: Date;
+    /**
+     * Let Postgres stamp `started_at`/`updated_at` from the column defaults, at the
+     * microsecond precision the driver truncates on the way back into JS. This is how every
+     * row written before managed controls stamped their own timestamps looks.
+     */
+    columnDefaultTimestamps?: boolean;
+  }) {
+    const id = randomUUID();
+    const handle = input.withLog
+      ? await getWorkspaceOperationLogStore().begin({ companyId: input.companyId, operationId: id })
+      : null;
+    const startedAt = input.startedAt ?? new Date();
+    await db.insert(workspaceOperations).values({
+      id,
+      companyId: input.companyId,
+      executionWorkspaceId: input.executionWorkspaceId,
+      phase: "workspace_provision",
+      command: "workspace command start",
+      cwd: "/tmp/runtime-control-lane-a",
+      status: "running",
+      logStore: handle?.store ?? null,
+      logRef: handle?.logRef ?? null,
+      metadata: {
+        action: "start",
+        executionWorkspaceId: input.executionWorkspaceId,
+        ...(input.owner
+          ? {
+              runtimeControlOwner: {
+                ownerId: input.owner.ownerId,
+                pid: input.owner.pid,
+                action: "start",
+                heartbeatAt: input.owner.heartbeatAt.toISOString(),
+              },
+            }
+          : {}),
+      },
+      ...(input.columnDefaultTimestamps ? {} : { startedAt, updatedAt: startedAt }),
+    });
+    return id;
+  }
+
+  it("recovers a start abandoned by a dead server process and frees managed control", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    // pid 2^22-1 is above every Linux/macOS pid ceiling, so it can never be alive.
+    const deadPid = 4_194_303;
+    const staleId = await seedRunningStart({
+      companyId,
+      executionWorkspaceId,
+      owner: { ownerId: randomUUID(), pid: deadPid, heartbeatAt: new Date() },
+      withLog: true,
+    });
+
+    await expect(service.reconcileStaleRuntimeControlOperations(executionWorkspaceId)).resolves.toEqual({
+      reconciled: 1,
+      operationIds: [staleId],
+    });
+
+    const recovered = await service.getById(staleId);
+    expect(recovered).toMatchObject({
+      status: "failed",
+      metadata: {
+        action: "start",
+        reconciled: true,
+        reconciliationReason: "orphaned_runtime_control",
+      },
+    });
+    expect(recovered?.finishedAt).toBeInstanceOf(Date);
+    expect(recovered?.stderrExcerpt).toContain(`the owning server process (pid ${deadPid}) is gone`);
+    expect((await service.readLog(staleId)).content).toContain("is gone");
+
+    // The workspace is controllable again through the ordinary managed path.
+    await expect(
+      service.assertRuntimeControlAvailable({ executionWorkspaceId, action: "stop" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses to steal a start whose owning process is still alive inside the staleness window", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const liveId = await seedRunningStart({
+      companyId,
+      executionWorkspaceId,
+      // A different server instance, but its pid is this very test process: genuinely alive.
+      owner: { ownerId: randomUUID(), pid: process.pid, heartbeatAt: new Date() },
+    });
+
+    await expect(service.reconcileStaleRuntimeControlOperations(executionWorkspaceId)).resolves.toEqual({
+      reconciled: 0,
+      operationIds: [],
+    });
+    expect((await service.getById(liveId))?.status).toBe("running");
+
+    // ...and a competing control gets the stable conflict, not a silent steal.
+    await expect(
+      service.assertRuntimeControlAvailable({ executionWorkspaceId, action: "start" }),
+    ).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "workspace_runtime_control_in_progress",
+        activeAction: "start",
+        requestedAction: "start",
+        activeOperationId: liveId,
+      },
+    });
+  });
+
+  it("bounds recovery: the same live owner is reclaimed once its heartbeat lapses", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const staleId = await seedRunningStart({
+      companyId,
+      executionWorkspaceId,
+      owner: { ownerId: randomUUID(), pid: process.pid, heartbeatAt: new Date() },
+    });
+
+    const afterWindow = new Date(Date.now() + RUNTIME_CONTROL_STALE_AFTER_MS + 1_000);
+    await expect(
+      service.reconcileStaleRuntimeControlOperations(executionWorkspaceId, { now: afterWindow }),
+    ).resolves.toEqual({ reconciled: 1, operationIds: [staleId] });
+    expect((await service.getById(staleId))?.status).toBe("failed");
+  });
+
+  it("recovers a legacy start with no ownership stamp only after the staleness window", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const legacyId = await seedRunningStart({ companyId, executionWorkspaceId });
+
+    await expect(service.reconcileStaleRuntimeControlOperations(executionWorkspaceId)).resolves.toEqual({
+      reconciled: 0,
+      operationIds: [],
+    });
+    await expect(
+      service.reconcileStaleRuntimeControlOperations(executionWorkspaceId, {
+        now: new Date(Date.now() + RUNTIME_CONTROL_STALE_AFTER_MS + 1_000),
+      }),
+    ).resolves.toEqual({ reconciled: 1, operationIds: [legacyId] });
+  });
+
+  it("recovers a start whose timestamps came from the column defaults", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    // Regression guard for the compare-and-swap: `updated_at` written by `defaultNow()` keeps
+    // microsecond precision, while the driver hands JS a millisecond-truncated Date. An `=`
+    // CAS against that read never matches, which would make recovery silently no-op on exactly
+    // the rows it exists to clear — the ones a previous build left `running`.
+    const legacyId = await seedRunningStart({
+      companyId,
+      executionWorkspaceId,
+      owner: { ownerId: randomUUID(), pid: 4_194_303, heartbeatAt: new Date() },
+      columnDefaultTimestamps: true,
+      withLog: true,
+    });
+
+    await expect(service.reconcileStaleRuntimeControlOperations(executionWorkspaceId)).resolves.toEqual({
+      reconciled: 1,
+      operationIds: [legacyId],
+    });
+    expect((await service.getById(legacyId))?.status).toBe("failed");
+  });
+
+  it("terminalizes exactly once when two recovery sweeps race the same operation", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const staleId = await seedRunningStart({
+      companyId,
+      executionWorkspaceId,
+      owner: { ownerId: randomUUID(), pid: 4_194_303, heartbeatAt: new Date() },
+    });
+
+    const [a, b] = await Promise.all([
+      service.reconcileStaleRuntimeControlOperations(executionWorkspaceId),
+      service.reconcileStaleRuntimeControlOperations(executionWorkspaceId),
+    ]);
+    expect(a.reconciled + b.reconciled).toBe(1);
+    expect((await service.getById(staleId))?.status).toBe("failed");
+  });
+
+  it("leaves non-runtime-control operations alone", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const provisionId = randomUUID();
+    await db.insert(workspaceOperations).values({
+      id: provisionId,
+      companyId,
+      executionWorkspaceId,
+      phase: "workspace_provision",
+      command: "bash ./scripts/provision-worktree.sh",
+      cwd: "/tmp/runtime-control-lane-a",
+      status: "running",
+      metadata: { created: true },
+      startedAt: new Date(Date.now() - 60 * 60_000),
+      updatedAt: new Date(Date.now() - 60 * 60_000),
+    });
+
+    await expect(service.reconcileStaleRuntimeControlOperations()).resolves.toEqual({
+      reconciled: 0,
+      operationIds: [],
+    });
+    const row = await db
+      .select({ status: workspaceOperations.status })
+      .from(workspaceOperations)
+      .where(eq(workspaceOperations.id, provisionId))
+      .then((rows) => rows[0]);
+    expect(row?.status).toBe("running");
+  });
+
+  it("keeps a company's recovery inside its own scope", async () => {
+    const laneA = await seedWorkspace();
+    const laneB = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const staleA = await seedRunningStart({
+      companyId: laneA.companyId,
+      executionWorkspaceId: laneA.executionWorkspaceId,
+      owner: { ownerId: randomUUID(), pid: 4_194_303, heartbeatAt: new Date() },
+    });
+    const staleB = await seedRunningStart({
+      companyId: laneB.companyId,
+      executionWorkspaceId: laneB.executionWorkspaceId,
+      owner: { ownerId: randomUUID(), pid: 4_194_303, heartbeatAt: new Date() },
+    });
+
+    await expect(
+      service.reconcileStaleRuntimeControlOperations(laneA.executionWorkspaceId),
+    ).resolves.toEqual({ reconciled: 1, operationIds: [staleA] });
+    expect((await service.getById(staleB))?.status).toBe("running");
+  });
+
+  it("holds the workspace while a start is genuinely live in this process, then releases it", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const recorder = service.createRecorder({ companyId, executionWorkspaceId });
+
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const inFlight = recorder.recordOperation({
+      phase: "workspace_provision",
+      command: "workspace command start",
+      metadata: { action: "start", executionWorkspaceId },
+      run: async () => {
+        await startGate;
+        return { status: "succeeded" as const, exitCode: 0 };
+      },
+    });
+
+    // The claim exists once the operation row lands, which is the point at which a competing
+    // control could observe it.
+    const liveOperationId = await waitForRunningOperation(executionWorkspaceId);
+
+    // The live claim is visible to another service instance on the same database, and a
+    // recovery sweep must not steal it even though this operation has not heartbeated yet.
+    const competitor = workspaceOperationService(db);
+    await expect(
+      competitor.assertRuntimeControlAvailable({ executionWorkspaceId, action: "restart" }),
+    ).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "workspace_runtime_control_in_progress",
+        requestedAction: "restart",
+        activeOperationId: liveOperationId,
+      },
+    });
+    await expect(
+      competitor.reconcileStaleRuntimeControlOperations(executionWorkspaceId),
+    ).resolves.toEqual({ reconciled: 0, operationIds: [] });
+
+    releaseStart();
+    const completed = await inFlight;
+    expect(completed.status).toBe("succeeded");
+    expect(completed.metadata).toMatchObject({
+      runtimeControlOwner: { ownerId: workspaceRuntimeControlOwnerIdForTests() },
+    });
+
+    // Terminal operation, so the next managed control proceeds.
+    await expect(
+      competitor.assertRuntimeControlAvailable({ executionWorkspaceId, action: "stop" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("protects an in-process start from recovery even with the staleness window collapsed", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const recorder = service.createRecorder({ companyId, executionWorkspaceId });
+    const sweeper = workspaceOperationService(db);
+
+    let sweeping = true;
+    let reconciled = 0;
+    // `staleAfterMs: 0` removes the heartbeat grace period, so the only thing that can keep
+    // this start alive is the in-process ownership claim. Sweeping continuously across the
+    // whole recordOperation lifetime also covers the row-insert window.
+    const sweeps = (async () => {
+      while (sweeping) {
+        const result = await sweeper.reconcileStaleRuntimeControlOperations(executionWorkspaceId, {
+          staleAfterMs: 0,
+        });
+        reconciled += result.reconciled;
+        await delay(2);
+      }
+    })();
+
+    const operation = await recorder.recordOperation({
+      phase: "workspace_provision",
+      command: "workspace command start",
+      metadata: { action: "start", executionWorkspaceId },
+      run: async () => {
+        await delay(120);
+        return { status: "succeeded" as const, exitCode: 0 };
+      },
+    });
+    sweeping = false;
+    await sweeps;
+
+    expect(reconciled).toBe(0);
+    expect(operation.status).toBe("succeeded");
+    expect((await service.getById(operation.id))?.status).toBe("succeeded");
+  });
+
+  it("fails a hung start on its own time budget so no active operation is left behind", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const recorder = service.createRecorder({ companyId, executionWorkspaceId });
+
+    await expect(
+      recorder.recordOperation({
+        phase: "workspace_provision",
+        command: "workspace command start",
+        metadata: { action: "start", executionWorkspaceId },
+        timeoutMs: 150,
+        // A start that never settles: the readiness probe that parked on a foreign listener.
+        run: () => new Promise(() => {}),
+      }),
+    ).rejects.toBeInstanceOf(WorkspaceOperationTimeoutError);
+
+    const rows = await db
+      .select()
+      .from(workspaceOperations)
+      .where(eq(workspaceOperations.executionWorkspaceId, executionWorkspaceId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: "failed" });
+    expect(rows[0]?.finishedAt).toBeInstanceOf(Date);
+    expect(rows[0]?.metadata).toMatchObject({ failureReason: "runtime_control_timeout" });
+    expect(rows[0]?.stderrExcerpt).toContain("time budget");
+
+    // No orphan active operation: a managed stop or retry goes straight through.
+    await expect(
+      service.assertRuntimeControlAvailable({ executionWorkspaceId, action: "stop" }),
+    ).resolves.toBeUndefined();
+    await expect(service.reconcileStaleRuntimeControlOperations(executionWorkspaceId)).resolves.toEqual({
+      reconciled: 0,
+      operationIds: [],
+    });
+  });
+
+  it("lets a managed retry succeed immediately after a failed start", async () => {
+    const { companyId, executionWorkspaceId } = await seedWorkspace();
+    const service = workspaceOperationService(db);
+    const recorder = service.createRecorder({ companyId, executionWorkspaceId });
+
+    await expect(
+      recorder.recordOperation({
+        phase: "workspace_provision",
+        command: "workspace command start",
+        metadata: { action: "start", executionWorkspaceId },
+        run: async () => {
+          throw new Error("Runtime service \"app\" could not start because port 42003 is already in use by pid 1234");
+        },
+      }),
+    ).rejects.toThrow(/already in use/);
+
+    await expect(
+      service.assertRuntimeControlAvailable({ executionWorkspaceId, action: "start" }),
+    ).resolves.toBeUndefined();
+
+    const retry = await recorder.recordOperation({
+      phase: "workspace_provision",
+      command: "workspace command start",
+      metadata: { action: "start", executionWorkspaceId },
+      run: async () => ({ status: "succeeded" as const, exitCode: 0 }),
+    });
+    expect(retry.status).toBe("succeeded");
+
+    const statuses = await db
+      .select({ status: workspaceOperations.status })
+      .from(workspaceOperations)
+      .where(eq(workspaceOperations.executionWorkspaceId, executionWorkspaceId));
+    expect(statuses.map((row) => row.status).sort()).toEqual(["failed", "succeeded"]);
+  });
+});

--- a/server/src/__tests__/workspace-runtime-https-live-exercise.test.ts
+++ b/server/src/__tests__/workspace-runtime-https-live-exercise.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Opt-in LIVE exercise of the PAP-17158 in-place HTTPS backfill.
+ *
+ * Unlike `workspace-runtime.test.ts`, which drives the backfill through an
+ * injected broker fake, this test uses the production exposure dependencies: the
+ * real Unix-socket broker client, real Tailscale MagicDNS resolution, and a real
+ * cert-validating HTTPS probe. It is the check that the fail-closed lifecycle
+ * actually terminates in a browser-trusted `https://<node>.<tailnet>.ts.net:<port>`
+ * URL rather than only in a mock's return value.
+ *
+ * It is skipped unless BOTH hold, because it mutates host-level Tailscale serve
+ * state and must never run in CI:
+ *
+ *   - `PAPERCLIP_LIVE_BROKER_EXERCISE=1`
+ *   - the broker socket exists (`PAPERCLIP_TAILSCALE_BROKER_SOCKET` or the default)
+ *
+ * Run it on a broker-provisioned host with:
+ *
+ *   PAPERCLIP_LIVE_BROKER_EXERCISE=1 pnpm --filter @paperclipai/server exec \
+ *     vitest run src/__tests__/workspace-runtime-https-live-exercise.test.ts
+ *
+ * The caller must be the broker's configured service UID/GID and its listeners
+ * must run as `BROKER_RUNTIME_UID`, or the broker correctly refuses to publish.
+ */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  createDb,
+  projectWorkspaces,
+  projects,
+  workspaceRuntimeServices,
+  type Db,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  reconcilePersistedRuntimeServicesOnStartup,
+  resetRuntimeServicesForTests,
+  startRuntimeServicesForWorkspaceControl,
+  stopRuntimeServicesForProjectWorkspace,
+  type RealizedExecutionWorkspace,
+} from "../services/workspace-runtime.ts";
+
+const DEFAULT_BROKER_SOCKET = "/run/paperclip-tailscale-broker/broker.sock";
+const brokerSocketPath = process.env.PAPERCLIP_TAILSCALE_BROKER_SOCKET ?? DEFAULT_BROKER_SOCKET;
+
+async function brokerSocketPresent() {
+  try {
+    return (await fs.stat(brokerSocketPath)).isSocket();
+  } catch {
+    return false;
+  }
+}
+
+const optedIn = process.env.PAPERCLIP_LIVE_BROKER_EXERCISE === "1";
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const live = optedIn && embeddedPostgresSupport.supported && (await brokerSocketPresent());
+
+if (optedIn && !live) {
+  console.warn(
+    `[PAP-17158] live exercise opted in but skipped: broker socket at ${brokerSocketPath} `
+      + `present=${await brokerSocketPresent()}, embeddedPostgres=${embeddedPostgresSupport.supported}`,
+  );
+}
+
+(live ? describe : describe.skip)("PAP-17158 live HTTPS backfill exercise", () => {
+  let db: Db;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("pap17158-live");
+    db = createDb(tempDb.connectionString);
+  }, 60_000);
+
+  afterAll(async () => {
+    await resetRuntimeServicesForTests();
+    await tempDb?.stop?.();
+  }, 60_000);
+
+  it("upgrades a pre-existing HTTP workspace in place to a browser-trusted HTTPS URL", async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pap17158-live-"));
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "pap17158-live-home-"));
+    const previousHome = process.env.PAPERCLIP_HOME;
+    const previousInstance = process.env.PAPERCLIP_INSTANCE_ID;
+    const previousMode = process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = `pap17158-live-${randomUUID()}`;
+
+    // An ephemeral legacy port rather than the real template's 45439, so this
+    // never contends with the live workspace runtime on the same host.
+    const reservePort = async () => {
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const probe = net.createServer();
+        await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+        const address = probe.address();
+        const port = typeof address === "object" && address ? address.port : null;
+        await new Promise<void>((resolve, reject) => probe.close((e) => (e ? reject(e) : resolve())));
+        if (port && port <= 55_535 && (port < 42_000 || port > 42_999)) return port;
+      }
+      throw new Error("failed to reserve a legacy port outside the broker range");
+    };
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const legacyPort = await reservePort();
+    // Serves 200 at /api/health on the app port and its HMR companion, loopback
+    // only — the shape the broker's /proc ownership proof requires.
+    const command =
+      "node -e \"const http=require('node:http');const p=Number(process.env.PORT);"
+      + "for(const q of [p,p+10000])http.createServer((req,res)=>{res.writeHead(200,{'content-type':'application/json'});"
+      + "res.end(JSON.stringify({status:'ok',port:q}))}).listen(q,'127.0.0.1');setInterval(()=>{},1000)\"";
+    const workspaceRuntime = {
+      services: [
+        {
+          name: "paperclip-dev",
+          command,
+          port: legacyPort,
+          // Pre-feature block: backend URL only, no exposure declaration.
+          expose: { type: "url", urlTemplate: "http://127.0.0.1:{{port}}" },
+          readiness: {
+            type: "http",
+            urlTemplate: "http://127.0.0.1:{{port}}/api/health",
+            timeoutSec: 20,
+            intervalMs: 100,
+          },
+          lifecycle: "shared",
+          reuseScope: "project_workspace",
+          stopPolicy: { type: "manual" },
+        },
+      ],
+    };
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `L${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "PAP-17158 live exercise",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: workspaceRoot,
+      isPrimary: true,
+      metadata: {
+        runtimeConfig: { workspaceRuntime, desiredState: "running", serviceStates: { "0": "running" } },
+      },
+    });
+
+    const evidence: Record<string, unknown> = {};
+    try {
+      // ---- Before: the workspace as it exists today, plain HTTP. ----
+      process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = "off";
+      const before = await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: { id: null, name: "Paperclip", companyId },
+        issue: null,
+        workspace: {
+          baseCwd: workspaceRoot,
+          source: "project_primary",
+          projectId,
+          workspaceId: projectWorkspaceId,
+          repoUrl: null,
+          repoRef: "HEAD",
+          strategy: "project_primary",
+          cwd: workspaceRoot,
+          branchName: null,
+          worktreePath: null,
+          warnings: [],
+          created: false,
+        } satisfies RealizedExecutionWorkspace,
+        config: { workspaceRuntime, desiredState: "running", serviceStates: { "0": "running" } },
+        adapterEnv: {},
+      });
+      const runtimeServiceId = before[0]?.id;
+      expect(runtimeServiceId).toBeTruthy();
+      const [httpRow] = await db.select().from(workspaceRuntimeServices);
+      expect(httpRow.exposure).toBeNull();
+      evidence.beforeUrl = httpRow.url;
+      evidence.beforePort = httpRow.port;
+      expect(String(httpRow.url)).toMatch(/^http:\/\//);
+      await expect(fetch(`http://127.0.0.1:${legacyPort}/api/health`)).resolves.toMatchObject({ ok: true });
+
+      // ---- Deploy: production exposure deps, automatic default on. ----
+      await resetRuntimeServicesForTests(); // restores the real broker client
+      delete process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+
+      const result = await reconcilePersistedRuntimeServicesOnStartup(db);
+      evidence.reconcile = result;
+      expect(result.backfilled).toBe(1);
+      expect(result.restartFailed).toBe(0);
+
+      // ---- After: same row, real cert-validated HTTPS URL. ----
+      const afterRows = await db.select().from(workspaceRuntimeServices);
+      expect(afterRows).toHaveLength(1);
+      const httpsRow = afterRows[0]!;
+      expect(httpsRow.id).toBe(runtimeServiceId);
+      evidence.afterUrl = httpsRow.url;
+      evidence.afterPort = httpsRow.port;
+      evidence.afterExposureState = httpsRow.exposure?.state;
+      expect(httpsRow.status).toBe("running");
+      expect(httpsRow.exposure?.state).toBe("ready");
+      expect(String(httpsRow.url)).toMatch(/^https:\/\/.+\.ts\.net:\d+$/);
+      expect(httpsRow.port).toBeGreaterThanOrEqual(42_000);
+      expect(httpsRow.port).toBeLessThanOrEqual(42_999);
+
+      // Strict TLS, no relaxed verification: this is the whole point.
+      const probe = await fetch(`${httpsRow.url}/api/health`, { redirect: "error" });
+      expect(probe.ok).toBe(true);
+      evidence.liveProbeStatus = probe.status;
+
+      // The old HTTP backend is gone, not merely shadowed.
+      await expect(fetch(`http://127.0.0.1:${legacyPort}/api/health`)).rejects.toThrow();
+
+      // ---- Repeat: idempotent, no churn. ----
+      await resetRuntimeServicesForTests();
+      const second = await reconcilePersistedRuntimeServicesOnStartup(db);
+      expect(second.backfilled).toBe(0);
+      const [repeatRow] = await db.select().from(workspaceRuntimeServices);
+      expect(repeatRow.port).toBe(httpsRow.port);
+      expect(repeatRow.url).toBe(httpsRow.url);
+      evidence.repeatUrl = repeatRow.url;
+    } finally {
+      // eslint-disable-next-line no-console
+      console.log("[PAP-17158 live exercise]", JSON.stringify(evidence, null, 2));
+      // Deprovisions the broker lease as well as the backend process.
+      await stopRuntimeServicesForProjectWorkspace({
+        db,
+        projectWorkspaceId,
+        workspaceCwd: workspaceRoot,
+      }).catch((error) => console.error("[PAP-17158] teardown failed", error));
+      await resetRuntimeServicesForTests();
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+      if (previousHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousHome;
+      if (previousInstance === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousInstance;
+      if (previousMode === undefined) delete process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+      else process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = previousMode;
+    }
+  }, 180_000);
+});

--- a/server/src/__tests__/workspace-runtime-leases.test.ts
+++ b/server/src/__tests__/workspace-runtime-leases.test.ts
@@ -1,0 +1,475 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  executionWorkspaceRuntimeLeases,
+  executionWorkspaces,
+  heartbeatRuns,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  WORKSPACE_RUNTIME_LEASE_TTL_MS,
+  workspaceRuntimeLeaseService,
+} from "../services/workspace-runtime-leases.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping execution workspace runtime lease tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("execution workspace runtime leases", () => {
+  let db!: ReturnType<typeof createDb>;
+  // A second client with its own connection pool stands in for a second server
+  // process: nothing is shared in memory, so exclusivity has to come from Postgres.
+  let otherProcessDb!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-runtime-lease-");
+    db = createDb(tempDb.connectionString);
+    otherProcessDb = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(executionWorkspaceRuntimeLeases);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedLane() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Runtime lease",
+      issuePrefix: `L${companyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Canary lane",
+      status: "in_progress",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "git_worktree",
+      name: "Shared canary workspace",
+      status: "active",
+      cwd: "/tmp/runtime-lease-workspace",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Security Engineer",
+      role: "engineer",
+    });
+
+    return { companyId, projectId, executionWorkspaceId, agentId };
+  }
+
+  async function seedIssue(
+    lane: { companyId: string; projectId: string; executionWorkspaceId: string; agentId: string },
+    input: { title: string; status?: string },
+  ) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: lane.companyId,
+      projectId: lane.projectId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      title: input.title,
+      status: input.status ?? "in_progress",
+      priority: "high",
+      assigneeAgentId: lane.agentId,
+    });
+    return issueId;
+  }
+
+  async function seedRun(
+    lane: { companyId: string; agentId: string },
+    input: { status?: string } = {},
+  ) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: lane.companyId,
+      agentId: lane.agentId,
+      status: input.status ?? "running",
+    });
+    return runId;
+  }
+
+  function ownerFor(input: { agentId: string; runId?: string | null; issueId?: string | null }) {
+    return {
+      actorType: "agent",
+      agentId: input.agentId,
+      runId: input.runId ?? null,
+      issueId: input.issueId ?? null,
+    };
+  }
+
+  it("grants the first claim and lets the same owner keep operating across runs", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const firstRunId = await seedRun(lane);
+    const secondRunId = await seedRun(lane);
+    const leases = workspaceRuntimeLeaseService(db);
+
+    const first = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, runId: firstRunId, issueId: canaryIssueId }),
+    });
+    expect(first.outcome).toBe("created");
+    expect(first.ownerKey).toBe(`issue:${canaryIssueId}`);
+    expect(first.lease?.lastAction).toBe("start");
+
+    // A later heartbeat of the same issue is still the same owner, even though the
+    // run identity changed.
+    const second = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "restart",
+      owner: ownerFor({ agentId: lane.agentId, runId: secondRunId, issueId: canaryIssueId }),
+    });
+    expect(second.outcome).toBe("renewed");
+    expect(second.lease?.id).toBe(first.lease?.id);
+    expect(second.lease?.lastAction).toBe("restart");
+    expect(second.lease?.ownerRunId).toBe(secondRunId);
+
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("rejects a sequential competing issue with 409 and leaves the lease untouched", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const competingIssueId = await seedIssue(lane, { title: "Unrelated shared-workspace work" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    const held = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    });
+
+    await expect(leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: competingIssueId }),
+    })).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "workspace_runtime_lease_conflict",
+        executionWorkspaceId: lane.executionWorkspaceId,
+        requestedAction: "start",
+        ownerKey: `issue:${canaryIssueId}`,
+        ownerIssueId: canaryIssueId,
+      },
+    });
+
+    const after = await leases.get(lane.executionWorkspaceId);
+    expect(after?.id).toBe(held.lease?.id);
+    expect(after?.ownerKey).toBe(`issue:${canaryIssueId}`);
+    expect(after?.renewedAt.getTime()).toBe(held.lease?.renewedAt.getTime());
+  });
+
+  it("serializes concurrent claims from separate database clients so exactly one owner wins", async () => {
+    const lane = await seedLane();
+    const contenderIssueIds = await Promise.all(
+      Array.from({ length: 6 }, (_, index) => seedIssue(lane, { title: `Contender ${index}` })),
+    );
+    const leaseClients = [workspaceRuntimeLeaseService(db), workspaceRuntimeLeaseService(otherProcessDb)];
+
+    const results = await Promise.allSettled(
+      contenderIssueIds.map((issueId, index) =>
+        leaseClients[index % leaseClients.length]!.claim({
+          companyId: lane.companyId,
+          executionWorkspaceId: lane.executionWorkspaceId,
+          action: "start",
+          owner: ownerFor({ agentId: lane.agentId, issueId }),
+        }),
+      ),
+    );
+
+    const granted = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(granted).toHaveLength(1);
+    expect(rejected).toHaveLength(contenderIssueIds.length - 1);
+    for (const failure of rejected) {
+      expect((failure as PromiseRejectedResult).reason).toMatchObject({
+        status: 409,
+        details: { code: "workspace_runtime_lease_conflict" },
+      });
+    }
+
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ownerKey).toBe(
+      (granted[0] as PromiseFulfilledResult<{ ownerKey: string | null }>).value.ownerKey,
+    );
+  });
+
+  it("keeps a competing claim out from another database client after the lease is established", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const competingIssueId = await seedIssue(lane, { title: "Competing lane" });
+
+    await workspaceRuntimeLeaseService(db).claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    });
+
+    await expect(workspaceRuntimeLeaseService(otherProcessDb).claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "stop",
+      owner: ownerFor({ agentId: lane.agentId, issueId: competingIssueId }),
+    })).rejects.toMatchObject({
+      status: 409,
+      details: { code: "workspace_runtime_lease_conflict", requestedAction: "stop" },
+    });
+  });
+
+  it("lets the teardown issue reclaim once the canary issue reaches a terminal status", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const teardownIssueId = await seedIssue(lane, { title: "Authorized teardown" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    });
+
+    await expect(leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "stop",
+      owner: ownerFor({ agentId: lane.agentId, issueId: teardownIssueId }),
+    })).rejects.toMatchObject({ status: 409 });
+
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, canaryIssueId));
+
+    const reclaimed = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "stop",
+      owner: ownerFor({ agentId: lane.agentId, issueId: teardownIssueId }),
+    });
+    expect(reclaimed.outcome).toBe("reclaimed");
+    expect(reclaimed.reclaimedFrom).toEqual({
+      ownerKey: `issue:${canaryIssueId}`,
+      reason: "owner_issue_terminal",
+    });
+    expect(reclaimed.lease?.ownerIssueId).toBe(teardownIssueId);
+  });
+
+  it("reclaims from a hidden owner issue and from a terminal owner run", async () => {
+    const lane = await seedLane();
+    const hiddenIssueId = await seedIssue(lane, { title: "Hidden owner" });
+    const nextIssueId = await seedIssue(lane, { title: "Next owner" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: hiddenIssueId }),
+    });
+    await db.update(issues).set({ hiddenAt: new Date() }).where(eq(issues.id, hiddenIssueId));
+
+    const afterHidden = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: nextIssueId }),
+    });
+    expect(afterHidden.reclaimedFrom?.reason).toBe("owner_issue_hidden");
+
+    // Run-scoped owners (no issue in run context) recover once the run is terminal.
+    await leases.release({ executionWorkspaceId: lane.executionWorkspaceId, force: true });
+    const staleRunId = await seedRun(lane, { status: "running" });
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, runId: staleRunId }),
+    });
+
+    await expect(leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: nextIssueId }),
+    })).rejects.toMatchObject({ status: 409 });
+
+    await db.update(heartbeatRuns).set({ status: "failed" }).where(eq(heartbeatRuns.id, staleRunId));
+    const afterRunTerminal = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: nextIssueId }),
+    });
+    expect(afterRunTerminal.reclaimedFrom).toEqual({
+      ownerKey: `run:${staleRunId}`,
+      reason: "owner_run_terminal",
+    });
+  });
+
+  it("bounds recovery with a lease TTL even when the owner still looks eligible", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const competingIssueId = await seedIssue(lane, { title: "Competing lane" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    const claimedAt = new Date(Date.now() - WORKSPACE_RUNTIME_LEASE_TTL_MS - 60_000);
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+      now: claimedAt,
+    });
+
+    const reclaimed = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: competingIssueId }),
+    });
+    expect(reclaimed.reclaimedFrom).toEqual({
+      ownerKey: `issue:${canaryIssueId}`,
+      reason: "lease_expired",
+    });
+  });
+
+  it("lets a teardown issue claim immediately after the owner releases the lane", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const teardownIssueId = await seedIssue(lane, { title: "Authorized teardown" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    });
+
+    // A non-owner cannot release the lane out from under the owner.
+    await expect(leases.release({
+      executionWorkspaceId: lane.executionWorkspaceId,
+      owner: ownerFor({ agentId: lane.agentId, issueId: teardownIssueId }),
+    })).resolves.toEqual({ released: false, ownerKey: null });
+
+    await expect(leases.release({
+      executionWorkspaceId: lane.executionWorkspaceId,
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    })).resolves.toEqual({ released: true, ownerKey: `issue:${canaryIssueId}` });
+
+    const claimed = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "stop",
+      owner: ownerFor({ agentId: lane.agentId, issueId: teardownIssueId }),
+    });
+    expect(claimed.outcome).toBe("created");
+    expect(claimed.lease?.ownerIssueId).toBe(teardownIssueId);
+  });
+
+  it("leaves board/operator control unleased", async () => {
+    const lane = await seedLane();
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    });
+
+    const boardClaim = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "restart",
+      owner: { actorType: "board", agentId: null, runId: null, issueId: null },
+    });
+    expect(boardClaim).toEqual({ outcome: "bypassed", ownerKey: null, lease: null, reclaimedFrom: null });
+
+    // The agent's lease survives the operator action.
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ownerKey).toBe(`issue:${canaryIssueId}`);
+  });
+
+  it("scopes leases per execution workspace", async () => {
+    const lane = await seedLane();
+    const otherWorkspaceId = randomUUID();
+    await db.insert(executionWorkspaces).values({
+      id: otherWorkspaceId,
+      companyId: lane.companyId,
+      projectId: lane.projectId,
+      mode: "shared_workspace",
+      strategyType: "git_worktree",
+      name: "Second lane",
+      status: "active",
+      cwd: "/tmp/runtime-lease-workspace-2",
+    });
+    const canaryIssueId = await seedIssue(lane, { title: "HTTPS canary" });
+    const competingIssueId = await seedIssue(lane, { title: "Competing lane" });
+    const leases = workspaceRuntimeLeaseService(db);
+
+    await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: lane.executionWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: canaryIssueId }),
+    });
+    const other = await leases.claim({
+      companyId: lane.companyId,
+      executionWorkspaceId: otherWorkspaceId,
+      action: "start",
+      owner: ownerFor({ agentId: lane.agentId, issueId: competingIssueId }),
+    });
+    expect(other.outcome).toBe("created");
+
+    const rows = await db.select().from(executionWorkspaceRuntimeLeases);
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/server/src/__tests__/workspace-runtime-routes-authz.test.ts
+++ b/server/src/__tests__/workspace-runtime-routes-authz.test.ts
@@ -26,6 +26,11 @@ const mockEnvironmentService = vi.hoisted(() => ({
 }));
 
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockWorkspaceRuntimeLeaseService = vi.hoisted(() => ({
+  claim: vi.fn(async () => ({ outcome: "created", ownerKey: "issue:issue-1", lease: null, reclaimedFrom: null })),
+  release: vi.fn(async () => ({ released: false, ownerKey: null })),
+  get: vi.fn(async () => null),
+}));
 const mockHeartbeatService = vi.hoisted(() => ({}));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
@@ -48,6 +53,8 @@ vi.mock("../services/index.js", () => ({
   projectService: () => mockProjectService,
   secretService: () => mockSecretService,
   workspaceOperationService: () => mockWorkspaceOperationService,
+  workspaceRuntimeLeaseService: () => mockWorkspaceRuntimeLeaseService,
+  LEASED_WORKSPACE_RUNTIME_ACTIONS: ["start", "stop", "restart"],
 }));
 
 vi.mock("../services/workspace-runtime.js", () => ({
@@ -76,6 +83,8 @@ function registerWorkspaceRouteMocks() {
     projectService: () => mockProjectService,
     secretService: () => mockSecretService,
     workspaceOperationService: () => mockWorkspaceOperationService,
+    workspaceRuntimeLeaseService: () => mockWorkspaceRuntimeLeaseService,
+    LEASED_WORKSPACE_RUNTIME_ACTIONS: ["start", "stop", "restart"],
   }));
 
   vi.doMock("../services/workspace-runtime.js", () => ({

--- a/server/src/__tests__/workspace-runtime-service-authz.test.ts
+++ b/server/src/__tests__/workspace-runtime-service-authz.test.ts
@@ -349,7 +349,11 @@ describeEmbeddedPostgres("workspace runtime service authz helper", () => {
     } as any, {
       companyId,
       executionWorkspaceId,
-    })).resolves.toBeUndefined();
+    })).resolves.toMatchObject({
+      actorType: "agent",
+      agentId: managerId,
+      issueId: null,
+    });
   });
 
   it("rejects unrelated same-company agents without matching workspace assignments", async () => {

--- a/server/src/__tests__/workspace-runtime-start-terminality.test.ts
+++ b/server/src/__tests__/workspace-runtime-start-terminality.test.ts
@@ -1,0 +1,161 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS,
+  allocateRuntimeServicePort,
+  claimRuntimeServiceBindPort,
+  resetRuntimeServicePortReservationsForTests,
+  waitForRuntimeServiceReadiness,
+} from "../services/workspace-runtime.js";
+
+/**
+ * Regression fixture for the adverse report on PAP-17207: two exclusive isolated workspaces
+ * asked for the same configured app/HMR pair at the same moment. One lane came up healthy,
+ * the loser was reallocated onto a port owned by an unrelated listener, and its managed start
+ * never reached a terminal state — leaving an active operation that rejected managed cleanup.
+ *
+ * The two mechanisms that produced the non-terminality are covered here:
+ *   1. a readiness probe against a socket that accepts but never answers, and
+ *   2. concurrent allocation handing the same port to two starts.
+ */
+describe("managed runtime start terminality", () => {
+  afterEach(() => {
+    resetRuntimeServicePortReservationsForTests();
+  });
+
+  const hangingService = {
+    readiness: { type: "http", timeoutSec: 1, intervalMs: 50 },
+  } as Record<string, unknown>;
+
+  it("fails a readiness check whose probes never answer instead of hanging forever", async () => {
+    let probes = 0;
+    const abortedProbes: string[] = [];
+    /** Accepts the request and only ever settles when the caller aborts, like a foreign listener. */
+    const neverAnsweringFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      probes += 1;
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          abortedProbes.push(String(init?.signal?.reason ?? "aborted"));
+          reject(new Error("The operation was aborted due to timeout"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const startedAt = Date.now();
+    await expect(
+      waitForRuntimeServiceReadiness({
+        service: hangingService,
+        serviceName: "app",
+        command: "pnpm dev",
+        url: "http://127.0.0.1:45439/",
+        readinessUrl: null,
+        fetchImpl: neverAnsweringFetch,
+      }),
+    ).rejects.toThrow(/Readiness check failed for http:\/\/127\.0\.0\.1:45439\//);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(probes).toBeGreaterThan(0);
+    expect(abortedProbes.length).toBeGreaterThan(0);
+    // Terminal well inside the 1s readiness budget plus one probe budget.
+    expect(elapsedMs).toBeLessThan(1_000 + RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS);
+  });
+
+  it("negative control: an unbounded probe loop never terminalizes the same start", async () => {
+    // This is the shape of the code that shipped: `fetch` with no abort signal, so the
+    // deadline at the top of the loop is never re-evaluated once a probe parks.
+    const legacyWait = async () => {
+      const deadline = Date.now() + 1_000;
+      while (Date.now() < deadline) {
+        await new Promise<never>(() => {});
+        await delay(50);
+      }
+      throw new Error("Readiness check failed");
+    };
+
+    const settled = await Promise.race([
+      legacyWait().then(() => "settled").catch(() => "settled"),
+      delay(1_500).then(() => "still-hanging"),
+    ]);
+    expect(settled).toBe("still-hanging");
+  });
+
+  it("stops probing as soon as the readiness budget is spent", async () => {
+    let probes = 0;
+    const refusingFetch = (async () => {
+      probes += 1;
+      throw new Error("connect ECONNREFUSED 127.0.0.1:45439");
+    }) as unknown as typeof fetch;
+
+    await expect(
+      waitForRuntimeServiceReadiness({
+        service: { readiness: { type: "http", timeoutSec: 1, intervalMs: 200 } },
+        url: "http://127.0.0.1:45439/",
+        readinessUrl: null,
+        fetchImpl: refusingFetch,
+      }),
+    ).rejects.toThrow(/ECONNREFUSED/);
+    // ~1s budget at a 200ms interval: a bounded handful of probes, never an unbounded spin.
+    expect(probes).toBeGreaterThan(1);
+    expect(probes).toBeLessThan(12);
+  });
+
+  it("hands two concurrent starts distinct ports even when the kernel repeats a candidate", async () => {
+    // The kernel really does hand the same ephemeral port to two `listen(0)` probes once the
+    // first probe socket has closed, which is exactly the reallocation collision in the report.
+    const candidates = [49871, 49871, 49871, 49872];
+    let index = 0;
+    const probe = async () => candidates[Math.min(index++, candidates.length - 1)]!;
+    const portOwnerLookup = async () => null;
+
+    const [first, second] = await Promise.all([
+      allocateRuntimeServicePort({ probe, portOwnerLookup }),
+      allocateRuntimeServicePort({ probe, portOwnerLookup }),
+    ]);
+
+    expect(first).not.toBe(second);
+    expect(new Set([first, second])).toEqual(new Set([49871, 49872]));
+  });
+
+  it("skips a candidate port that a live process already owns", async () => {
+    const candidates = [49881, 49882];
+    let index = 0;
+    const probe = async () => candidates[Math.min(index++, candidates.length - 1)]!;
+    const portOwnerLookup = async (port: number) => (port === 49881 ? 4242 : null);
+
+    await expect(allocateRuntimeServicePort({ probe, portOwnerLookup })).resolves.toBe(49882);
+    // The rejected candidate must not stay reserved, or later starts would leak allocations.
+    await expect(
+      allocateRuntimeServicePort({ probe: async () => 49881, portOwnerLookup: async () => null }),
+    ).resolves.toBe(49881);
+  });
+
+  it("refuses a configured port a sibling start is already claiming", () => {
+    // The reported collision was on a *configured* app/HMR pair, not an auto-allocated one:
+    // both lanes read the pair as free because neither had bound or persisted a row yet.
+    expect(claimRuntimeServiceBindPort(42003, null)).toBe(true);
+    expect(claimRuntimeServiceBindPort(42003, null)).toBe(false);
+    // The HMR companion is claimed independently, so a lane can lose on either port.
+    expect(claimRuntimeServiceBindPort(42004, null)).toBe(true);
+    expect(claimRuntimeServiceBindPort(42004, null)).toBe(false);
+  });
+
+  it("never lets a start be refused by its own allocation", async () => {
+    // An auto-allocated port arrives already reserved by this start, and its identity port can
+    // resolve to that same value. Treating that as a sibling's claim would fail the start on its
+    // own reservation.
+    const held = await allocateRuntimeServicePort({
+      probe: async () => 49901,
+      portOwnerLookup: async () => null,
+    });
+    expect(held).toBe(49901);
+    expect(claimRuntimeServiceBindPort(49901, held)).toBe(true);
+    // A different start still loses against that held reservation.
+    expect(claimRuntimeServiceBindPort(49901, null)).toBe(false);
+  });
+
+  it("fails terminally rather than looping when no free port can be found", async () => {
+    await expect(
+      allocateRuntimeServicePort({ probe: async () => 49891, portOwnerLookup: async () => 99 }),
+    ).rejects.toThrow(/Could not allocate a free loopback port/);
+  });
+});

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -41,13 +41,17 @@ import {
   resolveWorkspaceRuntimeReadinessTimeoutSec,
   resolveShell,
   sanitizeRuntimeServiceBaseEnv,
+  setWorkspaceRuntimeExposureDepsForTests,
   startRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace,
+  stopRuntimeServicesForProjectWorkspace,
+  WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS,
   type RealizedExecutionWorkspace,
 } from "../services/workspace-runtime.ts";
 import {
   findAdoptableLocalService,
   isLocalServiceRegistryCwdCompatible,
+  isLocalServiceProcessOwnedBy,
   isLocalServiceProcessInWorkspace,
   readLocalServicePortOwner,
   writeLocalServiceRegistryRecord,
@@ -57,7 +61,7 @@ import {
   buildWorkspaceRealizationRequest,
   readWorkspaceRealizationRequest,
 } from "../services/workspace-realization.ts";
-import type { Environment, EnvironmentLease } from "@paperclipai/shared";
+import { deriveViteHmrPort, type Environment, type EnvironmentLease } from "@paperclipai/shared";
 import { resolvePaperclipConfigPath } from "../paths.ts";
 import type { WorkspaceOperation } from "@paperclipai/shared";
 import type { WorkspaceOperationRecorder } from "../services/workspace-operations.ts";
@@ -280,6 +284,48 @@ function buildWorkspace(cwd: string): RealizedExecutionWorkspace {
     warnings: [],
     created: false,
   };
+}
+
+async function closeNetServer(server: net.Server) {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+async function listenOnPort(port: number) {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return server;
+}
+
+async function findFreePort() {
+  const server = await listenOnPort(0);
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : null;
+  await closeNetServer(server);
+  if (!port) throw new Error("Failed to find a free test port");
+  return port;
+}
+
+async function reserveContiguousPorts(count: number) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const basePort = await findFreePort();
+    if (basePort + count - 1 > 65_535) continue;
+    const servers: net.Server[] = [];
+    try {
+      for (let offset = 0; offset < count; offset += 1) {
+        servers.push(await listenOnPort(basePort + offset));
+      }
+      return { basePort, servers };
+    } catch {
+      await Promise.all(servers.map((server) => closeNetServer(server).catch(() => undefined)));
+    }
+  }
+  throw new Error(`Failed to reserve ${count} contiguous test ports`);
 }
 
 function createWorkspaceOperationRecorderDouble() {
@@ -4675,6 +4721,35 @@ describe("readLocalServicePortOwner", () => {
     }
   });
 
+  it("attributes a Windows listener to a descendant of the launched process", async () => {
+    const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-windows-tools-"));
+    const previousPath = process.env.PATH;
+    const port = 43_123;
+    const listenerPid = 43_210;
+    const launchedPid = 32_000;
+    await fs.writeFile(
+      path.join(fakeBin, "netstat"),
+      `#!/bin/sh\nprintf '  TCP    127.0.0.1:${port}    0.0.0.0:0    LISTENING    ${listenerPid}\\n'\n`,
+      { mode: 0o755 },
+    );
+    await fs.writeFile(
+      path.join(fakeBin, "powershell.exe"),
+      `#!/bin/sh\nprintf '${launchedPid}\\n'\n`,
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fakeBin}${path.delimiter}${previousPath ?? ""}`;
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      await expect(readLocalServicePortOwner(port)).resolves.toBe(listenerPid);
+      await expect(isLocalServiceProcessOwnedBy(listenerPid, launchedPid)).resolves.toBe(true);
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await fs.rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
   it("accepts service cwd nested within the requested workspace", async () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-workspace-"));
     const serviceCwd = path.join(workspace, "server");
@@ -5714,6 +5789,797 @@ describeEmbeddedPostgres("workspace runtime service control persistence", () => 
       else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
     }
   }, 15_000);
+
+  async function createRuntimeFixture(input?: {
+    companyId?: string;
+    workspaceModes?: Array<"isolated_workspace" | "shared_workspace">;
+  }) {
+    const companyId = input?.companyId ?? randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const baseRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-port-fixture-"));
+    const workspaceModes = input?.workspaceModes ?? ["isolated_workspace"];
+    const workspaceRows = await Promise.all(workspaceModes.map(async (mode, index) => {
+      const cwd = await fs.mkdtemp(path.join(baseRoot, `workspace-${index}-`));
+      return {
+        id: randomUUID(),
+        cwd,
+        mode,
+      };
+    }));
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: `Runtime ports ${companyId.slice(0, 8)}`,
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Runtime Port Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Runtime port allocation",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: baseRoot,
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values(workspaceRows.map((workspace, index) => ({
+      id: workspace.id,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: workspace.mode,
+      strategyType: workspace.mode === "isolated_workspace" ? "git_worktree" : "project_primary",
+      name: `Runtime workspace ${index + 1}`,
+      status: "active",
+      providerType: "local_fs",
+      cwd: workspace.cwd,
+      providerRef: workspace.cwd,
+    })));
+
+    const realizedWorkspace = (workspace: typeof workspaceRows[number]): RealizedExecutionWorkspace => ({
+      baseCwd: baseRoot,
+      source: "task_session",
+      projectId,
+      workspaceId: projectWorkspaceId,
+      repoUrl: null,
+      repoRef: "HEAD",
+      strategy: workspace.mode === "isolated_workspace" ? "git_worktree" : "project_primary",
+      cwd: workspace.cwd,
+      branchName: null,
+      worktreePath: workspace.mode === "isolated_workspace" ? workspace.cwd : null,
+      warnings: [],
+      created: false,
+    });
+
+    return {
+      companyId,
+      agentId,
+      projectId,
+      projectWorkspaceId,
+      workspaces: workspaceRows,
+      actor: { id: agentId, name: "Runtime Port Agent", companyId },
+      realizedWorkspace,
+      cleanup: async () => await fs.rm(baseRoot, { recursive: true, force: true }),
+    };
+  }
+
+  function fixedPortRuntimeConfig(port: number, command?: string) {
+    const serverCommand = command ?? [
+      JSON.stringify(process.execPath),
+      "-e",
+      JSON.stringify(
+        "require('node:http').createServer((_req,res)=>res.end('ok')).listen(Number(process.env.PORT),'127.0.0.1')",
+      ),
+    ].join(" ");
+    return {
+      workspaceRuntime: {
+        services: [{
+          name: "web",
+          command: serverCommand,
+          port: { type: "fixed", value: port, envKey: "PORT" },
+          readiness: {
+            type: "http",
+            urlTemplate: "http://127.0.0.1:{{port}}",
+            timeoutSec: 5,
+            intervalMs: 25,
+          },
+          expose: { type: "url", urlTemplate: "http://127.0.0.1:{{port}}" },
+          lifecycle: "shared",
+          reuseScope: "execution_workspace",
+          stopPolicy: { type: "manual" },
+        }],
+      },
+    };
+  }
+
+  async function createRuntimeHome() {
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-port-home-"));
+    const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    const previousPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = `runtime-ports-${randomUUID()}`;
+    return async () => {
+      if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+      if (previousPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+    };
+  }
+
+  async function isLoopbackPortFree(port: number) {
+    const probe = net.createServer();
+    return await new Promise<boolean>((resolve) => {
+      probe.once("error", () => resolve(false));
+      probe.listen(port, "127.0.0.1", () => {
+        probe.close(() => resolve(true));
+      });
+    });
+  }
+
+  function httpsRuntimeConfig(command: string) {
+    return {
+      workspaceRuntime: {
+        services: [{
+          name: "paperclip-dev",
+          command,
+          port: { type: "fixed", value: 45_439, envKey: "PORT" },
+          readiness: {
+            type: "http",
+            urlTemplate: "http://127.0.0.1:{{port}}",
+            timeoutSec: 5,
+            intervalMs: 25,
+          },
+          expose: {
+            type: "tailscale_https",
+            hostname: "auto",
+            publicPort: "same",
+            includePaperclipViteHmr: true,
+            failurePolicy: "fail_closed",
+          },
+          lifecycle: "shared",
+          reuseScope: "execution_workspace",
+          stopPolicy: { type: "manual" },
+        }],
+      },
+    };
+  }
+
+  it("waits for every managed process-tree listener before requesting HTTPS exposure", async () => {
+    const fixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const delayedHmrScript = [
+      "const http=require('node:http');",
+      "const port=Number(process.env.PORT);",
+      "http.createServer((_req,res)=>res.end('ok')).listen(port,'127.0.0.1');",
+      "setTimeout(()=>http.createServer((_req,res)=>res.end('hmr')).listen(port+10000,'127.0.0.1'),750);",
+      "setInterval(()=>{},1000);",
+    ].join("");
+    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(delayedHmrScript)}`;
+    let reservedListeners: Array<{ purpose: "app" | "vite_hmr"; port: number }> = [];
+    let exposeCalls = 0;
+    const broker = {
+      async reserve(_runtimeId: string, listeners: Array<{ purpose: "app" | "vite_hmr"; port: number }>) {
+        reservedListeners = listeners.map((listener) => ({ ...listener }));
+        return {
+          handle: "managed-listener-handle-1234",
+          reservedPorts: listeners.map((listener) => listener.port),
+        };
+      },
+      async expose(_runtimeId: string, handle: string) {
+        exposeCalls += 1;
+        const owners = await Promise.all(
+          reservedListeners.map((listener) => readLocalServicePortOwner(listener.port)),
+        );
+        if (owners.some((owner) => owner === null)) {
+          throw new Error("listener_ownership_mismatch");
+        }
+        return {
+          handle,
+          publicPorts: reservedListeners.map((listener) => listener.port),
+        };
+      },
+      async remove() {
+        return { removedPorts: reservedListeners.map((listener) => listener.port) };
+      },
+      async list() {
+        return [];
+      },
+    };
+    setWorkspaceRuntimeExposureDepsForTests({
+      broker,
+      isPortAvailable: isLoopbackPortFree,
+      isBrokerAvailable: async () => true,
+      resolveHostname: async () => "runner.tail123.ts.net",
+      probeHealth: async () => true,
+      now: () => new Date().toISOString(),
+    });
+
+    try {
+      const started = (await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config: httpsRuntimeConfig(command),
+        adapterEnv: {},
+      }))[0]!;
+
+      expect(exposeCalls).toBe(1);
+      expect(reservedListeners.map((listener) => listener.port)).toEqual([
+        started.port,
+        deriveViteHmrPort(started.port!),
+      ]);
+      expect(started).toMatchObject({
+        status: "running",
+        healthStatus: "healthy",
+        url: `https://runner.tail123.ts.net:${started.port}`,
+        exposure: { state: "ready" },
+      });
+    } finally {
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      await resetRuntimeServicesForTests({ terminateProcesses: true });
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 15_000);
+
+  it("rejects a foreign listener that races onto a reserved HTTPS companion port", async () => {
+    const fixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const appOnlyScript = [
+      "const http=require('node:http');",
+      "http.createServer((_req,res)=>res.end('ok')).listen(Number(process.env.PORT),'127.0.0.1');",
+      "setInterval(()=>{},1000);",
+    ].join("");
+    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(appOnlyScript)}`;
+    let foreignHmr: net.Server | null = null;
+    let exposeCalls = 0;
+    let reservedPorts: number[] = [];
+    const broker = {
+      async reserve(_runtimeId: string, listeners: Array<{ purpose: "app" | "vite_hmr"; port: number }>) {
+        reservedPorts = listeners.map((listener) => listener.port);
+        const hmrPort = listeners.find((listener) => listener.purpose === "vite_hmr")!.port;
+        foreignHmr = net.createServer((socket) => socket.destroy());
+        await new Promise<void>((resolve, reject) => {
+          foreignHmr!.once("error", reject);
+          foreignHmr!.listen(hmrPort, "127.0.0.1", resolve);
+        });
+        return { handle: "foreign-listener-handle-1234", reservedPorts };
+      },
+      async expose(_runtimeId: string, handle: string) {
+        exposeCalls += 1;
+        return { handle, publicPorts: reservedPorts };
+      },
+      async remove() {
+        return { removedPorts: reservedPorts };
+      },
+      async list() {
+        return [];
+      },
+    };
+    setWorkspaceRuntimeExposureDepsForTests({
+      broker,
+      isPortAvailable: isLoopbackPortFree,
+      isBrokerAvailable: async () => true,
+      resolveHostname: async () => "runner.tail123.ts.net",
+      probeHealth: async () => true,
+      now: () => new Date().toISOString(),
+    });
+
+    try {
+      await expect(startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config: httpsRuntimeConfig(command),
+        adapterEnv: {},
+      })).rejects.toThrow(/could not bind allocated port/);
+      expect(exposeCalls).toBe(0);
+    } finally {
+      if (foreignHmr) {
+        await new Promise<void>((resolve) => foreignHmr!.close(() => resolve()));
+      }
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      await resetRuntimeServicesForTests({ terminateProcesses: true });
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 15_000);
+
+  it("allocates distinct persisted ports for concurrent isolated siblings without stopping either service", async () => {
+    const fixture = await createRuntimeFixture({
+      workspaceModes: ["isolated_workspace", "isolated_workspace"],
+    });
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const basePort = await findFreePort();
+    const config = fixedPortRuntimeConfig(basePort);
+    const startedWorkspaceIds: string[] = [];
+
+    try {
+      const [first, second] = await Promise.all(fixture.workspaces.map(async (workspace) => {
+        const result = await startRuntimeServicesForWorkspaceControl({
+          db,
+          actor: fixture.actor,
+          issue: null,
+          workspace: fixture.realizedWorkspace(workspace),
+          executionWorkspaceId: workspace.id,
+          config,
+          adapterEnv: {},
+        });
+        startedWorkspaceIds.push(workspace.id);
+        return result[0]!;
+      }));
+
+      expect(first.port).toBe(basePort);
+      expect(second.port).not.toBe(first.port);
+      expect(second.port).toBeGreaterThan(basePort);
+      expect(first.url).toBe(`http://127.0.0.1:${first.port}`);
+      expect(second.url).toBe(`http://127.0.0.1:${second.port}`);
+      await expect(fetch(first.url!)).resolves.toMatchObject({ ok: true });
+      await expect(fetch(second.url!)).resolves.toMatchObject({ ok: true });
+
+      const persisted = await db
+        .select()
+        .from(workspaceRuntimeServices)
+        .where(eq(workspaceRuntimeServices.companyId, fixture.companyId));
+      expect(persisted).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          executionWorkspaceId: fixture.workspaces[0]!.id,
+          port: first.port,
+          url: first.url,
+          status: "running",
+        }),
+        expect.objectContaining({
+          executionWorkspaceId: fixture.workspaces[1]!.id,
+          port: second.port,
+          url: second.url,
+          status: "running",
+        }),
+      ]));
+    } finally {
+      await Promise.all(startedWorkspaceIds.map(async (executionWorkspaceId) => {
+        const workspace = fixture.workspaces.find((entry) => entry.id === executionWorkspaceId)!;
+        await stopRuntimeServicesForExecutionWorkspace({
+          db,
+          executionWorkspaceId,
+          workspaceCwd: workspace.cwd,
+        }).catch(() => undefined);
+      }));
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("commits fixed-port reservations before readiness windows longer than 60 seconds", async () => {
+    const fixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const basePort = await findFreePort();
+    const spawnedMarkerPath = path.join(workspace.cwd, "slow-readiness-spawned.marker");
+    const releaseMarkerPath = path.join(workspace.cwd, "slow-readiness-release.marker");
+    const serverScript = [
+      "const fs=require('node:fs');",
+      "const http=require('node:http');",
+      `const spawned=${JSON.stringify(spawnedMarkerPath)};`,
+      `const release=${JSON.stringify(releaseMarkerPath)};`,
+      "fs.writeFileSync(spawned,'spawned');",
+      "const timer=setInterval(()=>{",
+      "if(!fs.existsSync(release))return;",
+      "clearInterval(timer);",
+      "http.createServer((_req,res)=>res.end('ok')).listen(Number(process.env.PORT),'127.0.0.1');",
+      "},25);",
+      "setInterval(()=>{},1000);",
+    ].join("");
+    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(serverScript)}`;
+    const config = fixedPortRuntimeConfig(basePort, command);
+    config.workspaceRuntime.services[0]!.readiness.timeoutSec = 70;
+    let startPromise: ReturnType<typeof startRuntimeServicesForWorkspaceControl> | null = null;
+
+    try {
+      startPromise = startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config,
+        adapterEnv: {},
+      });
+      startPromise.catch(() => undefined);
+
+      const markerDeadline = Date.now() + 5_000;
+      while (!existsSync(spawnedMarkerPath) && Date.now() < markerDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(existsSync(spawnedMarkerPath)).toBe(true);
+
+      const parentWrite = (async () => await db
+        .update(executionWorkspaces)
+        .set({ updatedAt: new Date() })
+        .where(eq(executionWorkspaces.id, workspace.id)))();
+      const parentWriteOutcome = await Promise.race([
+        parentWrite.then(() => "committed" as const),
+        new Promise<"locked">((resolve) => setTimeout(() => resolve("locked"), 2_000)),
+      ]);
+
+      const readinessWaitStartedAt = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 60_250));
+      expect(Date.now() - readinessWaitStartedAt).toBeGreaterThanOrEqual(60_000);
+
+      await fs.writeFile(releaseMarkerPath, "release");
+      const started = (await startPromise)[0]!;
+      await parentWrite;
+
+      expect(parentWriteOutcome).toBe("committed");
+      expect(started).toMatchObject({
+        port: basePort,
+        url: `http://127.0.0.1:${basePort}`,
+        status: "running",
+        healthStatus: "healthy",
+      });
+      const persisted = await db
+        .select()
+        .from(workspaceRuntimeServices)
+        .where(eq(workspaceRuntimeServices.executionWorkspaceId, workspace.id))
+        .then((rows) => rows[0] ?? null);
+      expect(persisted).toMatchObject({
+        port: basePort,
+        url: `http://127.0.0.1:${basePort}`,
+        status: "running",
+      });
+    } finally {
+      await fs.writeFile(releaseMarkerPath, "release").catch(() => undefined);
+      await startPromise?.catch(() => undefined);
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 80_000);
+
+  it("reuses a stopped isolated workspace's actual port when it is free", async () => {
+    const fixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const config = fixedPortRuntimeConfig(await findFreePort());
+
+    try {
+      const first = (await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config,
+        adapterEnv: {},
+      }))[0]!;
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      });
+
+      const restarted = (await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config,
+        adapterEnv: {},
+      }))[0]!;
+
+      expect(restarted.id).toBe(first.id);
+      expect(restarted.port).toBe(first.port);
+      expect(restarted.url).toBe(first.url);
+      await expect(fetch(restarted.url!)).resolves.toMatchObject({ ok: true });
+    } finally {
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("retries a bind race on the next bounded port and persists the selected URL", async () => {
+    const fixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const basePort = await findFreePort();
+    const markerPath = path.join(workspace.cwd, "bind-race.marker");
+    const blockerPidPath = path.join(workspace.cwd, "bind-race.pid");
+    const blockerScript = [
+      "const net=require('node:net');",
+      "const port=Number(process.argv[1]);",
+      "net.createServer((socket)=>socket.destroy()).listen(port,'127.0.0.1');",
+    ].join("");
+    const raceScript = [
+      "const fs=require('node:fs');",
+      "const http=require('node:http');",
+      "const {spawn}=require('node:child_process');",
+      `const marker=${JSON.stringify(markerPath)};`,
+      `const pidFile=${JSON.stringify(blockerPidPath)};`,
+      `const blockerScript=${JSON.stringify(blockerScript)};`,
+      "const port=Number(process.env.PORT);",
+      "const start=()=>http.createServer((_req,res)=>res.end('ok')).listen(port,'127.0.0.1');",
+      "if(!fs.existsSync(marker)){",
+      "fs.writeFileSync(marker,String(port));",
+      "const blocker=spawn(process.execPath,['-e',blockerScript,String(port)],{detached:true,stdio:'ignore'});",
+      "fs.writeFileSync(pidFile,String(blocker.pid));blocker.unref();setTimeout(start,200);",
+      "}else{start();}",
+      "setInterval(()=>{},1000);",
+    ].join("");
+    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(raceScript)}`;
+
+    try {
+      const started = (await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config: fixedPortRuntimeConfig(basePort, command),
+        adapterEnv: {},
+      }))[0]!;
+
+      expect(await fs.readFile(markerPath, "utf8")).toBe(String(basePort));
+      expect(started.port).toBeGreaterThan(basePort);
+      expect(started.url).toBe(`http://127.0.0.1:${started.port}`);
+      await expect(fetch(started.url!)).resolves.toMatchObject({ ok: true });
+      const persisted = await db
+        .select()
+        .from(workspaceRuntimeServices)
+        .where(eq(workspaceRuntimeServices.executionWorkspaceId, workspace.id))
+        .then((rows) => rows[0] ?? null);
+      expect(persisted).toMatchObject({ port: started.port, url: started.url, status: "running" });
+    } finally {
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      const blockerPid = Number.parseInt(await fs.readFile(blockerPidPath, "utf8").catch(() => ""), 10);
+      if (Number.isInteger(blockerPid) && blockerPid > 0) {
+        try {
+          process.kill(blockerPid, "SIGTERM");
+        } catch {
+          // The bind-race process already exited.
+        }
+      }
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("does not accept an occupied allocated port when listener ownership is unavailable", async () => {
+    const fixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const basePort = await findFreePort();
+    const fakeBin = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-no-lsof-"));
+    const fakeLsof = path.join(fakeBin, "lsof");
+    const previousPath = process.env.PATH;
+    await fs.writeFile(fakeLsof, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    process.env.PATH = `${fakeBin}${path.delimiter}${previousPath ?? ""}`;
+
+    try {
+      await expect(startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(workspace),
+        executionWorkspaceId: workspace.id,
+        config: fixedPortRuntimeConfig(basePort),
+        adapterEnv: {},
+      })).rejects.toMatchObject({
+        status: 409,
+        details: {
+          code: "workspace_runtime_port_allocation_exhausted",
+          port: basePort,
+          attemptedPortCount: WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS,
+        },
+      });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      await fs.rm(fakeBin, { recursive: true, force: true });
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("returns a bounded structured conflict and exposes only same-company workspace references", async () => {
+    const fixture = await createRuntimeFixture({
+      workspaceModes: ["isolated_workspace", "isolated_workspace"],
+    });
+    const otherCompanyFixture = await createRuntimeFixture();
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const reservation = await reserveContiguousPorts(WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS);
+    const [baseReservation, ...otherReservations] = reservation.servers;
+    await closeNetServer(baseReservation!);
+    const firstWorkspace = fixture.workspaces[0]!;
+    const secondWorkspace = fixture.workspaces[1]!;
+    const otherCompanyWorkspace = otherCompanyFixture.workspaces[0]!;
+    const config = fixedPortRuntimeConfig(reservation.basePort);
+
+    try {
+      const first = (await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor: fixture.actor,
+        issue: null,
+        workspace: fixture.realizedWorkspace(firstWorkspace),
+        executionWorkspaceId: firstWorkspace.id,
+        config,
+        adapterEnv: {},
+      }))[0]!;
+      expect(first.port).toBe(reservation.basePort);
+
+      let sameCompanyError: unknown;
+      try {
+        await startRuntimeServicesForWorkspaceControl({
+          db,
+          actor: fixture.actor,
+          issue: null,
+          workspace: fixture.realizedWorkspace(secondWorkspace),
+          executionWorkspaceId: secondWorkspace.id,
+          config,
+          adapterEnv: {},
+        });
+      } catch (error) {
+        sameCompanyError = error;
+      }
+      expect(sameCompanyError).toMatchObject({
+        status: 409,
+        details: {
+          code: "workspace_runtime_port_allocation_exhausted",
+          port: reservation.basePort,
+          attemptedPortCount: WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS,
+          conflictingExecutionWorkspaceId: firstWorkspace.id,
+          remediation: expect.any(String),
+        },
+      });
+      expect(JSON.stringify(sameCompanyError)).not.toMatch(/(?:pid|cwd)/i);
+
+      let otherCompanyError: unknown;
+      try {
+        await startRuntimeServicesForWorkspaceControl({
+          db,
+          actor: otherCompanyFixture.actor,
+          issue: null,
+          workspace: otherCompanyFixture.realizedWorkspace(otherCompanyWorkspace),
+          executionWorkspaceId: otherCompanyWorkspace.id,
+          config,
+          adapterEnv: {},
+        });
+      } catch (error) {
+        otherCompanyError = error;
+      }
+      expect(otherCompanyError).toMatchObject({
+        status: 409,
+        details: {
+          code: "workspace_runtime_port_allocation_exhausted",
+          port: reservation.basePort,
+          attemptedPortCount: WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS,
+        },
+      });
+      expect(otherCompanyError).not.toMatchObject({
+        details: {
+          conflictingExecutionWorkspaceId: firstWorkspace.id,
+        },
+      });
+      expect(JSON.stringify(otherCompanyError)).not.toContain(firstWorkspace.id);
+    } finally {
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: firstWorkspace.id,
+        workspaceCwd: firstWorkspace.cwd,
+      }).catch(() => undefined);
+      await Promise.all(otherReservations.map((server) => closeNetServer(server).catch(() => undefined)));
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+      await otherCompanyFixture.cleanup();
+    }
+  }, 30_000);
+
+  it("keeps fixed ports strict for shared persisted workspaces and identity-less starts", async () => {
+    const fixture = await createRuntimeFixture({ workspaceModes: ["shared_workspace"] });
+    const cleanupRuntimeHome = await createRuntimeHome();
+    const workspace = fixture.workspaces[0]!;
+    const occupiedPort = await findFreePort();
+    const occupant = await listenOnPort(occupiedPort);
+    const config = fixedPortRuntimeConfig(occupiedPort);
+
+    try {
+      let sharedWorkspaceError: unknown;
+      try {
+        await startRuntimeServicesForWorkspaceControl({
+          db,
+          actor: fixture.actor,
+          issue: null,
+          workspace: fixture.realizedWorkspace(workspace),
+          executionWorkspaceId: workspace.id,
+          config,
+          adapterEnv: {},
+        });
+      } catch (error) {
+        sharedWorkspaceError = error;
+      }
+      expect(sharedWorkspaceError).toBeInstanceOf(Error);
+      expect(sharedWorkspaceError).not.toMatchObject({ status: 409 });
+
+      const identitylessCwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-identityless-"));
+      try {
+        await expect(startRuntimeServicesForWorkspaceControl({
+          actor: { id: null, name: "Board", companyId: fixture.companyId },
+          issue: null,
+          workspace: buildWorkspace(identitylessCwd),
+          config,
+          adapterEnv: {},
+        })).rejects.toBeInstanceOf(Error);
+      } finally {
+        await fs.rm(identitylessCwd, { recursive: true, force: true });
+      }
+
+      const rows = await db
+        .select()
+        .from(workspaceRuntimeServices)
+        .where(eq(workspaceRuntimeServices.executionWorkspaceId, workspace.id));
+      expect(rows.every((row) => row.port === occupiedPort)).toBe(true);
+    } finally {
+      await closeNetServer(occupant);
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      }).catch(() => undefined);
+      await cleanupRuntimeHome();
+      await fixture.cleanup();
+    }
+  }, 20_000);
 });
 
 describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
@@ -5738,6 +6604,379 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
     await db.delete(agents);
     await db.delete(companies);
   });
+
+  it("restores desired services when one row is stopped and a live registered service has no row", async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-desired-reconcile-"));
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-home-"));
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = `runtime-desired-reconcile-${randomUUID()}`;
+
+    const reservePort = async () => {
+      const probe = net.createServer();
+      await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+      const address = probe.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      await new Promise<void>((resolve, reject) => {
+        probe.close((error) => error ? reject(error) : resolve());
+      });
+      if (!port) throw new Error("Failed to reserve runtime reconciliation test port");
+      return port;
+    };
+    const stoppedPort = await reservePort();
+    const livePort = await reservePort();
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const command =
+      "node -e \"require('node:http').createServer((req,res)=>res.end(process.env.PORT)).listen(Number(process.env.PORT), '127.0.0.1')\"";
+    const workspaceRuntime = {
+      services: [
+        {
+          name: "persisted-service",
+          command,
+          port: stoppedPort,
+          expose: { urlTemplate: "http://127.0.0.1:{{port}}" },
+          readiness: { type: "http", urlTemplate: "http://127.0.0.1:{{port}}", timeoutSec: 10, intervalMs: 50 },
+          lifecycle: "shared",
+          reuseScope: "execution_workspace",
+          stopPolicy: { type: "manual" },
+        },
+        {
+          name: "registry-only-service",
+          command,
+          port: livePort,
+          expose: { urlTemplate: "http://127.0.0.1:{{port}}" },
+          readiness: { type: "http", urlTemplate: "http://127.0.0.1:{{port}}", timeoutSec: 10, intervalMs: 50 },
+          lifecycle: "shared",
+          reuseScope: "execution_workspace",
+          stopPolicy: { type: "manual" },
+        },
+      ],
+    };
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Runtime desired reconciliation",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: workspaceRoot,
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Runtime desired reconciliation workspace",
+      status: "active",
+      cwd: workspaceRoot,
+      providerType: "local_fs",
+      providerRef: workspaceRoot,
+      metadata: {
+        config: {
+          workspaceRuntime,
+          desiredState: "running",
+          serviceStates: { "0": "running", "1": "running" },
+        },
+      },
+    });
+
+    const actor = { id: null, name: "Paperclip", companyId };
+    const workspace = {
+      ...buildWorkspace(workspaceRoot),
+      projectId,
+      workspaceId: projectWorkspaceId,
+    };
+    let stoppedServiceId: string | null = null;
+    let registryOnlyServiceId: string | null = null;
+
+    try {
+      const persisted = await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor,
+        issue: null,
+        workspace,
+        executionWorkspaceId,
+        config: { workspaceRuntime },
+        adapterEnv: {},
+        serviceIndex: 0,
+      });
+      stoppedServiceId = persisted[0]?.id ?? null;
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId,
+        workspaceCwd: workspaceRoot,
+        runtimeServiceId: stoppedServiceId,
+      });
+
+      const registryOnly = await startRuntimeServicesForWorkspaceControl({
+        actor,
+        issue: null,
+        workspace,
+        executionWorkspaceId,
+        config: { workspaceRuntime },
+        adapterEnv: {},
+        serviceIndex: 1,
+      });
+      registryOnlyServiceId = registryOnly[0]?.id ?? null;
+      expect(registryOnlyServiceId).toBeTruthy();
+      expect(await db.select().from(workspaceRuntimeServices)).toHaveLength(1);
+
+      await resetRuntimeServicesForTests();
+      const result = await reconcilePersistedRuntimeServicesOnStartup(db);
+
+      expect(result).toMatchObject({ reconciled: 0, adopted: 0, stopped: 0, restarted: 1, restartFailed: 0 });
+      const rows = await db.select().from(workspaceRuntimeServices);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: stoppedServiceId, port: stoppedPort, status: "running" }),
+        expect.objectContaining({ id: registryOnlyServiceId, port: livePort, status: "running" }),
+      ]));
+      await expect(fetch(`http://127.0.0.1:${stoppedPort}`)).resolves.toMatchObject({ ok: true });
+      await expect(fetch(`http://127.0.0.1:${livePort}`)).resolves.toMatchObject({ ok: true });
+    } finally {
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId,
+        workspaceCwd: workspaceRoot,
+      });
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("backfills a pre-existing HTTP-only managed worktree runtime to verified HTTPS in place", async () => {
+    // PAP-17158: an eligible workspace created before the feature must come
+    // forward on the *same* workspace/runtime-service row — not by recreating it
+    // — and must never keep its HTTP URL as a healthy fallback.
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-https-backfill-"));
+    const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-home-"));
+    const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    const previousPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+    const previousHttpsMode = process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = `runtime-https-backfill-${randomUUID()}`;
+
+    const reservePort = async () => {
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const probe = net.createServer();
+        await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+        const address = probe.address();
+        const port = typeof address === "object" && address ? address.port : null;
+        await new Promise<void>((resolve, reject) => {
+          probe.close((error) => error ? reject(error) : resolve());
+        });
+        if (port && port <= 55_535 && (port < 42_000 || port > 42_999)) return port;
+      }
+      throw new Error("Failed to reserve an HTTPS backfill test port outside the broker range");
+    };
+    const isLoopbackPortFree = async (port: number) => {
+      const probe = net.createServer();
+      return await new Promise<boolean>((resolve) => {
+        probe.once("error", () => resolve(false));
+        probe.listen(port, "127.0.0.1", () => {
+          probe.close(() => resolve(true));
+        });
+      });
+    };
+
+    // Stands in for the persisted template's hard-coded 45439: a pinned port
+    // outside the broker's dedicated allowlist, so the backfill has to relocate.
+    const legacyPort = await reservePort();
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    // Binds the app port and its HMR companion, both loopback-only.
+    const command =
+      "node -e \"const http=require('node:http');const p=Number(process.env.PORT);for(const q of [p,p+10000])http.createServer((req,res)=>res.end('ok')).listen(q,'127.0.0.1');setInterval(()=>{},1000)\"";
+    const workspaceRuntime = {
+      services: [
+        {
+          name: "paperclip-dev",
+          command,
+          port: legacyPort,
+          // The pre-feature block: backend URL only, no exposure declaration.
+          expose: { type: "url", urlTemplate: "http://127.0.0.1:{{port}}" },
+          readiness: { type: "http", urlTemplate: "http://127.0.0.1:{{port}}", timeoutSec: 10, intervalMs: 50 },
+          lifecycle: "shared",
+          reuseScope: "project_workspace",
+          stopPolicy: { type: "manual" },
+        },
+      ],
+    };
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Runtime HTTPS backfill",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: workspaceRoot,
+      isPrimary: true,
+      metadata: {
+        runtimeConfig: {
+          workspaceRuntime,
+          desiredState: "running",
+          serviceStates: { "0": "running" },
+        },
+      },
+    });
+
+    const actor = { id: null, name: "Paperclip", companyId };
+    const workspace = {
+      ...buildWorkspace(workspaceRoot),
+      projectId,
+      workspaceId: projectWorkspaceId,
+    };
+
+    // A broker fake that remembers what it published, so a second reconciliation
+    // can recognize its own live listeners instead of tearing them down.
+    const exposedByRuntimeId = new Map<string, { port: number; purpose: "app" | "vite_hmr" }[]>();
+    const pendingByHandle = new Map<string, { runtimeId: string; listeners: { port: number; purpose: "app" | "vite_hmr" }[] }>();
+    let handleCounter = 0;
+    const brokerCalls: string[] = [];
+    const broker = {
+      async reserve(runtimeId: string, listeners: { port: number; purpose: "app" | "vite_hmr" }[]) {
+        brokerCalls.push("reserve");
+        handleCounter += 1;
+        const handle = `backfill-handle-${handleCounter}`;
+        pendingByHandle.set(handle, { runtimeId, listeners: listeners.map((l) => ({ ...l })) });
+        return { handle, reservedPorts: listeners.map((listener) => listener.port) };
+      },
+      async expose(runtimeId: string, handle: string) {
+        brokerCalls.push("expose");
+        const pending = pendingByHandle.get(handle);
+        if (!pending || pending.runtimeId !== runtimeId) throw new Error("listener_ownership_mismatch");
+        exposedByRuntimeId.set(runtimeId, pending.listeners);
+        return { handle, publicPorts: pending.listeners.map((listener) => listener.port) };
+      },
+      async remove(runtimeId: string, handle: string) {
+        brokerCalls.push("remove");
+        const listeners = exposedByRuntimeId.get(runtimeId) ?? pendingByHandle.get(handle)?.listeners ?? [];
+        exposedByRuntimeId.delete(runtimeId);
+        pendingByHandle.delete(handle);
+        return { removedPorts: listeners.map((listener) => listener.port) };
+      },
+      async list() {
+        return [...exposedByRuntimeId.entries()].flatMap(([runtimeId, listeners]) =>
+          listeners.map((listener) => ({ runtimeId, port: listener.port, purpose: listener.purpose })),
+        );
+      },
+    };
+    const installExposureDeps = () => setWorkspaceRuntimeExposureDepsForTests({
+      broker,
+      isPortAvailable: isLoopbackPortFree,
+      isBrokerAvailable: async () => true,
+      resolveHostname: async () => "runner.tail123.ts.net",
+      probeHealth: async () => true,
+      now: () => new Date().toISOString(),
+    });
+
+    try {
+      // ---- Before: the workspace as it exists today, on plain HTTP. ----
+      process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = "off";
+      const before = await startRuntimeServicesForWorkspaceControl({
+        db,
+        actor,
+        issue: null,
+        workspace,
+        config: { workspaceRuntime, desiredState: "running", serviceStates: { "0": "running" } },
+        adapterEnv: {},
+      });
+      const runtimeServiceId = before[0]?.id;
+      expect(runtimeServiceId).toBeTruthy();
+      expect(before[0]?.port).toBe(legacyPort);
+      expect(before[0]?.url).toBe(`http://127.0.0.1:${legacyPort}`);
+      const [httpRow] = await db.select().from(workspaceRuntimeServices);
+      expect(httpRow.exposure).toBeNull();
+      expect(httpRow.url).toBe(`http://127.0.0.1:${legacyPort}`);
+      await expect(fetch(`http://127.0.0.1:${legacyPort}`)).resolves.toMatchObject({ ok: true });
+      expect(brokerCalls).toEqual([]);
+
+      // ---- Deploy: the feature turns on and Paperclip restarts. ----
+      await resetRuntimeServicesForTests();
+      delete process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+      installExposureDeps();
+
+      const result = await reconcilePersistedRuntimeServicesOnStartup(db);
+      expect(result).toMatchObject({ backfilled: 1, restarted: 1, restartFailed: 0 });
+      expect(brokerCalls).toEqual(["reserve", "expose"]);
+
+      // ---- After: same row, verified HTTPS URL, no HTTP anywhere. ----
+      const afterRows = await db.select().from(workspaceRuntimeServices);
+      expect(afterRows).toHaveLength(1);
+      const httpsRow = afterRows[0]!;
+      expect(httpsRow.id).toBe(runtimeServiceId);
+      expect(httpsRow.status).toBe("running");
+      expect(httpsRow.port).not.toBe(legacyPort);
+      expect(httpsRow.port).toBeGreaterThanOrEqual(42_000);
+      expect(httpsRow.port).toBeLessThanOrEqual(42_999);
+      expect(httpsRow.url).toBe(`https://runner.tail123.ts.net:${httpsRow.port}`);
+      expect(httpsRow.exposure).toMatchObject({
+        provider: "tailscale_https",
+        state: "ready",
+        publicUrl: `https://runner.tail123.ts.net:${httpsRow.port}`,
+        hostname: "runner.tail123.ts.net",
+      });
+      expect(httpsRow.exposureHandle).toBeTruthy();
+      // The old HTTP backend is gone, not merely shadowed.
+      await expect(fetch(`http://127.0.0.1:${legacyPort}`)).rejects.toThrow();
+
+      // ---- Repeat deploy: converges, no listener churn, same port. ----
+      await resetRuntimeServicesForTests();
+      installExposureDeps();
+      brokerCalls.length = 0;
+      const second = await reconcilePersistedRuntimeServicesOnStartup(db);
+      expect(second).toMatchObject({ backfilled: 0 });
+      expect(brokerCalls).toEqual([]);
+      const [repeatRow] = await db.select().from(workspaceRuntimeServices);
+      expect(repeatRow.port).toBe(httpsRow.port);
+      expect(repeatRow.url).toBe(httpsRow.url);
+      expect(repeatRow.status).toBe("running");
+    } finally {
+      await stopRuntimeServicesForProjectWorkspace({
+        db,
+        projectWorkspaceId,
+        workspaceCwd: workspaceRoot,
+      }).catch(() => undefined);
+      await resetRuntimeServicesForTests();
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+      if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+      if (previousPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
+      if (previousHttpsMode === undefined) delete process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+      else process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = previousHttpsMode;
+    }
+  }, 40_000);
 
   it("adopts a live auto-port shared service after runtime state is reset", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-reconcile-"));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,10 @@
 import express, { Router, type Request as ExpressRequest } from "express";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Db } from "@paperclipai/db";
-import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
+import { derivePaperclipViteHmrPort, type DeploymentExposure, type DeploymentMode } from "@paperclipai/shared";
 import type { InspectDatabaseBackupHealthOptions } from "./services/database-backup-health.js";
 import type { StorageService } from "./storage/types.js";
 import { httpLogger, errorHandler } from "./middleware/index.js";
@@ -131,16 +132,41 @@ export function isDatabaseConnectionUnavailableError(err: unknown): boolean {
 }
 
 export function resolveViteHmrPort(serverPort: number): number {
-  if (serverPort <= 55_535) {
-    return serverPort + 10_000;
-  }
-  return Math.max(1_024, serverPort - 10_000);
+  return derivePaperclipViteHmrPort(serverPort);
 }
 
 export function resolveViteHmrHost(bindHost: string): string | undefined {
   const normalized = bindHost.trim().toLowerCase();
-  if (normalized === "0.0.0.0" || normalized === "::") return undefined;
+  if (
+    normalized === "0.0.0.0"
+    || normalized === "::"
+    || normalized === "127.0.0.1"
+    || normalized === "::1"
+    || normalized === "localhost"
+  ) return undefined;
   return bindHost;
+}
+
+export function resolveViteHmrProtocol(value: string | undefined): "ws" | "wss" | undefined {
+  if (!value) return undefined;
+  if (value === "ws" || value === "wss") return value;
+  throw new Error("PAPERCLIP_VITE_HMR_PROTOCOL must be ws or wss");
+}
+
+export function listenViteHmrServer(server: HttpServer, port: number, bindHost: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, bindHost);
+  });
 }
 
 export function shouldServeViteDevHtml(req: ExpressRequest): boolean {
@@ -512,6 +538,8 @@ export async function createApp(
   });
   const hostServiceCleanup = createPluginHostServiceCleanup(lifecycle, hostServicesDisposers);
   let viteHtmlRenderer: ReturnType<typeof createCachedViteHtmlRenderer> | null = null;
+  let viteDevServer: { close(): Promise<void> } | null = null;
+  let viteHmrServer: HttpServer | null = null;
   const loader = pluginLoader(
     db,
     {
@@ -642,20 +670,39 @@ export async function createApp(
     const publicUiRoot = path.resolve(uiRoot, "public");
     const hmrPort = resolveViteHmrPort(opts.serverPort);
     const hmrHost = resolveViteHmrHost(opts.bindHost);
+    const hmrProtocol = resolveViteHmrProtocol(process.env.PAPERCLIP_VITE_HMR_PROTOCOL);
+    const hmrServer = createHttpServer((_req, res) => {
+      res.writeHead(426, { "Content-Type": "text/plain" });
+      res.end("Upgrade Required");
+    });
     const { createServer: createViteServer } = await import("vite");
     const vite = await createViteServer({
       root: uiRoot,
       appType: "custom",
       server: {
+        // Listener binding and browser HMR hostname are deliberately separate:
+        // exposed branch runtimes stay loopback-only while the browser uses the
+        // current MagicDNS hostname through the broker's HTTPS listener.
+        host: opts.bindHost,
         middlewareMode: true,
         hmr: {
+          server: hmrServer,
           ...(hmrHost ? { host: hmrHost } : {}),
+          ...(hmrProtocol ? { protocol: hmrProtocol } : {}),
           port: hmrPort,
           clientPort: hmrPort,
         },
         allowedHosts: privateHostnameGateEnabled ? Array.from(privateHostnameAllowSet) : undefined,
       },
     });
+    try {
+      await listenViteHmrServer(hmrServer, hmrPort, opts.bindHost);
+    } catch (error) {
+      await vite.close();
+      throw error;
+    }
+    viteDevServer = vite;
+    viteHmrServer = hmrServer;
     viteHtmlRenderer = createCachedViteHtmlRenderer({
       vite,
       uiRoot,
@@ -829,6 +876,8 @@ export async function createApp(
     }
     devWatcher?.close();
     viteHtmlRenderer?.dispose();
+    void viteDevServer?.close().catch(() => undefined);
+    viteHmrServer?.close();
     hostServiceCleanup.disposeAll();
     hostServiceCleanup.teardown();
     // Cancel every live setup-token login session, so each direct child stops

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -62,6 +62,7 @@ import {
   routineService,
   statusCardService,
   toolAccessService,
+  workspaceOperationService,
 } from "./services/index.js";
 import { queueIssueAssignmentWakeup } from "./services/issue-assignment-wakeup.js";
 import { createSecretProposalsService } from "./services/secret-proposals.js";
@@ -816,11 +817,38 @@ export async function startServer(): Promise<StartedServer> {
     },
   });
 
+  try {
+    const result = await workspaceOperationService(db as any)
+      .reconcileStaleRuntimeControlOperations();
+    if (result.reconciled > 0) {
+      logger.warn(
+        { reconciled: result.reconciled, operationIds: result.operationIds },
+        "reconciled stale managed runtime control operations from a previous server process",
+      );
+    }
+  } catch (err) {
+    logger.error({ err }, "startup reconciliation of managed runtime control operations failed");
+  }
+
   void reconcilePersistedRuntimeServicesOnStartup(db as any)
     .then((result) => {
-      if (result.reconciled > 0) {
+      if (
+        result.reconciled > 0
+        || result.restarted > 0
+        || result.restartFailed > 0
+        || result.backfilled > 0
+      ) {
         logger.warn(
-          { reconciled: result.reconciled },
+          {
+            reconciled: result.reconciled,
+            adopted: result.adopted,
+            stopped: result.stopped,
+            // Managed HTTP-only services taken down so they come back on a
+            // verified HTTPS origin (PAP-17158).
+            httpsBackfilled: result.backfilled,
+            restarted: result.restarted,
+            restartFailed: result.restartFailed,
+          },
           "reconciled persisted runtime services from a previous server process",
         );
       }

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -12,11 +12,17 @@ import {
 } from "@paperclipai/shared";
 import type { WorkspaceRuntimeDesiredState, WorkspaceRuntimeServiceStateMap } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
-import { accessService, executionWorkspaceService, heartbeatService, logActivity, workspaceOperationService } from "../services/index.js";
 import {
-  mergeExecutionWorkspaceConfig,
-  readExecutionWorkspaceConfig,
-} from "../services/execution-workspaces.js";
+  accessService,
+  executionWorkspaceService,
+  heartbeatService,
+  logActivity,
+  workspaceOperationService,
+  workspaceRuntimeLeaseService,
+  LEASED_WORKSPACE_RUNTIME_ACTIONS,
+  type WorkspaceRuntimeLeaseClaim,
+} from "../services/index.js";
+import { mergeExecutionWorkspaceConfig, readExecutionWorkspaceConfig } from "../services/execution-workspaces.js";
 import { parseProjectExecutionWorkspacePolicy } from "../services/execution-workspace-policy.js";
 import { readProjectWorkspaceRuntimeConfig } from "../services/project-workspace-runtime-config.js";
 import {
@@ -38,6 +44,7 @@ import { assertCanManageExecutionWorkspaceRuntimeServices } from "./workspace-ru
 import { appendWithCap } from "../adapters/utils.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { runExclusiveWorkspaceRuntimeControl } from "../services/workspace-operations.js";
 
 const WORKSPACE_CONTROL_OUTPUT_MAX_CHARS = 256 * 1024;
 
@@ -46,6 +53,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
   const svc = executionWorkspaceService(db);
   const access = accessService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
+  const runtimeLeases = workspaceRuntimeLeaseService(db);
   const heartbeat = heartbeatService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
@@ -152,10 +160,18 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     if (!existing) return;
     if (!(await assertRuntimeManageAllowed(req, res, existing.companyId))) return;
 
-    await assertCanManageExecutionWorkspaceRuntimeServices(db, req, {
+    const authorization = await assertCanManageExecutionWorkspaceRuntimeServices(db, req, {
       companyId: existing.companyId,
       executionWorkspaceId: existing.id,
       sourceIssueId: existing.sourceIssueId,
+    });
+
+    // Recover any managed runtime-control operation this workspace was stranded with, then
+    // refuse only if one is genuinely still live. Authorization above still gates the caller,
+    // so recovery never widens who may control the workspace.
+    await workspaceOperationsSvc.assertRuntimeControlAvailable({
+      executionWorkspaceId: existing.id,
+      action,
     });
 
     const workspaceCwd = existing.cwd;
@@ -260,7 +276,57 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     let stdout = "";
     let stderr = "";
 
-    const operation = await recorder.recordOperation({
+    /**
+     * Bring runtime rows, local listeners and the recorded desired state back to a consistent
+     * stopped shape after a start failed part-way. Best-effort by design: the operation is
+     * still failed (terminal) even if teardown itself cannot complete, and every step is
+     * something a normal managed `stop` would do, so authorization is unchanged.
+     */
+    let failedStartReconciled = false;
+    async function reconcileFailedRuntimeStart(cause: unknown) {
+      if (failedStartReconciled) return;
+      failedStartReconciled = true;
+      try {
+        await stopRuntimeServicesForExecutionWorkspace({
+          db,
+          executionWorkspaceId: existing!.id,
+          workspaceCwd: workspaceCwd!,
+          runtimeServiceId: selectedRuntimeServiceId,
+        });
+      } catch (teardownError) {
+        logger.warn(
+          {
+            executionWorkspaceId: existing!.id,
+            err: teardownError,
+            cause: cause instanceof Error ? cause.message : String(cause),
+          },
+          "failed to tear down runtime services after a failed managed start",
+        );
+      }
+
+      try {
+        const failedDesiredState = buildWorkspaceRuntimeDesiredStatePatch({
+          config: { workspaceRuntime: effectiveRuntimeConfig },
+          currentDesiredState: existing!.config?.desiredState ?? null,
+          currentServiceStates: existing!.config?.serviceStates ?? null,
+          action: "stop",
+          serviceIndex: selectedServiceIndex,
+        });
+        await svc.update(existing!.id, {
+          metadata: mergeExecutionWorkspaceConfig(existing!.metadata as Record<string, unknown> | null, {
+            desiredState: failedDesiredState.desiredState,
+            serviceStates: failedDesiredState.serviceStates,
+          }),
+        });
+      } catch (patchError) {
+        logger.warn(
+          { executionWorkspaceId: existing!.id, err: patchError },
+          "failed to record the stopped desired state after a failed managed start",
+        );
+      }
+    }
+
+    const recordRuntimeControlOperation = () => recorder.recordOperation({
       phase: action === "stop" ? "workspace_teardown" : "workspace_provision",
       command: workspaceCommand?.command ?? `workspace command ${action}`,
       cwd: existing.cwd,
@@ -377,34 +443,43 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
           if (!availableWorkspace) {
             throw new Error("Execution workspace needs a local path before Paperclip can manage local runtime services");
           }
-          const startedServices = await startRuntimeServicesForWorkspaceControl({
-            db,
-            actor: {
-              id: actor.agentId ?? null,
-              name: actor.actorType === "user" ? "Board" : "Agent",
-              companyId: existing.companyId,
-            },
-            issue: existing.sourceIssueId
-              ? {
-                  id: existing.sourceIssueId,
-                  identifier: null,
-                  title: existing.name,
-                }
-              : null,
-            workspace: availableWorkspace,
-            executionWorkspaceId: existing.id,
-            config: {
-              workspaceRuntime: effectiveRuntimeConfig,
-              runtimeProvisionCommand:
-                existing.config?.runtimeProvisionCommand
-                ?? projectPolicy?.workspaceStrategy?.runtimeProvisionCommand
-                ?? null,
-            },
-            adapterEnv: {},
-            onLog,
-            recorder,
-            serviceIndex: selectedServiceIndex,
-          });
+          let startedServices;
+          try {
+            startedServices = await startRuntimeServicesForWorkspaceControl({
+              db,
+              actor: {
+                id: actor.agentId ?? null,
+                name: actor.actorType === "user" ? "Board" : "Agent",
+                companyId: existing.companyId,
+              },
+              issue: existing.sourceIssueId
+                ? {
+                    id: existing.sourceIssueId,
+                    identifier: null,
+                    title: existing.name,
+                  }
+                : null,
+              workspace: availableWorkspace,
+              executionWorkspaceId: existing.id,
+              config: {
+                workspaceRuntime: effectiveRuntimeConfig,
+                runtimeProvisionCommand:
+                  existing.config?.runtimeProvisionCommand
+                  ?? projectPolicy?.workspaceStrategy?.runtimeProvisionCommand
+                  ?? null,
+              },
+              adapterEnv: {},
+              onLog,
+              recorder,
+              serviceIndex: selectedServiceIndex,
+            });
+          } catch (error) {
+            // A failed start must leave the workspace stopped and retryable rather than
+            // "desired running" with a half-started listener: tear down residue and record
+            // the stopped desired state before the operation is marked failed.
+            await reconcileFailedRuntimeStart(error);
+            throw error;
+          }
           runtimeServiceCount = startedServices.length;
         } else {
           runtimeServiceCount = selectedRuntimeServiceId ? Math.max(0, (existing.runtimeServices?.length ?? 1) - 1) : 0;
@@ -458,6 +533,44 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
       },
     });
 
+    const { operation, leaseClaim } = await runExclusiveWorkspaceRuntimeControl({
+      executionWorkspaceId: existing.id,
+      action,
+      run: async () => {
+        // Claim the durable exclusivity lease before anything mutates the workspace or
+        // its runtime services. A competing issue/run throws 409 here, leaving no
+        // workspace operation row and no runtime-service change behind.
+        let leaseClaimResult: WorkspaceRuntimeLeaseClaim | null = null;
+        if (LEASED_WORKSPACE_RUNTIME_ACTIONS.includes(action)) {
+          leaseClaimResult = await runtimeLeases.claim({
+            companyId: existing.companyId,
+            executionWorkspaceId: existing.id,
+            action,
+            owner: authorization,
+          });
+        }
+        // Re-check inside the claim: recovery of stranded operations plus a refusal if one
+        // is genuinely still live. The same assertion ran before the lease was taken, but a
+        // row can be stranded in that window, and only the recovering path may proceed.
+        await workspaceOperationsSvc.assertRuntimeControlAvailable({
+          executionWorkspaceId: existing.id,
+          action,
+        });
+        try {
+          return {
+            operation: await recordRuntimeControlOperation(),
+            leaseClaim: leaseClaimResult,
+          };
+        } catch (error) {
+          // The operation is already terminal here. This also catches the recorder's own time
+          // budget expiring on a start that never settles, which is the one failure the inner
+          // handler cannot see — reconcile there too so no listener or desired state is left over.
+          if (action === "start" || action === "restart") await reconcileFailedRuntimeStart(error);
+          throw error;
+        }
+      },
+    });
+
     const workspace = await svc.getById(id);
     if (!workspace) {
       res.status(404).json({ error: "Execution workspace not found" });
@@ -481,6 +594,13 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         workspaceCommandName: workspaceCommand?.name ?? null,
         runtimeServiceId: selectedRuntimeServiceId,
         serviceIndex: selectedServiceIndex,
+        runtimeLease: leaseClaim
+          ? {
+              outcome: leaseClaim.outcome,
+              ownerKey: leaseClaim.ownerKey,
+              reclaimedFrom: leaseClaim.reclaimedFrom,
+            }
+          : null,
       },
     });
 
@@ -664,6 +784,10 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
       }
       workspace = archiveResult.workspace;
       const capturedGeneration = archiveResult.capturedGeneration;
+
+      // Closing the workspace ends the lane, so the runtime-control lease is released
+      // outright rather than waiting for owner-eligibility or TTL recovery.
+      await runtimeLeases.release({ executionWorkspaceId: existing.id, force: true });
 
       if (existing.mode === "shared_workspace") {
         await db

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5543,6 +5543,7 @@ export function issueRoutes(
       startedAt: service.startedAt,
       stoppedAt: service.stoppedAt,
       healthStatus: service.healthStatus,
+      exposure: service.exposure ?? null,
       configIndex: service.configIndex ?? null,
     };
   }

--- a/server/src/routes/workspace-runtime-service-authz.ts
+++ b/server/src/routes/workspace-runtime-service-authz.ts
@@ -8,15 +8,21 @@ import { assertCompanyAccess, hasCompanyAccess } from "./authz.js";
 import { parseProjectExecutionWorkspacePolicy } from "../services/execution-workspace-policy.js";
 import { isLowTrustRuntimeManagementAllowed } from "../services/low-trust-runtime-containment.js";
 import { resolveCoreTrustPreset, type TrustPresetResolution } from "../services/trust-preset-resolver.js";
+import { WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES } from "../services/workspace-runtime-leases.js";
 import { readObject } from "../lib/objects.js";
 
-const WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES: string[] = [
-  "backlog",
-  "todo",
-  "in_progress",
-  "in_review",
-  "blocked",
-];
+const WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUS_LIST: string[] = [...WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES];
+
+/**
+ * Identity of the actor authorized to drive a workspace runtime control, resolved once
+ * so the durable runtime lease and the authorization decision agree on who is calling.
+ */
+export type WorkspaceRuntimeControlAuthorization = {
+  actorType: string;
+  agentId: string | null;
+  runId: string | null;
+  issueId: string | null;
+};
 
 function readRunIssueId(context: Record<string, unknown> | null) {
   const directIssueId = context?.issueId;
@@ -68,7 +74,7 @@ async function assertAgentCanManageRuntimeServicesForWorkspace(
     executionWorkspaceId?: string | null;
     sourceIssueId?: string | null;
   },
-) {
+): Promise<{ runIssueId: string | null }> {
   if (req.actor.type !== "agent" || !req.actor.agentId) {
     throw forbidden("Agent authentication required");
   }
@@ -112,11 +118,12 @@ async function assertAgentCanManageRuntimeServicesForWorkspace(
     runExecutionPolicy,
   });
 
+  const runIssueId = readRunIssueId(runContext);
+
   if (actorAgent.role === "ceo" && actorRuntimeTrust.kind === "standard") {
-    return;
+    return { runIssueId };
   }
 
-  const runIssueId = readRunIssueId(runContext);
   const runScopedIssue = runIssueId
     ? await db
         .select({
@@ -171,7 +178,7 @@ async function assertAgentCanManageRuntimeServicesForWorkspace(
     .where(and(
       eq(issues.companyId, input.companyId),
       isNull(issues.hiddenAt),
-      inArray(issues.status, WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES),
+      inArray(issues.status, WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUS_LIST),
       workspaceScopeCondition,
     ));
 
@@ -185,7 +192,7 @@ async function assertAgentCanManageRuntimeServicesForWorkspace(
   }
 
   if (actorAgent.role === "ceo") {
-    return;
+    return { runIssueId };
   }
 
   const eligibleAgentIds = await listReportingSubtreeAgentIds(db, input.companyId, actorAgent.id);
@@ -202,7 +209,7 @@ async function assertAgentCanManageRuntimeServicesForWorkspace(
     .where(and(
       eq(issues.companyId, input.companyId),
       isNull(issues.hiddenAt),
-      inArray(issues.status, WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES),
+      inArray(issues.status, WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUS_LIST),
       inArray(issues.assigneeAgentId, eligibleAgentIds),
       workspaceScopeCondition,
     ))
@@ -215,7 +222,7 @@ async function assertAgentCanManageRuntimeServicesForWorkspace(
       projectExecutionWorkspacePolicy: linkedIssue.projectExecutionWorkspacePolicy,
       runExecutionPolicy,
     });
-    return;
+    return { runIssueId };
   }
 
   throw forbidden("Missing permission to manage workspace runtime services");
@@ -321,11 +328,19 @@ export async function assertCanManageExecutionWorkspaceRuntimeServices(
     executionWorkspaceId: string;
     sourceIssueId?: string | null;
   },
-) {
+): Promise<WorkspaceRuntimeControlAuthorization> {
   if (!hasCompanyAccess(req, input.companyId)) {
     throw notFound("Execution workspace not found");
   }
   assertCompanyAccess(req, input.companyId);
-  if (req.actor.type === "board") return;
-  await assertAgentCanManageRuntimeServicesForWorkspace(db, req, input);
+  if (req.actor.type === "board") {
+    return { actorType: "board", agentId: null, runId: null, issueId: null };
+  }
+  const { runIssueId } = await assertAgentCanManageRuntimeServicesForWorkspace(db, req, input);
+  return {
+    actorType: req.actor.type,
+    agentId: req.actor.agentId ?? null,
+    runId: req.actor.runId ?? null,
+    issueId: runIssueId,
+  };
 }

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -981,6 +981,7 @@ function toRuntimeService(
     stoppedAt: row.stoppedAt ?? null,
     stopPolicy: (row.stopPolicy as Record<string, unknown> | null) ?? null,
     healthStatus: row.healthStatus as WorkspaceRuntimeService["healthStatus"],
+    exposure: (row.exposure as WorkspaceRuntimeService["exposure"]) ?? null,
     configIndex: row.configIndex ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -1059,6 +1060,7 @@ function toWorkspaceOverviewPrimaryService(
     url: service.url,
     port: service.port,
     healthStatus: service.healthStatus,
+    exposure: service.exposure ?? null,
     updatedAt: service.updatedAt,
   };
 }

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -158,6 +158,16 @@ export {
 } from "./environment-custom-image-terminal-sessions.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
+export {
+  workspaceRuntimeLeaseService,
+  buildWorkspaceRuntimeLeaseOwnerKey,
+  LEASED_WORKSPACE_RUNTIME_ACTIONS,
+  WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES,
+  WORKSPACE_RUNTIME_LEASE_TTL_MS,
+  type WorkspaceRuntimeLeaseClaim,
+  type WorkspaceRuntimeLeaseOwner,
+  type WorkspaceRuntimeLeaseService,
+} from "./workspace-runtime-leases.js";
 export { workspaceFileResourceService } from "./workspace-file-resources.js";
 export { workProductService } from "./work-products.js";
 export {

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -285,7 +285,7 @@ export async function findAdoptableLocalService(input: {
   return record;
 }
 
-async function readProcessGroupId(pid: number) {
+export async function readLocalServiceProcessGroupId(pid: number) {
   if (process.platform === "win32") return null;
   try {
     const { stdout } = await execFileAsync("ps", ["-o", "pgid=", "-p", String(pid)]);
@@ -293,6 +293,39 @@ async function readProcessGroupId(pid: number) {
     return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
   } catch {
     return null;
+  }
+}
+
+export async function isLocalServiceProcessOwnedBy(pid: number, ownerProcessId: number) {
+  if (pid === ownerProcessId) return true;
+  if (process.platform !== "win32") {
+    return (await readLocalServiceProcessGroupId(pid)) === ownerProcessId;
+  }
+
+  try {
+    const script = [
+      `$currentProcessId = ${pid}`,
+      "while ($currentProcessId -gt 0) {",
+      "  $process = Get-CimInstance Win32_Process -Filter \"ProcessId = $currentProcessId\" -ErrorAction SilentlyContinue",
+      "  if ($null -eq $process) { break }",
+      "  $parentProcessId = [int]$process.ParentProcessId",
+      "  Write-Output $parentProcessId",
+      "  if ($parentProcessId -eq $currentProcessId) { break }",
+      "  $currentProcessId = $parentProcessId",
+      "}",
+    ].join("\n");
+    const { stdout } = await execFileAsync("powershell.exe", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      script,
+    ]);
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .some((ancestorPid) => ancestorPid === ownerProcessId);
+  } catch {
+    return false;
   }
 }
 
@@ -317,7 +350,7 @@ async function adoptLocalServiceFromPortOwner(input: {
     }
   }
 
-  const processGroupId = await readProcessGroupId(ownerPid);
+  const processGroupId = await readLocalServiceProcessGroupId(ownerPid);
   const pid = processGroupId && isPidAlive(processGroupId) ? processGroupId : ownerPid;
   const now = new Date().toISOString();
   const record: LocalServiceRegistryRecord = {
@@ -405,8 +438,24 @@ export async function terminateLocalService(
 }
 
 export async function readLocalServicePortOwner(port: number) {
-  if (!Number.isInteger(port) || port <= 0 || process.platform === "win32") return null;
+  if (!Number.isInteger(port) || port <= 0) return null;
   try {
+    if (process.platform === "win32") {
+      const { stdout } = await execFileAsync("netstat", ["-ano", "-p", "tcp"]);
+      for (const line of stdout.split(/\r?\n/)) {
+        const columns = line.trim().split(/\s+/);
+        if (columns.length < 5 || columns[0]?.toUpperCase() !== "TCP") continue;
+        const localAddress = columns[1] ?? "";
+        const separatorIndex = localAddress.lastIndexOf(":");
+        const localPort = Number.parseInt(localAddress.slice(separatorIndex + 1), 10);
+        const state = columns.at(-2)?.toUpperCase();
+        const pid = Number.parseInt(columns.at(-1) ?? "", 10);
+        if (localPort === port && state === "LISTENING" && Number.isInteger(pid) && pid > 0) {
+          return pid;
+        }
+      }
+      return null;
+    }
     const { stdout } = await execFileAsync("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"]);
     const firstPid = stdout
       .split("\n")

--- a/server/src/services/runtime-exposure/broker-client.test.ts
+++ b/server/src/services/runtime-exposure/broker-client.test.ts
@@ -1,0 +1,196 @@
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { existsSync, unlinkSync } from "node:fs";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BrokerClientError, UnixBrokerClient } from "./broker-client.js";
+
+const LENGTH_PREFIX_BYTES = 4;
+
+/**
+ * Minimal in-process broker that speaks the exact `[4-byte BE length][json]`
+ * framing of the real socket server, so these tests exercise the client's
+ * framing + parsing without linking the host-privileged broker package.
+ */
+function startFakeBroker(
+  handler: (request: Record<string, unknown>) => unknown,
+): { socketPath: string; server: net.Server } {
+  const socketPath = path.join(os.tmpdir(), `tsh-broker-${randomUUID()}.sock`);
+  const server = net.createServer((socket) => {
+    const chunks: Buffer[] = [];
+    let expected = -1;
+    socket.on("data", (chunk) => {
+      chunks.push(chunk);
+      const buf = Buffer.concat(chunks);
+      if (expected < 0) {
+        if (buf.byteLength < LENGTH_PREFIX_BYTES) return;
+        expected = buf.readUInt32BE(0);
+      }
+      if (buf.byteLength < LENGTH_PREFIX_BYTES + expected) return;
+      const body = buf.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + expected).toString("utf8");
+      const request = JSON.parse(body) as Record<string, unknown>;
+      const response = handler(request);
+      const respBody = Buffer.from(JSON.stringify(response), "utf8");
+      const frame = Buffer.allocUnsafe(LENGTH_PREFIX_BYTES + respBody.byteLength);
+      frame.writeUInt32BE(respBody.byteLength, 0);
+      respBody.copy(frame, LENGTH_PREFIX_BYTES);
+      socket.end(frame);
+    });
+  });
+  server.listen(socketPath);
+  return { socketPath, server };
+}
+
+const servers: net.Server[] = [];
+const sockets: string[] = [];
+
+function fake(handler: (request: Record<string, unknown>) => unknown): string {
+  const { socketPath, server } = startFakeBroker(handler);
+  servers.push(server);
+  sockets.push(socketPath);
+  return socketPath;
+}
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  for (const socketPath of sockets.splice(0)) {
+    if (existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+});
+
+const RUNTIME_ID = "11111111-2222-4333-8444-555566667777";
+
+describe("UnixBrokerClient", () => {
+  it("round-trips reservation and expose requests", async () => {
+    let seen: Record<string, unknown> | undefined;
+    const socketPath = fake((request) => {
+      seen = request;
+      if (request.op === "reserve") {
+        return { ok: true, op: "reserve", requestId: request.requestId, handle: "h".repeat(20), reservedPorts: [42000, 52000] };
+      }
+      return { ok: true, op: "expose", requestId: request.requestId, handle: "h".repeat(20), publicPorts: [42000, 52000] };
+    });
+    const client = new UnixBrokerClient({ socketPath });
+    const reserved = await client.reserve(RUNTIME_ID, [
+      { purpose: "app", port: 42000 },
+      { purpose: "vite_hmr", port: 52000 },
+    ]);
+    expect(reserved).toEqual({ handle: "h".repeat(20), reservedPorts: [42000, 52000] });
+    const result = await client.expose(RUNTIME_ID, reserved.handle);
+    expect(result).toEqual({ handle: "h".repeat(20), publicPorts: [42000, 52000] });
+    expect(seen).toMatchObject({
+      v: 1,
+      op: "expose",
+      runtimeId: RUNTIME_ID,
+      handle: "h".repeat(20),
+    });
+    expect(typeof seen?.requestId).toBe("string");
+  });
+
+  it("parses a remove response", async () => {
+    const socketPath = fake((request) => ({
+      ok: true,
+      op: "remove",
+      requestId: request.requestId,
+      removedPorts: [42000],
+    }));
+    const client = new UnixBrokerClient({ socketPath });
+    const result = await client.remove(RUNTIME_ID, "h".repeat(20));
+    expect(result.removedPorts).toEqual([42000]);
+  });
+
+  it("parses a list response into owned listeners", async () => {
+    const socketPath = fake((request) => ({
+      ok: true,
+      op: "list",
+      requestId: request.requestId,
+      listeners: [{ runtimeId: RUNTIME_ID, port: 42000, purpose: "app" }],
+    }));
+    const client = new UnixBrokerClient({ socketPath });
+    const listeners = await client.list();
+    expect(listeners).toEqual([{ runtimeId: RUNTIME_ID, port: 42000, purpose: "app" }]);
+  });
+
+  it("surfaces a broker error response as a coded BrokerClientError", async () => {
+    const socketPath = fake((request) => ({
+      ok: false,
+      requestId: request.requestId,
+      code: "port_not_allowlisted",
+      message: "denied",
+    }));
+    const client = new UnixBrokerClient({ socketPath });
+    await expect(client.reserve(RUNTIME_ID, [{ purpose: "app", port: 42000 }])).rejects.toMatchObject({
+      name: "BrokerClientError",
+      code: "port_not_allowlisted",
+    });
+  });
+
+  it("rejects a malformed (non-ok) response shape", async () => {
+    const socketPath = fake(() => ({ surprise: true }));
+    const client = new UnixBrokerClient({ socketPath });
+    await expect(client.list()).rejects.toBeInstanceOf(BrokerClientError);
+  });
+
+  it("rejects an expose response missing publicPorts", async () => {
+    const socketPath = fake((request) => ({ ok: true, op: "expose", requestId: request.requestId, handle: "h".repeat(20) }));
+    const client = new UnixBrokerClient({ socketPath });
+    await expect(client.expose(RUNTIME_ID, "h".repeat(20))).rejects.toMatchObject({
+      code: "malformed_response",
+    });
+  });
+
+  it("times out when the broker accepts but never responds", async () => {
+    await expect(silentTimeout()).resolves.toBe(true);
+  });
+
+  it("errors when the socket path does not exist (transport error)", async () => {
+    const client = new UnixBrokerClient({
+      socketPath: path.join(os.tmpdir(), `missing-${randomUUID()}.sock`),
+      timeoutMs: 500,
+    });
+    await expect(client.list()).rejects.toMatchObject({ code: "transport_error" });
+  });
+});
+
+/** Build a truly-silent broker and assert the client times out against it. */
+async function silentTimeout(): Promise<boolean> {
+  const socketPath = path.join(os.tmpdir(), `silent-${randomUUID()}.sock`);
+  const connections: net.Socket[] = [];
+  const server = net.createServer((socket) => {
+    // Accept, never respond. Swallow the abortive close the client sends when
+    // it times out so the connection socket does not emit an unhandled error.
+    socket.on("error", () => {});
+    connections.push(socket);
+  });
+  await new Promise<void>((resolve) => server.listen(socketPath, () => resolve()));
+  try {
+    const client = new UnixBrokerClient({ socketPath, timeoutMs: 150 });
+    try {
+      await client.list();
+      return false;
+    } catch (error) {
+      return error instanceof BrokerClientError && error.code === "cli_timeout";
+    }
+  } finally {
+    for (const socket of connections) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/server/src/services/runtime-exposure/broker-client.ts
+++ b/server/src/services/runtime-exposure/broker-client.ts
@@ -1,0 +1,292 @@
+/**
+ * Server-side client for the least-privilege Tailscale HTTPS host broker.
+ *
+ * The Paperclip server process holds NO Tailscale operator authority. Its only
+ * way to publish a same-number HTTPS-to-loopback listener is to ask the broker
+ * over its Unix domain socket. This client speaks the exact versioned,
+ * length-prefixed, byte-bounded wire protocol implemented by the broker's
+ * socket server (PAP-17049 plan, PAP-17050 verdict requirement #5).
+ *
+ * Framing (must match `packages/tailscale-https-broker/src/socket-server.ts`):
+ *   [4-byte big-endian body length][utf-8 JSON body]
+ * One request per connection; the broker writes a single framed response and
+ * closes the socket.
+ *
+ * Everything the broker returns is untrusted: the client validates the response
+ * shape before handing it back and never logs lease handles.
+ */
+import net from "node:net";
+
+/**
+ * Must match the broker's `BROKER_PROTOCOL_VERSION`. Kept as a local constant
+ * (rather than a dependency on the host-side broker package, which is installed
+ * and versioned separately under its own operator account) so the server does
+ * not import host-privileged code just to speak the wire protocol.
+ */
+const BROKER_PROTOCOL_VERSION = 1;
+
+/** Must match the broker's `MAX_REQUEST_BYTES` (8 KiB). */
+const MAX_REQUEST_BYTES = 8 * 1024;
+/** Must match the broker's `MAX_RESPONSE_BYTES` (16 KiB). */
+const MAX_RESPONSE_BYTES = 16 * 1024;
+const LENGTH_PREFIX_BYTES = 4;
+
+/** Listener purposes the broker understands. */
+export type BrokerListenerPurpose = "app" | "vite_hmr";
+
+export interface BrokerListenerRequest {
+  purpose: BrokerListenerPurpose;
+  /** Public HTTPS port == loopback target port (same-number invariant). */
+  port: number;
+}
+
+export interface BrokerExposeResult {
+  handle: string;
+  publicPorts: number[];
+}
+
+export interface BrokerReserveResult {
+  handle: string;
+  reservedPorts: number[];
+}
+
+export interface BrokerRemoveResult {
+  removedPorts: number[];
+}
+
+export interface BrokerOwnedListener {
+  runtimeId: string;
+  port: number;
+  purpose: BrokerListenerPurpose;
+}
+
+/**
+ * Error surfaced to the exposure manager. `code` is the broker's stable machine
+ * code (or a transport-level code) so lifecycle logic can branch without
+ * string-matching human messages.
+ */
+export class BrokerClientError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "BrokerClientError";
+  }
+}
+
+/**
+ * Minimal broker capability surface the exposure manager depends on. Defining
+ * it as an interface lets tests inject a fake broker with zero sockets.
+ */
+export interface BrokerClient {
+  reserve(runtimeId: string, listeners: BrokerListenerRequest[]): Promise<BrokerReserveResult>;
+  expose(runtimeId: string, handle: string): Promise<BrokerExposeResult>;
+  remove(runtimeId: string, handle: string): Promise<BrokerRemoveResult>;
+  list(): Promise<BrokerOwnedListener[]>;
+}
+
+export interface UnixBrokerClientOptions {
+  socketPath: string;
+  /** Per-request connect+round-trip deadline. Defaults to 5s. */
+  timeoutMs?: number;
+  /**
+   * Seam for tests: open a duplex stream to the broker. Defaults to a real Unix
+   * socket connection. Any injected connector must behave like a `net.Socket`.
+   */
+  connect?: (socketPath: string) => net.Socket;
+}
+
+let requestCounter = 0;
+
+function nextRequestId(): string {
+  requestCounter = (requestCounter + 1) % 1_000_000;
+  // Matches the broker's REQUEST_ID_RE (`[A-Za-z0-9_-]{1,64}`). No time/random
+  // needed for correctness; the broker keys responses by requestId echo only.
+  return `req-${requestCounter.toString(36)}`;
+}
+
+/**
+ * Unix-domain-socket implementation of {@link BrokerClient}. Each call opens a
+ * fresh connection, sends one length-prefixed frame, reads one length-prefixed
+ * response frame, and closes.
+ */
+export class UnixBrokerClient implements BrokerClient {
+  private readonly socketPath: string;
+  private readonly timeoutMs: number;
+  private readonly connect: (socketPath: string) => net.Socket;
+
+  constructor(options: UnixBrokerClientOptions) {
+    this.socketPath = options.socketPath;
+    this.timeoutMs = options.timeoutMs ?? 5_000;
+    this.connect = options.connect ?? ((p) => net.createConnection(p));
+  }
+
+  async reserve(
+    runtimeId: string,
+    listeners: BrokerListenerRequest[],
+  ): Promise<BrokerReserveResult> {
+    const response = await this.roundTrip({
+      v: BROKER_PROTOCOL_VERSION,
+      op: "reserve",
+      requestId: nextRequestId(),
+      runtimeId,
+      listeners: listeners.map((l) => ({ purpose: l.purpose, port: l.port })),
+    });
+    if (
+      typeof response.handle !== "string" ||
+      !Array.isArray(response.reservedPorts) ||
+      !response.reservedPorts.every((p) => Number.isInteger(p))
+    ) {
+      throw new BrokerClientError("malformed_response", "reserve response missing handle/reservedPorts");
+    }
+    return { handle: response.handle, reservedPorts: response.reservedPorts as number[] };
+  }
+
+  async expose(runtimeId: string, handle: string): Promise<BrokerExposeResult> {
+    const response = await this.roundTrip({
+      v: BROKER_PROTOCOL_VERSION,
+      op: "expose",
+      requestId: nextRequestId(),
+      runtimeId,
+      handle,
+    });
+    if (
+      typeof response.handle !== "string" ||
+      !Array.isArray(response.publicPorts) ||
+      !response.publicPorts.every((p) => Number.isInteger(p))
+    ) {
+      throw new BrokerClientError("malformed_response", "expose response missing handle/publicPorts");
+    }
+    return { handle: response.handle, publicPorts: response.publicPorts as number[] };
+  }
+
+  async remove(runtimeId: string, handle: string): Promise<BrokerRemoveResult> {
+    const response = await this.roundTrip({
+      v: BROKER_PROTOCOL_VERSION,
+      op: "remove",
+      requestId: nextRequestId(),
+      runtimeId,
+      handle,
+    });
+    if (!Array.isArray(response.removedPorts) || !response.removedPorts.every((p) => Number.isInteger(p))) {
+      throw new BrokerClientError("malformed_response", "remove response missing removedPorts");
+    }
+    return { removedPorts: response.removedPorts as number[] };
+  }
+
+  async list(): Promise<BrokerOwnedListener[]> {
+    const response = await this.roundTrip({
+      v: BROKER_PROTOCOL_VERSION,
+      op: "list",
+      requestId: nextRequestId(),
+    });
+    if (!Array.isArray(response.listeners)) {
+      throw new BrokerClientError("malformed_response", "list response missing listeners");
+    }
+    return response.listeners.map((entry): BrokerOwnedListener => {
+      const listener = entry as Record<string, unknown>;
+      if (
+        typeof listener.runtimeId !== "string" ||
+        !Number.isInteger(listener.port) ||
+        (listener.purpose !== "app" && listener.purpose !== "vite_hmr")
+      ) {
+        throw new BrokerClientError("malformed_response", "list returned a malformed listener");
+      }
+      return {
+        runtimeId: listener.runtimeId,
+        port: listener.port as number,
+        purpose: listener.purpose,
+      };
+    });
+  }
+
+  /** Send one request frame, resolve the single framed response as an object. */
+  private roundTrip(request: unknown): Promise<Record<string, unknown>> {
+    const body = Buffer.from(JSON.stringify(request), "utf8");
+    if (body.byteLength > MAX_REQUEST_BYTES) {
+      return Promise.reject(new BrokerClientError("request_too_large", "broker request exceeds size limit"));
+    }
+    const frame = Buffer.allocUnsafe(LENGTH_PREFIX_BYTES + body.byteLength);
+    frame.writeUInt32BE(body.byteLength, 0);
+    body.copy(frame, LENGTH_PREFIX_BYTES);
+
+    return new Promise((resolve, reject) => {
+      const socket = this.connect(this.socketPath);
+      const chunks: Buffer[] = [];
+      let received = 0;
+      let expected = -1;
+      let settled = false;
+
+      const done = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        socket.removeAllListeners();
+        socket.destroy();
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        done(() => reject(new BrokerClientError("cli_timeout", "broker request timed out")));
+      }, this.timeoutMs);
+      timer.unref?.();
+
+      socket.on("error", (err: Error) => {
+        done(() => reject(new BrokerClientError("transport_error", err.message)));
+      });
+
+      socket.on("close", () => {
+        // Closed before a full response was parsed.
+        done(() => reject(new BrokerClientError("transport_error", "broker closed connection early")));
+      });
+
+      socket.on("data", (chunk: Buffer) => {
+        received += chunk.byteLength;
+        if (received > LENGTH_PREFIX_BYTES + MAX_RESPONSE_BYTES) {
+          done(() => reject(new BrokerClientError("malformed_response", "broker response exceeds size limit")));
+          return;
+        }
+        chunks.push(chunk);
+        const buf = Buffer.concat(chunks);
+        if (expected < 0) {
+          if (buf.byteLength < LENGTH_PREFIX_BYTES) return;
+          expected = buf.readUInt32BE(0);
+          if (expected > MAX_RESPONSE_BYTES) {
+            done(() => reject(new BrokerClientError("malformed_response", "broker response length invalid")));
+            return;
+          }
+        }
+        if (buf.byteLength < LENGTH_PREFIX_BYTES + expected) return;
+        const payload = buf.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + expected).toString("utf8");
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(payload);
+        } catch {
+          done(() => reject(new BrokerClientError("malformed_response", "broker response is not valid JSON")));
+          return;
+        }
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          done(() => reject(new BrokerClientError("malformed_response", "broker response is not an object")));
+          return;
+        }
+        const obj = parsed as Record<string, unknown>;
+        if (obj.ok === false) {
+          const code = typeof obj.code === "string" ? obj.code : "internal_error";
+          const message = typeof obj.message === "string" ? obj.message : code;
+          done(() => reject(new BrokerClientError(code, message)));
+          return;
+        }
+        if (obj.ok !== true) {
+          done(() => reject(new BrokerClientError("malformed_response", "broker response missing ok flag")));
+          return;
+        }
+        done(() => resolve(obj));
+      });
+
+      socket.on("connect", () => {
+        socket.write(frame);
+      });
+    });
+  }
+}

--- a/server/src/services/runtime-exposure/exposure-manager.test.ts
+++ b/server/src/services/runtime-exposure/exposure-manager.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from "vitest";
+
+import { RUNTIME_EXPOSURE_APP_PORT_MIN, deriveViteHmrPort } from "@paperclipai/shared";
+
+import {
+  BrokerClientError,
+  type BrokerClient,
+  type BrokerExposeResult,
+  type BrokerListenerRequest,
+  type BrokerOwnedListener,
+  type BrokerReserveResult,
+  type BrokerRemoveResult,
+} from "./broker-client.js";
+import {
+  deprovisionExposure,
+  provisionExposure,
+  reconcileExposures,
+  reserveExposure,
+  type ExposureManagerDeps,
+} from "./exposure-manager.js";
+
+const RUNTIME_ID = "11111111-2222-4333-8444-555566667777";
+const APP_PORT = RUNTIME_EXPOSURE_APP_PORT_MIN;
+const HMR_PORT = deriveViteHmrPort(APP_PORT);
+const HOSTNAME = "runner-abc.tail-scale.ts.net";
+
+const CONFIG = {
+  type: "tailscale_https" as const,
+  hostname: "auto" as const,
+  publicPort: "same" as const,
+  includePaperclipViteHmr: true,
+  failurePolicy: "fail_closed" as const,
+};
+
+interface FakeBrokerScript {
+  reserve?: (runtimeId: string, listeners: BrokerListenerRequest[]) => BrokerReserveResult;
+  expose?: (runtimeId: string, handle: string) => BrokerExposeResult;
+  remove?: (runtimeId: string, handle: string) => BrokerRemoveResult;
+  list?: () => BrokerOwnedListener[];
+}
+
+interface FakeBrokerCalls {
+  reserve: Array<{ runtimeId: string; listeners: BrokerListenerRequest[] }>;
+  expose: Array<{ runtimeId: string; handle: string }>;
+  remove: Array<{ runtimeId: string; handle: string }>;
+  list: number;
+}
+
+function fakeBroker(script: FakeBrokerScript): { broker: BrokerClient; calls: FakeBrokerCalls } {
+  const calls: FakeBrokerCalls = { reserve: [], expose: [], remove: [], list: 0 };
+  const broker: BrokerClient = {
+    async reserve(runtimeId, listeners) {
+      calls.reserve.push({ runtimeId, listeners });
+      if (!script.reserve) throw new BrokerClientError("internal_error", "no reserve script");
+      return script.reserve(runtimeId, listeners);
+    },
+    async expose(runtimeId, handle) {
+      calls.expose.push({ runtimeId, handle });
+      if (!script.expose) throw new BrokerClientError("internal_error", "no expose script");
+      return script.expose(runtimeId, handle);
+    },
+    async remove(runtimeId, handle) {
+      calls.remove.push({ runtimeId, handle });
+      if (!script.remove) throw new BrokerClientError("internal_error", "no remove script");
+      return script.remove(runtimeId, handle);
+    },
+    async list() {
+      calls.list += 1;
+      return script.list ? script.list() : [];
+    },
+  };
+  return { broker, calls };
+}
+
+const HANDLE = "handle-abcdef1234567890";
+
+describe("reserveExposure", () => {
+  it("reserves the exact app + HMR pair before startup", async () => {
+    const { broker, calls } = fakeBroker({
+      reserve: () => ({ handle: HANDLE, reservedPorts: [APP_PORT, HMR_PORT] }),
+    });
+    const result = await reserveExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      appPort: APP_PORT,
+    });
+    expect(calls.reserve).toEqual([{
+      runtimeId: RUNTIME_ID,
+      listeners: [
+        { purpose: "app", port: APP_PORT },
+        { purpose: "vite_hmr", port: HMR_PORT },
+      ],
+    }]);
+    expect(result.handle).toBe(HANDLE);
+    expect(result.status.state).toBe("pending");
+  });
+
+  it("releases a malformed reservation response and fails closed", async () => {
+    const { broker, calls } = fakeBroker({
+      reserve: () => ({ handle: HANDLE, reservedPorts: [APP_PORT] }),
+      remove: () => ({ removedPorts: [] }),
+    });
+    const result = await reserveExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      appPort: APP_PORT,
+    });
+    expect(result.status.state).toBe("failed");
+    expect(result.handle).toBeNull();
+    expect(calls.remove).toEqual([{ runtimeId: RUNTIME_ID, handle: HANDLE }]);
+  });
+});
+
+function deps(broker: BrokerClient, probeHealth: () => Promise<boolean>): ExposureManagerDeps {
+  return { broker, probeHealth, now: () => "2026-08-11T00:00:00.000Z" };
+}
+
+describe("provisionExposure loopback diagnosis (PAP-17256)", () => {
+  it("fails before touching the broker when a listener is provably off-loopback", async () => {
+    const { broker, calls } = fakeBroker({
+      expose: () => ({ handle: HANDLE, publicPorts: [APP_PORT, HMR_PORT] }),
+    });
+    const seen: number[][] = [];
+    const result = await provisionExposure(
+      {
+        ...deps(broker, async () => true),
+        diagnoseListenerBinds: async (ports) => {
+          seen.push(ports);
+          return `port ${APP_PORT} is bound to 0.0.0.0 instead of loopback only`;
+        },
+      },
+      { runtimeId: RUNTIME_ID, config: CONFIG, handle: HANDLE, hostname: HOSTNAME, appPort: APP_PORT },
+    );
+
+    // Both the app port and its HMR companion are diagnosed, because the broker
+    // gates on both and either one can be the wildcard bind.
+    expect(seen).toEqual([[APP_PORT, HMR_PORT]]);
+    expect(calls.expose).toHaveLength(0);
+    expect(result.status.state).toBe("failed");
+    // The persisted code stays the broker's own vocabulary so retry/cleanup
+    // matching is unchanged; the reason rides alongside.
+    expect(result.status.lastError).toBe("listener_ownership_mismatch");
+    expect(result.errorDetail).toContain("0.0.0.0");
+    // The reservation handle survives so the caller can still tear the lease down.
+    expect(result.handle).toBe(HANDLE);
+  });
+
+  it("exposes normally when the diagnosis finds nothing wrong", async () => {
+    const { broker, calls } = fakeBroker({
+      expose: () => ({ handle: HANDLE, publicPorts: [APP_PORT, HMR_PORT] }),
+    });
+    const result = await provisionExposure(
+      { ...deps(broker, async () => true), diagnoseListenerBinds: async () => null },
+      { runtimeId: RUNTIME_ID, config: CONFIG, handle: HANDLE, hostname: HOSTNAME, appPort: APP_PORT },
+    );
+    expect(calls.expose).toHaveLength(1);
+    expect(result.status.state).toBe("ready");
+    expect(result.errorDetail ?? null).toBeNull();
+  });
+
+  it("surfaces the broker's own reason alongside its code", async () => {
+    const { broker } = fakeBroker({
+      expose: () => {
+        throw new BrokerClientError(
+          "listener_ownership_mismatch",
+          `listener on ${APP_PORT} is not loopback-only`,
+        );
+      },
+    });
+    const result = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+    expect(result.status.lastError).toBe("listener_ownership_mismatch");
+    expect(result.errorDetail).toBe(`listener on ${APP_PORT} is not loopback-only`);
+  });
+
+  it("does not repeat the code as a reason when the broker adds nothing", async () => {
+    const { broker } = fakeBroker({
+      expose: () => {
+        throw new BrokerClientError("cli_timeout", "cli_timeout");
+      },
+    });
+    const result = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+    expect(result.status.lastError).toBe("cli_timeout");
+    expect(result.errorDetail).toBeNull();
+  });
+});
+
+describe("provisionExposure", () => {
+  it("exposes app + HMR and reports ready once the HTTPS probe validates", async () => {
+    const { broker, calls } = fakeBroker({
+      expose: () => ({ handle: "handle-abcdef1234567890", publicPorts: [APP_PORT, HMR_PORT] }),
+    });
+    const { status, handle } = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+
+    expect(calls.expose).toHaveLength(1);
+    expect(calls.expose).toEqual([{ runtimeId: RUNTIME_ID, handle: HANDLE }]);
+    expect(status.state).toBe("ready");
+    expect(status.publicUrl).toBe(`https://${HOSTNAME}:${APP_PORT}`);
+    expect(status.hostname).toBe(HOSTNAME);
+    expect(status.listeners).toHaveLength(2);
+    expect(status.brokerRef).toBe(RUNTIME_ID);
+    expect(status.lastError).toBeNull();
+    expect(handle).toBe("handle-abcdef1234567890");
+  });
+
+  it("omits the HMR listener when HMR is not requested", async () => {
+    const { broker, calls } = fakeBroker({
+      expose: () => ({ handle: "handle-abcdef1234567890", publicPorts: [APP_PORT] }),
+    });
+    const { status } = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: { ...CONFIG, includePaperclipViteHmr: false },
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+    expect(calls.expose).toEqual([{ runtimeId: RUNTIME_ID, handle: HANDLE }]);
+    expect(status.listeners).toEqual([{ purpose: "app", publicPort: APP_PORT, targetPort: APP_PORT }]);
+    expect(status.state).toBe("ready");
+  });
+
+  it("fails closed without calling the broker when the app port is out of range", async () => {
+    const { broker, calls } = fakeBroker({});
+    const { status, handle } = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: 3100, // primary app port — never eligible
+    });
+    expect(calls.expose).toHaveLength(0);
+    expect(status.state).toBe("failed");
+    expect(handle).toBe(HANDLE);
+  });
+
+  it("fails when the broker rejects the expose request", async () => {
+    const { broker } = fakeBroker({
+      expose: () => {
+        throw new BrokerClientError("port_not_allowlisted", "denied");
+      },
+    });
+    const { status, handle } = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+    expect(status.state).toBe("failed");
+    expect(status.lastError).toBe("port_not_allowlisted");
+    expect(status.listeners).toHaveLength(2);
+    expect(handle).toBe(HANDLE);
+  });
+
+  it("tears the mapping back down and fails when returned ports do not match", async () => {
+    const { broker, calls } = fakeBroker({
+      expose: () => ({ handle: "handle-abcdef1234567890", publicPorts: [APP_PORT] }), // missing HMR
+      remove: () => ({ removedPorts: [APP_PORT] }),
+    });
+    const { status, handle } = await provisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+    expect(status.state).toBe("failed");
+    expect(status.lastError).toMatch(/unexpected public ports/);
+    expect(calls.remove).toHaveLength(1); // best-effort rollback
+    expect(handle).toBe(HANDLE);
+  });
+
+  it("fail-closed: keeps the handle but reports failed when the HTTPS probe does not validate", async () => {
+    const { broker } = fakeBroker({
+      expose: () => ({ handle: "handle-abcdef1234567890", publicPorts: [APP_PORT, HMR_PORT] }),
+    });
+    const { status, handle } = await provisionExposure(deps(broker, async () => false), {
+      runtimeId: RUNTIME_ID,
+      config: CONFIG,
+      handle: HANDLE,
+      hostname: HOSTNAME,
+      appPort: APP_PORT,
+    });
+    expect(status.state).toBe("failed");
+    expect(status.publicUrl).toBeNull();
+    expect(status.listeners).toHaveLength(2); // attempted mapping still surfaced
+    expect(status.lastError).toMatch(/health probe/);
+    // Handle retained so the caller can retry or clean up the dangling mapping.
+    expect(handle).toBe("handle-abcdef1234567890");
+  });
+
+  it("fail-closed: treats a probe that throws as unhealthy", async () => {
+    const { broker } = fakeBroker({
+      expose: () => ({ handle: "handle-abcdef1234567890", publicPorts: [APP_PORT, HMR_PORT] }),
+    });
+    const { status } = await provisionExposure(
+      deps(broker, async () => {
+        throw new Error("cert error");
+      }),
+      { runtimeId: RUNTIME_ID, config: CONFIG, handle: HANDLE, hostname: HOSTNAME, appPort: APP_PORT },
+    );
+    expect(status.state).toBe("failed");
+  });
+});
+
+describe("deprovisionExposure", () => {
+  it("is a no-op removal when no handle was ever recorded", async () => {
+    const { broker, calls } = fakeBroker({});
+    const { status, quarantinedPorts } = await deprovisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      handle: null,
+      ports: [APP_PORT, HMR_PORT],
+    });
+    expect(calls.remove).toHaveLength(0);
+    expect(status.state).toBe("removed");
+    expect(quarantinedPorts).toEqual([]);
+  });
+
+  it("removes cleanly with a handle", async () => {
+    const { broker, calls } = fakeBroker({ remove: () => ({ removedPorts: [APP_PORT, HMR_PORT] }) });
+    const { status, quarantinedPorts } = await deprovisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      handle: "handle-abcdef1234567890",
+      ports: [APP_PORT, HMR_PORT],
+    });
+    expect(calls.remove).toHaveLength(1);
+    expect(status.state).toBe("removed");
+    expect(quarantinedPorts).toEqual([]);
+  });
+
+  it("treats an already-gone mapping as removed (idempotent)", async () => {
+    const { broker } = fakeBroker({
+      remove: () => {
+        throw new BrokerClientError("invalid_handle", "gone");
+      },
+    });
+    const { status, quarantinedPorts } = await deprovisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      handle: "handle-abcdef1234567890",
+      ports: [APP_PORT, HMR_PORT],
+    });
+    expect(status.state).toBe("removed");
+    expect(quarantinedPorts).toEqual([]);
+  });
+
+  it("quarantines ports and reports cleanup_pending on an ambiguous cleanup failure", async () => {
+    const { broker } = fakeBroker({
+      remove: () => {
+        throw new BrokerClientError("cli_error", "tailscale serve failed");
+      },
+    });
+    const { status, quarantinedPorts } = await deprovisionExposure(deps(broker, async () => true), {
+      runtimeId: RUNTIME_ID,
+      handle: "handle-abcdef1234567890",
+      ports: [APP_PORT, HMR_PORT, APP_PORT],
+    });
+    expect(status.state).toBe("cleanup_pending");
+    expect(status.lastError).toBe("cli_error");
+    expect(quarantinedPorts).toEqual([APP_PORT, HMR_PORT]); // deduped
+  });
+});
+
+describe("reconcileExposures", () => {
+  it("adopts owned mappings that are still desired", async () => {
+    const { broker, calls } = fakeBroker({
+      list: () => [
+        { runtimeId: RUNTIME_ID, port: APP_PORT, purpose: "app" },
+        { runtimeId: RUNTIME_ID, port: HMR_PORT, purpose: "vite_hmr" },
+      ],
+    });
+    const result = await reconcileExposures(deps(broker, async () => true), {
+      desiredRuntimeIds: new Set([RUNTIME_ID]),
+      handlesByRuntimeId: new Map(),
+    });
+    expect(result.adopted).toEqual([RUNTIME_ID]);
+    expect(result.removedOrphanPorts).toEqual([]);
+    expect(calls.remove).toHaveLength(0);
+  });
+
+  it("removes an orphaned owned mapping when a handle is available", async () => {
+    const orphan = "99999999-2222-4333-8444-555566667777";
+    const { broker, calls } = fakeBroker({
+      list: () => [{ runtimeId: orphan, port: APP_PORT, purpose: "app" }],
+      remove: () => ({ removedPorts: [APP_PORT] }),
+    });
+    const result = await reconcileExposures(deps(broker, async () => true), {
+      desiredRuntimeIds: new Set([RUNTIME_ID]),
+      handlesByRuntimeId: new Map([[orphan, "handle-abcdef1234567890"]]),
+    });
+    expect(result.removedOrphanPorts).toEqual([APP_PORT]);
+    expect(calls.remove).toEqual([{ runtimeId: orphan, handle: "handle-abcdef1234567890" }]);
+    expect(result.unremovableOrphans).toEqual([]);
+  });
+
+  it("never mutates an orphan it has no handle for (no remove call)", async () => {
+    const orphan = "99999999-2222-4333-8444-555566667777";
+    const { broker, calls } = fakeBroker({
+      list: () => [{ runtimeId: orphan, port: APP_PORT, purpose: "app" }],
+    });
+    const result = await reconcileExposures(deps(broker, async () => true), {
+      desiredRuntimeIds: new Set([RUNTIME_ID]),
+      handlesByRuntimeId: new Map(),
+    });
+    expect(calls.remove).toHaveLength(0);
+    expect(result.unremovableOrphans).toEqual([orphan]);
+    expect(result.removedOrphanPorts).toEqual([]);
+  });
+
+  it("records non-fatal errors without aborting reconciliation", async () => {
+    const orphanA = "aaaaaaaa-2222-4333-8444-555566667777";
+    const orphanB = "bbbbbbbb-2222-4333-8444-555566667777";
+    const { broker } = fakeBroker({
+      list: () => [
+        { runtimeId: orphanA, port: APP_PORT, purpose: "app" },
+        { runtimeId: orphanB, port: APP_PORT + 1, purpose: "app" },
+      ],
+      remove: (runtimeId) => {
+        if (runtimeId === orphanA) throw new BrokerClientError("cli_error", "boom");
+        return { removedPorts: [APP_PORT + 1] };
+      },
+    });
+    const result = await reconcileExposures(deps(broker, async () => true), {
+      desiredRuntimeIds: new Set(),
+      handlesByRuntimeId: new Map([
+        [orphanA, "handle-aaaaaaaaaaaaaaaa"],
+        [orphanB, "handle-bbbbbbbbbbbbbbbb"],
+      ]),
+    });
+    expect(result.errors).toEqual([{ runtimeId: orphanA, code: "cli_error" }]);
+    expect(result.removedOrphanPorts).toEqual([APP_PORT + 1]);
+  });
+});

--- a/server/src/services/runtime-exposure/exposure-manager.ts
+++ b/server/src/services/runtime-exposure/exposure-manager.ts
@@ -1,0 +1,399 @@
+/**
+ * Runtime exposure lifecycle orchestrator for the `tailscale_https` mode.
+ *
+ * Owns the exposure state machine independently of the backend process
+ * lifecycle (PAP-17049 plan, PAP-17050 verdict). A backend can be running and
+ * healthy while its HTTPS exposure is still `pending`, `failed`, or
+ * `cleanup_pending`. This module never touches Tailscale directly — it drives
+ * the least-privilege broker through an injected {@link BrokerClient} and an
+ * injected external HTTPS health probe, so every branch is unit-testable
+ * against a fake broker with no sockets, no CLI, and no certificates.
+ *
+ * Invariants enforced here (in addition to the broker's own controls):
+ *  - fail-closed: a configured HTTPS preview is never reported `ready` unless an
+ *    external, normally-validating HTTPS probe succeeds.
+ *  - same-number: only the app port and its derived HMR companion are exposed.
+ *  - idempotent stop/cleanup: a missing/already-removed lease is success, not an
+ *    error; genuine cleanup failures quarantine the ports and never reuse them.
+ *  - reconcile touches only Paperclip-owned mappings the broker reports; it can
+ *    never mutate an unknown/manual mapping or the primary `:443` route (the
+ *    broker's `list` never returns those, and remove requires an owned handle).
+ */
+import type { RuntimeExposureConfigInput, RuntimeExposureStatus } from "@paperclipai/shared";
+import {
+  buildRuntimeExposureHealthUrl,
+  buildRuntimeExposureUrl,
+  deriveViteHmrPort,
+  isRuntimeExposureAppPort,
+} from "@paperclipai/shared";
+
+import {
+  BrokerClientError,
+  type BrokerClient,
+  type BrokerListenerRequest,
+} from "./broker-client.js";
+
+/** Injected seams — all side effects live behind these for testability. */
+export interface ExposureManagerDeps {
+  broker: BrokerClient;
+  /** External HTTPS probe; must reject/return false on cert or connection error. */
+  probeHealth: (healthUrl: string) => Promise<boolean>;
+  /** ISO timestamp source. Injected so tests are deterministic. */
+  now: () => string;
+  /**
+   * Optional operator-facing diagnosis of the about-to-be-exposed listeners,
+   * returning null when nothing is provably wrong (PAP-17256).
+   *
+   * This does not replace the broker's own loopback gate and cannot loosen it —
+   * it runs first only so a wildcard bind fails with the port and address named
+   * instead of a bare `listener_ownership_mismatch`.
+   */
+  diagnoseListenerBinds?: (ports: number[]) => Promise<string | null>;
+}
+
+export interface ProvisionInput {
+  runtimeId: string;
+  config: RuntimeExposureConfigInput;
+  /** Broker-issued reservation handle persisted before the backend starts. */
+  handle: string;
+  /** Resolved Tailscale node DNS hostname (the manager does not resolve it). */
+  hostname: string;
+  /** Loopback app port already allocated in the dedicated range. */
+  appPort: number;
+}
+
+export interface ProvisionResult {
+  status: RuntimeExposureStatus;
+  /**
+   * Server-only lease handle required to later remove the mapping. NEVER
+   * serialized to the UI or embedded in {@link RuntimeExposureStatus}; persist
+   * it in a server-private store. Null when nothing was exposed.
+   */
+  handle: string | null;
+  /**
+   * Human-readable elaboration of {@link RuntimeExposureStatus.lastError}, when
+   * one is available (PAP-17256).
+   *
+   * Deliberately NOT folded into the persisted status: `lastError` stays the
+   * broker's stable machine code so the retry/cleanup vocabularies keep matching
+   * on it. This rides alongside so the caller can put the reason in the failure
+   * the operator actually reads.
+   */
+  errorDetail?: string | null;
+}
+
+export interface ReserveInput {
+  runtimeId: string;
+  config: RuntimeExposureConfigInput;
+  appPort: number;
+}
+
+/** Reserve the app/HMR pair before the backend binds either listener. */
+export async function reserveExposure(
+  deps: ExposureManagerDeps,
+  input: ReserveInput,
+): Promise<ProvisionResult> {
+  const status = baseStatus(deps.now());
+  if (!isRuntimeExposureAppPort(input.appPort)) {
+    status.state = "failed";
+    status.lastError = "app port outside dedicated runtime exposure range";
+    return { status, handle: null };
+  }
+  const requested = buildListenerRequests(input.config, input.appPort);
+  status.listeners = requested.map((listener) => ({
+    purpose: listener.purpose,
+    publicPort: listener.port,
+    targetPort: listener.port,
+  }));
+  status.brokerRef = input.runtimeId;
+  try {
+    const result = await deps.broker.reserve(input.runtimeId, requested);
+    const requestedPorts = new Set(requested.map((listener) => listener.port));
+    const returnedPorts = new Set(result.reservedPorts);
+    if (requestedPorts.size !== returnedPorts.size || ![...requestedPorts].every((port) => returnedPorts.has(port))) {
+      await safeRemove(deps.broker, input.runtimeId, result.handle);
+      status.state = "failed";
+      status.lastError = "broker returned unexpected reserved ports";
+      return { status, handle: null };
+    }
+    return { status, handle: result.handle };
+  } catch (error) {
+    status.state = "failed";
+    status.lastError = brokerErrorCode(error);
+    return { status, handle: null };
+  }
+}
+
+export interface DeprovisionInput {
+  runtimeId: string;
+  /** Server-persisted lease handle, or null if none was ever recorded. */
+  handle: string | null;
+  /** Ports previously exposed for this runtime (for quarantine on failure). */
+  ports: number[];
+}
+
+export interface DeprovisionResult {
+  status: RuntimeExposureStatus;
+  /** Ports that must be quarantined (never reused) after an ambiguous cleanup. */
+  quarantinedPorts: number[];
+}
+
+/** Broker error codes that mean "the mapping is already gone" — cleanup is a no-op. */
+const ALREADY_GONE_CODES: ReadonlySet<string> = new Set([
+  "invalid_handle",
+  "listener_not_owned",
+  "listener_ownership_mismatch",
+]);
+
+function baseStatus(now: string): RuntimeExposureStatus {
+  return {
+    provider: "tailscale_https",
+    state: "pending",
+    publicUrl: null,
+    hostname: null,
+    listeners: [],
+    brokerRef: null,
+    lastError: null,
+    updatedAt: now,
+  };
+}
+
+/** Build the broker listener request list from a validated exposure config. */
+export function buildListenerRequests(
+  config: RuntimeExposureConfigInput,
+  appPort: number,
+): BrokerListenerRequest[] {
+  const listeners: BrokerListenerRequest[] = [{ purpose: "app", port: appPort }];
+  if (config.includePaperclipViteHmr) {
+    listeners.push({ purpose: "vite_hmr", port: deriveViteHmrPort(appPort) });
+  }
+  return listeners;
+}
+
+/**
+ * Provision (or re-provision) the HTTPS exposure for one runtime service.
+ * Idempotent at the broker level: a repeated call for a still-valid mapping
+ * simply re-exposes and re-probes. Always returns a fully-formed status; the
+ * caller persists both the status and the returned server-only handle.
+ */
+export async function provisionExposure(
+  deps: ExposureManagerDeps,
+  input: ProvisionInput,
+): Promise<ProvisionResult> {
+  const now = deps.now();
+  const status = baseStatus(now);
+  status.hostname = input.hostname;
+
+  if (!isRuntimeExposureAppPort(input.appPort)) {
+    status.state = "failed";
+    status.lastError = "app port outside dedicated runtime exposure range";
+    return { status, handle: input.handle };
+  }
+
+  const requested = buildListenerRequests(input.config, input.appPort);
+  status.listeners = requested.map((listener) => ({
+    purpose: listener.purpose,
+    publicPort: listener.port,
+    targetPort: listener.port,
+  }));
+  status.brokerRef = input.runtimeId;
+
+  // Explain a provable off-loopback bind before the broker denies it, so the
+  // failure names the port and the address instead of only the code.
+  if (deps.diagnoseListenerBinds) {
+    const violation = await deps.diagnoseListenerBinds(requested.map((listener) => listener.port));
+    if (violation) {
+      status.state = "failed";
+      status.lastError = "listener_ownership_mismatch";
+      return { status, handle: input.handle, errorDetail: violation };
+    }
+  }
+
+  let handle: string;
+  let publicPorts: number[];
+  try {
+    const result = await deps.broker.expose(input.runtimeId, input.handle);
+    handle = result.handle;
+    publicPorts = result.publicPorts;
+  } catch (error) {
+    status.state = "failed";
+    status.lastError = brokerErrorCode(error);
+    return { status, handle: input.handle, errorDetail: brokerErrorDetail(error) };
+  }
+
+  // The broker must return exactly the ports we asked for (same-number). A
+  // mismatch is a contract violation: tear the mapping back down and fail.
+  const requestedPorts = new Set(requested.map((l) => l.port));
+  const returnedPorts = new Set(publicPorts);
+  if (requestedPorts.size !== returnedPorts.size || ![...requestedPorts].every((p) => returnedPorts.has(p))) {
+    await safeRemove(deps.broker, input.runtimeId, handle);
+    status.state = "failed";
+    status.lastError = "broker returned unexpected public ports";
+    return { status, handle };
+  }
+
+  // Reflect the attempted mapping regardless of health so the UI can show what
+  // was provisioned even while probing.
+  // fail-closed: never report ready until an external, cert-validating probe
+  // succeeds. Keep the handle so the caller can retry or clean up.
+  const healthUrl = buildRuntimeExposureHealthUrl(input.hostname, input.appPort);
+  let healthy = false;
+  try {
+    healthy = await deps.probeHealth(healthUrl);
+  } catch {
+    healthy = false;
+  }
+  if (!healthy) {
+    status.state = "failed";
+    status.publicUrl = null;
+    status.lastError = "external HTTPS health probe did not validate";
+    return { status, handle };
+  }
+
+  status.state = "ready";
+  status.publicUrl = buildRuntimeExposureUrl(input.hostname, input.appPort);
+  status.lastError = null;
+  return { status, handle };
+}
+
+/**
+ * Tear down the HTTPS exposure for one runtime service. Idempotent: a null or
+ * already-gone handle resolves to `removed` with no quarantine. A genuine
+ * cleanup failure resolves to `cleanup_pending` and quarantines the ports.
+ */
+export async function deprovisionExposure(
+  deps: ExposureManagerDeps,
+  input: DeprovisionInput,
+): Promise<DeprovisionResult> {
+  const now = deps.now();
+  const status = baseStatus(now);
+  status.state = "removed";
+
+  if (input.handle === null) {
+    // Nothing the server knows to remove — treat as already cleaned up.
+    return { status, quarantinedPorts: [] };
+  }
+
+  try {
+    await deps.broker.remove(input.runtimeId, input.handle);
+    return { status, quarantinedPorts: [] };
+  } catch (error) {
+    const code = brokerErrorCode(error);
+    if (ALREADY_GONE_CODES.has(code)) {
+      // The mapping is already gone; cleanup is complete and safe.
+      return { status, quarantinedPorts: [] };
+    }
+    // Ambiguous failure: we cannot prove the mapping is gone. Quarantine the
+    // ports so they are never reused, and surface cleanup_pending.
+    status.state = "cleanup_pending";
+    status.lastError = code;
+    return { status, quarantinedPorts: [...new Set(input.ports)] };
+  }
+}
+
+export interface ReconcileInput {
+  /** Runtimes whose exposure SHOULD remain. Everything else owned is an orphan. */
+  desiredRuntimeIds: ReadonlySet<string>;
+  /** Every server-persisted lease handle, keyed by runtimeId (desired + orphaned). */
+  handlesByRuntimeId: ReadonlyMap<string, string>;
+}
+
+export interface ReconcileResult {
+  /** Owned+desired runtimes confirmed present in the broker's mapping. */
+  adopted: string[];
+  /** Ports removed because their runtime is no longer desired. */
+  removedOrphanPorts: number[];
+  /**
+   * Orphaned owned runtimes we could NOT remove because no handle was persisted.
+   * Reported for operator/broker-side quarantine; the manager never fabricates a
+   * handle and never touches a mapping it cannot prove ownership of.
+   */
+  unremovableOrphans: string[];
+  /** Non-fatal per-runtime removal errors during reconciliation. */
+  errors: Array<{ runtimeId: string; code: string }>;
+}
+
+/**
+ * Startup / periodic reconciliation. Adopts owned mappings that are still
+ * desired and removes owned mappings that are not. The broker's `list` only
+ * ever returns Paperclip-owned listeners, so unknown/manual mappings and the
+ * primary `:443` route are structurally out of scope here — they can never be
+ * enumerated, adopted, or removed by this routine.
+ */
+export async function reconcileExposures(
+  deps: ExposureManagerDeps,
+  input: ReconcileInput,
+): Promise<ReconcileResult> {
+  const result: ReconcileResult = {
+    adopted: [],
+    removedOrphanPorts: [],
+    unremovableOrphans: [],
+    errors: [],
+  };
+
+  const owned = await deps.broker.list();
+
+  // Group owned ports by runtimeId.
+  const portsByRuntime = new Map<string, number[]>();
+  for (const listener of owned) {
+    const ports = portsByRuntime.get(listener.runtimeId) ?? [];
+    ports.push(listener.port);
+    portsByRuntime.set(listener.runtimeId, ports);
+  }
+
+  for (const [runtimeId, ports] of portsByRuntime) {
+    if (input.desiredRuntimeIds.has(runtimeId)) {
+      result.adopted.push(runtimeId);
+      continue;
+    }
+    // Orphan: owned by us but no longer desired.
+    const handle = input.handlesByRuntimeId.get(runtimeId);
+    if (!handle) {
+      result.unremovableOrphans.push(runtimeId);
+      continue;
+    }
+    try {
+      const removed = await deps.broker.remove(runtimeId, handle);
+      result.removedOrphanPorts.push(...removed.removedPorts);
+    } catch (error) {
+      const code = brokerErrorCode(error);
+      if (ALREADY_GONE_CODES.has(code)) {
+        // Already gone — reconciled, count its ports as removed for reporting.
+        result.removedOrphanPorts.push(...ports);
+      } else {
+        result.errors.push({ runtimeId, code });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Best-effort remove used on rollback paths; swallows broker errors. */
+async function safeRemove(broker: BrokerClient, runtimeId: string, handle: string): Promise<void> {
+  try {
+    await broker.remove(runtimeId, handle);
+  } catch {
+    /* best effort — the outer flow has already decided to fail */
+  }
+}
+
+function brokerErrorCode(error: unknown): string {
+  if (error instanceof BrokerClientError) return error.code;
+  return "internal_error";
+}
+
+/**
+ * The broker's own explanation of a denial, when it adds anything to the code.
+ *
+ * The wire protocol already carries it (`BrokerClientError.message`, e.g.
+ * "listener on 42003 is not loopback-only"); dropping it is what made
+ * `listener_ownership_mismatch` unactionable in PAP-17254.
+ */
+function brokerErrorDetail(error: unknown): string | null {
+  if (!(error instanceof BrokerClientError)) {
+    return error instanceof Error ? error.message : null;
+  }
+  const message = error.message.trim();
+  return message && message !== error.code ? message : null;
+}

--- a/server/src/services/runtime-exposure/loopback-listener.test.ts
+++ b/server/src/services/runtime-exposure/loopback-listener.test.ts
@@ -1,0 +1,182 @@
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+
+import { RUNTIME_EXPOSURE_APP_PORT_MIN, deriveViteHmrPort } from "@paperclipai/shared";
+
+import {
+  diagnoseRuntimeListenerBinds,
+  formatProcAddressHex,
+  listenerBindFactsForPort,
+  parseProcNetListeners,
+} from "./loopback-listener.js";
+
+// Real header and row shape, copied from a live /proc/net/tcp{,6} on the host
+// that produced the PAP-17256 failures. Port 42003 is A40B; 52003 is CB23.
+const TCP_HEADER =
+  "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode                                                     ";
+const TCP6_HEADER =
+  "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+
+function tcpRow(addrHex: string, portHex: string, state = "0A") {
+  return `   0: ${addrHex}:${portHex} 00000000:0000 ${state} 00000000:00000000 00:00000000 00000000   999        0 74815359 1 0000000000000000 100 0 0 10 0`;
+}
+
+function tcp6Row(addrHex: string, portHex: string, state = "0A") {
+  return `   0: ${addrHex}:${portHex} 00000000000000000000000000000000:0000 ${state} 00000000:00000000 00:00000000 00000000   999        0 74815360 2 0000000000000000 100 0 0 10 0`;
+}
+
+/** The app port from the PAP-17256 lane, and its `/proc` hex form. */
+const APP_PORT = 42_003;
+const portHex = (port: number) => port.toString(16).toUpperCase().padStart(4, "0");
+const APP_PORT_HEX = portHex(APP_PORT);
+
+describe("formatProcAddressHex", () => {
+  it("byte-swaps IPv4 words", () => {
+    expect(formatProcAddressHex("0100007F")).toBe("127.0.0.1");
+    expect(formatProcAddressHex("00000000")).toBe("0.0.0.0");
+    expect(formatProcAddressHex("0400007F")).toBe("127.0.0.4");
+  });
+
+  it("renders the IPv6 loopback and wildcard forms /proc actually stores", () => {
+    expect(formatProcAddressHex("00000000000000000000000001000000")).toBe("::1");
+    expect(formatProcAddressHex("00000000000000000000000000000000")).toBe("::");
+  });
+});
+
+describe("listenerBindFactsForPort", () => {
+  it("accepts an IPv4 loopback listener", () => {
+    const facts = listenerBindFactsForPort(
+      parseProcNetListeners(`${TCP_HEADER}\n${tcpRow("0100007F", APP_PORT_HEX)}\n`),
+      [],
+      APP_PORT,
+    );
+    expect(facts).toEqual({ present: true, loopbackOnly: true, addresses: ["127.0.0.1"] });
+  });
+
+  it("accepts an IPv6 loopback listener in the little-endian ::1 form", () => {
+    const facts = listenerBindFactsForPort(
+      [],
+      parseProcNetListeners(
+        `${TCP6_HEADER}\n${tcp6Row("00000000000000000000000001000000", APP_PORT_HEX)}\n`,
+      ),
+      APP_PORT,
+    );
+    expect(facts).toEqual({ present: true, loopbackOnly: true, addresses: ["::1"] });
+  });
+
+  it("rejects the 0.0.0.0 wildcard bind that broke every managed lane", () => {
+    const facts = listenerBindFactsForPort(
+      parseProcNetListeners(`${TCP_HEADER}\n${tcpRow("00000000", APP_PORT_HEX)}\n`),
+      [],
+      APP_PORT,
+    );
+    expect(facts).toEqual({ present: true, loopbackOnly: false, addresses: ["0.0.0.0"] });
+  });
+
+  it("rejects the :: wildcard bind", () => {
+    const facts = listenerBindFactsForPort(
+      [],
+      parseProcNetListeners(
+        `${TCP6_HEADER}\n${tcp6Row("00000000000000000000000000000000", APP_PORT_HEX)}\n`,
+      ),
+      APP_PORT,
+    );
+    expect(facts.loopbackOnly).toBe(false);
+    expect(facts.addresses).toEqual(["::"]);
+  });
+
+  it("rejects a non-loopback unicast bind", () => {
+    // 100.123.243.20 — the tailnet address, stored little-endian.
+    const facts = listenerBindFactsForPort(
+      parseProcNetListeners(`${TCP_HEADER}\n${tcpRow("14F37B64", APP_PORT_HEX)}\n`),
+      [],
+      APP_PORT,
+    );
+    expect(facts.loopbackOnly).toBe(false);
+    expect(facts.addresses).toEqual(["100.123.243.20"]);
+  });
+
+  it("reports absent for a port with no LISTEN row", () => {
+    const facts = listenerBindFactsForPort(
+      // Same port, but ESTABLISHED (01) rather than LISTEN (0A).
+      parseProcNetListeners(`${TCP_HEADER}\n${tcpRow("0100007F", APP_PORT_HEX, "01")}\n`),
+      [],
+      APP_PORT,
+    );
+    expect(facts).toEqual({ present: false, loopbackOnly: true, addresses: [] });
+  });
+
+  it("ignores rows for other ports", () => {
+    const facts = listenerBindFactsForPort(
+      parseProcNetListeners(`${TCP_HEADER}\n${tcpRow("00000000", portHex(52_003))}\n`),
+      [],
+      APP_PORT,
+    );
+    expect(facts.present).toBe(false);
+  });
+
+  it("is not loopback-only when a wildcard row accompanies a loopback row", () => {
+    const facts = listenerBindFactsForPort(
+      parseProcNetListeners(
+        `${TCP_HEADER}\n${tcpRow("0100007F", APP_PORT_HEX)}\n${tcpRow("00000000", APP_PORT_HEX)}\n`,
+      ),
+      [],
+      APP_PORT,
+    );
+    expect(facts.loopbackOnly).toBe(false);
+    expect(facts.addresses).toEqual(["127.0.0.1", "0.0.0.0"]);
+  });
+});
+
+describe("diagnoseRuntimeListenerBinds against live listeners", () => {
+  const appPort = RUNTIME_EXPOSURE_APP_PORT_MIN + 900;
+  const hmrPort = deriveViteHmrPort(appPort);
+
+  async function withListener<T>(
+    port: number,
+    host: string | undefined,
+    body: () => Promise<T>,
+  ): Promise<T> {
+    const server = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      if (host === undefined) server.listen(port, () => resolve());
+      else server.listen(port, host, () => resolve());
+    });
+    try {
+      return await body();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  it("stays silent for a real loopback listener", async () => {
+    await withListener(appPort, "127.0.0.1", async () => {
+      expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+    });
+  });
+
+  it("names the port and the wildcard address for a real 0.0.0.0 listener", async () => {
+    await withListener(appPort, undefined, async () => {
+      const diagnosis = await diagnoseRuntimeListenerBinds([appPort]);
+      expect(diagnosis).toContain(`port ${appPort}`);
+      // Node's hostless listen is dual-stack, so /proc shows :: and/or 0.0.0.0.
+      expect(diagnosis).toMatch(/0\.0\.0\.0|::/);
+      expect(diagnosis).toContain("--bind custom --bind-host 127.0.0.1");
+    });
+  });
+
+  it("catches the HMR companion port too, not just the app port", async () => {
+    await withListener(appPort, "127.0.0.1", async () => {
+      await withListener(hmrPort, undefined, async () => {
+        const diagnosis = await diagnoseRuntimeListenerBinds([appPort, hmrPort]);
+        expect(diagnosis).toContain(`port ${hmrPort}`);
+        expect(diagnosis).not.toContain(`port ${appPort} is bound`);
+      });
+    });
+  });
+
+  it("stays silent for a port with no listener, leaving the verdict to the broker", async () => {
+    expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+  });
+});

--- a/server/src/services/runtime-exposure/loopback-listener.ts
+++ b/server/src/services/runtime-exposure/loopback-listener.ts
@@ -1,0 +1,165 @@
+/**
+ * Server-side loopback listener diagnosis for the `tailscale_https` mode
+ * (PAP-17256).
+ *
+ * The broker already refuses to expose a port whose listener is not
+ * loopback-only, and it must keep doing that check itself — it cannot trust the
+ * caller. But the broker only answers with a stable machine code, so when a
+ * managed lane bound `0.0.0.0` the operator saw a bare
+ * `listener_ownership_mismatch` with no port, no address, and no hint about
+ * which side was wrong. That opacity, not the denial, is what turned one bug
+ * into three diagnostic cycles.
+ *
+ * So the server runs the same read *before* it calls the broker, purely to
+ * produce a sentence a human can act on. This is deliberately a duplicate of
+ * the broker's `proc-listener` logic rather than a shared import: the broker is
+ * host-privileged and its gate must stay independent of anything the server
+ * says. If the two ever disagree, the broker still wins — this one only
+ * explains.
+ *
+ * Parsing helpers are exported pure so they can be tested without /proc.
+ */
+import { readFile } from "node:fs/promises";
+
+/** One listening row from `/proc/net/tcp` or `/proc/net/tcp6`. */
+export interface ProcListenerRow {
+  localAddressHex: string;
+  localPortHex: string;
+  state: string;
+}
+
+export interface ListenerBindFacts {
+  present: boolean;
+  loopbackOnly: boolean;
+  /** Bound addresses in human-readable form, for the diagnosis message. */
+  addresses: string[];
+}
+
+const TCP_STATE_LISTEN = "0A";
+
+/** Parse one `/proc/net/tcp{,6}` table into its listening rows. */
+export function parseProcNetListeners(content: string): ProcListenerRow[] {
+  const rows: ProcListenerRow[] = [];
+  for (const line of content.split("\n").slice(1)) {
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 10) continue;
+    const [addr, port] = cols[1].split(":");
+    if (!addr || !port) continue;
+    rows.push({ localAddressHex: addr, localPortHex: port, state: cols[3] });
+  }
+  return rows;
+}
+
+/** True for a wildcard bind (`0.0.0.0` / `::`), reachable off-loopback. */
+function isWildcardHex(addrHex: string): boolean {
+  return /^0+$/.test(addrHex);
+}
+
+/**
+ * Render a `/proc` address for humans. Both tables store 32-bit words in host
+ * (little-endian) byte order, so each 8-hex-digit word is byte-swapped.
+ */
+export function formatProcAddressHex(addrHex: string): string {
+  if (addrHex.length === 8) {
+    const octets = [6, 4, 2, 0].map((offset) => parseInt(addrHex.slice(offset, offset + 2), 16));
+    return octets.join(".");
+  }
+  if (addrHex.length === 32) {
+    const bytes: number[] = [];
+    for (let word = 0; word < 4; word += 1) {
+      const hex = addrHex.slice(word * 8, word * 8 + 8);
+      for (let offset = 6; offset >= 0; offset -= 2) {
+        bytes.push(parseInt(hex.slice(offset, offset + 2), 16));
+      }
+    }
+    if (bytes.every((byte) => byte === 0)) return "::";
+    if (bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1) return "::1";
+    const groups: string[] = [];
+    for (let index = 0; index < 16; index += 2) {
+      groups.push(((bytes[index] << 8) | bytes[index + 1]).toString(16));
+    }
+    return groups.join(":");
+  }
+  return `0x${addrHex}`;
+}
+
+/** True when a `/proc` IPv4 hex address is in 127.0.0.0/8. */
+function isLoopbackIpv4Hex(addrHex: string): boolean {
+  if (addrHex.length !== 8) return false;
+  return parseInt(addrHex.slice(6, 8), 16) === 127;
+}
+
+/** `::1` as `/proc/net/tcp6` stores it — final word byte-swapped. */
+const LOOPBACK_IPV6_PROC_HEX = "00000000000000000000000001000000";
+
+function isLoopbackIpv6Hex(addrHex: string): boolean {
+  return addrHex.toUpperCase() === LOOPBACK_IPV6_PROC_HEX;
+}
+
+/** Reduce both `/proc` tables to bind facts for one port. */
+export function listenerBindFactsForPort(
+  tcp: ProcListenerRow[],
+  tcp6: ProcListenerRow[],
+  port: number,
+): ListenerBindFacts {
+  const wantHex = port.toString(16).toUpperCase().padStart(4, "0");
+  const addresses: string[] = [];
+  let present = false;
+  let loopbackOnly = true;
+  const scan = (rows: ProcListenerRow[], isLoopback: (hex: string) => boolean) => {
+    for (const row of rows) {
+      if (row.localPortHex.toUpperCase() !== wantHex || row.state !== TCP_STATE_LISTEN) continue;
+      present = true;
+      addresses.push(formatProcAddressHex(row.localAddressHex));
+      if (isWildcardHex(row.localAddressHex) || !isLoopback(row.localAddressHex)) {
+        loopbackOnly = false;
+      }
+    }
+  };
+  scan(tcp, isLoopbackIpv4Hex);
+  scan(tcp6, isLoopbackIpv6Hex);
+  return { present, loopbackOnly, addresses: [...new Set(addresses)] };
+}
+
+/** Read live bind facts for one port. Unreadable `/proc` yields "unknown". */
+export async function readListenerBindFacts(port: number): Promise<ListenerBindFacts | null> {
+  let tcp: ProcListenerRow[];
+  try {
+    tcp = parseProcNetListeners(await readFile("/proc/net/tcp", "utf8"));
+  } catch {
+    // No /proc (non-Linux, or a restricted sandbox): the server simply cannot
+    // explain, so it stays silent and lets the broker's own gate decide.
+    return null;
+  }
+  let tcp6: ProcListenerRow[] = [];
+  try {
+    tcp6 = parseProcNetListeners(await readFile("/proc/net/tcp6", "utf8"));
+  } catch {
+    /* optional table */
+  }
+  return listenerBindFactsForPort(tcp, tcp6, port);
+}
+
+/**
+ * Build the operator-facing diagnosis for a set of ports about to be exposed, or
+ * null when nothing is provably wrong.
+ *
+ * Only a *proven* violation is reported. A missing listener is not treated as a
+ * violation here: readiness already gates on the bind, and guessing would turn a
+ * benign race into a misleading error.
+ */
+export async function diagnoseRuntimeListenerBinds(ports: number[]): Promise<string | null> {
+  const violations: string[] = [];
+  for (const port of ports) {
+    const facts = await readListenerBindFacts(port);
+    if (!facts || !facts.present || facts.loopbackOnly) continue;
+    violations.push(`port ${port} is bound to ${facts.addresses.join(", ")}`);
+  }
+  if (violations.length === 0) return null;
+  return (
+    `${violations.join("; ")} instead of loopback only. The broker will not expose a listener `
+    + "reachable off-loopback. This means the workspace checkout's dev server ignored the managed "
+    + "loopback bind — a checkout that predates managed HTTPS exposure overwrites PAPERCLIP_BIND "
+    + "from its own --bind argv, so the start command must pass --bind custom --bind-host 127.0.0.1."
+  );
+}

--- a/server/src/services/runtime-exposure/port-pair.test.ts
+++ b/server/src/services/runtime-exposure/port-pair.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RUNTIME_EXPOSURE_APP_PORT_MIN,
+  RUNTIME_EXPOSURE_HMR_PORT_OFFSET,
+} from "@paperclipai/shared";
+
+import { allocateExposurePortPair } from "./port-pair.js";
+
+describe("allocateExposurePortPair", () => {
+  it("returns the first free app port with a free HMR companion", async () => {
+    const pair = await allocateExposurePortPair({ isPortAvailable: async () => true });
+    expect(pair.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN);
+    expect(pair.hmrPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN + RUNTIME_EXPOSURE_HMR_PORT_OFFSET);
+  });
+
+  it("skips an app port whose HMR companion is busy", async () => {
+    const busyHmr = RUNTIME_EXPOSURE_APP_PORT_MIN + RUNTIME_EXPOSURE_HMR_PORT_OFFSET;
+    const pair = await allocateExposurePortPair({
+      isPortAvailable: async (port) => port !== busyHmr,
+    });
+    // First app port's companion is busy, so it advances to the next app port.
+    expect(pair.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN + 1);
+    expect(pair.hmrPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN + 1 + RUNTIME_EXPOSURE_HMR_PORT_OFFSET);
+  });
+
+  it("skips a busy app port", async () => {
+    const pair = await allocateExposurePortPair({
+      isPortAvailable: async (port) => port !== RUNTIME_EXPOSURE_APP_PORT_MIN,
+    });
+    expect(pair.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN + 1);
+  });
+
+  it("never returns a reserved (e.g. quarantined) app or HMR port", async () => {
+    const reserved = new Set<number>([
+      RUNTIME_EXPOSURE_APP_PORT_MIN,
+      // reserve the SECOND app port's HMR companion too
+      RUNTIME_EXPOSURE_APP_PORT_MIN + 1 + RUNTIME_EXPOSURE_HMR_PORT_OFFSET,
+    ]);
+    const pair = await allocateExposurePortPair({
+      isPortAvailable: async () => true,
+      reserved,
+    });
+    expect(pair.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN + 2);
+  });
+
+  describe("preferredAppPort (keep existing runtime ports when safe)", () => {
+    it("keeps a preferred in-range port instead of restarting the scan", async () => {
+      const pair = await allocateExposurePortPair({
+        isPortAvailable: async () => true,
+        preferredAppPort: 42_500,
+      });
+      expect(pair.appPort).toBe(42_500);
+      expect(pair.hmrPort).toBe(42_500 + RUNTIME_EXPOSURE_HMR_PORT_OFFSET);
+    });
+
+    it("ignores a legacy pinned port outside the dedicated range", async () => {
+      // 45439 is the pre-feature Paperclip App port; the broker can never
+      // publish it, so the allocator must relocate rather than fail.
+      const pair = await allocateExposurePortPair({
+        isPortAvailable: async () => true,
+        preferredAppPort: 45_439,
+      });
+      expect(pair.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN);
+    });
+
+    it("falls back to the scan when the preferred port is busy or reserved", async () => {
+      const busy = await allocateExposurePortPair({
+        isPortAvailable: async (port) => port !== 42_500,
+        preferredAppPort: 42_500,
+      });
+      expect(busy.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN);
+
+      const reservedCompanion = await allocateExposurePortPair({
+        isPortAvailable: async () => true,
+        reserved: new Set([42_500 + RUNTIME_EXPOSURE_HMR_PORT_OFFSET]),
+        preferredAppPort: 42_500,
+      });
+      expect(reservedCompanion.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN);
+    });
+
+    it("ignores a preferred HMR-range port (never an app port)", async () => {
+      const pair = await allocateExposurePortPair({
+        isPortAvailable: async () => true,
+        preferredAppPort: RUNTIME_EXPOSURE_APP_PORT_MIN + RUNTIME_EXPOSURE_HMR_PORT_OFFSET,
+      });
+      expect(pair.appPort).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN);
+    });
+  });
+
+  it("throws when the dedicated range is exhausted", async () => {
+    await expect(
+      allocateExposurePortPair({ isPortAvailable: async () => false }),
+    ).rejects.toThrow(/no free app\/HMR port pair/);
+  });
+
+  it("only probes the companion after the app port is free (short-circuits)", async () => {
+    const probed: number[] = [];
+    await allocateExposurePortPair({
+      isPortAvailable: async (port) => {
+        probed.push(port);
+        return true;
+      },
+    });
+    // First two probes are the first app port and its companion, in order.
+    expect(probed[0]).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN);
+    expect(probed[1]).toBe(RUNTIME_EXPOSURE_APP_PORT_MIN + RUNTIME_EXPOSURE_HMR_PORT_OFFSET);
+  });
+});

--- a/server/src/services/runtime-exposure/port-pair.ts
+++ b/server/src/services/runtime-exposure/port-pair.ts
@@ -1,0 +1,87 @@
+/**
+ * Paired app + Vite HMR port allocation for the `tailscale_https` exposure mode.
+ *
+ * A managed runtime that opts into HTTPS exposure needs TWO deterministically
+ * related loopback ports reserved together (PAP-17049 plan, PAP-17050 verdict
+ * requirement #2): the app port and its Paperclip Vite HMR companion at a fixed
+ * offset. Allocating them as a pair — and only from the dedicated allowlisted
+ * range — means a compromised caller can never ask the broker to publish an
+ * arbitrary existing loopback service, and the HMR listener is never orphaned
+ * from its app listener.
+ *
+ * Pure orchestration over an injected availability probe: no sockets here, so
+ * the scan order and skip logic are unit-testable.
+ */
+import {
+  RUNTIME_EXPOSURE_APP_PORT_MIN,
+  RUNTIME_EXPOSURE_APP_PORT_MAX,
+  deriveViteHmrPort,
+  isRuntimeExposureAppPort,
+} from "@paperclipai/shared";
+
+export interface ExposurePortPair {
+  appPort: number;
+  hmrPort: number;
+}
+
+export interface AllocateExposurePortPairInput {
+  /**
+   * Returns true if the port can currently be bound loopback-only. Both the app
+   * port and its HMR companion must pass before a pair is returned.
+   */
+  isPortAvailable: (port: number) => Promise<boolean>;
+  /**
+   * Ports that must never be handed out — e.g. quarantined after an ambiguous
+   * cleanup, or already reserved by other live runtimes this cycle.
+   */
+  reserved?: ReadonlySet<number>;
+  /**
+   * The port this runtime is already using, if any. Tried first so a restart or
+   * a backfilled service keeps its port instead of drifting across the range on
+   * every deploy ("keep existing runtime ports when safe", PAP-17158).
+   *
+   * Only honored when it is genuinely safe: the port must be an allowlisted app
+   * port, unreserved, and free together with its HMR companion. A legacy pinned
+   * port outside the dedicated range (the Paperclip App template's 45439) can
+   * never be published by the broker, so it is ignored here rather than making
+   * the caller special-case it.
+   */
+  preferredAppPort?: number | null;
+}
+
+/**
+ * Return an app port whose HMR companion is also free and unreserved: the
+ * preferred port when it is eligible, otherwise the first such port scanning the
+ * dedicated range in ascending order. Throws when the range is exhausted so the
+ * caller fails closed rather than binding an out-of-range port.
+ */
+export async function allocateExposurePortPair(
+  input: AllocateExposurePortPairInput,
+): Promise<ExposurePortPair> {
+  const reserved = input.reserved ?? new Set<number>();
+
+  const claimIfFree = async (appPort: number): Promise<ExposurePortPair | null> => {
+    if (reserved.has(appPort)) return null;
+    if (!isRuntimeExposureAppPort(appPort)) return null;
+    const hmrPort = deriveViteHmrPort(appPort);
+    if (reserved.has(hmrPort)) return null;
+    // Probe the app port first; short-circuit before probing the companion.
+    if (!(await input.isPortAvailable(appPort))) return null;
+    if (!(await input.isPortAvailable(hmrPort))) return null;
+    return { appPort, hmrPort };
+  };
+
+  if (input.preferredAppPort != null) {
+    const preferred = await claimIfFree(input.preferredAppPort);
+    if (preferred) return preferred;
+  }
+
+  for (let appPort = RUNTIME_EXPOSURE_APP_PORT_MIN; appPort <= RUNTIME_EXPOSURE_APP_PORT_MAX; appPort += 1) {
+    const pair = await claimIfFree(appPort);
+    if (pair) return pair;
+  }
+  throw new Error(
+    `no free app/HMR port pair available in the dedicated runtime exposure range ` +
+      `[${RUNTIME_EXPOSURE_APP_PORT_MIN}, ${RUNTIME_EXPOSURE_APP_PORT_MAX}]`,
+  );
+}

--- a/server/src/services/runtime-exposure/tailscale-hostname.test.ts
+++ b/server/src/services/runtime-exposure/tailscale-hostname.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTailscaleDnsName } from "./tailscale-hostname.js";
+
+describe("parseTailscaleDnsName", () => {
+  it("normalizes the local node MagicDNS hostname", () => {
+    expect(parseTailscaleDnsName({ Self: { DNSName: "Branch-Runner.tail123.ts.net." } }))
+      .toBe("branch-runner.tail123.ts.net");
+  });
+
+  it("rejects missing, single-label, and injected hostnames", () => {
+    expect(() => parseTailscaleDnsName({})).toThrow(/Self\.DNSName/);
+    expect(() => parseTailscaleDnsName({ Self: { DNSName: "localhost" } })).toThrow(/invalid/);
+    expect(() => parseTailscaleDnsName({ Self: { DNSName: "host/evil.ts.net" } })).toThrow(/invalid/);
+  });
+});

--- a/server/src/services/runtime-exposure/tailscale-hostname.ts
+++ b/server/src/services/runtime-exposure/tailscale-hostname.ts
@@ -1,0 +1,45 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_TAILSCALE_BIN = "/usr/bin/tailscale";
+
+type TailscaleStatus = {
+  Self?: { DNSName?: unknown };
+};
+
+/** Parse only this node's MagicDNS name from `tailscale status --json`. */
+export function parseTailscaleDnsName(value: unknown): string {
+  const dnsName = (value as TailscaleStatus | null)?.Self?.DNSName;
+  if (typeof dnsName !== "string") {
+    throw new Error("tailscale status did not include Self.DNSName");
+  }
+  const normalized = dnsName.trim().replace(/\.$/, "").toLowerCase();
+  if (!/^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$/.test(normalized) || !normalized.includes(".")) {
+    throw new Error("tailscale status returned an invalid Self.DNSName");
+  }
+  return normalized;
+}
+
+/**
+ * Read-only hostname discovery. This does not require Tailscale operator
+ * authority; all Serve mutations remain isolated in the host broker.
+ */
+export async function resolveTailscaleDnsName(input?: {
+  tailscaleBinPath?: string;
+  timeoutMs?: number;
+}): Promise<string> {
+  const configured = process.env.PAPERCLIP_TAILSCALE_DNS_NAME?.trim();
+  if (configured) return parseTailscaleDnsName({ Self: { DNSName: configured } });
+
+  const tailscaleBinPath = input?.tailscaleBinPath ?? DEFAULT_TAILSCALE_BIN;
+  if (!tailscaleBinPath.startsWith("/")) {
+    throw new Error("tailscale binary path must be absolute");
+  }
+  const { stdout } = await execFileAsync(tailscaleBinPath, ["status", "--json"], {
+    encoding: "utf8",
+    timeout: input?.timeoutMs ?? 3_000,
+    maxBuffer: 1024 * 1024,
+  });
+  return parseTailscaleDnsName(JSON.parse(stdout));
+}

--- a/server/src/services/workspace-operations.ts
+++ b/server/src/services/workspace-operations.ts
@@ -2,13 +2,183 @@ import { randomUUID } from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { workspaceOperations } from "@paperclipai/db";
 import type { WorkspaceOperation, WorkspaceOperationPhase, WorkspaceOperationStatus } from "@paperclipai/shared";
-import { asc, desc, eq, inArray, isNull, or, and } from "drizzle-orm";
-import { notFound } from "../errors.js";
+import { asc, desc, eq, gte, inArray, isNull, lt, or, and } from "drizzle-orm";
+import { conflict, notFound } from "../errors.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { getWorkspaceOperationLogStore } from "./workspace-operation-log-store.js";
 
 type WorkspaceOperationRow = typeof workspaceOperations.$inferSelect;
+
+/**
+ * Managed runtime control actions. Every one of these mutates the runtime rows and
+ * local listeners of a single execution workspace, so only one may be live at a time.
+ */
+const RUNTIME_CONTROL_ACTIONS = new Set(["start", "stop", "restart", "run"]);
+
+/**
+ * Identity of this server process. A `running` runtime-control operation stamped with a
+ * different owner id can only have been left behind by another (now gone) process, which
+ * is what makes bounded recovery safe: we never guess about our own live operations.
+ */
+const RUNTIME_CONTROL_OWNER_ID = randomUUID();
+
+/** How often a live operation refreshes its ownership stamp. */
+export const RUNTIME_CONTROL_HEARTBEAT_MS = 10_000;
+
+/**
+ * How long an operation may go without a heartbeat before another owner may terminalize
+ * it. Deliberately several heartbeat intervals so a slow-but-live start is never stolen.
+ */
+export const RUNTIME_CONTROL_STALE_AFTER_MS = 60_000;
+
+/**
+ * Last-resort ceiling for a managed runtime lifecycle control. Past this the operation is
+ * failed by its own owner so it always reaches a terminal state, even when the underlying
+ * start hangs on an unresponsive process or provider that keeps the owner alive. Generous
+ * enough to cover a cold runtime provision (a full dependency install) on a large repo.
+ */
+export const RUNTIME_CONTROL_MAX_DURATION_MS = 30 * 60_000;
+
+/**
+ * Workspace jobs are operator-authored commands (builds, migrations, test suites) that can
+ * legitimately run far longer than a lifecycle control, so they get a much wider ceiling —
+ * still finite, so a wedged job cannot hold the workspace forever.
+ */
+export const WORKSPACE_JOB_MAX_DURATION_MS = 4 * 60 * 60_000;
+
+function defaultRuntimeControlTimeoutMs(action: string | null) {
+  if (!action) return null;
+  return action === "run" ? WORKSPACE_JOB_MAX_DURATION_MS : RUNTIME_CONTROL_MAX_DURATION_MS;
+}
+
+export class WorkspaceOperationTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number, action: string | null) {
+    super(
+      `Managed workspace ${action ?? "runtime"} operation exceeded its ${Math.round(timeoutMs / 1000)}s time budget and was failed so it can be retried or stopped.`,
+    );
+    this.name = "WorkspaceOperationTimeoutError";
+  }
+}
+
+type RuntimeControlOwnerStamp = {
+  ownerId: string;
+  pid: number;
+  action: string;
+  heartbeatAt: string;
+};
+
+function readRuntimeControlAction(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const action = (metadata as Record<string, unknown>).action;
+  if (typeof action !== "string" || !RUNTIME_CONTROL_ACTIONS.has(action)) return null;
+  return action;
+}
+
+function readRuntimeControlOwner(metadata: unknown): RuntimeControlOwnerStamp | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const owner = (metadata as Record<string, unknown>).runtimeControlOwner;
+  if (!owner || typeof owner !== "object") return null;
+  const record = owner as Record<string, unknown>;
+  if (typeof record.ownerId !== "string") return null;
+  return {
+    ownerId: record.ownerId,
+    pid: typeof record.pid === "number" ? record.pid : 0,
+    action: typeof record.action === "string" ? record.action : "start",
+    heartbeatAt: typeof record.heartbeatAt === "string" ? record.heartbeatAt : new Date(0).toISOString(),
+  };
+}
+
+/**
+ * Operation ids this process is actively driving. An operation owned by this process but
+ * missing from this set can only be a leftover from a request that died without unwinding,
+ * so it is safe to terminalize immediately instead of waiting out the staleness window.
+ */
+const liveRuntimeControlOperationIds = new Set<string>();
+
+/**
+ * Whether the process that stamped an operation is still alive on this host. A dead owner can
+ * never heartbeat again, so its operation is recoverable immediately instead of after the
+ * staleness window — which is what makes recovery after a crash or restart prompt. Signal 0
+ * only probes; it never touches the process.
+ */
+function ownerProcessIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the pid exists but belongs to another user: treat it as alive.
+    return (error as NodeJS.ErrnoException)?.code === "EPERM";
+  }
+}
+
+/**
+ * Compare-and-swap predicate for an operation's `updated_at`.
+ *
+ * Postgres stores `timestamptz` at microsecond precision but the driver hands JS a
+ * millisecond-precision `Date`, so an `=` against the value we just read never matches a row
+ * whose timestamp came from the column's `defaultNow()` — which is exactly the shape of every
+ * row a pre-recovery build left behind, i.e. the stranded operations this sweep exists to
+ * clear. Matching the millisecond bucket instead is still a true CAS: a concurrent heartbeat
+ * writes a `Date` in a different millisecond, so it still wins the row.
+ */
+function updatedAtUnchanged(updatedAt: Date) {
+  return and(
+    gte(workspaceOperations.updatedAt, updatedAt),
+    lt(workspaceOperations.updatedAt, new Date(updatedAt.getTime() + 1)),
+  );
+}
+
+export function resetWorkspaceRuntimeControlStateForTests() {
+  liveRuntimeControlOperationIds.clear();
+}
+
+export function workspaceRuntimeControlOwnerIdForTests() {
+  return RUNTIME_CONTROL_OWNER_ID;
+}
+
+/**
+ * Same-process serialization of managed runtime controls. The durable sweep below is what
+ * recovers stranded operations across processes; this in-memory claim is the cheaper first
+ * line of defense that rejects an overlapping control in this process before any row is
+ * written. Kept from the runtime-lease chain (PAP-17205) and composed with the ownership
+ * machinery above: the claim is taken before the operation row exists, so a recovery sweep
+ * can never see a live control it is not yet tracking.
+ */
+const activeRuntimeControls = new Map<string, { action: string; startedAt: Date }>();
+
+export async function runExclusiveWorkspaceRuntimeControl<T>(input: {
+  executionWorkspaceId: string;
+  action: string;
+  run: () => Promise<T>;
+}): Promise<T> {
+  const active = activeRuntimeControls.get(input.executionWorkspaceId);
+  if (active) {
+    throw conflict("A managed runtime control operation is already in progress for this execution workspace.", {
+      code: "workspace_runtime_control_in_progress",
+      executionWorkspaceId: input.executionWorkspaceId,
+      activeAction: active.action,
+      requestedAction: input.action,
+      startedAt: active.startedAt.toISOString(),
+      remediation: "Wait for the active operation to reach a terminal state before retrying.",
+    });
+  }
+
+  const claim = { action: input.action, startedAt: new Date() };
+  activeRuntimeControls.set(input.executionWorkspaceId, claim);
+  try {
+    return await input.run();
+  } finally {
+    if (activeRuntimeControls.get(input.executionWorkspaceId) === claim) {
+      activeRuntimeControls.delete(input.executionWorkspaceId);
+    }
+  }
+}
+
+export function resetWorkspaceRuntimeControlLocksForTests() {
+  activeRuntimeControls.clear();
+}
 
 function toWorkspaceOperation(row: WorkspaceOperationRow): WorkspaceOperation {
   return {
@@ -59,6 +229,11 @@ export interface WorkspaceOperationRecorder {
     command?: string | null;
     cwd?: string | null;
     metadata?: Record<string, unknown> | null;
+    /**
+     * Wall-clock ceiling for `run`. On expiry the operation is failed (terminal) and the
+     * timeout error is rethrown, so a hung provider can never leave an active operation.
+     */
+    timeoutMs?: number | null;
     run: () => Promise<{
       status?: WorkspaceOperationStatus;
       exitCode?: number | null;
@@ -83,8 +258,181 @@ export function workspaceOperationService(db: Db) {
     return row ? toWorkspaceOperation(row) : null;
   }
 
+  /**
+   * Terminalize `running` managed runtime-control operations that no live owner can still
+   * be driving, and return the ones that are genuinely still live.
+   *
+   * Recovery is bounded on both axes: an operation owned by another server process is only
+   * reclaimed after {@link RUNTIME_CONTROL_STALE_AFTER_MS} without a heartbeat, and the
+   * terminalizing UPDATE is a compare-and-swap on `updated_at`, so an owner that heartbeats
+   * concurrently keeps its operation. Only this process's own abandoned operations (owned
+   * by us but no longer tracked in-process) are reclaimed without waiting.
+   */
+  async function sweepRuntimeControlOperations(
+    executionWorkspaceId: string | null | undefined,
+    options?: { now?: Date; staleAfterMs?: number },
+  ) {
+    const now = options?.now ?? new Date();
+    const staleAfterMs = options?.staleAfterMs ?? RUNTIME_CONTROL_STALE_AFTER_MS;
+    const candidates = await db
+      .select()
+      .from(workspaceOperations)
+      .where(
+        executionWorkspaceId
+          ? and(
+              eq(workspaceOperations.executionWorkspaceId, executionWorkspaceId),
+              eq(workspaceOperations.status, "running"),
+            )
+          : eq(workspaceOperations.status, "running"),
+      );
+
+    const reconciledIds: string[] = [];
+    const live: WorkspaceOperation[] = [];
+
+    for (const candidate of candidates) {
+      const action = readRuntimeControlAction(candidate.metadata);
+      if (!action) continue;
+
+      const owner = readRuntimeControlOwner(candidate.metadata);
+      const lastSignalAt = owner
+        ? new Date(owner.heartbeatAt)
+        : (candidate.updatedAt ?? candidate.startedAt ?? new Date(0));
+      const silentForMs = now.getTime() - lastSignalAt.getTime();
+
+      const ownedByThisProcess = owner?.ownerId === RUNTIME_CONTROL_OWNER_ID;
+      const abandonedByThisProcess = ownedByThisProcess && !liveRuntimeControlOperationIds.has(candidate.id);
+      const ownedHereAndLive = ownedByThisProcess && liveRuntimeControlOperationIds.has(candidate.id);
+      // A previous server process that no longer exists cannot heartbeat again, so its
+      // operations are recoverable at once instead of after the staleness window.
+      const ownerProcessGone = owner !== null && !ownedByThisProcess && !ownerProcessIsAlive(owner.pid);
+
+      if (ownedHereAndLive) {
+        // This process is driving it right now; its own time budget is what terminalizes it.
+        live.push(toWorkspaceOperation(candidate));
+        continue;
+      }
+      if (!abandonedByThisProcess && !ownerProcessGone && silentForMs < staleAfterMs) {
+        live.push(toWorkspaceOperation(candidate));
+        continue;
+      }
+
+      const finishedAt = new Date();
+      const reconciliationMessage =
+        `Reconciled stale managed runtime ${action} operation: ${
+          ownerProcessGone
+            ? `the owning server process (pid ${owner?.pid}) is gone`
+            : abandonedByThisProcess
+              ? "the owning request no longer exists"
+              : `no live owner has reported progress for ${Math.round(silentForMs / 1000)}s`
+        }, so the operation was failed to release the execution workspace for retry or stop.\n`;
+      // Compare-and-swap on `updated_at`: a live owner that heartbeats between the read and
+      // this write moves the column and keeps its operation.
+      const claimed = await db
+        .update(workspaceOperations)
+        .set({
+          status: "failed",
+          stderrExcerpt: appendExcerpt(candidate.stderrExcerpt ?? "", reconciliationMessage),
+          metadata: combineMetadata(candidate.metadata as Record<string, unknown> | null, {
+            reconciled: true,
+            reconciliationReason: abandonedByThisProcess
+              ? "abandoned_runtime_control"
+              : "orphaned_runtime_control",
+            reconciledAt: finishedAt.toISOString(),
+          }),
+          finishedAt,
+          updatedAt: finishedAt,
+        })
+        .where(
+          and(
+            eq(workspaceOperations.id, candidate.id),
+            eq(workspaceOperations.status, "running"),
+            candidate.updatedAt
+              ? updatedAtUnchanged(candidate.updatedAt)
+              : isNull(workspaceOperations.updatedAt),
+          ),
+        )
+        .returning({ id: workspaceOperations.id })
+        .then((rows) => rows[0] ?? null);
+      if (!claimed) {
+        // Someone else moved the row; re-read so callers see the current truth.
+        const refreshed = await getById(candidate.id);
+        if (refreshed?.status === "running") live.push(refreshed);
+        continue;
+      }
+
+      liveRuntimeControlOperationIds.delete(candidate.id);
+      reconciledIds.push(candidate.id);
+
+      if (candidate.logStore && candidate.logRef) {
+        const handle = {
+          store: candidate.logStore as "local_file",
+          logRef: candidate.logRef,
+        };
+        try {
+          await logStore.append(handle, {
+            stream: "stderr",
+            chunk: reconciliationMessage,
+            ts: finishedAt.toISOString(),
+          });
+          const finalized = await logStore.finalize(handle);
+          await db
+            .update(workspaceOperations)
+            .set({
+              logBytes: finalized.bytes,
+              logSha256: finalized.sha256,
+              logCompressed: finalized.compressed,
+              updatedAt: new Date(),
+            })
+            .where(eq(workspaceOperations.id, candidate.id));
+        } catch {
+          // The terminal row and stderr excerpt stay inspectable even when the external log
+          // file from the previous process is gone.
+        }
+      }
+    }
+
+    return { reconciled: reconciledIds.length, operationIds: reconciledIds, live };
+  }
+
   return {
     getById,
+
+    /**
+     * Bounded recovery entrypoint. Safe to call on startup and before every managed control.
+     */
+    async reconcileStaleRuntimeControlOperations(
+      executionWorkspaceId?: string | null,
+      options?: { now?: Date; staleAfterMs?: number },
+    ) {
+      const result = await sweepRuntimeControlOperations(executionWorkspaceId, options);
+      return { reconciled: result.reconciled, operationIds: result.operationIds };
+    },
+
+    /**
+     * Refuse a managed runtime control while another one is genuinely live for the same
+     * execution workspace. Stale operations are recovered first, so a workspace stranded by
+     * a dead request or a previous server process becomes controllable again on its own.
+     */
+    async assertRuntimeControlAvailable(input: {
+      executionWorkspaceId: string;
+      action: string;
+      options?: { now?: Date; staleAfterMs?: number };
+    }) {
+      const { live } = await sweepRuntimeControlOperations(input.executionWorkspaceId, input.options);
+      const blocking = live[0];
+      if (!blocking) return;
+      const owner = readRuntimeControlOwner(blocking.metadata);
+      throw conflict("A managed runtime control operation is already in progress for this execution workspace.", {
+        code: "workspace_runtime_control_in_progress",
+        executionWorkspaceId: input.executionWorkspaceId,
+        activeAction: readRuntimeControlAction(blocking.metadata) ?? owner?.action ?? null,
+        requestedAction: input.action,
+        activeOperationId: blocking.id,
+        startedAt: blocking.startedAt instanceof Date ? blocking.startedAt.toISOString() : blocking.startedAt,
+        remediation:
+          "Wait for the active operation to reach a terminal state before retrying; abandoned operations are recovered automatically.",
+      });
+    },
 
     createRecorder(input: {
       companyId: string;
@@ -133,28 +481,91 @@ export function workspaceOperationService(db: Db) {
             });
           };
 
-          await db.insert(workspaceOperations).values({
-            id,
-            companyId: input.companyId,
-            executionWorkspaceId,
-            heartbeatRunId: input.heartbeatRunId ?? null,
-            issueId: input.issueId ?? null,
-            phase: recordInput.phase,
-            command: recordInput.command ?? null,
-            cwd: recordInput.cwd ?? null,
-            status: "running",
-            logStore: handle.store,
-            logRef: handle.logRef,
-            metadata: redactCurrentUserValue(
-              recordInput.metadata ?? null,
-              currentUserRedactionOptions,
-            ) as Record<string, unknown> | null,
-            startedAt,
-          });
-          createdIds.push(id);
+          // Managed runtime controls get an ownership stamp so bounded recovery can tell a
+          // slow-but-live operation from one abandoned by a dead request or server process.
+          const runtimeControlAction = readRuntimeControlAction(recordInput.metadata);
+          const insertedMetadata = runtimeControlAction
+            ? {
+                ...(recordInput.metadata ?? {}),
+                runtimeControlOwner: {
+                  ownerId: RUNTIME_CONTROL_OWNER_ID,
+                  pid: process.pid,
+                  action: runtimeControlAction,
+                  heartbeatAt: startedAt.toISOString(),
+                } satisfies RuntimeControlOwnerStamp,
+              }
+            : recordInput.metadata ?? null;
+
+          // Claim in-process before the row exists, so there is no ordering in which a recovery
+          // sweep can observe an operation stamped by this process but not yet tracked by it —
+          // which is the one state that would let recovery terminalize a genuinely live start.
+          if (runtimeControlAction) liveRuntimeControlOperationIds.add(id);
 
           try {
-            const result = await recordInput.run();
+            await db.insert(workspaceOperations).values({
+              id,
+              companyId: input.companyId,
+              executionWorkspaceId,
+              heartbeatRunId: input.heartbeatRunId ?? null,
+              issueId: input.issueId ?? null,
+              phase: recordInput.phase,
+              command: recordInput.command ?? null,
+              cwd: recordInput.cwd ?? null,
+              status: "running",
+              logStore: handle.store,
+              logRef: handle.logRef,
+              metadata: redactCurrentUserValue(
+                insertedMetadata,
+                currentUserRedactionOptions,
+              ) as Record<string, unknown> | null,
+              startedAt,
+              updatedAt: startedAt,
+            });
+          } catch (insertError) {
+            liveRuntimeControlOperationIds.delete(id);
+            throw insertError;
+          }
+          createdIds.push(id);
+
+          let heartbeatTimer: NodeJS.Timeout | null = null;
+          let timeoutTimer: NodeJS.Timeout | null = null;
+          if (runtimeControlAction) {
+            heartbeatTimer = setInterval(() => {
+              const heartbeatAt = new Date();
+              void db
+                .update(workspaceOperations)
+                .set({
+                  metadata: combineMetadata(insertedMetadata, {
+                    runtimeControlOwner: {
+                      ownerId: RUNTIME_CONTROL_OWNER_ID,
+                      pid: process.pid,
+                      action: runtimeControlAction,
+                      heartbeatAt: heartbeatAt.toISOString(),
+                    } satisfies RuntimeControlOwnerStamp,
+                  }),
+                  updatedAt: heartbeatAt,
+                })
+                .where(and(eq(workspaceOperations.id, id), eq(workspaceOperations.status, "running")))
+                .catch(() => undefined);
+            }, RUNTIME_CONTROL_HEARTBEAT_MS);
+            heartbeatTimer.unref?.();
+          }
+
+          const timeoutMs = recordInput.timeoutMs ?? defaultRuntimeControlTimeoutMs(runtimeControlAction);
+          const settle = async () => {
+            if (!timeoutMs || timeoutMs <= 0) return await recordInput.run();
+            const timeout = new Promise<never>((_resolve, reject) => {
+              timeoutTimer = setTimeout(
+                () => reject(new WorkspaceOperationTimeoutError(timeoutMs, runtimeControlAction)),
+                timeoutMs,
+              );
+              timeoutTimer.unref?.();
+            });
+            return await Promise.race([recordInput.run(), timeout]);
+          };
+
+          try {
+            const result = await settle();
             await append("system", result.system ?? null);
             await append("stdout", result.stdout ?? null);
             await append("stderr", result.stderr ?? null);
@@ -172,7 +583,7 @@ export function workspaceOperationService(db: Db) {
                 logSha256: finalized.sha256,
                 logCompressed: finalized.compressed,
                 metadata: redactCurrentUserValue(
-                  combineMetadata(recordInput.metadata, result.metadata),
+                  combineMetadata(insertedMetadata, result.metadata),
                   currentUserRedactionOptions,
                 ) as Record<string, unknown> | null,
                 finishedAt,
@@ -197,11 +608,31 @@ export function workspaceOperationService(db: Db) {
                 logBytes: finalized?.bytes ?? null,
                 logSha256: finalized?.sha256 ?? null,
                 logCompressed: finalized?.compressed ?? false,
+                // Only managed controls carry a failure reason; other phases keep the metadata
+                // they were recorded with.
+                ...(runtimeControlAction
+                  ? {
+                      metadata: redactCurrentUserValue(
+                        combineMetadata(insertedMetadata, {
+                          failureReason: error instanceof WorkspaceOperationTimeoutError
+                            ? "runtime_control_timeout"
+                            : "runtime_control_error",
+                        }),
+                        currentUserRedactionOptions,
+                      ) as Record<string, unknown> | null,
+                    }
+                  : {}),
                 finishedAt,
                 updatedAt: finishedAt,
               })
               .where(eq(workspaceOperations.id, id));
             throw error;
+          } finally {
+            // Releasing the in-process claim before the request unwinds is what lets the very
+            // next control call proceed, and lets recovery treat a leftover row as abandoned.
+            if (heartbeatTimer) clearInterval(heartbeatTimer);
+            if (timeoutTimer) clearTimeout(timeoutTimer);
+            liveRuntimeControlOperationIds.delete(id);
           }
         },
       };

--- a/server/src/services/workspace-runtime-exposure-backfill.test.ts
+++ b/server/src/services/workspace-runtime-exposure-backfill.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Backfill decision coverage for PAP-17158.
+ *
+ * `decideManagedRuntimeExposureBackfill` is the whole contract for which
+ * pre-feature workspaces get upgraded to HTTPS in place and which are left
+ * alone, so each branch is asserted by its reason code rather than only by the
+ * resulting action.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  decideManagedRuntimeExposureBackfill,
+  decideStaleExposureReclaim,
+} from "./workspace-runtime.js";
+
+/** A persisted, running, pre-feature Paperclip App dev runtime. */
+function httpOnlyRunningRow(overrides: Partial<Parameters<typeof decideManagedRuntimeExposureBackfill>[0]> = {}) {
+  return {
+    mode: "auto" as const,
+    brokerAvailable: true,
+    provider: "local_process",
+    serviceName: "paperclip-dev",
+    command: "pnpm dev --bind lan",
+    status: "running",
+    hasExposure: false,
+    declaredIntent: "unset" as const,
+    ...overrides,
+  };
+}
+
+describe("decideManagedRuntimeExposureBackfill", () => {
+  it("reprovisions a running HTTP-only managed worktree runtime", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow())).toEqual({
+      action: "reprovision",
+      reason: "http_only_managed_service",
+    });
+  });
+
+  it("reprovisions a service that is mid-start as well as one already running", () => {
+    for (const status of ["provisioning", "starting", "running"]) {
+      expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ status })).action).toBe("reprovision");
+    }
+  });
+
+  it("leaves a stopped service to pick the default up on its next start", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ status: "stopped" }))).toEqual({
+      action: "keep",
+      reason: "stopped_defaults_on_next_start",
+    });
+  });
+
+  it("preserves a deliberate opt-out", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ declaredIntent: "disabled" }))).toEqual({
+      action: "keep",
+      reason: "deliberate_opt_out",
+    });
+  });
+
+  it("is idempotent: a row that already carries exposure state is never re-driven", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ hasExposure: true }))).toEqual({
+      action: "keep",
+      reason: "already_exposed",
+    });
+    // Repeated deploys see the same row and must keep converging on "keep".
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ hasExposure: true })).action).toBe("keep");
+  });
+
+  it("leaves unmanaged and custom services alone", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({
+      serviceName: "preview",
+      command: "pnpm vite",
+    }))).toEqual({ action: "keep", reason: "unmanaged_or_custom_service" });
+  });
+
+  it("leaves external (non local_process) runtime services alone", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ provider: "external" }))).toEqual({
+      action: "keep",
+      reason: "not_a_managed_local_process",
+    });
+  });
+
+  it("does nothing when the automatic default is switched off", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ mode: "off" }))).toEqual({
+      action: "keep",
+      reason: "https_default_disabled",
+    });
+  });
+
+  it("skips the backfill when the host broker is unavailable, unless forced", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ brokerAvailable: false }))).toEqual({
+      action: "keep",
+      reason: "broker_unavailable",
+    });
+    expect(
+      decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ brokerAvailable: false, mode: "force" })).action,
+    ).toBe("reprovision");
+  });
+
+  it("never takes down a row it cannot restart from a configured entry", () => {
+    expect(decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ declaredIntent: null }))).toEqual({
+      action: "keep",
+      reason: "no_configured_service_entry",
+    });
+  });
+
+  it("reprovisions an explicit opt-in that is somehow running without exposure", () => {
+    expect(
+      decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({ declaredIntent: "enabled" })).action,
+    ).toBe("reprovision");
+  });
+
+  it("checks the opt-out before broker availability so an opt-out never depends on host state", () => {
+    expect(
+      decideManagedRuntimeExposureBackfill(httpOnlyRunningRow({
+        declaredIntent: "disabled",
+        brokerAvailable: false,
+      })).reason,
+    ).toBe("deliberate_opt_out");
+  });
+});
+
+/**
+ * PAP-17285 regression coverage for the global startup exposure sweep.
+ *
+ * A server restart at 12:25:49 UTC deleted the operator-preserved `42000/52000`
+ * Serve mappings by issuing broker removals for two stale `stopped` rows — 2 and
+ * 3 days old, both claiming the same recycled pair — purely on those rows'
+ * authority. The sweep spans every execution workspace and company on the host
+ * and runs on every start, so "trust the row" is an unbounded delete primitive.
+ * These pin the corroboration contract that replaced it.
+ */
+const RUNTIME = "c4a0f1d8-be27-4f95-970e-443fe4a517b7";
+const OTHER_RUNTIME = "c0cca855-0d56-47fc-beca-9f3e3b8d341f";
+
+describe("decideStaleExposureReclaim", () => {
+  it("defers instead of removing when the broker cannot be reached", () => {
+    // Unreachable broker proves nothing. Fail closed toward preservation: a
+    // mapping we cannot attribute must never be deleted on a guess.
+    expect(decideStaleExposureReclaim({ runtimeId: RUNTIME, ownedListeners: null })).toEqual({
+      action: "defer",
+      reason: "broker_unreachable",
+    });
+  });
+
+  it("clears stale bookkeeping WITHOUT a Serve mutation when the broker owns nothing for the runtime", () => {
+    // The 12:28:19 row: 3 days old, claiming a pair that had since been recycled.
+    // Nothing of ours is published under this runtime, so there is nothing to
+    // remove — only local bookkeeping to tidy.
+    expect(decideStaleExposureReclaim({ runtimeId: RUNTIME, ownedListeners: [] })).toEqual({
+      action: "clear_bookkeeping",
+      reason: "not_owned_by_broker",
+    });
+    expect(
+      decideStaleExposureReclaim({
+        runtimeId: RUNTIME,
+        ownedListeners: [{ runtimeId: OTHER_RUNTIME, port: 42000 }],
+      }),
+    ).toEqual({ action: "clear_bookkeeping", reason: "not_owned_by_broker" });
+  });
+
+  it("reclaims only when the broker still attributes a listener to that exact runtime", () => {
+    // Genuine orphan GC — the behaviour PAP-17207 row 7 requires — is preserved.
+    expect(
+      decideStaleExposureReclaim({
+        runtimeId: RUNTIME,
+        ownedListeners: [{ runtimeId: RUNTIME, port: 42001 }],
+      }),
+    ).toEqual({ action: "reclaim", reason: "owned_by_broker" });
+  });
+
+  it("attributes by runtimeId and never by port, so a recycled port cannot cross-authorize", () => {
+    // Two rows claiming the same recycled pair is exactly the observed state. If
+    // this matched on port, either row could authorize deleting the other's
+    // mapping — which is the shape of the original loss.
+    expect(
+      decideStaleExposureReclaim({
+        runtimeId: RUNTIME,
+        ownedListeners: [{ runtimeId: OTHER_RUNTIME, port: 42000 }, { runtimeId: OTHER_RUNTIME, port: 52000 }],
+      }).action,
+    ).toBe("clear_bookkeeping");
+  });
+});

--- a/server/src/services/workspace-runtime-exposure.test.ts
+++ b/server/src/services/workspace-runtime-exposure.test.ts
@@ -1,0 +1,542 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import type { BrokerClient, BrokerListenerRequest } from "./runtime-exposure/broker-client.js";
+import { diagnoseRuntimeListenerBinds } from "./runtime-exposure/loopback-listener.js";
+import {
+  resetRuntimeServicesForTests,
+  setWorkspaceRuntimeExposureDepsForTests,
+  startRuntimeServicesForWorkspaceControl,
+  stopRuntimeServicesForExecutionWorkspace,
+} from "./workspace-runtime.js";
+
+const EXECUTION_WORKSPACE_ID = "11111111-2222-4333-8444-555566667777";
+const HANDLE = "handle-abcdef1234567890";
+
+// The shared test setup pins the automatic default off so unrelated suites do
+// not probe for a real host broker. This suite is about the default, so it opts
+// back in and restores the harness value afterwards.
+let previousHttpsMode: string | undefined;
+beforeEach(() => {
+  previousHttpsMode = process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+  process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = "auto";
+});
+
+afterEach(async () => {
+  if (previousHttpsMode === undefined) delete process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS;
+  else process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS = previousHttpsMode;
+  // These tests spawn real loopback backends on dedicated-range ports; reap them
+  // rather than leaving one squatting 42xxx/52xxx for every test in the file.
+  await resetRuntimeServicesForTests({ terminateProcesses: true });
+});
+
+function serviceCommand() {
+  return `node -e 'const http=require("http");const p=Number(process.env.PORT);for(const q of [p,p+10000])http.createServer((_,r)=>{r.statusCode=200;r.end("ok")}).listen(q,"127.0.0.1");setInterval(()=>{},1000)'`;
+}
+
+/**
+ * Fake guest dev runners written to disk (PAP-17256).
+ *
+ * They must be real files named `dev-runner*.mjs` for two reasons: the command
+ * has to look like a dev-runner invocation for the rewrite to apply at all, and
+ * `node <file> --bind lan` hands the flags to the script, which is exactly how a
+ * real `pnpm dev --bind lan` reaches `scripts/dev-runner.ts`.
+ */
+let guestDir: string;
+
+/**
+ * A guest checkout from *before* managed HTTPS exposure existed.
+ *
+ * Reproduces the behaviour that actually broke the lanes: `scripts/dev-runner.ts`
+ * on plain master derives its bind mode from its own `--bind` / `--bind-host`
+ * argv and **ignores `PAPERCLIP_BIND` / `PAPERCLIP_MANAGED_RUNTIME_EXPOSURE`
+ * entirely** — so env-only hardening cannot reach it. `--bind lan` therefore
+ * means `0.0.0.0`, which the broker must refuse.
+ */
+const PRE_MANAGED_EXPOSURE_GUEST = `
+import http from "node:http";
+const argv = process.argv.slice(2);
+const valueOf = (flag) => {
+  const at = argv.indexOf(flag);
+  const value = at >= 0 ? argv[at + 1] : undefined;
+  return value && !value.startsWith("--") ? value : undefined;
+};
+const mode = valueOf("--bind") ?? "loopback";
+const host = mode === "custom" ? (valueOf("--bind-host") ?? "127.0.0.1")
+  : mode === "lan" ? "0.0.0.0"
+  : "127.0.0.1";
+const p = Number(process.env.PORT);
+for (const q of [p, p + 10000]) {
+  http.createServer((_, r) => { r.statusCode = 200; r.end("ok"); }).listen(q, host);
+}
+setInterval(() => {}, 1000);
+`;
+
+/**
+ * The true shape of the deployed failure: a guest that honours the bind argv for
+ * its own HTTP listener but whose Vite gets `hmr.port` with no `hmr.server` and
+ * no `server.host`, so Vite opens its *own* HMR websocket on the IPv6 wildcard
+ * regardless of the bind mode. Plain master's `server/src/app.ts` does exactly
+ * this, which is why forcing the bind is necessary but not sufficient there.
+ */
+const WILDCARD_HMR_GUEST = `
+import http from "node:http";
+const argv = process.argv.slice(2);
+const at = argv.indexOf("--bind-host");
+const host = at >= 0 ? argv[at + 1] : "127.0.0.1";
+const p = Number(process.env.PORT);
+http.createServer((_, r) => { r.statusCode = 200; r.end("ok"); }).listen(p, host);
+// No host argument: Vite's own HMR listener lands on the wildcard.
+http.createServer((_, r) => { r.statusCode = 426; r.end(); }).listen(p + 10000);
+setInterval(() => {}, 1000);
+`;
+
+/** A guest so old it has no bind flags at all and always binds the wildcard. */
+const ALWAYS_WILDCARD_GUEST = `
+import http from "node:http";
+const p = Number(process.env.PORT);
+for (const q of [p, p + 10000]) {
+  http.createServer((_, r) => { r.statusCode = 200; r.end("ok"); }).listen(q, "0.0.0.0");
+}
+setInterval(() => {}, 1000);
+`;
+
+beforeAll(async () => {
+  guestDir = await fs.mkdtemp(path.join(os.tmpdir(), "pap-17256-guest-"));
+  await fs.writeFile(path.join(guestDir, "dev-runner.mjs"), PRE_MANAGED_EXPOSURE_GUEST);
+  await fs.writeFile(path.join(guestDir, "dev-runner-legacy.mjs"), ALWAYS_WILDCARD_GUEST);
+  await fs.writeFile(path.join(guestDir, "dev-runner-wildcard-hmr.mjs"), WILDCARD_HMR_GUEST);
+});
+
+afterAll(async () => {
+  await fs.rm(guestDir, { recursive: true, force: true });
+});
+
+const guestCommand = (file: string) => `node ${path.join(guestDir, file)}`;
+
+function createBroker() {
+  const calls: string[] = [];
+  let listeners: BrokerListenerRequest[] = [];
+  const broker: BrokerClient = {
+    async reserve(_runtimeId, requested) {
+      calls.push("reserve");
+      listeners = requested;
+      return { handle: HANDLE, reservedPorts: requested.map((listener) => listener.port) };
+    },
+    async expose() {
+      calls.push("expose");
+      return { handle: HANDLE, publicPorts: listeners.map((listener) => listener.port) };
+    },
+    async remove() {
+      calls.push("remove");
+      return { removedPorts: listeners.map((listener) => listener.port) };
+    },
+    async list() {
+      return [];
+    },
+  };
+  return { broker, calls };
+}
+
+function installDeps(overrides: {
+  broker: BrokerClient;
+  probeHealth?: () => Promise<boolean>;
+  isBrokerAvailable?: () => Promise<boolean>;
+  isPortAvailable?: (port: number) => Promise<boolean>;
+  diagnoseListenerBinds?: (ports: number[]) => Promise<string | null>;
+}) {
+  setWorkspaceRuntimeExposureDepsForTests({
+    broker: overrides.broker,
+    isPortAvailable: overrides.isPortAvailable ?? (async () => true),
+    isBrokerAvailable: overrides.isBrokerAvailable ?? (async () => true),
+    resolveHostname: async () => "runner.tail123.ts.net",
+    probeHealth: overrides.probeHealth ?? (async () => true),
+    now: () => "2026-08-11T00:00:00.000Z",
+    // The real /proc-backed diagnosis, not a fake: the fake broker below always
+    // says yes, so this is what has to catch an off-loopback bind here.
+    diagnoseListenerBinds: overrides.diagnoseListenerBinds ?? diagnoseRuntimeListenerBinds,
+  });
+}
+
+const DECLARED_EXPOSE = {
+  type: "tailscale_https",
+  hostname: "auto",
+  publicPort: "same",
+  includePaperclipViteHmr: true,
+  failurePolicy: "fail_closed",
+} as const;
+
+/**
+ * The pre-feature Paperclip App project template, verbatim: a hard-coded HTTP
+ * `urlTemplate`, a pinned port outside the broker's dedicated range, and no
+ * exposure declaration at all.
+ */
+const LEGACY_HTTP_EXPOSE = {
+  type: "url",
+  urlTemplate: "http://paperclip-dev:{{port}}",
+} as const;
+
+function startInput(options?: {
+  serviceName?: string;
+  expose?: Record<string, unknown> | null;
+  port?: Record<string, unknown> | number;
+  command?: string;
+}) {
+  const expose = options?.expose === undefined ? DECLARED_EXPOSE : options.expose;
+  return {
+    invocationId: "runtime-exposure-test",
+    actor: { id: null, name: "Paperclip", companyId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" },
+    issue: null,
+    workspace: {
+      baseCwd: process.cwd(),
+      source: "project_primary" as const,
+      projectId: null,
+      workspaceId: null,
+      repoUrl: null,
+      repoRef: null,
+      strategy: "project_primary" as const,
+      cwd: process.cwd(),
+      branchName: "test",
+      worktreePath: null,
+      warnings: [],
+      created: false,
+    },
+    executionWorkspaceId: EXECUTION_WORKSPACE_ID,
+    config: {
+      workspaceRuntime: {
+        services: [{
+          name: options?.serviceName ?? "preview",
+          command: options?.command ?? serviceCommand(),
+          port: options?.port ?? { type: "auto", envKey: "PORT" },
+          readiness: { type: "http", urlTemplate: "http://127.0.0.1:{{port}}", timeoutSec: 5 },
+          ...(expose ? { expose } : {}),
+        }],
+      },
+    },
+    adapterEnv: {},
+  };
+}
+
+describe("workspace runtime tailscale_https lifecycle", () => {
+  it("reserves before spawn, exposes after backend readiness, and removes on stop", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput());
+    expect(calls.slice(0, 2)).toEqual(["reserve", "expose"]);
+    expect(runtime.port).toBeGreaterThanOrEqual(42000);
+    expect(runtime.url).toBe(`https://runner.tail123.ts.net:${runtime.port}`);
+    expect(runtime.exposure?.state).toBe("ready");
+
+    await stopRuntimeServicesForExecutionWorkspace({
+      executionWorkspaceId: EXECUTION_WORKSPACE_ID,
+      runtimeServiceId: runtime.id,
+    });
+    expect(calls).toEqual(["reserve", "expose", "remove"]);
+  }, 15_000);
+
+  it("fails closed and removes the mapping when external HTTPS validation fails", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker, probeHealth: async () => false });
+
+    await expect(startRuntimeServicesForWorkspaceControl(startInput())).rejects.toThrow(/HTTPS exposure failed/);
+    expect(calls).toEqual(["reserve", "expose", "remove"]);
+  }, 15_000);
+});
+
+describe("automatic tailscale_https default for managed worktree runtimes", () => {
+  it("defaults a legacy paperclip-dev service with no exposure block, relocating its pinned port", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    // Exactly the persisted pre-feature shape: pinned 45439 + HTTP urlTemplate.
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      expose: LEGACY_HTTP_EXPOSE,
+      port: 45_439,
+    }));
+
+    expect(calls.slice(0, 2)).toEqual(["reserve", "expose"]);
+    // 45439 is outside the broker allowlist, so the pinned port cannot be kept.
+    expect(runtime.port).not.toBe(45_439);
+    expect(runtime.port).toBeGreaterThanOrEqual(42_000);
+    expect(runtime.port).toBeLessThanOrEqual(42_999);
+    // The canonical URL is the verified HTTPS origin; HTTP is never retained.
+    expect(runtime.url).toBe(`https://runner.tail123.ts.net:${runtime.port}`);
+    expect(runtime.url).not.toContain("http://");
+    expect(runtime.exposure?.state).toBe("ready");
+  }, 15_000);
+
+  it("keeps an existing runtime port that is already inside the dedicated range", async () => {
+    const { broker } = createBroker();
+    installDeps({ broker });
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      expose: LEGACY_HTTP_EXPOSE,
+      port: 42_500,
+    }));
+
+    expect(runtime.port).toBe(42_500);
+    expect(runtime.url).toBe("https://runner.tail123.ts.net:42500");
+  }, 15_000);
+
+  it("preserves a deliberate opt-out and leaves the service on plain HTTP", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      expose: { ...LEGACY_HTTP_EXPOSE, tailscaleHttps: false },
+      port: { type: "auto", envKey: "PORT" },
+    }));
+
+    expect(calls).toEqual([]);
+    expect(runtime.exposure ?? null).toBeNull();
+    expect(runtime.url).toBe(`http://paperclip-dev:${runtime.port}`);
+  }, 15_000);
+
+  it("leaves an unmanaged/custom service untouched", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "preview",
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    }));
+
+    expect(calls).toEqual([]);
+    expect(runtime.exposure ?? null).toBeNull();
+    expect(runtime.url).toBe(`http://paperclip-dev:${runtime.port}`);
+  }, 15_000);
+
+  it("does not default when the host broker is unavailable", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker, isBrokerAvailable: async () => false });
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    }));
+
+    expect(calls).toEqual([]);
+    expect(runtime.exposure ?? null).toBeNull();
+  }, 15_000);
+
+  it("still honors an explicit opt-in when the broker socket is missing, failing loudly", async () => {
+    // A missing broker must never silently downgrade a requested HTTPS preview.
+    const { broker, calls } = createBroker();
+    const failing: BrokerClient = {
+      ...broker,
+      async reserve() {
+        calls.push("reserve");
+        throw new Error("ENOENT: broker socket missing");
+      },
+    };
+    installDeps({ broker: failing, isBrokerAvailable: async () => false });
+
+    await expect(
+      startRuntimeServicesForWorkspaceControl(startInput({ serviceName: "paperclip-dev" })),
+    ).rejects.toThrow();
+    expect(calls).toEqual(["reserve"]);
+  }, 15_000);
+
+  it("is idempotent across repeated starts: the same port pair is reserved again", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const [first] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      expose: LEGACY_HTTP_EXPOSE,
+      port: 45_439,
+    }));
+    const firstPort = first.port;
+    await stopRuntimeServicesForExecutionWorkspace({
+      executionWorkspaceId: EXECUTION_WORKSPACE_ID,
+      runtimeServiceId: first.id,
+    });
+    calls.length = 0;
+
+    const [second] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      expose: LEGACY_HTTP_EXPOSE,
+      port: 45_439,
+    }));
+
+    expect(calls.slice(0, 2)).toEqual(["reserve", "expose"]);
+    expect(second.port).toBe(firstPort);
+    expect(second.url).toBe(`https://runner.tail123.ts.net:${firstPort}`);
+  }, 25_000);
+});
+
+/**
+ * PAP-17256: the deployed regression. A fresh managed lane on service index 0
+ * failed every start with `listener_ownership_mismatch` because the branch
+ * checkout it launched bound `0.0.0.0`, and the server only asked for loopback
+ * via env vars that checkout never read.
+ */
+describe("loopback bind is forced on the guest, not merely requested (PAP-17256)", () => {
+  it("starts a fresh service-index-0 lane whose guest only honours argv", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      // Verbatim the command every failing lane recorded, modulo the fake guest.
+      command: `${guestCommand("dev-runner.mjs")} --bind lan`,
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    }));
+
+    // The launched command carries the loopback bind, replacing `--bind lan`.
+    expect(runtime.command).toContain("--bind custom --bind-host 127.0.0.1");
+    expect(runtime.command).not.toContain("--bind lan");
+
+    // And because the guest honoured it, both listeners are loopback-only, so
+    // the exposure completes instead of being denied.
+    expect(calls.slice(0, 2)).toEqual(["reserve", "expose"]);
+    expect(runtime.exposure?.state).toBe("ready");
+    expect(runtime.exposure?.lastError ?? null).toBeNull();
+    expect(runtime.port).toBeGreaterThanOrEqual(42_000);
+    expect(runtime.url).toBe(`https://runner.tail123.ts.net:${runtime.port}`);
+
+    // Independent confirmation on the live listeners, using the same /proc read
+    // the broker's gate performs.
+    const hmrPort = runtime.port! + 10_000;
+    expect(await diagnoseRuntimeListenerBinds([runtime.port!, hmrPort])).toBeNull();
+
+    await stopRuntimeServicesForExecutionWorkspace({
+      executionWorkspaceId: EXECUTION_WORKSPACE_ID,
+      runtimeServiceId: runtime.id,
+    });
+    expect(calls).toEqual(["reserve", "expose", "remove"]);
+  }, 20_000);
+
+  it("reaches a terminal failure naming the port and address when a guest still binds the wildcard", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    // A guest with no bind flags at all: the argv rewrite cannot reach it, so
+    // this is the residual case that must fail loudly rather than expose.
+    await expect(startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      command: guestCommand("dev-runner-legacy.mjs"),
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    }))).rejects.toThrow(/listener_ownership_mismatch.*(?:0\.0\.0\.0|::)/s);
+
+    // Terminal recovery: the reservation is released and nothing was exposed.
+    // The diagnosis runs before the broker, so `expose` is never attempted.
+    expect(calls).toEqual(["reserve", "remove"]);
+  }, 20_000);
+
+  it("explains rather than only coding the failure, so the next operator can act", async () => {
+    const { broker } = createBroker();
+    installDeps({ broker });
+
+    const error = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      command: guestCommand("dev-runner-legacy.mjs"),
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    })).then(() => null, (err: unknown) => err as Error);
+
+    expect(error).not.toBeNull();
+    // The bare code alone is what cost PAP-17254 three diagnostic cycles.
+    expect(error!.message).toContain("listener_ownership_mismatch");
+    expect(error!.message).toContain("loopback");
+    expect(error!.message).toContain("--bind custom --bind-host 127.0.0.1");
+  }, 20_000);
+
+  it("leaves a non-Paperclip service's --bind argument alone", async () => {
+    // `--bind` means something entirely different to the HTTPS probe canaries
+    // (`python3 -m http.server --bind 127.0.0.1`); rewriting it would break them.
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const declared = `${serviceCommand()} -- --bind 127.0.0.1`;
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "https-probe-canary",
+      command: declared,
+      port: { type: "auto", envKey: "PORT" },
+    }));
+
+    expect(runtime.command).toBe(declared);
+    expect(runtime.command).not.toContain("--bind custom");
+    expect(calls.slice(0, 2)).toEqual(["reserve", "expose"]);
+    expect(runtime.exposure?.state).toBe("ready");
+  }, 20_000);
+
+  it("does not rewrite a Paperclip dev command when the service is not exposed", async () => {
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const declared = `${guestCommand("dev-runner.mjs")} --bind lan`;
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      command: declared,
+      expose: { ...LEGACY_HTTP_EXPOSE, tailscaleHttps: false },
+      port: { type: "auto", envKey: "PORT" },
+    }));
+
+    expect(calls).toEqual([]);
+    expect(runtime.command).toBe(declared);
+  }, 20_000);
+});
+
+describe("readiness probes loopback for an exposed runtime (PAP-17256)", () => {
+  it("starts even when the only readiness target is the MagicDNS display URL", async () => {
+    // The live project config declares a loopback readiness URL, but when it does
+    // not, readiness falls back to `expose.urlTemplate` — a MagicDNS name that
+    // resolves off-loopback. That only ever answered because the guest was bound
+    // to the wildcard, so it must be normalised alongside the bind fix.
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const input = startInput({
+      serviceName: "paperclip-dev",
+      command: `${guestCommand("dev-runner.mjs")} --bind lan`,
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    });
+    // Drop the explicit loopback readiness URL so the fallback path is exercised.
+    const service = input.config.workspaceRuntime.services[0] as Record<string, unknown>;
+    service.readiness = { type: "http", timeoutSec: 10, intervalMs: 100 };
+
+    const [runtime] = await startRuntimeServicesForWorkspaceControl(input);
+
+    expect(calls.slice(0, 2)).toEqual(["reserve", "expose"]);
+    expect(runtime.exposure?.state).toBe("ready");
+    expect(runtime.url).toBe(`https://runner.tail123.ts.net:${runtime.port}`);
+  }, 20_000);
+});
+
+describe("the deployed failure shape: loopback app port, wildcard HMR (PAP-17256)", () => {
+  it("fails terminally naming the HMR port, because forcing the bind cannot reach Vite's own listener", async () => {
+    // Plain master's app.ts passes Vite `hmr.port` without `hmr.server` or
+    // `server.host`, so the HMR websocket binds `::` no matter what the bind mode
+    // is. The argv rewrite fixes the app port; only the preflight catches this.
+    const { broker, calls } = createBroker();
+    installDeps({ broker });
+
+    const error = await startRuntimeServicesForWorkspaceControl(startInput({
+      serviceName: "paperclip-dev",
+      command: `${guestCommand("dev-runner-wildcard-hmr.mjs")} --bind lan`,
+      expose: LEGACY_HTTP_EXPOSE,
+      port: { type: "auto", envKey: "PORT" },
+    })).then(() => null, (err: unknown) => err as Error);
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain("listener_ownership_mismatch");
+    // The app port obeyed the forced bind; the HMR companion is the offender, and
+    // the diagnosis has to say so rather than blaming the lane as a whole.
+    expect(error!.message).toMatch(/port 5\d{4} is bound to/);
+    expect(error!.message).not.toMatch(/port 4\d{4} is bound to/);
+    expect(calls).toEqual(["reserve", "remove"]);
+  }, 20_000);
+});

--- a/server/src/services/workspace-runtime-leases.ts
+++ b/server/src/services/workspace-runtime-leases.ts
@@ -1,0 +1,317 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { executionWorkspaceRuntimeLeases, heartbeatRuns, issues } from "@paperclipai/db";
+import { conflict } from "../errors.js";
+
+type ExecutionWorkspaceRuntimeLeaseRow = typeof executionWorkspaceRuntimeLeases.$inferSelect;
+type LeaseTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+/**
+ * Issue statuses that keep an issue eligible to drive workspace runtime controls.
+ * Shared with the runtime authorization path so "still authorized" and "still owns
+ * the lease" cannot drift apart.
+ */
+export const WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES: readonly string[] = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "in_review",
+  "blocked",
+];
+
+const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set([
+  "succeeded",
+  "interrupted",
+  "failed",
+  "cancelled",
+  "timed_out",
+]);
+
+/** Runtime control actions that mutate the workspace and therefore need the lease. */
+export const LEASED_WORKSPACE_RUNTIME_ACTIONS: readonly string[] = ["start", "stop", "restart"];
+
+/**
+ * Upper bound on how long a lease survives without the owner touching it. Recovery
+ * from a stale owner is otherwise driven by owner eligibility, which is cheaper and
+ * more precise; the TTL only bounds the cases eligibility cannot see (for example an
+ * agent-scoped owner with no run or issue identity).
+ */
+export const WORKSPACE_RUNTIME_LEASE_TTL_MS = 30 * 60 * 1000;
+
+export type WorkspaceRuntimeLeaseOwner = {
+  actorType: string;
+  agentId?: string | null;
+  runId?: string | null;
+  issueId?: string | null;
+};
+
+export type WorkspaceRuntimeLeaseStaleReason =
+  | "lease_expired"
+  | "owner_issue_missing"
+  | "owner_issue_hidden"
+  | "owner_issue_terminal"
+  | "owner_run_missing"
+  | "owner_run_terminal";
+
+export type WorkspaceRuntimeLeaseClaim = {
+  outcome: "created" | "renewed" | "reclaimed" | "bypassed";
+  ownerKey: string | null;
+  lease: ExecutionWorkspaceRuntimeLeaseRow | null;
+  reclaimedFrom: { ownerKey: string; reason: WorkspaceRuntimeLeaseStaleReason } | null;
+};
+
+/**
+ * Durable owner identity for a lease. The controlling issue is preferred because a
+ * canary lane outlives any single heartbeat run; runs and bare agent keys are only
+ * used when no issue is in scope.
+ */
+export function buildWorkspaceRuntimeLeaseOwnerKey(owner: WorkspaceRuntimeLeaseOwner): string | null {
+  if (owner.issueId) return `issue:${owner.issueId}`;
+  if (owner.runId) return `run:${owner.runId}`;
+  if (owner.agentId) return `agent:${owner.agentId}`;
+  return null;
+}
+
+function parseOwnerKey(ownerKey: string): { kind: "issue" | "run" | "agent"; id: string } | null {
+  const separator = ownerKey.indexOf(":");
+  if (separator <= 0) return null;
+  const kind = ownerKey.slice(0, separator);
+  const id = ownerKey.slice(separator + 1);
+  if (!id) return null;
+  if (kind !== "issue" && kind !== "run" && kind !== "agent") return null;
+  return { kind, id };
+}
+
+async function evaluateStaleOwner(
+  tx: LeaseTx,
+  lease: ExecutionWorkspaceRuntimeLeaseRow,
+  now: Date,
+): Promise<WorkspaceRuntimeLeaseStaleReason | null> {
+  if (lease.expiresAt.getTime() <= now.getTime()) return "lease_expired";
+
+  const owner = parseOwnerKey(lease.ownerKey);
+  if (owner?.kind === "issue") {
+    const ownerIssue = await tx
+      .select({ status: issues.status, hiddenAt: issues.hiddenAt })
+      .from(issues)
+      .where(and(eq(issues.id, owner.id), eq(issues.companyId, lease.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!ownerIssue) return "owner_issue_missing";
+    if (ownerIssue.hiddenAt) return "owner_issue_hidden";
+    if (!WORKSPACE_RUNTIME_ELIGIBLE_ISSUE_STATUSES.includes(ownerIssue.status)) return "owner_issue_terminal";
+    return null;
+  }
+
+  if (owner?.kind === "run") {
+    const ownerRun = await tx
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.id, owner.id), eq(heartbeatRuns.companyId, lease.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!ownerRun) return "owner_run_missing";
+    if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(ownerRun.status)) return "owner_run_terminal";
+    return null;
+  }
+
+  // Agent-scoped and unparseable owners have no lifecycle to inspect, so the TTL
+  // checked above is their only recovery path.
+  return null;
+}
+
+function throwLeaseConflict(input: {
+  lease: ExecutionWorkspaceRuntimeLeaseRow;
+  requestedAction: string;
+  requestedOwnerKey: string;
+}): never {
+  const { lease } = input;
+  throw conflict(
+    "Another issue run holds the exclusive runtime lease for this execution workspace.",
+    {
+      code: "workspace_runtime_lease_conflict",
+      executionWorkspaceId: lease.executionWorkspaceId,
+      requestedAction: input.requestedAction,
+      requestedOwnerKey: input.requestedOwnerKey,
+      ownerKey: lease.ownerKey,
+      ownerIssueId: lease.ownerIssueId,
+      ownerRunId: lease.ownerRunId,
+      ownerAgentId: lease.ownerAgentId,
+      lastAction: lease.lastAction,
+      claimedAt: lease.claimedAt.toISOString(),
+      renewedAt: lease.renewedAt.toISOString(),
+      expiresAt: lease.expiresAt.toISOString(),
+      remediation:
+        "Do not retry against this execution workspace. Wait for the owning issue to reach a terminal status, ask its owner to release the workspace, or wait for the lease to expire, then retry.",
+    },
+  );
+}
+
+export function workspaceRuntimeLeaseService(db: Db) {
+  return {
+    async get(executionWorkspaceId: string) {
+      return await db
+        .select()
+        .from(executionWorkspaceRuntimeLeases)
+        .where(eq(executionWorkspaceRuntimeLeases.executionWorkspaceId, executionWorkspaceId))
+        .then((rows) => rows[0] ?? null);
+    },
+
+    /**
+     * Atomically claim (or renew, or reclaim from a stale owner) the exclusive runtime
+     * lease for an execution workspace. Cross-process exclusivity comes from the unique
+     * constraint on execution_workspace_id plus a `SELECT ... FOR UPDATE` on the existing
+     * row, so competing claims serialize in the database rather than in one process.
+     *
+     * Board/operator actors bypass the lease entirely: they keep unconditional control
+     * and never take the lane away from an agent run.
+     */
+    async claim(input: {
+      companyId: string;
+      executionWorkspaceId: string;
+      action: string;
+      owner: WorkspaceRuntimeLeaseOwner;
+      now?: Date;
+      ttlMs?: number;
+    }): Promise<WorkspaceRuntimeLeaseClaim> {
+      if (input.owner.actorType !== "agent") {
+        return { outcome: "bypassed", ownerKey: null, lease: null, reclaimedFrom: null };
+      }
+
+      const ownerKey = buildWorkspaceRuntimeLeaseOwnerKey(input.owner);
+      if (!ownerKey) {
+        return { outcome: "bypassed", ownerKey: null, lease: null, reclaimedFrom: null };
+      }
+
+      const now = input.now ?? new Date();
+      const expiresAt = new Date(now.getTime() + (input.ttlMs ?? WORKSPACE_RUNTIME_LEASE_TTL_MS));
+      const ownerColumns = {
+        ownerKey,
+        ownerIssueId: input.owner.issueId ?? null,
+        ownerRunId: input.owner.runId ?? null,
+        ownerAgentId: input.owner.agentId ?? null,
+      };
+
+      return await db.transaction(async (tx) => {
+        const created = await tx
+          .insert(executionWorkspaceRuntimeLeases)
+          .values({
+            companyId: input.companyId,
+            executionWorkspaceId: input.executionWorkspaceId,
+            ...ownerColumns,
+            lastAction: input.action,
+            claimedAt: now,
+            renewedAt: now,
+            expiresAt,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoNothing({ target: executionWorkspaceRuntimeLeases.executionWorkspaceId })
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (created) {
+          return { outcome: "created" as const, ownerKey, lease: created, reclaimedFrom: null };
+        }
+
+        // The insert above conflicted, so a row exists (and, if a competing claim was
+        // mid-flight, the conflict already waited for it to commit). Lock it before
+        // deciding whether this caller may take or keep the lane.
+        const current = await tx
+          .select()
+          .from(executionWorkspaceRuntimeLeases)
+          .where(eq(executionWorkspaceRuntimeLeases.executionWorkspaceId, input.executionWorkspaceId))
+          .for("update")
+          .then((rows) => rows[0] ?? null);
+        if (!current) {
+          // The holder released between the conflict and the lock; the caller can retry
+          // immediately rather than mutating a workspace it does not own.
+          throw conflict("The execution workspace runtime lease changed while it was being claimed.", {
+            code: "workspace_runtime_lease_contended",
+            executionWorkspaceId: input.executionWorkspaceId,
+            requestedAction: input.action,
+            remediation: "Retry the runtime control request.",
+          });
+        }
+
+        if (current.ownerKey === ownerKey) {
+          const renewed = await tx
+            .update(executionWorkspaceRuntimeLeases)
+            .set({
+              ...ownerColumns,
+              lastAction: input.action,
+              renewedAt: now,
+              expiresAt,
+              updatedAt: now,
+            })
+            .where(eq(executionWorkspaceRuntimeLeases.id, current.id))
+            .returning()
+            .then((rows) => rows[0] ?? current);
+          return { outcome: "renewed" as const, ownerKey, lease: renewed, reclaimedFrom: null };
+        }
+
+        const staleReason = await evaluateStaleOwner(tx, current, now);
+        if (!staleReason) {
+          throwLeaseConflict({ lease: current, requestedAction: input.action, requestedOwnerKey: ownerKey });
+        }
+
+        const reclaimed = await tx
+          .update(executionWorkspaceRuntimeLeases)
+          .set({
+            companyId: input.companyId,
+            ...ownerColumns,
+            lastAction: input.action,
+            claimedAt: now,
+            renewedAt: now,
+            expiresAt,
+            updatedAt: now,
+            metadata: {
+              reclaimedFromOwnerKey: current.ownerKey,
+              reclaimReason: staleReason,
+              reclaimedAt: now.toISOString(),
+            },
+          })
+          .where(eq(executionWorkspaceRuntimeLeases.id, current.id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!reclaimed) {
+          throwLeaseConflict({ lease: current, requestedAction: input.action, requestedOwnerKey: ownerKey });
+        }
+
+        return {
+          outcome: "reclaimed" as const,
+          ownerKey,
+          lease: reclaimed,
+          reclaimedFrom: { ownerKey: current.ownerKey, reason: staleReason },
+        };
+      });
+    },
+
+    /**
+     * Give up the lane. `force` is for operator/lifecycle paths (workspace archive);
+     * owner-scoped releases only remove a lease the caller actually holds.
+     */
+    async release(input: {
+      executionWorkspaceId: string;
+      owner?: WorkspaceRuntimeLeaseOwner;
+      force?: boolean;
+    }): Promise<{ released: boolean; ownerKey: string | null }> {
+      const ownerKey = input.owner ? buildWorkspaceRuntimeLeaseOwnerKey(input.owner) : null;
+      if (!input.force && !ownerKey) return { released: false, ownerKey: null };
+
+      const condition = input.force
+        ? eq(executionWorkspaceRuntimeLeases.executionWorkspaceId, input.executionWorkspaceId)
+        : and(
+            eq(executionWorkspaceRuntimeLeases.executionWorkspaceId, input.executionWorkspaceId),
+            eq(executionWorkspaceRuntimeLeases.ownerKey, ownerKey!),
+          );
+
+      const deleted = await db
+        .delete(executionWorkspaceRuntimeLeases)
+        .where(condition)
+        .returning({ ownerKey: executionWorkspaceRuntimeLeases.ownerKey })
+        .then((rows) => rows[0] ?? null);
+
+      return { released: Boolean(deleted), ownerKey: deleted?.ownerKey ?? null };
+    },
+  };
+}
+
+export type WorkspaceRuntimeLeaseService = ReturnType<typeof workspaceRuntimeLeaseService>;

--- a/server/src/services/workspace-runtime-ready-comment.test.ts
+++ b/server/src/services/workspace-runtime-ready-comment.test.ts
@@ -56,6 +56,7 @@ function runtimeService(
     stoppedAt: null,
     stopPolicy: null,
     healthStatus: "healthy",
+    exposure: null,
     reused: false,
     ...overrides,
   };

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -10,7 +10,18 @@ import type { AdapterRuntimeServiceReport } from "@paperclipai/adapter-utils";
 import type { Db } from "@paperclipai/db";
 import { executionWorkspaces, issueComments, issues, projectWorkspaces, workspaceRuntimeServices } from "@paperclipai/db";
 import {
+  DEFAULT_TAILSCALE_HTTPS_EXPOSURE,
+  deriveViteHmrPort,
+  forceLoopbackBindInCommand,
   listWorkspaceServiceCommandDefinitions,
+  RUNTIME_EXPOSURE_BIND_HOST,
+  RUNTIME_EXPOSURE_BIND_MODE,
+  rewriteUrlHostToLoopback,
+  readRuntimeExposureIntent,
+  resolveDeclaredRuntimeExposureConfig,
+  type RuntimeExposureConfigInput,
+  type RuntimeExposureIntent,
+  type RuntimeExposureStatus,
   type GitWorktreeBranchAncestryVerdict,
   type GitWorktreeBranchIncoherenceEvidence as SharedGitWorktreeBranchIncoherenceEvidence,
   type GitWorktreeInProgressOperation,
@@ -20,13 +31,15 @@ import {
   type WorkspaceRuntimeDesiredState,
   type WorkspaceRuntimeServiceStateMap,
 } from "@paperclipai/shared";
-import { and, desc, eq, inArray, isNull, ne } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lte, ne, or } from "drizzle-orm";
 import { asNumber, asString, parseObject, renderTemplate } from "../adapters/utils.js";
+import { conflict } from "../errors.js";
 import { resolveHomeAwarePath } from "../home-paths.js";
 import {
   createLocalServiceKey,
   findLocalServiceRegistryRecordByRuntimeServiceId,
   findAdoptableLocalService,
+  isLocalServiceProcessOwnedBy,
   isLocalServiceProcessInWorkspace,
   readLocalServiceProcessCwd,
   readLocalServicePortOwner,
@@ -46,6 +59,16 @@ import {
   WORKTREE_INSTANCE_ROOT_METADATA_KEY,
   type WorktreeInstancePointer,
 } from "./workspace-instance-cleanup.js";
+import { UnixBrokerClient, type BrokerClient } from "./runtime-exposure/broker-client.js";
+import {
+  deprovisionExposure,
+  provisionExposure,
+  reserveExposure,
+  type ExposureManagerDeps,
+} from "./runtime-exposure/exposure-manager.js";
+import { diagnoseRuntimeListenerBinds } from "./runtime-exposure/loopback-listener.js";
+import { allocateExposurePortPair } from "./runtime-exposure/port-pair.js";
+import { resolveTailscaleDnsName } from "./runtime-exposure/tailscale-hostname.js";
 
 export function resolveShell(): string {
   const fallback = process.platform === "win32" ? "sh" : "/bin/sh";
@@ -154,6 +177,7 @@ export interface RuntimeServiceRef {
   stoppedAt: string | null;
   stopPolicy: Record<string, unknown> | null;
   healthStatus: "unknown" | "healthy" | "unhealthy";
+  exposure: RuntimeExposureStatus | null;
   reused: boolean;
 }
 
@@ -166,11 +190,20 @@ interface RuntimeServiceRecord extends RuntimeServiceRef {
   serviceKey: string;
   profileKind: string;
   processGroupId: number | null;
+  /** Server-private broker lease handle; never returned by toRuntimeServiceRef. */
+  exposureHandle: string | null;
+  /** Loopback URL used for backend readiness/adoption; never serialized. */
+  backendUrl: string | null;
+  exposureConfig: RuntimeExposureConfigInput | null;
 }
 
 type LocalRuntimeServiceStart = {
   record: RuntimeServiceRecord;
   readiness: Promise<void>;
+};
+
+type PendingRuntimeServiceReadiness = LocalRuntimeServiceStart & {
+  service: Record<string, unknown>;
 };
 
 type StoppedRuntimeServiceReuseCandidate = {
@@ -182,7 +215,198 @@ const runtimeServicesById = new Map<string, RuntimeServiceRecord>();
 const runtimeServicesByReuseKey = new Map<string, string>();
 const runtimeServiceLeasesByRun = new Map<string, string[]>();
 const runtimeProvisionByWorkspace = new Map<string, Promise<void>>();
+const quarantinedRuntimeExposurePorts = new Set<number>();
 const DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES = 256 * 1024;
+export const WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS = 32;
+const ACTIVE_RUNTIME_PORT_RESERVATION_STATUSES = ["provisioning", "starting", "running"] as const;
+const DEFAULT_TAILSCALE_BROKER_SOCKET = "/run/paperclip-tailscale-broker/broker.sock";
+
+class RuntimeServicePortBindCollision extends Error {
+  readonly port: number;
+
+  constructor(port: number) {
+    super(`Runtime service could not bind allocated port ${port}`);
+    this.name = "RuntimeServicePortBindCollision";
+    this.port = port;
+  }
+}
+
+export type WorkspaceRuntimeExposureDeps = ExposureManagerDeps & {
+  resolveHostname: () => Promise<string>;
+  isPortAvailable: (port: number) => Promise<boolean>;
+  /**
+   * Whether this host can actually broker HTTPS exposures right now. Gating the
+   * automatic default on broker availability is what keeps a Paperclip install
+   * without the host broker from failing every managed runtime start closed.
+   * An explicit opt-in still bypasses this and fails loudly.
+   */
+  isBrokerAvailable: () => Promise<boolean>;
+};
+
+async function isLoopbackPortAvailable(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+function resolveTailscaleBrokerSocketPath(): string {
+  return process.env.PAPERCLIP_TAILSCALE_BROKER_SOCKET?.trim() || DEFAULT_TAILSCALE_BROKER_SOCKET;
+}
+
+function defaultWorkspaceRuntimeExposureDeps(): WorkspaceRuntimeExposureDeps {
+  const socketPath = resolveTailscaleBrokerSocketPath();
+  const broker: BrokerClient = new UnixBrokerClient({ socketPath });
+  return {
+    broker,
+    resolveHostname: () => resolveTailscaleDnsName(),
+    isPortAvailable: isLoopbackPortAvailable,
+    isBrokerAvailable: async () => {
+      try {
+        // Presence of the socket, not a probe request: availability is checked
+        // on every managed start, and an unauthenticated connect storm against
+        // the broker would be its own problem.
+        const stats = await fs.stat(socketPath);
+        return stats.isSocket();
+      } catch {
+        return false;
+      }
+    },
+    probeHealth: async (url) => {
+      try {
+        const response = await fetch(url, {
+          redirect: "error",
+          signal: AbortSignal.timeout(5_000),
+        });
+        return response.ok;
+      } catch {
+        return false;
+      }
+    },
+    now: () => new Date().toISOString(),
+    diagnoseListenerBinds: diagnoseRuntimeListenerBinds,
+  };
+}
+
+let workspaceRuntimeExposureDeps = defaultWorkspaceRuntimeExposureDeps();
+
+/** Test-only seam; resetRuntimeServicesForTests restores production defaults. */
+export function setWorkspaceRuntimeExposureDepsForTests(deps: WorkspaceRuntimeExposureDeps) {
+  workspaceRuntimeExposureDeps = deps;
+}
+
+/**
+ * Deployment-level switch for the automatic default (PAP-17158).
+ *
+ *  - `auto` (default): eligible Paperclip-managed worktree runtimes get
+ *    `tailscale_https` without any project template or UI caller supplying an
+ *    exposure block, provided the host broker is available.
+ *  - `off`: no automatic default. Explicit opt-ins still work.
+ *  - `force`: default even when the broker socket is missing, so a
+ *    misconfigured host fails closed and loudly instead of silently serving
+ *    plain HTTP. Intended for deployments that require HTTPS previews.
+ */
+export type ManagedRuntimeHttpsMode = "auto" | "off" | "force";
+
+export function resolveManagedRuntimeHttpsMode(): ManagedRuntimeHttpsMode {
+  const raw = process.env.PAPERCLIP_MANAGED_RUNTIME_HTTPS?.trim().toLowerCase();
+  if (raw === "off" || raw === "false" || raw === "0") return "off";
+  if (raw === "force") return "force";
+  return "auto";
+}
+
+/**
+ * Whether a service would be defaulted to HTTPS if it declared nothing.
+ *
+ * Intentionally narrow: only the Paperclip-managed dev runtime. Unmanaged and
+ * custom external services are left exactly as they are, because the broker
+ * only publishes allowlisted loopback ports it can prove Paperclip owns and we
+ * do not want to relocate a service somebody else addresses by port.
+ *
+ * A *pinned* port is still a candidate. The pre-feature Paperclip App template
+ * hard-codes `port: 45439`, which the broker's dedicated allowlist can never
+ * publish, so defaulting it to HTTPS necessarily relocates it into the
+ * dedicated range. "Keep existing runtime ports when safe" is honored one layer
+ * down, by preferring the current port when it already *is* an allowlisted app
+ * port with a free HMR companion.
+ */
+function isManagedHttpsDefaultCandidate(input: {
+  serviceName: string;
+  command: string | null;
+}): boolean {
+  return isPaperclipDevRuntimeService(input);
+}
+
+export type ResolvedRuntimeServiceExposure = {
+  config: RuntimeExposureConfigInput;
+  /**
+   * `declared` — the project template or UI caller asked for HTTPS.
+   * `default` — the server applied the automatic default (PAP-17158).
+   *
+   * The distinction matters for port handling: a declared opt-in on a pinned
+   * port is an operator misconfiguration and fails loudly, while the automatic
+   * default is allowed to relocate a legacy pinned port into the dedicated
+   * exposure range.
+   */
+  origin: "declared" | "default";
+};
+
+/**
+ * Resolve the exposure config for one runtime service start.
+ *
+ * Precedence: deliberate opt-out → explicit opt-in → automatic default for
+ * eligible managed runtimes → none.
+ */
+async function resolveRuntimeServiceExposure(input: {
+  service: Record<string, unknown>;
+  serviceName: string;
+  command: string | null;
+}): Promise<ResolvedRuntimeServiceExposure | null> {
+  const expose = parseObject(input.service.expose);
+  const intent = readRuntimeExposureIntent(expose);
+  if (intent === "disabled") return null;
+  // An explicit opt-in is honored verbatim and is never gated on broker
+  // availability: the operator asked for HTTPS, so a missing broker must fail
+  // the start rather than silently downgrade it to HTTP.
+  if (intent === "enabled") {
+    const declared = resolveDeclaredRuntimeExposureConfig(expose);
+    return declared ? { config: declared, origin: "declared" } : null;
+  }
+
+  const mode = resolveManagedRuntimeHttpsMode();
+  if (mode === "off") return null;
+  if (!isManagedHttpsDefaultCandidate({ serviceName: input.serviceName, command: input.command })) {
+    return null;
+  }
+  if (mode !== "force" && !(await workspaceRuntimeExposureDeps.isBrokerAvailable())) return null;
+  return { config: DEFAULT_TAILSCALE_HTTPS_EXPOSURE, origin: "default" };
+}
+
+/**
+ * Whether any entry in a start batch will take the HTTPS exposure path.
+ *
+ * Reads the service name and command straight off the raw config entry rather
+ * than resolving the full reuse identity: templates never rewrite a service
+ * name, and the substrings `isPaperclipDevRuntimeService` matches survive
+ * rendering, so this agrees with the per-service decision made during spawn.
+ */
+async function anyRuntimeServiceUsesHttpsExposure(
+  services: Record<string, unknown>[],
+): Promise<boolean> {
+  for (const service of services) {
+    const resolved = await resolveRuntimeServiceExposure({
+      service,
+      serviceName: asString(service.name, "service"),
+      command: asString(service.command, ""),
+    });
+    if (resolved) return true;
+  }
+  return false;
+}
 
 type ProcessOutputCapture = {
   text: string;
@@ -195,7 +419,27 @@ type ProcessOutputAccumulator = {
   finish(): ProcessOutputCapture;
 };
 
-export async function resetRuntimeServicesForTests() {
+/**
+ * Drops in-memory runtime state between tests.
+ *
+ * By default the spawned backend processes are deliberately left running: the
+ * startup-reconciliation suites use this to simulate a Paperclip restart, where
+ * the point is that a live backend survives and has to be adopted.
+ *
+ * Suites that spawn real backends and do *not* need that must pass
+ * `terminateProcesses` — otherwise every test leaks a listener that keeps
+ * squatting a port in the dedicated exposure range for the life of the host.
+ * Termination runs before the exposure deps are restored so the suite's own
+ * broker fake handles the removal rather than the real host broker.
+ */
+export async function resetRuntimeServicesForTests(
+  opts: { terminateProcesses?: boolean } = {},
+) {
+  if (opts.terminateProcesses) {
+    for (const serviceId of [...runtimeServicesById.keys()]) {
+      await stopRuntimeService(serviceId).catch(() => undefined);
+    }
+  }
   for (const record of runtimeServicesById.values()) {
     clearIdleTimer(record);
   }
@@ -203,6 +447,8 @@ export async function resetRuntimeServicesForTests() {
   runtimeServicesByReuseKey.clear();
   runtimeServiceLeasesByRun.clear();
   runtimeProvisionByWorkspace.clear();
+  quarantinedRuntimeExposurePorts.clear();
+  workspaceRuntimeExposureDeps = defaultWorkspaceRuntimeExposureDeps();
 }
 
 function stableStringify(value: unknown): string {
@@ -416,6 +662,7 @@ function toRuntimeServiceRef(record: RuntimeServiceRecord, overrides?: Partial<R
     startedAt: record.startedAt,
     stoppedAt: record.stoppedAt,
     stopPolicy: record.stopPolicy,
+    exposure: record.exposure,
     healthStatus: record.healthStatus,
     reused: record.reused,
     ...overrides,
@@ -2396,21 +2643,6 @@ export function formatManagedGitWorktreeBranchInspection(input: ManagedGitWorktr
   };
 }
 
-function terminateChildProcess(child: ChildProcess) {
-  if (!child.pid) return;
-  if (process.platform !== "win32") {
-    try {
-      process.kill(-child.pid, "SIGTERM");
-      return;
-    } catch {
-      // Fall through to the direct child kill.
-    }
-  }
-  if (!child.killed) {
-    child.kill("SIGTERM");
-  }
-}
-
 function buildWorkspaceCommandEnv(input: {
   base: ExecutionWorkspaceInput;
   repoRoot: string;
@@ -3556,7 +3788,46 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
   };
 }
 
-async function allocatePort(): Promise<number> {
+/**
+ * Ports this process has handed to a starting runtime service but that no listener owns yet.
+ * The kernel will happily hand the same ephemeral port to two concurrent `listen(0)` probes
+ * once each probe socket closes, which is how two isolated workspaces starting at the same
+ * moment ended up fighting over one port pair. Reserving the port for the duration of the
+ * start makes concurrent allocations distinct.
+ */
+const inFlightAllocatedPorts = new Map<number, number>();
+const PORT_RESERVATION_TTL_MS = 120_000;
+const PORT_ALLOCATION_ATTEMPTS = 12;
+
+export function resetRuntimeServicePortReservationsForTests() {
+  inFlightAllocatedPorts.clear();
+}
+
+function reservePortIfFree(port: number, now = Date.now()): boolean {
+  const heldUntil = inFlightAllocatedPorts.get(port);
+  if (heldUntil !== undefined && heldUntil > now) return false;
+  inFlightAllocatedPorts.set(port, now + PORT_RESERVATION_TTL_MS);
+  return true;
+}
+
+/**
+ * Claim the loopback port a start is about to bind. A configured port that reads free right now
+ * can still be taken by a sibling workspace that is mid-start — neither has bound yet and
+ * neither has a persisted row — so the claim is what makes the loser fail terminally here
+ * instead of racing to bind and then hanging on a readiness probe it can never satisfy.
+ * A start already holding the port from its own allocation must not be refused by itself.
+ */
+export function claimRuntimeServiceBindPort(bindPort: number, alreadyReservedPort: number | null) {
+  if (bindPort === alreadyReservedPort) return true;
+  return reservePortIfFree(bindPort);
+}
+
+function releasePortReservation(port: number | null | undefined) {
+  if (typeof port !== "number") return;
+  inFlightAllocatedPorts.delete(port);
+}
+
+async function probeEphemeralPort(): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
     const server = net.createServer();
     server.listen(0, "127.0.0.1", () => {
@@ -3575,6 +3846,246 @@ async function allocatePort(): Promise<number> {
     });
     server.on("error", reject);
   });
+}
+
+async function collectReservedExposurePorts(db: Db | undefined, companyId: string): Promise<Set<number>> {
+  const reserved = new Set(quarantinedRuntimeExposurePorts);
+  for (const record of runtimeServicesById.values()) {
+    if (record.companyId !== companyId || !record.exposure) continue;
+    for (const listener of record.exposure.listeners) reserved.add(listener.targetPort);
+  }
+  if (!db) return reserved;
+  const rows = await db
+    .select({ exposure: workspaceRuntimeServices.exposure })
+    .from(workspaceRuntimeServices)
+    .where(eq(workspaceRuntimeServices.companyId, companyId));
+  for (const row of rows) {
+    if (!row.exposure || row.exposure.state === "removed") continue;
+    for (const listener of row.exposure.listeners) reserved.add(listener.targetPort);
+  }
+  return reserved;
+}
+
+async function allocateAndReserveExposure(input: {
+  db?: Db;
+  companyId: string;
+  runtimeId: string;
+  config: RuntimeExposureConfigInput;
+  /** Port this runtime already used, preserved when it is still safe to use. */
+  preferredAppPort?: number | null;
+}): Promise<{ appPort: number; status: RuntimeExposureStatus; handle: string }> {
+  const reserved = await collectReservedExposurePorts(input.db, input.companyId);
+  const retryable = new Set(["reservation_conflict", "manual_mapping_present", "quarantined"]);
+  let preferredAppPort = input.preferredAppPort ?? null;
+  while (true) {
+    const pair = await allocateExposurePortPair({
+      isPortAvailable: workspaceRuntimeExposureDeps.isPortAvailable,
+      reserved,
+      preferredAppPort,
+    });
+    const result = await reserveExposure(workspaceRuntimeExposureDeps, {
+      runtimeId: input.runtimeId,
+      config: input.config,
+      appPort: pair.appPort,
+    });
+    if (result.handle) {
+      return { appPort: pair.appPort, status: result.status, handle: result.handle };
+    }
+    if (!result.status.lastError || !retryable.has(result.status.lastError)) {
+      throw new Error(`HTTPS exposure reservation failed: ${result.status.lastError ?? "unknown broker error"}`);
+    }
+    reserved.add(pair.appPort);
+    reserved.add(pair.hmrPort);
+    // The preference lost its race with a conflicting/manual/quarantined
+    // mapping; drop it so the retry scans instead of re-offering the same port.
+    preferredAppPort = null;
+  }
+}
+
+async function canBindRuntimePort(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EADDRINUSE" || error.code === "EACCES") {
+        resolve(false);
+        return;
+      }
+      reject(error);
+    });
+    server.listen(port, "127.0.0.1", () => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(true);
+      });
+    });
+  });
+}
+
+async function readReservedRuntimePorts(input: {
+  db?: Db;
+  ports: number[];
+  executionWorkspaceId: string | null;
+}) {
+  if (!input.db || input.ports.length === 0) return new Set<number>();
+  const lowerBound = Math.min(...input.ports);
+  const upperBound = Math.max(...input.ports);
+  const otherWorkspaceCondition = input.executionWorkspaceId
+    ? or(
+        isNull(workspaceRuntimeServices.executionWorkspaceId),
+        ne(workspaceRuntimeServices.executionWorkspaceId, input.executionWorkspaceId),
+      )
+    : undefined;
+  const rows = await input.db
+    .select({ port: workspaceRuntimeServices.port })
+    .from(workspaceRuntimeServices)
+    .where(
+      and(
+        inArray(workspaceRuntimeServices.status, [...ACTIVE_RUNTIME_PORT_RESERVATION_STATUSES]),
+        gte(workspaceRuntimeServices.port, lowerBound),
+        lte(workspaceRuntimeServices.port, upperBound),
+        otherWorkspaceCondition,
+      ),
+    );
+  return new Set(rows.flatMap((row) => row.port === null ? [] : [row.port]));
+}
+
+async function buildRuntimePortAllocationConflict(input: {
+  db?: Db;
+  companyId: string;
+  executionWorkspaceId: string | null;
+  preferredPort: number;
+  attemptedPorts: number[];
+}) {
+  const conflictRows = input.db && input.attemptedPorts.length > 0
+    ? await input.db
+        .select({
+          port: workspaceRuntimeServices.port,
+          executionWorkspaceId: workspaceRuntimeServices.executionWorkspaceId,
+          projectWorkspaceId: workspaceRuntimeServices.projectWorkspaceId,
+        })
+        .from(workspaceRuntimeServices)
+        .where(
+          and(
+            eq(workspaceRuntimeServices.companyId, input.companyId),
+            inArray(workspaceRuntimeServices.status, [...ACTIVE_RUNTIME_PORT_RESERVATION_STATUSES]),
+            inArray(workspaceRuntimeServices.port, input.attemptedPorts),
+            input.executionWorkspaceId
+              ? or(
+                  isNull(workspaceRuntimeServices.executionWorkspaceId),
+                  ne(workspaceRuntimeServices.executionWorkspaceId, input.executionWorkspaceId),
+                )
+              : undefined,
+          ),
+        )
+    : [];
+  const attemptedRank = new Map(input.attemptedPorts.map((port, index) => [port, index]));
+  const authorizedConflict = conflictRows
+    .sort((left, right) =>
+      (attemptedRank.get(left.port ?? -1) ?? Number.MAX_SAFE_INTEGER)
+      - (attemptedRank.get(right.port ?? -1) ?? Number.MAX_SAFE_INTEGER))
+    .find((row) => row.executionWorkspaceId || row.projectWorkspaceId) ?? null;
+  const remediation =
+    "Stop the conflicting managed service or configure a different preferred port, then retry the start.";
+
+  return conflict(
+    `No safe runtime service port is available in the bounded allocation range starting at ${input.preferredPort}.`,
+    {
+      code: "workspace_runtime_port_allocation_exhausted",
+      port: input.preferredPort,
+      attemptedPortCount: input.attemptedPorts.length,
+      ...(authorizedConflict?.executionWorkspaceId
+        ? { conflictingExecutionWorkspaceId: authorizedConflict.executionWorkspaceId }
+        : {}),
+      ...(authorizedConflict?.projectWorkspaceId
+        ? { conflictingProjectWorkspaceId: authorizedConflict.projectWorkspaceId }
+        : {}),
+      remediation,
+    },
+  );
+}
+
+async function allocateIsolatedWorkspacePort(input: {
+  db?: Db;
+  companyId: string;
+  executionWorkspaceId: string;
+  preferredPort: number;
+  stoppedPort: number | null;
+  excludedPorts: ReadonlySet<number>;
+}) {
+  const lastPort = Math.min(
+    65_535,
+    input.preferredPort + WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS - 1,
+  );
+  const candidates: number[] = [];
+  const addCandidate = (port: number | null) => {
+    if (
+      port === null
+      || port < input.preferredPort
+      || port > lastPort
+      || input.excludedPorts.has(port)
+      || candidates.includes(port)
+    ) return;
+    candidates.push(port);
+  };
+  addCandidate(input.stoppedPort);
+  for (let port = input.preferredPort; port <= lastPort; port += 1) addCandidate(port);
+
+  const reservedPorts = await readReservedRuntimePorts({
+    db: input.db,
+    ports: candidates,
+    executionWorkspaceId: input.executionWorkspaceId,
+  });
+  for (const port of candidates) {
+    if (reservedPorts.has(port)) continue;
+    // Claim the candidate in-process before probing it: a sibling start that already holds it
+    // has not persisted a row yet, so `reservedPorts` cannot see it and both lanes would
+    // otherwise pick the same port (PAP-17249).
+    if (!reservePortIfFree(port)) continue;
+    if (await canBindRuntimePort(port)) return port;
+    releasePortReservation(port);
+  }
+  const attemptedPorts = [
+    ...input.excludedPorts,
+    ...candidates,
+  ].filter((port, index, ports) =>
+    port >= input.preferredPort
+    && port <= lastPort
+    && ports.indexOf(port) === index);
+
+  throw await buildRuntimePortAllocationConflict({
+    db: input.db,
+    companyId: input.companyId,
+    executionWorkspaceId: input.executionWorkspaceId,
+    preferredPort: input.preferredPort,
+    attemptedPorts,
+  });
+}
+
+
+/**
+ * Allocate a loopback port that no other in-flight managed start already holds and that no
+ * live process owns. Callers must {@link releasePortReservation} once the service either
+ * reached a terminal state or bound the port itself.
+ */
+export async function allocateRuntimeServicePort(overrides?: {
+  probe?: () => Promise<number>;
+  portOwnerLookup?: (port: number) => Promise<number | null>;
+}): Promise<number> {
+  const probe = overrides?.probe ?? probeEphemeralPort;
+  const portOwnerLookup = overrides?.portOwnerLookup ?? readLocalServicePortOwner;
+  let lastCandidate: number | null = null;
+  for (let attempt = 0; attempt < PORT_ALLOCATION_ATTEMPTS; attempt += 1) {
+    const candidate = await probe();
+    lastCandidate = candidate;
+    if (!reservePortIfFree(candidate)) continue;
+    const ownerPid = await portOwnerLookup(candidate);
+    if (!ownerPid) return candidate;
+    releasePortReservation(candidate);
+  }
+  throw new Error(
+    `Could not allocate a free loopback port for a managed runtime service after ${PORT_ALLOCATION_ATTEMPTS} attempts`
+      + `${lastCandidate ? ` (last candidate ${lastCandidate})` : ""}.`,
+  );
 }
 
 function buildTemplateData(input: {
@@ -3670,6 +4181,7 @@ function resolveRuntimeServiceReuseIdentity(input: {
               cwd: serviceCwd,
               port: identityPort,
               env: renderedEnv,
+              expose: input.service.expose ?? null,
             }),
           )
           .digest("hex")
@@ -3806,12 +4318,22 @@ export function resolveWorkspaceRuntimeReadinessTimeoutSec(service: Record<strin
   return looksLikeWorkspaceDevServerCommand(asString(service.command, "")) ? 90 : 30;
 }
 
-async function waitForReadiness(input: {
+/**
+ * Longest a single readiness probe may stay outstanding. Without this an unrelated process
+ * that accepts the connection but never answers (exactly what a reallocated port produces)
+ * parks `fetch` forever, the readiness deadline is never re-checked, and the managed start
+ * never reaches a terminal state.
+ */
+export const RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS = 5_000;
+
+export async function waitForRuntimeServiceReadiness(input: {
   service: Record<string, unknown>;
   serviceName?: string | null;
   command?: string | null;
   url: string | null;
   readinessUrl: string | null;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
 }) {
   const readiness = parseObject(input.service.readiness);
   const readinessType = asString(readiness.type, "");
@@ -3824,21 +4346,72 @@ async function waitForReadiness(input: {
   if (!readinessUrl) {
     throw new Error(`Readiness check failed: could not resolve health URL for ${input.url}`);
   }
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const now = input.now ?? Date.now;
   const timeoutSec = resolveWorkspaceRuntimeReadinessTimeoutSec(input.service);
   const intervalMs = Math.max(100, asNumber(readiness.intervalMs, 500));
-  const deadline = Date.now() + timeoutSec * 1000;
+  const deadline = now() + timeoutSec * 1000;
   let lastError = "service did not become ready";
-  while (Date.now() < deadline) {
+  while (now() < deadline) {
+    const probeBudgetMs = Math.max(1, Math.min(RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS, deadline - now()));
     try {
-      const response = await fetch(readinessUrl);
+      const response = await fetchImpl(readinessUrl, { signal: AbortSignal.timeout(probeBudgetMs) });
       if (response.ok) return;
       lastError = `received HTTP ${response.status}`;
     } catch (err) {
       lastError = err instanceof Error ? err.message : String(err);
     }
-    await delay(intervalMs);
+    if (now() >= deadline) break;
+    await delay(Math.min(intervalMs, Math.max(0, deadline - now())));
   }
   throw new Error(`Readiness check failed for ${readinessUrl}: ${lastError}`);
+}
+
+async function waitForAllocatedPortBind(input: {
+  service: Record<string, unknown>;
+  port: number;
+  child: ChildProcess;
+}) {
+  const deadline = Date.now() + resolveWorkspaceRuntimeReadinessTimeoutSec(input.service) * 1000;
+  while (Date.now() < deadline) {
+    if (input.child.exitCode !== null || input.child.signalCode !== null) {
+      throw new Error("service process exited before binding its allocated port");
+    }
+
+    const ownerPid = await readLocalServicePortOwner(input.port);
+    if (ownerPid) {
+      const childPid = input.child.pid ?? null;
+      if (!childPid || !(await isLocalServiceProcessOwnedBy(ownerPid, childPid))) {
+        throw new RuntimeServicePortBindCollision(input.port);
+      }
+      // Require the same launched process group to retain ownership across a stability delay.
+      // Cwd matching alone is insufficient because sibling services can share a workspace.
+      await delay(250);
+      if (input.child.exitCode !== null || input.child.signalCode !== null) {
+        throw new Error("service process exited after losing its allocated port");
+      }
+      const stableOwnerPid = await readLocalServicePortOwner(input.port);
+      if (!stableOwnerPid || !(await isLocalServiceProcessOwnedBy(stableOwnerPid, childPid))) {
+        throw new RuntimeServicePortBindCollision(input.port);
+      }
+      return;
+    }
+
+    // A failed bind probe proves only that some listener appeared. If listener ownership cannot
+    // be attributed to this child after a stability delay, retry instead of accepting a sibling.
+    if (!(await canBindRuntimePort(input.port))) {
+      await delay(250);
+      if (input.child.exitCode !== null || input.child.signalCode !== null) {
+        throw new Error("service process exited after losing its allocated port");
+      }
+      const stableOwnerPid = await readLocalServicePortOwner(input.port);
+      const childPid = input.child.pid ?? null;
+      if (stableOwnerPid && childPid && await isLocalServiceProcessOwnedBy(stableOwnerPid, childPid)) return;
+      throw new RuntimeServicePortBindCollision(input.port);
+    }
+    await delay(50);
+  }
+  throw new Error(`Runtime service did not bind allocated port ${input.port} before timeout`);
 }
 
 function isPaperclipDevRuntimeService(input: { serviceName?: string | null; command?: string | null }) {
@@ -3911,6 +4484,9 @@ function toPersistedWorkspaceRuntimeService(record: RuntimeServiceRecord): typeo
     startedAt: new Date(record.startedAt),
     stoppedAt: record.stoppedAt ? new Date(record.stoppedAt) : null,
     stopPolicy: record.stopPolicy,
+    exposure: record.exposure,
+    exposureHandle: record.exposureHandle,
+    backendUrl: record.backendUrl,
     healthStatus: record.healthStatus,
     updatedAt: new Date(),
   };
@@ -3947,6 +4523,9 @@ async function persistRuntimeServiceRecord(db: Db | undefined, record: RuntimeSe
         startedAt: values.startedAt,
         stoppedAt: values.stoppedAt,
         stopPolicy: values.stopPolicy,
+        exposure: values.exposure,
+        exposureHandle: values.exposureHandle,
+        backendUrl: values.backendUrl,
         healthStatus: values.healthStatus,
         updatedAt: values.updatedAt,
       },
@@ -4083,6 +4662,7 @@ export function normalizeAdapterManagedRuntimeServices(input: {
       stoppedAt: status === "running" || status === "starting" ? null : nowIso,
       stopPolicy: report.stopPolicy ?? null,
       healthStatus,
+      exposure: null,
       reused: false,
     };
   });
@@ -4105,6 +4685,8 @@ type StartLocalRuntimeServiceInput = {
   provisionCoordinator?: RuntimeProvisionCoordinator;
   preparedProvisioningRecord?: RuntimeServiceRecord | null;
   runtimeServiceId?: string;
+  allowFixedPortFallback?: boolean;
+  excludedPorts?: ReadonlySet<number>;
   reuseKey: string | null;
   scopeType: "project_workspace" | "execution_workspace" | "run" | "agent";
   scopeId: string | null;
@@ -4249,6 +4831,7 @@ function createProvisioningRuntimeServiceRecord(
     stoppedAt: null,
     stopPolicy: parseObject(input.service.stopPolicy),
     healthStatus: "unknown",
+    exposure: null,
     reused: false,
     db: input.db,
     child: null,
@@ -4258,6 +4841,9 @@ function createProvisioningRuntimeServiceRecord(
     serviceKey: `runtime-provision:${runtimeProvisionWorkspaceKey(input)}:${id}`,
     profileKind: "workspace-runtime",
     processGroupId: null,
+    exposureHandle: null,
+    backendUrl: null,
+    exposureConfig: null,
   };
 }
 
@@ -4275,14 +4861,41 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
   });
   const serviceName = identity.serviceName;
   const lifecycle = identity.lifecycle;
-  const command = identity.command;
-  if (!command) throw new Error(`Runtime service "${serviceName}" is missing command`);
+  const declaredCommand = identity.command;
+  if (!declaredCommand) throw new Error(`Runtime service "${serviceName}" is missing command`);
   const portConfig = parseObject(input.service.port);
   const envConfig = identity.envConfig;
   const envFingerprint = identity.envFingerprint;
   const serviceIdentityFingerprint = input.reuseKey ?? envFingerprint;
   const explicitPort = identity.explicitPort;
   const identityPort = identity.identityPort;
+  const resolvedExposure = await resolveRuntimeServiceExposure({
+    service: input.service,
+    serviceName,
+    command: declaredCommand,
+  });
+  const exposureConfig = resolvedExposure?.config ?? null;
+  // An exposed listener MUST be loopback-only or the broker denies it. Env vars
+  // alone cannot guarantee that: the process that has to honour them is the
+  // *guest checkout's* dev runner, and one from before managed exposure existed
+  // overwrites PAPERCLIP_BIND from its own `--bind` argv and deletes
+  // PAPERCLIP_BIND_HOST — which is exactly how a branch pinned at plain master
+  // bound 0.0.0.0 and failed every start (PAP-17256). argv is honoured by every
+  // dev-runner version, so put the loopback bind there.
+  //
+  // Scoped by `forceLoopbackBindInCommand` to commands that actually parse these
+  // flags: `--bind` means something else entirely to an unrelated service (the
+  // HTTPS probe canaries pass it to `python3 -m http.server`), and appending
+  // flags a command cannot parse would make it exit on startup.
+  const command = exposureConfig ? forceLoopbackBindInCommand(declaredCommand) : declaredCommand;
+  const portType = asString(portConfig.type, "");
+  const canAllocateFixedPort = Boolean(
+    !exposureConfig
+    && input.allowFixedPortFallback
+    && input.db
+    && input.executionWorkspaceId
+    && explicitPort > 0,
+  );
   const stoppedReuseCandidate = await findStoppedRuntimeServiceReuseCandidate({
     db: input.db,
     companyId: input.agent.companyId,
@@ -4293,17 +4906,135 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     scopeType: input.scopeType,
     scopeId: input.scopeId,
   });
-  let reusableStoppedPort: number | null = null;
-  if (asString(portConfig.type, "") === "auto" && stoppedReuseCandidate?.port) {
-    const ownerPid = await readLocalServicePortOwner(stoppedReuseCandidate.port);
-    reusableStoppedPort = ownerPid ? null : stoppedReuseCandidate.port;
+  let fixedPortRegistryMatch = false;
+  if (!exposureConfig && canAllocateFixedPort && identityPort) {
+    const identityTemplateData = buildTemplateData({
+      workspace: input.workspace,
+      agent: input.agent,
+      issue: input.issue,
+      adapterEnv: input.adapterEnv,
+      port: identityPort,
+    });
+    const identityExpose = parseObject(input.service.expose);
+    const identityReadiness = parseObject(input.service.readiness);
+    const identityUrlTemplate =
+      asString(identityExpose.urlTemplate, "")
+      || asString(identityReadiness.urlTemplate, "");
+    const identityBackendUrl = identityUrlTemplate
+      ? renderTemplate(identityUrlTemplate, identityTemplateData)
+      : null;
+    const identityServiceKey = createLocalServiceKey({
+      profileKind: "workspace-runtime",
+      serviceName,
+      cwd: identity.serviceCwd,
+      command,
+      envFingerprint: serviceIdentityFingerprint,
+      port: identityPort,
+      scope: {
+        scopeType: input.scopeType,
+        scopeId: input.scopeId,
+        executionWorkspaceId: input.executionWorkspaceId ?? null,
+        reuseKey: input.reuseKey,
+      },
+    });
+    fixedPortRegistryMatch = Boolean(await findAdoptableLocalService({
+      serviceKey: identityServiceKey,
+      profileKind: "workspace-runtime",
+      serviceName,
+      command,
+      cwd: identity.serviceCwd,
+      envFingerprint: serviceIdentityFingerprint,
+      port: identityPort,
+      url: identityBackendUrl,
+    }));
   }
-  const port =
-    asString(portConfig.type, "") === "auto"
-      ? (reusableStoppedPort ?? await allocatePort())
-      : explicitPort > 0
-        ? explicitPort
-        : null;
+  const runtimeId = input.runtimeServiceId ?? stoppedReuseCandidate?.id ?? randomUUID();
+  // An exposed runtime always takes its port from the dedicated broker range, so
+  // a configured or previously used port is a *preference*, not a constraint. It
+  // is honored when it is already an allowlisted app port whose HMR companion is
+  // free — that keeps a restart on the same port and keeps a backfilled service
+  // stable across deploys — and quietly relocated when it is not, which is the
+  // only way a legacy pinned port (the Paperclip App template's 45439) can be
+  // published at all. If the backend then fails to listen where we allocated,
+  // the broker's /proc ownership proof refuses the mapping and the start fails
+  // closed; it never falls back to HTTP.
+  const reservedExposure = exposureConfig
+    ? await allocateAndReserveExposure({
+        db: input.db,
+        companyId: input.agent.companyId,
+        runtimeId,
+        config: exposureConfig,
+        preferredAppPort: stoppedReuseCandidate?.port ?? (explicitPort > 0 ? explicitPort : null),
+      })
+    : null;
+  // Loopback port this start claimed in-process for its own duration (PAP-17249). A bare
+  // `listen(0)` probe is closed before the child binds, so the kernel is free to hand the same
+  // candidate to a sibling start; holding the claim until the child owns the port — or until the
+  // start reaches a terminal state — is what keeps two concurrent lanes distinct. Exposed
+  // runtimes carry no in-process claim: their port pair is held by the broker reservation.
+  let reservedPort: number | null = null;
+  let port: number | null = reservedExposure?.appPort ?? null;
+  if (!reservedExposure && portType === "auto") {
+    if (
+      stoppedReuseCandidate?.port
+      && !input.excludedPorts?.has(stoppedReuseCandidate.port)
+      // Reserving the reuse candidate keeps two concurrent starts of the same stopped service
+      // from both deciding the old port is free.
+      && reservePortIfFree(stoppedReuseCandidate.port)
+    ) {
+      if (await canBindRuntimePort(stoppedReuseCandidate.port)) {
+        port = stoppedReuseCandidate.port;
+        reservedPort = stoppedReuseCandidate.port;
+      } else {
+        releasePortReservation(stoppedReuseCandidate.port);
+      }
+    }
+    for (let attempt = 0; port === null && attempt < WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS; attempt += 1) {
+      // Reserves its candidate in-process and re-checks it for a live owner before returning.
+      const candidate = await allocateRuntimeServicePort();
+      if (input.excludedPorts?.has(candidate)) {
+        releasePortReservation(candidate);
+        continue;
+      }
+      port = candidate;
+      reservedPort = candidate;
+    }
+    if (port === null) {
+      throw conflict("No safe automatically allocated runtime service port is available.", {
+        code: "workspace_runtime_port_allocation_exhausted",
+        attemptedPortCount: WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS,
+        remediation: "Retry the start or configure a different runtime service port.",
+      });
+    }
+  } else if (!reservedExposure && canAllocateFixedPort && fixedPortRegistryMatch) {
+    port = explicitPort;
+  } else if (!reservedExposure && canAllocateFixedPort) {
+    port = await allocateIsolatedWorkspacePort({
+      db: input.db,
+      companyId: input.agent.companyId,
+      executionWorkspaceId: input.executionWorkspaceId!,
+      preferredPort: explicitPort,
+      stoppedPort: stoppedReuseCandidate?.port ?? null,
+      excludedPorts: input.excludedPorts ?? new Set<number>(),
+    });
+    // The bounded fixed-port scan reserves the port it hands back for the same reason.
+    reservedPort = port;
+  } else if (!reservedExposure) {
+    port = explicitPort > 0 ? explicitPort : null;
+  }
+  let exposureHostname: string | null = null;
+  if (reservedExposure) {
+    try {
+      exposureHostname = await workspaceRuntimeExposureDeps.resolveHostname();
+      reservedExposure.status.hostname = exposureHostname;
+      reservedExposure.status.updatedAt = new Date().toISOString();
+    } catch {
+      await workspaceRuntimeExposureDeps.broker
+        .remove(runtimeId, reservedExposure.handle)
+        .catch(() => undefined);
+      throw new Error("HTTPS exposure failed: Tailscale MagicDNS hostname unavailable");
+    }
+  }
   const templateData = buildTemplateData({
     workspace: input.workspace,
     agent: input.agent,
@@ -4327,12 +5058,32 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     env[portEnvKey] = String(port);
   }
 
+  if (exposureConfig) {
+    // Paperclip dev-runtime-specific hardening. Other managed processes are
+    // still rejected by the broker unless /proc proves loopback-only listeners.
+    //
+    // Three independent layers force the loopback bind, because a guest checkout
+    // can be arbitrarily old (PAP-17256): the `--bind custom --bind-host` argv
+    // added above, these env vars for a runner that reads them, and HOST for one
+    // old enough to ignore both and infer its bind mode from HOST alone.
+    env.PAPERCLIP_BIND = RUNTIME_EXPOSURE_BIND_MODE;
+    env.PAPERCLIP_BIND_HOST = RUNTIME_EXPOSURE_BIND_HOST;
+    env.HOST = RUNTIME_EXPOSURE_BIND_HOST;
+    env.PAPERCLIP_VITE_HMR_PROTOCOL = "wss";
+    env.PAPERCLIP_MANAGED_RUNTIME_EXPOSURE = "tailscale_https";
+    env.PAPERCLIP_ALLOWED_HOSTNAMES = exposureHostname!;
+    env.PAPERCLIP_AUTH_BASE_URL_MODE = "explicit";
+    env.PAPERCLIP_AUTH_PUBLIC_BASE_URL = `https://${exposureHostname}:${port}`;
+    env.PAPERCLIP_PUBLIC_URL = `https://${exposureHostname}:${port}`;
+  }
+
   const expose = parseObject(input.service.expose);
   const readiness = parseObject(input.service.readiness);
   const urlTemplate =
     asString(expose.urlTemplate, "") ||
     asString(readiness.urlTemplate, "");
-  const url = urlTemplate ? renderTemplate(urlTemplate, templateData) : null;
+  const backendUrl = urlTemplate ? renderTemplate(urlTemplate, templateData) : null;
+  let url = exposureConfig ? null : backendUrl;
   const readinessUrlTemplate = asString(readiness.urlTemplate, "");
   const readinessUrl = readinessUrlTemplate ? renderTemplate(readinessUrlTemplate, templateData) : null;
   const stopPolicy = parseObject(input.service.stopPolicy);
@@ -4350,7 +5101,7 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
       reuseKey: input.reuseKey,
     },
   });
-  const adoptedRecord = await findAdoptableLocalService({
+  const adoptedRecord = exposureConfig ? null : await findAdoptableLocalService({
     serviceKey,
     profileKind: "workspace-runtime",
     serviceName,
@@ -4358,14 +5109,15 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     cwd: serviceCwd,
     envFingerprint: serviceIdentityFingerprint,
     port: port ?? identityPort,
-    url,
+    url: backendUrl,
   });
   if (adoptedRecord) {
-    const adoptedUrl = adoptedRecord.url ?? url;
+    const adoptedUrl = adoptedRecord.url ?? backendUrl;
     if (!(await isRuntimeServiceUrlHealthy(adoptedUrl, { serviceName, command }))) {
       await terminateLocalService(adoptedRecord);
       await removeLocalServiceRegistryRecord(adoptedRecord.serviceKey);
     } else {
+      releasePortReservation(reservedPort);
       return {
         record: {
           id: adoptedRecord.runtimeServiceId ?? randomUUID(),
@@ -4393,6 +5145,7 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
           stoppedAt: null,
           stopPolicy,
           healthStatus: "healthy",
+          exposure: null,
           reused: true,
           db: input.db,
           child: null,
@@ -4402,62 +5155,59 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
           serviceKey,
           profileKind: "workspace-runtime",
           processGroupId: adoptedRecord.processGroupId ?? null,
+          exposureHandle: null,
+          backendUrl: adoptedUrl,
+          exposureConfig: null,
         },
         readiness: Promise.resolve(),
       };
     }
   }
-  if (identityPort) {
-      const ownerPid = await readLocalServicePortOwner(identityPort);
+  // A pinned port is only worth a conflict check when the service will actually
+  // bind it. Under HTTPS exposure the port comes from the broker's dedicated
+  // range instead, and both ports in that pair were already probed free before
+  // the lease was taken — so checking the pinned port here would reject a
+  // legacy `port: 45439` service purely because the pre-backfill instance still
+  // holds 45439, which is exactly the workspace this feature has to upgrade.
+  const conflictPort = reservedExposure ? null : port;
+  if (conflictPort) {
+    const ownerPid = await readLocalServicePortOwner(conflictPort);
     if (ownerPid) {
+      if (canAllocateFixedPort || portType === "auto") {
+        throw new RuntimeServicePortBindCollision(conflictPort);
+      }
       const ownerCwd = await readLocalServiceProcessCwd(ownerPid);
       const ownerIsInWorkspace = ownerCwd
         ? await isLocalServiceProcessInWorkspace(ownerCwd, serviceCwd)
         : null;
       const ownerDescription = ownerCwd ? `pid ${ownerPid} (cwd: ${ownerCwd})` : `pid ${ownerPid} (cwd unavailable)`;
+      releasePortReservation(reservedPort);
       if (ownerIsInWorkspace === false) {
         throw new Error(
-          `Runtime service "${serviceName}" could not start because port ${identityPort} has a cross-workspace port conflict with ${ownerDescription}; requested workspace: ${serviceCwd}. Stop the other service or configure a different port.`,
+          `Runtime service "${serviceName}" could not start because port ${conflictPort} has a cross-workspace port conflict with ${ownerDescription}; requested workspace: ${serviceCwd}. Stop the other service or configure a different port.`,
         );
       }
       throw new Error(
-        `Runtime service "${serviceName}" could not start because port ${identityPort} is already in use by ${ownerDescription}`,
+        `Runtime service "${serviceName}" could not start because port ${conflictPort} is already in use by ${ownerDescription}`,
+      );
+    }
+    // A configured port that is free right now can still be taken by a sibling workspace that
+    // is mid-start. Claiming it in-process makes the loser fail terminally here instead of
+    // silently racing to bind and then hanging on a readiness probe it can never satisfy.
+    // `conflictPort !== reservedPort` guards the port this start allocated for itself: we
+    // must not fail a start by colliding with our own reservation.
+    if (!claimRuntimeServiceBindPort(conflictPort, reservedPort)) {
+      releasePortReservation(reservedPort);
+      throw new Error(
+        `Runtime service "${serviceName}" could not start because configured port ${conflictPort} is already being claimed by another managed start in this instance. Retry once that start settles, or configure a different port.`,
       );
     }
   }
-
-  await ensureServerWorkspaceLinksCurrent(serviceCwd, {
-    onLog: input.onLog,
-  });
-
-  const shell = resolveShell();
-  const child = spawn(shell, ["-lc", command], {
-    cwd: serviceCwd,
-    env,
-    detached: process.platform !== "win32",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  const spawnErrorPromise = new Promise<never>((_, reject) => {
-    child.once("error", (err) => {
-      reject(err);
-    });
-  });
-  let stderrExcerpt = "";
-  let stdoutExcerpt = "";
-  child.stdout?.on("data", async (chunk) => {
-    const text = String(chunk);
-    stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
-    if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
-  });
-  child.stderr?.on("data", async (chunk) => {
-    const text = String(chunk);
-    stderrExcerpt = (stderrExcerpt + text).slice(-4096);
-    if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
-  });
+  const claimedIdentityPort = conflictPort && conflictPort !== reservedPort ? conflictPort : null;
 
   const nowIso = new Date().toISOString();
   const record: RuntimeServiceRecord = {
-    id: input.runtimeServiceId ?? stoppedReuseCandidate?.id ?? randomUUID(),
+    id: runtimeId,
     companyId: input.agent.companyId,
     projectId: input.workspace.projectId,
     projectWorkspaceId: input.workspace.workspaceId,
@@ -4474,7 +5224,7 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     port,
     url,
     provider: "local_process",
-    providerRef: child.pid ? String(child.pid) : null,
+    providerRef: null,
     ownerAgentId: input.agent.id ?? null,
     startedByRunId,
     lastUsedAt: nowIso,
@@ -4482,16 +5232,76 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     stoppedAt: null,
     stopPolicy,
     healthStatus: "unknown",
+    exposure: reservedExposure?.status ?? null,
     reused: false,
     db: input.db,
-    child,
+    child: null,
     leaseRunIds: leaseRunId ? new Set([leaseRunId]) : new Set(),
     idleTimer: null,
     envFingerprint,
     serviceKey,
     profileKind: "workspace-runtime",
-    processGroupId: child.pid ?? null,
+    processGroupId: null,
+    exposureHandle: reservedExposure?.handle ?? null,
+    backendUrl,
+    exposureConfig,
   };
+  if (reservedExposure) {
+    // The broker reservation and its unguessable handle must be durable before
+    // the child can bind, so a server crash cannot lose cleanup authority.
+    try {
+      await persistRuntimeServiceRecord(input.db, record);
+    } catch (error) {
+      await cleanupRecordExposure(record);
+      throw error;
+    }
+  }
+
+  try {
+    await ensureServerWorkspaceLinksCurrent(serviceCwd, {
+      onLog: input.onLog,
+    });
+  } catch (error) {
+    releasePortReservation(reservedPort);
+    releasePortReservation(claimedIdentityPort);
+    if (reservedExposure) await cleanupRecordExposure(record);
+    throw error;
+  }
+
+  const shell = resolveShell();
+  const child = spawn(shell, ["-lc", command], {
+    cwd: serviceCwd,
+    env,
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  record.child = child;
+  record.providerRef = child.pid ? String(child.pid) : null;
+  record.processGroupId = child.pid ?? null;
+  const spawnErrorPromise = new Promise<never>((_, reject) => {
+    child.once("error", (err) => {
+      reject(err);
+    });
+  });
+  const earlyExitPromise = new Promise<never>((_, reject) => {
+    child.once("exit", (code, signal) => {
+      reject(new Error(
+        `service process exited before readiness (code ${code ?? "unknown"}, signal ${signal ?? "none"})`,
+      ));
+    });
+  });
+  let stderrExcerpt = "";
+  let stdoutExcerpt = "";
+  child.stdout?.on("data", async (chunk) => {
+    const text = String(chunk);
+    stdoutExcerpt = (stdoutExcerpt + text).slice(-4096);
+    if (input.onLog) await input.onLog("stdout", `[service:${serviceName}] ${text}`);
+  });
+  child.stderr?.on("data", async (chunk) => {
+    const text = String(chunk);
+    stderrExcerpt = (stderrExcerpt + text).slice(-4096);
+    if (input.onLog) await input.onLog("stderr", `[service:${serviceName}] ${text}`);
+  });
 
   if (child.pid) {
     await writeLocalServiceRegistryRecord({
@@ -4503,7 +5313,7 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
       cwd: serviceCwd,
       envFingerprint: serviceIdentityFingerprint,
       port,
-      url,
+      url: backendUrl,
       pid: child.pid,
       processGroupId: child.pid,
       provider: "local_process",
@@ -4522,10 +5332,59 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     });
   }
 
+  const ownershipCheckedPorts = port
+    ? exposureConfig
+      ? [
+          port,
+          ...(exposureConfig.includePaperclipViteHmr ? [deriveViteHmrPort(port)] : []),
+        ]
+      : canAllocateFixedPort
+        ? [port]
+        : []
+    : [];
   const readinessPromise = Promise.race([
-    waitForReadiness({ service: input.service, serviceName, command, url, readinessUrl }),
+    Promise.all([
+      waitForRuntimeServiceReadiness({
+        service: input.service,
+        serviceName,
+        command,
+        // An exposed runtime is loopback-only by construction, so its readiness
+        // probe has to target loopback too. The fallback target is the display
+        // URL (a MagicDNS name), which only ever answered because the guest was
+        // wrongly bound to the wildcard (PAP-17256).
+        url: exposureConfig ? rewriteUrlHostToLoopback(backendUrl) : backendUrl,
+        readinessUrl: exposureConfig ? rewriteUrlHostToLoopback(readinessUrl) : readinessUrl,
+      }),
+      ...ownershipCheckedPorts.map((ownedPort) =>
+        waitForAllocatedPortBind({ service: input.service, port: ownedPort, child })
+      ),
+    ]).then(() => undefined),
     spawnErrorPromise,
+    earlyExitPromise,
   ]).then(async () => {
+    releasePortReservation(reservedPort);
+    releasePortReservation(claimedIdentityPort);
+    if (record.exposureConfig && record.exposureHandle && record.port) {
+      const provisioned = await provisionExposure(workspaceRuntimeExposureDeps, {
+        runtimeId: record.id,
+        config: record.exposureConfig,
+        handle: record.exposureHandle,
+        hostname: exposureHostname!,
+        appPort: record.port,
+      });
+      record.exposure = provisioned.status;
+      record.exposureHandle = provisioned.handle;
+      record.url = provisioned.status.publicUrl;
+      await persistRuntimeServiceRecord(record.db, record);
+      if (provisioned.status.state !== "ready" || !record.url) {
+        // Carry the reason, not just the code: a bare `listener_ownership_mismatch`
+        // in the operation log is what made PAP-17254 undiagnosable (PAP-17256).
+        const code = provisioned.status.lastError ?? "unknown error";
+        throw new Error(
+          `HTTPS exposure failed: ${code}${provisioned.errorDetail ? ` — ${provisioned.errorDetail}` : ""}`,
+        );
+      }
+    }
     record.status = "running";
     record.healthStatus = "healthy";
     record.lastUsedAt = new Date().toISOString();
@@ -4535,14 +5394,34 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
       lastSeenAt: record.lastUsedAt,
     });
   }).catch(async (err) => {
-    terminateChildProcess(child);
+    releasePortReservation(reservedPort);
+    releasePortReservation(claimedIdentityPort);
+        const failureMessage = err instanceof Error ? err.message : String(err);
+    const bindCollision = !exposureConfig && (
+      err instanceof RuntimeServicePortBindCollision || Boolean(
+        port
+        && (input.allowFixedPortFallback || portType === "auto")
+        && /(?:EADDRINUSE|address already in use)/i.test(`${failureMessage}\n${stderrExcerpt}`),
+      )
+    );
+    if (child.pid) {
+      await terminateLocalService({
+        pid: child.pid,
+        processGroupId: child.pid,
+      });
+    }
+    await cleanupRecordExposure(record, { preserveFailure: true });
     record.status = "stopped";
     record.healthStatus = "unhealthy";
     record.lastUsedAt = new Date().toISOString();
     record.stoppedAt = new Date().toISOString();
     await removeLocalServiceRegistryRecord(record.serviceKey).catch(() => undefined);
+    if (exposureConfig) {
+      await persistRuntimeServiceRecord(record.db, record).catch(() => undefined);
+    }
+    if (bindCollision && port) throw new RuntimeServicePortBindCollision(port);
     throw new Error(
-      `Failed to start runtime service "${serviceName}": ${err instanceof Error ? err.message : String(err)}${stderrExcerpt ? ` | stderr: ${stderrExcerpt.trim()}` : ""}`,
+      `Failed to start runtime service "${serviceName}": ${failureMessage}${stderrExcerpt ? ` | stderr: ${stderrExcerpt.trim()}` : ""}`,
     );
   });
 
@@ -4612,24 +5491,57 @@ async function startLocalRuntimeService(
     ? await prepareRuntimeProvisioning(input)
     : input.preparedProvisioningRecord;
   let started: LocalRuntimeServiceStart | null = null;
+  const excludedPorts = new Set(input.excludedPorts ?? []);
+  const portConfig = parseObject(input.service.port);
+  const portType = asString(portConfig.type, "");
+  const explicitPort = asNumber(portConfig.value, asNumber(input.service.port, 0));
+  const fixedPortFallbackEnabled = Boolean(
+    input.allowFixedPortFallback && portType !== "auto" && explicitPort > 0,
+  );
+  const retryBindCollisions = fixedPortFallbackEnabled || portType === "auto";
+  const deferReadiness = Boolean(options?.deferReadiness);
 
   try {
-    started = await spawnLocalRuntimeService({
-      ...input,
-      runtimeServiceId: provisioningRecord?.id ?? input.runtimeServiceId,
+    for (let attempt = 0; attempt < WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS; attempt += 1) {
+      try {
+        started = await spawnLocalRuntimeService({
+          ...input,
+          excludedPorts,
+          runtimeServiceId: provisioningRecord?.id ?? input.runtimeServiceId,
+        });
+        if (runtimeProvisionCommand) {
+          await persistRuntimeServiceRecord(input.db, started.record);
+        }
+        if (provisioningRecord && started.record.id !== provisioningRecord.id && input.db) {
+          await input.db
+            .delete(workspaceRuntimeServices)
+            .where(eq(workspaceRuntimeServices.id, provisioningRecord.id));
+        }
+        if (!deferReadiness) {
+          await started.readiness;
+        }
+        return started;
+      } catch (error) {
+        if (!(error instanceof RuntimeServicePortBindCollision) || !retryBindCollisions) throw error;
+        excludedPorts.add(error.port);
+        started = null;
+      }
+    }
+
+    if (fixedPortFallbackEnabled && input.executionWorkspaceId) {
+      throw await buildRuntimePortAllocationConflict({
+        db: input.db,
+        companyId: input.agent.companyId,
+        executionWorkspaceId: input.executionWorkspaceId,
+        preferredPort: explicitPort,
+        attemptedPorts: [...excludedPorts],
+      });
+    }
+    throw conflict("No safe automatically allocated runtime service port is available.", {
+      code: "workspace_runtime_port_allocation_exhausted",
+      attemptedPortCount: excludedPorts.size,
+      remediation: "Retry the start or configure a different runtime service port.",
     });
-    if (runtimeProvisionCommand) {
-      await persistRuntimeServiceRecord(input.db, started.record);
-    }
-    if (provisioningRecord && started.record.id !== provisioningRecord.id && input.db) {
-      await input.db
-        .delete(workspaceRuntimeServices)
-        .where(eq(workspaceRuntimeServices.id, provisioningRecord.id));
-    }
-    if (!options?.deferReadiness) {
-      await started.readiness;
-    }
-    return started;
   } catch (error) {
     if (!started && provisioningRecord && provisioningRecord.status === "starting") {
       const nowIso = new Date().toISOString();
@@ -4653,6 +5565,37 @@ function scheduleIdleStop(record: RuntimeServiceRecord) {
   }, idleSeconds * 1000);
 }
 
+async function cleanupRecordExposure(
+  record: RuntimeServiceRecord,
+  options?: { preserveFailure?: boolean },
+) {
+  if (!record.exposure) return;
+  const previous = record.exposure;
+  const ports = previous.listeners.map((listener) => listener.targetPort);
+  const result = await deprovisionExposure(workspaceRuntimeExposureDeps, {
+    runtimeId: record.id,
+    handle: record.exposureHandle,
+    ports,
+  });
+  for (const port of result.quarantinedPorts) quarantinedRuntimeExposurePorts.add(port);
+  if (result.status.state === "removed") {
+    record.exposureHandle = null;
+    record.exposure = options?.preserveFailure && previous.state === "failed"
+      ? { ...previous, publicUrl: null, updatedAt: new Date().toISOString() }
+      : { ...previous, state: "removed", publicUrl: null, lastError: null, updatedAt: new Date().toISOString() };
+  } else {
+    record.exposure = {
+      ...previous,
+      state: "cleanup_pending",
+      publicUrl: null,
+      lastError: result.status.lastError,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+  record.url = null;
+  await persistRuntimeServiceRecord(record.db, record).catch(() => undefined);
+}
+
 async function stopRuntimeService(serviceId: string) {
   const record = runtimeServicesById.get(serviceId);
   if (!record) return;
@@ -4665,6 +5608,7 @@ async function stopRuntimeService(serviceId: string) {
   if (record.reuseKey && runtimeServicesByReuseKey.get(record.reuseKey) === record.id) {
     runtimeServicesByReuseKey.delete(record.reuseKey);
   }
+  await cleanupRecordExposure(record);
   if (record.child && record.child.pid) {
     await terminateLocalService({
       pid: record.child.pid,
@@ -4688,6 +5632,43 @@ async function markPersistedRuntimeServicesStoppedForExecutionWorkspace(input: {
   executionWorkspaceId: string;
 }) {
   const now = new Date();
+  const exposureRows = await input.db
+    .select({
+      id: workspaceRuntimeServices.id,
+      exposure: workspaceRuntimeServices.exposure,
+      exposureHandle: workspaceRuntimeServices.exposureHandle,
+    })
+    .from(workspaceRuntimeServices)
+    .where(
+      and(
+        eq(workspaceRuntimeServices.executionWorkspaceId, input.executionWorkspaceId),
+        inArray(workspaceRuntimeServices.status, ["provisioning", "starting", "running"]),
+      ),
+    );
+  for (const row of exposureRows) {
+    if (!row.exposure) continue;
+    const cleanup = await deprovisionExposure(workspaceRuntimeExposureDeps, {
+      runtimeId: row.id,
+      handle: row.exposureHandle,
+      ports: row.exposure.listeners.map((listener) => listener.targetPort),
+    });
+    for (const port of cleanup.quarantinedPorts) quarantinedRuntimeExposurePorts.add(port);
+    const exposure: RuntimeExposureStatus = {
+      ...row.exposure,
+      state: cleanup.status.state,
+      publicUrl: null,
+      lastError: cleanup.status.lastError,
+      updatedAt: now.toISOString(),
+    };
+    await input.db
+      .update(workspaceRuntimeServices)
+      .set({
+        exposure,
+        exposureHandle: cleanup.status.state === "removed" ? null : row.exposureHandle,
+        url: null,
+      })
+      .where(eq(workspaceRuntimeServices.id, row.id));
+  }
   await input.db
     .update(workspaceRuntimeServices)
     .set({
@@ -4703,6 +5684,133 @@ async function markPersistedRuntimeServicesStoppedForExecutionWorkspace(input: {
         inArray(workspaceRuntimeServices.status, ["provisioning", "starting", "running"]),
       ),
     );
+}
+
+/**
+ * Corroboration for a reclamation driven by persisted rows rather than by a live
+ * operation (PAP-17285).
+ *
+ * `ownedListeners` is the broker's own current ownership view (`broker.list()`),
+ * or `null` when the broker could not be reached. Passing it switches
+ * `cleanupPersistedExposureRows` from "trust the row" to "trust the broker",
+ * which is the difference between reclaiming what is actually published and
+ * issuing removals from stale bookkeeping. Targeted stop paths omit it and keep
+ * their existing behaviour, because there the caller named the runtime.
+ */
+interface ExposureReclaimCorroboration {
+  ownedListeners: Array<{ runtimeId: string; port: number }> | null;
+}
+
+export type StaleExposureReclaimDecision =
+  /** Broker unreachable: prove nothing, mutate nothing, surface cleanup_pending. */
+  | { action: "defer"; reason: "broker_unreachable" }
+  /** Broker owns nothing for this runtime: clear local bookkeeping, no Serve op. */
+  | { action: "clear_bookkeeping"; reason: "not_owned_by_broker" }
+  /** Broker still publishes this runtime's mapping: reclaiming it is correct. */
+  | { action: "reclaim"; reason: "owned_by_broker" };
+
+/**
+ * Decide what a persisted-row-driven reclamation may do, given the broker's live
+ * ownership view (PAP-17285).
+ *
+ * Extracted as a pure function because it is the entire safety contract for the
+ * global startup sweep, and the sweep itself needs a database. Every branch is
+ * asserted by reason code in `workspace-runtime-exposure-backfill.test.ts`.
+ */
+export function decideStaleExposureReclaim(input: {
+  runtimeId: string;
+  ownedListeners: Array<{ runtimeId: string; port: number }> | null;
+}): StaleExposureReclaimDecision {
+  if (input.ownedListeners === null) {
+    return { action: "defer", reason: "broker_unreachable" };
+  }
+  const owned = input.ownedListeners.some((listener) => listener.runtimeId === input.runtimeId);
+  return owned
+    ? { action: "reclaim", reason: "owned_by_broker" }
+    : { action: "clear_bookkeeping", reason: "not_owned_by_broker" };
+}
+
+async function cleanupPersistedExposureRows(
+  db: Db,
+  rows: Array<{
+    id: string;
+    exposure: RuntimeExposureStatus | null;
+    exposureHandle: string | null;
+  }>,
+  corroboration?: ExposureReclaimCorroboration,
+) {
+  for (const row of rows) {
+    if (!row.exposure) continue;
+
+    if (corroboration) {
+      // Fail closed toward PRESERVATION. A stale row is not evidence that a
+      // mapping is ours to delete: rows outlive the lanes that created them, get
+      // duplicated as ports are recycled, and can be days old. Reclaiming on that
+      // basis alone is what destroyed the `42000/52000` mappings.
+      const decision = decideStaleExposureReclaim({
+        runtimeId: row.id,
+        ownedListeners: corroboration.ownedListeners,
+      });
+      if (decision.action === "defer") {
+        // Broker unreachable — we cannot prove anything. Never guess; surface it.
+        await db
+          .update(workspaceRuntimeServices)
+          .set({
+            exposure: {
+              ...row.exposure,
+              state: "cleanup_pending",
+              publicUrl: null,
+              lastError: decision.reason,
+              updatedAt: new Date().toISOString(),
+            },
+          })
+          .where(eq(workspaceRuntimeServices.id, row.id));
+        continue;
+      }
+      if (decision.action === "clear_bookkeeping") {
+        // The broker attributes nothing to this runtime, so there is nothing of
+        // ours published. This is stale local bookkeeping: clear it WITHOUT
+        // issuing any Serve mutation. `exposure.listeners` is retained so the
+        // historical mapping stays inspectable and restorable.
+        await db
+          .update(workspaceRuntimeServices)
+          .set({
+            url: null,
+            exposure: {
+              ...row.exposure,
+              state: "removed",
+              publicUrl: null,
+              lastError: null,
+              updatedAt: new Date().toISOString(),
+            },
+            exposureHandle: null,
+          })
+          .where(eq(workspaceRuntimeServices.id, row.id));
+        continue;
+      }
+    }
+
+    const cleanup = await deprovisionExposure(workspaceRuntimeExposureDeps, {
+      runtimeId: row.id,
+      handle: row.exposureHandle,
+      ports: row.exposure.listeners.map((listener) => listener.targetPort),
+    });
+    for (const port of cleanup.quarantinedPorts) quarantinedRuntimeExposurePorts.add(port);
+    await db
+      .update(workspaceRuntimeServices)
+      .set({
+        url: null,
+        exposure: {
+          ...row.exposure,
+          state: cleanup.status.state,
+          publicUrl: null,
+          lastError: cleanup.status.lastError,
+          updatedAt: new Date().toISOString(),
+        },
+        exposureHandle: cleanup.status.state === "removed" ? null : row.exposureHandle,
+      })
+      .where(eq(workspaceRuntimeServices.id, row.id));
+  }
 }
 
 function registerRuntimeService(db: Db | undefined, record: RuntimeServiceRecord) {
@@ -4724,8 +5832,11 @@ function registerRuntimeService(db: Db | undefined, record: RuntimeServiceRecord
     if (current.reuseKey && runtimeServicesByReuseKey.get(current.reuseKey) === current.id) {
       runtimeServicesByReuseKey.delete(current.reuseKey);
     }
-    void removeLocalServiceRegistryRecord(current.serviceKey);
-    void persistRuntimeServiceRecord(db, current);
+    void (async () => {
+      await cleanupRecordExposure(current);
+      await removeLocalServiceRegistryRecord(current.serviceKey);
+      await persistRuntimeServiceRecord(db, current);
+    })();
   });
 }
 
@@ -4819,6 +5930,26 @@ function selectRuntimeServiceEntries(input: {
   });
 }
 
+async function isPersistedIsolatedExecutionWorkspace(input: {
+  db?: Db;
+  companyId: string;
+  executionWorkspaceId?: string | null;
+}) {
+  if (!input.db || !input.executionWorkspaceId) return false;
+  const row = await input.db
+    .select({ mode: executionWorkspaces.mode })
+    .from(executionWorkspaces)
+    .where(
+      and(
+        eq(executionWorkspaces.id, input.executionWorkspaceId),
+        eq(executionWorkspaces.companyId, input.companyId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+  return row?.mode === "isolated_workspace";
+}
+
 export async function ensureRuntimeServicesForRun(input: {
   db?: Db;
   runId: string;
@@ -4841,6 +5972,11 @@ export async function ensureRuntimeServicesForRun(input: {
   const refs: RuntimeServiceRef[] = [];
   const runtimeProvisionCommand = resolveRuntimeProvisionCommand(input);
   const provisionCoordinator = createRuntimeProvisionCoordinator();
+  const allowFixedPortFallback = await isPersistedIsolatedExecutionWorkspace({
+    db: input.db,
+    companyId: input.agent.companyId,
+    executionWorkspaceId: input.executionWorkspaceId,
+  });
   runtimeServiceLeasesByRun.set(input.runId, acquiredServiceIds);
 
   try {
@@ -4895,6 +6031,7 @@ export async function ensureRuntimeServicesForRun(input: {
         runtimeProvisionCommand,
         recorder: input.recorder,
         provisionCoordinator,
+        allowFixedPortFallback,
         reuseKey,
         scopeType,
         scopeId,
@@ -4930,7 +6067,7 @@ type StartRuntimeServicesForWorkspaceControlInput = {
 
 type WorkspaceControlStartBatch = {
   refs: RuntimeServiceRef[];
-  pendingReadiness: LocalRuntimeServiceStart[];
+  pendingReadiness: PendingRuntimeServiceReadiness[];
   startedServiceIds: string[];
 };
 
@@ -4942,16 +6079,18 @@ async function startRuntimeServicesForWorkspaceControlUnlocked(
   registryDb = input.db,
   options?: {
     deferReadiness?: boolean;
+    allowFixedPortFallback?: boolean;
     runtimeProvisionCommand?: string;
     provisionCoordinator?: RuntimeProvisionCoordinator;
     preparedProvisioning?: {
       service: Record<string, unknown>;
       record: RuntimeServiceRecord;
     } | null;
+    excludedPorts?: ReadonlySet<number>;
   },
 ): Promise<WorkspaceControlStartBatch> {
   const refs: RuntimeServiceRef[] = [];
-  const pendingReadiness: LocalRuntimeServiceStart[] = [];
+  const pendingReadiness: PendingRuntimeServiceReadiness[] = [];
   const startedServiceIds: string[] = [];
 
   for (const service of rawServices) {
@@ -5015,6 +6154,8 @@ async function startRuntimeServicesForWorkspaceControlUnlocked(
         options?.preparedProvisioning?.service === service
           ? options.preparedProvisioning.record
           : undefined,
+      allowFixedPortFallback: options?.allowFixedPortFallback,
+      excludedPorts: options?.excludedPorts,
       reuseKey,
       scopeType,
       scopeId,
@@ -5029,16 +6170,73 @@ async function startRuntimeServicesForWorkspaceControlUnlocked(
     await persistRuntimeServiceRecord(persistenceDb, started.record);
     refs.push(toRuntimeServiceRef(started.record));
 
-    if (options?.deferReadiness && !started.record.reused) {
+    if (options?.deferReadiness && started.record.status === "starting" && !started.record.reused) {
       // Attach a rejection handler immediately; the caller awaits the same promise after
       // the DB transaction commits, but transaction failures may skip that wait path.
       started.readiness.catch(() => undefined);
-      pendingReadiness.push(started);
+      pendingReadiness.push({ ...started, service });
       startedServiceIds.push(started.record.id);
     }
   }
 
   return { refs, pendingReadiness, startedServiceIds };
+}
+
+async function lockWorkspaceRuntimeStartParents(
+  db: Db,
+  input: StartRuntimeServicesForWorkspaceControlInput,
+) {
+  let allowFixedPortFallback = false;
+  if (input.executionWorkspaceId) {
+    const [lockedExecutionWorkspace] = await db
+      .select({ id: executionWorkspaces.id, mode: executionWorkspaces.mode })
+      .from(executionWorkspaces)
+      .where(
+        and(
+          eq(executionWorkspaces.id, input.executionWorkspaceId),
+          eq(executionWorkspaces.companyId, input.actor.companyId),
+        ),
+      )
+      .for("update");
+    if (!lockedExecutionWorkspace) throw new Error("Execution workspace not found before starting runtime services");
+    allowFixedPortFallback = lockedExecutionWorkspace.mode === "isolated_workspace";
+  }
+
+  if (input.workspace.workspaceId) {
+    const [lockedProjectWorkspace] = await db
+      .select({ id: projectWorkspaces.id })
+      .from(projectWorkspaces)
+      .where(
+        and(
+          eq(projectWorkspaces.id, input.workspace.workspaceId),
+          eq(projectWorkspaces.companyId, input.actor.companyId),
+        ),
+      )
+      .for("update");
+    if (!lockedProjectWorkspace) throw new Error("Project workspace not found before starting runtime services");
+  }
+
+  return allowFixedPortFallback;
+}
+
+function canRetryDeferredPortBindCollision(
+  service: Record<string, unknown>,
+  allowFixedPortFallback: boolean,
+) {
+  const portConfig = parseObject(service.port);
+  const portType = asString(portConfig.type, "");
+  const explicitPort = asNumber(portConfig.value, asNumber(service.port, 0));
+  return portType === "auto" || Boolean(allowFixedPortFallback && explicitPort > 0);
+}
+
+async function discardFailedDeferredRuntimeStart(db: Db, record: RuntimeServiceRecord) {
+  clearIdleTimer(record);
+  if (runtimeServicesById.get(record.id) === record) runtimeServicesById.delete(record.id);
+  if (record.reuseKey && runtimeServicesByReuseKey.get(record.reuseKey) === record.id) {
+    runtimeServicesByReuseKey.delete(record.reuseKey);
+  }
+  await removeLocalServiceRegistryRecord(record.serviceKey).catch(() => undefined);
+  await persistRuntimeServiceRecord(db, record);
 }
 
 export async function startRuntimeServicesForWorkspaceControl(
@@ -5054,8 +6252,17 @@ export async function startRuntimeServicesForWorkspaceControl(
   const invocationId = input.invocationId ?? randomUUID();
   const runtimeProvisionCommand = resolveRuntimeProvisionCommand(input);
   const provisionCoordinator = createRuntimeProvisionCoordinator();
+  const hasHttpsExposure = await anyRuntimeServiceUsesHttpsExposure(rawServices);
 
-  if (rawServices.length === 0 || !input.db || (!input.executionWorkspaceId && !input.workspace.workspaceId)) {
+  if (
+    rawServices.length === 0
+    || !input.db
+    || (!input.executionWorkspaceId && !input.workspace.workspaceId)
+    // The reservation row must commit before the backend binds. Keeping this
+    // path outside the parent-row transaction avoids a crash window where the
+    // broker lease exists but the DB transaction has not committed its handle.
+    || hasHttpsExposure
+  ) {
     const batch = await startRuntimeServicesForWorkspaceControlUnlocked(
       input,
       rawServices,
@@ -5076,6 +6283,7 @@ export async function startRuntimeServicesForWorkspaceControl(
     service: Record<string, unknown>;
     record: RuntimeServiceRecord;
   } | null = null;
+  let allowFixedPortFallback = false;
   try {
     if (runtimeProvisionCommand) {
       for (const service of rawServices) {
@@ -5126,34 +6334,7 @@ export async function startRuntimeServicesForWorkspaceControl(
 
     await input.db.transaction(async (tx) => {
       const txDb = tx as unknown as Db;
-
-      if (input.executionWorkspaceId) {
-        const [lockedExecutionWorkspace] = await tx
-          .select({ id: executionWorkspaces.id })
-          .from(executionWorkspaces)
-          .where(
-            and(
-              eq(executionWorkspaces.id, input.executionWorkspaceId),
-              eq(executionWorkspaces.companyId, input.actor.companyId),
-            ),
-          )
-          .for("update");
-        if (!lockedExecutionWorkspace) throw new Error("Execution workspace not found before starting runtime services");
-      }
-
-      if (input.workspace.workspaceId) {
-        const [lockedProjectWorkspace] = await tx
-          .select({ id: projectWorkspaces.id })
-          .from(projectWorkspaces)
-          .where(
-            and(
-              eq(projectWorkspaces.id, input.workspace.workspaceId),
-              eq(projectWorkspaces.companyId, input.actor.companyId),
-            ),
-          )
-          .for("update");
-        if (!lockedProjectWorkspace) throw new Error("Project workspace not found before starting runtime services");
-      }
+      allowFixedPortFallback = await lockWorkspaceRuntimeStartParents(txDb, input);
 
       // Branch reconciliation takes these same parent row locks before mutating
       // a recorded branch. Persisting a `starting` service row before commit closes
@@ -5166,6 +6347,7 @@ export async function startRuntimeServicesForWorkspaceControl(
         input.db,
         {
           deferReadiness: true,
+          allowFixedPortFallback,
           runtimeProvisionCommand,
           provisionCoordinator,
           preparedProvisioning,
@@ -5173,13 +6355,86 @@ export async function startRuntimeServicesForWorkspaceControl(
       );
     });
 
-    for (const pending of startBatch.pendingReadiness) {
-      try {
-        await pending.readiness;
-        await persistRuntimeServiceRecord(input.db, pending.record);
-      } catch (error) {
-        await persistRuntimeServiceRecord(input.db, pending.record).catch(() => undefined);
-        throw error;
+    // Readiness never uses the transaction-scoped DB handle. A late bind collision is
+    // recorded after commit, then only the next bounded reservation re-enters a short
+    // parent-locked transaction. Slow builds therefore cannot retain the parent locks.
+    for (const initialPending of startBatch.pendingReadiness) {
+      let pending: PendingRuntimeServiceReadiness | null = initialPending;
+      const excludedPorts = new Set<number>();
+
+      while (pending) {
+        try {
+          await pending.readiness;
+          await persistRuntimeServiceRecord(input.db, pending.record);
+          break;
+        } catch (error) {
+          await discardFailedDeferredRuntimeStart(input.db, pending.record);
+          if (
+            !(error instanceof RuntimeServicePortBindCollision)
+            || !canRetryDeferredPortBindCollision(pending.service, allowFixedPortFallback)
+          ) {
+            throw error;
+          }
+
+          excludedPorts.add(error.port);
+          if (excludedPorts.size >= WORKSPACE_RUNTIME_PORT_ALLOCATION_ATTEMPTS) {
+            const portConfig = parseObject(pending.service.port);
+            const portType = asString(portConfig.type, "");
+            const preferredPort = asNumber(portConfig.value, asNumber(pending.service.port, 0));
+            if (allowFixedPortFallback && portType !== "auto" && preferredPort > 0 && input.executionWorkspaceId) {
+              throw await buildRuntimePortAllocationConflict({
+                db: input.db,
+                companyId: input.actor.companyId,
+                executionWorkspaceId: input.executionWorkspaceId,
+                preferredPort,
+                attemptedPorts: [...excludedPorts],
+              });
+            }
+            throw conflict("No safe automatically allocated runtime service port is available.", {
+              code: "workspace_runtime_port_allocation_exhausted",
+              attemptedPortCount: excludedPorts.size,
+              remediation: "Retry the start or configure a different runtime service port.",
+            });
+          }
+
+          const failedRecordId = pending.record.id;
+          let retryBatch: WorkspaceControlStartBatch = {
+            refs: [],
+            pendingReadiness: [],
+            startedServiceIds: [],
+          };
+          let retryAllowsFixedPortFallback = false;
+          await input.db.transaction(async (tx) => {
+            const txDb = tx as unknown as Db;
+            retryAllowsFixedPortFallback = await lockWorkspaceRuntimeStartParents(txDb, input);
+            if (!canRetryDeferredPortBindCollision(pending!.service, retryAllowsFixedPortFallback)) {
+              throw error;
+            }
+            retryBatch = await startRuntimeServicesForWorkspaceControlUnlocked(
+              { ...input, db: txDb },
+              [pending!.service],
+              invocationId,
+              txDb,
+              input.db,
+              {
+                deferReadiness: true,
+                allowFixedPortFallback: retryAllowsFixedPortFallback,
+                provisionCoordinator,
+                excludedPorts,
+              },
+            );
+          });
+          allowFixedPortFallback = retryAllowsFixedPortFallback;
+          for (const serviceId of retryBatch.startedServiceIds) {
+            if (!startBatch.startedServiceIds.includes(serviceId)) {
+              startBatch.startedServiceIds.push(serviceId);
+            }
+          }
+          const replacementRef = retryBatch.refs[0];
+          const failedRefIndex = startBatch.refs.findIndex((ref) => ref.id === failedRecordId);
+          if (replacementRef && failedRefIndex >= 0) startBatch.refs[failedRefIndex] = replacementRef;
+          pending = retryBatch.pendingReadiness[0] ?? null;
+        }
       }
     }
 
@@ -5250,6 +6505,15 @@ export async function stopRuntimeServicesForExecutionWorkspace(input: {
   if (input.db) {
     if (input.runtimeServiceId) {
       const now = new Date();
+      const rows = await input.db
+        .select({
+          id: workspaceRuntimeServices.id,
+          exposure: workspaceRuntimeServices.exposure,
+          exposureHandle: workspaceRuntimeServices.exposureHandle,
+        })
+        .from(workspaceRuntimeServices)
+        .where(eq(workspaceRuntimeServices.id, input.runtimeServiceId));
+      await cleanupPersistedExposureRows(input.db, rows);
       await input.db
         .update(workspaceRuntimeServices)
         .set({
@@ -5287,6 +6551,22 @@ export async function stopRuntimeServicesForProjectWorkspace(input: {
 
   if (input.db) {
     const now = new Date();
+    const exposureCondition = input.runtimeServiceId
+      ? eq(workspaceRuntimeServices.id, input.runtimeServiceId)
+      : and(
+          eq(workspaceRuntimeServices.projectWorkspaceId, input.projectWorkspaceId),
+          eq(workspaceRuntimeServices.scopeType, "project_workspace"),
+          inArray(workspaceRuntimeServices.status, ["provisioning", "starting", "running"]),
+        );
+    const exposureRows = await input.db
+      .select({
+        id: workspaceRuntimeServices.id,
+        exposure: workspaceRuntimeServices.exposure,
+        exposureHandle: workspaceRuntimeServices.exposureHandle,
+      })
+      .from(workspaceRuntimeServices)
+      .where(exposureCondition);
+    await cleanupPersistedExposureRows(input.db, exposureRows);
     await input.db
       .update(workspaceRuntimeServices)
       .set({
@@ -5297,13 +6577,7 @@ export async function stopRuntimeServicesForProjectWorkspace(input: {
         updatedAt: now,
       })
       .where(
-        input.runtimeServiceId
-          ? eq(workspaceRuntimeServices.id, input.runtimeServiceId)
-          : and(
-              eq(workspaceRuntimeServices.projectWorkspaceId, input.projectWorkspaceId),
-              eq(workspaceRuntimeServices.scopeType, "project_workspace"),
-              inArray(workspaceRuntimeServices.status, ["provisioning", "starting", "running"]),
-            ),
+        exposureCondition,
       );
   }
 }
@@ -5336,6 +6610,96 @@ export async function listWorkspaceRuntimeServicesForProjectWorkspaces(
   return grouped;
 }
 
+/**
+ * Statuses that mean "there is, or is supposed to be, a live backend process".
+ * A row in one of these states is what the backfill has to reprovision; a
+ * `stopped` row simply picks the default up on its next start.
+ */
+const LIVE_RUNTIME_SERVICE_STATUSES = new Set(["provisioning", "starting", "running"]);
+
+export type ManagedRuntimeExposureBackfillDecision = {
+  action: "keep" | "reprovision";
+  reason: string;
+};
+
+/**
+ * Decide what the HTTPS backfill should do with one persisted runtime-service
+ * row (PAP-17158).
+ *
+ * Pure so every branch is directly testable: the reasons below are the whole
+ * contract for which pre-feature workspaces get upgraded and which are left
+ * exactly as they are.
+ *
+ * `declaredIntent === null` means no configured service entry could be matched
+ * to this row. Such a row is deliberately left alone: reprovisioning works by
+ * stopping the HTTP backend and letting the desired-state restart bring it back
+ * with exposure, so without a config to restart from we would take a service
+ * down and never bring it back.
+ */
+export function decideManagedRuntimeExposureBackfill(input: {
+  mode: ManagedRuntimeHttpsMode;
+  brokerAvailable: boolean;
+  provider: string;
+  serviceName: string;
+  command: string | null;
+  status: string;
+  hasExposure: boolean;
+  declaredIntent: RuntimeExposureIntent | null;
+}): ManagedRuntimeExposureBackfillDecision {
+  if (input.mode === "off") return { action: "keep", reason: "https_default_disabled" };
+  if (input.provider !== "local_process") return { action: "keep", reason: "not_a_managed_local_process" };
+  // Idempotence: a row that already carries exposure state is never re-driven,
+  // so repeated deploys and restarts converge instead of churning listeners.
+  if (input.hasExposure) return { action: "keep", reason: "already_exposed" };
+  if (input.declaredIntent === "disabled") return { action: "keep", reason: "deliberate_opt_out" };
+  if (input.declaredIntent === null) return { action: "keep", reason: "no_configured_service_entry" };
+  if (!isManagedHttpsDefaultCandidate({ serviceName: input.serviceName, command: input.command })) {
+    return { action: "keep", reason: "unmanaged_or_custom_service" };
+  }
+  if (input.mode !== "force" && !input.brokerAvailable) {
+    return { action: "keep", reason: "broker_unavailable" };
+  }
+  if (!LIVE_RUNTIME_SERVICE_STATUSES.has(input.status)) {
+    return { action: "keep", reason: "stopped_defaults_on_next_start" };
+  }
+  return { action: "reprovision", reason: "http_only_managed_service" };
+}
+
+/**
+ * Look up the exposure intent a persisted runtime-service row inherits from its
+ * owning workspace configuration, by matching the row's service name against the
+ * configured entries. Returns null when no entry matches.
+ */
+async function buildPersistedRuntimeExposureIntentLookup(db: Db) {
+  const [projectWorkspaceRows, executionWorkspaceRows] = await Promise.all([
+    db.select().from(projectWorkspaces),
+    db.select().from(executionWorkspaces),
+  ]);
+  const projectRuntimeById = new Map(projectWorkspaceRows.map((row) => [
+    row.id,
+    readProjectWorkspaceRuntimeConfig((row.metadata as Record<string, unknown> | null) ?? null)?.workspaceRuntime ?? null,
+  ] as const));
+  const executionRuntimeById = new Map(executionWorkspaceRows.map((row) => [
+    row.id,
+    readExecutionWorkspaceConfig((row.metadata as Record<string, unknown> | null) ?? null)?.workspaceRuntime
+      ?? (row.projectWorkspaceId ? projectRuntimeById.get(row.projectWorkspaceId) ?? null : null),
+  ] as const));
+
+  return (row: {
+    serviceName: string;
+    projectWorkspaceId: string | null;
+    executionWorkspaceId: string | null;
+  }): RuntimeExposureIntent | null => {
+    const runtime = (row.executionWorkspaceId ? executionRuntimeById.get(row.executionWorkspaceId) : null)
+      ?? (row.projectWorkspaceId ? projectRuntimeById.get(row.projectWorkspaceId) ?? null : null);
+    if (!runtime) return null;
+    const entries = listConfiguredRuntimeServiceEntries({ workspaceRuntime: runtime });
+    const entry = entries.find((candidate) => asString(candidate.name, "service") === row.serviceName);
+    if (!entry) return null;
+    return readRuntimeExposureIntent(parseObject(entry.expose));
+  };
+}
+
 export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
   const rows = await db
     .select()
@@ -5347,12 +6711,78 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
       ),
     );
 
-  if (rows.length === 0) return { reconciled: 0, adopted: 0, stopped: 0 };
+  // Backfill inputs, resolved once per startup rather than per row.
+  const httpsMode = resolveManagedRuntimeHttpsMode();
+  const brokerAvailable = httpsMode === "off"
+    ? false
+    : await workspaceRuntimeExposureDeps.isBrokerAvailable().catch(() => false);
+  const readDeclaredExposureIntent = await buildPersistedRuntimeExposureIntentLookup(db);
+
+  let ownedExposureListeners: Awaited<ReturnType<BrokerClient["list"]>> | null = [];
+  if (rows.some((row) => row.exposure && row.exposure.state !== "removed")) {
+    try {
+      ownedExposureListeners = await workspaceRuntimeExposureDeps.broker.list();
+    } catch {
+      ownedExposureListeners = null;
+    }
+  }
 
   let reconciled = 0;
   let adopted = 0;
   let stopped = 0;
+  let backfilled = 0;
   for (const row of rows) {
+    if (row.status === "stopped" && row.exposure && row.exposure.state !== "removed") {
+      // This branch is a GLOBAL sweep: `rows` spans every execution workspace and
+      // company on the host, at any age, and it runs on every server start. It
+      // used to issue a broker removal for each stale row on the row's authority
+      // alone — which is how a restart at 12:25:49 UTC deleted the preserved
+      // `42000/52000` mappings from two rows that were 2 and 3 days old
+      // (PAP-17285). Corroborate against the broker's live ownership view, which
+      // this function has already fetched, instead of trusting the row.
+      await cleanupPersistedExposureRows(
+        db,
+        [{ id: row.id, exposure: row.exposure, exposureHandle: row.exposureHandle }],
+        { ownedListeners: ownedExposureListeners },
+      );
+      reconciled += 1;
+      continue;
+    }
+    const rowExposureListeners = ownedExposureListeners?.filter((listener) => listener.runtimeId === row.id) ?? [];
+    const exposureMappingMatches = !row.exposure || (
+      row.exposure.state === "ready"
+      && Boolean(row.exposureHandle)
+      && rowExposureListeners.length === row.exposure.listeners.length
+      && row.exposure.listeners.every((expected) => rowExposureListeners.some((actual) => (
+        actual.port === expected.targetPort && actual.purpose === expected.purpose
+      )))
+    );
+    const exposureHealthMatches = !row.exposure || (
+      exposureMappingMatches
+      && Boolean(row.exposure.publicUrl)
+      && await workspaceRuntimeExposureDeps.probeHealth(
+        new URL("/api/health", row.exposure.publicUrl!).toString(),
+      )
+    );
+    // Pre-feature rows carry no exposure state at all. An eligible one that is
+    // still serving plain HTTP must not be adopted as-is, or the deploy would
+    // leave `http://paperclip-dev:<port>` as the canonical URL forever. Stopping
+    // it here hands it to the desired-state restart below, which brings it back
+    // through the normal fail-closed exposure lifecycle.
+    const backfillDecision = decideManagedRuntimeExposureBackfill({
+      mode: httpsMode,
+      brokerAvailable,
+      provider: row.provider,
+      serviceName: row.serviceName,
+      command: row.command,
+      status: row.status,
+      hasExposure: Boolean(row.exposure && row.exposure.state !== "removed"),
+      declaredIntent: readDeclaredExposureIntent({
+        serviceName: row.serviceName,
+        projectWorkspaceId: row.projectWorkspaceId ?? null,
+        executionWorkspaceId: row.executionWorkspaceId ?? null,
+      }),
+    });
     let adoptedRecord = await findLocalServiceRegistryRecordByRuntimeServiceId({
       runtimeServiceId: row.id,
       profileKind: "workspace-runtime",
@@ -5392,12 +6822,18 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
         cwd: row.cwd,
         envFingerprint: row.reuseKey ?? "",
         port: row.port ?? null,
-        url: row.url ?? null,
+        url: row.backendUrl ?? row.url ?? null,
       });
     }
     if (adoptedRecord) {
-      const adoptedUrl = adoptedRecord.url ?? row.url ?? null;
-      if (!(await isRuntimeServiceUrlHealthy(adoptedUrl, { serviceName: row.serviceName, command: row.command }))) {
+      const adoptedUrl = adoptedRecord.url ?? row.backendUrl ?? row.url ?? null;
+      if (
+        backfillDecision.action === "reprovision"
+        || !exposureHealthMatches
+        || !(await isRuntimeServiceUrlHealthy(adoptedUrl, { serviceName: row.serviceName, command: row.command }))
+      ) {
+        if (backfillDecision.action === "reprovision") backfilled += 1;
+        await terminateLocalService(adoptedRecord);
         await removeLocalServiceRegistryRecord(adoptedRecord.serviceKey);
       } else {
         const record: RuntimeServiceRecord = {
@@ -5416,7 +6852,7 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
           command: row.command ?? null,
           cwd: row.cwd ?? null,
           port: adoptedRecord.port ?? row.port ?? null,
-          url: adoptedRecord.url ?? row.url ?? null,
+          url: row.exposure?.publicUrl ?? adoptedRecord.url ?? row.url ?? null,
           provider: "local_process",
           providerRef: String(adoptedRecord.pid),
           ownerAgentId: row.ownerAgentId ?? null,
@@ -5426,6 +6862,7 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
           stoppedAt: null,
           stopPolicy: (row.stopPolicy as Record<string, unknown> | null) ?? null,
           healthStatus: "healthy",
+          exposure: row.exposure ?? null,
           reused: true,
           db,
           child: null,
@@ -5435,6 +6872,9 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
           serviceKey: adoptedRecord.serviceKey,
           profileKind: "workspace-runtime",
           processGroupId: adoptedRecord.processGroupId ?? null,
+          exposureHandle: row.exposureHandle ?? null,
+          backendUrl: adoptedUrl,
+          exposureConfig: null,
         };
         registerRuntimeService(db, record);
         await touchLocalServiceRegistryRecord(adoptedRecord.serviceKey, {
@@ -5453,11 +6893,35 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
     }
 
     const now = new Date();
+    let stoppedExposure = row.exposure ?? null;
+    let stoppedExposureHandle = row.exposureHandle ?? null;
+    if (stoppedExposure) {
+      const cleanup = await deprovisionExposure(workspaceRuntimeExposureDeps, {
+        runtimeId: row.id,
+        handle: stoppedExposureHandle,
+        ports: stoppedExposure.listeners.map((listener) => listener.targetPort),
+      });
+      for (const port of cleanup.quarantinedPorts) quarantinedRuntimeExposurePorts.add(port);
+      stoppedExposure = {
+        ...stoppedExposure,
+        state: cleanup.status.state,
+        publicUrl: null,
+        lastError: cleanup.status.lastError,
+        updatedAt: now.toISOString(),
+      };
+      if (cleanup.status.state === "removed") stoppedExposureHandle = null;
+    }
     await db
       .update(workspaceRuntimeServices)
       .set({
         status: "stopped",
         healthStatus: "unknown",
+        // A row queued for HTTPS backfill drops its HTTP URL now rather than
+        // keeping it until the restart succeeds: if the restart fails, the
+        // fail-closed contract says show no URL, not a working HTTP one.
+        url: stoppedExposure || backfillDecision.action === "reprovision" ? null : row.url,
+        exposure: stoppedExposure,
+        exposureHandle: stoppedExposureHandle,
         stoppedAt: now,
         lastUsedAt: now,
         updatedAt: now,
@@ -5474,7 +6938,26 @@ export async function reconcilePersistedRuntimeServicesOnStartup(db: Db) {
     stopped += 1;
   }
 
-  return { reconciled, adopted, stopped };
+  // Row reconciliation alone cannot repair the process-start crash window: the
+  // local service registry may contain a healthy managed process whose DB row
+  // was never committed. Re-applying persisted desired state adopts that
+  // registry entry (or restarts a missing service) and makes it visible to
+  // workspace cleanup through workspace_runtime_services again.
+  //
+  // It is also the second half of the HTTPS backfill: services stopped above as
+  // HTTP-only come back here through the ordinary start path, which now applies
+  // the `tailscale_https` default and only reports them healthy behind a
+  // verified HTTPS URL.
+  const desiredState = await restartDesiredRuntimeServicesOnStartup(db);
+
+  return {
+    reconciled,
+    adopted,
+    stopped,
+    backfilled,
+    restarted: desiredState.restarted,
+    restartFailed: desiredState.failed,
+  };
 }
 
 export async function restartDesiredRuntimeServicesOnStartup(db: Db) {
@@ -5632,6 +7115,9 @@ export async function persistAdapterManagedRuntimeServices(input: {
         startedAt,
         stoppedAt: ref.stoppedAt ? new Date(ref.stoppedAt) : null,
         stopPolicy: ref.stopPolicy,
+        exposure: null,
+        exposureHandle: null,
+        backendUrl: null,
         healthStatus: ref.healthStatus,
         createdAt,
         updatedAt: new Date(),
@@ -5661,6 +7147,9 @@ export async function persistAdapterManagedRuntimeServices(input: {
           startedAt,
           stoppedAt: ref.stoppedAt ? new Date(ref.stoppedAt) : null,
           stopPolicy: ref.stopPolicy,
+          exposure: null,
+          exposureHandle: null,
+          backendUrl: null,
           healthStatus: ref.healthStatus,
           updatedAt: new Date(),
         },

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -860,6 +860,18 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                           service.command ?? "No URL"
                         )}
                       </div>
+                      {service.exposure && service.exposure.state !== "removed" ? (
+                        <div
+                          className={cn(
+                            "text-(length:--text-nano)",
+                            service.exposure.state === "failed" || service.exposure.state === "cleanup_pending"
+                              ? "text-destructive"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          HTTPS {service.exposure.state.replace("_", " ")}
+                        </div>
+                      ) : null}
                     </div>
                     <div className="text-(length:--text-nano) text-muted-foreground whitespace-nowrap">
                       {service.lifecycle}

--- a/ui/src/components/WorkspaceRuntimeControls.test.tsx
+++ b/ui/src/components/WorkspaceRuntimeControls.test.tsx
@@ -47,6 +47,7 @@ function createRuntimeService(overrides: Partial<WorkspaceRuntimeService> = {}):
     stoppedAt: overrides.stoppedAt ?? null,
     stopPolicy: overrides.stopPolicy ?? null,
     healthStatus: overrides.healthStatus ?? "unknown",
+    exposure: overrides.exposure ?? null,
     configIndex: overrides.configIndex ?? null,
     createdAt: overrides.createdAt ?? new Date("2026-04-12T00:00:00.000Z"),
     updatedAt: overrides.updatedAt ?? new Date("2026-04-12T00:00:00.000Z"),
@@ -423,6 +424,61 @@ describe("WorkspaceRuntimeControls", () => {
     act(() => root.unmount());
   });
 
+  it.each([
+    ["failed", "external HTTPS health probe did not validate", "HTTPS unavailable", "Check the Tailscale broker and node HTTPS configuration."],
+    ["cleanup_pending", "host broker cleanup confirmation timed out", "HTTPS cleanup pending", "Restart the host broker before reusing this port."],
+  ] as const)(
+    "shows %s exposure state, last error, and remediation on service cards",
+    (state, lastError, label, remediation) => {
+      const sections = buildWorkspaceRuntimeControlSections({
+        runtimeConfig: {
+          commands: [
+            { id: "web", name: "web", kind: "service", command: "pnpm dev" },
+          ],
+        },
+        runtimeServices: [
+          createRuntimeService({
+            id: "service-web",
+            serviceName: "web",
+            status: "stopped",
+            exposure: {
+              provider: "tailscale_https",
+              state,
+              publicUrl: null,
+              hostname: "paperclip-dev.tail29c1aa.ts.net",
+              listeners: [{ purpose: "app", publicPort: 42002, targetPort: 42002 }],
+              brokerRef: "service-web",
+              lastError,
+              updatedAt: "2026-08-12T00:00:00.000Z",
+            },
+          }),
+        ],
+        canStartServices: true,
+      });
+
+      const root = createRoot(container);
+      act(() => {
+        root.render(
+          <WorkspaceRuntimeControls
+            sections={sections}
+            onAction={vi.fn()}
+          />,
+        );
+      });
+
+      const alert = container.querySelector('[role="alert"]');
+      const summary = alert?.firstElementChild;
+      expect(alert?.classList.contains("text-destructive")).toBe(true);
+      expect(summary?.classList.contains("line-clamp-3")).toBe(true);
+      expect(summary?.getAttribute("title")).toBe(lastError);
+      expect(alert?.textContent).toContain(label);
+      expect(alert?.textContent).toContain(lastError);
+      expect(alert?.textContent).toContain(remediation);
+
+      act(() => root.unmount());
+    },
+  );
+
   it("can render square plain surfaces for embedded configuration pages", () => {
     const sections = buildWorkspaceRuntimeControlSections({
       runtimeConfig: {
@@ -626,6 +682,98 @@ describe("buildWorkspaceServiceControlEntries", () => {
 
     expect(entries[0].state).toBe("failed");
     expect(entries[0].failureDetail).toMatch(/^Service failed · /);
+  });
+
+  it("surfaces HTTPS failure independently while the backend remains running", () => {
+    const running = createRuntimeService({
+      status: "running",
+      healthStatus: "healthy",
+      port: 42000,
+      url: null,
+      exposure: {
+        provider: "tailscale_https",
+        state: "failed",
+        publicUrl: null,
+        hostname: "runner.tail123.ts.net",
+        listeners: [{ purpose: "app", publicPort: 42000, targetPort: 42000 }],
+        brokerRef: "service-1",
+        lastError: "cli_error",
+        updatedAt: "2026-08-11T00:00:00.000Z",
+      },
+    });
+    const built = buildWorkspaceRuntimeControlSections({
+      runtimeConfig: { commands: [{ id: "web", name: "web", kind: "service", command: "pnpm dev" }] },
+      runtimeServices: [running],
+      canStartServices: true,
+    });
+    const [entry] = buildWorkspaceServiceControlEntries({ sections: built, runtimeServices: [running] });
+
+    expect(entry.state).toBe("running");
+    expect(entry.exposureState).toBe("failed");
+    expect(entry.exposureDetail).toMatch(/^HTTPS unavailable/);
+    expect(entry.exposureDetail).not.toContain("cli_error");
+  });
+
+  it("carries the verified HTTPS URL into the launch entry, and no HTTP fallback while pending", () => {
+    // PAP-17158: the workspace/project/issue launch links are rendered from these
+    // entries, so the tailnet HTTPS URL has to survive the mapping intact — and a
+    // service whose exposure is not yet verified must offer no URL at all rather
+    // than the loopback backend it is really listening on.
+    const httpsUrl = "https://paperclip-dev.tail29c1aa.ts.net:42010";
+    const buildEntry = (service: ReturnType<typeof createRuntimeService>) => {
+      const sections = buildWorkspaceRuntimeControlSections({
+        runtimeConfig: { commands: [{ id: "web", name: "web", kind: "service", command: "pnpm dev" }] },
+        runtimeServices: [service],
+        canStartServices: true,
+      });
+      return buildWorkspaceServiceControlEntries({ sections, runtimeServices: [service] })[0];
+    };
+
+    const ready = buildEntry(createRuntimeService({
+      status: "running",
+      healthStatus: "healthy",
+      port: 42_010,
+      url: httpsUrl,
+      exposure: {
+        provider: "tailscale_https",
+        state: "ready",
+        publicUrl: httpsUrl,
+        hostname: "paperclip-dev.tail29c1aa.ts.net",
+        listeners: [
+          { purpose: "app", publicPort: 42_010, targetPort: 42_010 },
+          { purpose: "vite_hmr", publicPort: 52_010, targetPort: 52_010 },
+        ],
+        brokerRef: "service-1",
+        lastError: null,
+        updatedAt: "2026-08-12T00:00:00.000Z",
+      },
+    }));
+    expect(ready.state).toBe("running");
+    expect(ready.url).toBe(httpsUrl);
+    expect(ready.exposureState).toBe("ready");
+    // A ready exposure reports plainly and never as a remediation prompt.
+    expect(ready.exposureDetail).toBe("HTTPS ready");
+    expect(ready.exposureDetail).not.toMatch(/unavailable|cleanup|Check the/i);
+
+    const pending = buildEntry(createRuntimeService({
+      status: "running",
+      healthStatus: "healthy",
+      port: 42_020,
+      url: null,
+      exposure: {
+        provider: "tailscale_https",
+        state: "pending",
+        publicUrl: null,
+        hostname: "paperclip-dev.tail29c1aa.ts.net",
+        listeners: [],
+        brokerRef: null,
+        lastError: null,
+        updatedAt: "2026-08-12T00:00:00.000Z",
+      },
+    }));
+    expect(pending.url ?? null).toBeNull();
+    expect(pending.exposureDetail).toBe("Provisioning HTTPS…");
+    expect(JSON.stringify(pending)).not.toContain("http://");
   });
 });
 

--- a/ui/src/components/WorkspaceRuntimeControls.tsx
+++ b/ui/src/components/WorkspaceRuntimeControls.tsx
@@ -1,5 +1,6 @@
 import type {
   WorkspaceCommandDefinition,
+  RuntimeExposureStatus,
   WorkspaceRuntimeControlTarget,
   WorkspaceRuntimeService,
 } from "@paperclipai/shared";
@@ -30,6 +31,7 @@ export type WorkspaceRuntimeControlItem = {
   statusLabel: string;
   lifecycle: "shared" | "ephemeral" | null;
   healthStatus: "unknown" | "healthy" | "unhealthy" | null;
+  exposure: RuntimeExposureStatus | null;
   command: string | null;
   cwd: string | null;
   port: number | null;
@@ -96,6 +98,7 @@ function buildServiceItem(
     statusLabel: runtimeService?.status ?? "stopped",
     lifecycle: runtimeService?.lifecycle ?? command.lifecycle,
     healthStatus: runtimeService?.healthStatus ?? "unknown",
+    exposure: runtimeService?.exposure ?? null,
     command: runtimeService?.command ?? command.command,
     cwd: runtimeService?.cwd ?? command.cwd,
     port: runtimeService?.port ?? null,
@@ -120,6 +123,7 @@ function buildJobItem(
     statusLabel: "run once",
     lifecycle: null,
     healthStatus: null,
+    exposure: null,
     command: command.command,
     cwd: command.cwd,
     port: null,
@@ -169,6 +173,7 @@ export function buildWorkspaceRuntimeControlSections(input: {
       statusLabel: runtimeService.status,
       lifecycle: runtimeService.lifecycle,
       healthStatus: runtimeService.healthStatus,
+      exposure: runtimeService.exposure ?? null,
       command: runtimeService.command ?? null,
       cwd: runtimeService.cwd ?? null,
       port: runtimeService.port ?? null,
@@ -211,6 +216,39 @@ export function getRunningRuntimeServiceUrl(
 
 function isActiveStatusLabel(statusLabel: string) {
   return statusLabel === "running" || statusLabel === "starting" || statusLabel === "provisioning";
+}
+
+function exposureFailureCopy(exposure: RuntimeExposureStatus | null) {
+  if (exposure?.state === "failed") {
+    return {
+      label: "HTTPS unavailable",
+      remediation: "Check the Tailscale broker and node HTTPS configuration.",
+    };
+  }
+  if (exposure?.state === "cleanup_pending") {
+    return {
+      label: "HTTPS cleanup pending",
+      remediation: "Restart the host broker before reusing this port.",
+    };
+  }
+  return null;
+}
+
+function ExposureFailureDetail({ exposure }: { exposure: RuntimeExposureStatus | null }) {
+  const copy = exposureFailureCopy(exposure);
+  if (!copy) return null;
+  return (
+    <div className="space-y-1 break-words text-xs text-destructive" role="alert">
+      <div
+        className="line-clamp-3 font-medium"
+        title={exposure?.lastError ?? undefined}
+      >
+        {copy.label}
+        {exposure?.lastError ? ` · ${exposure.lastError}` : ""}
+      </div>
+      <div>{copy.remediation}</div>
+    </div>
+  );
 }
 
 /**
@@ -260,6 +298,15 @@ export function buildWorkspaceServiceControlEntries(input: {
     const failureDetail = state === "failed"
       ? `Service failed${runtimeService?.stoppedAt ? ` · ${timeAgo(runtimeService.stoppedAt)}` : ""}`
       : null;
+    const exposure = runtimeService?.exposure ?? item.exposure;
+    const exposureFailure = exposureFailureCopy(exposure);
+    const exposureDetail = exposure?.state === "pending"
+      ? "Provisioning HTTPS…"
+      : exposure?.state === "ready"
+        ? "HTTPS ready"
+        : exposureFailure
+          ? `${exposureFailure.label} · ${exposureFailure.remediation}`
+          : null;
 
     return {
       key: item.key,
@@ -269,6 +316,8 @@ export function buildWorkspaceServiceControlEntries(input: {
       url: item.url,
       port: item.port,
       failureDetail,
+      exposureState: exposure?.state ?? null,
+      exposureDetail,
       canStart: item.canStart,
     };
   });
@@ -456,6 +505,7 @@ function CommandSection({
                   {item.cwd ? <div className="break-all font-mono">{item.cwd}</div> : null}
                   {item.disabledReason ? <div>{item.disabledReason}</div> : null}
                 </div>
+                <ExposureFailureDetail exposure={item.exposure} />
                 {item.healthStatus && item.statusLabel !== "stopped" ? (
                   <div className="flex items-center gap-2">
                     <Badge variant="outline" className={cn(

--- a/ui/src/components/WorkspaceServiceControlBar.test.tsx
+++ b/ui/src/components/WorkspaceServiceControlBar.test.tsx
@@ -1,12 +1,23 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceServiceControlBar } from "./WorkspaceServiceControlBar";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let pending: void | Promise<void>;
+  flushSync(() => {
+    pending = callback();
+  });
+  await pending!;
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+}
 
 describe("WorkspaceServiceControlBar", () => {
   let container: HTMLDivElement;
@@ -104,5 +115,117 @@ describe("WorkspaceServiceControlBar", () => {
     const runningSegment = await renderService("running", "http://127.0.0.1:3100");
     expect(runningSegment).not.toBeNull();
     expect(runningSegment?.className).toBe(stoppedSegment?.className);
+  });
+
+  it("links a managed HTTPS runtime at its tailnet URL and offers no link before it is verified", async () => {
+    // PAP-17158: this bar renders the launch link on the workspace, project, and
+    // issue surfaces. The href must be the verified tailnet HTTPS URL including
+    // its non-standard port, and an unverified exposure must render no anchor at
+    // all — an `http://` fallback link is the failure this feature prevents.
+    const httpsUrl = "https://paperclip-dev.tail29c1aa.ts.net:42010";
+    const renderExposed = async (url: string | null, exposureState: "ready" | "pending") => {
+      await act(() => {
+        root.render(
+          <WorkspaceServiceControlBar
+            services={[{
+              key: "paperclip-dev",
+              name: "paperclip-dev",
+              state: "running",
+              healthStatus: "healthy",
+              url,
+              port: 42_010,
+              exposureState,
+            }]}
+            onAction={() => {}}
+          />,
+        );
+      });
+    };
+
+    await renderExposed(httpsUrl, "ready");
+    const links = Array.from(container.querySelectorAll<HTMLAnchorElement>("a[href]"));
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) expect(link.getAttribute("href")).toBe(httpsUrl);
+    // The port is what makes a preview reachable, so it must stay visible.
+    expect(container.textContent).toContain("paperclip-dev.tail29c1aa.ts.net:42010");
+    // Scoped to hrefs, titles, and text: an SVG `xmlns` is not a launch link.
+    const advertisedUrls = () => [
+      ...Array.from(container.querySelectorAll("a[href]"), (el) => el.getAttribute("href")),
+      ...Array.from(container.querySelectorAll("[title]"), (el) => el.getAttribute("title")),
+      container.textContent,
+    ].join(" ");
+    expect(advertisedUrls()).not.toContain("http://");
+
+    const copyButton = container.querySelector<HTMLButtonElement>('button[aria-label="Copy URL"]')!;
+    await act(async () => {
+      copyButton.click();
+      await Promise.resolve();
+    });
+    expect(writeText).toHaveBeenCalledWith(httpsUrl);
+
+    // Exposure still pending: the backend is up but has no publishable URL yet.
+    await renderExposed(null, "pending");
+    expect(container.querySelectorAll("a[href]")).toHaveLength(0);
+    expect(advertisedUrls()).not.toContain("http://");
+    expect(container.textContent).toContain(":42010");
+  });
+
+  it("renders HTTPS cleanup separately from process running state", async () => {
+    await act(() => {
+      root.render(
+        <WorkspaceServiceControlBar
+          services={[{
+            key: "web",
+            name: "Web",
+            state: "running",
+            healthStatus: "healthy",
+            exposureState: "cleanup_pending",
+            exposureDetail: "HTTPS cleanup pending · Restart the host broker before reusing this port.",
+          }]}
+          onAction={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Running");
+    expect(container.textContent).toContain("HTTPS cleanup pending");
+    expect(container.querySelector(".text-destructive")).not.toBeNull();
+  });
+
+  it.each([
+    ["failed", "HTTPS unavailable · Check the Tailscale broker and node HTTPS configuration."],
+    ["cleanup_pending", "HTTPS cleanup pending · Restart the host broker before reusing this port."],
+  ] as const)("keeps the full %s remediation visible in the multi-service popover", async (exposureState, exposureDetail) => {
+    await act(() => {
+      root.render(
+        <WorkspaceServiceControlBar
+          services={[
+            {
+              key: "web",
+              name: "Web",
+              state: "running",
+              healthStatus: "healthy",
+              exposureState,
+              exposureDetail,
+            },
+            {
+              key: "api",
+              name: "API",
+              state: "stopped",
+              port: 42001,
+            },
+          ]}
+          defaultServicesOpen
+          onAction={() => {}}
+        />,
+      );
+    });
+
+    const detail = Array.from(document.body.querySelectorAll("span"))
+      .find((element) => element.textContent === exposureDetail);
+    expect(detail).toBeDefined();
+    expect(detail?.classList.contains("text-destructive")).toBe(true);
+    expect(detail?.classList.contains("truncate")).toBe(false);
+    expect(detail?.classList.contains("whitespace-normal")).toBe(true);
   });
 });

--- a/ui/src/components/WorkspaceServiceControlBar.tsx
+++ b/ui/src/components/WorkspaceServiceControlBar.tsx
@@ -35,6 +35,9 @@ export type WorkspaceServiceControlEntry = {
   port?: number | null;
   /** Short human-readable failure summary, e.g. "dev exited with code 1, 12s ago". */
   failureDetail?: string | null;
+  /** HTTPS exposure lifecycle, intentionally separate from process health. */
+  exposureState?: "pending" | "ready" | "failed" | "cleanup_pending" | "removed" | null;
+  exposureDetail?: string | null;
   canStart?: boolean;
 };
 
@@ -276,18 +279,20 @@ function ActionSlots({
   );
 }
 
-function FailureDetail({
+function ServiceDetail({
   entry,
   onViewLogs,
 }: {
   entry: WorkspaceServiceControlEntry;
   onViewLogs?: () => void;
 }) {
-  if (entry.state !== "failed" || !entry.failureDetail) return null;
+  const detail = entry.exposureDetail ?? (entry.state === "failed" ? entry.failureDetail : null);
+  if (!detail) return null;
+  const exposureFailed = entry.exposureState === "failed" || entry.exposureState === "cleanup_pending";
   return (
-    <div className="flex items-center gap-1 text-xs text-muted-foreground">
-      <span>{entry.failureDetail}</span>
-      {onViewLogs ? (
+    <div className={cn("flex items-center gap-1 text-xs", exposureFailed ? "text-destructive" : "text-muted-foreground")}>
+      <span>{detail}</span>
+      {onViewLogs && entry.state === "failed" ? (
         <>
           <span aria-hidden>·</span>
           <button
@@ -339,7 +344,7 @@ function SingleServiceBar({
           <UrlSegment entry={entry} compact />
         </div>
       </div>
-      <FailureDetail entry={entry} onViewLogs={onViewLogs} />
+      <ServiceDetail entry={entry} onViewLogs={onViewLogs} />
     </div>
   );
 }
@@ -354,8 +359,11 @@ function ServicePopoverRow({
   const meta = statusMeta(entry);
   const displayUrl = formatServiceUrl(entry.url);
   const live = entry.state === "running" && Boolean(entry.url);
-  const secondary = live
-    ? displayUrl
+  const exposureFailed = entry.exposureState === "failed" || entry.exposureState === "cleanup_pending";
+  const secondary = entry.exposureDetail
+    ? entry.exposureDetail
+    : live
+      ? displayUrl
     : entry.state === "starting" && entry.port
       ? `starting on :${entry.port}…`
       : entry.state === "failed" && entry.failureDetail
@@ -382,7 +390,16 @@ function ServicePopoverRow({
               <CopyUrlButton url={entry.url} />
             </>
           ) : (
-            <span className="min-w-0 truncate text-xs text-muted-foreground">{secondary}</span>
+            <span
+              className={cn(
+                "min-w-0 text-xs",
+                exposureFailed
+                  ? "whitespace-normal break-words text-destructive"
+                  : "truncate text-muted-foreground",
+              )}
+            >
+              {secondary}
+            </span>
           )}
         </div>
       </div>


### PR DESCRIPTION
<!-- Simplified Technical English (ASD-STE100). -->

> **Stacked pull request.** This targets #11524. Merge #11524 first. Review only the second commit, `feat(runtime): managed Tailscale HTTPS lifecycle...`.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip starts and supervises managed runtime services, so an agent's branch can be previewed while the agent works
> - The previous pull request added the host broker, the shared contract, and the database columns, but no code used them
> - A managed runtime can only be exposed over HTTPS if it holds a stable loopback port pair for the whole life of the service. The current control path cannot promise this: two controls can race the same execution workspace, a stranded control can stay `running` forever, and a start can adopt a port it does not own
> - This pull request adds the HTTPS lifecycle and the control-path hardening that the lifecycle depends on
> - The benefit is that a managed preview becomes reachable from another device, and a managed control now always reaches a terminal state

## Linked Issues or Issue Description

No public GitHub issue exists. The change follows the feature request template.

**Subsystem affected**

Managed workspace runtime services, workspace operations, the execution workspace routes, and the workspace runtime UI.

**Problem or motivation**

A managed runtime service is reachable only on loopback, so a preview cannot be opened from a phone or a second computer. Exposing it safely needs an exclusively held port pair. Three existing gaps block that. Overlapping controls can race the same workspace. A control whose owner dies stays `running` and blocks the lane forever. Port allocation does not confirm that the process holding a port is the process Paperclip spawned.

**Proposed solution**

Add the exposure lifecycle on top of the broker from #11524: reserve before spawn, expose after readiness, validate the public URL, and remove on stop. In the same change, make managed controls mutually exclusive per workspace, give each control a durable issue-owned lease and a terminal state, and verify port ownership before use.

**Alternatives considered**

- Add HTTPS exposure without the control hardening. This was rejected because a raced or stranded control makes exposure point at the wrong process.
- Guard the lane with an in-memory lock only. This was rejected because the lock does not survive a server restart, so the lane can be lost or double-claimed.
- Trust the requested bind address. This was rejected because a checkout that predates managed HTTPS overwrites `PAPERCLIP_BIND` from its own `--bind` argument, and then binds the wildcard address.

**Roadmap alignment**

This completes the managed workspace runtime capability that already exists. It adds no new product surface beyond the HTTPS link.

**Additional context**

This is the second of three pull requests. The third adds central mediation of leased port pairs.

## What Changed

Exposure lifecycle:

- Add the server-side broker client and the exposure lifecycle manager. The manager reserves the mapping before spawn, exposes after backend readiness, validates the public URL, and removes the mapping on stop.
- Default managed worktree runtimes to `tailscale_https`, read exposure intent from legacy `expose` blocks, and backfill runtimes that are still HTTP-only.
- Verify listener ownership for the app port and its Vite HMR companion before the broker is asked to expose anything. An unrelated listener on either port fails the start closed.
- Force the loopback bind through argv instead of environment hints. Leave a non-Paperclip service's `--bind` argument alone.
- Probe loopback for readiness instead of the public URL, and give Vite HMR its own loopback-bound server in middleware mode.
- Preserve operator-declared Serve mappings across the managed lifecycle, so cleanup never removes a mapping that Paperclip did not create.
- Name which listener predicate denied an expose, so an operator can act on the message.

Control-path hardening:

- Make `start`, `stop`, `restart`, and job `run` mutually exclusive per execution workspace. An overlap gets `409 workspace_runtime_control_in_progress`, and authorization is still checked first.
- Take a durable exclusivity lease on the execution workspace, owned by the controlling issue. A different issue gets `409 workspace_runtime_lease_conflict` before any operation is recorded. Board and operator actions bypass the lease.
- Give every control a terminal state. Each control stamps its owning process and pid, heartbeats while it runs, and has a wall-clock ceiling. Recovery of a stranded control uses a compare-and-swap on `updated_at`, so a live owner is never stolen.
- Bound readiness probes, verify allocated port ownership on POSIX and Windows, harden sibling port allocation, and reconcile desired runtimes on server startup.
- Surface exposure state and bounded runtime errors in the workspace runtime UI.
- Record the new behavior in `doc/DEVELOPING.md`.

## Verification

Focused checks, all run on this branch:

- `npx tsc --noEmit -p server/tsconfig.json` — 139 errors, exactly the count on `master`. All 139 come from the unbuilt `@paperclipai/plugin-sdk` package.
- `pnpm --filter @paperclipai/ui typecheck` — clean.
- Server suites, 177 tests pass across 9 files: `workspace-runtime.test.ts`, `workspace-runtime-leases.test.ts`, `workspace-runtime-control-recovery.test.ts`, `execution-workspace-runtime-control-conflict.test.ts`, `execution-workspace-runtime-lease-route.test.ts`, `workspace-operations-reconciliation.test.ts`, `workspace-runtime-start-terminality.test.ts`, `app-hmr-port.test.ts`, and `workspace-runtime-ready-comment.test.ts`.
- Exposure unit suites, 77 tests pass: `src/services/runtime-exposure/` and `workspace-runtime-exposure-backfill.test.ts`.
- UI: `WorkspaceRuntimeControls.test.tsx` and `WorkspaceServiceControlBar.test.tsx` — 34 tests pass.

**One suite is red on the development host and is expected to be green in CI.** `server/src/services/workspace-runtime-exposure.test.ts` has 10 failures on the machine used to write this branch. The cause is host contamination, not the code. That machine already runs an HTTPS canary that holds ports 42000, 42001, 52000, and 52001 on a tailnet address. The suite allocates from the same range, so the new listener-ownership check correctly reports:

```
listener_ownership_mismatch — port 42000 is bound to 100.123.243.20, 127.0.0.1,
fd7a:115c:a1e0:0:0:0:dd3a:f314 ... instead of loopback only
```

A CI runner has no listener on those ports, so the check sees loopback only and the suite passes. Please confirm this from the CI result on this pull request rather than from a local run on a host that already exposes a managed runtime. This is a real weakness of the current test fixture, and the third pull request in the series removes it by allocating the pair through a central mediator instead of a stubbed availability check.

`workspace-runtime-https-live-exercise.test.ts` needs a live `tailscale` host and was not run locally.

## Risks

- This is the behavior-bearing pull request of the three, so it carries the most risk.
- Two new `409` responses appear on managed control routes. A caller that assumed a control always starts must handle a conflict. Board and operator actions are deliberately exempt, so an agent lease cannot lock an operator out.
- Managed worktree runtimes now default to `tailscale_https`. If the host has no working broker, the start fails closed and reports the exposure failure instead of silently serving plain HTTP. This is intended, and it is the reason the failure message names the denying predicate.
- Startup reconciliation touches persisted runtime rows. It is scoped to desired state and does not resurrect a service that never came up.
- The lease has a 30-minute time to live and explicit release paths, so a crashed owner cannot hold a lane forever.
- No migration runs in this pull request. The tables and columns land in #11524.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass, with the one host-contaminated suite explained above
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
