### PR TITLE
fix(recovery): inject blocked-on capacity marker when budget_blocked escalates to blocked

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -6585,6 +6585,22 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("injects a blocked-on capacity marker into the description for budget_blocked escalations", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      runErrorCode: "budget_blocked",
+      runError: "Budget exceeded; refusing to dispatch.",
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.reconcileStrandedAssignedIssues();
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.description).toContain('<!-- blocked-on: {"kind":"capacity","ref":"quota","recheck":"budget cleared","owner":"platform"} -->');
+  });
+
   it("leaves the productive-but-stranded continuation path unchanged under the new classifier", async () => {
     const { agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -356,6 +356,15 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "issue_dependencies_blocked",
 ]);
 
+const BUDGET_BLOCKED_MARKER =
+  '<!-- blocked-on: {"kind":"capacity","ref":"quota","recheck":"budget cleared","owner":"platform"} -->';
+
+function appendBudgetBlockedMarker(description: string | null | undefined): string {
+  const base = description?.trim() ?? "";
+  if (base.includes(BUDGET_BLOCKED_MARKER)) return base;
+  return base ? `${base}\n\n---\n\n${BUDGET_BLOCKED_MARKER}` : BUDGET_BLOCKED_MARKER;
+}
+
 // A continuation cancelled with this code is a *deliberate wait* (the latest run
 // reported it was parked for review/approval), not a lost execution path. When the
 // issue has a real waiting target we convert it into a normal dependency wait rather
@@ -4226,6 +4235,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           if (updated) {
             result.escalated += 1;
             result.issueIds.push(issue.id);
+            // For budget_blocked, inject a machine-readable blocked-on marker so
+            // stall-recovery can classify it as a capacity blocker and re-enqueue
+            // when quota clears — instead of escalating to Inspector as "intent-unparseable".
+            if (classification.errorCode === "budget_blocked") {
+              await issuesSvc.update(issue.id, {
+                description: appendBudgetBlockedMarker(updated.description),
+              });
+            }
           } else {
             result.skipped += 1;
           }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The stall-recovery subsystem monitors `blocked` issues and tries to recover them mechanically — for `ci` kind it re-reads CI checks, for others it re-enqueues the issue, and when intent is unparseable it escalates to a human Inspector
> - When an agent run fails with `budget_blocked`, the continuation-recovery path classifies it as `non_retryable` and calls `escalateStrandedAssignedIssue`, which sets the issue to `blocked`
> - The escalation leaves the issue with no `<!-- blocked-on: {...} -->` HTML comment in the description, so stall-recovery cannot determine the intent — it burns two mechanical retries then escalates to the Inspector as "intent-unparseable"
> - This is unnecessary: a capacity blocker is purely mechanical — when the quota window clears, the issue can be re-enqueued without human judgment
> - This pull request injects a `<!-- blocked-on: {"kind":"capacity",...} -->` marker into the issue description whenever the `budget_blocked` path escalates an issue to `blocked`
> - The benefit is that stall-recovery can classify the blocker as `capacity`, re-enqueue the issue when quota clears, and the Inspector never sees it

## Linked Issues or Issue Description

No public GitHub issue exists for this. Describing the problem here:

**What happened:** When a Paperclip agent run fails with `budget_blocked` (quota exceeded), `reconcileStrandedAssignedIssues` classifies it as non-retryable and moves the issue to `blocked`. The system comment reads "Continuation failed / non-retryable failure (`budget_blocked`)" but no machine-readable `<!-- blocked-on: {...} -->` marker is written to the description. Stall-recovery cannot parse the intent and escalates to the Inspector after two failed recovery attempts.

**Expected behavior:** The issue should carry a `kind: "capacity"` blocked-on marker. Stall-recovery should re-enqueue the issue when quota clears — no Inspector escalation needed.

**Steps to reproduce:**
1. Issue is `in_progress`.
2. Agent run fails with `errorCode: "budget_blocked"`.
3. `reconcileStrandedAssignedIssues` fires — escalates to `blocked` with no description marker.
4. Stall-recovery fires twice — "intent-unparseable" both times — escalates to Inspector.

**Paperclip version:** Any (observed on a deployed managed instance).

## What Changed

- `server/src/services/recovery/service.ts`: Added `BUDGET_BLOCKED_MARKER` constant and `appendBudgetBlockedMarker` helper. After `escalateStrandedAssignedIssue` succeeds for a `budget_blocked` non-retryable failure, the issue description is updated to append the capacity blocked-on marker (idempotent — skips if already present).
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: Added a test that asserts the marker is written to the description after reconciliation.

## Verification

Run the targeted test:

```
pnpm exec vitest run --project @paperclipai/server --reporter min server/src/__tests__/heartbeat-process-recovery.test.ts -t "budget_blocked"
```

Or the full heartbeat-process-recovery suite:

```
pnpm exec vitest run --project @paperclipai/server --reporter min server/src/__tests__/heartbeat-process-recovery.test.ts
```

Manually: seed an issue with `in_progress` status and a `heartbeatRun` with `errorCode: "budget_blocked"`, call `reconcileStrandedAssignedIssues()`, and confirm the issue description contains the marker.

## Risks

Low risk. The change adds one extra `UPDATE` to the issues table after the escalation `UPDATE`, only for `budget_blocked` failures. All other non-retryable error codes are unaffected. The helper is idempotent — it checks for the marker before appending.

## Model Used

Anthropic Claude Sonnet 4.6 (claude-sonnet-4-6), extended reasoning, tool use, code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/budget-blocked-adds-capacity-blocked-on-marker`) and contains no internal Paperclip ticket id
- [ ] I have run tests locally and they pass (dependencies not installed in CI sandbox — test logic is correct and matches existing test patterns)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs needed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green