### PR TITLE
feat(plugins): company-scoped scheduled jobs

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -988,7 +988,7 @@ A job declaration carries an optional `scope`, `"instance"` (the default) or `"c
 
 | | `scope: "instance"` | `scope: "company"` |
 | --- | --- | --- |
-| Runs per tick | one | one per company the plugin is enabled for |
+| Runs per occurrence | one | one per company the plugin is enabled for, subject to the concurrency cap (§17.2) |
 | `job.companyId` in the handler | `null` | that company's id |
 | Company-scoped host calls | **refused** | authorized for that company |
 
@@ -997,6 +997,30 @@ A job declaration carries an optional `scope`, `"instance"` (the default) or `"c
 A company is "enabled" for a plugin when the company is `active` and has no `plugin_company_settings` row disabling the plugin (absence of a row means enabled). A company-scoped job on an instance with no such companies dispatches nothing, which is not an error.
 
 Job *definitions* stay plugin-global — `plugin_jobs` has no company column, one row per `(plugin, job_key)`. Only runs are scoped: `plugin_job_runs.company_id` records the company a run fired for, and is `NULL` for an instance-scoped run.
+
+### 17.2 Fan-out under the concurrency cap
+
+`maxConcurrentJobs` is a **global** ceiling across every plugin job on the instance, so a
+company-scoped job whose enabled-company count exceeds the capacity free at tick time cannot
+serve all of its companies in one occurrence. This is a capacity limit, not a scheduling
+choice, and the contract is written so a plugin author can reason about it:
+
+- The fan-out is ordered **least-recently-run first**, computed from `plugin_job_runs` — durable
+  state, not scheduler memory, so it survives a restart mid-pass.
+- A *pass* over N companies therefore completes in `ceil(N / free capacity)` occurrences, and
+  **no company is served a second time before every company has been served once**.
+- The schedule pointer belongs to the job row and advances once per occurrence. Under
+  saturation the effective per-company cadence is the declared cron interval multiplied by the
+  number of occurrences a pass takes — a company-scoped job at `*/5` with a pass spanning three
+  occurrences reaches each company every fifteen minutes, not every five.
+- Deferral is logged at `warn` with the deferred count and the company the next occurrence
+  resumes from. It is a visible throttle, never a silent drop.
+
+The host deliberately does not drain a wide fan-out inside a single tick: doing so would let one
+plugin's fan-out hold the global cap and stall every other plugin's due jobs, and a handler that
+hangs would hold the job's schedule pointer open indefinitely. A job that needs a hard
+per-occurrence guarantee across many companies should be declared at an interval its instance
+has the capacity to satisfy.
 
 ## 18. Webhooks
 

--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -591,6 +591,7 @@ The host provides:
 - trigger source
 - run id
 - schedule metadata
+- company id — the company this run is scoped to, or `null` for an instance-scoped job (see §17.1)
 
 ### 13.7 `handleWebhook`
 
@@ -976,10 +977,26 @@ Job rules:
 
 1. Each job has a stable `job_key`.
 2. The host is the scheduler of record.
-3. The host prevents overlapping execution of the same plugin/job combination unless explicitly allowed later.
+3. The host prevents overlapping execution of the same plugin/job/target combination unless explicitly allowed later. The target is a company for a company-scoped job and the instance otherwise.
 4. Every job run is recorded in Postgres.
 5. Failed jobs are retryable.
 6. For recurring business workflows that should create visible Paperclip work, prefer managed routines and managed resources over jobs. Jobs remain useful for private plugin-runtime maintenance tasks.
+
+### 17.1 Job scope
+
+A job declaration carries an optional `scope`, `"instance"` (the default) or `"company"`.
+
+| | `scope: "instance"` | `scope: "company"` |
+| --- | --- | --- |
+| Runs per tick | one | one per company the plugin is enabled for |
+| `job.companyId` in the handler | `null` | that company's id |
+| Company-scoped host calls | **refused** | authorized for that company |
+
+"Company-scoped host calls" means anything that takes a company: `ctx.config.get`, `ctx.secrets.resolve`, `ctx.issues.*`, and `state` at company scope. The invocation scope the host mints from `job.companyId` is the *only* thing that authorizes them — a `companyId` the plugin supplies itself is compared against the host scope, never accepted in place of one. An instance-scoped job therefore cannot reach company data by any route; that is by design, and a job that needs company data must declare `scope: "company"`.
+
+A company is "enabled" for a plugin when the company is `active` and has no `plugin_company_settings` row disabling the plugin (absence of a row means enabled). A company-scoped job on an instance with no such companies dispatches nothing, which is not an error.
+
+Job *definitions* stay plugin-global — `plugin_jobs` has no company column, one row per `(plugin, job_key)`. Only runs are scoped: `plugin_job_runs.company_id` records the company a run fired for, and is `NULL` for an instance-scoped run.
 
 ## 18. Webhooks
 

--- a/packages/db/src/migrations/0227_plugin_jobs_scope.sql
+++ b/packages/db/src/migrations/0227_plugin_jobs_scope.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "plugin_jobs" ADD COLUMN "scope" text DEFAULT 'instance' NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1576,6 +1576,13 @@
       "when": 1787261199301,
       "tag": "0226_tan_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 227,
+      "version": "7",
+      "when": 1787261199302,
+      "tag": "0227_plugin_jobs_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/plugin_jobs.ts
+++ b/packages/db/src/schema/plugin_jobs.ts
@@ -10,7 +10,12 @@ import {
 } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { plugins } from "./plugins.js";
-import type { PluginJobStatus, PluginJobRunStatus, PluginJobRunTrigger } from "@paperclipai/shared";
+import type {
+  PluginJobScope,
+  PluginJobStatus,
+  PluginJobRunStatus,
+  PluginJobRunTrigger,
+} from "@paperclipai/shared";
 
 /**
  * `plugin_jobs` table — registration and runtime configuration for
@@ -25,6 +30,15 @@ import type { PluginJobStatus, PluginJobRunStatus, PluginJobRunTrigger } from "@
  * - `active` — job is enabled and will run on schedule
  * - `paused` — job is temporarily disabled by the operator
  * - `error` — job has been disabled due to repeated failures
+ *
+ * Scope values (mirrored from the manifest declaration):
+ * - `instance` — one unscoped run per tick (the default)
+ * - `company` — one run per tick per company the plugin is enabled for, each
+ *   carrying that company's invocation scope
+ *
+ * Note there is deliberately no `company_id` here: a job *definition* stays
+ * plugin-global. Only the runs it produces (`plugin_job_runs.company_id`) are
+ * company-scoped.
  *
  * @see PLUGIN_SPEC.md §21.3 — `plugin_jobs`
  */
@@ -42,6 +56,8 @@ export const pluginJobs = pgTable(
     schedule: text("schedule").notNull(),
     /** Current scheduling state. */
     status: text("status").$type<PluginJobStatus>().notNull().default("active"),
+    /** Tenancy of the job, mirrored from the manifest declaration. */
+    scope: text("scope").$type<PluginJobScope>().notNull().default("instance"),
     /** Timestamp of the most recent successful execution. */
     lastRunAt: timestamp("last_run_at", { withTimezone: true }),
     /** Pre-computed timestamp of the next scheduled execution. */

--- a/packages/plugins/sdk/src/index.ts
+++ b/packages/plugins/sdk/src/index.ts
@@ -329,6 +329,7 @@ export type {
 export type {
   PaperclipPluginManifestV1,
   PluginJobDeclaration,
+  PluginJobScope,
   PluginWebhookDeclaration,
   PluginToolDeclaration,
   PluginEnvironmentDriverDeclaration,

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -2607,6 +2607,10 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         runId: partial.runId ?? randomUUID(),
         trigger: partial.trigger ?? "manual",
         scheduledAt: partial.scheduledAt ?? new Date().toISOString(),
+        // Defaults to instance scope, matching a manifest declaration that
+        // omits `scope`. Pass `companyId` to simulate a `scope: "company"`
+        // job.
+        companyId: partial.companyId ?? null,
       });
     },
     async getData<T = unknown>(key: string, params: Record<string, unknown> = {}) {

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -59,6 +59,7 @@ import type { PluginPerformActionContext } from "./protocol.js";
 export type {
   PaperclipPluginManifestV1,
   PluginJobDeclaration,
+  PluginJobScope,
   PluginWebhookDeclaration,
   PluginToolDeclaration,
   PluginEnvironmentDriverDeclaration,
@@ -238,6 +239,20 @@ export interface PluginJobContext {
   trigger: "schedule" | "manual" | "retry";
   /** ISO 8601 timestamp when the run was scheduled to start. */
   scheduledAt: string;
+  /**
+   * Company this run is scoped to, or `null` for an instance-scoped job.
+   *
+   * Populated only when the job's manifest declaration says
+   * `scope: "company"`. It is the id to pass to company-scoped host calls
+   * (`ctx.config.get(companyId)`, `ctx.secrets.resolve(..., { companyId })`,
+   * `ctx.issues.*`) — and the host has already minted the matching invocation
+   * scope, so those calls are authorized.
+   *
+   * `null`/absent on an instance-scoped job, and there is no way to obtain one
+   * from inside the handler: every company-scoped host call will be refused
+   * with "company context is required". Declare `scope: "company"` instead.
+   */
+  companyId?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1408,6 +1408,7 @@ export type {
   RoutineListItem,
   JsonSchema,
   PluginJobDeclaration,
+  PluginJobScope,
   PluginWebhookDeclaration,
   PluginToolDeclaration,
   PluginEnvironmentDriverDeclaration,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -952,6 +952,7 @@ export type {
 export type {
   JsonSchema,
   PluginJobDeclaration,
+  PluginJobScope,
   PluginWebhookDeclaration,
   PluginToolDeclaration,
   PluginEnvironmentDriverDeclaration,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -71,6 +71,21 @@ export type {
 // ---------------------------------------------------------------------------
 
 /**
+ * Tenancy of a declared scheduled job.
+ *
+ * - `"instance"` (default) — the job fires once per tick with no company
+ *   scope. The run carries no invocation scope, so company-scoped host calls
+ *   (`config.get`, `secrets.resolve`, `issues.*`, company-scoped `state.*`)
+ *   are refused. Use for plugin-runtime maintenance.
+ * - `"company"` — the job fires once per tick *per company the plugin is
+ *   enabled for*. Each run carries that company's invocation scope, so
+ *   company-scoped host calls are authorized.
+ *
+ * @see PLUGIN_SPEC.md §17 — Scheduled Jobs
+ */
+export type PluginJobScope = "instance" | "company";
+
+/**
  * Declares a scheduled job a plugin can run.
  *
  * @see PLUGIN_SPEC.md §17 — Scheduled Jobs
@@ -84,6 +99,15 @@ export interface PluginJobDeclaration {
   description?: string;
   /** Cron expression for the schedule (e.g. "star/15 star star star star" or "0 * * * *"). */
   schedule?: string;
+  /**
+   * Tenancy of the job. Defaults to `"instance"` when omitted, which is the
+   * pre-existing behavior: one unscoped run per tick.
+   *
+   * Declare `"company"` when the handler needs company data. Without it the
+   * handler gets no invocation scope and every company-scoped host call is
+   * refused with "company context is required".
+   */
+  scope?: PluginJobScope;
 }
 
 /**

--- a/packages/shared/src/validators/plugin.ts
+++ b/packages/shared/src/validators/plugin.ts
@@ -87,6 +87,7 @@ export const pluginJobDeclarationSchema = z.object({
     (val) => isValidCronExpression(val),
     { message: "schedule must be a valid 5-field cron expression (e.g. '*/15 * * * *')" },
   ).optional(),
+  scope: z.enum(["instance", "company"]).optional(),
 });
 
 export type PluginJobDeclarationInput = z.infer<typeof pluginJobDeclarationSchema>;

--- a/server/src/__tests__/fixtures/plugin-worker-invocation-scope.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-invocation-scope.cjs
@@ -98,7 +98,7 @@ rl.on("line", (line) => {
       id: message.id,
       result: {
         ok: true,
-        supportedMethods: ["getData", "performAction"],
+        supportedMethods: ["getData", "performAction", "runJob"],
       },
     });
     return;
@@ -106,6 +106,16 @@ rl.on("line", (line) => {
 
   if (method === "getData" || method === "performAction") {
     sendNestedHostRequest(message, message.paperclipInvocation?.id);
+    return;
+  }
+
+  if (method === "runJob") {
+    // A scheduled job's probe params ride on the job context, so reshape into
+    // the { params: { ... } } envelope sendNestedHostRequest expects.
+    sendNestedHostRequest(
+      { id: message.id, params: { params: message.params?.job?.probe ?? {} } },
+      message.paperclipInvocation?.id,
+    );
     return;
   }
 

--- a/server/src/__tests__/plugin-job-company-scope.test.ts
+++ b/server/src/__tests__/plugin-job-company-scope.test.ts
@@ -381,16 +381,16 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
     expect([...byCompany.values()].filter((status) => status === "succeeded")).toHaveLength(1);
   });
 
-  it("finishes a pass wider than the concurrency cap across occurrences, with no company served twice first", async () => {
+  it("reaches every company when the fan-out is wider than the concurrency cap, none twice before all once", async () => {
     const pluginId = await seedPlugin();
     const seeded: string[] = [];
     for (let i = 0; i < 5; i += 1) seeded.push(await seedCompany(`company ${i}`));
     const jobId = await seedDueJob(pluginId, "company");
 
-    // 5 companies, cap 2. The fan-out set is deterministically ordered, so
-    // without carrying the remainder forward the same two companies would be
-    // admitted on every occurrence and the other three would never run at all
-    // — starvation, not lateness.
+    // 5 companies, cap 2. With any *stable* ordering the same two companies
+    // would win every occurrence and the other three would never run at all —
+    // starvation, not lateness. Least-recently-run ordering moves a served
+    // company to the back.
     const { scheduler, captured } = createHarness({ maxConcurrentJobs: 2 });
 
     // Group by occurrence. Runs admitted within one tick are dispatched
@@ -407,30 +407,48 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
       perTick.push(captured.slice(before).map((job) => job.companyId as string));
     }
 
-    // ceil(5 / 2) = 3 occurrences to complete one pass: 2, 2, then the last 1.
-    expect(perTick.map((tick) => tick.length)).toEqual([2, 2, 1]);
+    expect(perTick.map((tick) => tick.length)).toEqual([2, 2, 2]);
 
-    // Every company served exactly once. No company gets a second run while
-    // another is still waiting for its first.
-    expect(captured).toHaveLength(5);
+    // Everyone reached within ceil(5 / 2) = 3 occurrences...
     expect([...new Set(captured.map((job) => job.companyId))].sort()).toEqual(
       [...seeded].sort(),
     );
+    // ...and the first four slots went to four *distinct* companies, so no one
+    // took a second run while another was still waiting for its first.
+    expect(new Set([...perTick[0]!, ...perTick[1]!]).size).toBe(4);
 
     const runs = await runsForJob(jobId);
-    expect(runs).toHaveLength(5);
+    expect(runs).toHaveLength(6);
     expect(runs.every((run) => run.companyId !== null)).toBe(true);
+  });
 
-    // The pass is complete, so the next occurrence starts a fresh full one.
+  it("keeps fan-out progress across a scheduler restart, because the ordering is derived from run history", async () => {
+    const pluginId = await seedPlugin();
+    const seeded: string[] = [];
+    for (let i = 0; i < 4; i += 1) seeded.push(await seedCompany(`company ${i}`));
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const first = createHarness({ maxConcurrentJobs: 2 });
+    await first.scheduler.tick();
+    expect(first.captured).toHaveLength(2);
+
+    // A brand-new scheduler — the process restarted. Any in-memory cursor or
+    // carried remainder is gone. The two companies already served must still
+    // not be picked ahead of the two that have never run.
+    const second = createHarness({ maxConcurrentJobs: 2 });
     await db
       .update(pluginJobs)
       .set({ nextRunAt: new Date(Date.now() - 60_000) })
       .where(eq(pluginJobs.id, jobId));
-    await scheduler.tick();
-    expect(captured).toHaveLength(7);
+    await second.scheduler.tick();
+
+    const servedFirst = first.captured.map((job) => job.companyId);
+    const servedSecond = second.captured.map((job) => job.companyId);
+    expect(servedSecond).toHaveLength(2);
+    expect([...servedFirst, ...servedSecond].sort()).toEqual([...seeded].sort());
   });
 
-  it("drops a company from a carried-forward pass once it disables the plugin", async () => {
+  it("stops dispatching to a company that disables the plugin mid-pass", async () => {
     const pluginId = await seedPlugin();
     const seeded: string[] = [];
     for (let i = 0; i < 4; i += 1) seeded.push(await seedCompany(`company ${i}`));
@@ -440,8 +458,8 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
     await scheduler.tick();
     expect(captured).toHaveLength(2);
 
-    // Disable the plugin for both companies still owed a run. The carried
-    // remainder must honor that rather than replay a stale membership list.
+    // Disable the plugin for both companies still owed a run — the ones the
+    // cap deferred and that the next occurrence would otherwise serve first.
     const owed = seeded.filter(
       (companyId) => !captured.some((job) => job.companyId === companyId),
     );
@@ -456,8 +474,8 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
       .where(eq(pluginJobs.id, jobId));
     await scheduler.tick();
 
-    // The remainder emptied, so a fresh pass ran over the two that remain
-    // enabled — and neither disabled company was ever dispatched.
+    // The next occurrence served the two that remain enabled, and neither
+    // disabled company was ever dispatched.
     expect(captured).toHaveLength(4);
     for (const companyId of owed) {
       expect(captured.some((job) => job.companyId === companyId)).toBe(false);

--- a/server/src/__tests__/plugin-job-company-scope.test.ts
+++ b/server/src/__tests__/plugin-job-company-scope.test.ts
@@ -381,18 +381,19 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
     expect([...byCompany.values()].filter((status) => status === "succeeded")).toHaveLength(1);
   });
 
-  it("serves every company across ticks when the fan-out is wider than the concurrency cap", async () => {
+  it("finishes a pass wider than the concurrency cap across occurrences, with no company served twice first", async () => {
     const pluginId = await seedPlugin();
     const seeded: string[] = [];
     for (let i = 0; i < 5; i += 1) seeded.push(await seedCompany(`company ${i}`));
     const jobId = await seedDueJob(pluginId, "company");
 
-    // The fan-out set is deterministically ordered, so without a resume cursor
-    // the same two companies would be admitted on every tick and the other
-    // three would never run — starvation, not lateness.
+    // 5 companies, cap 2. The fan-out set is deterministically ordered, so
+    // without carrying the remainder forward the same two companies would be
+    // admitted on every occurrence and the other three would never run at all
+    // — starvation, not lateness.
     const { scheduler, captured } = createHarness({ maxConcurrentJobs: 2 });
 
-    // Group by tick. The runs admitted within one tick are dispatched
+    // Group by occurrence. Runs admitted within one tick are dispatched
     // concurrently, so their arrival order is not deterministic — only the set
     // per tick is.
     const perTick: string[][] = [];
@@ -406,18 +407,61 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
       perTick.push(captured.slice(before).map((job) => job.companyId as string));
     }
 
-    // The starvation guarantee: three ticks at two per tick reach all five.
-    const served = new Set(captured.map((job) => job.companyId));
-    expect([...served].sort()).toEqual([...seeded].sort());
+    // ceil(5 / 2) = 3 occurrences to complete one pass: 2, 2, then the last 1.
+    expect(perTick.map((tick) => tick.length)).toEqual([2, 2, 1]);
 
-    // Each tick honors the cap exactly, and the cursor advances rather than
-    // replaying — the first two ticks must cover four distinct companies.
-    expect(perTick.map((tick) => tick.length)).toEqual([2, 2, 2]);
-    expect(new Set([...perTick[0]!, ...perTick[1]!]).size).toBe(4);
+    // Every company served exactly once. No company gets a second run while
+    // another is still waiting for its first.
+    expect(captured).toHaveLength(5);
+    expect([...new Set(captured.map((job) => job.companyId))].sort()).toEqual(
+      [...seeded].sort(),
+    );
 
     const runs = await runsForJob(jobId);
-    expect(runs).toHaveLength(6);
+    expect(runs).toHaveLength(5);
     expect(runs.every((run) => run.companyId !== null)).toBe(true);
+
+    // The pass is complete, so the next occurrence starts a fresh full one.
+    await db
+      .update(pluginJobs)
+      .set({ nextRunAt: new Date(Date.now() - 60_000) })
+      .where(eq(pluginJobs.id, jobId));
+    await scheduler.tick();
+    expect(captured).toHaveLength(7);
+  });
+
+  it("drops a company from a carried-forward pass once it disables the plugin", async () => {
+    const pluginId = await seedPlugin();
+    const seeded: string[] = [];
+    for (let i = 0; i < 4; i += 1) seeded.push(await seedCompany(`company ${i}`));
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler, captured } = createHarness({ maxConcurrentJobs: 2 });
+    await scheduler.tick();
+    expect(captured).toHaveLength(2);
+
+    // Disable the plugin for both companies still owed a run. The carried
+    // remainder must honor that rather than replay a stale membership list.
+    const owed = seeded.filter(
+      (companyId) => !captured.some((job) => job.companyId === companyId),
+    );
+    expect(owed).toHaveLength(2);
+    await db.insert(pluginCompanySettings).values(
+      owed.map((companyId) => ({ pluginId, companyId, enabled: false })),
+    );
+
+    await db
+      .update(pluginJobs)
+      .set({ nextRunAt: new Date(Date.now() - 60_000) })
+      .where(eq(pluginJobs.id, jobId));
+    await scheduler.tick();
+
+    // The remainder emptied, so a fresh pass ran over the two that remain
+    // enabled — and neither disabled company was ever dispatched.
+    expect(captured).toHaveLength(4);
+    for (const companyId of owed) {
+      expect(captured.some((job) => job.companyId === companyId)).toBe(false);
+    }
   });
 
   // -------------------------------------------------------------------------

--- a/server/src/__tests__/plugin-job-company-scope.test.ts
+++ b/server/src/__tests__/plugin-job-company-scope.test.ts
@@ -103,8 +103,12 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
     return pluginId;
   }
 
-  async function seedCompany(name: string, status = "active"): Promise<string> {
-    const companyId = randomUUID();
+  async function seedCompany(
+    name: string,
+    status = "active",
+    id?: string,
+  ): Promise<string> {
+    const companyId = id ?? randomUUID();
     await db.insert(companies).values({
       id: companyId,
       name,
@@ -446,6 +450,58 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
     const servedSecond = second.captured.map((job) => job.companyId);
     expect(servedSecond).toHaveLength(2);
     expect([...servedFirst, ...servedSecond].sort()).toEqual([...seeded].sort());
+  });
+
+  it("counts an interrupted run as service, so a company that dies mid-run cannot monopolise the fan-out", async () => {
+    const pluginId = await seedPlugin();
+    // Deterministic ids, smallest first for the interrupted pair. The
+    // tiebreaker among never-run companies is `company_id asc`, so an ordering
+    // that counted only *completed* runs would rank these two first and serve
+    // them again — this test would then fail every time rather than on 5 runs
+    // out of 6.
+    // (They differ in the leading bytes, not the trailing ones, because the
+    // test's issue prefix is derived from the first six hex digits and has a
+    // unique index on it.)
+    const interrupted = [
+      await seedCompany("company a", "active", "10000000-0000-4000-8000-000000000000"),
+      await seedCompany("company b", "active", "20000000-0000-4000-8000-000000000000"),
+    ];
+    const neverRun = [
+      await seedCompany("company c", "active", "30000000-0000-4000-8000-000000000000"),
+      await seedCompany("company d", "active", "40000000-0000-4000-8000-000000000000"),
+    ];
+    const jobId = await seedDueJob(pluginId, "company");
+
+    // The occurrence that died: rows created, handlers never finished, no
+    // completion ever written. Nothing reaps them, so they stay `running`.
+    await db.insert(pluginJobRuns).values(
+      interrupted.map((companyId) => ({
+        jobId,
+        pluginId,
+        companyId,
+        trigger: "schedule" as const,
+        status: "running" as const,
+      })),
+    );
+
+    const { scheduler, captured } = createHarness({ maxConcurrentJobs: 2 });
+    await scheduler.tick();
+
+    // Fairness is over *attempts*, not completions — deliberately. Retrying
+    // the interrupted pair ahead of companies that have never run once is how
+    // a job that reliably dies mid-run for one tenant starves every other
+    // tenant forever. The interrupted companies are not dropped; they are
+    // behind the never-run pair, and the next occurrence reaches them.
+    expect(captured.map((job) => job.companyId).sort()).toEqual([...neverRun].sort());
+
+    await db
+      .update(pluginJobs)
+      .set({ nextRunAt: new Date(Date.now() - 60_000) })
+      .where(eq(pluginJobs.id, jobId));
+    await scheduler.tick();
+    expect(captured.slice(2).map((job) => job.companyId).sort()).toEqual(
+      [...interrupted].sort(),
+    );
   });
 
   it("stops dispatching to a company that disables the plugin mid-pass", async () => {

--- a/server/src/__tests__/plugin-job-company-scope.test.ts
+++ b/server/src/__tests__/plugin-job-company-scope.test.ts
@@ -118,7 +118,9 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
    * A scheduler wired to the real store and DB, with the worker faked so the
    * test can read exactly what the `runJob` RPC would have carried.
    */
-  function createHarness(options: { runJob?: () => Promise<void> } = {}) {
+  function createHarness(
+    options: { runJob?: () => Promise<void>; maxConcurrentJobs?: number } = {},
+  ) {
     const jobStore = pluginJobStore(db);
     const captured: CapturedJob[] = [];
 
@@ -133,7 +135,14 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
       }),
     } as any;
 
-    const scheduler = createPluginJobScheduler({ db, jobStore, workerManager });
+    const scheduler = createPluginJobScheduler({
+      db,
+      jobStore,
+      workerManager,
+      ...(options.maxConcurrentJobs !== undefined
+        ? { maxConcurrentJobs: options.maxConcurrentJobs }
+        : {}),
+    });
     return { jobStore, workerManager, scheduler, captured };
   }
 
@@ -370,6 +379,45 @@ describeEmbeddedPostgres("company-scoped plugin jobs", () => {
     const byCompany = new Map(runs.map((run) => [run.companyId, run.status]));
     expect(byCompany.get(failFor)).toBe("failed");
     expect([...byCompany.values()].filter((status) => status === "succeeded")).toHaveLength(1);
+  });
+
+  it("serves every company across ticks when the fan-out is wider than the concurrency cap", async () => {
+    const pluginId = await seedPlugin();
+    const seeded: string[] = [];
+    for (let i = 0; i < 5; i += 1) seeded.push(await seedCompany(`company ${i}`));
+    const jobId = await seedDueJob(pluginId, "company");
+
+    // The fan-out set is deterministically ordered, so without a resume cursor
+    // the same two companies would be admitted on every tick and the other
+    // three would never run — starvation, not lateness.
+    const { scheduler, captured } = createHarness({ maxConcurrentJobs: 2 });
+
+    // Group by tick. The runs admitted within one tick are dispatched
+    // concurrently, so their arrival order is not deterministic — only the set
+    // per tick is.
+    const perTick: string[][] = [];
+    for (let tick = 0; tick < 3; tick += 1) {
+      const before = captured.length;
+      await db
+        .update(pluginJobs)
+        .set({ nextRunAt: new Date(Date.now() - 60_000) })
+        .where(eq(pluginJobs.id, jobId));
+      await scheduler.tick();
+      perTick.push(captured.slice(before).map((job) => job.companyId as string));
+    }
+
+    // The starvation guarantee: three ticks at two per tick reach all five.
+    const served = new Set(captured.map((job) => job.companyId));
+    expect([...served].sort()).toEqual([...seeded].sort());
+
+    // Each tick honors the cap exactly, and the cursor advances rather than
+    // replaying — the first two ticks must cover four distinct companies.
+    expect(perTick.map((tick) => tick.length)).toEqual([2, 2, 2]);
+    expect(new Set([...perTick[0]!, ...perTick[1]!]).size).toBe(4);
+
+    const runs = await runsForJob(jobId);
+    expect(runs).toHaveLength(6);
+    expect(runs.every((run) => run.companyId !== null)).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/server/src/__tests__/plugin-job-company-scope.test.ts
+++ b/server/src/__tests__/plugin-job-company-scope.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Company-scoped plugin jobs.
+ *
+ * Regression coverage for the defect where a scheduled job got no invocation
+ * scope at all: `runJob` shipped without a company, the worker's
+ * `AsyncLocalStorage` was never populated, and so every company-scoped host
+ * call the handler made (`config.get`, `secrets.resolve`, `issues.*`, company
+ * `state.*`) was refused with "company context is required" — on every tick,
+ * forever, while the scheduler still recorded the run as succeeded.
+ *
+ * These run against a real embedded Postgres because the fan-out set is a SQL
+ * anti-join over `plugin_company_settings`, and getting that join wrong is the
+ * difference between "runs for the right tenants" and "runs for tenants that
+ * disabled the plugin".
+ *
+ * @see doc/plugins/PLUGIN_SPEC.md §17.1 — Job scope
+ */
+
+import { randomUUID } from "node:crypto";
+import { asc, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  companies,
+  createDb,
+  pluginCompanySettings,
+  pluginJobs,
+  pluginJobRuns,
+  plugins,
+} from "@paperclipai/db";
+import { pluginJobStore } from "../services/plugin-job-store.js";
+import { createPluginJobScheduler } from "../services/plugin-job-scheduler.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping plugin job company-scope tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+function issuePrefix(id: string) {
+  return `T${id.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+}
+
+/** The `job` payload of a captured `runJob` RPC call. */
+type CapturedJob = {
+  jobKey: string;
+  runId: string;
+  trigger: string;
+  scheduledAt: string;
+  companyId: string | null;
+};
+
+describeEmbeddedPostgres("company-scoped plugin jobs", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-job-company-scope-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(pluginJobRuns);
+    await db.delete(pluginJobs);
+    await db.delete(pluginCompanySettings);
+    await db.delete(plugins);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedPlugin(): Promise<string> {
+    const pluginId = randomUUID();
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "paperclip.job-company-scope-test",
+      packageName: "@paperclipai/plugin-job-company-scope-test",
+      version: "0.0.1",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "paperclip.job-company-scope-test",
+        apiVersion: 1,
+        version: "0.0.1",
+        displayName: "Job Company Scope Test",
+        description: "Test plugin",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: [],
+        entrypoints: { worker: "./dist/worker.js" },
+      },
+      status: "ready",
+      installOrder: 1,
+    });
+    return pluginId;
+  }
+
+  async function seedCompany(name: string, status = "active"): Promise<string> {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name,
+      status,
+      issuePrefix: issuePrefix(companyId),
+    });
+    return companyId;
+  }
+
+  /**
+   * A scheduler wired to the real store and DB, with the worker faked so the
+   * test can read exactly what the `runJob` RPC would have carried.
+   */
+  function createHarness(options: { runJob?: () => Promise<void> } = {}) {
+    const jobStore = pluginJobStore(db);
+    const captured: CapturedJob[] = [];
+
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "runJob") {
+          captured.push(params.job as CapturedJob);
+          if (options.runJob) await options.runJob();
+        }
+        return null;
+      }),
+    } as any;
+
+    const scheduler = createPluginJobScheduler({ db, jobStore, workerManager });
+    return { jobStore, workerManager, scheduler, captured };
+  }
+
+  /** Insert a due job row directly — the scheduler picks up anything past `nextRunAt`. */
+  async function seedDueJob(
+    pluginId: string,
+    scope: "instance" | "company",
+  ): Promise<string> {
+    const jobId = randomUUID();
+    await db.insert(pluginJobs).values({
+      id: jobId,
+      pluginId,
+      jobKey: "sweep",
+      schedule: "*/5 * * * *",
+      scope,
+      status: "active",
+      nextRunAt: new Date(Date.now() - 60_000),
+    });
+    return jobId;
+  }
+
+  async function runsForJob(jobId: string) {
+    return db
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId))
+      .orderBy(asc(pluginJobRuns.companyId));
+  }
+
+  // -------------------------------------------------------------------------
+  // Manifest → DB
+  // -------------------------------------------------------------------------
+
+  it("defaults a job with no declared scope to instance scope", async () => {
+    const pluginId = await seedPlugin();
+    const jobStore = pluginJobStore(db);
+
+    await jobStore.syncJobDeclarations(pluginId, [
+      { jobKey: "sweep", displayName: "Sweep", schedule: "*/5 * * * *" },
+    ]);
+
+    const [job] = await db.select().from(pluginJobs).where(eq(pluginJobs.pluginId, pluginId));
+    expect(job?.scope).toBe("instance");
+  });
+
+  it("persists a declared company scope, and a later change to it", async () => {
+    const pluginId = await seedPlugin();
+    const jobStore = pluginJobStore(db);
+
+    await jobStore.syncJobDeclarations(pluginId, [
+      { jobKey: "sweep", displayName: "Sweep", schedule: "*/5 * * * *", scope: "company" },
+    ]);
+    let [job] = await db.select().from(pluginJobs).where(eq(pluginJobs.pluginId, pluginId));
+    expect(job?.scope).toBe("company");
+
+    // A plugin that narrows the job back to instance scope must actually lose
+    // the company fan-out — a stale `scope` would keep minting scopes the
+    // manifest no longer asks for.
+    await jobStore.syncJobDeclarations(pluginId, [
+      { jobKey: "sweep", displayName: "Sweep", schedule: "*/5 * * * *", scope: "instance" },
+    ]);
+    [job] = await db.select().from(pluginJobs).where(eq(pluginJobs.pluginId, pluginId));
+    expect(job?.scope).toBe("instance");
+  });
+
+  // -------------------------------------------------------------------------
+  // The fan-out set
+  // -------------------------------------------------------------------------
+
+  it("counts a company with no settings row as enabled, and excludes disabled and non-active companies", async () => {
+    const pluginId = await seedPlugin();
+    const jobStore = pluginJobStore(db);
+
+    const enabledByDefault = await seedCompany("no settings row");
+    const explicitlyEnabled = await seedCompany("enabled = true");
+    const disabled = await seedCompany("enabled = false");
+    const paused = await seedCompany("paused", "paused");
+
+    await db.insert(pluginCompanySettings).values([
+      { pluginId, companyId: explicitlyEnabled, enabled: true },
+      { pluginId, companyId: disabled, enabled: false },
+    ]);
+
+    const ids = await jobStore.listEnabledCompanyIds(pluginId);
+
+    expect([...ids].sort()).toEqual([enabledByDefault, explicitlyEnabled].sort());
+    expect(ids).not.toContain(disabled);
+    expect(ids).not.toContain(paused);
+  });
+
+  it("does not let another plugin's disable row shrink this plugin's fan-out", async () => {
+    const pluginId = await seedPlugin();
+    const otherPluginId = randomUUID();
+    await db.insert(plugins).values({
+      id: otherPluginId,
+      pluginKey: "paperclip.other",
+      packageName: "@paperclipai/plugin-other",
+      version: "0.0.1",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {},
+      status: "ready",
+      installOrder: 2,
+    });
+
+    const companyId = await seedCompany("disabled for the other plugin only");
+    await db.insert(pluginCompanySettings).values({
+      pluginId: otherPluginId,
+      companyId,
+      enabled: false,
+    });
+
+    const jobStore = pluginJobStore(db);
+    await expect(jobStore.listEnabledCompanyIds(pluginId)).resolves.toEqual([companyId]);
+    await expect(jobStore.listEnabledCompanyIds(otherPluginId)).resolves.toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Dispatch — the actual defect
+  // -------------------------------------------------------------------------
+
+  it("sends a companyId with runJob for every enabled company, and records it on the run", async () => {
+    const pluginId = await seedPlugin();
+    const companyA = await seedCompany("A");
+    const companyB = await seedCompany("B");
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler, captured } = createHarness();
+    await scheduler.tick();
+
+    expect(captured).toHaveLength(2);
+    expect(captured.map((job) => job.companyId).sort()).toEqual([companyA, companyB].sort());
+    for (const job of captured) {
+      expect(job.jobKey).toBe("sweep");
+      expect(job.trigger).toBe("schedule");
+    }
+
+    const runs = await runsForJob(jobId);
+    expect(runs).toHaveLength(2);
+    expect(runs.map((run) => run.companyId).sort()).toEqual([companyA, companyB].sort());
+    expect(runs.every((run) => run.status === "succeeded")).toBe(true);
+  });
+
+  it("skips a company that has disabled the plugin", async () => {
+    const pluginId = await seedPlugin();
+    const included = await seedCompany("included");
+    const excluded = await seedCompany("excluded");
+    await db.insert(pluginCompanySettings).values({
+      pluginId,
+      companyId: excluded,
+      enabled: false,
+    });
+    await seedDueJob(pluginId, "company");
+
+    const { scheduler, captured } = createHarness();
+    await scheduler.tick();
+
+    expect(captured.map((job) => job.companyId)).toEqual([included]);
+  });
+
+  it("dispatches nothing — and does not fail — when a company-scoped job has no enabled companies", async () => {
+    const pluginId = await seedPlugin();
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler, captured } = createHarness();
+    await scheduler.tick();
+
+    expect(captured).toHaveLength(0);
+    await expect(runsForJob(jobId)).resolves.toHaveLength(0);
+
+    // The pointer still advances, so the job is not stuck permanently due.
+    const [job] = await db.select().from(pluginJobs).where(eq(pluginJobs.id, jobId));
+    expect(job?.nextRunAt?.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("leaves an instance-scoped job unscoped — one run, companyId null", async () => {
+    const pluginId = await seedPlugin();
+    await seedCompany("A");
+    await seedCompany("B");
+    const jobId = await seedDueJob(pluginId, "instance");
+
+    const { scheduler, captured } = createHarness();
+    await scheduler.tick();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.companyId).toBeNull();
+
+    const runs = await runsForJob(jobId);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.companyId).toBeNull();
+  });
+
+  it("records a run as failed when the handler throws, per company", async () => {
+    const pluginId = await seedPlugin();
+    await seedCompany("A");
+    await seedCompany("B");
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler } = createHarness({
+      runJob: async () => {
+        throw new Error("handler exploded");
+      },
+    });
+    await scheduler.tick();
+
+    const runs = await runsForJob(jobId);
+    expect(runs).toHaveLength(2);
+    expect(runs.every((run) => run.status === "failed")).toBe(true);
+    expect(runs.every((run) => run.error === "handler exploded")).toBe(true);
+    expect(runs.every((run) => run.companyId !== null)).toBe(true);
+  });
+
+  it("does not let one company's failure suppress another company's run", async () => {
+    const pluginId = await seedPlugin();
+    const companyA = await seedCompany("A");
+    const companyB = await seedCompany("B");
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const failFor = [companyA, companyB].sort()[0]!;
+    const jobStore = pluginJobStore(db);
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async (_pluginId: string, _method: string, params: any) => {
+        if (params.job.companyId === failFor) throw new Error("only this company fails");
+        return null;
+      }),
+    } as any;
+    const scheduler = createPluginJobScheduler({ db, jobStore, workerManager });
+
+    await scheduler.tick();
+
+    const runs = await runsForJob(jobId);
+    expect(runs).toHaveLength(2);
+    const byCompany = new Map(runs.map((run) => [run.companyId, run.status]));
+    expect(byCompany.get(failFor)).toBe("failed");
+    expect([...byCompany.values()].filter((status) => status === "succeeded")).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Manual trigger
+  // -------------------------------------------------------------------------
+
+  it("refuses to trigger a company-scoped job without a company", async () => {
+    const pluginId = await seedPlugin();
+    await seedCompany("A");
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler } = createHarness();
+    await expect(scheduler.triggerJob(jobId, "manual")).rejects.toThrow(
+      /company-scoped/,
+    );
+    await expect(runsForJob(jobId)).resolves.toHaveLength(0);
+  });
+
+  it("refuses to trigger a company-scoped job for a company that disabled the plugin", async () => {
+    const pluginId = await seedPlugin();
+    const disabled = await seedCompany("disabled");
+    await db.insert(pluginCompanySettings).values({
+      pluginId,
+      companyId: disabled,
+      enabled: false,
+    });
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler } = createHarness();
+    await expect(scheduler.triggerJob(jobId, "manual", disabled)).rejects.toThrow(
+      /not enabled for company/,
+    );
+    await expect(runsForJob(jobId)).resolves.toHaveLength(0);
+  });
+
+  it("refuses to trigger an instance-scoped job for a company", async () => {
+    const pluginId = await seedPlugin();
+    const companyId = await seedCompany("A");
+    const jobId = await seedDueJob(pluginId, "instance");
+
+    const { scheduler } = createHarness();
+    await expect(scheduler.triggerJob(jobId, "manual", companyId)).rejects.toThrow(
+      /instance-scoped/,
+    );
+    await expect(runsForJob(jobId)).resolves.toHaveLength(0);
+  });
+
+  it("triggers a company-scoped job for one enabled company", async () => {
+    const pluginId = await seedPlugin();
+    const companyA = await seedCompany("A");
+    await seedCompany("B");
+    const jobId = await seedDueJob(pluginId, "company");
+
+    const { scheduler, captured } = createHarness();
+    const result = await scheduler.triggerJob(jobId, "manual", companyA);
+
+    expect(result.companyId).toBe(companyA);
+
+    // The dispatch is intentionally backgrounded; wait for it to land.
+    await vi.waitFor(async () => {
+      const runs = await runsForJob(jobId);
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.status).toBe("succeeded");
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.companyId).toBe(companyA);
+    expect(captured[0]?.trigger).toBe("manual");
+  });
+});

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -960,7 +960,33 @@ describe.sequential("plugin tool and bridge authz", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ runId: "run-1", jobId: "job-1" });
-    expect(scheduler.triggerJob).toHaveBeenCalledWith("job-1", "manual");
+    expect(scheduler.triggerJob).toHaveBeenCalledWith("job-1", "manual", null);
+  });
+
+  it("forwards the requested companyId to a manual job trigger", async () => {
+    readyPlugin();
+    const scheduler = {
+      triggerJob: vi.fn().mockResolvedValue({
+        runId: "run-1",
+        jobId: "job-1",
+        companyId: "company-1",
+      }),
+    };
+    const jobStore = { getJobByIdForPlugin: vi.fn().mockResolvedValue({ id: "job-1" }) };
+    const { app } = await createApp(boardActor({
+      userId: "admin-1",
+      isInstanceAdmin: true,
+      companyIds: [],
+    }), {}, {
+      jobDeps: { scheduler, jobStore },
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/jobs/job-1/trigger`)
+      .send({ companyId: "company-1" });
+
+    expect(res.status).toBe(200);
+    expect(scheduler.triggerJob).toHaveBeenCalledWith("job-1", "manual", "company-1");
   });
 
   // ─── Agent JWT tool execution (cherry-picked from #5549) ─────────────────────

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -291,6 +291,91 @@ describe("plugin-worker-manager stderr failure context", () => {
     }
   });
 
+  it("passes a company-scoped job's invocation scope to nested worker host calls", async () => {
+    const companiesGet = vi.fn(async (
+      params: { companyId: string },
+      context?: { invocationScope?: { companyId?: string | null } | null },
+    ) => ({
+      id: params.companyId,
+      scopedCompanyId: context?.invocationScope?.companyId ?? null,
+    }));
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: { instanceId: "instance-1", hostVersion: "1.0.0" },
+      apiVersion: 1,
+      hostHandlers: { "companies.get": companiesGet as never },
+    });
+
+    try {
+      await handle.start();
+
+      await expect(handle.call("runJob", {
+        job: {
+          jobKey: "sweep",
+          runId: "run-1",
+          trigger: "schedule",
+          scheduledAt: new Date(0).toISOString(),
+          companyId: "company-a",
+          probe: { mode: "echo", requestedCompanyId: "company-a" },
+        },
+      } as never)).resolves.toEqual({
+        id: "company-a",
+        scopedCompanyId: "company-a",
+      });
+      expect(companiesGet).toHaveBeenCalledWith(
+        { companyId: "company-a" },
+        { invocationScope: { companyId: "company-a" } },
+      );
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("mints no scope for an instance-scoped job, so its company-scoped host calls stay unscoped", async () => {
+    const companiesGet = vi.fn(async (
+      params: { companyId: string },
+      context?: { invocationScope?: { companyId?: string | null } | null },
+    ) => ({
+      id: params.companyId,
+      scopedCompanyId: context?.invocationScope?.companyId ?? null,
+    }));
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: { instanceId: "instance-1", hostVersion: "1.0.0" },
+      apiVersion: 1,
+      hostHandlers: { "companies.get": companiesGet as never },
+    });
+
+    try {
+      await handle.start();
+
+      // `companyId: null` is what an instance-scoped job carries. The plugin
+      // asking for a company anyway must not be an authorization source — the
+      // host handler sees no invocation scope and it is the SDK's
+      // requireInvocationCompanyScope that then refuses.
+      await expect(handle.call("runJob", {
+        job: {
+          jobKey: "sweep",
+          runId: "run-1",
+          trigger: "schedule",
+          scheduledAt: new Date(0).toISOString(),
+          companyId: null,
+          probe: { mode: "omit", requestedCompanyId: "company-a" },
+        },
+      } as never)).resolves.toEqual({
+        id: "company-a",
+        scopedCompanyId: null,
+      });
+      expect(companiesGet).toHaveBeenCalledWith({ companyId: "company-a" }, {});
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
   it("passes echoed invocation scope to worker-to-host handlers", async () => {
     const companiesGet = vi.fn(async () => ({ id: "company-1" }));
     const handle = createPluginWorkerHandle("test.plugin", {

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -333,7 +333,7 @@ describe("plugin-worker-manager stderr failure context", () => {
     }
   });
 
-  it("mints no scope for an instance-scoped job, so its company-scoped host calls stay unscoped", async () => {
+  it("gives an instance-scoped job a real invocation carrying no company", async () => {
     const companiesGet = vi.fn(async (
       params: { companyId: string },
       context?: { invocationScope?: { companyId?: string | null } | null },
@@ -353,10 +353,9 @@ describe("plugin-worker-manager stderr failure context", () => {
     try {
       await handle.start();
 
-      // `companyId: null` is what an instance-scoped job carries. The plugin
-      // asking for a company anyway must not be an authorization source — the
-      // host handler sees no invocation scope and it is the SDK's
-      // requireInvocationCompanyScope that then refuses.
+      // An invocation IS registered, so the nested call has a valid id to echo
+      // and cannot be denied just because unrelated work is in flight. The
+      // company it carries is empty, which is what withholds authorization.
       await expect(handle.call("runJob", {
         job: {
           jobKey: "sweep",
@@ -364,13 +363,62 @@ describe("plugin-worker-manager stderr failure context", () => {
           trigger: "schedule",
           scheduledAt: new Date(0).toISOString(),
           companyId: null,
-          probe: { mode: "omit", requestedCompanyId: "company-a" },
+          probe: { mode: "echo", requestedCompanyId: "company-a" },
         },
       } as never)).resolves.toEqual({
         id: "company-a",
-        scopedCompanyId: null,
+        scopedCompanyId: "",
       });
-      expect(companiesGet).toHaveBeenCalledWith({ companyId: "company-a" }, {});
+      expect(companiesGet).toHaveBeenCalledWith(
+        { companyId: "company-a" },
+        { invocationScope: { companyId: "" } },
+      );
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("refuses an instance-scoped job's company-scoped call with the accurate reason, not a race", async () => {
+    const handlers = createHostClientHandlers({
+      pluginId: "test.plugin",
+      capabilities: ["companies.read"],
+      services: {
+        companies: {
+          list: vi.fn(async () => []),
+          get: vi.fn(async (params: { companyId: string }) => ({ id: params.companyId })),
+        },
+      } as unknown as HostServices,
+    });
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: { instanceId: "instance-1", hostVersion: "1.0.0" },
+      apiVersion: 1,
+      hostHandlers: handlers,
+    });
+
+    try {
+      await handle.start();
+
+      // The message matters as much as the refusal. "company context is
+      // required" tells a plugin author to declare `scope: "company"`;
+      // "missing, expired, or unknown invocation scope" — what an unregistered
+      // invocation produced whenever the instance was busy — sends them
+      // hunting a TTL bug that does not exist.
+      await expect(handle.call("runJob", {
+        job: {
+          jobKey: "sweep",
+          runId: "run-1",
+          trigger: "schedule",
+          scheduledAt: new Date(0).toISOString(),
+          companyId: null,
+          probe: { mode: "echo", requestedCompanyId: "company-a" },
+        },
+      } as never)).rejects.toMatchObject({
+        code: PLUGIN_RPC_ERROR_CODES.INVOCATION_SCOPE_DENIED,
+        message: expect.stringContaining("company context is required"),
+      });
     } finally {
       await handle.stop().catch(() => undefined);
     }

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -2627,10 +2627,14 @@ export function pluginRoutes(
    * Creates a run with `trigger: "manual"` and dispatches immediately.
    * The response returns before the job completes (non-blocking).
    *
-   * Response: `{ runId: string, jobId: string }`
+   * Body: `{ companyId?: string }` — required for a `scope: "company"` job,
+   * rejected for an instance-scoped one (see PLUGIN_SPEC.md §17.1).
+   *
+   * Response: `{ runId: string, jobId: string, companyId: string | null }`
    * Errors:
    * - 404 if plugin not found
-   * - 400 if job not found, not active, already running, or worker unavailable
+   * - 400 if job not found, not active, already running, worker unavailable,
+   *   or the `companyId` does not match the job's declared scope
    */
   router.post("/plugins/:pluginId/jobs/:jobId/trigger", async (req, res) => {
     assertInstanceAdmin(req);
@@ -2652,8 +2656,12 @@ export function pluginRoutes(
       return;
     }
 
+    const companyId = typeof req.body?.companyId === "string" && req.body.companyId.trim()
+      ? req.body.companyId.trim()
+      : null;
+
     try {
-      const result = await jobDeps.scheduler.triggerJob(jobId, "manual");
+      const result = await jobDeps.scheduler.triggerJob(jobId, "manual", companyId);
       res.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -276,6 +276,18 @@ export function createPluginJobScheduler(
     return [...activeRuns].filter((key) => key.startsWith(prefix));
   }
 
+  /**
+   * Where each job's fan-out should resume next tick, when the concurrency cap
+   * cut it short.
+   *
+   * `listEnabledCompanyIds` is deterministically ordered, so without this a
+   * fan-out wider than `maxConcurrentJobs` would admit the *same* prefix every
+   * tick and the tail would never run at all — not late, never. Resuming from
+   * the first company we could not admit turns the cap into a delay instead of
+   * a starvation. In-memory only; a restart just resumes from the top.
+   */
+  const fanOutCursor = new Map<string, string | null>();
+
   /** Total number of ticks since start. */
   let tickCount = 0;
 
@@ -412,10 +424,21 @@ export function createPluginJobScheduler(
         return;
       }
 
+      // Resume the fan-out where the cap cut it short last tick.
+      const resumeAt = fanOutCursor.get(jobId);
+      const resumeIndex = resumeAt === undefined
+        ? 0
+        : Math.max(0, targets.indexOf(resumeAt));
+      const ordered = resumeIndex === 0
+        ? targets
+        : [...targets.slice(resumeIndex), ...targets.slice(0, resumeIndex)];
+
       // Admit targets synchronously so a concurrent tick or manual trigger
       // cannot slip past the overlap check while we await below.
       const admitted: { companyId: string | null; key: string }[] = [];
-      for (const companyId of targets) {
+      let deferredFrom: string | null | undefined;
+
+      for (const [index, companyId] of ordered.entries()) {
         const key = runKey(jobId, companyId);
 
         if (activeRuns.has(key)) {
@@ -427,15 +450,27 @@ export function createPluginJobScheduler(
         }
 
         if (activeRuns.size >= maxConcurrentJobs) {
+          deferredFrom = companyId;
           jobLog.warn(
-            { maxConcurrentJobs, activeJobCount: activeRuns.size },
-            "max concurrent jobs reached, deferring remaining targets",
+            {
+              maxConcurrentJobs,
+              activeJobCount: activeRuns.size,
+              deferredCount: ordered.length - index,
+              resumesAtCompanyId: companyId,
+            },
+            "max concurrent jobs reached — deferring the rest of the fan-out to the next tick",
           );
           break;
         }
 
         activeRuns.add(key);
         admitted.push({ companyId, key });
+      }
+
+      if (deferredFrom === undefined) {
+        fanOutCursor.delete(jobId);
+      } else {
+        fanOutCursor.set(jobId, deferredFrom);
       }
 
       if (admitted.length > 0) {
@@ -853,6 +888,7 @@ export function createPluginJobScheduler(
       for (const key of activeRunKeysForJob(job.id)) {
         activeRuns.delete(key);
       }
+      fanOutCursor.delete(job.id);
     }
   }
 

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -276,26 +276,6 @@ export function createPluginJobScheduler(
     return [...activeRuns].filter((key) => key.startsWith(prefix));
   }
 
-  /**
-   * Targets still owed a run from a fan-out the concurrency cap cut short.
-   *
-   * A job with more enabled companies than `maxConcurrentJobs` cannot serve
-   * them all in one pass — that is a capacity fact, not something the scheduler
-   * can fix. What it *can* control is who gets left out and for how long.
-   *
-   * Without this, the deferred tail is dropped: `listEnabledCompanyIds` is
-   * deterministically ordered, so the same prefix would be admitted on every
-   * later occurrence and the tail would never run at all — not late, never.
-   *
-   * Carrying the remainder forward finishes the interrupted pass before
-   * starting a new one, so a pass over N companies simply takes
-   * `ceil(N / maxConcurrentJobs)` occurrences and no company gets a second run
-   * before every company has had its first.
-   *
-   * In-memory only. A restart drops the remainder and begins a fresh pass,
-   * which costs at most one delayed run and never a duplicate.
-   */
-  const pendingFanOut = new Map<string, (string | null)[]>();
 
   /** Total number of ticks since start. */
   let tickCount = 0;
@@ -398,17 +378,21 @@ export function createPluginJobScheduler(
   // -----------------------------------------------------------------------
 
   /**
-   * Resolve the companies one due job fires for on this tick.
+   * Resolve the companies one due job fires for on this tick, in the order
+   * they should be admitted.
    *
    * An instance-scoped job has exactly one target: `null`, the instance.
    * A company-scoped job has one target per company the plugin is enabled
-   * for — possibly none, on an instance with no companies.
+   * for — possibly none, on an instance with no companies — ordered
+   * least-recently-run first so that a fan-out wider than
+   * `maxConcurrentJobs` still reaches everyone. See
+   * `plugin-job-store.listFanOutCompanyIds`.
    */
   async function resolveJobTargets(
     job: typeof pluginJobs.$inferSelect,
   ): Promise<(string | null)[]> {
     if (job.scope !== "company") return [null];
-    return jobStore.listEnabledCompanyIds(job.pluginId);
+    return jobStore.listFanOutCompanyIds(job.pluginId, job.id);
   }
 
   /**
@@ -423,19 +407,11 @@ export function createPluginJobScheduler(
     const jobLog = log.child({ jobId, pluginId, jobKey, scope: job.scope });
 
     try {
-      const enabled = await resolveJobTargets(job);
-
-      // Finish an interrupted pass before starting a new one, so no company
-      // gets a second run while another is still waiting for its first. Drop
-      // anything from the remainder that is no longer enabled; if that empties
-      // it, the pass is over and a fresh one starts.
-      const carried = pendingFanOut.get(jobId) ?? [];
-      const enabledSet = new Set(enabled);
-      const remaining = carried.filter((companyId) => enabledSet.has(companyId));
-      const targets = remaining.length > 0 ? remaining : enabled;
+      // Least-recently-run first, so the companies the cap turned away last
+      // occurrence are at the front of this one.
+      const targets = await resolveJobTargets(job);
 
       if (targets.length === 0) {
-        pendingFanOut.delete(jobId);
         jobLog.info(
           {},
           "company-scoped job has no enabled companies — nothing to dispatch",
@@ -446,13 +422,10 @@ export function createPluginJobScheduler(
       // Admit targets synchronously so a concurrent tick or manual trigger
       // cannot slip past the overlap check while we await below.
       const admitted: { companyId: string | null; key: string }[] = [];
-      let deferred: (string | null)[] = [];
 
       for (const [index, companyId] of targets.entries()) {
         const key = runKey(jobId, companyId);
 
-        // Already in flight, so it is being served — owed nothing, and not
-        // carried forward.
         if (activeRuns.has(key)) {
           jobLog.debug(
             { companyId },
@@ -462,29 +435,21 @@ export function createPluginJobScheduler(
         }
 
         if (activeRuns.size >= maxConcurrentJobs) {
-          deferred = targets
-            .slice(index)
-            .filter((pending) => !activeRuns.has(runKey(jobId, pending)));
           jobLog.warn(
             {
               maxConcurrentJobs,
               activeJobCount: activeRuns.size,
-              deferredCount: deferred.length,
-              resumesAtCompanyId: companyId,
+              deferredCount: targets.length - index,
+              deferredFromCompanyId: companyId,
             },
-            "max concurrent jobs reached — carrying the rest of this pass to the next occurrence",
+            "max concurrent jobs reached — deferring the rest of the fan-out; "
+              + "least-recently-run ordering puts these first next occurrence",
           );
           break;
         }
 
         activeRuns.add(key);
         admitted.push({ companyId, key });
-      }
-
-      if (deferred.length > 0) {
-        pendingFanOut.set(jobId, deferred);
-      } else {
-        pendingFanOut.delete(jobId);
       }
 
       if (admitted.length > 0) {
@@ -902,7 +867,6 @@ export function createPluginJobScheduler(
       for (const key of activeRunKeysForJob(job.id)) {
         activeRuns.delete(key);
       }
-      pendingFanOut.delete(job.id);
     }
   }
 

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -277,16 +277,25 @@ export function createPluginJobScheduler(
   }
 
   /**
-   * Where each job's fan-out should resume next tick, when the concurrency cap
-   * cut it short.
+   * Targets still owed a run from a fan-out the concurrency cap cut short.
    *
-   * `listEnabledCompanyIds` is deterministically ordered, so without this a
-   * fan-out wider than `maxConcurrentJobs` would admit the *same* prefix every
-   * tick and the tail would never run at all — not late, never. Resuming from
-   * the first company we could not admit turns the cap into a delay instead of
-   * a starvation. In-memory only; a restart just resumes from the top.
+   * A job with more enabled companies than `maxConcurrentJobs` cannot serve
+   * them all in one pass — that is a capacity fact, not something the scheduler
+   * can fix. What it *can* control is who gets left out and for how long.
+   *
+   * Without this, the deferred tail is dropped: `listEnabledCompanyIds` is
+   * deterministically ordered, so the same prefix would be admitted on every
+   * later occurrence and the tail would never run at all — not late, never.
+   *
+   * Carrying the remainder forward finishes the interrupted pass before
+   * starting a new one, so a pass over N companies simply takes
+   * `ceil(N / maxConcurrentJobs)` occurrences and no company gets a second run
+   * before every company has had its first.
+   *
+   * In-memory only. A restart drops the remainder and begins a fresh pass,
+   * which costs at most one delayed run and never a duplicate.
    */
-  const fanOutCursor = new Map<string, string | null>();
+  const pendingFanOut = new Map<string, (string | null)[]>();
 
   /** Total number of ticks since start. */
   let tickCount = 0;
@@ -414,9 +423,19 @@ export function createPluginJobScheduler(
     const jobLog = log.child({ jobId, pluginId, jobKey, scope: job.scope });
 
     try {
-      const targets = await resolveJobTargets(job);
+      const enabled = await resolveJobTargets(job);
+
+      // Finish an interrupted pass before starting a new one, so no company
+      // gets a second run while another is still waiting for its first. Drop
+      // anything from the remainder that is no longer enabled; if that empties
+      // it, the pass is over and a fresh one starts.
+      const carried = pendingFanOut.get(jobId) ?? [];
+      const enabledSet = new Set(enabled);
+      const remaining = carried.filter((companyId) => enabledSet.has(companyId));
+      const targets = remaining.length > 0 ? remaining : enabled;
 
       if (targets.length === 0) {
+        pendingFanOut.delete(jobId);
         jobLog.info(
           {},
           "company-scoped job has no enabled companies — nothing to dispatch",
@@ -424,23 +443,16 @@ export function createPluginJobScheduler(
         return;
       }
 
-      // Resume the fan-out where the cap cut it short last tick.
-      const resumeAt = fanOutCursor.get(jobId);
-      const resumeIndex = resumeAt === undefined
-        ? 0
-        : Math.max(0, targets.indexOf(resumeAt));
-      const ordered = resumeIndex === 0
-        ? targets
-        : [...targets.slice(resumeIndex), ...targets.slice(0, resumeIndex)];
-
       // Admit targets synchronously so a concurrent tick or manual trigger
       // cannot slip past the overlap check while we await below.
       const admitted: { companyId: string | null; key: string }[] = [];
-      let deferredFrom: string | null | undefined;
+      let deferred: (string | null)[] = [];
 
-      for (const [index, companyId] of ordered.entries()) {
+      for (const [index, companyId] of targets.entries()) {
         const key = runKey(jobId, companyId);
 
+        // Already in flight, so it is being served — owed nothing, and not
+        // carried forward.
         if (activeRuns.has(key)) {
           jobLog.debug(
             { companyId },
@@ -450,15 +462,17 @@ export function createPluginJobScheduler(
         }
 
         if (activeRuns.size >= maxConcurrentJobs) {
-          deferredFrom = companyId;
+          deferred = targets
+            .slice(index)
+            .filter((pending) => !activeRuns.has(runKey(jobId, pending)));
           jobLog.warn(
             {
               maxConcurrentJobs,
               activeJobCount: activeRuns.size,
-              deferredCount: ordered.length - index,
+              deferredCount: deferred.length,
               resumesAtCompanyId: companyId,
             },
-            "max concurrent jobs reached — deferring the rest of the fan-out to the next tick",
+            "max concurrent jobs reached — carrying the rest of this pass to the next occurrence",
           );
           break;
         }
@@ -467,10 +481,10 @@ export function createPluginJobScheduler(
         admitted.push({ companyId, key });
       }
 
-      if (deferredFrom === undefined) {
-        fanOutCursor.delete(jobId);
+      if (deferred.length > 0) {
+        pendingFanOut.set(jobId, deferred);
       } else {
-        fanOutCursor.set(jobId, deferredFrom);
+        pendingFanOut.delete(jobId);
       }
 
       if (admitted.length > 0) {
@@ -888,7 +902,7 @@ export function createPluginJobScheduler(
       for (const key of activeRunKeysForJob(job.id)) {
         activeRuns.delete(key);
       }
-      fanOutCursor.delete(job.id);
+      pendingFanOut.delete(job.id);
     }
   }
 

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -17,8 +17,10 @@
  *    `nextRunAt` timestamp after each run or when a new job is registered.
  *
  * 3. **Overlap prevention** — Before dispatching a job, the scheduler checks
- *    for an existing `running` run for the same job. If one exists, the job
- *    is skipped for that tick.
+ *    for an existing `running` run for the same job *and target*. If one
+ *    exists, that target is skipped for the tick. For a company-scoped job the
+ *    target is a company, so a slow run for one company does not hold up the
+ *    others.
  *
  * 4. **Job run recording** — Every execution creates a `plugin_job_runs` row:
  *    `queued` → `running` → `succeeded` | `failed`. Duration and error are
@@ -29,12 +31,25 @@
  *    scheduling when plugins start/stop. On registration, the scheduler
  *    computes `nextRunAt` for all active jobs that don't already have one.
  *
+ * ## Company scope
+ *
+ * A job declared `scope: "company"` in the manifest fans out to one run per
+ * company the plugin is enabled for, and each `runJob` call carries that
+ * company's id. The worker manager turns that id into a host-minted invocation
+ * scope, which is the *only* thing that authorizes company-scoped host calls
+ * (`config.get`, `secrets.resolve`, `issues.*`, company `state.*`).
+ *
+ * A job left at the default `scope: "instance"` gets no company id and
+ * therefore no invocation scope — every company-scoped host call it attempts
+ * is refused with "company context is required". That is the intended
+ * behavior, not a bug: an instance job has no tenant to act for.
+ *
  * @see PLUGIN_SPEC.md §17 — Scheduled Jobs
  * @see ./plugin-job-store.ts — Persistence layer
  * @see ./cron.ts — Cron parsing utilities
  */
 
-import { and, eq, lte, or } from "drizzle-orm";
+import { and, eq, isNull, lte, or } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { pluginJobs, pluginJobRuns } from "@paperclipai/db";
 import type { PluginJobStore } from "./plugin-job-store.js";
@@ -85,6 +100,8 @@ export interface TriggerJobResult {
   runId: string;
   /** The job ID that was triggered. */
   jobId: string;
+  /** Company the run is scoped to, or `null` for an instance-scoped job. */
+  companyId: string | null;
 }
 
 /**
@@ -93,9 +110,12 @@ export interface TriggerJobResult {
 export interface SchedulerDiagnostics {
   /** Whether the tick loop is running. */
   running: boolean;
-  /** Number of jobs currently executing. */
+  /**
+   * Number of job *runs* currently executing. A company-scoped job with a
+   * fan-out in flight contributes one per company.
+   */
   activeJobCount: number;
-  /** Set of job IDs currently in-flight. */
+  /** Distinct job IDs with at least one run in-flight. */
   activeJobIds: string[];
   /** Total number of ticks executed since start. */
   tickCount: number;
@@ -152,12 +172,24 @@ export interface PluginJobScheduler {
    * Creates a run with `trigger: "manual"` and dispatches immediately,
    * respecting the overlap prevention check.
    *
+   * A company-scoped job must be triggered for exactly one company, and that
+   * company must be one the plugin is enabled for — a manual trigger is not a
+   * way to mint a scope the scheduler would never mint. An instance-scoped job
+   * must be triggered with no company at all.
+   *
    * @param jobId - UUID of the job to trigger
    * @param trigger - What triggered this run (default: "manual")
+   * @param companyId - Company to run for; required iff the job is
+   *   `scope: "company"`
    * @returns The created run info
-   * @throws {Error} if the job is not found, not active, or already running
+   * @throws {Error} if the job is not found, not active, already running, or
+   *   the company argument does not match the job's declared scope
    */
-  triggerJob(jobId: string, trigger?: "manual" | "retry"): Promise<TriggerJobResult>;
+  triggerJob(
+    jobId: string,
+    trigger?: "manual" | "retry",
+    companyId?: string | null,
+  ): Promise<TriggerJobResult>;
 
   /**
    * Run a single scheduler tick immediately (for testing).
@@ -224,8 +256,25 @@ export function createPluginJobScheduler(
   /** Whether the scheduler is running. */
   let running = false;
 
-  /** Set of job IDs currently being executed (for overlap prevention). */
-  const activeJobs = new Set<string>();
+  /**
+   * Keys of the job *runs* currently being executed, for overlap prevention.
+   *
+   * One entry per (job, target) — the target being a company for a
+   * company-scoped job, or the instance for everything else. Keyed rather than
+   * job-id'd so one slow company cannot stall the rest of the fan-out.
+   */
+  const activeRuns = new Set<string>();
+
+  /** Overlap-prevention key for one (job, target) pair. */
+  function runKey(jobId: string, companyId: string | null): string {
+    return `${jobId}::${companyId ?? "instance"}`;
+  }
+
+  /** The in-flight run keys belonging to a job. */
+  function activeRunKeysForJob(jobId: string): string[] {
+    const prefix = `${jobId}::`;
+    return [...activeRuns].filter((key) => key.startsWith(prefix));
+  }
 
   /** Total number of ticks since start. */
   let tickCount = 0;
@@ -281,21 +330,12 @@ export function createPluginJobScheduler(
 
       for (const job of dueJobs) {
         // Concurrency limit
-        if (activeJobs.size >= maxConcurrentJobs) {
+        if (activeRuns.size >= maxConcurrentJobs) {
           log.warn(
-            { maxConcurrentJobs, activeJobCount: activeJobs.size },
+            { maxConcurrentJobs, activeJobCount: activeRuns.size },
             "max concurrent jobs reached, deferring remaining jobs",
           );
           break;
-        }
-
-        // Overlap prevention: skip if this job is already running
-        if (activeJobs.has(job.id)) {
-          log.debug(
-            { jobId: job.id, jobKey: job.jobKey, pluginId: job.pluginId },
-            "skipping job — already running (overlap prevention)",
-          );
-          continue;
         }
 
         // Check if the worker is available
@@ -337,17 +377,104 @@ export function createPluginJobScheduler(
   // -----------------------------------------------------------------------
 
   /**
-   * Dispatch a single job run — create the run record, call the worker,
-   * record the result, and advance the schedule pointer.
+   * Resolve the companies one due job fires for on this tick.
+   *
+   * An instance-scoped job has exactly one target: `null`, the instance.
+   * A company-scoped job has one target per company the plugin is enabled
+   * for — possibly none, on an instance with no companies.
+   */
+  async function resolveJobTargets(
+    job: typeof pluginJobs.$inferSelect,
+  ): Promise<(string | null)[]> {
+    if (job.scope !== "company") return [null];
+    return jobStore.listEnabledCompanyIds(job.pluginId);
+  }
+
+  /**
+   * Dispatch every run one due job produces this tick, then advance the
+   * schedule pointer exactly once — the pointer belongs to the job row, not
+   * to any individual company's run.
    */
   async function dispatchJob(
     job: typeof pluginJobs.$inferSelect,
   ): Promise<void> {
-    const { id: jobId, pluginId, jobKey, schedule } = job;
-    const jobLog = log.child({ jobId, pluginId, jobKey });
+    const { id: jobId, pluginId, jobKey } = job;
+    const jobLog = log.child({ jobId, pluginId, jobKey, scope: job.scope });
 
-    // Mark as active (overlap prevention)
-    activeJobs.add(jobId);
+    try {
+      const targets = await resolveJobTargets(job);
+
+      if (targets.length === 0) {
+        jobLog.info(
+          {},
+          "company-scoped job has no enabled companies — nothing to dispatch",
+        );
+        return;
+      }
+
+      // Admit targets synchronously so a concurrent tick or manual trigger
+      // cannot slip past the overlap check while we await below.
+      const admitted: { companyId: string | null; key: string }[] = [];
+      for (const companyId of targets) {
+        const key = runKey(jobId, companyId);
+
+        if (activeRuns.has(key)) {
+          jobLog.debug(
+            { companyId },
+            "skipping run — already running (overlap prevention)",
+          );
+          continue;
+        }
+
+        if (activeRuns.size >= maxConcurrentJobs) {
+          jobLog.warn(
+            { maxConcurrentJobs, activeJobCount: activeRuns.size },
+            "max concurrent jobs reached, deferring remaining targets",
+          );
+          break;
+        }
+
+        activeRuns.add(key);
+        admitted.push({ companyId, key });
+      }
+
+      if (admitted.length > 0) {
+        await Promise.allSettled(
+          admitted.map((target) =>
+            dispatchScheduledRun(job, target.companyId, target.key),
+          ),
+        );
+      }
+    } catch (err) {
+      jobLog.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        "failed to dispatch job",
+      );
+    } finally {
+      // Always advance the schedule pointer (even on failure)
+      try {
+        await advanceSchedulePointer(job);
+      } catch (err) {
+        jobLog.error(
+          { err: err instanceof Error ? err.message : String(err) },
+          "failed to advance schedule pointer",
+        );
+      }
+    }
+  }
+
+  /**
+   * Dispatch one scheduled run — create the run record, call the worker, and
+   * record the result. The caller has already reserved `key` in
+   * {@link activeRuns}; this function releases it.
+   */
+  async function dispatchScheduledRun(
+    job: typeof pluginJobs.$inferSelect,
+    companyId: string | null,
+    key: string,
+  ): Promise<void> {
+    const { id: jobId, pluginId, jobKey } = job;
+    const jobLog = log.child({ jobId, pluginId, jobKey, companyId });
 
     let runId: string | undefined;
     const startedAt = Date.now();
@@ -357,6 +484,7 @@ export function createPluginJobScheduler(
       const run = await jobStore.createRun({
         jobId,
         pluginId,
+        companyId,
         trigger: "schedule",
       });
       runId = run.id;
@@ -366,7 +494,8 @@ export function createPluginJobScheduler(
       // 2. Mark run as running
       await jobStore.markRunning(runId);
 
-      // 3. Call worker via RPC
+      // 3. Call worker via RPC. `companyId` is what the worker manager turns
+      //    into the host-minted invocation scope for this run.
       await workerManager.call(
         pluginId,
         "runJob",
@@ -376,6 +505,7 @@ export function createPluginJobScheduler(
             runId,
             trigger: "schedule" as const,
             scheduledAt: (job.nextRunAt ?? new Date()).toISOString(),
+            companyId,
           },
         },
         jobTimeoutMs,
@@ -417,18 +547,7 @@ export function createPluginJobScheduler(
         }
       }
     } finally {
-      // Remove from active set
-      activeJobs.delete(jobId);
-
-      // 5. Always advance the schedule pointer (even on failure)
-      try {
-        await advanceSchedulePointer(job);
-      } catch (err) {
-        jobLog.error(
-          { err: err instanceof Error ? err.message : String(err) },
-          "failed to advance schedule pointer",
-        );
-      }
+      activeRuns.delete(key);
     }
   }
 
@@ -436,9 +555,47 @@ export function createPluginJobScheduler(
   // Core: manual trigger
   // -----------------------------------------------------------------------
 
+  /**
+   * Validate the caller's company argument against the job's declared scope
+   * and return the company the run should be scoped to.
+   *
+   * A manual trigger must not be able to mint a scope the scheduler itself
+   * would never mint, so a company-scoped job can only be triggered for a
+   * company the plugin is actually enabled for.
+   */
+  async function resolveTriggerCompanyId(
+    job: typeof pluginJobs.$inferSelect,
+    companyId: string | null | undefined,
+  ): Promise<string | null> {
+    if (job.scope !== "company") {
+      if (companyId) {
+        throw new Error(
+          `Job "${job.jobKey}" is instance-scoped — it cannot be triggered for a company`,
+        );
+      }
+      return null;
+    }
+
+    if (!companyId) {
+      throw new Error(
+        `Job "${job.jobKey}" is company-scoped — a companyId is required to trigger it`,
+      );
+    }
+
+    const enabled = await jobStore.listEnabledCompanyIds(job.pluginId);
+    if (!enabled.includes(companyId)) {
+      throw new Error(
+        `Plugin "${job.pluginId}" is not enabled for company "${companyId}" — cannot trigger job "${job.jobKey}"`,
+      );
+    }
+
+    return companyId;
+  }
+
   async function triggerJob(
     jobId: string,
     trigger: "manual" | "retry" = "manual",
+    companyId?: string | null,
   ): Promise<TriggerJobResult> {
     const job = await jobStore.getJobById(jobId);
     if (!job) {
@@ -451,8 +608,11 @@ export function createPluginJobScheduler(
       );
     }
 
+    const targetCompanyId = await resolveTriggerCompanyId(job, companyId);
+    const key = runKey(jobId, targetCompanyId);
+
     // Overlap prevention
-    if (activeJobs.has(jobId)) {
+    if (activeRuns.has(key)) {
       throw new Error(
         `Job "${job.jobKey}" is already running — cannot trigger while in progress`,
       );
@@ -466,6 +626,9 @@ export function createPluginJobScheduler(
         and(
           eq(pluginJobRuns.jobId, jobId),
           eq(pluginJobRuns.status, "running"),
+          targetCompanyId
+            ? eq(pluginJobRuns.companyId, targetCompanyId)
+            : isNull(pluginJobRuns.companyId),
         ),
       );
 
@@ -486,27 +649,33 @@ export function createPluginJobScheduler(
     const run = await jobStore.createRun({
       jobId,
       pluginId: job.pluginId,
+      companyId: targetCompanyId,
       trigger,
     });
 
-    // Dispatch in background — don't block the caller
-    void dispatchManualRun(job, run.id, trigger);
+    // Reserve before returning — the background dispatch releases it.
+    activeRuns.add(key);
 
-    return { runId: run.id, jobId };
+    // Dispatch in background — don't block the caller
+    void dispatchManualRun(job, run.id, trigger, targetCompanyId, key);
+
+    return { runId: run.id, jobId, companyId: targetCompanyId };
   }
 
   /**
-   * Dispatch a manually triggered job run.
+   * Dispatch a manually triggered job run. The caller has already reserved
+   * `key` in {@link activeRuns}; this function releases it.
    */
   async function dispatchManualRun(
     job: typeof pluginJobs.$inferSelect,
     runId: string,
     trigger: "manual" | "retry",
+    companyId: string | null,
+    key: string,
   ): Promise<void> {
     const { id: jobId, pluginId, jobKey } = job;
-    const jobLog = log.child({ jobId, pluginId, jobKey, runId, trigger });
+    const jobLog = log.child({ jobId, pluginId, jobKey, runId, trigger, companyId });
 
-    activeJobs.add(jobId);
     const startedAt = Date.now();
 
     try {
@@ -521,6 +690,7 @@ export function createPluginJobScheduler(
             runId,
             trigger,
             scheduledAt: new Date().toISOString(),
+            companyId,
           },
         },
         jobTimeoutMs,
@@ -553,7 +723,7 @@ export function createPluginJobScheduler(
         );
       }
     } finally {
-      activeJobs.delete(jobId);
+      activeRuns.delete(key);
     }
   }
 
@@ -680,7 +850,9 @@ export function createPluginJobScheduler(
     // Remove any active tracking for jobs owned by this plugin
     const jobs = await jobStore.listJobs(pluginId);
     for (const job of jobs) {
-      activeJobs.delete(job.id);
+      for (const key of activeRunKeysForJob(job.id)) {
+        activeRuns.delete(key);
+      }
     }
   }
 
@@ -717,7 +889,7 @@ export function createPluginJobScheduler(
     running = false;
 
     log.info(
-      { activeJobCount: activeJobs.size },
+      { activeJobCount: activeRuns.size },
       "plugin job scheduler stopped",
     );
   }
@@ -729,8 +901,8 @@ export function createPluginJobScheduler(
   function diagnostics(): SchedulerDiagnostics {
     return {
       running,
-      activeJobCount: activeJobs.size,
-      activeJobIds: [...activeJobs],
+      activeJobCount: activeRuns.size,
+      activeJobIds: [...new Set([...activeRuns].map((key) => key.slice(0, key.indexOf("::"))))],
       tickCount,
       lastTickAt: lastTickAt?.toISOString() ?? null,
     };

--- a/server/src/services/plugin-job-store.ts
+++ b/server/src/services/plugin-job-store.ts
@@ -292,6 +292,16 @@ export function pluginJobStore(db: Db) {
      * front, and — unlike a remembered cursor — this survives a restart,
      * because it is derived from `plugin_job_runs` rather than from memory.
      *
+     * The ordering deliberately counts **attempts, not completions**: every run
+     * row for the company, whatever its status, including one left `queued` or
+     * `running` by a restart that killed the handler mid-occurrence. Counting
+     * only terminal-successful runs would rank a company whose handler always
+     * dies ahead of everyone else on every occurrence — it would take a slot
+     * each time and never give it up, which is the starvation this ordering
+     * exists to prevent. The cost is bounded and the opposite of a drop: an
+     * interrupted company waits behind the companies queued ahead of it and is
+     * reached on the following occurrence.
+     *
      * @param pluginId - UUID of the plugin
      * @param jobId - UUID of the job whose run history orders the fan-out
      * @returns Company UUIDs, possibly empty

--- a/server/src/services/plugin-job-store.ts
+++ b/server/src/services/plugin-job-store.ts
@@ -23,7 +23,9 @@
  *    to fire next.
  *
  * 5. **Company fan-out set** — `listEnabledCompanyIds()` answers "which
- *    companies does a `scope: "company"` job run for on this tick".
+ *    companies is this plugin enabled for", and `listFanOutCompanyIds()`
+ *    orders that set least-recently-run-first for one job, so a fan-out wider
+ *    than the scheduler's concurrency cap stays fair across occurrences.
  *
  * The capability check (`jobs.schedule`) is enforced upstream by the host
  * client factory and manifest validator — this store trusts that the caller
@@ -33,7 +35,7 @@
  * @see PLUGIN_SPEC.md §21.3 — `plugin_jobs` / `plugin_job_runs` tables
  */
 
-import { and, asc, desc, eq, notExists } from "drizzle-orm";
+import { and, asc, desc, eq, notExists, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   companies,
@@ -119,6 +121,29 @@ export function pluginJobStore(db: Db) {
   // -----------------------------------------------------------------------
   // Internal helpers
   // -----------------------------------------------------------------------
+
+  /**
+   * "Enabled for this company" per the opt-out semantic documented on
+   * `plugin_company_settings`: no row means enabled, a row with
+   * `enabled = false` means disabled. Non-`active` companies are excluded.
+   */
+  function enabledCompanyConditions(pluginId: string) {
+    return [
+      eq(companies.status, "active"),
+      notExists(
+        db
+          .select({ one: pluginCompanySettings.id })
+          .from(pluginCompanySettings)
+          .where(
+            and(
+              eq(pluginCompanySettings.pluginId, pluginId),
+              eq(pluginCompanySettings.companyId, companies.id),
+              eq(pluginCompanySettings.enabled, false),
+            ),
+          ),
+      ),
+    ];
+  }
 
   async function assertPluginExists(pluginId: string): Promise<void> {
     const rows = await db
@@ -233,7 +258,8 @@ export function pluginJobStore(db: Db) {
      * not `active` (paused/suspended) are excluded — a paused company should
      * not have background work run against it.
      *
-     * Ordered by id so a fan-out is deterministic across ticks.
+     * Ordered by id so membership checks are deterministic. For dispatch
+     * ordering use {@link listFanOutCompanyIds}, which is fairness-ordered.
      *
      * @param pluginId - UUID of the plugin
      * @returns Company UUIDs, possibly empty
@@ -242,24 +268,47 @@ export function pluginJobStore(db: Db) {
       const rows = await db
         .select({ id: companies.id })
         .from(companies)
-        .where(
-          and(
-            eq(companies.status, "active"),
-            notExists(
-              db
-                .select({ one: pluginCompanySettings.id })
-                .from(pluginCompanySettings)
-                .where(
-                  and(
-                    eq(pluginCompanySettings.pluginId, pluginId),
-                    eq(pluginCompanySettings.companyId, companies.id),
-                    eq(pluginCompanySettings.enabled, false),
-                  ),
-                ),
-            ),
-          ),
-        )
+        .where(and(...enabledCompanyConditions(pluginId)))
         .orderBy(asc(companies.id));
+
+      return rows.map((row) => row.id);
+    },
+
+    /**
+     * The same set as {@link listEnabledCompanyIds}, ordered
+     * least-recently-run-first for one specific job.
+     *
+     * A job with more enabled companies than the scheduler's concurrency cap
+     * cannot serve them all in one occurrence. That is capacity, not something
+     * the scheduler can fix. What it *can* control is who gets left out and for
+     * how long — and a stable ordering (by company id, say) is the worst
+     * possible answer, because the same prefix wins every occurrence and the
+     * tail never runs at all.
+     *
+     * Ordering by each company's most recent run **for this job**, with
+     * never-run companies first, makes that fair without any in-process state:
+     * serving a company moves it to the back. A company gets a second run only
+     * after every company has had a first, new companies go straight to the
+     * front, and — unlike a remembered cursor — this survives a restart,
+     * because it is derived from `plugin_job_runs` rather than from memory.
+     *
+     * @param pluginId - UUID of the plugin
+     * @param jobId - UUID of the job whose run history orders the fan-out
+     * @returns Company UUIDs, possibly empty
+     */
+    async listFanOutCompanyIds(pluginId: string, jobId: string): Promise<string[]> {
+      const lastRunAt = sql<Date | null>`(
+        select max(${pluginJobRuns.createdAt})
+        from ${pluginJobRuns}
+        where ${pluginJobRuns.jobId} = ${jobId}
+          and ${pluginJobRuns.companyId} = ${companies.id}
+      )`;
+
+      const rows = await db
+        .select({ id: companies.id })
+        .from(companies)
+        .where(and(...enabledCompanyConditions(pluginId)))
+        .orderBy(sql`${lastRunAt} asc nulls first`, asc(companies.id));
 
       return rows.map((row) => row.id);
     },

--- a/server/src/services/plugin-job-store.ts
+++ b/server/src/services/plugin-job-store.ts
@@ -22,6 +22,9 @@
  *    `updateNextRunAt()` with the next cron tick so the scheduler knows when
  *    to fire next.
  *
+ * 5. **Company fan-out set** — `listEnabledCompanyIds()` answers "which
+ *    companies does a `scope: "company"` job run for on this tick".
+ *
  * The capability check (`jobs.schedule`) is enforced upstream by the host
  * client factory and manifest validator — this store trusts that the caller
  * has already been authorised.
@@ -30,14 +33,21 @@
  * @see PLUGIN_SPEC.md §21.3 — `plugin_jobs` / `plugin_job_runs` tables
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, notExists } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { plugins, pluginJobs, pluginJobRuns } from "@paperclipai/db";
+import {
+  companies,
+  plugins,
+  pluginCompanySettings,
+  pluginJobs,
+  pluginJobRuns,
+} from "@paperclipai/db";
 import type {
   PluginJobDeclaration,
   PluginJobRunStatus,
   PluginJobRunTrigger,
   PluginJobRecord,
+  PluginJobScope,
 } from "@paperclipai/shared";
 import { notFound } from "../errors.js";
 
@@ -62,6 +72,11 @@ export interface CreateJobRunInput {
   pluginId: string;
   /** What triggered this run. */
   trigger: PluginJobRunTrigger;
+  /**
+   * Company this run is scoped to, or `null`/omitted for an instance-scoped
+   * run. `null` is the explicit instance marker — not "unknown".
+   */
+  companyId?: string | null;
 }
 
 /**
@@ -165,14 +180,18 @@ export function pluginJobStore(db: Db) {
 
         const existing = existingByKey.get(decl.jobKey);
         const schedule = decl.schedule ?? "";
+        const scope: PluginJobScope = decl.scope ?? "instance";
 
         if (existing) {
-          // Update schedule if it changed; re-activate if it was paused
+          // Update schedule/scope if they changed; re-activate if it was paused
           const updates: Record<string, unknown> = {
             updatedAt: new Date(),
           };
           if (existing.schedule !== schedule) {
             updates.schedule = schedule;
+          }
+          if (existing.scope !== scope) {
+            updates.scope = scope;
           }
           if (existing.status === "paused") {
             updates.status = "active";
@@ -188,6 +207,7 @@ export function pluginJobStore(db: Db) {
             pluginId,
             jobKey: decl.jobKey,
             schedule,
+            scope,
             status: "active",
           });
         }
@@ -202,6 +222,46 @@ export function pluginJobStore(db: Db) {
             .where(eq(pluginJobs.id, existing.id));
         }
       }
+    },
+
+    /**
+     * List the companies a `scope: "company"` job should fan out to.
+     *
+     * Plugins are installed instance-wide, so "enabled for a company" is the
+     * opt-out semantic documented on `plugin_company_settings`: a company is
+     * in scope unless it has a row with `enabled = false`. Companies that are
+     * not `active` (paused/suspended) are excluded — a paused company should
+     * not have background work run against it.
+     *
+     * Ordered by id so a fan-out is deterministic across ticks.
+     *
+     * @param pluginId - UUID of the plugin
+     * @returns Company UUIDs, possibly empty
+     */
+    async listEnabledCompanyIds(pluginId: string): Promise<string[]> {
+      const rows = await db
+        .select({ id: companies.id })
+        .from(companies)
+        .where(
+          and(
+            eq(companies.status, "active"),
+            notExists(
+              db
+                .select({ one: pluginCompanySettings.id })
+                .from(pluginCompanySettings)
+                .where(
+                  and(
+                    eq(pluginCompanySettings.pluginId, pluginId),
+                    eq(pluginCompanySettings.companyId, companies.id),
+                    eq(pluginCompanySettings.enabled, false),
+                  ),
+                ),
+            ),
+          ),
+        )
+        .orderBy(asc(companies.id));
+
+      return rows.map((row) => row.id);
     },
 
     /**
@@ -356,6 +416,7 @@ export function pluginJobStore(db: Db) {
         .values({
           jobId: input.jobId,
           pluginId: input.pluginId,
+          companyId: input.companyId ?? null,
           trigger: input.trigger,
           status: "queued",
         })

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1022,11 +1022,23 @@ export function createPluginWorkerHandle(
     }
 
     // A scheduled job carries a company only when its manifest declared
-    // `scope: "company"`. An instance-scoped job legitimately has none, gets
-    // no scope, and so its company-scoped host calls stay refused.
+    // `scope: "company"` (PLUGIN_SPEC.md §17.1).
+    //
+    // An instance-scoped job gets a real invocation with an EMPTY company
+    // rather than no invocation at all. The distinction matters: with no
+    // invocation the job's nested worker→host calls carry no id, and
+    // `contextForWorkerMessage` cannot tell "never scoped" from "lost its
+    // scope" — so it denies them whenever any unrelated invocation happens to
+    // be in flight. That makes an instance job fail intermittently, in
+    // proportion to how busy the instance is, reporting a misleading
+    // "missing, expired, or unknown invocation scope".
+    //
+    // An empty company is falsy to `readNonEmptyString`, so
+    // `requireInvocationCompanyScope` still refuses company-scoped calls —
+    // now deterministically, with the accurate "company context is required".
+    // Credit to #9310 / #9368 for isolating this half.
     if (method === "runJob" && isRecord(params.job)) {
-      const companyId = readNonEmptyString(params.job.companyId);
-      return companyId ? { companyId } : null;
+      return { companyId: readNonEmptyString(params.job.companyId) ?? "" };
     }
 
     return null;

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1021,6 +1021,14 @@ export function createPluginWorkerHandle(
       return companyId ? { companyId } : null;
     }
 
+    // A scheduled job carries a company only when its manifest declared
+    // `scope: "company"`. An instance-scoped job legitimately has none, gets
+    // no scope, and so its company-scoped host calls stay refused.
+    if (method === "runJob" && isRecord(params.job)) {
+      const companyId = readNonEmptyString(params.job.companyId);
+      return companyId ? { companyId } : null;
+    }
+
     return null;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins extend it, and a plugin can declare scheduled jobs that the host fires on a cron
> - Host-to-worker RPC is company-scoped. The host mints an invocation scope on dispatch, and a nested worker-to-host call must echo that invocation id to be authorized
> - `deriveInvocationScope` mints that scope for `onEvent`, `performAction` and `executeTool`. It has no case for `runJob`, and it could not have one — `PluginJobContext` carried no company, and `plugin_jobs` has no tenant column
> - So a scheduled job's handler is refused on every company-scoped host call it makes: `config.get`, `secrets.resolve`, `issues.createComment`, and company-scoped `state.*`. It fails on the first tick and on every tick after that
> - The plugin cannot work around this. The `companyId` a plugin passes is only ever compared against a host-minted scope. It is never an authorization source
> - This pull request adds an opt-in company dimension to job declarations, and mints the scope from it
> - The benefit is that a plugin can do per-tenant work on a schedule, which it cannot do at all today

## Linked Issues or Issue Description

Refs #9310

That issue covers the invocation-id half of this defect, and #9368 is the fix for that half. This pull request contains that fix and adds the company-scope half. More detail in "Relationship to #9310 and #9368" below.

The remainder of the defect is not covered by an existing issue, so it is described here.

**What happened?**

A plugin declared a scheduled job with a `*/5 * * * *` cron. The job handler called `ctx.config.get(companyId)`. Every tick produced this, from the first tick after install:

```
[plugin-job-scheduler] dispatching scheduled job  jobKey="sweep-armed-issues"
[plugin-worker] ERROR host handler error  method="config.get"
    err: Plugin "..." is not allowed to perform "config.get": company context is required
[plugin-job-scheduler] job completed successfully
```

The same `ctx.config.get(companyId)` call, from the same plugin, succeeds inside an `issue.updated` handler. It is the job dispatch path that is unscoped, not the plugin.

**Expected behavior**

A scheduled job can act for a company. It can read that company's plugin config, resolve that company's secrets, and comment on that company's issues.

**Steps to reproduce**

1. Declare a job in a plugin manifest: `{ "jobKey": "sweep", "displayName": "Sweep", "schedule": "*/5 * * * *" }`.
2. In the worker, register a handler for `sweep` that calls `ctx.config.get(someCompanyId)`.
3. Install the plugin and configure it for that company.
4. Wait for a tick. The call is refused. It is refused on every subsequent tick.

**Paperclip version or commit**

Reproduced on `master`.

**Deployment mode / Installation method / Database mode**

Local, from source, embedded Postgres.

**Agent adapter(s) involved**

Not adapter-specific — core bug in the plugin host.

**Root cause**

1. `deriveInvocationScope` (`server/src/services/plugin-worker-manager.ts`) is the only place a scope is minted. It has no `runJob` branch.
2. It could not have one. `RunJobParams` is `{ job: PluginJobContext }`, and `PluginJobContext` carried `jobKey`, `runId`, `trigger` and `scheduledAt` — no company. `plugin_jobs` has no tenant column either, so one schedule row fires once no matter how many companies exist.
3. The `runJob` RPC therefore ships with no `paperclipInvocation`, the worker's `AsyncLocalStorage` is never populated, and every nested worker-to-host call carries no invocation id.
4. `requireInvocationCompanyScope` (`packages/plugins/sdk/src/host-client-factory.ts`) refuses any call whose params carry a company, or `scopeKind: "company"`, when no host-minted scope exists.

Scaffolding for the fix was already in the tree and unused. `plugin_job_runs.company_id` has existed since the table was added, commented "Company scope — NULL for instance-level jobs", and `plugin-registry.ts:createJobRun` accepts a `companyId`. That function has zero production callers. The live path, `plugin-job-store.ts:createRun`, always wrote `NULL`.

## What Changed

- `packages/shared`: `PluginJobDeclaration.scope`, a new `PluginJobScope` type (`"instance"` or `"company"`), and the matching zod enum. The field is optional and defaults to `"instance"`.
- `packages/db`: `plugin_jobs.scope`, plus migration `0223`. One `ADD COLUMN ... DEFAULT 'instance' NOT NULL`. The scheduler reads job rows directly at tick time, so the declared scope must be on the row.
- `packages/plugins/sdk`: `PluginJobContext.companyId`. `RunJobParams` wraps that type, so it carries the company too.
- `server/src/services/plugin-worker-manager.ts`: `deriveInvocationScope` gets its `runJob` branch, reading `params.job.companyId`.
- `server/src/services/plugin-job-store.ts`: `syncJobDeclarations` persists the declared scope; `createRun` accepts and writes `companyId`; new `listEnabledCompanyIds` returns the fan-out set.
- `server/src/services/plugin-job-scheduler.ts`: a `scope: "company"` job dispatches one run per enabled company. Overlap prevention moves from per-job to per-(job, target). The schedule pointer still advances exactly once per job row.
- `server/src/routes/plugins.ts`: the manual-trigger route accepts an optional `companyId` and returns it.
- `doc/plugins/PLUGIN_SPEC.md`: new section 17.1, plus the company id in section 13.6.

Two decisions worth calling out.

**Scope is opt-in, not automatic.** The alternative was to fan every job out per company. That silently changes the behavior of every job in every installation, and it wakes an instance-level maintenance job once per tenant. A manifest flag changes nothing until a plugin asks for it. Job definitions stay plugin-global — `plugin_jobs` deliberately gets no `company_id`. Only runs are scoped.

**The manual-trigger route is now scope-checked.** `triggerJob` requires exactly one enabled company for a company-scoped job, and none for an instance-scoped one. Without that check, `POST /plugins/:pluginId/jobs/:jobId/trigger` becomes a way to mint a scope the scheduler itself would never mint, including for a company that explicitly disabled the plugin.

"Enabled" follows the semantics already documented on `plugin_company_settings`: an `active` company with no row disabling the plugin. Absence of a row means enabled.

## Relationship to #9310 and #9368

I found #9368 after opening this. The two overlap and touch the same three files.

#9368 fixes a real and distinct half of the problem: with no invocation registered at all, `contextForWorkerMessage` cannot tell "never scoped" from "lost its scope", so it denies id-less nested calls whenever any unrelated invocation is in flight. A job therefore fails intermittently, in proportion to how busy the instance is, and reports a misleading "missing, expired, or unknown invocation scope".

This pull request now contains that fix. An instance-scoped job gets a real invocation carrying an empty company, exactly as #9368 proposed. An empty company is falsy to `readNonEmptyString`, so a company-scoped call is still refused — now deterministically, and with the accurate "company context is required".

One correction. #9368 states that "company-scoped jobs are unaffected; they already get their scope from the existing top-level `params.companyId` check". That check never fires for `runJob`: `RunJobParams` has no top-level `companyId`, only `{ job }`. Before this pull request there was no way for a job to be company-scoped, which is why #9368 alone leaves `config.get` and `secrets.resolve` refused.

The two changes compose rather than compete, so this is offered as a superset. Credit for the id-less race is #9310 and #9368, not this pull request. If the maintainers prefer to land #9368 first, I will rebase.

## Verification

New: `server/src/__tests__/plugin-job-company-scope.test.ts`, 14 tests against a real embedded Postgres. The fan-out set is a SQL anti-join, and getting it wrong means running for tenants that disabled the plugin, so a fake database would not have proved anything.

Also new: 3 cases in `server/src/__tests__/plugin-worker-manager.test.ts` that drive a real worker child process, and 1 route test.

```
npx vitest run server/src/__tests__/plugin-job-company-scope.test.ts     # 14 passed
npx vitest run server/src/__tests__/plugin-worker-manager.test.ts        # 50 passed
npx vitest run server/src/__tests__/plugin-routes-authz.test.ts          # 38 passed
pnpm --filter @paperclipai/shared     run typecheck
pnpm --filter @paperclipai/db         run typecheck
pnpm --filter @paperclipai/plugin-sdk run typecheck
pnpm --filter @paperclipai/server     run typecheck
```

All green.

Mutation tested. Seven mutations, seven caught.

| Mutation | Tests that failed |
| --- | --- |
| Remove the `runJob` branch from `deriveInvocationScope` | 1 |
| `resolveJobTargets` always returns `[null]` | 5 |
| Drop `companyId` from the `createRun` insert | 3 |
| Drop the `notExists` disable-row anti-join | 4 |
| Drop the manual-trigger scope guard | 3 |
| Stop persisting the manifest `scope` | 1 |
| Stop forwarding `companyId` from the trigger route | 2 |

## Risks

**Migration.** One `ADD COLUMN` with a constant default on a small table. Postgres 11 and later do not rewrite the table for this. `check-migration-safety` passes.

**Behavior change for existing jobs: none.** `scope` is optional and defaults to `"instance"`, which is the current behavior. `PluginJobContext.companyId` is optional, so existing handlers compile and run unchanged.

**Behavior change for the manual-trigger route.** The route previously accepted any job. It now rejects a `companyId` on an instance-scoped job, and requires one on a company-scoped job. No job is company-scoped before this pull request, so nothing existing can hit either rejection. The response gains a `companyId` field.

**Fan-out load.** A `scope: "company"` job on an instance with many companies dispatches one run per company per tick. This is the declared intent of the flag, and `maxConcurrentJobs` still caps concurrency. An operator who does not want it does not set the flag.

**Paused companies are skipped.** `listEnabledCompanyIds` filters to `companies.status = 'active'`. I judged that background work should not run for a paused tenant. If the project's convention is otherwise, this is a one-line change.

**Known gap, deliberately not fixed here.** `createTestHarness` (`packages/plugins/sdk/src/testing.ts`) does not model invocation scope at all, so `ctx.config.get(companyId)` succeeds in the harness regardless of context. That is why this defect survived a full end-to-end pilot with green plugin tests: a fake that is more permissive than the host hides exactly this class of bug. Making the harness enforce `requireInvocationCompanyScope` is the class-level fix. It is a large change to a widely depended on file and would break any test that touches `ctx.config` outside an invocation, so it is not bundled here. This pull request does the narrow part: `harness.runJob()` now accepts a `companyId` and defaults it to `null`.

## Model Used

Claude Opus 5 (Anthropic), running in Claude Code with extended thinking, tool use, and code execution. Subagents on Claude Sonnet 5 (`claude-sonnet-5`) ran the mutation campaign and the codebase survey; every design decision and all source edits are from the Opus session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
