### PR TITLE
Fix issue document deep-link routing

### DIFF
--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -12,7 +12,7 @@ import type {
   WorkspaceRuntimeService,
 } from "@paperclipai/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue } from "@paperclipai/shared";
+import type { Issue, IssueDocument } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IssueProperties } from "./IssueProperties";
 import { queryKeys } from "../lib/queryKeys";
@@ -36,6 +36,8 @@ const mockIssuesApi = vi.hoisted(() => ({
   getDocument: vi.fn(),
   listAcceptedPlanDecompositions: vi.fn(),
   listAttachments: vi.fn(),
+  listDocuments: vi.fn(),
+  listWorkProducts: vi.fn(),
   listInteractions: vi.fn(),
   listLabels: vi.fn(),
   createLabel: vi.fn(),
@@ -153,6 +155,15 @@ vi.mock("@/lib/router", () => ({
 
 vi.mock("@/components/ui/separator", () => ({
   Separator: () => <hr />,
+}));
+
+vi.mock("@/components/MarkdownBody", () => ({
+  MarkdownBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/IssueDocumentAnnotations", () => ({
+  DocumentAnnotationsCountChip: ({ docKey }: { docKey: string }) => <span data-doc-key={docKey} />,
+  IssueDocumentAnnotations: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock("@/components/ui/popover", () => ({
@@ -458,6 +469,8 @@ describe("IssueProperties", () => {
     mockIssuesApi.getDocument.mockResolvedValue(null);
     mockIssuesApi.listAcceptedPlanDecompositions.mockResolvedValue([]);
     mockIssuesApi.listAttachments.mockResolvedValue([]);
+    mockIssuesApi.listDocuments.mockResolvedValue([]);
+    mockIssuesApi.listWorkProducts.mockResolvedValue([]);
     mockIssuesApi.listInteractions.mockResolvedValue([]);
     mockIssuesApi.listLabels.mockResolvedValue([]);
     mockIssuesApi.createLabel.mockResolvedValue(createLabel({
@@ -526,6 +539,76 @@ describe("IssueProperties", () => {
       expect(container.textContent).toContain("A plan confirmation is pending, but the plan document it should confirm is missing.");
     });
 
+    act(() => root.unmount());
+  });
+
+  it("overrides a previously selected pane tab for a document deep link", async () => {
+    const planDocument = {
+      id: "document-plan",
+      companyId: "company-1",
+      issueId: "issue-1",
+      key: "plan",
+      title: "Plan",
+      format: "markdown",
+      body: "Plan body",
+      latestRevisionId: "revision-plan",
+      latestRevisionNumber: 1,
+      createdByAgentId: null,
+      createdByUserId: null,
+      updatedByAgentId: null,
+      updatedByUserId: null,
+      lockedAt: null,
+      lockedByAgentId: null,
+      lockedByUserId: null,
+      createdAt: new Date("2026-08-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-08-01T00:00:00.000Z"),
+    } satisfies IssueDocument;
+    const artifactDocument = {
+      ...planDocument,
+      id: "document-evidence",
+      key: "qa-evidence",
+      title: "QA evidence",
+      body: "Evidence body",
+      latestRevisionId: "revision-evidence",
+    } satisfies IssueDocument;
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableTaskWatchdogs: false,
+      enableClassicTaskInterface: false,
+    });
+    mockIssuesApi.getDocument.mockResolvedValue(planDocument);
+    mockIssuesApi.listDocuments.mockResolvedValue([planDocument, artifactDocument]);
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const props = {
+      issue: createIssue(),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
+    } satisfies ComponentProps<typeof IssueProperties>;
+    const { root, queryClient } = renderPropertiesWithQueryClient(container, props);
+    await waitForAssertion(() => {
+      const planTab = Array.from(container.querySelectorAll("button"))
+        .find((button) => button.textContent === "Plan");
+      expect(planTab?.getAttribute("data-state")).toBe("active");
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueProperties
+            {...props}
+            documentDeepLink={{ tab: "artifacts", documentKey: "qa-evidence", requestId: 1 }}
+          />
+        </QueryClientProvider>,
+      );
+    });
+
+    await waitForAssertion(() => {
+      const artifactsTab = Array.from(container.querySelectorAll("button"))
+        .find((button) => button.textContent === "Artifacts");
+      expect(artifactsTab?.getAttribute("data-state")).toBe("active");
+      expect(container.querySelector('button[aria-expanded="true"]')).not.toBeNull();
+    });
     act(() => root.unmount());
   });
 

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -1,1 +1,1 @@
-export { IssueProperties } from "./issue-properties";
+export { IssueProperties, type IssuePropertiesDocumentDeepLink } from "./issue-properties";

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -148,6 +148,13 @@ interface IssuePropertiesProps {
   onRetryExternalObjects?: () => void;
   onCheckMonitorNow?: () => void;
   checkingMonitorNow?: boolean;
+  documentDeepLink?: IssuePropertiesDocumentDeepLink | null;
+}
+
+export interface IssuePropertiesDocumentDeepLink {
+  requestId: number;
+  tab: "plans" | "artifacts";
+  documentKey: string;
 }
 
 const ISSUE_BLOCKER_SEARCH_LIMIT = 50;
@@ -166,6 +173,7 @@ export function IssueProperties({
   onRetryExternalObjects,
   onCheckMonitorNow,
   checkingMonitorNow = false,
+  documentDeepLink,
 }: IssuePropertiesProps) {
   const { selectedCompanyId } = useCompany();
   const { isMobile } = useSidebar();
@@ -245,6 +253,11 @@ export function IssueProperties({
       setPaneTab("plans");
     }
   }, [hasPlanTab]);
+  useEffect(() => {
+    if (!documentDeepLink) return;
+    paneTabUserChosenRef.current = true;
+    setPaneTab(documentDeepLink.tab);
+  }, [documentDeepLink]);
   const [assigneeOpen, setAssigneeOpen] = useState(false);
   const [assigneeSearch, setAssigneeSearch] = useState("");
   /** When a run is live, a selection is staged here until the operator confirms
@@ -2655,7 +2668,10 @@ export function IssueProperties({
       ) : null}
       {hasArtifactsTab ? (
         <TabsContent value="artifacts">
-          <IssuePropertiesArtifactsTab issue={issue} />
+          <IssuePropertiesArtifactsTab
+            issue={issue}
+            documentDeepLink={documentDeepLink?.tab === "artifacts" ? documentDeepLink : null}
+          />
         </TabsContent>
       ) : null}
     </Tabs>

--- a/ui/src/components/issue-properties/IssuePropertiesArtifactsTab.tsx
+++ b/ui/src/components/issue-properties/IssuePropertiesArtifactsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Issue, IssueDocument, IssueWorkProduct } from "@paperclipai/shared";
@@ -31,6 +31,10 @@ import { useLocation } from "@/lib/router";
 
 interface IssuePropertiesArtifactsTabProps {
   issue: Issue;
+  documentDeepLink?: {
+    requestId: number;
+    documentKey: string;
+  } | null;
 }
 
 function formatBytes(n: number): string {
@@ -118,14 +122,31 @@ function WorkProductRow({ workProduct }: { workProduct: IssueWorkProduct }) {
   return <div className={ROW_CLASS}>{body}</div>;
 }
 
-function DocumentRow({ issueId, doc }: { issueId: string; doc: IssueDocument }) {
+function DocumentRow({
+  issueId,
+  doc,
+  openRequestId,
+}: {
+  issueId: string;
+  doc: IssueDocument;
+  openRequestId?: number;
+}) {
   const [expanded, setExpanded] = useState(false);
   const [annotationPanelOpen, setAnnotationPanelOpen] = useState(false);
+  const headerRef = useRef<HTMLDivElement | null>(null);
   const location = useLocation();
   const Chevron = expanded ? ChevronDown : ChevronRight;
+  useEffect(() => {
+    if (openRequestId === undefined) return;
+    setExpanded(true);
+  }, [openRequestId]);
+  useEffect(() => {
+    if (openRequestId === undefined || !expanded) return;
+    headerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [expanded, openRequestId]);
   return (
     <div className="rounded-md border border-border bg-card/50">
-      <div className="flex items-center hover:bg-accent/50">
+      <div ref={headerRef} className="flex items-center hover:bg-accent/50">
         <button
           type="button"
           onClick={() => setExpanded((open) => !open)}
@@ -182,7 +203,7 @@ function DocumentRow({ issueId, doc }: { issueId: string; doc: IssueDocument }) 
  * user uploads are excluded — those stay first-class in the conversation
  * thread.
  */
-export function IssuePropertiesArtifactsTab({ issue }: IssuePropertiesArtifactsTabProps) {
+export function IssuePropertiesArtifactsTab({ issue, documentDeepLink }: IssuePropertiesArtifactsTabProps) {
   const { data: attachments } = useQuery({
     queryKey: queryKeys.issues.attachments(issue.id),
     queryFn: () => issuesApi.listAttachments(issue.id),
@@ -225,7 +246,13 @@ export function IssuePropertiesArtifactsTab({ issue }: IssuePropertiesArtifactsT
           <ul className="flex flex-col gap-1">
             {documentRows.map((doc) => (
               <li key={doc.key}>
-                <DocumentRow issueId={issue.id} doc={doc} />
+                <DocumentRow
+                  issueId={issue.id}
+                  doc={doc}
+                  openRequestId={documentDeepLink?.documentKey === doc.key
+                    ? documentDeepLink.requestId
+                    : undefined}
+                />
               </li>
             ))}
           </ul>

--- a/ui/src/components/issue-properties/IssuePropertiesDocumentAnnotations.test.tsx
+++ b/ui/src/components/issue-properties/IssuePropertiesDocumentAnnotations.test.tsx
@@ -49,6 +49,7 @@ describe("issue properties document annotation mounting", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
+    Element.prototype.scrollIntoView = vi.fn();
   });
 
   afterEach(() => {
@@ -72,6 +73,36 @@ describe("issue properties document annotation mounting", () => {
     await act(async () => expand.click());
     expect(container.querySelector('[data-testid="annotation-surface-qa-evidence"]')?.getAttribute("data-document-id"))
       .toBe("document-1");
+    await act(async () => root.unmount());
+  });
+
+  it("expands and scrolls the requested document into view", async () => {
+    const root = createRoot(container);
+    await act(async () => root.render(
+      <IssuePropertiesArtifactsTab
+        issue={issue}
+        documentDeepLink={{ documentKey: "qa-evidence", requestId: 1 }}
+      />,
+    ));
+
+    expect(container.querySelector('button[aria-expanded="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="annotation-surface-qa-evidence"]')).not.toBeNull();
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    await act(async () => root.unmount());
+  });
+
+  it("does not expand an unrelated document when the requested key is missing", async () => {
+    const root = createRoot(container);
+    await act(async () => root.render(
+      <IssuePropertiesArtifactsTab
+        issue={issue}
+        documentDeepLink={{ documentKey: "deleted-document", requestId: 1 }}
+      />,
+    ));
+
+    expect(container.querySelector('button[aria-expanded="true"]')).toBeNull();
+    expect(container.querySelector('[data-testid="annotation-surface-qa-evidence"]')).toBeNull();
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
     await act(async () => root.unmount());
   });
 });

--- a/ui/src/components/issue-properties/index.ts
+++ b/ui/src/components/issue-properties/index.ts
@@ -1,4 +1,4 @@
-export { IssueProperties } from "./IssueProperties";
+export { IssueProperties, type IssuePropertiesDocumentDeepLink } from "./IssueProperties";
 export { ExternalObjectRows } from "./external-object-rows";
 export { PropertyPicker } from "./property-picker";
 export { PropertyChip, PropertyRow, PropertySection } from "./primitives";

--- a/ui/src/lib/document-annotation-hash.test.ts
+++ b/ui/src/lib/document-annotation-hash.test.ts
@@ -35,6 +35,10 @@ describe("parseDocumentAnnotationHash", () => {
       commentId: null,
     });
   });
+
+  it("returns null for a malformed encoded document key", () => {
+    expect(parseDocumentAnnotationHash("#document-%E0%A4%A")).toBeNull();
+  });
 });
 
 describe("buildDocumentAnnotationHash", () => {

--- a/ui/src/lib/document-annotation-hash.ts
+++ b/ui/src/lib/document-annotation-hash.ts
@@ -11,7 +11,13 @@ export function parseDocumentAnnotationHash(hash: string): DocumentAnnotationHas
   const stripped = hash.slice(DOCUMENT_HASH_PREFIX.length);
   const [rawKey, ...rest] = stripped.split("&");
   if (!rawKey) return null;
-  const documentKey = decodeURIComponent(rawKey);
+  let documentKey: string;
+  try {
+    documentKey = decodeURIComponent(rawKey);
+  } catch {
+    return null;
+  }
+  if (!documentKey) return null;
   const params = new URLSearchParams(rest.join("&"));
   const threadId = params.get("thread");
   const commentId = params.get("comment");

--- a/ui/src/lib/issue-document-deep-link.test.ts
+++ b/ui/src/lib/issue-document-deep-link.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveIssueDocumentDeepLink } from "./issue-document-deep-link";
+
+describe("resolveIssueDocumentDeepLink", () => {
+  it("preserves continuation-summary routing", () => {
+    expect(resolveIssueDocumentDeepLink("#document-continuation-summary")).toEqual({
+      kind: "continuation-summary",
+    });
+  });
+
+  it("routes plan to its dedicated pane tab", () => {
+    expect(resolveIssueDocumentDeepLink("#document-plan")).toEqual({
+      kind: "properties-pane",
+      tab: "plans",
+      documentKey: "plan",
+    });
+  });
+
+  it("routes ordinary and annotated documents to Artifacts", () => {
+    expect(resolveIssueDocumentDeepLink("#document-qa%20evidence&thread=thread-1")).toEqual({
+      kind: "properties-pane",
+      tab: "artifacts",
+      documentKey: "qa evidence",
+    });
+  });
+
+  it("ignores empty, unrelated, and malformed hashes", () => {
+    expect(resolveIssueDocumentDeepLink("#document-")).toBeNull();
+    expect(resolveIssueDocumentDeepLink("#work-product-1")).toBeNull();
+    expect(resolveIssueDocumentDeepLink("#document-%E0%A4%A")).toBeNull();
+  });
+});

--- a/ui/src/lib/issue-document-deep-link.ts
+++ b/ui/src/lib/issue-document-deep-link.ts
@@ -1,0 +1,26 @@
+import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
+import { parseDocumentAnnotationHash } from "./document-annotation-hash";
+
+export type IssueDocumentDeepLinkRoute =
+  | { kind: "continuation-summary" }
+  | { kind: "properties-pane"; tab: "plans"; documentKey: "plan" }
+  | { kind: "properties-pane"; tab: "artifacts"; documentKey: string };
+
+/**
+ * Maps an issue document hash to the surface that owns that document.
+ *
+ * The continuation summary remains in the activity/handoff surface, the plan
+ * keeps its dedicated pane tab, and every other document belongs to Artifacts.
+ */
+export function resolveIssueDocumentDeepLink(hash: string): IssueDocumentDeepLinkRoute | null {
+  const target = parseDocumentAnnotationHash(hash);
+  if (!target) return null;
+
+  if (target.documentKey === ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY) {
+    return { kind: "continuation-summary" };
+  }
+  if (target.documentKey === "plan") {
+    return { kind: "properties-pane", tab: "plans", documentKey: "plan" };
+  }
+  return { kind: "properties-pane", tab: "artifacts", documentKey: target.documentKey };
+}

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -1159,6 +1159,64 @@ describe("IssueDetail", () => {
     });
   });
 
+  it("leaves ordinary document links to the classic center-column surface", async () => {
+    mockPanelState.panelVisible = false;
+    mockLocation.hash = "#document-qa-evidence";
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIssuePlanDecompositions: false,
+      enableExperimentalFileViewer: false,
+      enableExternalObjects: false,
+      enableClassicTaskInterface: true,
+    });
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="issue-chat-thread"]')).not.toBeNull();
+      expect(mockSetPanelVisible).not.toHaveBeenCalled();
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect(panel?.props?.documentDeepLink).toBeNull();
+    });
+  });
+
+  it("clears document routing when the URL no longer names a document", async () => {
+    mockLocation.hash = "#document-qa-evidence";
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await waitForAssertion(() => {
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect(panel?.props?.documentDeepLink).toMatchObject({ documentKey: "qa-evidence" });
+    });
+
+    mockLocation.hash = "#work-product-1";
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+
+    await waitForAssertion(() => {
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect(panel?.props?.documentDeepLink).toBeNull();
+    });
+  });
+
   it("routes plan to the Plan pane tab and leaves continuation-summary on its existing surface", async () => {
     mockPanelState.panelVisible = false;
     mockLocation.hash = "#document-plan";

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -90,6 +90,10 @@ const mockLocation = vi.hoisted(() => ({
 }));
 const mockOpenPanel = vi.hoisted(() => vi.fn());
 const mockClosePanel = vi.hoisted(() => vi.fn());
+const mockSetPanelVisible = vi.hoisted(() => vi.fn());
+const mockPanelState = vi.hoisted(() => ({ panelVisible: true }));
+const mockSidebarState = vi.hoisted(() => ({ isMobile: false }));
+const mockIssuePropertiesRender = vi.hoisted(() => vi.fn());
 const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
 const mockSetMobileToolbar = vi.hoisted(() => vi.fn());
 const mockPushToast = vi.hoisted(() => vi.fn());
@@ -207,15 +211,13 @@ vi.mock("../context/PanelContext", () => ({
   usePanel: () => ({
     openPanel: mockOpenPanel,
     closePanel: mockClosePanel,
-    panelVisible: true,
-    setPanelVisible: vi.fn(),
+    panelVisible: mockPanelState.panelVisible,
+    setPanelVisible: mockSetPanelVisible,
   }),
 }));
 
 vi.mock("../context/SidebarContext", () => ({
-  useSidebar: () => ({
-    isMobile: false,
-  }),
+  useSidebar: () => mockSidebarState,
 }));
 
 vi.mock("../context/BreadcrumbContext", () => ({
@@ -365,7 +367,10 @@ vi.mock("../components/IssuesList", () => ({
 }));
 
 vi.mock("../components/IssueProperties", () => ({
-  IssueProperties: () => <div>Properties</div>,
+  IssueProperties: (props: unknown) => {
+    mockIssuePropertiesRender(props);
+    return <div>Properties</div>;
+  },
 }));
 
 vi.mock("../components/IssueRunLedger", () => ({
@@ -1022,6 +1027,8 @@ describe("IssueDetail", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    mockPanelState.panelVisible = true;
+    mockSidebarState.isMobile = false;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -1078,6 +1085,8 @@ describe("IssueDetail", () => {
     mockIssuesApi.getDocument.mockResolvedValue(null);
     mockOpenPanel.mockClear();
     mockClosePanel.mockClear();
+    mockSetPanelVisible.mockClear();
+    mockIssuePropertiesRender.mockClear();
     mockIssuesListRender.mockClear();
     mockIssueChatThreadRender.mockClear();
     mockImageGalleryRender.mockClear();
@@ -1125,6 +1134,114 @@ describe("IssueDetail", () => {
         String(call[0]).includes("React has detected a change in the order of Hooks"),
       ),
     ).toBe(false);
+  });
+
+  it("opens a closed desktop pane and routes an ordinary document to Artifacts on direct load", async () => {
+    mockPanelState.panelVisible = false;
+    mockLocation.hash = "#document-qa-evidence";
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+
+    await waitForAssertion(() => {
+      expect(mockSetPanelVisible).toHaveBeenCalledWith(true);
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect(panel?.props?.documentDeepLink).toMatchObject({
+        tab: "artifacts",
+        documentKey: "qa-evidence",
+      });
+    });
+  });
+
+  it("routes plan to the Plan pane tab and leaves continuation-summary on its existing surface", async () => {
+    mockPanelState.panelVisible = false;
+    mockLocation.hash = "#document-plan";
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await waitForAssertion(() => {
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect(panel?.props?.documentDeepLink).toMatchObject({ tab: "plans", documentKey: "plan" });
+    });
+
+    mockSetPanelVisible.mockClear();
+    mockLocation.hash = "#document-continuation-summary";
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    expect(mockSetPanelVisible).not.toHaveBeenCalled();
+    await waitForAssertion(() => {
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect(panel?.props?.documentDeepLink).toBeNull();
+    });
+  });
+
+  it("replays document routing when the current same-page hash is clicked again", async () => {
+    mockLocation.hash = "#document-qa-evidence";
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await waitForAssertion(() => {
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect((panel?.props?.documentDeepLink as { requestId?: number } | null)?.requestId).toBe(1);
+    });
+
+    const link = document.createElement("a");
+    link.href = "#document-qa-evidence";
+    link.textContent = "QA evidence";
+    container.appendChild(link);
+    await act(async () => link.click());
+
+    await waitForAssertion(() => {
+      const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+      expect((panel?.props?.documentDeepLink as { requestId?: number } | null)?.requestId).toBe(2);
+    });
+  });
+
+  it("opens the mobile properties sheet for a document deep link", async () => {
+    mockSidebarState.isMobile = true;
+    mockLocation.hash = "#document-qa-evidence";
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+
+    await waitForAssertion(() => {
+      expect(mockIssuePropertiesRender).toHaveBeenCalledWith(expect.objectContaining({
+        inline: true,
+        documentDeepLink: expect.objectContaining({
+          tab: "artifacts",
+          documentKey: "qa-evidence",
+        }),
+      }));
+    });
+    expect(mockSetPanelVisible).not.toHaveBeenCalled();
   });
 
   it("renders the full sub-task tree below the title in the chat center pane", async () => {

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -130,7 +130,7 @@ import {
   hasVisibleMonitorSurface,
 } from "../components/IssueMonitorBanner";
 import { IssueScheduledRetryCard } from "../components/IssueScheduledRetryCard";
-import { IssueProperties } from "../components/IssueProperties";
+import { IssueProperties, type IssuePropertiesDocumentDeepLink } from "../components/IssueProperties";
 import { PauseAffectsSummaryView } from "../components/interrupt-handoff/InterruptHandoffViews";
 import { computePauseAffectsSummary } from "../lib/interrupt-handoff";
 import { useIssueExternalObjects } from "../hooks/useIssueExternalObjects";
@@ -171,6 +171,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { formatIssueActivityAction } from "@/lib/activity-format";
 import { copyTextToClipboard } from "../lib/clipboard";
 import { buildIssuePropertiesPanelKey } from "../lib/issue-properties-panel-key";
+import { resolveIssueDocumentDeepLink } from "../lib/issue-document-deep-link";
 import { buildIssueSiblingNavigation, shouldRenderRichSubIssuesSection } from "../lib/issue-detail-subissues";
 import { filterIssueDescendants } from "../lib/issue-tree";
 import { buildSubIssueDefaultsForViewer } from "../lib/subIssueDefaults";
@@ -1718,6 +1719,9 @@ export function IssueDetail() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
+  const [documentDeepLink, setDocumentDeepLink] = useState<
+    (IssuePropertiesDocumentDeepLink & { issueId: string }) | null
+  >(null);
   const [fileViewerPromptOpen, setFileViewerPromptOpen] = useState(false);
   const [detailTab, setDetailTab] = useState("chat");
   // Redesign: the center tab strip is hidden, so chat is the only surface —
@@ -3508,6 +3512,7 @@ export function IssueDetail() {
         onRetryExternalObjects={externalObjectsState.isEnabled ? externalObjectsState.refetch : undefined}
         onCheckMonitorNow={() => checkIssueMonitorNow.mutate()}
         checkingMonitorNow={checkIssueMonitorNow.isPending}
+        documentDeepLink={documentDeepLink?.issueId === panelIssue.id ? documentDeepLink : null}
       />
     );
     return () => closePanel();
@@ -3528,6 +3533,7 @@ export function IssueDetail() {
     externalObjectsState.isLoading,
     externalObjectsState.isError,
     externalObjectsState.refetch,
+    documentDeepLink,
   ]);
 
   const goToInboxShortcutArmedRef = useRef(false);
@@ -3655,14 +3661,67 @@ export function IssueDetail() {
     };
   }, [fileViewerEnabled, keyboardShortcutsEnabled, navigate, sourceBreadcrumb.href]);
 
+  const routeIssueDocumentDeepLink = useCallback((hash: string) => {
+    const route = resolveIssueDocumentDeepLink(hash);
+    if (!route) return false;
+
+    if (route.kind === "continuation-summary") {
+      setDocumentDeepLink(null);
+      setDetailTab("activity");
+      setHandoffFocusSignal((current) => current + 1);
+      return true;
+    }
+
+    if (isMobile) {
+      setMobilePropsOpen(true);
+    } else {
+      if (suppressPanelForFirstTask && issue?.id) {
+        setFirstTaskPanelOverrideIssueId(issue.id);
+      }
+      setPanelVisible(true);
+    }
+    const targetIssueId = issue?.id ?? issueId ?? "";
+    setDocumentDeepLink((current) => ({
+      issueId: targetIssueId,
+      tab: route.tab,
+      documentKey: route.documentKey,
+      requestId: current?.issueId === targetIssueId ? current.requestId + 1 : 1,
+    }));
+    return true;
+  }, [isMobile, issue?.id, issueId, setPanelVisible, suppressPanelForFirstTask]);
+
   useEffect(() => {
-    const hash = location.hash;
-    if (!hash.startsWith("#document-")) return;
-    const documentKey = decodeURIComponent(hash.slice("#document-".length));
-    if (documentKey !== ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY) return;
-    setDetailTab("activity");
-    setHandoffFocusSignal((current) => current + 1);
-  }, [location.hash]);
+    routeIssueDocumentDeepLink(location.hash);
+  }, [issueId, location.hash, routeIssueDocumentDeepLink]);
+
+  // React Router does not emit a location update when the user clicks a link
+  // whose hash is already current. Capture that repeated intent so a manually
+  // collapsed document reopens and scrolls back into view.
+  useEffect(() => {
+    const handleSameHashDocumentClick = (event: MouseEvent) => {
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const anchor = target.closest<HTMLAnchorElement>("a[href]");
+      if (!anchor) return;
+      const rawHref = anchor.getAttribute("href");
+      if (!rawHref) return;
+
+      let targetUrl: URL;
+      try {
+        targetUrl = new URL(rawHref, window.location.href);
+      } catch {
+        return;
+      }
+      const sameIssue = rawHref.startsWith("#")
+        || (targetUrl.pathname === location.pathname && targetUrl.search === location.search);
+      if (!sameIssue || targetUrl.hash !== location.hash) return;
+      routeIssueDocumentDeepLink(targetUrl.hash);
+    };
+
+    document.addEventListener("click", handleSameHashDocumentClick, true);
+    return () => document.removeEventListener("click", handleSameHashDocumentClick, true);
+  }, [location.hash, location.pathname, location.search, routeIssueDocumentDeepLink]);
 
   // Scroll + briefly highlight work-product / direct-attachment anchors so the
   // company Artifacts page (PAP-10359) can deep-link to a specific artifact in
@@ -5519,6 +5578,7 @@ export function IssueDetail() {
                 onRetryExternalObjects={externalObjectsState.isEnabled ? externalObjectsState.refetch : undefined}
                 onCheckMonitorNow={() => checkIssueMonitorNow.mutate()}
                 checkingMonitorNow={checkIssueMonitorNow.isPending}
+                documentDeepLink={documentDeepLink?.issueId === issue.id ? documentDeepLink : null}
               />
             </div>
           </ScrollArea>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1699,7 +1699,10 @@ export function IssueDetail() {
   // legacy title/description block, sub-tasks table, plan decompositions and
   // Documents section are gated off (plan lives in the properties-pane Plan
   // tab). Flag ON restores the legacy page.
-  const { enabled: classicTaskInterfaceEnabled } = useClassicTaskInterfaceEnabled();
+  const {
+    enabled: classicTaskInterfaceEnabled,
+    loaded: classicTaskInterfaceLoaded,
+  } = useClassicTaskInterfaceEnabled();
   const taskChatShellEnabled = !classicTaskInterfaceEnabled;
   // Chat-style: the page wrapper spans the full center pane so the thread's
   // scroll viewport (and its scrollbar) reaches the properties-pane border;
@@ -3672,6 +3675,10 @@ export function IssueDetail() {
       return true;
     }
 
+    // The classic interface owns document links in its center-column
+    // Documents section. Do not open its tab-less properties panel.
+    if (!classicTaskInterfaceLoaded || !taskChatShellEnabled) return false;
+
     if (isMobile) {
       setMobilePropsOpen(true);
     } else {
@@ -3688,10 +3695,20 @@ export function IssueDetail() {
       requestId: current?.issueId === targetIssueId ? current.requestId + 1 : 1,
     }));
     return true;
-  }, [isMobile, issue?.id, issueId, setPanelVisible, suppressPanelForFirstTask]);
+  }, [
+    classicTaskInterfaceLoaded,
+    isMobile,
+    issue?.id,
+    issueId,
+    setPanelVisible,
+    suppressPanelForFirstTask,
+    taskChatShellEnabled,
+  ]);
 
   useEffect(() => {
-    routeIssueDocumentDeepLink(location.hash);
+    if (!routeIssueDocumentDeepLink(location.hash)) {
+      setDocumentDeepLink(null);
+    }
   }, [issueId, location.hash, routeIssueDocumentDeepLink]);
 
   // React Router does not emit a location update when the user clicks a link


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue page shows task conversation, plans, and artifacts
> - Document links changed the URL but did not open the surface that owned the document
> - Users could not reach linked plans or artifacts when the properties pane was closed or on another tab
> - This pull request adds one routing contract for issue document links
> - The benefit is that each valid link opens the correct surface and exposes the exact document

## Linked Issues or Issue Description

**What happened?**

Issue document links only changed the URL hash. They did not open the properties pane, select the correct tab, expand the target document, or scroll it into view.

**Expected behavior**

Plan links must open the Plan tab. Other document links must open the Artifacts tab and expose the exact document. Continuation summary links must keep their existing activity behavior.

**Steps to reproduce**

1. Open an issue in the chat-style task interface.
2. Close the properties pane.
3. Select a document link in the conversation.
4. Observe that the pane stays closed.
5. Open the pane on the Plan tab and select the link again.
6. Observe that the named artifact does not open.

**Paperclip version or commit**

The bug reproduced on `1a17cbf232d40dbaca3262720c39a4c0f225ddea`.

**Deployment mode**

Local development build from source.

## What Changed

- Added an explicit route resolver for plan, artifact, and continuation summary document hashes.
- Opened the desktop properties pane or mobile properties sheet for linked documents.
- Selected the owning tab and passed repeated link intent to the artifact list.
- Expanded the exact document and scrolled its header into view.
- Ignored malformed and missing document targets without opening another document.
- Left classic-interface document links on their existing center-column surface.
- Cleared stale document routing when the URL no longer names a document.
- Added focused tests for direct loads, clicks, closed panes, wrong tabs, classic mode, mobile, missing keys, and continuation summary behavior.

## Verification

- `pnpm exec vitest run ui/src/lib/document-annotation-hash.test.ts ui/src/lib/issue-document-deep-link.test.ts ui/src/pages/IssueDetail.test.tsx ui/src/components/IssueProperties.test.tsx ui/src/components/issue-properties/IssuePropertiesDocumentAnnotations.test.tsx` passed: 133 tests.
- `pnpm --filter @paperclipai/ui typecheck` passed.
- `pnpm check:token-gates` passed all four gates.
- `pnpm build` passed.
- Manual desktop checks covered direct load, a closed pane, the wrong starting tab, a repeated same-hash click, and a missing key.
- Manual mobile checks confirmed that the properties sheet opened with Artifacts active and the target row expanded.
- The repository test command passed 4,006 tests. It also reported 27 unrelated macOS failures in server runtime tests. The failures came from `/tmp` path aliases and generated ports above 65,535. The pull request CI runs those suites on Linux.

### Visual evidence

The crops hide task content and show only the affected surface.

| Closed pane before | Same link after |
| --- | --- |
| ![The right-side region is empty before the link opens the properties pane](https://gist.githubusercontent.com/nguyenm7/419ddfe93206d9242da2071dd70a9780/raw/9ecb08f8b0aba13923180289bd02c059512709f8/closed-pane-before.png) | ![The Artifacts tab is active and the target row is expanded](https://gist.githubusercontent.com/nguyenm7/419ddfe93206d9242da2071dd70a9780/raw/9ecb08f8b0aba13923180289bd02c059512709f8/closed-pane-after.png) |

Mobile edge case:

![The mobile properties sheet is open with Artifacts active and the target row expanded](https://gist.githubusercontent.com/nguyenm7/419ddfe93206d9242da2071dd70a9780/raw/9ecb08f8b0aba13923180289bd02c059512709f8/mobile-after.png)

Visual baselines were not updated because this change does not change component styling.

## Risks

- Low risk. The change only handles issue document hashes.
- A missing document still opens the Artifacts surface when that surface exists. It does not expand another row.
- Work product and attachment hash behavior is unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex `gpt-5.6-sol`, 272k context window, high reasoning mode, tool use, code execution, and browser automation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge