### PR TITLE
fix(server): route automated reviews via company config

### DIFF
--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -12,7 +12,9 @@ export interface InteractionResolverKindGovernance {
 
 export type InteractionResolverGovernance = Partial<
   Record<IssueThreadInteractionKind, InteractionResolverKindGovernance>
->;
+> & {
+  operationalReviewOwnerAgentId?: string;
+};
 
 export interface Company {
   id: string;

--- a/packages/shared/src/validators/company.test.ts
+++ b/packages/shared/src/validators/company.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { interactionResolverGovernanceSchema } from "./company.js";
+
+describe("interactionResolverGovernanceSchema", () => {
+  it("accepts an operational review owner agent id", () => {
+    const ownerId = "c085a343-d57f-47fa-b114-0c6ed7f76c41";
+
+    expect(interactionResolverGovernanceSchema.parse({
+      operationalReviewOwnerAgentId: ownerId,
+    })).toEqual({ operationalReviewOwnerAgentId: ownerId });
+  });
+
+  it("rejects non-uuid operational review owner values", () => {
+    expect(() =>
+      interactionResolverGovernanceSchema.parse({
+        operationalReviewOwnerAgentId: "pm",
+      })
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -25,6 +25,7 @@ export const interactionResolverGovernanceSchema = z.object({
   request_confirmation: interactionResolverKindGovernanceSchema.optional(),
   request_checkbox_confirmation: interactionResolverKindGovernanceSchema.optional(),
   request_item_verdicts: interactionResolverKindGovernanceSchema.optional(),
+  operationalReviewOwnerAgentId: z.string().uuid().optional(),
 }).strict().default({});
 
 export const createCompanySchema = z.object({

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -322,6 +322,28 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluation?.assigneeAgentId).toBe(pmId);
   });
 
+  it("does not route silent-run evaluations back to the stale-run agent", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, managerId, coderId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      operationalReviewOwnerAgentId: null,
+    });
+    await db
+      .update(companies)
+      .set({ interactionResolverGovernance: { operationalReviewOwnerAgentId: coderId } })
+      .where(eq(companies.id, companyId));
+
+    const result = await heartbeatService(db).scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(1);
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.assigneeAgentId).toBe(managerId);
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -131,6 +131,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
+    operationalReviewOwnerAgentId?: string | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -148,6 +149,9 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       name: "Watchdog Co",
       issuePrefix,
       defaultResponsibleUserId: "responsible-user",
+      interactionResolverGovernance: opts.operationalReviewOwnerAgentId
+        ? { operationalReviewOwnerAgentId: opts.operationalReviewOwnerAgentId }
+        : {},
       requireBoardApprovalForNewAgents: false,
     });
     await db.insert(agents).values([
@@ -286,6 +290,36 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(evaluations[0]?.description).toContain("Decision Checklist");
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
+  });
+
+  it("routes silent-run evaluations to the configured operational review owner before manager fallback", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const pmId = "c085a343-d57f-47fa-b114-0c6ed7f76c41";
+    const { companyId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      operationalReviewOwnerAgentId: pmId,
+    });
+    await db.insert(agents).values({
+      id: pmId,
+      companyId,
+      name: "PM",
+      role: "pm",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const result = await heartbeatService(db).scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(1);
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.assigneeAgentId).toBe(pmId);
   });
 
   it("redacts sensitive values from actual run-log evidence", async () => {

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -344,6 +344,37 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluation?.assigneeAgentId).toBe(managerId);
   });
 
+  it("falls back when the configured stale-run evaluation owner is not assignable", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const invalidOwnerId = randomUUID();
+    const { companyId, managerId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      operationalReviewOwnerAgentId: invalidOwnerId,
+    });
+    await db.insert(agents).values({
+      id: invalidOwnerId,
+      companyId,
+      name: "PM with missing manager",
+      role: "pm",
+      status: "idle",
+      reportsTo: randomUUID(),
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const result = await heartbeatService(db).scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(1);
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.assigneeAgentId).toBe(managerId);
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -273,6 +273,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.assigneeAgentId).toBe(seeded.managerId);
   });
 
+  it("falls back when the configured productivity review owner is not assignable", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const invalidOwnerId = randomUUID();
+    const seeded = await seedAssignedIssue({ operationalReviewOwnerAgentId: invalidOwnerId });
+    await db.insert(agents).values({
+      id: invalidOwnerId,
+      companyId: seeded.companyId,
+      name: "PM with missing manager",
+      role: "pm",
+      status: "idle",
+      reportsTo: randomUUID(),
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const reviews = await listProductivityReviews(seeded.companyId);
+    expect(reviews[0]?.assigneeAgentId).toBe(seeded.managerId);
+  });
+
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -248,6 +248,31 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.assigneeAgentId).toBe(pmId);
   });
 
+  it("does not route productivity reviews back to the reviewed agent", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await db
+      .update(companies)
+      .set({ interactionResolverGovernance: { operationalReviewOwnerAgentId: seeded.coderId } })
+      .where(eq(companies.id, seeded.companyId));
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const reviews = await listProductivityReviews(seeded.companyId);
+    expect(reviews[0]?.assigneeAgentId).toBe(seeded.managerId);
+  });
+
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -55,6 +55,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
+    operationalReviewOwnerAgentId?: string | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -67,6 +68,9 @@ describeEmbeddedPostgres("productivity review service", () => {
       id: companyId,
       name: "Productivity Review Co",
       issuePrefix,
+      interactionResolverGovernance: opts?.operationalReviewOwnerAgentId
+        ? { operationalReviewOwnerAgentId: opts.operationalReviewOwnerAgentId }
+        : {},
       requireBoardApprovalForNewAgents: false,
     });
     await db.insert(agents).values([
@@ -208,6 +212,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
 
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
+  });
+
+  it("routes productivity reviews to the configured operational review owner before manager fallback", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const pmId = "c085a343-d57f-47fa-b114-0c6ed7f76c41";
+    const seeded = await seedAssignedIssue({ operationalReviewOwnerAgentId: pmId });
+    await db.insert(agents).values({
+      id: pmId,
+      companyId: seeded.companyId,
+      name: "PM",
+      role: "pm",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const reviews = await listProductivityReviews(seeded.companyId);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]?.assigneeAgentId).toBe(pmId);
   });
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {

--- a/server/src/services/operational-review-routing.ts
+++ b/server/src/services/operational-review-routing.ts
@@ -1,0 +1,20 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, companies } from "@paperclipai/db";
+
+export async function resolveConfiguredOperationalReviewOwnerAgentId(db: Db, companyId: string) {
+  const company = await db
+    .select({ interactionResolverGovernance: companies.interactionResolverGovernance })
+    .from(companies)
+    .where(eq(companies.id, companyId))
+    .then((rows) => rows[0] ?? null);
+  const configuredAgentId = company?.interactionResolverGovernance?.operationalReviewOwnerAgentId;
+  if (!configuredAgentId) return null;
+
+  const configuredOwner = await db
+    .select({ id: agents.id })
+    .from(agents)
+    .where(and(eq(agents.companyId, companyId), eq(agents.id, configuredAgentId)))
+    .then((rows) => rows[0] ?? null);
+  return configuredOwner?.id ?? null;
+}

--- a/server/src/services/operational-review-routing.ts
+++ b/server/src/services/operational-review-routing.ts
@@ -1,8 +1,13 @@
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, companies } from "@paperclipai/db";
+import { assertAssignableAgent } from "./agent-assignability.js";
 
-export async function resolveConfiguredOperationalReviewOwnerAgentId(db: Db, companyId: string) {
+export async function resolveConfiguredOperationalReviewOwnerAgentId(
+  db: Db,
+  companyId: string,
+  opts?: { excludeAgentIds?: string[] },
+) {
   const company = await db
     .select({ interactionResolverGovernance: companies.interactionResolverGovernance })
     .from(companies)
@@ -10,11 +15,18 @@ export async function resolveConfiguredOperationalReviewOwnerAgentId(db: Db, com
     .then((rows) => rows[0] ?? null);
   const configuredAgentId = company?.interactionResolverGovernance?.operationalReviewOwnerAgentId;
   if (!configuredAgentId) return null;
+  if (opts?.excludeAgentIds?.includes(configuredAgentId)) return null;
 
   const configuredOwner = await db
     .select({ id: agents.id })
     .from(agents)
     .where(and(eq(agents.companyId, companyId), eq(agents.id, configuredAgentId)))
     .then((rows) => rows[0] ?? null);
+  if (!configuredOwner) return null;
+  try {
+    await assertAssignableAgent(db, companyId, configuredOwner.id, { kind: "work" });
+  } catch {
+    return null;
+  }
   return configuredOwner?.id ?? null;
 }

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -596,7 +596,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
 
   async function resolveReviewOwnerAgentId(sourceIssue: IssueRow, sourceAgent: AgentRow) {
     const candidateIds: string[] = [];
-    const configuredOwnerId = await resolveConfiguredOperationalReviewOwnerAgentId(db, sourceIssue.companyId);
+    const configuredOwnerId = await resolveConfiguredOperationalReviewOwnerAgentId(db, sourceIssue.companyId, {
+      excludeAgentIds: [sourceAgent.id],
+    });
     if (configuredOwnerId) candidateIds.push(configuredOwnerId);
     if (sourceAgent.reportsTo) candidateIds.push(sourceAgent.reportsTo);
     if (sourceIssue.createdByAgentId) candidateIds.push(sourceIssue.createdByAgentId);

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -16,6 +16,7 @@ import { logActivity } from "./activity-log.js";
 import { budgetService } from "./budgets.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
+import { resolveConfiguredOperationalReviewOwnerAgentId } from "./operational-review-routing.js";
 import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
@@ -595,6 +596,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
 
   async function resolveReviewOwnerAgentId(sourceIssue: IssueRow, sourceAgent: AgentRow) {
     const candidateIds: string[] = [];
+    const configuredOwnerId = await resolveConfiguredOperationalReviewOwnerAgentId(db, sourceIssue.companyId);
+    if (configuredOwnerId) candidateIds.push(configuredOwnerId);
     if (sourceAgent.reportsTo) candidateIds.push(sourceAgent.reportsTo);
     if (sourceIssue.createdByAgentId) candidateIds.push(sourceIssue.createdByAgentId);
     if (sourceIssue.projectId) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -41,6 +41,7 @@ import { instanceSettingsService } from "../instance-settings.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
 import { TERMINAL_HEARTBEAT_RUN_STATUSES, issueService } from "../issues.js";
+import { resolveConfiguredOperationalReviewOwnerAgentId } from "../operational-review-routing.js";
 import {
   applyIssueMonitorPolicyTransition,
   normalizeIssueExecutionPolicy,
@@ -1813,6 +1814,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     sourceIssue: typeof issues.$inferSelect | null;
   }) {
     const candidateIds: string[] = [];
+    const configuredOwnerId = await resolveConfiguredOperationalReviewOwnerAgentId(db, input.run.companyId);
+    if (configuredOwnerId) candidateIds.push(configuredOwnerId);
     if (input.sourceIssue?.assigneeAgentId) {
       const sourceAssignee = await getAgent(input.sourceIssue.assigneeAgentId);
       if (sourceAssignee?.reportsTo) candidateIds.push(sourceAssignee.reportsTo);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1814,7 +1814,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     sourceIssue: typeof issues.$inferSelect | null;
   }) {
     const candidateIds: string[] = [];
-    const configuredOwnerId = await resolveConfiguredOperationalReviewOwnerAgentId(db, input.run.companyId);
+    const configuredOwnerId = await resolveConfiguredOperationalReviewOwnerAgentId(db, input.run.companyId, {
+      excludeAgentIds: [input.runningAgent.id],
+    });
     if (configuredOwnerId) candidateIds.push(configuredOwnerId);
     if (input.sourceIssue?.assigneeAgentId) {
       const sourceAssignee = await getAgent(input.sourceIssue.assigneeAgentId);


### PR DESCRIPTION
## Issue
Paperclip automated operational review issues for Taronja currently follow generic manager/CTO/CEO fallback routing. For Taronja productivity and silent-run review issues, the operational owner should be PM when company configuration says so, while explicit/manual issue assignment paths must remain unchanged.

This PR implements [SLA-7006](/SLA/issues/SLA-7006): company-configurable PM routing for productivity reviews and stale active-run evaluations without hard-coding Taronja agent UUIDs into generic behavior.

### Inline Enhancement Template
- Pre-submission checklist: confirmed this improves existing automated review routing behavior; searched existing open and closed issues/PRs for duplicates.
- What existing behavior does this improve? Server automated issue owner routing for productivity reviews and stale active-run evaluations.
- Subsystem affected: Cross-cutting (`server/` services plus `packages/shared` company config validation).
- Current behavior: automated productivity and silent-run review issues route through manager/CTO/CEO fallback even when a company wants a dedicated operational review owner such as PM.
- Proposed behavior: when `interactionResolverGovernance.operationalReviewOwnerAgentId` is configured, automated operational reviews try that same-company, assignable, non-reviewed agent first, then fall back to the existing manager/CTO/CEO ladder.
- Reason and benefit: Taronja operational review tickets should land with PM by default so CTO/CEO are not the default queue owners for productivity/silent-run triage, while explicit manual assignments remain unchanged.
- Breaking changes: none expected; the setting is optional and absent/invalid/self-review/ineligible configured owners fall through to existing routing.
- Additional context: source work item is [SLA-7006](/SLA/issues/SLA-7006).

## Thinking Path
- [SLA-7006](/SLA/issues/SLA-7006) requires automated operational review issues to route to Taronja PM by company config, not hard-coded generic behavior.
- The existing productivity and silent-run paths already have ordered fallback ladders; the smallest safe change is to prepend a configured company owner candidate before existing manager/CTO/CEO fallbacks.
- The existing `companies.interactionResolverGovernance` JSONB field is already company-scoped and exposed through shared validators, so no DB migration is needed.

## What Changed
- Added optional `interactionResolverGovernance.operationalReviewOwnerAgentId` to shared company governance typing/validation.
- Added `resolveConfiguredOperationalReviewOwnerAgentId()` to validate the configured owner belongs to the same company.
- Applied that configured owner first in:
- `server/src/services/productivity-review.ts`
- `server/src/services/recovery/service.ts`
- Added focused tests proving productivity reviews and stale active-run evaluations route to configured PM `c085a343-d57f-47fa-b114-0c6ed7f76c41`.

## Verification
- [x] I searched existing open PRs for similar changes before opening this PR; no SLA-7006 / operational-review routing overlap found.
- PASS: `git diff --check`
- PASS: `pnpm vitest run packages/shared/src/validators/company.test.ts --reporter=verbose` (1 file, 2 tests)
- PASS: `server/node_modules/.bin/tsx.cmd -e "(async()=>{ await import('./server/src/services/operational-review-routing.ts'); await import('./server/src/services/productivity-review.ts'); await import('./server/src/services/recovery/service.ts'); await import('./packages/shared/src/validators/company.ts'); console.log('changed module import smoke ok'); })()"`
- BLOCKED locally: `pnpm vitest run server/src/__tests__/productivity-review-service.test.ts server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts` timed out at 120s and 300s before test output.
- BLOCKED locally: individual focused Vitest files timed out before test output; direct `getEmbeddedPostgresTestSupport()` probe also timed out after 90s, indicating embedded-Postgres startup/probe hang in this local environment.

## Risks
- Low schema risk: this uses an existing JSONB governance field and does not change DB shape.
- Low behavior risk for explicit/manual issue assignment: only automated productivity and stale-run owner resolver candidate order changed; generic manual issue create/update assignment paths are untouched.
- Configured owner falls through to existing behavior if absent, cross-company, non-invokable, or budget-blocked.

## Model Used
- gpt-5.5 via OpenCode (`openai/gpt-5.5`).

PR-State: ready_for_codequality
Owner: cto
Next-Action: WAIT_CURRENT_LANE
Due: 2026-08-17

Owner: @cto, Lane: CTO_REVIEW_AND_MERGE, Next checkpoint: 2026-08-17
