### PR TITLE
fix(costs): estimate subscription-billed run costs from token usage

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -828,7 +828,7 @@ export const BILLING_TYPES = [
 ] as const;
 export type BillingType = (typeof BILLING_TYPES)[number];
 
-export const COST_STATUSES = ["reported", "unpriced"] as const;
+export const COST_STATUSES = ["reported", "unpriced", "estimated"] as const;
 export type CostStatus = (typeof COST_STATUSES)[number];
 
 export const FINANCE_EVENT_KINDS = [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -242,6 +242,7 @@ export {
   recommendedDefaultsForApp,
 } from "./app-definitions.js";
 export { APP_DEFINITIONS } from "./app-definitions.generated.js";
+export { estimateSubscriptionCostCents, type ModelPriceRate } from "./model-pricing.js";
 export * from "./validators/status-card.js";
 export { appDefinitionSchema, appDefinitionsSchema, connectionMethodDefSchema } from "./validators/app-definition.js";
 export {

--- a/packages/shared/src/model-pricing.test.ts
+++ b/packages/shared/src/model-pricing.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { estimateSubscriptionCostCents } from "./model-pricing.js";
+
+describe("estimateSubscriptionCostCents", () => {
+  it("prices a known Anthropic model from input, output, and cache-read tokens", () => {
+    // claude-sonnet-5: $2/MTok in, $10/MTok out, $0.20/MTok cache read.
+    const cents = estimateSubscriptionCostCents({
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cachedInputTokens: 1_000_000,
+    });
+    // 200 (input) + 1000 (output) + 20 (cache read) = 1220 cents.
+    expect(cents).toBe(1220);
+  });
+
+  it("prices a known OpenAI Codex model", () => {
+    const cents = estimateSubscriptionCostCents({
+      provider: "openai",
+      model: "gpt-5.3-codex",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cachedInputTokens: 0,
+    });
+    // 175 (input) + 1400 (output) = 1575 cents.
+    expect(cents).toBe(1575);
+  });
+
+  it("matches a dated/versioned model id against its family entry", () => {
+    const cents = estimateSubscriptionCostCents({
+      provider: "anthropic",
+      model: "claude-sonnet-5-20260215",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    });
+    expect(cents).toBe(200);
+  });
+
+  it("is case-insensitive on provider and model", () => {
+    const cents = estimateSubscriptionCostCents({
+      provider: "Anthropic",
+      model: "Claude-Sonnet-5",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    });
+    expect(cents).toBe(200);
+  });
+
+  it("returns null instead of guessing for an unpriced model", () => {
+    expect(estimateSubscriptionCostCents({
+      provider: "openai",
+      model: "some-future-model-nobody-has-priced-yet",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cachedInputTokens: 0,
+    })).toBeNull();
+  });
+
+  it("returns null for an unpriced provider", () => {
+    expect(estimateSubscriptionCostCents({
+      provider: "cursor",
+      model: "claude-sonnet-5",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cachedInputTokens: 0,
+    })).toBeNull();
+  });
+
+  it("returns null when provider or model is missing", () => {
+    expect(estimateSubscriptionCostCents({
+      provider: null,
+      model: "claude-sonnet-5",
+      inputTokens: 100,
+      outputTokens: 100,
+      cachedInputTokens: 0,
+    })).toBeNull();
+    expect(estimateSubscriptionCostCents({
+      provider: "anthropic",
+      model: undefined,
+      inputTokens: 100,
+      outputTokens: 100,
+      cachedInputTokens: 0,
+    })).toBeNull();
+  });
+
+  it("rounds to the nearest cent and never goes negative", () => {
+    const cents = estimateSubscriptionCostCents({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      inputTokens: 1_234,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    });
+    // 1234 tokens * $1/MTok = $0.001234 -> 0.1234 cents -> rounds to 0.
+    expect(cents).toBe(0);
+  });
+});

--- a/packages/shared/src/model-pricing.ts
+++ b/packages/shared/src/model-pricing.ts
@@ -1,0 +1,74 @@
+/**
+ * Official public per-token list pricing, used to estimate an equivalent cost for
+ * heartbeat runs billed under a flat-fee subscription (Claude Pro/Max, ChatGPT
+ * Plus/Pro/Team, etc.), where the underlying provider reports token usage but no
+ * per-call dollar cost.
+ *
+ * Only exact `provider` + normalized `model` matches are priced. An unmatched model
+ * returns `null` rather than guessing at a nearby model's rate, so unsupported models
+ * stay `unpriced` instead of being silently mis-costed.
+ *
+ * Rates are $ per million tokens, captured from provider pricing pages on 2026-08-17:
+ * - https://platform.claude.com/docs/en/about-claude/pricing
+ * - https://developers.openai.com/api/docs/pricing
+ * Re-verify against those pages before adding entries or trusting these for real
+ * budget enforcement — provider pricing changes over time.
+ */
+
+export interface ModelPriceRate {
+  /** $ per 1,000,000 standard input tokens. */
+  inputPerMTokUsd: number;
+  /** $ per 1,000,000 output tokens. */
+  outputPerMTokUsd: number;
+  /** $ per 1,000,000 cache-read (cache hit) input tokens. */
+  cachedInputPerMTokUsd: number;
+}
+
+const MODEL_PRICING_TABLE: Record<string, Record<string, ModelPriceRate>> = {
+  anthropic: {
+    "claude-sonnet-5": { inputPerMTokUsd: 2, outputPerMTokUsd: 10, cachedInputPerMTokUsd: 0.2 },
+    "claude-haiku-4-5": { inputPerMTokUsd: 1, outputPerMTokUsd: 5, cachedInputPerMTokUsd: 0.1 },
+  },
+  openai: {
+    "gpt-5.3-codex": { inputPerMTokUsd: 1.75, outputPerMTokUsd: 14, cachedInputPerMTokUsd: 0.175 },
+  },
+};
+
+/**
+ * Strips a trailing dated/versioned suffix (e.g. `-20260215`, `-latest`) so a
+ * fully-qualified model id still matches the family entry in the pricing table.
+ */
+function normalizeModelId(model: string): string {
+  return model
+    .trim()
+    .toLowerCase()
+    .replace(/-\d{8}$/, "")
+    .replace(/-latest$/, "");
+}
+
+/**
+ * Estimates a cost in whole cents for a subscription-billed run from raw token
+ * counts, or returns `null` when the provider/model has no known public rate —
+ * callers should keep those runs `unpriced` rather than apply a guessed price.
+ */
+export function estimateSubscriptionCostCents(input: {
+  provider: string | null | undefined;
+  model: string | null | undefined;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+}): number | null {
+  const provider = input.provider?.trim().toLowerCase();
+  const model = input.model?.trim();
+  if (!provider || !model) return null;
+
+  const rate = MODEL_PRICING_TABLE[provider]?.[normalizeModelId(model)];
+  if (!rate) return null;
+
+  const usd =
+    (Math.max(0, input.inputTokens) / 1_000_000) * rate.inputPerMTokUsd +
+    (Math.max(0, input.outputTokens) / 1_000_000) * rate.outputPerMTokUsd +
+    (Math.max(0, input.cachedInputTokens) / 1_000_000) * rate.cachedInputPerMTokUsd;
+
+  return Math.max(0, Math.round(usd * 100));
+}

--- a/server/src/__tests__/heartbeat-cost-accounting.test.ts
+++ b/server/src/__tests__/heartbeat-cost-accounting.test.ts
@@ -64,4 +64,40 @@ describe("heartbeat cost accounting", () => {
       cacheAdjustedCostUsd: 1.5,
     })).toBe(1.5);
   });
+
+  it("estimates a subscription-billed run against known public model pricing", () => {
+    expect(resolveLedgerCostStatus({
+      costUsd: null,
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 1_000_000,
+      billingType: "subscription_included",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+    })).toBe("estimated");
+  });
+
+  it("keeps a subscription-billed run unpriced when the model has no known rate", () => {
+    expect(resolveLedgerCostStatus({
+      costUsd: null,
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 1_000_000,
+      billingType: "subscription_included",
+      provider: "openai",
+      model: "some-future-model-nobody-has-priced-yet",
+    })).toBe("unpriced");
+  });
+
+  it("does not mark a subscription run priced when it has no token usage at all", () => {
+    expect(resolveLedgerCostStatus({
+      costUsd: null,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      billingType: "subscription_included",
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+    })).toBe("reported");
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -278,7 +278,7 @@ import {
   UNMANAGED_BACKGROUND_TASK_STOP_REASON,
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
-import { extractSkillMentionIds, isUuidLike } from "@paperclipai/shared";
+import { estimateSubscriptionCostCents, extractSkillMentionIds, isUuidLike } from "@paperclipai/shared";
 import { evaluateCodexCredentialReadiness } from "@paperclipai/adapter-codex-local/server";
 import { environmentService } from "./environments.js";
 import { parseExecutionPolicyBootstrapEnv } from "./execution-policy-bootstrap.js";
@@ -3772,8 +3772,22 @@ function resolveLedgerBiller(result: AdapterExecutionResult): string {
   return readNonEmptyString(result.biller) ?? readNonEmptyString(result.provider) ?? "unknown";
 }
 
-function normalizeBilledCostCents(costUsd: number | null | undefined, billingType: BillingType): number {
-  if (billingType === "subscription_included") return 0;
+function normalizeBilledCostCents(
+  costUsd: number | null | undefined,
+  billingType: BillingType,
+  usage: { provider: string | null | undefined; model: string | null | undefined; inputTokens: number; outputTokens: number; cachedInputTokens: number },
+): number {
+  if (billingType === "subscription_included") {
+    return (
+      estimateSubscriptionCostCents({
+        provider: usage.provider,
+        model: usage.model,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cachedInputTokens: usage.cachedInputTokens,
+      }) ?? 0
+    );
+  }
   if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) return 0;
   return Math.max(0, Math.round(costUsd * 100));
 }
@@ -3783,9 +3797,24 @@ export function resolveLedgerCostStatus(input: {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
+  billingType?: BillingType;
+  provider?: string | null;
+  model?: string | null;
 }): CostStatus {
   const hasTokenUsage = input.inputTokens > 0 || input.cachedInputTokens > 0 || input.outputTokens > 0;
-  return input.costUsd == null && hasTokenUsage ? "unpriced" : "reported";
+  if (input.costUsd != null) return "reported";
+  if (!hasTokenUsage) return "reported";
+  if (input.billingType === "subscription_included") {
+    const estimatedCents = estimateSubscriptionCostCents({
+      provider: input.provider,
+      model: input.model,
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      cachedInputTokens: input.cachedInputTokens,
+    });
+    return estimatedCents == null ? "unpriced" : "estimated";
+  }
+  return "unpriced";
 }
 
 export function resolveCacheAdjustedCostUsd(input: {
@@ -13657,15 +13686,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const cachedInputTokens = usage?.cachedInputTokens ?? 0;
     const billingType = normalizeLedgerBillingType(result.billingType);
     const billedCostUsd = resolveCacheAdjustedCostUsd(result);
-    const additionalCostCents = normalizeBilledCostCents(billedCostUsd, billingType);
+    const provider = result.provider ?? "unknown";
+    const additionalCostCents = normalizeBilledCostCents(billedCostUsd, billingType, {
+      provider,
+      model: result.model,
+      inputTokens,
+      outputTokens,
+      cachedInputTokens,
+    });
     const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const costStatus = resolveLedgerCostStatus({
       costUsd: billedCostUsd,
       inputTokens,
       cachedInputTokens,
       outputTokens,
+      billingType,
+      provider,
+      model: result.model,
     });
-    const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
     const ledgerScope = await resolveLedgerScopeForRun(db, agent.companyId, run);
 
@@ -16118,6 +16156,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 inputTokens: normalizedUsage?.inputTokens ?? 0,
                 cachedInputTokens: normalizedUsage?.cachedInputTokens ?? 0,
                 outputTokens: normalizedUsage?.outputTokens ?? 0,
+                billingType: normalizeLedgerBillingType(adapterResult.billingType),
+                provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
+                model: adapterResult.model,
               }),
               billingType: normalizeLedgerBillingType(adapterResult.billingType),
             } as Record<string, unknown>)


### PR DESCRIPTION
## Summary
- Subscription-billed heartbeat runs (Claude Pro/Max, ChatGPT Plus/Pro/Team, etc.) always recorded `cost_cents=0` because `normalizeBilledCostCents` short-circuited on `billingType === "subscription_included"` without looking at the token usage it already had on hand. Budgets and cost dashboards were effectively inert for any company running on subscription auth instead of a metered API key.
- Adds a small public-pricing lookup table (`model-pricing.ts`) and uses it to estimate a cost when no provider-reported cost is available but the billing type is subscription.
- New `"estimated"` cost status, kept distinct from `"reported"` (real metered cost) and `"unpriced"` (no rate on file), so downstream consumers can still tell them apart.
- Unmatched provider/model pairs return `null` and stay `unpriced` rather than guessing at a nearby model's rate — deliberately no fallback/default rate.

## Test plan
- [x] `vitest run model-pricing` (packages/shared) — 8 new tests
- [x] `vitest run heartbeat-cost-accounting` (server) — 10 tests (7 existing + 3 new)
- [x] `vitest run costs-service budgets-service` (server) — 24 tests, no regressions
- [x] `tsc --noEmit` on server package, `tsc` build on packages/shared
- [x] Smoke-tested a production build of this change end-to-end against a fresh Postgres (211 migrations, clean boot, `/api/health` OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
