### PR TITLE
fix(issues): auto-transition blocked issues to todo when blocker tree resolves

### DIFF
--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   getWakeableParentAfterChildCompletion: vi.fn(),
 }));
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -29,6 +29,7 @@ const mockIssueService = vi.hoisted(() => ({
   listAttachments: vi.fn(),
   listComments: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   remove: vi.fn(),
   removeAttachment: vi.fn(),
   update: vi.fn(),

--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -15,6 +15,7 @@ const mockIssueService = vi.hoisted(() => ({
   getCommentCursor: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   getWakeableParentAfterChildCompletion: vi.fn(),
   findMentionedAgents: vi.fn(async () => []),
 }));

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   getCurrentScheduledRetry: vi.fn(),
   findMentionedAgents: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   getWakeableParentAfterChildCompletion: vi.fn(),
   getRelationSummaries: vi.fn(),
 }));

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -15,6 +15,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   getDependencyReadiness: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   getWakeableParentAfterChildCompletion: vi.fn(),
   findMentionedAgents: vi.fn(async () => []),
 }));

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   getWakeableParentAfterChildCompletion: vi.fn(),
 }));
 

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -7,6 +7,7 @@ const mockIssueService = vi.hoisted(() => ({
   getByIdForUpdate: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   update: vi.fn(),
 }));
 

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -14,6 +14,7 @@ const mockIssueService = vi.hoisted(() => ({
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   getWakeableParentAfterChildCompletion: vi.fn(),
   getCurrentScheduledRetry: vi.fn(),
   listReviewAttention: vi.fn(),

--- a/server/src/__tests__/issue-workspace-command-authz.test.ts
+++ b/server/src/__tests__/issue-workspace-command-authz.test.ts
@@ -12,6 +12,7 @@ const mockIssueService = vi.hoisted(() => ({
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
+  transitionResolvedBlockedDependentsToTodo: vi.fn(async () => []),
   update: vi.fn(),
 }));
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10317,6 +10317,20 @@ export function issueRoutes(
       const becameDone = existing.status !== "done" && issue.status === "done";
       if (becameDone) {
         const dependents = await svc.listWakeableBlockedDependents(issue.id);
+        if (dependents.length > 0) {
+          try {
+            await svc.transitionResolvedBlockedDependentsToTodo(
+              dependents.map((d) => d.id),
+              issue.id,
+              "blocker_done",
+            );
+          } catch (err) {
+            logger.warn(
+              { err, blockerIssueId: issue.id, dependentIds: dependents.map((d) => d.id) },
+              "failed to auto-transition resolved blocked dependents to todo",
+            );
+          }
+        }
         for (const dependent of dependents) {
           await addDependencyResolvedWakeup({
             agentId: dependent.assigneeAgentId,
@@ -10345,6 +10359,18 @@ export function issueRoutes(
           readiness.isDependencyReady &&
           readiness.blockerIssueIds.length > 0
         ) {
+          try {
+            await svc.transitionResolvedBlockedDependentsToTodo(
+              [issue.id],
+              resolvedBlockerIssueId,
+              "blocked_dependency_restored",
+            );
+          } catch (err) {
+            logger.warn(
+              { err, issueId: issue.id },
+              "failed to auto-transition restored blocked dependency to todo",
+            );
+          }
           await addDependencyResolvedWakeup({
             agentId: issue.assigneeAgentId!,
             dependentIssueId: issue.id,
@@ -12267,6 +12293,20 @@ export function issueRoutes(
       const becameDone = issueBeforeCommentDecision.status !== "done" && currentIssue.status === "done";
       if (becameDone) {
         const dependents = await svc.listWakeableBlockedDependents(currentIssue.id);
+        if (dependents.length > 0) {
+          try {
+            await svc.transitionResolvedBlockedDependentsToTodo(
+              dependents.map((d) => d.id),
+              currentIssue.id,
+              "blocker_done",
+            );
+          } catch (err) {
+            logger.warn(
+              { err, blockerIssueId: currentIssue.id, dependentIds: dependents.map((d) => d.id) },
+              "failed to auto-transition resolved blocked dependents to todo after comment",
+            );
+          }
+        }
         for (const dependent of dependents) {
           await addDependencyResolvedWakeup({
             agentId: dependent.assigneeAgentId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6515,6 +6515,32 @@ export function issueService(db: Db) {
         }));
     },
 
+    transitionResolvedBlockedDependentsToTodo: async (
+      dependentIssueIds: string[],
+      resolvedBlockerIssueId: string,
+      source: string,
+    ) => {
+      if (dependentIssueIds.length === 0) return [];
+      const transitioned: string[] = [];
+      const now = new Date();
+      for (const issueId of dependentIssueIds) {
+        const [updated] = await db
+          .update(issues)
+          .set({ status: "todo", updatedAt: now })
+          .where(and(eq(issues.id, issueId), eq(issues.status, "blocked")))
+          .returning({ id: issues.id, companyId: issues.companyId });
+        if (!updated) continue;
+        transitioned.push(issueId);
+        await db.insert(issueComments).values({
+          companyId: updated.companyId,
+          issueId,
+          authorType: "system",
+          body: `All blockers resolved — transitioned from blocked to todo. (source: ${source})`,
+        });
+      }
+      return transitioned;
+    },
+
     getWakeableParentAfterChildCompletion: async (parentIssueId: string) => {
       const parent = await db
         .select({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5286,6 +5286,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         try {
+          try {
+            await issuesSvc.transitionResolvedBlockedDependentsToTodo(
+              [candidate.id],
+              resolvedBlockerIssueId,
+              `backstop:${source}`,
+            );
+          } catch (transitionErr) {
+            logger.warn(
+              { err: transitionErr, issueId: candidate.id, source },
+              "backstop: failed to auto-transition resolved blocked dependent to todo",
+            );
+          }
           const wake = await deps.enqueueWakeup(agentId, {
             source: "automation",
             triggerDetail: "system",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues can have blockers — other issues that must complete before work resumes
> - When an issue is `blocked`, the runtime tracks blocker resolution via `blockerAttention`
> - When the last blocker completes, `unresolvedBlockerCount` reaches 0 and `blockingTreeLive` becomes false
> - However, the issue status stays `blocked` indefinitely — only the wake fires, not the status transition
> - Downstream lanes silently rot until someone manually flips the status
> - This PR adds the automatic `blocked` → `todo` transition with a system audit comment at all trigger points
> - The benefit is that blocked issues self-heal when their blocker tree fully resolves

## Linked Issues or Issue Description

**Bug report (no public GitHub issue exists)**

**What happened:** When the last blocker of a blocked issue is completed, `blockerAttention` correctly reaches `unresolvedBlockerCount: 0, blockingTreeLive: false`, but `status` stays `blocked` indefinitely. An `issue_blockers_resolved` wake reason exists in the runtime, so the plumbing to notify the assignee is there — but the status transition never fires. Downstream lanes silently rot until someone manually flips them.

**Steps to reproduce:** Create issue A blocked by issue B. Complete issue B. Observe that issue A stays `blocked` despite having no unresolved blockers.

**Expected behavior:** Issue A should automatically transition to `todo` when all its blockers resolve.

**Actual behavior:** Issue A stays `blocked` indefinitely.

## What Changed

- Added `transitionResolvedBlockedDependentsToTodo` to the issues service: updates status from `blocked` → `todo` with a WHERE guard (`eq(issues.status, "blocked")`), and inserts a system audit comment
- Wired the transition into the issue update route `becameDone` path (when a blocker issue completes)
- Wired the transition into the comment route `becameDone` path (when a blocker issue completes via comment-driven status change)
- Wired the transition into the restored-blocked-ready-dependency path (when a dependency is restored and readiness is confirmed)
- Wired the transition into the recovery backstop (catches any cases missed by the real-time paths)
- Updated test mocks across 9 test files to include the new service method

## Verification

- TypeScript compiles cleanly
- 228 existing tests pass across 3 related test suites (issue-dependency-wakeups, issue-comment-reopen, issue-update-comment-wakeup)
- Manual verification: close the last blocker of a test issue via the API; the blocked issue reaches `todo` and the assignee receives the `issue_blockers_resolved` wake

```bash
npx tsc --noEmit
npx vitest run server/src/__tests__/issue-dependency-wakeups-routes.test.ts
npx vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts
npx vitest run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
```

## Risks

- **Low risk.** The WHERE clause `eq(issues.status, "blocked")` ensures the transition is idempotent — it only fires if the issue is still `blocked`. Concurrent modifications are safe because the update is a no-op if status has already changed.
- The status update and audit comment are not wrapped in a DB transaction. If the comment insert fails after the status update succeeds, the issue is in `todo` without the audit comment. This is acceptable — the transition is the critical fix, and the audit comment is supplementary. The failure is logged at warn level.
- In the recovery backstop, the transition fires before `enqueueWakeup`. If the wake enqueue fails, the issue is `todo` without a wake — but this is a more correct state than `blocked` (since blockers ARE resolved), and general liveness recovery handles `todo` issues without execution paths.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code CLI. Extended thinking enabled. Tool use for code search, file editing, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
