### PR TITLE
fix(adapter-utils): strip server secrets from agent env

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -365,6 +365,7 @@ interface AcpxPreparedRuntime {
   workspaceRepoUrl: string;
   workspaceRepoRef: string;
   env: Record<string, string>;
+  launchEnv: Record<string, string>;
   loggedEnv: Record<string, string>;
   stateDir: string;
   permissionMode: "approve-all" | "approve-reads" | "deny-all";
@@ -2167,6 +2168,7 @@ async function buildRuntime(input: {
     workspaceRepoUrl,
     workspaceRepoRef,
     env,
+    launchEnv: runtimeEnv,
     loggedEnv,
     stateDir,
     permissionMode,
@@ -2255,16 +2257,28 @@ async function applySessionConfigOptions(input: {
   }
 }
 
+const AGENT_SUBPROCESS_ENV_DENYLIST = new Set([
+  "PAPERCLIP_AGENT_JWT_SECRET",
+  "BETTER_AUTH_SECRET",
+  "PAPERCLIP_SECRETS_MASTER_KEY_FILE",
+  "DATABASE_URL",
+]);
+
 /**
  * Build the process-session launch env: the host env overlaid with the run's
  * `env` (so the merged paperclip bridge vars win) and a guaranteed `PATH`,
  * narrowed to string values. Shared by the remote concurrent bring-up and the
  * local / runner-less lane so both resolve the runtime env identically.
+ *
+ * Server-only credentials are removed after the merge so neither the host
+ * environment nor adapter-supplied overrides can expose them to an agent.
+ * Run-scoped PAPERCLIP_* values remain available to the child.
  */
 function resolveRuntimeEnv(env: Record<string, string>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && !AGENT_SUBPROCESS_ENV_DENYLIST.has(entry[0]),
     ),
   );
 }
@@ -3516,7 +3530,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
                   mode: prepared.mode,
                   cwd: prepared.cwd,
                   resumeSessionId,
-                  sessionOptions: { env: prepared.env },
+                  sessionOptions: { env: prepared.launchEnv },
                 });
                 ensureSessionMs = now() - ensureSessionStart;
                 return established;
@@ -3547,7 +3561,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
                   agent: prepared.acpxAgent,
                   mode: prepared.mode,
                   cwd: prepared.cwd,
-                  sessionOptions: { env: prepared.env },
+                  sessionOptions: { env: prepared.launchEnv },
                 });
                 retryEnsureSessionMs = now() - ensureSessionStart;
                 return established;

--- a/packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
@@ -46,6 +46,58 @@ it("spawns a real Node ACP agent with per-session env on this platform", async (
   expect(stderr).toContain("paperclip-acp-echo-agent started");
 });
 
+it("does not export server-only secrets to the spawned agent", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-acpx-spawn-env-"));
+  tempRoots.push(root);
+  const secretKeys = [
+    "PAPERCLIP_AGENT_JWT_SECRET",
+    "BETTER_AUTH_SECRET",
+    "PAPERCLIP_SECRETS_MASTER_KEY_FILE",
+    "DATABASE_URL",
+  ];
+  const inspectedKeys = [...secretKeys, "PAPERCLIP_API_KEY"];
+  const previousValues = Object.fromEntries(secretKeys.map((key) => [key, process.env[key]]));
+  const marker = "must-not-reach-agent";
+  for (const key of secretKeys) process.env[key] = marker;
+
+  try {
+    const logs: string[] = [];
+    const execute = createAcpxEngineExecutor();
+    const result = await execute({
+      runId: "spawn-env-smoke",
+      agent: { id: "spawn-agent", companyId: "spawn-company" },
+      runtime: {},
+      config: {
+        agent: "custom",
+        agentCommand: `${JSON.stringify(process.execPath.replaceAll("\\", "/"))} ${JSON.stringify(fixturePath.replaceAll("\\", "/"))}`,
+        mode: "oneshot",
+        stateDir: path.join(root, "state"),
+        cwd: repoRoot,
+        env: {
+          PAPERCLIP_ACPX_INSPECT_ENV_KEYS: inspectedKeys.join(","),
+          PAPERCLIP_API_KEY: "run-scoped-value",
+          DATABASE_URL: marker,
+        },
+      },
+      context: {},
+      onLog: async (_stream: string, text: string) => logs.push(text),
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode, JSON.stringify({ result, logs }, null, 2)).toBe(0);
+    const output = logs.join("");
+    for (const key of secretKeys) expect(output).toContain(`\\"${key}\\":false`);
+    expect(output).toContain(`\\"PAPERCLIP_API_KEY\\":true`);
+    expect(output).not.toContain(marker);
+  } finally {
+    for (const key of secretKeys) {
+      const previous = previousValues[key];
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+  }
+});
+
 it("captures the Node error shape for a host-invalid spawn cwd", async () => {
   // Regression anchor for the primitive behind the remote-lane bug: a host
   // `spawn()` whose `cwd` does not exist fails BEFORE `exec`, when libuv

--- a/patches/acpx@0.12.0.patch
+++ b/patches/acpx@0.12.0.patch
@@ -55,6 +55,14 @@ index 243c9d13bcba520923b63adfddad75cf2d94362d..336a1699b80b9e99416f9da4346ca73e
  		};
  	}
  	logAgentLaunch(plan) {
+diff --git a/dist/live-checkpoint-ClPCSdrW.js b/dist/live-checkpoint-ClPCSdrW.js
+--- a/dist/live-checkpoint-ClPCSdrW.js
++++ b/dist/live-checkpoint-ClPCSdrW.js
+@@ -2925,0 +2926,4 @@ function buildAgentEnvironment(authCredentials, sessionEnv) {
++	for (const key of [
++		"PAPERCLIP_AGENT_JWT_SECRET", "BETTER_AUTH_SECRET",
++		"PAPERCLIP_SECRETS_MASTER_KEY_FILE", "DATABASE_URL"
++	]) delete env[key];
 diff --git a/dist/runtime.d.ts b/dist/runtime.d.ts
 index ccdbe5b032521518022223733049b8b38793473b..3d4e04231e78efeecd8540735b08e1e43547ff2d 100644
 --- a/dist/runtime.d.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
 
 patchedDependencies:
   acpx@0.12.0:
-    hash: dqnw5too5j72u3kff55fcrb3ue
+    hash: x3fethhotv43zektyl5prdwf54
     path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
@@ -124,7 +124,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=dqnw5too5j72u3kff55fcrb3ue)
+        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -13000,7 +13000,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  acpx@0.12.0(patch_hash=dqnw5too5j72u3kff55fcrb3ue):
+  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
 
 patchedDependencies:
   acpx@0.12.0:
-    hash: x3fethhotv43zektyl5prdwf54
+    hash: dqnw5too5j72u3kff55fcrb3ue
     path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
@@ -124,7 +124,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
+        version: 0.12.0(patch_hash=dqnw5too5j72u3kff55fcrb3ue)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -13000,7 +13000,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
+  acpx@0.12.0(patch_hash=dqnw5too5j72u3kff55fcrb3ue):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0

--- a/scripts/mcp-fixtures/servers/acp-echo-agent.mjs
+++ b/scripts/mcp-fixtures/servers/acp-echo-agent.mjs
@@ -6,6 +6,11 @@ function writeMessage(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
 }
 
+const inspectedEnvKeys = (process.env.PAPERCLIP_ACPX_INSPECT_ENV_KEYS ?? "")
+  .split(",")
+  .map((key) => key.trim())
+  .filter(Boolean);
+
 async function handleRequest(request) {
   if (request.method === "initialize") {
     process.stderr.write("Error handling request { method: 'nes/close' } { code: -32601 }\n");
@@ -25,7 +30,15 @@ async function handleRequest(request) {
         sessionId: request.params.sessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: process.env.PAPERCLIP_ACPX_SPAWN_SMOKE ?? "missing" },
+          content: {
+            type: "text",
+            text: JSON.stringify({
+              smoke: process.env.PAPERCLIP_ACPX_SPAWN_SMOKE ?? "missing",
+              envKeysPresent: Object.fromEntries(
+                inspectedEnvKeys.map((key) => [key, Object.hasOwn(process.env, key)]),
+              ),
+            }),
+          },
         },
       },
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip starts agent subprocesses through adapter utilities.
> - These subprocesses inherit the server process environment.
> - The environment contains credentials that only the server must use.
> - An agent can list its environment during a normal run.
> - This pull request removes four server-only keys at the shared launch boundary.
> - The benefit is a smaller credential exposure area for every agent run.

## Linked Issues or Issue Description

**What happened?**

Agent subprocesses receive server-only authentication, secret-store, and database configuration. A normal agent command can list these environment keys.

**Expected behavior**

Agent subprocesses must receive run-scoped credentials. They must not receive server-only credentials.

**Steps to reproduce**

1. Start the server with marker values for the four server-only keys.
2. Start an ACP agent through the adapter utility.
3. Ask the child process whether each selected key exists.
4. Observe that the child process receives the server-only keys before this change.

**Paperclip version or commit**

The problem exists on the current `master` branch.

## What Changed

- Remove four server-only keys after the host and run environments merge.
- Use the same filtered launch environment for local and remote ACP sessions.
- Keep run-scoped Paperclip keys available to agents.
- Add a real child-process regression test.
- Update the bundled ACP patch so package behavior matches source behavior.

## Verification

- Ran `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts`.
- One test file passed. Three tests passed.
- The child process reports that all denied keys are absent.
- The child process reports that `PAPERCLIP_API_KEY` is present.
- No marker value reaches test output.

## Risks

- Risk is low.
- An unsupported agent workflow can fail if it depends on a server-only credential.
- Such a workflow must use a run-scoped credential.
- Revert the patch if an unsupported dependency is found.

## Model Used

- OpenAI Codex on GPT-5 with reasoning and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing issue or described the issue in this PR
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge