### PR TITLE
fix(plugin-ui-static): fall back to key lookup on drizzle-wrapped 22P02

### DIFF
--- a/server/src/__tests__/plugin-ui-static.test.ts
+++ b/server/src/__tests__/plugin-ui-static.test.ts
@@ -109,6 +109,42 @@ describe("plugin UI static route", () => {
     expect(mockRegistry.getConfig).not.toHaveBeenCalled();
   });
 
+  it("falls back to key lookup when getById rejects with a drizzle-wrapped 22P02 (non-UUID pluginKey)", async () => {
+    const packageRoot = createPluginPackage(
+      "export const marker = 'key-bundle';\n",
+    );
+    // A non-UUID :pluginId makes getById's `WHERE id = $1` reject with Postgres
+    // 22P02; drizzle-orm wraps that error and exposes the code on `.cause`.
+    const wrapped = Object.assign(new Error("Failed query: select ..."), {
+      cause: Object.assign(
+        new Error('invalid input syntax for type uuid: "agent-pixels.camera"'),
+        { code: "22P02" },
+      ),
+    });
+    mockRegistry.getById.mockRejectedValue(wrapped);
+    mockRegistry.getByKey.mockResolvedValue({
+      id: pluginId,
+      pluginKey: "agent-pixels.camera",
+      packageName: "paperclip-plugin-example",
+      packagePath: packageRoot,
+      version: "1.0.0",
+      status: "ready",
+      manifestJson: {
+        id: "agent-pixels.camera",
+        entrypoints: { ui: "./dist/ui" },
+      },
+    });
+    const app = await createApp({ type: "none", source: "none" });
+
+    const res = await request(app).get(
+      "/_plugins/agent-pixels.camera/ui/index.js",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("key-bundle");
+    expect(mockRegistry.getByKey).toHaveBeenCalledWith("agent-pixels.camera");
+  });
+
   it("requires authentication before reading company-scoped devUiUrl config", async () => {
     readyPlugin(createPluginPackage());
     const app = await createApp({ type: "none", source: "none" });

--- a/server/src/routes/plugin-ui-static.ts
+++ b/server/src/routes/plugin-ui-static.ts
@@ -248,11 +248,16 @@ export function pluginUiStaticRoutes(db: Db, options: PluginUiStaticRouteOptions
     try {
       plugin = await registry.getById(pluginId);
     } catch (error) {
-      const maybeCode =
-        typeof error === "object" && error !== null && "code" in error
-          ? (error as { code?: unknown }).code
-          : undefined;
-      if (maybeCode !== "22P02") {
+      // drizzle-orm (0.45+) wraps the underlying pg error on `.cause` rather
+      // than re-exposing `.code`, so a non-UUID :pluginId surfaces Postgres
+      // 22P02 (invalid_text_representation) one level down. Inspect both so the
+      // lookup falls through to getByKey instead of surfacing as a 500.
+      const record = error as
+        | { code?: unknown; cause?: { code?: unknown } }
+        | null
+        | undefined;
+      const pgCode = record?.code ?? record?.cause?.code;
+      if (pgCode !== "22P02") {
         throw error;
       }
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The plugin system serves each plugin's built UI as static assets under `GET /_plugins/:pluginId/ui/*`.
> - The front end mounts plugin UIs by plugin **key**, so asset requests arrive with a non-UUID `:pluginId`.
> - The route looks the plugin up with `getById` first, then falls back to `getByKey`.
> - For a non-UUID key, `getById` runs `WHERE id = $1`. Postgres rejects it with `22P02` (invalid UUID text).
> - `drizzle-orm` 0.45+ wraps that error and puts the pg code on `.cause`, not `.code`. The guard checked only `.code`, so it rethrew instead of falling through.
> - Every key-addressed plugin asset request therefore returns a 500. This pull request makes the guard read `.cause.code` too, so the `getByKey` fallback runs.
> - The benefit is that installed plugins that load sub-assets (sprites, layouts, JSON) work again.

## Linked Issues or Issue Description

Refs #5843
Refs #6295
Refs #7639

These issues report the same symptom: the plugin UI static route returns 500 when accessed by plugin key. This change is a focused, single-purpose version of the `plugin-ui-static` part of #6877 (that PR bundles several unrelated changes).

## What Changed

- `server/src/routes/plugin-ui-static.ts`: the `getById` error guard now reads both `error.code` and `error.cause.code` when it checks for Postgres `22P02`. A non-UUID `:pluginId` now falls through to `getByKey` instead of surfacing as a 500.
- `server/src/__tests__/plugin-ui-static.test.ts`: adds a regression test. `getById` rejects with a drizzle-wrapped `22P02`, `getByKey` resolves the plugin, and the asset request returns 200.

## Verification

- Run the route tests:
  - `cd server && npx vitest run src/__tests__/plugin-ui-static.test.ts`
  - Result: 5 passed (5), including the new regression test.
- Manual repro on `master` (dc6fcd1f): install a community plugin whose UI loads sub-assets by key, then open its page. Before the fix, `GET /_plugins/<plugin-key>/ui/assets/...` returns 500 and the server logs `Failed query: select ... from plugins where id = $1` with `params: <plugin-key>`. After the fix, the asset loads and the page renders.

## Risks

Low risk. The change only widens an existing error check. It affects one code path (plugin UI asset lookup by a non-UUID id). A genuine database error still propagates, because only `22P02` falls through to `getByKey`. No schema, API, or behavior change for UUID lookups.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, extended thinking, with tool use and code execution. The fix was verified by running the test suite and reproducing the 500 on a live instance.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
