### PR TITLE
fix(stall-recovery): skip escalation when a pending approval card is linked to the issue

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -10,6 +10,7 @@ import {
   agents,
   agentRuntimeState,
   agentWakeupRequests,
+  approvals,
   authUsers,
   budgetPolicies,
   companySecretBindings,
@@ -28,6 +29,7 @@ import {
   executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueApprovals,
   issueComments,
   issueDocuments,
   issuePlanDecompositions,
@@ -447,6 +449,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       await db.delete(projects);
       await db.delete(issuePlanDecompositions);
       await db.delete(issueThreadInteractions);
+      await db.delete(issueApprovals);
+      await db.delete(approvals);
       await db.delete(documentAnnotationComments);
       await db.delete(documentAnnotationAnchorSnapshots);
       await db.delete(documentAnnotationThreads);
@@ -6007,6 +6011,57 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("in_progress");
+  });
+
+  it("skips stranded recovery when a pending approval card is linked to the issue", async () => {
+    const { companyId, agentId, issueId, runId, wakeupRequestId, stageId } =
+      await seedInReviewParticipantRunFixture({
+        wakeReason: "execution_review_participant_recovery",
+        retryReason: "execution_review_participant_recovery",
+      });
+    const approvalId = randomUUID();
+    const finishedAt = new Date("2026-03-19T00:05:00.000Z");
+
+    // Make the participant run terminal so stall-recovery would normally escalate
+    await db
+      .update(agentWakeupRequests)
+      .set({ status: "failed", finishedAt, updatedAt: finishedAt })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        startedAt: new Date("2026-03-19T00:00:00.000Z"),
+        finishedAt,
+        updatedAt: finishedAt,
+        errorCode: "adapter_failed",
+        error: "review recovery failed before submitting a decision",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // Link a pending board approval card to the issue — stall-recovery must
+    // detect this and skip escalation (card-escalator owns the next action).
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Approve merge", summary: "Ready to ship." },
+    });
+    await db.insert(issueApprovals).values({ companyId, issueId, approvalId });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    const updatedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("in_review");
   });
 
   it("requeues accepted interaction continuations stranded in_review without execution state", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -10,6 +10,7 @@ import {
   agents,
   agentRuntimeState,
   agentWakeupRequests,
+  approvals,
   authUsers,
   budgetPolicies,
   companySecretBindings,
@@ -28,6 +29,7 @@ import {
   executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueApprovals,
   issueComments,
   issueDocuments,
   issuePlanDecompositions,
@@ -442,6 +444,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       await db.delete(projects);
       await db.delete(issuePlanDecompositions);
       await db.delete(issueThreadInteractions);
+      await db.delete(issueApprovals);
+      await db.delete(approvals);
       await db.delete(documentAnnotationComments);
       await db.delete(documentAnnotationAnchorSnapshots);
       await db.delete(documentAnnotationThreads);
@@ -5260,6 +5264,57 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("in_progress");
+  });
+
+  it("skips stranded recovery when a pending approval card is linked to the issue", async () => {
+    const { companyId, agentId, issueId, runId, wakeupRequestId, stageId } =
+      await seedInReviewParticipantRunFixture({
+        wakeReason: "execution_review_participant_recovery",
+        retryReason: "execution_review_participant_recovery",
+      });
+    const approvalId = randomUUID();
+    const finishedAt = new Date("2026-03-19T00:05:00.000Z");
+
+    // Make the participant run terminal so stall-recovery would normally escalate
+    await db
+      .update(agentWakeupRequests)
+      .set({ status: "failed", finishedAt, updatedAt: finishedAt })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        startedAt: new Date("2026-03-19T00:00:00.000Z"),
+        finishedAt,
+        updatedAt: finishedAt,
+        errorCode: "adapter_failed",
+        error: "review recovery failed before submitting a decision",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // Link a pending board approval card to the issue — stall-recovery must
+    // detect this and skip escalation (card-escalator owns the next action).
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Approve merge", summary: "Ready to ship." },
+    });
+    await db.insert(issueApprovals).values({ companyId, issueId, approvalId });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+    const updatedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("in_review");
   });
 
   it("requeues accepted interaction continuations stranded in_review without execution state", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -942,6 +942,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasPendingApprovalCard(companyId: string, issueId: string) {
+    return db
+      .select({ id: approvals.id })
+      .from(issueApprovals)
+      .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+      .where(
+        and(
+          eq(issueApprovals.companyId, companyId),
+          eq(issueApprovals.issueId, issueId),
+          eq(approvals.status, "pending"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
   async function hasPersistedDurableWaitPath(issue: typeof issues.$inferSelect) {
     if (issue.monitorNextCheckAt) return true;
 
@@ -3655,6 +3671,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         issue.id,
       );
       if (activeRecoveryAction?.ownerType === "board") {
+        result.skipped += 1;
+        continue;
+      }
+
+      // A pending approval card is the same kind of human-owned wait: the issue
+      // is not stalled, it is waiting for someone to answer. Escalating it
+      // buries the card under a recovery issue nobody asked for.
+      if (await hasPendingApprovalCard(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -941,6 +941,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasPendingApprovalCard(companyId: string, issueId: string) {
+    return db
+      .select({ id: approvals.id })
+      .from(issueApprovals)
+      .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+      .where(
+        and(
+          eq(issueApprovals.companyId, companyId),
+          eq(issueApprovals.issueId, issueId),
+          eq(approvals.status, "pending"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
   async function hasPersistedDurableWaitPath(issue: typeof issues.$inferSelect) {
     if (issue.monitorNextCheckAt) return true;
 
@@ -3708,6 +3724,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasPendingApprovalCard(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
Fixes #11550

## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents for work
> - The `recovery` subsystem periodically reconciles tasks in stalled states and escalates them to the Inspector when no live actor is found
> - `reconcileStrandedAssignedIssues` was escalating `in_review` tasks to Inspector even when a pending board approval card existed for that task
> - `hasPendingWakeInteraction` only checks `issueThreadInteractions`, not the `approvals` join table — a terminal participant run with a pending card triggered the escalation path that belongs to `card-escalator`, not stall-recovery
> - This PR adds a `hasPendingApprovalCard` guard that short-circuits the stranded-issue loop body when a pending approval card is linked
> - The benefit is that tasks correctly waiting for a board decision are no longer falsely escalated to Inspector

## Linked Issues or Issue Description

**What happened?**

`reconcileStrandedAssignedIssues` (stall-recovery) escalated an `in_review` task to the Inspector even when a pending board approval card was linked to that task. The card-escalator sidecar was already on the chase ladder for the pending card; the Inspector returned `human-latency` — the task was correctly waiting, not stalled. The false escalation was noise.

**Expected behavior**

stall-recovery should skip Inspector escalation when a pending board approval card is linked to the task. The `card-escalator` sidecar owns the ladder for pending cards; stall-recovery should defer to it.

**Steps to reproduce**

1. File a board approval card for an `in_review` task
2. Ensure the task has a terminal execution participant run (so stall-recovery would normally escalate)
3. Wait for stall-recovery to run
4. Observe: task is escalated to Inspector despite the pending card — Inspector returns `human-latency`

**Paperclip version or commit**

Reproducible on master as of `1a17cbf232d40dbaca3262720c39a4c0f225ddea`

## What Changed

- Added `hasPendingApprovalCard` helper in `server/src/services/recovery/service.ts` — queries `issueApprovals ⋈ approvals WHERE status = pending AND companyId = ?` for the issue and returns `true` when any row exists
- Added the guard in `reconcileStrandedAssignedIssues` — short-circuits the stranded-issue loop body when `hasPendingApprovalCard` returns `true`
- Added regression test in `server/src/__tests__/heartbeat-process-recovery.test.ts` — seeds a pending approval card linked to an `in_review` task with a terminal participant run, asserts `escalated=0`

## Verification

```
cd server && npx vitest run src/__tests__/heartbeat-process-recovery.test.ts
# All tests pass including: "skips stranded recovery when a pending approval card is linked to the issue"
```

## Risks

Low. The change only adds a short-circuit skip condition before the existing escalation path. If the approval lookup fails or returns no rows, behavior is unchanged (falls through to existing escalation logic). No new code paths are introduced for the happy path.

## Model Used

claude-sonnet-4-6 (tool use, standard reasoning)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 4/5 — pre-existing finding in approvals.ts (not in this diff; tracked separately)
- [x] I will address all Greptile and reviewer comments before requesting merge