### PR TITLE
fix(tool-access): bound outbound requests to remote MCP and OAuth endpoints

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -20,6 +20,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
 | `PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS` | `30000` | Timeout for each outbound request to a remote MCP or OAuth endpoint (tool connections, provider metadata, token exchange). Raise it for a slow provider. |
+| `PAPERCLIP_REMOTE_HTTP_MAX_RESPONSE_BYTES` | `4194304` | Maximum size of a response body from a remote MCP or OAuth endpoint. Raise it only if a provider returns unusually large metadata. |
 
 ## Secrets
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -19,6 +19,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS` | `30000` | Timeout for each outbound request to a remote MCP or OAuth endpoint (tool connections, provider metadata, token exchange). Raise it for a slow provider. |
 
 ## Secrets
 

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -4762,6 +4762,41 @@ describeEmbeddedPostgres("tool access service", () => {
     }
   });
 
+  it("reports a remote endpoint that stalls its body as a timeout, not a missing field", async () => {
+    process.env.PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS = "300";
+    const company = await createCompany(db);
+    const app = createRouteApp(db);
+    // Headers arrive, then the body never completes. The fetch promise resolves,
+    // so only a body-read bound can end this.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"jsonrpc":"2.0"'));
+          init?.signal?.addEventListener("abort", () => {
+            controller.error(init.signal?.reason ?? new Error("aborted"));
+          });
+        },
+      });
+      return new Response(body, { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const startedAt = Date.now();
+    let res: Awaited<ReturnType<ReturnType<typeof request>["post"]>>;
+    try {
+      res = await request(app)
+        .post(`/api/companies/${company.id}/tools/apps/connect`)
+        .send({ link: "https://stalled-body.example.test/mcp", name: "Stalled body app" });
+    } finally {
+      delete process.env.PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS;
+    }
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(Date.now() - startedAt).toBeLessThan(8000);
+    // The failure must describe the timeout rather than a downstream symptom of
+    // an empty payload.
+    expect(JSON.stringify(res.body)).toMatch(/remote_http_timeout|did not respond in time/);
+  });
+
   it("rejects OAuth metadata redirects to private endpoints", async () => {
     const company = await createCompany(db);
     const app = createRouteApp(db, undefined, undefined, {

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -4729,6 +4729,39 @@ describeEmbeddedPostgres("tool access service", () => {
     await expect(db.select().from(toolConnections)).resolves.toHaveLength(0);
   });
 
+  it("gives up on a remote endpoint that accepts the request and never answers", async () => {
+    process.env.PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS = "300";
+    const company = await createCompany(db);
+    const app = createRouteApp(db);
+    // Stands in for a host that holds the connection open: this only settles when
+    // the request is aborted, so nothing but a timeout can end it.
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason ?? new Error("aborted")));
+      }),
+    );
+
+    const startedAt = Date.now();
+    let res: Awaited<ReturnType<ReturnType<typeof request>["post"]>>;
+    try {
+      res = await request(app)
+        .post(`/api/companies/${company.id}/tools/apps/connect`)
+        .send({ link: "https://stalled.example.test/mcp", name: "Stalled app" });
+    } finally {
+      delete process.env.PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS;
+    }
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    // Generous headroom over the 300ms budget: this asserts "bounded", not a
+    // specific latency.
+    expect(Date.now() - startedAt).toBeLessThan(8000);
+    // Every attempt carried an abort signal, so no call could outlive the budget.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
   it("rejects OAuth metadata redirects to private endpoints", async () => {
     const company = await createCompany(db);
     const app = createRouteApp(db, undefined, undefined, {

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -127,6 +127,7 @@ type ActorInfo = {
 
 const ACTIVE_BROKER_RUN_STATUSES = new Set(["running"]);
 const REMOTE_HTTP_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const REMOTE_HTTP_NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
 const MAX_REMOTE_HTTP_REDIRECTS = 5;
 // Budget for a whole remote OAuth exchange, redirects included. Generous for a
 // metadata, registration or token call, and overridable for a slow provider.
@@ -143,18 +144,89 @@ function remoteHttpTimeoutMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_REMOTE_HTTP_TIMEOUT_MS;
 }
 
-// Translate an aborted remote request into a described gateway error. Without
-// this the raw AbortError escapes callers that do not wrap the call — for
-// example oauthProviderEndpoints — and surfaces as an unexplained 500.
+// Ceiling for a remote MCP or OAuth response body. These are metadata, token and
+// tools/list payloads, so this is far above any legitimate response while still
+// bounding what one untrusted endpoint can make us allocate.
+const DEFAULT_REMOTE_HTTP_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+function remoteHttpMaxResponseBytes() {
+  const parsed = Number.parseInt(process.env.PAPERCLIP_REMOTE_HTTP_MAX_RESPONSE_BYTES ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_REMOTE_HTTP_MAX_RESPONSE_BYTES;
+}
+
+function remoteHttpTimeout() {
+  return new HttpError(504, "Remote endpoint did not respond in time", { code: "remote_http_timeout" });
+}
+
+/**
+ * Fetch a remote endpoint under a time bound, then buffer its body under the
+ * same bound and hand back a Response carrying the buffered bytes.
+ *
+ * Returning the live Response would leave every caller's `response.json()` /
+ * `.text()` outside this translation: an abort during the body would surface as
+ * a raw AbortError, or — where the caller writes `.catch(() => ({}))` — as a
+ * silently empty payload and a misleading "missing field" error. Buffering here
+ * means the body is already in memory by the time a caller reads it, so no
+ * caller can observe a body-read abort.
+ *
+ * The read is streamed against a size ceiling rather than buffered blindly,
+ * because these endpoints are operator- or app-supplied and `arrayBuffer()`
+ * would have already allocated everything before its length could be checked.
+ */
 async function fetchRemoteHttpWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  let response: Response;
   try {
-    return await fetch(url, init);
+    response = await fetch(url, init);
   } catch (err) {
-    if (init.signal?.aborted) {
-      throw new HttpError(504, "Remote endpoint did not respond in time", { code: "remote_http_timeout" });
-    }
+    if (init.signal?.aborted) throw remoteHttpTimeout();
     throw err;
   }
+
+  // A redirect is inspected for its Location header and never read, so leave its
+  // body alone; fetchRemoteHttpUrl follows it with a fresh request.
+  if (REMOTE_HTTP_REDIRECT_STATUSES.has(response.status)) return response;
+  // Statuses that cannot carry a body have nothing to buffer, and the Response
+  // constructor rejects a body for them.
+  if (REMOTE_HTTP_NULL_BODY_STATUSES.has(response.status)) return response;
+  // Only a real streaming Response can abort mid-body. Anything else — including
+  // the object-literal responses used in tests — is already fully in hand.
+  const stream = response.body;
+  if (typeof stream?.getReader !== "function") return response;
+
+  const limit = remoteHttpMaxResponseBytes();
+  let buffered: ArrayBuffer;
+  try {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel();
+        throw new HttpError(502, "Remote endpoint returned an oversized response", {
+          code: "remote_http_response_too_large",
+        });
+      }
+      chunks.push(value);
+    }
+    // Copy into a plain ArrayBuffer: Buffer/Uint8Array are generic over
+    // ArrayBufferLike, which BodyInit does not accept.
+    const joined = Buffer.concat(chunks);
+    buffered = new ArrayBuffer(joined.byteLength);
+    new Uint8Array(buffered).set(joined);
+  } catch (err) {
+    if (err instanceof HttpError) throw err;
+    if (init.signal?.aborted) throw remoteHttpTimeout();
+    throw err;
+  }
+
+  return new Response(buffered, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 type OAuthProviderEndpoints = {

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -128,11 +128,34 @@ type ActorInfo = {
 const ACTIVE_BROKER_RUN_STATUSES = new Set(["running"]);
 const REMOTE_HTTP_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const MAX_REMOTE_HTTP_REDIRECTS = 5;
+// Budget for a whole remote OAuth exchange, redirects included. Generous for a
+// metadata, registration or token call, and overridable for a slow provider.
+const DEFAULT_REMOTE_HTTP_TIMEOUT_MS = 30_000;
+
 const MAX_OAUTH_DCR_CLIENT_ID_LENGTH = 4_096;
 const MAX_OAUTH_DCR_CLIENT_SECRET_LENGTH = 16_384;
 const OAUTH_REFRESH_LEASE_MS = 120_000;
 const OAUTH_REFRESH_LEASE_WAIT_MS = 30_000;
 const OAUTH_REFRESH_LEASE_POLL_MS = 25;
+
+function remoteHttpTimeoutMs() {
+  const parsed = Number.parseInt(process.env.PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_REMOTE_HTTP_TIMEOUT_MS;
+}
+
+// Translate an aborted remote request into a described gateway error. Without
+// this the raw AbortError escapes callers that do not wrap the call — for
+// example oauthProviderEndpoints — and surfaces as an unexplained 500.
+async function fetchRemoteHttpWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    if (init.signal?.aborted) {
+      throw new HttpError(504, "Remote endpoint did not respond in time", { code: "remote_http_timeout" });
+    }
+    throw err;
+  }
+}
 
 type OAuthProviderEndpoints = {
   provider: string;
@@ -1393,9 +1416,17 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   async function fetchRemoteHttpUrl(value: string, init: RequestInit = {}): Promise<Response> {
     let currentUrl = value;
     const method = (init.method ?? "GET").toUpperCase();
+    // `fetch` has no default timeout, and these endpoints are operator- or
+    // app-supplied, so a host that accepts the connection and never answers would
+    // hold this call — and the request handler awaiting it — open indefinitely.
+    // One signal for the whole loop, so a chain of slow redirects cannot spend
+    // MAX_REMOTE_HTTP_REDIRECTS times the budget. A caller-supplied signal is
+    // still honoured.
+    const timeout = AbortSignal.timeout(remoteHttpTimeoutMs());
+    const signal = init.signal ? AbortSignal.any([init.signal, timeout]) : timeout;
     for (let redirectCount = 0; redirectCount <= MAX_REMOTE_HTTP_REDIRECTS; redirectCount += 1) {
       const safeUrl = await assertRemoteHttpUrlAllowed(currentUrl);
-      const response = await fetch(safeUrl, { ...init, redirect: "manual" });
+      const response = await fetchRemoteHttpWithTimeout(safeUrl, { ...init, redirect: "manual", signal });
       const location = REMOTE_HTTP_REDIRECT_STATUSES.has(response.status)
         ? response.headers?.get?.("location") ?? null
         : null;
@@ -1907,20 +1938,22 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       body.set("requested_token_type", readConfigString(broker, "requestedTokenType") ?? "urn:ietf:params:oauth:token-type:access_token");
       body.set("actor_token", Buffer.from(JSON.stringify(actor)).toString("base64url"));
       body.set("actor_token_type", readConfigString(broker, "actorTokenType") ?? "urn:ietf:params:oauth:token-type:jwt");
-      response = await fetch(url, {
+      response = await fetchRemoteHttpWithTimeout(url, {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
         body,
+        signal: AbortSignal.timeout(remoteHttpTimeoutMs()),
       });
     } else {
       const namespace = isPages ? pagesNamespaceFromScope(input.scope) : null;
       const body = isPages && namespace
         ? { namespace, ttlSeconds: input.ttlSeconds, actions: ["publish"], actor }
         : { scope: input.scope, ttlSeconds: input.ttlSeconds, actor, audience: readConfigString(broker, "audience") };
-      response = await fetch(url, {
+      response = await fetchRemoteHttpWithTimeout(url, {
         method: "POST",
         headers: { authorization: `Bearer ${parentToken}`, "content-type": "application/json" },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(remoteHttpTimeoutMs()),
       });
     }
     const payload = await response.json().catch(() => ({})) as unknown;
@@ -2865,7 +2898,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   async function remoteTools(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {
     const headers = await resolveCredentialHeaders(connection);
     const endpoint = await assertRemoteEndpointAllowed(connection.config);
-    const response = await fetch(endpoint, {
+    const response = await fetchRemoteHttpWithTimeout(endpoint, {
       method: "POST",
       // MCP Streamable HTTP requires advertising that we accept both a JSON body
       // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
@@ -2876,6 +2909,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         method: "tools/list",
         params: {},
       }),
+      signal: AbortSignal.timeout(remoteHttpTimeoutMs()),
     });
     if (!response.ok) {
       const authenticate = response.headers.get("www-authenticate") ?? "";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach outside tools through tool connections. `tool-access.ts` connects them: it probes a pasted MCP link, discovers an OAuth provider's endpoints, registers a client, exchanges tokens, and mints broker credentials
> - Every one of those endpoints is operator- or app-supplied, so none of them is trusted input
> - Each of those requests called `fetch()` with no signal, and Node's `fetch` has no default timeout. A remote endpoint that accepts the connection and then never answers held the call, and the request handler awaiting it, open indefinitely
> - `tool-gateway.ts` already bounds its own MCP tool calls with an `AbortController` and a timer, so the discipline exists in the codebase; `tool-access.ts` was the gap
> - This pull request bounds all four outbound call sites in `tool-access.ts` and translates an aborted request into a described gateway error
> - The benefit is that one unresponsive remote endpoint can no longer hold a request handler open, and the failure is reported as a timeout instead of an unexplained 500

## Linked Issues or Issue Description

No existing issue — describing the problem here, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

None of the outbound requests in `server/src/services/tool-access.ts` had a time bound. There were four call sites:

- `fetchRemoteHttpUrl` — the shared, SSRF-guarded helper behind OAuth protected-resource discovery, provider metadata, dynamic client registration, and token exchange.
- `remoteTools` — the MCP `tools/list` probe. This is the first request made when a pasted MCP link is connected.
- `mintExchangeConnectionToken` — one call per protocol branch (`rfc8693` and the default), against the configured credential broker.

Because Node's `fetch` has no default timeout, a host that completed the TCP handshake and then never responded blocked the awaiting request handler for as long as it kept the connection open.

The `POST /api/companies/:companyId/tools/apps/connect` route made this reachable with nothing but a pasted link: its first call is the `remoteTools` probe. The added regression test reproduces it as a hang.

`fetchRemoteHttpUrl` had a second problem. It loops up to `MAX_REMOTE_HTTP_REDIRECTS` (5) times, so a per-attempt bound would still allow a host feeding slow redirects to spend six times the intended budget.

**Expected behavior**

An outbound request to a remote MCP or OAuth endpoint fails after a bounded time, and the whole redirect chain is covered by one budget. The caller receives a described gateway error rather than a raw `AbortError`.

**Steps to reproduce**

1. Start a server that accepts connections and never answers, for example `node -e "require('node:http').createServer(() => {}).listen(3000,'127.0.0.1')"`.
2. `POST /api/companies/{companyId}/tools/apps/connect` with `link` pointing at it.
3. The request never returns.

**Paperclip version or commit**

`master` at 6d0adbfb.

**Deployment mode**

Not deployment-specific. Note that in `local_trusted` or non-public deployments, private-network endpoints are allowed by design (`allowPrivateRemoteEndpoints`), so a loopback address reproduces it directly.

## What Changed

- `server/src/services/tool-access.ts`: `fetchRemoteHttpUrl` now builds one `AbortSignal.timeout` for its entire redirect loop, rather than one per attempt, so a chain of slow redirects cannot spend `MAX_REMOTE_HTTP_REDIRECTS` times the budget. A caller-supplied `init.signal` is still honoured, composed with `AbortSignal.any`.
- `server/src/services/tool-access.ts`: `remoteTools` and both credential-broker calls each get a bounded signal. After this change the only bare `await fetch(` left in the file is inside the new wrapper.
- `server/src/services/tool-access.ts`: added `fetchRemoteHttpWithTimeout`, which translates an aborted request into `HttpError(504, "Remote endpoint did not respond in time", { code: "remote_http_timeout" })`. Without it the raw `AbortError` escapes callers that do not wrap the call — `oauthProviderEndpoints` is one — and surfaces as an unexplained 500.
- `server/src/services/tool-access.ts`: `fetchRemoteHttpWithTimeout` buffers the response body under the same signal and returns a `Response` carrying the buffered bytes. Callers read the body after the wrapper returns, so without this a body-read abort escaped the translation: the pasted-link path surfaced the raw `The operation was aborted due to timeout`, and the three sites written as `response.json().catch(() => ({}))` turned an abort into an empty payload and then a misleading missing-field error. Buffering here means no caller can observe a body-read abort, and no call site changed. This is the P1 Greptile raised on the first revision.
- `server/src/services/tool-access.ts`: the buffered read is streamed against a 4 MiB ceiling (`PAPERCLIP_REMOTE_HTTP_MAX_RESPONSE_BYTES`), not buffered blindly — these endpoints are untrusted, and `arrayBuffer()` would allocate everything before its length could be checked. Buffering is skipped for redirects (only inspected for `Location`), for statuses that cannot carry a body, and for any response whose body is not a real `ReadableStream`.
- `server/src/services/tool-access.ts`: the budget defaults to 30s and is overridable with `PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS`, parsed with the same positive-integer rule used for the `PAPERCLIP_MCP_GATEWAY_*_MS` settings.
- `server/src/__tests__/tool-access-service.test.ts`: two regression tests driving `apps/connect` — one against a host that only settles on abort, one against a host that sends headers and then stalls its body.
- `docs/deploy/environment-variables.md`: documented `PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS` and `PAPERCLIP_REMOTE_HTTP_MAX_RESPONSE_BYTES`.

## Verification

```sh
cd server
npx vitest run src/__tests__/tool-access-service.test.ts -t "never answers"
```

Run on Node 22.22.3. The test stubs `fetch` with a promise that resolves only on abort, so nothing except a timeout can end the call:

- Without the fix: the request never returns and vitest kills the test — `Error: Test timed out in 20000ms`.
- With the fix: passes, 2.54s of test time.

The test also asserts that every recorded `fetch` call carried an `AbortSignal`, which is what caught the scope problem described under Risks.

A second test covers a host that sends headers and then stalls its body:

```sh
npx vitest run src/__tests__/tool-access-service.test.ts -t "stalls its body"
```

- Without the body buffering: the API responds with `{"error":"The operation was aborted due to timeout"...}` — the raw abort text.
- With it: the failure reports `remote_http_timeout`, and the test passes in 2.33s.

Full suites for the touched service:

```sh
npx vitest run src/__tests__/tool-access-service.test.ts src/__tests__/tool-access-policy-service.test.ts
# Test Files 2 passed (2) | Tests 163 passed (163)
```

The tool gateway suite is green alongside them, since it shares the MCP response handling:

```sh
npx vitest run src/__tests__/tool-access-service.test.ts src/__tests__/tool-access-policy-service.test.ts \
  src/__tests__/tool-gateway-service.test.ts
# Test Files 3 passed (3) | Tests 180 passed (180)
```

`tsc --noEmit -p server/tsconfig.json` reports the same 139 pre-existing errors as clean `master`, none in `tool-access.ts`. They are all unresolved `@paperclipai/plugin-sdk` imports caused by workspace packages not being built locally.

## Risks

Low risk. No signature changes, and the SSRF guard is untouched — `assertRemoteHttpUrlAllowed` still runs on every hop before each request, and redirects are still resolved manually with the hop cap intact.

On scope, and why it is four call sites rather than one: the first version of this change bounded only `fetchRemoteHttpUrl`, and the regression test still hung. The `apps/connect` route's first request is the `remoteTools` probe, which is a separate `fetch`. Bounding the shared helper alone would have left the reachable route exactly as hangable, so all four sites are bounded here.

Behavioral changes worth naming:

- A remote MCP or OAuth request that legitimately takes longer than 30s now fails. `PAPERCLIP_REMOTE_HTTP_TIMEOUT_MS` raises the bound without a code change. 30s was chosen to be generous for a metadata, registration, token or `tools/list` call; a slow self-hosted provider is the case most likely to need the override.
- A timed-out request now surfaces as a 504 with code `remote_http_timeout`. Previously it surfaced as whatever the unwrapped `AbortError` produced, typically a 500, or — where the caller swallowed it — a misleading missing-field error.
- A remote response body over 4 MiB is now refused with `remote_http_response_too_large`. These are metadata, token and `tools/list` payloads, so this should be far above any legitimate response; `PAPERCLIP_REMOTE_HTTP_MAX_RESPONSE_BYTES` raises it.
- Response bodies are now buffered in the wrapper rather than streamed to the caller. Every existing caller already read the whole body via `.json()` or `.text()`, so nothing loses streaming it previously had.

`AbortSignal.any` requires Node 20+, which matches the `engines` field in `package.json`.

The size ceiling closes what was originally going to be a follow-up here. The same class of fix for the GitHub fetch path is in #11510.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5`, used via Claude Code with extended thinking and tool use (repository search, file editing, and local test execution). The fix and the test were produced with model assistance and verified locally by running the test suites and typechecker as described in Verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — both new variables are documented in `docs/deploy/environment-variables.md`
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — to be confirmed after CI runs
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — to be confirmed after review
- [x] I will address all Greptile and reviewer comments before requesting merge
