### PR TITLE
fix(server): pick the runtime API URL agents can actually reach

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildRuntimeApiCandidateUrls,
   choosePrimaryRuntimeApiUrl,
   collectReachableInterfaceHosts,
+  createRuntimeApiProbe,
+  getRuntimeApiInstanceToken,
   rankRuntimeApiCandidatesByBindAddress,
   resolveRuntimeApiUrl,
+  RUNTIME_API_INSTANCE_HEADER,
 } from "../runtime-api.js";
 
 describe("runtime API discovery", () => {
@@ -334,5 +339,97 @@ describe("runtime API reachability resolution", () => {
       "http://no-such-name:3100",
       "http://unreachable-name:3100",
     ]);
+  });
+});
+
+describe("runtime API probe identity", () => {
+  // An allow-listed hostname can resolve to a machine running something else
+  // entirely. "A listener answered" is therefore not enough to promote an origin
+  // to PAPERCLIP_API_URL: agents send bearer tokens there, so the probe has to
+  // establish that the responder is this process.
+  const servers: http.Server[] = [];
+
+  const startListener = async (
+    handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+  ): Promise<string> => {
+    const server = http.createServer(handler);
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  };
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+    );
+  });
+
+  it("accepts an origin that answers with this process's instance token", async () => {
+    const origin = await startListener((_req, res) => {
+      res.setHeader(RUNTIME_API_INSTANCE_HEADER, getRuntimeApiInstanceToken());
+      res.writeHead(200).end("{}");
+    });
+
+    const probe = createRuntimeApiProbe(600, getRuntimeApiInstanceToken());
+    expect(await probe(origin)).toBe(true);
+  });
+
+  it("accepts our own listener even when it rejects the probe unauthenticated", async () => {
+    // The header is set ahead of any authorization decision, so tightening auth
+    // on /api/health must not make this server look unreachable to itself.
+    const origin = await startListener((_req, res) => {
+      res.setHeader(RUNTIME_API_INSTANCE_HEADER, getRuntimeApiInstanceToken());
+      res.writeHead(401).end("unauthorized");
+    });
+
+    const probe = createRuntimeApiProbe(600, getRuntimeApiInstanceToken());
+    expect(await probe(origin)).toBe(true);
+  });
+
+  it("rejects an unrelated HTTP service that answers on a candidate origin", async () => {
+    const origin = await startListener((_req, res) => {
+      res.writeHead(200).end("hello from something else");
+    });
+
+    const probe = createRuntimeApiProbe(600, getRuntimeApiInstanceToken());
+    expect(await probe(origin)).toBe(false);
+  });
+
+  it("rejects another Paperclip process listening on a candidate origin", async () => {
+    const origin = await startListener((_req, res) => {
+      res.setHeader(RUNTIME_API_INSTANCE_HEADER, "a-different-paperclip-process");
+      res.writeHead(200).end("{}");
+    });
+
+    const probe = createRuntimeApiProbe(600, getRuntimeApiInstanceToken());
+    expect(await probe(origin)).toBe(false);
+  });
+
+  it("falls back to the ranked pick when only a foreign listener answers", async () => {
+    // End to end: a stranger on the wrong name must not be promoted just because
+    // it replies. Ranking still decides, and the reason records that nothing of
+    // ours answered.
+    const foreign = await startListener((_req, res) => {
+      res.writeHead(200).end("hello from something else");
+    });
+
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: "100.108.64.76",
+      port: 3100,
+      networkInterfacesMap: {},
+      lookupHost: async (hostname) => {
+        if (hostname === "good-name") return ["100.108.64.76"];
+        if (hostname === "unreachable-name") return ["10.0.0.4"];
+        return [];
+      },
+      probeOrigin: createRuntimeApiProbe(600, getRuntimeApiInstanceToken()),
+      probeTimeoutMs: 600,
+    });
+
+    expect(foreign).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(resolved.reason).toBe("unreachable-fallback");
+    expect(resolved.url).toBe("http://good-name:3100");
   });
 });

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -3,6 +3,8 @@ import {
   buildRuntimeApiCandidateUrls,
   choosePrimaryRuntimeApiUrl,
   collectReachableInterfaceHosts,
+  rankRuntimeApiCandidatesByBindAddress,
+  resolveRuntimeApiUrl,
 } from "../runtime-api.js";
 
 describe("runtime API discovery", () => {
@@ -153,6 +155,184 @@ describe("runtime API discovery", () => {
     ).toEqual([
       "192.168.6.178",
       "fd7a:115c:a1e0::8a3a:a11d",
+    ]);
+  });
+});
+
+describe("runtime API reachability resolution", () => {
+  // Mirrors a tailnet-bound host whose short machine name also exists in the
+  // cloud provider's internal DNS: both names are allow-listed, but only the
+  // tailnet name resolves to the address the server actually bound.
+  const BIND_HOST = "100.108.64.76";
+  const PORT = 3100;
+
+  const lookupHost = async (hostname: string): Promise<string[]> => {
+    if (hostname === "good-name") return ["100.108.64.76"];
+    if (hostname === "unreachable-name") return ["10.0.0.4"];
+    return [];
+  };
+
+  const probeOnlyGoodName = async (origin: string): Promise<boolean> =>
+    origin === "http://good-name:3100";
+
+  it("picks the allowed hostname that resolves to the bind address and answers a probe", async () => {
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+
+    expect(resolved.url).toBe("http://good-name:3100");
+    expect(resolved.reason).toBe("probe");
+    // The known-wrong name must never be probed before the working one.
+    expect(resolved.probed.map((entry) => entry.url)).not.toContain("http://unreachable-name:3100");
+  });
+
+  it("is not order-dependent: swapping the allowed hostnames yields the same URL", async () => {
+    const forward = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+    const reversed = await resolveRuntimeApiUrl({
+      allowedHostnames: ["good-name", "unreachable-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+
+    expect(reversed.url).toBe(forward.url);
+    expect(reversed.url).toBe("http://good-name:3100");
+  });
+
+  it("puts the reachable origin first in the candidate list it returns", async () => {
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: probeOnlyGoodName,
+    });
+
+    expect(resolved.candidates[0]).toBe("http://good-name:3100");
+    expect(resolved.candidates).toContain("http://unreachable-name:3100");
+  });
+
+  it("keeps the resolve-ranked order when no candidate answers", async () => {
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin: async () => false,
+    });
+
+    expect(resolved.reason).toBe("unreachable-fallback");
+    expect(resolved.url).toBe("http://good-name:3100");
+    expect(resolved.probed.every((entry) => entry.reachable === false)).toBe(true);
+  });
+
+  it("stops probing once the budget is spent instead of stalling startup", async () => {
+    let clock = 0;
+    const resolved = await resolveRuntimeApiUrl({
+      allowedHostnames: ["unreachable-name", "good-name", "no-such-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeBudgetMs: 1_000,
+      now: () => clock,
+      probeOrigin: async () => {
+        clock += 1_500;
+        return false;
+      },
+    });
+
+    // The top-ranked candidate is always probed; the rest are dropped once the
+    // budget is gone, so a fully dead list costs one timeout instead of N.
+    expect(resolved.probed).toHaveLength(1);
+    expect(resolved.probed[0]?.url).toBe("http://good-name:3100");
+    expect(resolved.skipped).toEqual([
+      // The bind address itself is also a candidate, and ranks alongside the
+      // allowed hostname that resolves to it.
+      "http://100.108.64.76:3100",
+      "http://no-such-name:3100",
+      "http://unreachable-name:3100",
+    ]);
+    expect(resolved.reason).toBe("unreachable-fallback");
+    expect(resolved.url).toBe("http://good-name:3100");
+  });
+
+  it("honors an explicit public base URL without probing", async () => {
+    const probeOrigin = async (): Promise<boolean> => {
+      throw new Error("probe must not run when a public base URL is configured");
+    };
+
+    const resolved = await resolveRuntimeApiUrl({
+      authPublicBaseUrl: "https://paperclip.example.com/base/path",
+      allowedHostnames: ["unreachable-name", "good-name"],
+      bindHost: BIND_HOST,
+      port: PORT,
+      networkInterfacesMap: {},
+      lookupHost,
+      probeOrigin,
+    });
+
+    expect(resolved.url).toBe("https://paperclip.example.com");
+    expect(resolved.reason).toBe("explicit-public-base-url");
+    expect(resolved.probed).toEqual([]);
+  });
+
+  it("leaves candidate order alone for a wildcard bind, where DNS carries no signal", async () => {
+    const ranked = await rankRuntimeApiCandidatesByBindAddress({
+      candidates: ["http://unreachable-name:3100", "http://good-name:3100"],
+      bindHost: "0.0.0.0",
+      lookupHost,
+    });
+
+    expect(ranked.map((entry) => entry.url)).toEqual([
+      "http://unreachable-name:3100",
+      "http://good-name:3100",
+    ]);
+  });
+
+  it("does not stall ranking when a resolver never answers", async () => {
+    // `dns.lookup` has no timeout of its own, and the probe budget only covers
+    // probing. A wedged resolver must degrade to "unknown", not hang startup.
+    const ranked = await rankRuntimeApiCandidatesByBindAddress({
+      candidates: ["http://wedged-resolver-name:3100", `http://${BIND_HOST}:3100`],
+      bindHost: BIND_HOST,
+      lookupHost: () => new Promise<string[]>(() => {}),
+      lookupTimeoutMs: 10,
+    });
+
+    expect(ranked.map((entry) => entry.url)).toEqual([
+      `http://${BIND_HOST}:3100`,
+      "http://wedged-resolver-name:3100",
+    ]);
+    expect(ranked[1]?.addresses).toEqual([]);
+  });
+
+  it("ranks a name that does not resolve above one that resolves off the bind address", async () => {
+    const ranked = await rankRuntimeApiCandidatesByBindAddress({
+      candidates: ["http://unreachable-name:3100", "http://no-such-name:3100"],
+      bindHost: BIND_HOST,
+      lookupHost,
+    });
+
+    expect(ranked.map((entry) => entry.url)).toEqual([
+      "http://no-such-name:3100",
+      "http://unreachable-name:3100",
     ]);
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -347,6 +347,7 @@ vi.mock("../auth/better-auth.js", () => ({
 }));
 
 import { startServer } from "../index.ts";
+import { printStartupBanner } from "../startup-banner.js";
 
 describe("startServer feedback export wiring", () => {
   beforeEach(() => {
@@ -708,6 +709,37 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.apiUrl).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
+  });
+
+  it("resumes queued runs only after the probed runtime API URL is settled", async () => {
+    // A resumed run spawns an agent, and the child snapshots PAPERCLIP_API_URL at
+    // spawn time. If recovery runs before the post-listen probe, the child
+    // inherits the unprobed origin and no later promotion can repair it.
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      bind: "custom",
+      customBindHost: "192.0.2.10",
+      host: "192.0.2.10",
+      allowedHostnames: ["unreachable-name.invalid", "192.0.2.10"],
+      heartbeatSchedulerEnabled: true,
+      heartbeatSchedulerIntervalMs: 30000,
+    }));
+    let apiUrlSeenByResume: string | undefined;
+    heartbeatServiceMock.resumeQueuedRuns.mockImplementationOnce(async () => {
+      apiUrlSeenByResume = process.env.PAPERCLIP_API_URL;
+      return undefined;
+    });
+
+    await startServer();
+
+    expect(heartbeatServiceMock.resumeQueuedRuns).toHaveBeenCalled();
+    expect(apiUrlSeenByResume).toBe("http://192.0.2.10:3210");
+    // The probe can only run once the listener is open, so recovery must be
+    // sequenced after the listen callback, not before it.
+    const bannerMock = vi.mocked(printStartupBanner);
+    expect(bannerMock).toHaveBeenCalled();
+    expect(bannerMock.mock.invocationCallOrder[0]).toBeLessThan(
+      heartbeatServiceMock.resumeQueuedRuns.mock.invocationCallOrder[0]!,
+    );
   });
 
   it("preserves explicit-port external auth public URLs when detect-port selects a new port", async () => {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -742,6 +742,49 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     );
   });
 
+  it("skips scheduler ticks that fire before the probed runtime API URL is settled", async () => {
+    // The scheduler interval is registered before `server.listen`. A tick that
+    // fires in that window can enqueue a run through tickTimers /
+    // tickScheduledTriggers, and the spawned child snapshots the still-unprobed
+    // PAPERCLIP_API_URL, which later promotion cannot repair.
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      bind: "custom",
+      customBindHost: "192.0.2.10",
+      host: "192.0.2.10",
+      allowedHostnames: ["unreachable-name.invalid", "192.0.2.10"],
+      heartbeatSchedulerEnabled: true,
+      heartbeatSchedulerIntervalMs: 30000,
+    }));
+    let intervalCallback: (() => void) | null = null;
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockImplementation(((callback: () => void) => {
+        intervalCallback = callback;
+        // Fire the tick at registration time, i.e. during startup and before the
+        // listener is open.
+        callback();
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval);
+
+    try {
+      await startServer();
+
+      expect(heartbeatServiceMock.tickTimers).not.toHaveBeenCalled();
+      expect(routineServiceMock.tickScheduledTriggers).not.toHaveBeenCalled();
+
+      // Once the URL has settled the same tick does its normal work.
+      intervalCallback?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(heartbeatServiceMock.tickTimers).toHaveBeenCalledTimes(1);
+      expect(routineServiceMock.tickScheduledTriggers).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
   it("preserves explicit-port external auth public URLs when detect-port selects a new port", async () => {
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
       port: 3100,

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
 const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL;
-const ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
 
@@ -645,12 +644,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     if (ORIGINAL_PAPERCLIP_RUNTIME_API_URL === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
     else process.env.PAPERCLIP_RUNTIME_API_URL = ORIGINAL_PAPERCLIP_RUNTIME_API_URL;
 
-    if (ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON === undefined) {
-      delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
-    } else {
-      process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
-    }
-
     if (ORIGINAL_PAPERCLIP_LISTEN_HOST === undefined) delete process.env.PAPERCLIP_LISTEN_HOST;
     else process.env.PAPERCLIP_LISTEN_HOST = ORIGINAL_PAPERCLIP_LISTEN_HOST;
 
@@ -665,10 +658,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.apiUrl).toBe("http://custom-api:3100");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://custom-api:3100");
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
-      expect.arrayContaining(["http://custom-api:3100"]),
-    );
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")[0]).toBe("http://custom-api:3100");
   });
 
   it("falls back to host-based URL when PAPERCLIP_API_URL is not set", async () => {
@@ -676,6 +665,37 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.apiUrl).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
+  });
+
+  it("no longer exports the write-only runtime API candidate list", async () => {
+    // The candidate list used to be exported for adapters to retry against, but
+    // nothing ever read it. Startup now probes the candidates itself and exports
+    // a single origin that answered, so the list has no consumer left.
+    delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+
+    await startServer();
+
+    expect(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON).toBeUndefined();
+  });
+
+  it("does not export an allowed hostname that resolves away from the bind address", async () => {
+    // The reported shape, on a non-loopback bind: `allowedHostnames` is a
+    // Host-header accept list, so its first entry carries no guarantee that it
+    // resolves to the address the server bound. Startup must not hand agents
+    // that name just because it sorts first. 192.0.2.0/24 is TEST-NET-1 and
+    // `.invalid` never resolves, so this stays hermetic in CI.
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      bind: "custom",
+      customBindHost: "192.0.2.10",
+      host: "192.0.2.10",
+      allowedHostnames: ["unreachable-name.invalid", "192.0.2.10"],
+    }));
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("http://192.0.2.10:3210");
+    expect(process.env.PAPERCLIP_API_URL).toBe("http://192.0.2.10:3210");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://192.0.2.10:3210");
   });
 
   it("keeps loopback as the runtime API URL when allowed hostnames are present", async () => {
@@ -688,9 +708,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.apiUrl).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
-      expect.arrayContaining(["http://127.0.0.1:3210", "http://192.168.1.50:3210"]),
-    );
   });
 
   it("preserves explicit-port external auth public URLs when detect-port selects a new port", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1270,6 +1270,14 @@ export async function startServer(): Promise<StartedServer> {
       // captures the authoritative set of running heartbeat rows.
       trackHeartbeatSchedulerWork((async () => {
         if (heartbeatSchedulerStopped) return;
+        // The interval is registered before `server.listen`, so a tick can fire
+        // while PAPERCLIP_API_URL is still the unprobed derivation. Nearly every
+        // branch below can enqueue a run (timers, routine triggers, watchdogs,
+        // queued-run recovery), and a spawned child snapshots the URL, so skip
+        // the whole tick rather than gate each branch; the next tick picks the
+        // work up. Settlement happens immediately after listen, so at most the
+        // first tick is skipped.
+        if (!runtimeApiUrlIsSettled) return;
         trackHeartbeatSchedulerWork(decisionExecutor.sweepExpired().catch((err: unknown) => {
           logger.error({ err }, "decision expiry sweep failed");
         }));
@@ -1379,9 +1387,6 @@ export async function startServer(): Promise<StartedServer> {
           }));
 
         if (heartbeatSchedulerStopped) return;
-        // Same spawn-time snapshot hazard as startup recovery; skip this tick
-        // rather than block the scheduler, the next tick picks the work up.
-        if (!runtimeApiUrlIsSettled) return;
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
           // Periodically reap orphaned runs (5-min staleness threshold) and make sure
           // persisted queued work is still being driven forward.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -781,42 +781,65 @@ export async function startServer(): Promise<StartedServer> {
     bindHost: runtimeListenHost,
     port: listenPort,
   };
-  // DNS ranking only at this point: the listener is not open yet, so probing here
-  // would reject every candidate. `promoteReachableRuntimeApiUrl` below re-runs
-  // this with probing once the server is listening.
-  const initialRuntimeApi = await resolveRuntimeApiUrl({ ...runtimeApiResolverInput, probe: false });
-  let configuredApiUrl = runtimeApiOverride || initialRuntimeApi.url;
+  // An explicit PAPERCLIP_API_URL is operator intent and wins outright, so the
+  // candidate resolver is not run at all in that case: its result would only be
+  // discarded, and a slow or wedged DNS server would delay startup for nothing.
+  //
+  // Without an override: DNS ranking only at this point, because the listener is
+  // not open yet and probing here would reject every candidate.
+  // `promoteReachableRuntimeApiUrl` below re-runs this with probing once the
+  // server is listening.
+  const initialRuntimeApi = runtimeApiOverride
+    ? null
+    : await resolveRuntimeApiUrl({ ...runtimeApiResolverInput, probe: false });
+  let configuredApiUrl = runtimeApiOverride || initialRuntimeApi!.url;
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = initialRuntimeApi.url;
+  process.env.PAPERCLIP_RUNTIME_API_URL = initialRuntimeApi?.url ?? configuredApiUrl;
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
+
+  // Agents inherit PAPERCLIP_API_URL as a snapshot at spawn time, so anything
+  // that can spawn a run has to wait until this settles or it hands the child an
+  // unprobed URL that later promotion cannot repair.
+  let runtimeApiUrlIsSettled = false;
 
   // `allowedHostnames` is a Host-header accept list, so a name in it can resolve
   // to an address nothing listens on — which is exactly what agents inherit as
   // PAPERCLIP_API_URL. Once the listener is up, probe the ranked candidates and
   // promote the first origin that actually answers.
   const promoteReachableRuntimeApiUrl = async (): Promise<void> => {
-    if (runtimeApiOverride) return;
-    if (initialRuntimeApi.reason !== "resolve-rank") return;
+    try {
+      if (!initialRuntimeApi) return;
+      if (initialRuntimeApi.reason !== "resolve-rank") return;
 
-    const probedRuntimeApi = await resolveRuntimeApiUrl(runtimeApiResolverInput);
-    if (probedRuntimeApi.reason === "unreachable-fallback") {
+      const probedRuntimeApi = await resolveRuntimeApiUrl(runtimeApiResolverInput);
+      if (probedRuntimeApi.reason === "unreachable-fallback") {
+        logger.warn(
+          { candidates: probedRuntimeApi.candidates, probed: probedRuntimeApi.probed, skipped: probedRuntimeApi.skipped },
+          `No runtime API candidate answered a probe; agents will use ${probedRuntimeApi.url}, which may be unreachable`,
+        );
+        return;
+      }
+      if (probedRuntimeApi.url === initialRuntimeApi.url) return;
+
       logger.warn(
-        { candidates: probedRuntimeApi.candidates, probed: probedRuntimeApi.probed, skipped: probedRuntimeApi.skipped },
-        `No runtime API candidate answered a probe; agents will use ${probedRuntimeApi.url}, which may be unreachable`,
+        { previousApiUrl: initialRuntimeApi.url, probed: probedRuntimeApi.probed },
+        `Promoted runtime API URL to ${probedRuntimeApi.url} after probing; the derived URL did not answer`,
       );
-      return;
+      configuredApiUrl = probedRuntimeApi.url;
+      process.env.PAPERCLIP_RUNTIME_API_URL = probedRuntimeApi.url;
+      process.env.PAPERCLIP_API_URL = probedRuntimeApi.url;
+    } catch (err) {
+      logger.warn({ err }, "runtime API reachability probe failed; keeping the derived API URL");
+    } finally {
+      runtimeApiUrlIsSettled = true;
     }
-    if (probedRuntimeApi.url === initialRuntimeApi.url) return;
-
-    logger.warn(
-      { previousApiUrl: initialRuntimeApi.url, probed: probedRuntimeApi.probed },
-      `Promoted runtime API URL to ${probedRuntimeApi.url} after probing; the derived URL did not answer`,
-    );
-    configuredApiUrl = probedRuntimeApi.url;
-    process.env.PAPERCLIP_RUNTIME_API_URL = probedRuntimeApi.url;
-    process.env.PAPERCLIP_API_URL = probedRuntimeApi.url;
   };
+
+  // Startup recovery can resume queued runs, which spawn agents that snapshot
+  // PAPERCLIP_API_URL. It is therefore defined here but invoked only after the
+  // listener is open and `promoteReachableRuntimeApiUrl` has settled the URL.
+  let runStartupHeartbeatRecovery: (() => Promise<void>) | null = null;
 
   setupEnvironmentCustomImageTerminalWebSocketServer(server, db as any, {
     pluginWorkerManager,
@@ -1109,7 +1132,7 @@ export async function startServer(): Promise<StartedServer> {
         "heartbeat scheduling suppressed for this runtime instance",
       );
     } else {
-      const startupHeartbeatRecovery = (async () => {
+      const startupHeartbeatRecovery = async (): Promise<void> => {
         try {
           const hotRestart = await heartbeat.reconcileHotRestartAdoption();
           if (hotRestart.mode === "reported") {
@@ -1192,11 +1215,14 @@ export async function startServer(): Promise<StartedServer> {
         if (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0) {
           logger.warn({ ...reviewed }, "startup productivity reconciliation created or updated review work");
         }
-      })().catch((err) => {
-        logger.error({ err }, "startup heartbeat recovery failed");
-      });
-      trackHeartbeatSchedulerWork(startupHeartbeatRecovery);
-      await startupHeartbeatRecovery;
+      };
+      runStartupHeartbeatRecovery = () => {
+        const work = startupHeartbeatRecovery().catch((err) => {
+          logger.error({ err }, "startup heartbeat recovery failed");
+        });
+        trackHeartbeatSchedulerWork(work);
+        return work;
+      };
     }
 
     const setupCleanup = await environmentCustomImages.cleanupExpiredSetupSessions();
@@ -1353,6 +1379,9 @@ export async function startServer(): Promise<StartedServer> {
           }));
 
         if (heartbeatSchedulerStopped) return;
+        // Same spawn-time snapshot hazard as startup recovery; skip this tick
+        // rather than block the scheduler, the next tick picks the work up.
+        if (!runtimeApiUrlIsSettled) return;
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
           // Periodically reap orphaned runs (5-min staleness threshold) and make sure
           // persisted queued work is still being driven forward.
@@ -1521,6 +1550,10 @@ export async function startServer(): Promise<StartedServer> {
   });
 
   await promoteReachableRuntimeApiUrl();
+
+  // Only now is PAPERCLIP_API_URL proven, so resuming queued runs cannot hand a
+  // child an origin nothing answers on.
+  if (runStartupHeartbeatRecovery) await runStartupHeartbeatRecovery();
 
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -77,7 +77,7 @@ import {
   reconcileAdapterAvailability,
 } from "./services/adapter-registry-bootstrap.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
-import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
+import { resolveRuntimeApiUrl } from "./runtime-api.js";
 import { isLoopbackHost, rewriteLoopbackUrlPort } from "./url-utils.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
@@ -774,26 +774,50 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
-  const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
+  const runtimeApiOverride = process.env.PAPERCLIP_API_URL?.trim();
+  const runtimeApiResolverInput = {
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
-  });
-  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
-  const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
-    preferredApiUrl: configuredApiUrl,
-    authPublicBaseUrl: config.authPublicBaseUrl ?? null,
-    allowedHostnames: config.allowedHostnames,
-    bindHost: runtimeListenHost,
-    port: listenPort,
-  });
+  };
+  // DNS ranking only at this point: the listener is not open yet, so probing here
+  // would reject every candidate. `promoteReachableRuntimeApiUrl` below re-runs
+  // this with probing once the server is listening.
+  const initialRuntimeApi = await resolveRuntimeApiUrl({ ...runtimeApiResolverInput, probe: false });
+  let configuredApiUrl = runtimeApiOverride || initialRuntimeApi.url;
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
-  process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
+  process.env.PAPERCLIP_RUNTIME_API_URL = initialRuntimeApi.url;
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
-  
+
+  // `allowedHostnames` is a Host-header accept list, so a name in it can resolve
+  // to an address nothing listens on — which is exactly what agents inherit as
+  // PAPERCLIP_API_URL. Once the listener is up, probe the ranked candidates and
+  // promote the first origin that actually answers.
+  const promoteReachableRuntimeApiUrl = async (): Promise<void> => {
+    if (runtimeApiOverride) return;
+    if (initialRuntimeApi.reason !== "resolve-rank") return;
+
+    const probedRuntimeApi = await resolveRuntimeApiUrl(runtimeApiResolverInput);
+    if (probedRuntimeApi.reason === "unreachable-fallback") {
+      logger.warn(
+        { candidates: probedRuntimeApi.candidates, probed: probedRuntimeApi.probed, skipped: probedRuntimeApi.skipped },
+        `No runtime API candidate answered a probe; agents will use ${probedRuntimeApi.url}, which may be unreachable`,
+      );
+      return;
+    }
+    if (probedRuntimeApi.url === initialRuntimeApi.url) return;
+
+    logger.warn(
+      { previousApiUrl: initialRuntimeApi.url, probed: probedRuntimeApi.probed },
+      `Promoted runtime API URL to ${probedRuntimeApi.url} after probing; the derived URL did not answer`,
+    );
+    configuredApiUrl = probedRuntimeApi.url;
+    process.env.PAPERCLIP_RUNTIME_API_URL = probedRuntimeApi.url;
+    process.env.PAPERCLIP_API_URL = probedRuntimeApi.url;
+  };
+
   setupEnvironmentCustomImageTerminalWebSocketServer(server, db as any, {
     pluginWorkerManager,
   });
@@ -1495,7 +1519,9 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
+
+  await promoteReachableRuntimeApiUrl();
+
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
       await systemdNotify(["--stopping", `--status=Stopping after ${signal}`]);

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -6,6 +6,7 @@ import { heartbeatRuns, instanceUserRoles, invites } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { readPersistedDevServerStatus, toDevServerHealthStatus, writeDevServerRestartRequest } from "../dev-server-status.js";
 import { logger } from "../middleware/logger.js";
+import { getRuntimeApiInstanceToken, RUNTIME_API_INSTANCE_HEADER } from "../runtime-api.js";
 import { getServerInfoSnapshot, type ServerInfoSnapshot } from "../server-info.js";
 import {
   getCloudStackContext,
@@ -91,6 +92,15 @@ export function healthRoutes(
   },
 ) {
   const router = Router();
+
+  // Startup's reachability probe uses this header to tell our own listener apart
+  // from an unrelated HTTP service that happens to answer on a candidate
+  // hostname. Set it ahead of every handler and every authorization decision, so
+  // the probe keeps working on redacted and rejected responses alike.
+  router.use((_req, res, next) => {
+    res.setHeader(RUNTIME_API_INSTANCE_HEADER, getRuntimeApiInstanceToken());
+    next();
+  });
 
   router.post("/dev-server/restart", async (req, res) => {
     const actorType = "actor" in req ? req.actor?.type : null;

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -1,5 +1,29 @@
+import { randomUUID } from "node:crypto";
 import dns from "node:dns/promises";
 import os from "node:os";
+
+/**
+ * Response header carrying this process's runtime-API instance token.
+ *
+ * The startup probe below has to answer "is this origin me?", not merely "is
+ * something listening?". A candidate hostname can resolve to an unrelated HTTP
+ * service, and promoting that origin would hand every agent a control-plane URL
+ * pointing at a stranger — bearer tokens included. Only this process knows the
+ * token, so echoing it is what separates our listener from any other.
+ */
+export const RUNTIME_API_INSTANCE_HEADER = "x-paperclip-instance";
+
+let runtimeApiInstanceToken: string | null = null;
+
+/**
+ * Per-process identity for the reachability probe. Random and minted once; it
+ * names no config and encodes nothing, so serving it to anonymous callers on
+ * `/api/health` leaks nothing a port scan would not already reveal.
+ */
+export function getRuntimeApiInstanceToken(): string {
+  if (!runtimeApiInstanceToken) runtimeApiInstanceToken = randomUUID();
+  return runtimeApiInstanceToken;
+}
 
 /** Per-hostname DNS timeout. Ranking every candidate must stay bounded too. */
 const DEFAULT_LOOKUP_TIMEOUT_MS = 500;
@@ -256,15 +280,20 @@ function withLookupTimeout(lookupHost: RuntimeApiLookupHost, timeoutMs: number):
   };
 }
 
-function createDefaultProbe(timeoutMs: number): RuntimeApiProbe {
+export function createRuntimeApiProbe(timeoutMs: number, instanceToken: string): RuntimeApiProbe {
   return async (origin) => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      // Any HTTP response proves a listener is there. The status does not
-      // matter, so an auth change on /api/health cannot silently break this.
-      await fetch(new URL("/api/health", origin), { redirect: "manual", signal: controller.signal });
-      return true;
+      const response = await fetch(new URL("/api/health", origin), {
+        redirect: "manual",
+        signal: controller.signal,
+      });
+      // A reply proves a listener; only the instance header proves it is *this*
+      // listener. The status is deliberately not checked, so an auth change on
+      // /api/health cannot silently break the probe — the header is set ahead of
+      // any authorization decision.
+      return response.headers.get(RUNTIME_API_INSTANCE_HEADER) === instanceToken;
     } catch {
       return false;
     } finally {
@@ -395,7 +424,9 @@ export async function resolveRuntimeApiUrl(input: {
 
   const now = input.now ?? Date.now;
   const probeBudgetMs = input.probeBudgetMs ?? DEFAULT_PROBE_BUDGET_MS;
-  const probeOrigin = input.probeOrigin ?? createDefaultProbe(input.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS);
+  const probeOrigin =
+    input.probeOrigin ??
+    createRuntimeApiProbe(input.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS, getRuntimeApiInstanceToken());
 
   const probed: Array<{ url: string; reachable: boolean }> = [];
   const skipped: string[] = [];

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -1,7 +1,30 @@
+import dns from "node:dns/promises";
 import os from "node:os";
+
+/** Per-hostname DNS timeout. Ranking every candidate must stay bounded too. */
+const DEFAULT_LOOKUP_TIMEOUT_MS = 500;
+/** Per-candidate probe timeout. One dead candidate must not stall startup. */
+const DEFAULT_PROBE_TIMEOUT_MS = 600;
+/** Total time startup is willing to spend probing every candidate combined. */
+const DEFAULT_PROBE_BUDGET_MS = 1_200;
+
+/** The candidate hostname resolves to (or is) the address the server bound. */
+const RANK_MATCHES_BIND = 0;
+/** The candidate hostname does not resolve at all; unknown, not disqualified. */
+const RANK_UNRESOLVED = 1;
+/** The candidate hostname resolves somewhere the server is not listening. */
+const RANK_RESOLVES_ELSEWHERE = 2;
 
 function normalizeHost(value: string | null | undefined): string {
   return (value ?? "").trim();
+}
+
+function stripBrackets(host: string): string {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
+
+function canonicalHost(value: string | null | undefined): string {
+  return stripBrackets(normalizeHost(value)).toLowerCase();
 }
 
 function isLoopbackHost(host: string): boolean {
@@ -168,4 +191,239 @@ export function buildRuntimeApiCandidateUrls(input: {
   }
 
   return candidates;
+}
+
+export type RuntimeApiLookupHost = (hostname: string) => Promise<string[]>;
+export type RuntimeApiProbe = (origin: string) => Promise<boolean>;
+
+export type RuntimeApiResolutionReason =
+  /** Config named the public origin outright; nothing to discover. */
+  | "explicit-public-base-url"
+  /** A loopback bind only ever answers on loopback, whatever else is allow-listed. */
+  | "loopback-bind"
+  /** DNS ranking only; the caller asked us not to probe (e.g. before listen). */
+  | "resolve-rank"
+  /** A candidate answered an HTTP probe. */
+  | "probe"
+  /** Nothing answered; we fall back to the best DNS-ranked candidate. */
+  | "unreachable-fallback";
+
+export interface RuntimeApiCandidateRanking {
+  url: string;
+  hostname: string;
+  rank: number;
+  addresses: string[];
+}
+
+export interface RuntimeApiResolution {
+  url: string;
+  reason: RuntimeApiResolutionReason;
+  /** Ranked candidates, with the chosen URL first. */
+  candidates: string[];
+  probed: Array<{ url: string; reachable: boolean }>;
+  /** Candidates never probed, because one already answered or the budget ran out. */
+  skipped: string[];
+}
+
+async function defaultLookupHost(hostname: string): Promise<string[]> {
+  const entries = await dns.lookup(hostname, { all: true, verbatim: true });
+  return entries.map((entry) => entry.address);
+}
+
+/**
+ * `dns.lookup` has no timeout of its own, and the probe budget below only covers
+ * probing. Without this, one wedged resolver stalls startup before a single
+ * candidate is probed.
+ */
+function withLookupTimeout(lookupHost: RuntimeApiLookupHost, timeoutMs: number): RuntimeApiLookupHost {
+  return async (hostname) => {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        lookupHost(hostname),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error(`DNS lookup for ${hostname} timed out`)), timeoutMs);
+        }),
+      ]);
+    } catch {
+      // A name that does not resolve, or resolves too slowly to be worth
+      // waiting for, is unknown rather than disqualified: split-horizon DNS and
+      // hosts-file entries differ between the server and its agents.
+      return [];
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+}
+
+function createDefaultProbe(timeoutMs: number): RuntimeApiProbe {
+  return async (origin) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      // Any HTTP response proves a listener is there. The status does not
+      // matter, so an auth change on /api/health cannot silently break this.
+      await fetch(new URL("/api/health", origin), { redirect: "manual", signal: controller.signal });
+      return true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * Order candidate origins by whether their hostname resolves to the address the
+ * server actually bound. `allowedHostnames` is a Host-header accept list, so its
+ * order says nothing about reachability: on a tailnet-bound host the short
+ * machine name can also exist in the cloud provider's internal DNS and point at
+ * an address with no listener.
+ */
+export async function rankRuntimeApiCandidatesByBindAddress(input: {
+  candidates: string[];
+  bindHost: string;
+  lookupHost?: RuntimeApiLookupHost;
+  lookupTimeoutMs?: number;
+}): Promise<RuntimeApiCandidateRanking[]> {
+  const lookupHost = withLookupTimeout(
+    input.lookupHost ?? defaultLookupHost,
+    input.lookupTimeoutMs ?? DEFAULT_LOOKUP_TIMEOUT_MS,
+  );
+  const bindHost = canonicalHost(input.bindHost);
+  // A wildcard bind answers on every address, so DNS carries no signal about
+  // which candidate is reachable. Leave the caller's order alone.
+  const rankable = Boolean(bindHost) && !isWildcardHost(bindHost);
+
+  const ranked = await Promise.all(
+    input.candidates.map(async (url, index) => {
+      const hostname = (() => {
+        try {
+          return new URL(url).hostname;
+        } catch {
+          return "";
+        }
+      })();
+
+      if (!rankable || !hostname) {
+        return { url, hostname, rank: RANK_MATCHES_BIND, addresses: [] as string[], index };
+      }
+      if (canonicalHost(hostname) === bindHost) {
+        return { url, hostname, rank: RANK_MATCHES_BIND, addresses: [bindHost], index };
+      }
+
+      const addresses = await lookupHost(hostname).catch(() => [] as string[]);
+      const rank = addresses.some((address) => canonicalHost(address) === bindHost)
+        ? RANK_MATCHES_BIND
+        : addresses.length === 0
+          ? RANK_UNRESOLVED
+          : RANK_RESOLVES_ELSEWHERE;
+      return { url, hostname, rank, addresses, index };
+    }),
+  );
+
+  return ranked
+    .sort((left, right) => left.rank - right.rank || left.index - right.index)
+    .map(({ url, hostname, rank, addresses }) => ({ url, hostname, rank, addresses }));
+}
+
+/**
+ * Pick the origin agents should dial for the control plane.
+ *
+ * Replaces the old "first allow-listed hostname wins" derivation, which was pure
+ * array order and handed agents an unreachable name whenever a better one sat
+ * later in the list. Candidates are ranked by DNS against the bind address and
+ * then probed in that order; the first origin that answers wins.
+ *
+ * Pass `probe: false` before the server is listening — every probe would fail
+ * against its own not-yet-open port — and call again afterwards to promote.
+ */
+export async function resolveRuntimeApiUrl(input: {
+  authPublicBaseUrl?: string | null;
+  allowedHostnames: string[];
+  bindHost: string;
+  port: number;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  probe?: boolean;
+  probeBudgetMs?: number;
+  probeTimeoutMs?: number;
+  lookupHost?: RuntimeApiLookupHost;
+  lookupTimeoutMs?: number;
+  probeOrigin?: RuntimeApiProbe;
+  now?: () => number;
+}): Promise<RuntimeApiResolution> {
+  const explicitPublicBaseUrl = input.authPublicBaseUrl?.trim();
+  if (explicitPublicBaseUrl) {
+    try {
+      const origin = new URL(explicitPublicBaseUrl).origin;
+      return { url: origin, reason: "explicit-public-base-url", candidates: [origin], probed: [], skipped: [] };
+    } catch {
+      // Fall through to derived candidates if config parsing drifted.
+    }
+  }
+
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && !isWildcardHost(bindHost) && isLoopbackHost(bindHost)) {
+    const origin = formatOrigin("http:", bindHost, input.port);
+    return { url: origin, reason: "loopback-bind", candidates: [origin], probed: [], skipped: [] };
+  }
+
+  const ranked = await rankRuntimeApiCandidatesByBindAddress({
+    candidates: buildRuntimeApiCandidateUrls({
+      authPublicBaseUrl: input.authPublicBaseUrl,
+      allowedHostnames: input.allowedHostnames,
+      bindHost: input.bindHost,
+      port: input.port,
+      networkInterfacesMap: input.networkInterfacesMap,
+    }),
+    bindHost: input.bindHost,
+    lookupHost: input.lookupHost,
+    lookupTimeoutMs: input.lookupTimeoutMs,
+  });
+  const rankedUrls = ranked.map((entry) => entry.url);
+  const bestRankedUrl = rankedUrls[0] ?? formatOrigin("http:", "localhost", input.port);
+
+  if (input.probe === false) {
+    return {
+      url: bestRankedUrl,
+      reason: "resolve-rank",
+      candidates: rankedUrls.length > 0 ? rankedUrls : [bestRankedUrl],
+      probed: [],
+      skipped: rankedUrls.slice(1),
+    };
+  }
+
+  const now = input.now ?? Date.now;
+  const probeBudgetMs = input.probeBudgetMs ?? DEFAULT_PROBE_BUDGET_MS;
+  const probeOrigin = input.probeOrigin ?? createDefaultProbe(input.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS);
+
+  const probed: Array<{ url: string; reachable: boolean }> = [];
+  const skipped: string[] = [];
+  const startedAt = now();
+  let reachableUrl: string | null = null;
+
+  for (const url of rankedUrls) {
+    if (reachableUrl) {
+      skipped.push(url);
+      continue;
+    }
+    // The top-ranked candidate is always probed. After that a spent budget means
+    // we hand back the ranked pick rather than stalling startup on N timeouts.
+    if (probed.length > 0 && now() - startedAt >= probeBudgetMs) {
+      skipped.push(url);
+      continue;
+    }
+    const reachable = await probeOrigin(url).catch(() => false);
+    probed.push({ url, reachable });
+    if (reachable) reachableUrl = url;
+  }
+
+  const url = reachableUrl ?? bestRankedUrl;
+  return {
+    url,
+    reason: reachableUrl ? "probe" : "unreachable-fallback",
+    candidates: [url, ...rankedUrls.filter((candidate) => candidate !== url)],
+    probed,
+    skipped,
+  };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server starts, decides which origin agents must dial for the control plane, and exports it to every agent run as `PAPERCLIP_API_URL`
> - That origin was derived from the first entry of `server.allowedHostnames`
> - `allowedHostnames` is a Host-header accept list, so it says which names the server answers for, not which names reach it
> - The selection was therefore pure array order, and a name in that list can resolve to an address where nothing listens
> - On a tailnet-bound host whose short machine name also exists in the cloud provider's internal DNS, every agent run got a connection refused on its first control-plane call, while a working name sat later in the same list
> - This pull request ranks the candidates by whether they resolve to the bind address, then probes them and exports the first origin that answers as this server
> - The benefit is that the exported URL is verified before agents receive it, on any bind topology, with no new configuration

## Linked Issues or Issue Description

No existing issue was found for this defect. A search of open and closed pull requests found related but distinct work on `PAPERCLIP_API_URL` derivation: #5692 and #4877 make the URL loopback-safe for same-host local adapters, and #10315 bridges runtime API access for isolated sandboxes. None of them address the ordering of `allowedHostnames` against the bind address, so this change does not duplicate them.

**What happened?**

The server exports the first entry of `server.allowedHostnames` as `PAPERCLIP_API_URL`. That list is a Host-header accept list. Its order carries no guarantee that the name resolves to the address the server bound. On a host bound to a tailnet address, the short machine name also existed in the cloud provider's internal DNS and resolved to a different address with no listener. Every agent run received that name and failed its first control-plane call with a connection refused. A name that did resolve to the bound address was present in the same list, at the second position.

**Expected behavior**

The server must export an origin that agents can reach. When the configuration offers more than one candidate, the server must select a candidate that answers, not the candidate that sorts first.

**Steps to reproduce**

1. Bind the server to a private address, for example a tailnet address. Set `server.bind` to that interface and `server.host` to that address.
2. Set `server.allowedHostnames` to two names. Put a name that resolves elsewhere first. Put the name that resolves to the bound address second.
3. Do not set `PAPERCLIP_API_URL` and do not set an auth public base URL.
4. Start the server and read the exported `PAPERCLIP_API_URL`.
5. Send a request to that URL. Before this change the request fails with a connection refused, because the exported name resolves to an address with no listener.

**Paperclip version or commit**

Reproduced on `master` at 40e7add71c8eccc18abab21244e6edb7cb226f34.

**Deployment mode**

Self-hosted, `authenticated` mode, bound to a private interface rather than loopback or a wildcard address.

**Agent adapter(s) involved**

Not adapter-specific (core bug). The URL is exported before any adapter runs, so every adapter inherits it.

## What Changed

- Add `resolveRuntimeApiUrl` in `server/src/runtime-api.ts`. It ranks candidate origins by whether the hostname resolves to the bind address, then probes them in that order and returns the first origin that answers.
- Rank a name that does not resolve above a name that resolves somewhere else. Split-horizon DNS and hosts-file entries differ between the server and its agents, so a name that the server cannot resolve is unknown, not disqualified.
- Run the resolution in two phases in `server/src/index.ts`. Before the listener opens, rank only. After the listener opens, probe and promote the origin that answered.
- Prove the responder is this server. The process mints a random instance token, `/api/health` returns it in an `x-paperclip-instance` header, and the probe accepts an origin only when the header matches. Without this check an unrelated HTTP service on a candidate hostname would be exported to agents as their control-plane origin.
- Set that header in router-level middleware, ahead of every handler and every authorization decision. The probe therefore ignores the status code, so a future change to health authorization cannot silently break it.
- Never override operator intent. An explicit `PAPERCLIP_API_URL` or an auth public base URL is used as given, because it can name a reverse proxy that this process cannot reach itself. A loopback bind returns early, before any lookup.
- Bound the work. DNS lookups time out after 500 ms per hostname, each probe times out after 600 ms, and probing after the first candidate stops at a 1200 ms budget. If nothing answers, the server keeps the best ranked candidate and logs a warning with the full probe record.
- Delete `PAPERCLIP_RUNTIME_API_CANDIDATES_JSON`. Startup wrote this candidate list for clients to retry against, but nothing in the tree read it. Startup now does the retrying itself and exports one origin that answered.

## Verification

Automated, from `server/`:

```
npx vitest run src/__tests__/runtime-api.test.ts               # 20 passed
npx vitest run src/__tests__/server-startup-feedback-export.test.ts  # 18 passed
npx tsc --noEmit -p tsconfig.json                              # clean
```

The new tests cover the reported shape and the identity check:

- The reachable hostname is selected when it is second in `allowedHostnames`.
- Swapping the two entries returns the same URL, so the result is not order-dependent.
- Against real HTTP listeners: our own token is accepted, our own `401` is still accepted, an unrelated service is rejected, and a second Paperclip process is rejected.
- When only a foreign listener answers, the server falls back to the ranked candidate instead of exporting the stranger.

The first test fails on `master`, where the derivation returns the unreachable name:

```
AssertionError: expected 'http://unreachable-name:3100' to be 'http://good-name:3100'
```

Manual, on the affected host, using its real resolver and its real configuration
(`allowedHostnames: ["<short-name>", "<tailnet-name>"]`, bound to the tailnet address, no override set):

```
phase 1 (DNS rank, pre-listen): http://<tailnet-name>:33011 [resolve-rank]
phase 2 (probe, post-listen)  : http://<tailnet-name>:33011 [probe]

old derivation (allowedHostnames[0]): http://<short-name>:33011   -> 000 (fetch failed)
new derivation (probed)             : http://<tailnet-name>:33011 -> 200
```

## Risks

Low risk, and the risk is bounded to startup.

- Startup latency increases by at most the probe budget, which is 600 ms for the first candidate plus 1200 ms for the rest. A wedged resolver cannot extend this, because lookups have their own 500 ms timeout.
- Behaviour is unchanged for the common deployments. A loopback bind, a wildcard bind, an explicit `PAPERCLIP_API_URL`, and an auth public base URL all keep their current results. Only a non-loopback bind with more than one candidate can change.
- If no candidate answers, the result is the best ranked candidate. That is no worse than the current first-entry behaviour, and the server logs a warning that names every candidate and every probe result.
- `/api/health` gains one response header. It is a random per-process value that encodes nothing, so it reveals nothing to an anonymous caller that a port scan would not.

## Model Used

Claude Opus 5 (`claude-opus-5`), by Anthropic, used through Claude Code with extended thinking and tool use, including repository search, file editing, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — verified with `gh pr checks 11564` at the time of this edit.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — confirmed via the Greptile Review comment: "Confidence Score: 5/5", no open P2s or follow-ups listed.
- [x] I will address all Greptile and reviewer comments before requesting merge

