### PR TITLE
fix(recovery): surface pending board asks in reviewAttention regardless of issue status

### DIFF
--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -1628,6 +1628,11 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
         }));
       }
 
+      const pendingBoardAskIssueIds = new Set<string>();
+      for (const interaction of boardInteractionRows) {
+        pendingBoardAskIssueIds.add(interaction.issueId);
+      }
+
       const reviewRows = await db
         .select({
           id: issues.id,
@@ -1643,7 +1648,14 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
           updatedAt: issues.updatedAt,
         })
         .from(issues)
-        .where(and(eq(issues.companyId, companyId), eq(issues.status, "in_review"), visibleIssueCondition()))
+        .where(and(
+          eq(issues.companyId, companyId),
+          or(
+            eq(issues.status, "in_review"),
+            inArray(issues.id, [...pendingBoardAskIssueIds]),
+          ),
+          visibleIssueCondition(),
+        ))
         .orderBy(desc(issues.updatedAt), desc(issues.id));
       const reviewIssueIds = reviewRows.map((row) => row.id);
       const pendingReviewApprovalRows = reviewIssueIds.length === 0

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2849,8 +2849,44 @@ async function listIssueReviewAttentionMap(
   const result = new Map<string, IssueReviewAttention>();
   for (const row of issueRows) result.set(row.id, reviewAttentionNone());
 
+  const candidateIds = issueRows
+    .filter((row) => row.companyId === companyId)
+    .map((row) => row.id);
+  if (candidateIds.length === 0) return result;
+
+  const interactionRows: Array<{
+    id: string;
+    companyId: string;
+    issueId: string;
+    status: string;
+    kind: string;
+    createdAt: Date;
+  }> = [];
+  for (const chunk of chunkList(candidateIds, ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
+    interactionRows.push(...await dbOrTx
+      .select({
+        id: issueThreadInteractions.id,
+        companyId: issueThreadInteractions.companyId,
+        issueId: issueThreadInteractions.issueId,
+        status: issueThreadInteractions.status,
+        kind: issueThreadInteractions.kind,
+        createdAt: issueThreadInteractions.createdAt,
+      })
+      .from(issueThreadInteractions)
+      .where(and(
+        eq(issueThreadInteractions.companyId, companyId),
+        eq(issueThreadInteractions.status, "pending"),
+        inArray(issueThreadInteractions.issueId, chunk),
+      )));
+  }
+
+  // A pending interaction is a live review path regardless of issue status:
+  // every resolver policy includes the Board, so a `blocked` card with a
+  // pending ask still needs the full path pipeline run, not just `in_review`.
+  const pendingInteractionIssueIds = new Set(interactionRows.map((row) => row.issueId));
   const reviewIds = issueRows
-    .filter((row) => row.companyId === companyId && row.status === "in_review")
+    .filter((row) => row.companyId === companyId
+      && (row.status === "in_review" || pendingInteractionIssueIds.has(row.id)))
     .map((row) => row.id);
   if (reviewIds.length === 0) return result;
 
@@ -2863,7 +2899,7 @@ async function listIssueReviewAttentionMap(
   }
   if (reviewIssues.length === 0) return result;
 
-  const [agentRows, activeRunRows, wakeRows, interactionRows, approvalRows, recoveryActionRows, recoveryIssueRows] = await Promise.all([
+  const [agentRows, activeRunRows, wakeRows, approvalRows, recoveryActionRows, recoveryIssueRows] = await Promise.all([
     dbOrTx
       .select({
         id: agents.id,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2854,7 +2854,7 @@ async function listIssueReviewAttentionMap(
     .map((row) => row.id);
   if (candidateIds.length === 0) return result;
 
-  const interactionRows: Array<{
+  const candidateInteractionRows: Array<{
     id: string;
     companyId: string;
     issueId: string;
@@ -2863,7 +2863,7 @@ async function listIssueReviewAttentionMap(
     createdAt: Date;
   }> = [];
   for (const chunk of chunkList(candidateIds, ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
-    interactionRows.push(...await dbOrTx
+    candidateInteractionRows.push(...await dbOrTx
       .select({
         id: issueThreadInteractions.id,
         companyId: issueThreadInteractions.companyId,
@@ -2883,7 +2883,7 @@ async function listIssueReviewAttentionMap(
   // A pending interaction is a live review path regardless of issue status:
   // every resolver policy includes the Board, so a `blocked` card with a
   // pending ask still needs the full path pipeline run, not just `in_review`.
-  const pendingInteractionIssueIds = new Set(interactionRows.map((row) => row.issueId));
+  const pendingInteractionIssueIds = new Set(candidateInteractionRows.map((row) => row.issueId));
   const reviewIds = issueRows
     .filter((row) => row.companyId === companyId
       && (row.status === "in_review" || pendingInteractionIssueIds.has(row.id)))
@@ -2899,7 +2899,7 @@ async function listIssueReviewAttentionMap(
   }
   if (reviewIssues.length === 0) return result;
 
-  const [agentRows, activeRunRows, wakeRows, approvalRows, recoveryActionRows, recoveryIssueRows] = await Promise.all([
+  const [agentRows, activeRunRows, wakeRows, interactionRows, approvalRows, recoveryActionRows, recoveryIssueRows] = await Promise.all([
     dbOrTx
       .select({
         id: agents.id,

--- a/server/src/services/recovery/issue-graph-liveness.test.ts
+++ b/server/src/services/recovery/issue-graph-liveness.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { classifyIssueReviewPaths } from "./issue-graph-liveness.js";
+
+const companyId = "company-1";
+
+const issue = {
+  id: "issue-1",
+  companyId,
+  identifier: "ORU-1",
+  title: "Blocked issue with a pending board ask",
+  status: "blocked",
+};
+
+describe("classifyIssueReviewPaths", () => {
+  it("surfaces a pending interaction path even when the issue is not in_review", () => {
+    const paths = classifyIssueReviewPaths(
+      {
+        issues: [issue],
+        relations: [],
+        agents: [],
+        pendingInteractions: [
+          { id: "interaction-1", companyId, issueId: issue.id, status: "pending" },
+        ],
+      },
+      issue,
+    );
+
+    expect(paths).toEqual([
+      { kind: "interaction", ref: "interaction-1", agentId: null, userId: null, since: null },
+    ]);
+  });
+
+  it("returns no paths for a non in_review issue with no pending interaction", () => {
+    const paths = classifyIssueReviewPaths(
+      { issues: [issue], relations: [], agents: [], pendingInteractions: [] },
+      issue,
+    );
+
+    expect(paths).toEqual([]);
+  });
+});

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -212,10 +212,32 @@ export function classifyIssueReviewPaths(
   input: IssueGraphLivenessInput,
   issue: IssueLivenessIssueInput,
 ): IssueReviewPathFact[] {
-  if (issue.status !== "in_review") return [];
+  const paths: IssueReviewPathFact[] = [];
+
+  const appendWaitingPaths = (
+    entries: IssueLivenessWaitingPathInput[],
+    kind: "interaction" | "approval" | "recovery",
+  ) => {
+    for (const entry of entries) {
+      if (entry.companyId !== issue.companyId || entry.issueId !== issue.id) continue;
+      paths.push({
+        kind,
+        ref: entry.id ?? null,
+        agentId: null,
+        userId: null,
+        since: entry.createdAt ?? null,
+      });
+    }
+  };
+
+  // A pending interaction is a live review path regardless of issue status:
+  // a `blocked` card with a board-addressed ask is exactly the case that most
+  // needs surfacing, since nobody can act until the ask is answered.
+  appendWaitingPaths(input.pendingInteractions ?? [], "interaction");
+
+  if (issue.status !== "in_review") return paths;
   const nowMs = readDateMs(input.now ?? new Date()) ?? Date.now();
   const agentsById = new Map(input.agents.map((agent) => [agent.id, agent]));
-  const paths: IssueReviewPathFact[] = [];
 
   if (issue.assigneeUserId) {
     paths.push({
@@ -275,22 +297,6 @@ export function classifyIssueReviewPaths(
   appendExecutionPaths(input.activeRuns ?? [], "active_run");
   appendExecutionPaths(input.queuedWakeRequests ?? [], "queued_wake");
 
-  const appendWaitingPaths = (
-    entries: IssueLivenessWaitingPathInput[],
-    kind: "interaction" | "approval" | "recovery",
-  ) => {
-    for (const entry of entries) {
-      if (entry.companyId !== issue.companyId || entry.issueId !== issue.id) continue;
-      paths.push({
-        kind,
-        ref: entry.id ?? null,
-        agentId: null,
-        userId: null,
-        since: entry.createdAt ?? null,
-      });
-    }
-  };
-  appendWaitingPaths(input.pendingInteractions ?? [], "interaction");
   appendWaitingPaths(input.pendingApprovals ?? [], "approval");
   appendWaitingPaths(input.openRecoveryIssues ?? [], "recovery");
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies.
> - Its attention service tells the board which work needs action.
> - Pending interactions are live board action paths.
> - The current classifier and candidate queries only publish those paths for issues in review.
> - A blocked issue can therefore hide the board action that is required to unblock it.
> - This pull request makes pending interactions independent of issue status.
> - The benefit is a complete founder queue without manual status changes.

## Linked Issues or Issue Description

**What happened?**

A pending issue interaction produces no `reviewAttention` path when its issue is `blocked` or has another non-review status. Queues built on `reviewAttention` cannot show that board ask.

**Expected behavior**

A pending interaction must publish an interaction path for its issue, independent of issue status. An issue without a pending interaction must keep its existing status-based behavior.

**Steps to reproduce**

1. Create a blocked issue.
2. Add a pending board interaction to the issue.
3. Read the issue attention data.
4. Observe that `reviewAttention.paths` is empty before this change.
5. Change only the issue status to `in_review`.
6. Observe that the unchanged interaction now appears.

**Paperclip version or commit**

Reproduced on the `master` branch before commit `8856affae61982423655633e863926ddeb85691e`.

**Deployment mode**

Self-hosted server.

## What Changed

- Build pending-interaction paths before the `in_review` status gate.
- Include issues with pending interactions in issue-list review-attention classification.
- Include issues with pending board interactions in the attention feed candidate query.
- Keep the candidate lookup and the full interaction metadata query separate.
- Add direct regression tests for a blocked issue with and without a pending interaction.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/services/recovery/issue-graph-liveness.test.ts --reporter=verbose`
- Result: 1 test file passed and 2 tests passed.

## Risks

- Low migration risk. This change does not modify the database schema.
- The attention feed can return more issues because it now includes hidden pending asks as intended.
- The added candidate query scans only the current issue-list candidate IDs and uses the existing chunk size.

> This is a defect fix in existing review-attention behavior. It does not add roadmap scope.

## Model Used

OpenAI Codex with GPT-5. The runtime provided agentic reasoning, repository tools, code execution, GitHub access, and test execution. The runtime did not expose a more specific model snapshot or context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
