### PR TITLE
fix(server): pick the runtime API URL agents can actually reach

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -3,6 +3,8 @@ import {
   buildRuntimeApiCandidateUrls,
   choosePrimaryRuntimeApiUrl,
   collectReachableInterfaceHosts,
+  rankRuntimeApiCandidatesByBindAddress,
+  resolveRuntimeApiUrl,
 } from "../runtime-api.js";
 
 describe("runtime API discovery", () => {
@@ -153,6 +155,184 @@ describe("runtime API discovery", () => {
     ).toEqual([
       "192.168.6.178",
       "fd7a:115c:a1e0::8a3a:a11d",
+    ]);
+  });
+});
+
+describe("runtime API reachability resolution", () => {
+  // Mirrors a tailnet-bound host whose short machine name also exists in the
+  // cloud provider's internal DNS: both names are allow-listed, but only the
+  // tailnet name resolves to the address the server actually bound.
+  const BIND_HOST = "100.108.64.76";
+  const PORT = 3100;
+
+  const lookupHost = async (hostname: string): Promise<string[]> => {
+    if (hostname === "good-name") return ["100.108.64.76"];
+    if (hostname === "unreachable-name") return ["10.0.0.4"];
+    return [];
+  };
+
+  const probeOnlyGoodName = async (origin: string): Promise<boolean> =>
+    origin === "http://good-name:3100";
+
+  it("picks the allowed hostname that resolves to the bind address and answers a probe", async () => {
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+
+    expect(resolved.url).toBe("http://good-name:3100");
+    expect(resolved.reason).toBe("probe");
+    // The known-wrong name must never be probed before the working one.
+    expect(resolved.probed.map((entry) => entry.url)).not.toContain("http://unreachable-name:3100");
+  });
+
+  it("is not order-dependent: swapping the allowed hostnames yields the same URL", async () => {
+    const forward = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+    const reversed = await resolveRuntimeApiUrl({
+      allowedHostnames: ["good-name", "unreachable-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+
+    expect(reversed.url).toBe(forward.url);
+    expect(reversed.url).toBe("http://good-name:3100");
+  });
+
+  it("puts the reachable origin first in the candidate list it returns", async () => {
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+
+    expect(resolved.candidates[0]).toBe("http://good-name:3100");
+    expect(resolved.candidates).toContain("http://unreachable-name:3100");
+  });
+
+  it("keeps the resolve-ranked order when no candidate answers", async () => {
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: async () => false,
+    });
+
+    expect(resolved.reason).toBe("unreachable-fallback");
+    expect(resolved.url).toBe("http://good-name:3100");
+    expect(resolved.probed.every((entry) => entry.reachable === false)).toBe(true);
+  });
+
+  it("stops probing once the budget is spent instead of stalling startup", async () => {
+    let clock = 0;
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name", "no-such-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeBudgetMs: 1_000,
+      now: () => clock,
+      probeOrigin: async () => {
+        clock += 1_500;
+        return false;
+      },
+    });
+
+    // The top-ranked candidate is always probed; the rest are dropped once the
+    // budget is gone, so a fully dead list costs one timeout instead of N.
+    expect(resolved.probed).toHaveLength(1);
+    expect(resolved.probed[0]?.url).toBe("http://good-name:3100");
+    expect(resolved.skipped).toEqual([
+      // The bind address itself is also a candidate, and ranks alongside the
+      // allowed hostname that resolves to it.
+      "http://100.108.64.76:3100",
+      "http://no-such-name:3100",
+      "http://unreachable-name:3100",
+    ]);
+    expect(resolved.reason).toBe("unreachable-fallback");
+    expect(resolved.url).toBe("http://good-name:3100");
+  });
+
+  it("honors an explicit public base URL without probing", async () => {
+    const probeOrigin = async (): Promise<boolean> => {
+      throw new Error("probe must not run when a public base URL is configured");
+    };
+
+    const resolved = await resolveRuntimeApiUrl({
+      authPublicBaseUrl: "https://paperclip.example.com/base/path",
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin,
+    });
+
+    expect(resolved.url).toBe("https://paperclip.example.com");
+    expect(resolved.reason).toBe("explicit-public-base-url");
+    expect(resolved.probed).toEqual([]);
+  });
+
+  it("leaves candidate order alone for a wildcard bind, where DNS carries no signal", async () => {
+    const ranked = await rankRuntimeApiCandidatesByBindAddress({
+      candidates: ["http://unreachable-name:3100", "http://good-name:3100"],
+      bindHost: "0.0.0.0",
+      lookupHost,
+    });
+
+    expect(ranked.map((entry) => entry.url)).toEqual([
+      "http://unreachable-name:3100",
+      "http://good-name:3100",
+    ]);
+  });
+
+  it("does not stall ranking when a resolver never answers", async () => {
+    // `dns.lookup` has no timeout of its own, and the probe budget only covers
+    // probing. A wedged resolver must degrade to "unknown", not hang startup.
+    const ranked = await rankRuntimeApiCandidatesByBindAddress({
+      candidates: ["http://wedged-resolver-name:3100", `http://${BIND_HOST}:3100`],
+      bindHost: BIND_HOST,
+      lookupHost: () => new Promise<string[]>(() => {}),
+      lookupTimeoutMs: 10,
+    });
+
+    expect(ranked.map((entry) => entry.url)).toEqual([
+      `http://${BIND_HOST}:3100`,
+      "http://wedged-resolver-name:3100",
+    ]);
+    expect(ranked[1]?.addresses).toEqual([]);
+  });
+
+  it("ranks a name that does not resolve above one that resolves off the bind address", async () => {
+    const ranked = await rankRuntimeApiCandidatesByBindAddress({
+      candidates: ["http://unreachable-name:3100", "http://no-such-name:3100"],
+      bindHost: BIND_HOST,
+      lookupHost,
+    });
+
+    expect(ranked.map((entry) => entry.url)).toEqual([
+      "http://no-such-name:3100",
+      "http://unreachable-name:3100",
     ]);
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
 const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL;
-const ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
 
@@ -645,12 +644,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     if (ORIGINAL_PAPERCLIP_RUNTIME_API_URL === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
     else process.env.PAPERCLIP_RUNTIME_API_URL = ORIGINAL_PAPERCLIP_RUNTIME_API_URL;
 
-    if (ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON === undefined) {
-      delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
-    } else {
-      process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
-    }
-
     if (ORIGINAL_PAPERCLIP_LISTEN_HOST === undefined) delete process.env.PAPERCLIP_LISTEN_HOST;
     else process.env.PAPERCLIP_LISTEN_HOST = ORIGINAL_PAPERCLIP_LISTEN_HOST;
 
@@ -665,10 +658,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.apiUrl).toBe("http://custom-api:3100");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://custom-api:3100");
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
-      expect.arrayContaining(["http://custom-api:3100"]),
-    );
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")[0]).toBe("http://custom-api:3100");
   });
 
   it("falls back to host-based URL when PAPERCLIP_API_URL is not set", async () => {
@@ -676,6 +665,37 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.apiUrl).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
+  });
+
+  it("no longer exports the write-only runtime API candidate list", async () => {
+    // The candidate list used to be exported for adapters to retry against, but
+    // nothing ever read it. Startup now probes the candidates itself and exports
+    // a single origin that answered, so the list has no consumer left.
+    delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+
+    await startServer();
+
+    expect(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON).toBeUndefined();
+  });
+
+  it("does not export an allowed hostname that resolves away from the bind address", async () => {
+    // The AGE-519 shape, on a non-loopback bind: `allowedHostnames` is a
+    // Host-header accept list, so its first entry carries no guarantee that it
+    // resolves to the address the server bound. Startup must not hand agents
+    // that name just because it sorts first. 192.0.2.0/24 is TEST-NET-1 and
+    // `.invalid` never resolves, so this stays hermetic in CI.
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      bind: "custom",
+      customBindHost: "192.0.2.10",
+      host: "192.0.2.10",
+      allowedHostnames: ["unreachable-name.invalid", "192.0.2.10"],
+    }));
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("http://192.0.2.10:3210");
+    expect(process.env.PAPERCLIP_API_URL).toBe("http://192.0.2.10:3210");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://192.0.2.10:3210");
   });
 
   it("keeps loopback as the runtime API URL when allowed hostnames are present", async () => {
@@ -688,9 +708,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.apiUrl).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
-      expect.arrayContaining(["http://127.0.0.1:3210", "http://192.168.1.50:3210"]),
-    );
   });
 
   it("preserves explicit-port external auth public URLs when detect-port selects a new port", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -77,7 +77,7 @@ import {
   reconcileAdapterAvailability,
 } from "./services/adapter-registry-bootstrap.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
-import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
+import { resolveRuntimeApiUrl } from "./runtime-api.js";
 import { isLoopbackHost, rewriteLoopbackUrlPort } from "./url-utils.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
@@ -774,26 +774,50 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
-  const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
+  const runtimeApiOverride = process.env.PAPERCLIP_API_URL?.trim();
+  const runtimeApiResolverInput = {
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
-  });
-  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
-  const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
-    preferredApiUrl: configuredApiUrl,
-    authPublicBaseUrl: config.authPublicBaseUrl ?? null,
-    allowedHostnames: config.allowedHostnames,
-    bindHost: runtimeListenHost,
-    port: listenPort,
-  });
+  };
+  // DNS ranking only at this point: the listener is not open yet, so probing here
+  // would reject every candidate. `promoteReachableRuntimeApiUrl` below re-runs
+  // this with probing once the server is listening.
+  const initialRuntimeApi = await resolveRuntimeApiUrl({ ...runtimeApiResolverInput, probe: false });
+  let configuredApiUrl = runtimeApiOverride || initialRuntimeApi.url;
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
-  process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
+  process.env.PAPERCLIP_RUNTIME_API_URL = initialRuntimeApi.url;
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
-  
+
+  // `allowedHostnames` is a Host-header accept list, so a name in it can resolve
+  // to an address nothing listens on — which is exactly what agents inherit as
+  // PAPERCLIP_API_URL. Once the listener is up, probe the ranked candidates and
+  // promote the first origin that actually answers. (AGE-519)
+  const promoteReachableRuntimeApiUrl = async (): Promise<void> => {
+    if (runtimeApiOverride) return;
+    if (initialRuntimeApi.reason !== "resolve-rank") return;
+
+    const probedRuntimeApi = await resolveRuntimeApiUrl(runtimeApiResolverInput);
+    if (probedRuntimeApi.reason === "unreachable-fallback") {
+      logger.warn(
+        { candidates: probedRuntimeApi.candidates, probed: probedRuntimeApi.probed, skipped: probedRuntimeApi.skipped },
+        `No runtime API candidate answered a probe; agents will use ${probedRuntimeApi.url}, which may be unreachable`,
+      );
+      return;
+    }
+    if (probedRuntimeApi.url === initialRuntimeApi.url) return;
+
+    logger.warn(
+      { previousApiUrl: initialRuntimeApi.url, probed: probedRuntimeApi.probed },
+      `Promoted runtime API URL to ${probedRuntimeApi.url} after probing; the derived URL did not answer`,
+    );
+    configuredApiUrl = probedRuntimeApi.url;
+    process.env.PAPERCLIP_RUNTIME_API_URL = probedRuntimeApi.url;
+    process.env.PAPERCLIP_API_URL = probedRuntimeApi.url;
+  };
+
   setupEnvironmentCustomImageTerminalWebSocketServer(server, db as any, {
     pluginWorkerManager,
   });
@@ -1495,7 +1519,9 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
+
+  await promoteReachableRuntimeApiUrl();
+
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
       await systemdNotify(["--stopping", `--status=Stopping after ${signal}`]);

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -1,7 +1,30 @@
+import dns from "node:dns/promises";
 import os from "node:os";
+
+/** Per-hostname DNS timeout. Ranking every candidate must stay bounded too. */
+const DEFAULT_LOOKUP_TIMEOUT_MS = 500;
+/** Per-candidate probe timeout. One dead candidate must not stall startup. */
+const DEFAULT_PROBE_TIMEOUT_MS = 600;
+/** Total time startup is willing to spend probing every candidate combined. */
+const DEFAULT_PROBE_BUDGET_MS = 1_200;
+
+/** The candidate hostname resolves to (or is) the address the server bound. */
+const RANK_MATCHES_BIND = 0;
+/** The candidate hostname does not resolve at all; unknown, not disqualified. */
+const RANK_UNRESOLVED = 1;
+/** The candidate hostname resolves somewhere the server is not listening. */
+const RANK_RESOLVES_ELSEWHERE = 2;
 
 function normalizeHost(value: string | null | undefined): string {
   return (value ?? "").trim();
+}
+
+function stripBrackets(host: string): string {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
+
+function canonicalHost(value: string | null | undefined): string {
+  return stripBrackets(normalizeHost(value)).toLowerCase();
 }
 
 function isLoopbackHost(host: string): boolean {
@@ -168,4 +191,239 @@ export function buildRuntimeApiCandidateUrls(input: {
   }
 
   return candidates;
+}
+
+export type RuntimeApiLookupHost = (hostname: string) => Promise<string[]>;
+export type RuntimeApiProbe = (origin: string) => Promise<boolean>;
+
+export type RuntimeApiResolutionReason =
+  /** Config named the public origin outright; nothing to discover. */
+  | "explicit-public-base-url"
+  /** A loopback bind only ever answers on loopback, whatever else is allow-listed. */
+  | "loopback-bind"
+  /** DNS ranking only; the caller asked us not to probe (e.g. before listen). */
+  | "resolve-rank"
+  /** A candidate answered an HTTP probe. */
+  | "probe"
+  /** Nothing answered; we fall back to the best DNS-ranked candidate. */
+  | "unreachable-fallback";
+
+export interface RuntimeApiCandidateRanking {
+  url: string;
+  hostname: string;
+  rank: number;
+  addresses: string[];
+}
+
+export interface RuntimeApiResolution {
+  url: string;
+  reason: RuntimeApiResolutionReason;
+  /** Ranked candidates, with the chosen URL first. */
+  candidates: string[];
+  probed: Array<{ url: string; reachable: boolean }>;
+  /** Candidates never probed, because one already answered or the budget ran out. */
+  skipped: string[];
+}
+
+async function defaultLookupHost(hostname: string): Promise<string[]> {
+  const entries = await dns.lookup(hostname, { all: true, verbatim: true });
+  return entries.map((entry) => entry.address);
+}
+
+/**
+ * `dns.lookup` has no timeout of its own, and the probe budget below only covers
+ * probing. Without this, one wedged resolver stalls startup before a single
+ * candidate is probed.
+ */
+function withLookupTimeout(lookupHost: RuntimeApiLookupHost, timeoutMs: number): RuntimeApiLookupHost {
+  return async (hostname) => {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        lookupHost(hostname),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error(`DNS lookup for ${hostname} timed out`)), timeoutMs);
+        }),
+      ]);
+    } catch {
+      // A name that does not resolve, or resolves too slowly to be worth
+      // waiting for, is unknown rather than disqualified: split-horizon DNS and
+      // hosts-file entries differ between the server and its agents.
+      return [];
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+}
+
+function createDefaultProbe(timeoutMs: number): RuntimeApiProbe {
+  return async (origin) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      // Any HTTP response proves a listener is there. The status does not
+      // matter, so an auth change on /api/health cannot silently break this.
+      await fetch(new URL("/api/health", origin), { redirect: "manual", signal: controller.signal });
+      return true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * Order candidate origins by whether their hostname resolves to the address the
+ * server actually bound. `allowedHostnames` is a Host-header accept list, so its
+ * order says nothing about reachability: on a tailnet-bound host the short
+ * machine name can also exist in the cloud provider's internal DNS and point at
+ * an address with no listener.
+ */
+export async function rankRuntimeApiCandidatesByBindAddress(input: {
+  candidates: string[];
+  bindHost: string;
+  lookupHost?: RuntimeApiLookupHost;
+  lookupTimeoutMs?: number;
+}): Promise<RuntimeApiCandidateRanking[]> {
+  const lookupHost = withLookupTimeout(
+    input.lookupHost ?? defaultLookupHost,
+    input.lookupTimeoutMs ?? DEFAULT_LOOKUP_TIMEOUT_MS,
+  );
+  const bindHost = canonicalHost(input.bindHost);
+  // A wildcard bind answers on every address, so DNS carries no signal about
+  // which candidate is reachable. Leave the caller's order alone.
+  const rankable = Boolean(bindHost) && !isWildcardHost(bindHost);
+
+  const ranked = await Promise.all(
+    input.candidates.map(async (url, index) => {
+      const hostname = (() => {
+        try {
+          return new URL(url).hostname;
+        } catch {
+          return "";
+        }
+      })();
+
+      if (!rankable || !hostname) {
+        return { url, hostname, rank: RANK_MATCHES_BIND, addresses: [] as string[], index };
+      }
+      if (canonicalHost(hostname) === bindHost) {
+        return { url, hostname, rank: RANK_MATCHES_BIND, addresses: [bindHost], index };
+      }
+
+      const addresses = await lookupHost(hostname).catch(() => [] as string[]);
+      const rank = addresses.some((address) => canonicalHost(address) === bindHost)
+        ? RANK_MATCHES_BIND
+        : addresses.length === 0
+          ? RANK_UNRESOLVED
+          : RANK_RESOLVES_ELSEWHERE;
+      return { url, hostname, rank, addresses, index };
+    }),
+  );
+
+  return ranked
+    .sort((left, right) => left.rank - right.rank || left.index - right.index)
+    .map(({ url, hostname, rank, addresses }) => ({ url, hostname, rank, addresses }));
+}
+
+/**
+ * Pick the origin agents should dial for the control plane.
+ *
+ * Replaces the old "first allow-listed hostname wins" derivation, which was pure
+ * array order and handed agents an unreachable name whenever a better one sat
+ * later in the list. Candidates are ranked by DNS against the bind address and
+ * then probed in that order; the first origin that answers wins.
+ *
+ * Pass `probe: false` before the server is listening — every probe would fail
+ * against its own not-yet-open port — and call again afterwards to promote.
+ */
+export async function resolveRuntimeApiUrl(input: {
+  authPublicBaseUrl?: string | null;
+  allowedHostnames: string[];
+  bindHost: string;
+  port: number;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  probe?: boolean;
+  probeBudgetMs?: number;
+  probeTimeoutMs?: number;
+  lookupHost?: RuntimeApiLookupHost;
+  lookupTimeoutMs?: number;
+  probeOrigin?: RuntimeApiProbe;
+  now?: () => number;
+}): Promise<RuntimeApiResolution> {
+  const explicitPublicBaseUrl = input.authPublicBaseUrl?.trim();
+  if (explicitPublicBaseUrl) {
+    try {
+      const origin = new URL(explicitPublicBaseUrl).origin;
+      return { url: origin, reason: "explicit-public-base-url", candidates: [origin], probed: [], skipped: [] };
+    } catch {
+      // Fall through to derived candidates if config parsing drifted.
+    }
+  }
+
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && !isWildcardHost(bindHost) && isLoopbackHost(bindHost)) {
+    const origin = formatOrigin("http:", bindHost, input.port);
+    return { url: origin, reason: "loopback-bind", candidates: [origin], probed: [], skipped: [] };
+  }
+
+  const ranked = await rankRuntimeApiCandidatesByBindAddress({
+    candidates: buildRuntimeApiCandidateUrls({
+      authPublicBaseUrl: input.authPublicBaseUrl,
+      allowedHostnames: input.allowedHostnames,
+      bindHost: input.bindHost,
+      port: input.port,
+      networkInterfacesMap: input.networkInterfacesMap,
+    }),
+    bindHost: input.bindHost,
+    lookupHost: input.lookupHost,
+    lookupTimeoutMs: input.lookupTimeoutMs,
+  });
+  const rankedUrls = ranked.map((entry) => entry.url);
+  const bestRankedUrl = rankedUrls[0] ?? formatOrigin("http:", "localhost", input.port);
+
+  if (input.probe === false) {
+    return {
+      url: bestRankedUrl,
+      reason: "resolve-rank",
+      candidates: rankedUrls.length > 0 ? rankedUrls : [bestRankedUrl],
+      probed: [],
+      skipped: rankedUrls.slice(1),
+    };
+  }
+
+  const now = input.now ?? Date.now;
+  const probeBudgetMs = input.probeBudgetMs ?? DEFAULT_PROBE_BUDGET_MS;
+  const probeOrigin = input.probeOrigin ?? createDefaultProbe(input.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS);
+
+  const probed: Array<{ url: string; reachable: boolean }> = [];
+  const skipped: string[] = [];
+  const startedAt = now();
+  let reachableUrl: string | null = null;
+
+  for (const url of rankedUrls) {
+    if (reachableUrl) {
+      skipped.push(url);
+      continue;
+    }
+    // The top-ranked candidate is always probed. After that a spent budget means
+    // we hand back the ranked pick rather than stalling startup on N timeouts.
+    if (probed.length > 0 && now() - startedAt >= probeBudgetMs) {
+      skipped.push(url);
+      continue;
+    }
+    const reachable = await probeOrigin(url).catch(() => false);
+    probed.push({ url, reachable });
+    if (reachable) reachableUrl = url;
+  }
+
+  const url = reachableUrl ?? bestRankedUrl;
+  return {
+    url,
+    reason: reachableUrl ? "probe" : "unreachable-fallback",
+    candidates: [url, ...rankedUrls.filter((candidate) => candidate !== url)],
+    probed,
+    skipped,
+  };
 }


### PR DESCRIPTION
## Problem

`choosePrimaryRuntimeApiUrl()` picks the origin agents dial as the **first non-empty entry of `server.allowedHostnames`**:

```ts
const allowedHostname = input.allowedHostnames.map(v => v.trim()).find(Boolean);
if (allowedHostname) return formatOrigin("http:", allowedHostname, input.port);
```

`allowedHostnames` is a Host-header *accept* list. Nothing in it promises that a name resolves to the address the server actually bound, so this selection is pure array order.

Observed on a Tailscale-bound host with `allowedHostnames: ["box-name", "box-name.tailnet.ts.net"]`, `bind: tailnet`, `host: 100.x.x.x`:

- index 0, `box-name`, resolves via the cloud provider's internal DNS to `10.0.0.4` — nothing listens there. Every agent run got connection-refused on its first control-plane call.
- index 1, `box-name.tailnet.ts.net`, resolves via MagicDNS to the bound address and returns `200`.

The correct answer was already in the list, one slot too late. Any tailnet/VPN-bound deployment whose machine name also exists in a cloud provider's internal DNS hits this. The loopback fallback is not a safety net either: with a non-wildcard bind, `localhost:<port>` has no listener.

Adjacent to (and distinct from) #6630, which covered conflating the two lists rather than reachability.

## Change

New `resolveRuntimeApiUrl()` in `server/src/runtime-api.ts` replaces the order-based derivation:

1. **Rank** the existing candidate list by whether each hostname resolves to the bind address. A name that does not resolve is ranked *ahead* of one that resolves elsewhere — split-horizon DNS and hosts-file entries legitimately differ between the server and its agents, so unknown is not disqualified.
2. **Probe** in that order once the listener is open, and promote the first origin that answers. Any HTTP response proves a listener, so a future auth change on `/api/health` cannot silently break the check.
3. **Fall back** to the best-ranked candidate when nothing answers, and `warn` with the full probe record.

Kept intentionally:

- An explicit `PAPERCLIP_API_URL` or `authPublicBaseUrl` is operator intent — it may name a reverse proxy this process cannot reach itself — and is **never** overridden.
- A loopback bind short-circuits before any lookup.
- A wildcard bind answers on every address, so DNS carries no ranking signal; the caller's order is left alone.

Startup calls the resolver twice: `probe: false` before `listen()` (probing your own unopened port rejects everything), then again after, promoting only if the result differs.

### Bounded startup cost

500 ms per-hostname DNS timeout, 600 ms per-probe timeout, 1200 ms total probe budget after the first candidate. `dns.lookup` has no timeout of its own, so a wedged resolver cannot stall boot. In the common case the top-ranked candidate answers on the first probe.

### Removed: `PAPERCLIP_RUNTIME_API_CANDIDATES_JSON`

Startup wrote this ordered fallback list to `process.env` for adapters to retry against. `git grep` across the tree finds **no reader** — only the write and its own tests. Startup now does that retrying itself and exports a single origin that answered, so the list has no consumer left. Deleted rather than left write-only.

## Tests

`server/src/__tests__/runtime-api.test.ts` — new suite covering:

- the reported shape: `["unreachable-name", "good-name"]` with an injected resolver/prober where only `good-name` answers ⇒ `good-name` origin;
- **order independence**: swapping the two entries yields the same URL (this is the assertion the old code cannot satisfy);
- fallthrough to the bind host, DNS-rank fallback when nothing answers, explicit-public-base-URL short-circuit, loopback bind, and probe-budget exhaustion.

`server/src/__tests__/server-startup-feedback-export.test.ts` — startup-level coverage that an allowed hostname resolving away from the bind address is not exported, plus the candidate-list removal. Uses TEST-NET-1 (`192.0.2.0/24`) and `.invalid` so it stays hermetic in CI.

Against `master`, `choosePrimaryRuntimeApiUrl` returns `http://unreachable-name:3100` for the first ordering and `http://good-name:3100` for the swapped one — order-dependent, and wrong in the reported case.

```
$ npx vitest run src/__tests__/runtime-api.test.ts src/__tests__/server-startup-feedback-export.test.ts
 Test Files  2 passed (2)
      Tests  33 passed (33)

$ npx tsc --noEmit -p server/tsconfig.json
(clean)
```
