### PR TITLE
fix(activity): apply since/until bounds and offset paging to company activity

### DIFF
--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -29,6 +29,10 @@ so `?since=2026-08-10&until=2026-08-16` returns those seven full days. Any
 other format returns `400` rather than being ignored — the endpoint will not
 silently widen a bounded query back to "everything".
 
+A date that does not exist on the calendar, such as `2026-02-31` or
+`2027-02-29`, also returns `400`. It is not rolled forward to the next real
+day, because that would answer a different question than the one asked.
+
 Records come back newest-first, ordered by `createdAt` then `id`. The `id`
 tiebreaker makes a given `(limit, offset)` pair address a stable row, so
 paging through a window will not skip or repeat records when several share a

--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -18,6 +18,32 @@ Query parameters:
 | `agentId` | Filter by actor agent |
 | `entityType` | Filter by entity type (`issue`, `agent`, `approval`) |
 | `entityId` | Filter by specific entity |
+| `since` | ISO-8601 timestamp; only records with `createdAt >= since` (inclusive) |
+| `until` | ISO-8601 timestamp; only records with `createdAt <= until` (inclusive) |
+| `limit` | Page size, 1–1000 (default 100). Out-of-range values are clamped, not rejected |
+| `offset` | Rows to skip for pagination (default 0) |
+
+An unparseable `since`/`until` returns `400` rather than being ignored.
+
+Records come back newest-first, ordered by `createdAt` then `id`. The `id`
+tiebreaker makes a given `(limit, offset)` pair address a stable row, so
+paging through a window will not skip or repeat records when several share a
+timestamp.
+
+To pull a full window larger than one page, walk `offset` until a page comes
+back short:
+
+```bash
+OFFSET=0
+while :; do
+  PAGE=$(curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+    "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/activity?since=2026-08-10T00:00:00Z&until=2026-08-17T00:00:00Z&limit=1000&offset=$OFFSET")
+  COUNT=$(printf '%s' "$PAGE" | jq 'length')
+  printf '%s' "$PAGE" | jq -c '.[]'
+  [ "$COUNT" -lt 1000 ] && break
+  OFFSET=$((OFFSET + 1000))
+done
+```
 
 ## Activity Record
 

--- a/docs/api/activity.md
+++ b/docs/api/activity.md
@@ -18,20 +18,33 @@ Query parameters:
 | `agentId` | Filter by actor agent |
 | `entityType` | Filter by entity type (`issue`, `agent`, `approval`) |
 | `entityId` | Filter by specific entity |
-| `since` | ISO-8601 timestamp; only records with `createdAt >= since` (inclusive) |
-| `until` | ISO-8601 timestamp; only records with `createdAt <= until` (inclusive) |
+| `since` | ISO-8601 bound; only records with `createdAt >= since` (inclusive) |
+| `until` | ISO-8601 bound; only records with `createdAt <= until` (inclusive) |
 | `limit` | Page size, 1–1000 (default 100). Out-of-range values are clamped, not rejected |
 | `offset` | Rows to skip for pagination (default 0) |
 
-An unparseable `since`/`until` returns `400` rather than being ignored.
+`since` and `until` accept a date-time (`2026-08-10T00:00:00Z`, offsets
+allowed) or a bare date (`2026-08-10`). A bare date covers that whole UTC day,
+so `?since=2026-08-10&until=2026-08-16` returns those seven full days. Any
+other format returns `400` rather than being ignored — the endpoint will not
+silently widen a bounded query back to "everything".
 
 Records come back newest-first, ordered by `createdAt` then `id`. The `id`
 tiebreaker makes a given `(limit, offset)` pair address a stable row, so
 paging through a window will not skip or repeat records when several share a
 timestamp.
 
-To pull a full window larger than one page, walk `offset` until a page comes
-back short:
+### Paging a window
+
+Always pass `until` when you page. Each request re-runs the query, so `offset`
+is only meaningful against a result set that cannot change between requests.
+Records are written with `createdAt` set to the present, and rows are returned
+newest-first, so a pinned `until` in the past freezes the result set: anything
+written mid-sweep sorts after `until` and is excluded. Without `until`, a
+concurrent write shifts every later row by one position and the sweep repeats
+records.
+
+Pin `until`, then walk `offset` until a page comes back short:
 
 ```bash
 OFFSET=0

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -310,6 +310,18 @@ describe.sequential("activity routes", () => {
     ["2026/08/10", "host-specific format, no zone"],
     ["2026-08-10T00:00:00", "ISO shape but no zone, so locale-dependent"],
     ["1786060800000", "epoch millis, not ISO-8601"],
+    // `new Date()` rolls these forward rather than failing — "2026-02-31"
+    // becomes March 3 — so a shape-only check would accept a window the caller
+    // never asked for. The date-time forms matter too: Zod's `.datetime()`
+    // validates format, not calendar validity.
+    ["2026-02-31", "ISO shape, impossible day"],
+    ["2026-02-31T00:00:00Z", "impossible day in a date-time"],
+    ["2026-02-31T00:00:00+05:00", "impossible day with an offset"],
+    ["2027-02-29", "Feb 29 in a non-leap year"],
+    ["2026-13-01", "month 13"],
+    ["2026-04-31", "April has 30 days"],
+    ["2026-00-10", "month 0"],
+    ["2026-08-00", "day 0"],
   ])("rejects since=%s (%s) instead of silently ignoring it", async (raw) => {
     mockActivityService.list.mockResolvedValue([]);
 
@@ -320,6 +332,25 @@ describe.sequential("activity routes", () => {
 
     expect(res.status).toBe(400);
     expect(mockActivityService.list).not.toHaveBeenCalled();
+  });
+
+  // The guard rejects impossible days, so prove it does not also reject real
+  // ones — Feb 29 in a leap year is the case a naive 28-day rule breaks.
+  it.each([
+    ["2028-02-29", new Date("2028-02-29T00:00:00.000Z")],
+    ["2026-01-31", new Date("2026-01-31T00:00:00.000Z")],
+    ["2028-02-29T06:30:00Z", new Date("2028-02-29T06:30:00.000Z")],
+    ["2026-08-10T00:00:00+05:00", new Date("2026-08-09T19:00:00.000Z")],
+  ])("accepts the real date %s", async (raw, expected) => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/company-1/activity?since=${encodeURIComponent(raw)}`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockActivityService.list).toHaveBeenCalledWith(expect.objectContaining({ since: expected }));
   });
 
   it("widens a bare date bound to cover that whole UTC day", async () => {

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -251,7 +251,7 @@ describe.sequential("activity routes", () => {
     });
   });
 
-  it("forwards since/until/offset to the activity query (BRO-2207)", async () => {
+  it("forwards since/until/offset to the activity query", async () => {
     mockActivityService.list.mockResolvedValue([]);
 
     const app = await createApp();
@@ -274,9 +274,9 @@ describe.sequential("activity routes", () => {
     });
   });
 
-  // Category safeguard for BRO-2207: the underlying defect was a query param
-  // the route accepted and then silently dropped, so a bounded query quietly
-  // returned unbounded data. Any param documented in docs/api/activity.md must
+  // Category safeguard: the underlying defect was a query param the route
+  // accepted and then silently dropped, so a bounded query quietly returned
+  // unbounded data. Any param documented in docs/api/activity.md must
   // demonstrably reach the service layer.
   it.each([
     ["agentId", "agent-9", "agentId", "agent-9"],
@@ -300,16 +300,45 @@ describe.sequential("activity routes", () => {
     );
   });
 
-  it("rejects a malformed since bound instead of silently ignoring it", async () => {
+  // `new Date(string)` accepts each of these, and resolves the ones without a
+  // zone against the server's local timezone — so the same request would
+  // select a different window depending on where it ran. Rejecting beats
+  // quietly answering a question the caller did not ask.
+  it.each([
+    ["last-tuesday", "not a date at all"],
+    ["Aug 10 2026", "host-specific format, no zone"],
+    ["2026/08/10", "host-specific format, no zone"],
+    ["2026-08-10T00:00:00", "ISO shape but no zone, so locale-dependent"],
+    ["1786060800000", "epoch millis, not ISO-8601"],
+  ])("rejects since=%s (%s) instead of silently ignoring it", async (raw) => {
     mockActivityService.list.mockResolvedValue([]);
 
     const app = await createApp();
     const res = await requestApp(app, (baseUrl) =>
-      request(baseUrl).get("/api/companies/company-1/activity?since=last-tuesday"),
+      request(baseUrl).get(`/api/companies/company-1/activity?since=${encodeURIComponent(raw)}`),
     );
 
     expect(res.status).toBe(400);
     expect(mockActivityService.list).not.toHaveBeenCalled();
+  });
+
+  it("widens a bare date bound to cover that whole UTC day", async () => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/companies/company-1/activity?since=2026-08-10&until=2026-08-16"),
+    );
+
+    expect(res.status).toBe(200);
+    // `until` lands at end-of-day, not midnight: `since=2026-08-10&until=2026-08-16`
+    // has to mean seven full days, otherwise the last day is silently dropped.
+    expect(mockActivityService.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        since: new Date("2026-08-10T00:00:00.000Z"),
+        until: new Date("2026-08-16T23:59:59.999Z"),
+      }),
+    );
   });
 
   it("resolves alphanumeric issue identifiers before loading runs", async () => {

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -30,9 +30,14 @@ const mockAgentActionAuditService = vi.hoisted(() => ({
 
 vi.mock("../services/activity.js", () => ({
   activityService: () => mockActivityService,
+  MAX_ACTIVITY_LIMIT: 1000,
   normalizeActivityLimit: (limit: number | undefined) => {
     if (!Number.isFinite(limit)) return 100;
-    return Math.max(1, Math.min(500, Math.floor(limit ?? 100)));
+    return Math.max(1, Math.min(1000, Math.floor(limit ?? 100)));
+  },
+  normalizeActivityOffset: (offset: number | undefined) => {
+    if (!Number.isFinite(offset)) return 0;
+    return Math.max(0, Math.floor(offset ?? 0));
   },
 }));
 
@@ -218,7 +223,10 @@ describe.sequential("activity routes", () => {
       agentId: undefined,
       entityType: undefined,
       entityId: undefined,
+      since: undefined,
+      until: undefined,
       limit: 100,
+      offset: 0,
     });
   });
 
@@ -236,8 +244,72 @@ describe.sequential("activity routes", () => {
       agentId: undefined,
       entityType: "issue",
       entityId: undefined,
-      limit: 500,
+      since: undefined,
+      until: undefined,
+      limit: 1000,
+      offset: 0,
     });
+  });
+
+  it("forwards since/until/offset to the activity query (BRO-2207)", async () => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(
+        "/api/companies/company-1/activity?since=2026-08-10T00:00:00Z&until=2026-08-17T00:00:00Z&limit=1000&offset=250",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockActivityService.list).toHaveBeenCalledWith({
+      companyId: "company-1",
+      agentId: undefined,
+      entityType: undefined,
+      entityId: undefined,
+      since: new Date("2026-08-10T00:00:00.000Z"),
+      until: new Date("2026-08-17T00:00:00.000Z"),
+      limit: 1000,
+      offset: 250,
+    });
+  });
+
+  // Category safeguard for BRO-2207: the underlying defect was a query param
+  // the route accepted and then silently dropped, so a bounded query quietly
+  // returned unbounded data. Any param documented in docs/api/activity.md must
+  // demonstrably reach the service layer.
+  it.each([
+    ["agentId", "agent-9", "agentId", "agent-9"],
+    ["entityType", "issue", "entityType", "issue"],
+    ["entityId", "issue-9", "entityId", "issue-9"],
+    ["since", "2026-08-10T00:00:00Z", "since", new Date("2026-08-10T00:00:00.000Z")],
+    ["until", "2026-08-17T00:00:00Z", "until", new Date("2026-08-17T00:00:00.000Z")],
+    ["limit", "250", "limit", 250],
+    ["offset", "40", "offset", 40],
+  ])("forwards the %s query param to the activity service", async (param, raw, key, expected) => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/company-1/activity?${param}=${encodeURIComponent(raw)}`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockActivityService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ [key]: expected }),
+    );
+  });
+
+  it("rejects a malformed since bound instead of silently ignoring it", async () => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const app = await createApp();
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/companies/company-1/activity?since=last-tuesday"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockActivityService.list).not.toHaveBeenCalled();
   });
 
   it("resolves alphanumeric issue identifiers before loading runs", async () => {

--- a/server/src/__tests__/activity-service.test.ts
+++ b/server/src/__tests__/activity-service.test.ts
@@ -117,7 +117,7 @@ describeEmbeddedPostgres("activity service", () => {
     expect(result.map((event) => event.action)).toEqual(["test.newest", "test.middle"]);
   });
 
-  describe("date-windowed company activity (BRO-2207)", () => {
+  describe("date-windowed company activity", () => {
     async function seedWindowCompany() {
       const companyId = randomUUID();
 
@@ -182,8 +182,8 @@ describeEmbeddedPostgres("activity service", () => {
         requireBoardApprovalForNewAgents: false,
       });
 
-      // Must exceed the old 500 cap, otherwise clamping is invisible: the
-      // weekly founder-leverage report asks for limit=1000 and used to get 500.
+      // Must exceed the old 500 cap, otherwise clamping is invisible: a caller
+      // asking for limit=1000 used to get 500 with no indication of truncation.
       await db.insert(activityLog).values(
         Array.from({ length: 600 }, (_, i) => ({
           companyId,
@@ -252,6 +252,48 @@ describeEmbeddedPostgres("activity service", () => {
       // Without the id tiebreaker, equal-timestamp rows can reorder between
       // queries and a paginated sweep silently loses records.
       expect(new Set(paged).size).toBe(10);
+    });
+
+    it("keeps a pinned-until sweep stable while new activity is written", async () => {
+      const companyId = await seedWindowCompany();
+      const svc = activityService(db);
+      const filters = {
+        companyId,
+        since: new Date("2026-08-10T00:00:00.000Z"),
+        until: new Date("2026-08-17T00:00:00.000Z"),
+      };
+
+      // Offset paging is only sound against a result set that cannot change
+      // between requests. `until` is what supplies that: records are written
+      // with createdAt at the present, so a bound in the past excludes them and
+      // the sweep sees a frozen window. Interleave writes to prove it — without
+      // `until`, each insert shifts every later row by one and the sweep
+      // repeats records.
+      const paged: string[] = [];
+      for (let offset = 0; offset < 9; offset += 3) {
+        await db.insert(activityLog).values({
+          companyId,
+          actorType: "system" as const,
+          actorId: "system",
+          action: `test.concurrent${offset}`,
+          entityType: "company",
+          entityId: companyId,
+          createdAt: new Date("2026-08-20T12:00:00.000Z"),
+        });
+
+        const page = await svc.list({ ...filters, limit: 3, offset });
+        paged.push(...page.map((e) => e.action));
+      }
+
+      expect(paged).toEqual([
+        "test.aug16",
+        "test.aug15",
+        "test.aug14",
+        "test.aug13",
+        "test.aug12",
+        "test.aug11",
+        "test.aug10",
+      ]);
     });
   });
 

--- a/server/src/__tests__/activity-service.test.ts
+++ b/server/src/__tests__/activity-service.test.ts
@@ -17,7 +17,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { activityService } from "../services/activity.ts";
+import { activityService, normalizeActivityLimit } from "../services/activity.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -115,6 +115,144 @@ describeEmbeddedPostgres("activity service", () => {
     const result = await activityService(db).list({ companyId, limit: 2 });
 
     expect(result.map((event) => event.action)).toEqual(["test.newest", "test.middle"]);
+  });
+
+  describe("date-windowed company activity (BRO-2207)", () => {
+    async function seedWindowCompany() {
+      const companyId = randomUUID();
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      // One event per day across Aug 8 - Aug 18, so a 7-day window has a
+      // strictly smaller answer than "the most recent N rows".
+      await db.insert(activityLog).values(
+        Array.from({ length: 11 }, (_, i) => {
+          const day = String(8 + i).padStart(2, "0");
+          return {
+            companyId,
+            actorType: "system" as const,
+            actorId: "system",
+            action: `test.aug${day}`,
+            entityType: "company",
+            entityId: companyId,
+            createdAt: new Date(`2026-08-${day}T12:00:00.000Z`),
+          };
+        }),
+      );
+
+      return companyId;
+    }
+
+    it("applies since/until as inclusive bounds rather than ignoring them", async () => {
+      const companyId = await seedWindowCompany();
+
+      const result = await activityService(db).list({
+        companyId,
+        since: new Date("2026-08-10T00:00:00.000Z"),
+        until: new Date("2026-08-17T00:00:00.000Z"),
+        limit: 1000,
+      });
+
+      // Aug 17's event is at 12:00, past the 00:00 upper bound, so the window
+      // is Aug 10-16 inclusive: the regression returned the newest rows
+      // (through Aug 18) regardless of the bounds.
+      expect(result.map((event) => event.action)).toEqual([
+        "test.aug16",
+        "test.aug15",
+        "test.aug14",
+        "test.aug13",
+        "test.aug12",
+        "test.aug11",
+        "test.aug10",
+      ]);
+    });
+
+    it("honors a limit above the old 500-row cap", async () => {
+      const companyId = randomUUID();
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      // Must exceed the old 500 cap, otherwise clamping is invisible: the
+      // weekly founder-leverage report asks for limit=1000 and used to get 500.
+      await db.insert(activityLog).values(
+        Array.from({ length: 600 }, (_, i) => ({
+          companyId,
+          actorType: "system" as const,
+          actorId: "system",
+          action: `test.bulk${i}`,
+          entityType: "company",
+          entityId: companyId,
+          createdAt: new Date(Date.UTC(2026, 7, 12, 0, 0, 0, i)),
+        })),
+      );
+
+      expect(normalizeActivityLimit(1000)).toBe(1000);
+      const result = await activityService(db).list({ companyId, limit: 1000 });
+      expect(result).toHaveLength(600);
+    });
+
+    it("pages through a window with offset without repeating or dropping rows", async () => {
+      const companyId = await seedWindowCompany();
+      const svc = activityService(db);
+      const filters = {
+        companyId,
+        since: new Date("2026-08-10T00:00:00.000Z"),
+        until: new Date("2026-08-17T00:00:00.000Z"),
+      };
+
+      const firstPage = await svc.list({ ...filters, limit: 3, offset: 0 });
+      const secondPage = await svc.list({ ...filters, limit: 3, offset: 3 });
+      const thirdPage = await svc.list({ ...filters, limit: 3, offset: 6 });
+
+      expect(firstPage.map((e) => e.action)).toEqual(["test.aug16", "test.aug15", "test.aug14"]);
+      expect(secondPage.map((e) => e.action)).toEqual(["test.aug13", "test.aug12", "test.aug11"]);
+      expect(thirdPage.map((e) => e.action)).toEqual(["test.aug10"]);
+    });
+
+    it("keeps offset paging stable when rows share a createdAt", async () => {
+      const companyId = randomUUID();
+      const sameInstant = new Date("2026-08-12T12:00:00.000Z");
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(activityLog).values(
+        Array.from({ length: 10 }, (_, i) => ({
+          companyId,
+          actorType: "system" as const,
+          actorId: "system",
+          action: `test.tie${i}`,
+          entityType: "company",
+          entityId: companyId,
+          createdAt: sameInstant,
+        })),
+      );
+
+      const svc = activityService(db);
+      const paged: string[] = [];
+      for (let offset = 0; offset < 10; offset += 2) {
+        const page = await svc.list({ companyId, limit: 2, offset });
+        paged.push(...page.map((e) => e.action));
+      }
+
+      // Without the id tiebreaker, equal-timestamp rows can reorder between
+      // queries and a paginated sweep silently loses records.
+      expect(new Set(paged).size).toBe(10);
+    });
   });
 
   it("returns compact usage and result summaries for issue runs", async () => {

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { Db } from "@paperclipai/db";
 import { normalizeIssueIdentifier } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
-import { activityService, normalizeActivityLimit } from "../services/activity.js";
+import { activityService, normalizeActivityLimit, normalizeActivityOffset } from "../services/activity.js";
 import { assertAuthenticated, assertBoard, assertCompanyAccess, getAccessibleResource, hasCompanyAccess } from "./authz.js";
 import { accessService, heartbeatService, issueService } from "../services/index.js";
 import { sanitizeRecord } from "../redaction.js";
@@ -97,6 +97,20 @@ const createActivitySchema = z.object({
   entityId: z.string().min(1),
   agentId: z.string().uuid().optional().nullable(),
   details: z.record(z.unknown()).optional().nullable(),
+});
+
+// Inclusive `createdAt` bounds. Before BRO-2207 these were accepted from
+// callers but never read, so a date-windowed query silently returned the
+// most-recent page instead of the requested range. Malformed dates are
+// rejected rather than dropped — silently widening a bounded query back to
+// "everything" is the exact failure this endpoint just had.
+//
+// `limit`/`offset` stay deliberately lenient (coerced then clamped, never
+// 400) to preserve the endpoint's existing contract for callers that pass
+// oversized values and rely on capping.
+const companyActivityQuerySchema = z.object({
+  since: z.coerce.date().optional(),
+  until: z.coerce.date().optional(),
 });
 
 const agentActionAuditActorScopeSchema = z.enum(["agents", "all"]);
@@ -224,12 +238,20 @@ export function activityRoutes(db: Db) {
     assertCompanyAccess(req, companyId);
     if (!(await assertCompanyScopeReadAllowed(req, res, companyId))) return;
 
+    const parsedQuery = companyActivityQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      throw badRequest("Invalid activity query", parsedQuery.error.issues);
+    }
+
     const filters = {
       companyId,
       agentId: req.query.agentId as string | undefined,
       entityType: req.query.entityType as string | undefined,
       entityId: req.query.entityId as string | undefined,
+      since: parsedQuery.data.since,
+      until: parsedQuery.data.until,
       limit: normalizeActivityLimit(Number(req.query.limit)),
+      offset: normalizeActivityOffset(Number(req.query.offset)),
     };
     const result = await svc.list(filters);
     res.json(result);

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -99,18 +99,39 @@ const createActivitySchema = z.object({
   details: z.record(z.unknown()).optional().nullable(),
 });
 
-// Inclusive `createdAt` bounds. Before BRO-2207 these were accepted from
-// callers but never read, so a date-windowed query silently returned the
-// most-recent page instead of the requested range. Malformed dates are
-// rejected rather than dropped — silently widening a bounded query back to
-// "everything" is the exact failure this endpoint just had.
+// Inclusive `createdAt` bounds. These were previously accepted from callers
+// but never read, so a date-windowed query silently returned the most-recent
+// page instead of the requested range. Malformed dates are rejected rather
+// than dropped — silently widening a bounded query back to "everything" is
+// the exact failure this endpoint just had.
 //
+// Parsing is restricted to real ISO-8601 forms rather than `z.coerce.date()`.
+// Coercion delegates to `new Date(string)`, which also accepts host-specific
+// formats such as `"Aug 10 2026"` and `"2026/08/10"`. Those parse against the
+// server's local timezone, so the same request would select a different
+// window depending on where it ran. A date-only bound is widened to that whole
+// UTC day, which keeps `?since=2026-08-10&until=2026-08-16` meaning the seven
+// full days a reader expects.
+const isoDateOnly = /^\d{4}-\d{2}-\d{2}$/;
+const isoDateTime = z.string().datetime({ offset: true });
+
+function isoBound(edge: "start" | "end") {
+  const dayEdge = edge === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
+  return z
+    .string()
+    .refine((value) => isoDateOnly.test(value) || isoDateTime.safeParse(value).success, {
+      message: "Expected an ISO-8601 date (YYYY-MM-DD) or date-time (YYYY-MM-DDTHH:mm:ssZ)",
+    })
+    .transform((value) => new Date(isoDateOnly.test(value) ? `${value}${dayEdge}` : value))
+    .optional();
+}
+
 // `limit`/`offset` stay deliberately lenient (coerced then clamped, never
 // 400) to preserve the endpoint's existing contract for callers that pass
 // oversized values and rely on capping.
 const companyActivityQuerySchema = z.object({
-  since: z.coerce.date().optional(),
-  until: z.coerce.date().optional(),
+  since: isoBound("start"),
+  until: isoBound("end"),
 });
 
 const agentActionAuditActorScopeSchema = z.enum(["agents", "all"]);

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -114,14 +114,35 @@ const createActivitySchema = z.object({
 // full days a reader expects.
 const isoDateOnly = /^\d{4}-\d{2}-\d{2}$/;
 const isoDateTime = z.string().datetime({ offset: true });
+const calendarDate = /^(\d{4})-(\d{2})-(\d{2})/;
+
+// Both checks above validate shape, not whether the day exists, and
+// `new Date()` rolls an impossible date forward — "2026-02-31" becomes March 3.
+// A rolled-over bound reads as valid and quietly selects a different window
+// than the caller asked for, so verify the civil date itself. This is
+// deliberately independent of any UTC offset on the string: "2026-02-31" is not
+// a date in any zone.
+function hasRealCalendarDate(value: string) {
+  const match = calendarDate.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1) return false;
+  // Day 0 of the following month is the last day of this one, so this stays
+  // correct for February in a leap year without a special case.
+  return day <= new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
 
 function isoBound(edge: "start" | "end") {
   const dayEdge = edge === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
   return z
     .string()
-    .refine((value) => isoDateOnly.test(value) || isoDateTime.safeParse(value).success, {
-      message: "Expected an ISO-8601 date (YYYY-MM-DD) or date-time (YYYY-MM-DDTHH:mm:ssZ)",
-    })
+    .refine(
+      (value) =>
+        (isoDateOnly.test(value) || isoDateTime.safeParse(value).success) && hasRealCalendarDate(value),
+      { message: "Expected an ISO-8601 date (YYYY-MM-DD) or date-time (YYYY-MM-DDTHH:mm:ssZ)" },
+    )
     .transform((value) => new Date(isoDateOnly.test(value) ? `${value}${dayEdge}` : value))
     .optional();
 }

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, lte, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -24,15 +24,25 @@ export interface ActivityFilters {
   agentId?: string;
   entityType?: string;
   entityId?: string;
+  /** Inclusive lower bound on `createdAt`. */
+  since?: Date;
+  /** Inclusive upper bound on `createdAt`. */
+  until?: Date;
   limit?: number;
+  offset?: number;
 }
 
 const DEFAULT_ACTIVITY_LIMIT = 100;
-const MAX_ACTIVITY_LIMIT = 500;
+export const MAX_ACTIVITY_LIMIT = 1000;
 
 export function normalizeActivityLimit(limit: number | undefined) {
   if (!Number.isFinite(limit)) return DEFAULT_ACTIVITY_LIMIT;
   return Math.max(1, Math.min(MAX_ACTIVITY_LIMIT, Math.floor(limit ?? DEFAULT_ACTIVITY_LIMIT)));
+}
+
+export function normalizeActivityOffset(offset: number | undefined) {
+  if (!Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.floor(offset ?? 0));
 }
 
 export function activityService(db: Db) {
@@ -329,6 +339,7 @@ export function activityService(db: Db) {
     list: (filters: ActivityFilters) => {
       const conditions = [eq(activityLog.companyId, filters.companyId)];
       const limit = normalizeActivityLimit(filters.limit);
+      const offset = normalizeActivityOffset(filters.offset);
 
       if (filters.agentId) {
         conditions.push(eq(activityLog.agentId, filters.agentId));
@@ -338,6 +349,14 @@ export function activityService(db: Db) {
       }
       if (filters.entityId) {
         conditions.push(eq(activityLog.entityId, filters.entityId));
+      }
+      // Date bounds are inclusive on both ends, matching the sibling
+      // agent-action audit query. Backed by activity_log_company_created_idx.
+      if (filters.since) {
+        conditions.push(gte(activityLog.createdAt, filters.since));
+      }
+      if (filters.until) {
+        conditions.push(lte(activityLog.createdAt, filters.until));
       }
 
       return db
@@ -359,8 +378,12 @@ export function activityService(db: Db) {
             ),
           ),
         )
-        .orderBy(desc(activityLog.createdAt))
+        // `id` breaks ties so a given (limit, offset) pair addresses a stable
+        // row; ordering by createdAt alone lets same-timestamp rows shuffle
+        // between pages and silently drop records from a paginated sweep.
+        .orderBy(desc(activityLog.createdAt), desc(activityLog.id))
         .limit(limit)
+        .offset(offset)
         .then((rows) => rows.map((r) => r.activityLog));
     },
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators need a durable record of what changed and who caused it, so Paperclip keeps a company activity log
> - Reporting tools read that log through `GET /api/companies/{companyId}/activity`
> - A report almost always wants a date window, such as one week
> - But the route read `agentId`, `entityType`, and `entityId` from the query string, and never read `since` or `until`
> - The service had no date fields on its filter type either, so the bounds had nowhere to go
> - The endpoint therefore answered every windowed request with the most recent rows, and capped the page at 500
> - The caller got a plausible response and no error, so the wrong data looked correct
> - This pull request applies the date bounds in SQL, raises the cap to 1000, and adds `offset` paging
> - The benefit is that a client can read an exact date window instead of rebuilding it from the issue and comment endpoints

## Linked Issues or Issue Description

Fixes #5893 — `?since=` is accepted and then ignored, so the endpoint returns the full history for every value.

Refs #5907 — an earlier open pull request for the same `since` bug. It is narrower: it adds `since` only, and leaves `until`, the 500-row cap, and paging unaddressed. This pull request covers all four. If #5907 lands first, this branch needs a rebase. See "Risks".

**One behavior difference to confirm:** #5893 proposes `createdAt > since` (exclusive). This pull request uses `>=` (inclusive), to match the sibling agent-action audit query and to make `since`/`until` read as a normal closed interval. An incremental polling client that passes its last-seen timestamp will re-receive that one boundary record. Say the word and I will switch it to exclusive.

## What Changed

- `services/activity.ts`: added `since`, `until`, and `offset` to `ActivityFilters`, and applied them as `gte` / `lte` / `.offset()` in `list()`.
- `services/activity.ts`: raised `MAX_ACTIVITY_LIMIT` from 500 to 1000, matching `ISSUE_LIST_MAX_LIMIT`.
- `services/activity.ts`: added `desc(id)` as an order tiebreaker. Without it, rows that share a `createdAt` can reorder between requests, and a paged sweep drops records.
- `routes/activity.ts`: parsed `since`, `until`, and `offset`, and forwarded them to the service.
- `routes/activity.ts`: parsed the date bounds with an explicit ISO-8601 schema instead of `z.coerce.date()`. Coercion delegates to `new Date(string)`, which also accepts host-specific forms such as `"Aug 10 2026"` and `"2026/08/10"`. Those resolve against the server's local timezone, so one request could select different windows on different hosts.
- `routes/activity.ts`: a bare date now covers the whole UTC day, and `until` lands at end-of-day. `?since=2026-08-10&until=2026-08-16` therefore means seven full days.
- `routes/activity.ts`: rejected date bounds that are not real calendar days. A shape check is not a validity check: `2026-02-31` and `2027-02-29` match the ISO pattern, and `new Date()` rolls them forward to a different day. The bound looked valid and quietly selected a window the caller never asked for. This affected the date-time forms too, not only bare dates.
- `routes/activity.ts`: a malformed bound returns `400`. Ignoring it would widen a bounded query back to everything, which is the bug being fixed.
- `docs/api/activity.md`: documented the parameters, the accepted formats, and a paging loop.

## Verification

Both suites pass locally:

```
pnpm -C server vitest run src/__tests__/activity-routes.test.ts src/__tests__/activity-service.test.ts
  Test Files  2 passed (2)
       Tests  46 passed (46)

pnpm -C server typecheck
  clean
```

The service tests run against embedded Postgres, so the SQL is executed and not mocked. They seed one event per day across Aug 8–18 and assert that a Aug 10–17 window returns exactly the seven in-window rows. Before this change the same call returned the newest rows, through Aug 18.

New cases:

- `since`/`until` apply as inclusive bounds instead of being ignored.
- A `limit` of 1000 returns 600 seeded rows, which the old 500 cap truncated.
- Paging a window with `offset` neither repeats nor drops a record.
- Paging stays stable when ten rows share one `createdAt`.
- A pinned-`until` sweep stays stable while new activity is written during the sweep.
- A table of rejected formats: `last-tuesday`, `Aug 10 2026`, `2026/08/10`, `2026-08-10T00:00:00` (no zone), and epoch millis.
- A bare date widens to the whole UTC day.
- Impossible calendar days are rejected: `2026-02-31`, `2027-02-29`, `2026-13-01`, `2026-04-31`, month 0, day 0, and the same impossible day inside a date-time with and without an offset.
- Real dates the guard must still accept: `2028-02-29` (leap year), `2026-01-31`, and offset date-times.

Manual check against a running server:

```bash
curl -s -H "Authorization: Bearer $API_KEY" \
  "$BASE/api/companies/$COMPANY_ID/activity?since=2026-08-10&until=2026-08-16&limit=1000" \
  | jq 'length, (max_by(.createdAt).createdAt), (min_by(.createdAt).createdAt)'
```

Every `createdAt` must fall inside the requested window.

## Risks

Low to moderate.

- **Behavior change for existing callers.** A caller that already sent `since` or `until` was silently ignored, and now gets the window it asked for. That is the intended fix, but the response will shrink for those callers. A caller that sent a malformed date used to get data and now gets `400`.
- **Inclusive vs exclusive `since`.** See the note under "Linked Issues". This differs from the acceptance criteria in #5893.
- **Offset paging under concurrent writes.** `offset` addresses positions in a result set that each request recomputes. A sweep is only stable if the caller pins `until` to a past timestamp, because new records carry a present `createdAt` and sort outside the window. The docs state this, and a test proves it. An unbounded sweep with no `until` can still repeat records; keyset pagination would remove that caveat and is a reasonable follow-up.
- **Query cost.** The bounds sit on `(company_id, created_at)`, which `activity_log_company_created_idx` already covers, so the window is index-backed. The raised cap lets one request return up to 1000 rows instead of 500, which roughly doubles the worst-case payload.
- **No migration.** This is a read-path change. There is no schema change and no data backfill.
- **Conflict with #5907.** Both branches edit the same two files. Whichever lands second needs a rebase.

## Category Safeguard

The class of bug here is not "someone forgot `since`." It is that the handler read query
parameters as raw casts:

```ts
agentId: req.query.agentId as string | undefined,
```

Nothing in that line connects the handler to the documented contract, so a parameter can be
published in the docs, accepted by the server, and never read — with no type error, no
validation error, and a `200` carrying plausible-looking data. That is the worst shape a bug
can take: it is invisible from the outside. This one survived three consecutive weekly reports
because the response looked fine.

The fix in this PR routes the new parameters through a `zod` query schema
(`companyActivityQuerySchema`) instead. Applied as a rule, that closes the whole class: if
every route parses `req.query` through a schema and reads only from the parsed result, a
documented-but-unread parameter becomes a visible omission in one reviewable object rather
than an absence spread across a handler.

**Proposed, not included here:** an ESLint `no-restricted-syntax` rule banning
`req.query.<name> as <type>` casts inside route handlers, requiring a validated query schema.
I did not add it to this PR because the raw-cast pattern is widespread across `server/src/routes/`,
so landing the rule means either a baseline suppression file or a sweep — both materially wider
than the bug being fixed, and both worse reviewed while stapled to it. Flagging it here for a
maintainer to take or decline as a standalone change.

## Model Used

Claude Opus (Anthropic), model id `claude-opus-5`, running in Claude Code with extended thinking and tool use enabled. The model wrote the diff, the tests, and this description. A human ran the tests and reviewed the result.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

