### PR TITLE
docs: mark Connected Apps roadmap milestone as shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ See [doc/DEVELOPING.md](doc/DEVELOPING.md) for the full development guide.
 - 🟡 Cloud deployments (multi-tenant isolation & company Import/Export shipped)
 - ⚪ Desktop App
 - ⚪ Bring-your-own-ticket-system (Asana / Linear / Jira as on-ramps)
-- ⚪ Connected Apps (one-click integrations, e.g. Vercel)
+- ✅ Connected Apps (one-click integrations: Vercel, Linear, Notion, Sentry, GitHub, Slack, and more)
 
 This is the short roadmap preview. See the full roadmap in [ROADMAP.md](ROADMAP.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,6 +122,6 @@ A desktop app can make Paperclip feel more accessible and persistent for day-to-
 
 Existing ticket systems should be able to feed work into Paperclip without becoming the agent control plane themselves. Asana, Linear, and Jira can act as familiar on-ramps while Paperclip owns execution, governance, and outcomes.
 
-### ⚪ Connected Apps (one-click integrations, e.g. Vercel)
+### ✅ Connected Apps (one-click integrations: Vercel, Linear, Notion, Sentry, GitHub, Slack, and more)
 
-Common services should connect without bespoke setup for every company. One-click integrations can package credentials, permissions, and useful workflows for apps such as Vercel while keeping access governed and auditable.
+Common services should connect without bespoke setup for every company. One-click integrations package credentials, permissions, and useful workflows for apps such as Vercel while keeping access governed and auditable.


### PR DESCRIPTION
## What changed

- Flipped **Connected Apps** from ⚪ to ✅ in `ROADMAP.md` and the README roadmap preview, and named the shipped providers.

## Why

`ROADMAP.md` still listed Connected Apps as planned, citing Vercel as the example integration. Wave 1 of the AppDefinition catalog (#9981) shipped one-click, non-experimental connections for Vercel, Linear, Notion, Sentry, GitHub, Slack, Google Sheets, Zapier, Context7, and Anthropic. That landed the day after the last roadmap refresh (#9922), so the doc never caught up.

Checked and left unchanged (already accurate against current `master`):
- Cloud/Sandbox agents, Artifacts & Work Products, Deep Planning, Enforced Outcomes — already ✅
- Cloud deployments 🟡 note (blob-store relay still pending) — still accurate
- CEO Chat — still behind `enableConferenceRoomChat`, default off, correctly ⚪
- Bring-your-own-ticket-system — no Asana/Jira app-definitions exist yet, correctly ⚪
- Memory/Knowledge, MAXIMIZER MODE, Work Queues, Self-Organization, Automatic Organizational Learning, Desktop App — no shipping evidence found, correctly ⚪

## Verification

- `grep "^### "` on `ROADMAP.md` vs the README roadmap block: same 28 entries, same order, same statuses (19 ✅ / 8 ⚪ / 1 🟡).
- Confirmed `packages/shared/src/app-definitions/vercel.json` (and 9 sibling definitions) exist on `master`, and the connections UI (`ui/src/pages/apps/Connections.tsx`) is not gated behind an experimental flag.