### PR TITLE
test(plugins): make the SDK test harness enforce invocation company scope

### DIFF
--- a/packages/plugins/examples/plugin-orchestration-smoke-example/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-orchestration-smoke-example/tests/plugin.spec.ts
@@ -102,14 +102,18 @@ describe("orchestration smoke plugin", () => {
     expect(harness.dbExecutes[0]?.sql).toContain(".smoke_runs");
     expect(harness.dbQueries.some((entry) => entry.sql.includes("JOIN public.issues"))).toBe(true);
 
-    const relations = await harness.ctx.issues.relations.get(result.childIssueId, companyId);
+    // Driven straight off `ctx`, outside any host invocation, so the assertion
+    // has to say which company it reads as.
+    const relations = await harness.withCompanyScope(companyId, () =>
+      harness.ctx.issues.relations.get(result.childIssueId, companyId));
     expect(relations.blockedBy).toEqual([
       expect.objectContaining({
         id: result.blockerIssueId,
         status: "done",
       }),
     ]);
-    const docs = await harness.ctx.issues.documents.list(result.childIssueId, companyId);
+    const docs = await harness.withCompanyScope(companyId, () =>
+      harness.ctx.issues.documents.list(result.childIssueId, companyId));
     expect(docs).toEqual([
       expect.objectContaining({
         key: "orchestration-smoke",
@@ -135,7 +139,10 @@ describe("orchestration smoke plugin", () => {
     });
     await plugin.definition.setup(harness.ctx);
 
-    await expect(plugin.definition.onApiRequest?.({
+    // The host mints an invocation scope from `ApiRequestParams.companyId`
+    // before it dispatches an API route, so a test that calls the hook directly
+    // has to stand in for that.
+    await expect(harness.withCompanyScope(companyId, async () => await plugin.definition.onApiRequest?.({
       routeKey: "initialize",
       method: "POST",
       path: `/issues/${rootIssueId}/smoke`,
@@ -151,7 +158,7 @@ describe("orchestration smoke plugin", () => {
       },
       companyId,
       headers: {},
-    })).resolves.toMatchObject({
+    }))).resolves.toMatchObject({
       status: 201,
       body: expect.objectContaining({
         rootIssueId,

--- a/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
@@ -1699,10 +1699,10 @@ Duplicate headings receive stable suffixes.
     });
 
     expect(writes).toHaveLength(0);
-    const operations = await harness.ctx.issues.list({
+    const operations = await harness.withCompanyScope(COMPANY_ID, () => harness.ctx.issues.list({
       companyId: COMPANY_ID,
       originKindPrefix: String(OPERATION_ORIGIN_KIND),
-    });
+    }));
     expect(operations).toHaveLength(0);
     expect(harness.dbExecutes.some((execute) => execute.sql.includes("wiki_sources"))).toBe(false);
     expect(harness.dbExecutes.some((execute) => execute.sql.includes("wiki_operations"))).toBe(false);
@@ -1979,13 +1979,13 @@ Duplicate headings receive stable suffixes.
     });
 
     await plugin.definition.setup(harness.ctx);
-    await harness.ctx.issues.documents.upsert({
+    await harness.withCompanyScope(COMPANY_ID, () => harness.ctx.issues.documents.upsert({
       companyId: COMPANY_ID,
       issueId: child.id,
       key: "plan",
       title: "Plan",
       body: "Document evidence for the source bundle.",
-    });
+    }));
 
     const first = await harness.performAction<{
       markdown: string;
@@ -2045,13 +2045,13 @@ Duplicate headings receive stable suffixes.
     });
 
     await plugin.definition.setup(harness.ctx);
-    await harness.ctx.issues.documents.upsert({
+    await harness.withCompanyScope(COMPANY_ID, () => harness.ctx.issues.documents.upsert({
       companyId: COMPANY_ID,
       issueId: issue.id,
       key: "plan",
       title: "Plan",
       body: "OPENAI_API_KEY=sk-supersecretdocumentvalue1234567890",
-    });
+    }));
 
     const run = await harness.performAction<{
       bundle: {
@@ -2554,13 +2554,13 @@ Duplicate headings receive stable suffixes.
     };
 
     await plugin.definition.setup(harness.ctx);
-    await harness.ctx.issues.documents.upsert({
+    await harness.withCompanyScope(COMPANY_ID, () => harness.ctx.issues.documents.upsert({
       companyId: COMPANY_ID,
       issueId: issue.id,
       key: "plan",
       title: "Plan",
       body: "OPENAI_API_KEY=sk-patchsecretdocumentvalue1234567890",
-    });
+    }));
 
     const result = await harness.performAction<{
       status: string;
@@ -3144,10 +3144,10 @@ Duplicate headings receive stable suffixes.
       projectId: existingProject().id,
     })).rejects.toThrow("Paperclip ingestion policy denied queue");
 
-    const operations = await harness.ctx.issues.list({
+    const operations = await harness.withCompanyScope(COMPANY_ID, () => harness.ctx.issues.list({
       companyId: COMPANY_ID,
       originKindPrefix: String(OPERATION_ORIGIN_KIND),
-    });
+    }));
     expect(operations).toHaveLength(0);
     expect(harness.dbExecutes.some((execute) => execute.sql.includes("paperclip_distillation_work_items"))).toBe(false);
   });
@@ -3448,10 +3448,10 @@ Duplicate headings receive stable suffixes.
     expect(writes).toHaveLength(0);
     expect(harness.dbExecutes.some((execute) => execute.sql.includes("wiki_sources"))).toBe(false);
     expect(harness.dbExecutes.some((execute) => execute.sql.includes("wiki_operations"))).toBe(false);
-    const operations = await harness.ctx.issues.list({
+    const operations = await harness.withCompanyScope(COMPANY_ID, () => harness.ctx.issues.list({
       companyId: COMPANY_ID,
       originKindPrefix: String(OPERATION_ORIGIN_KIND),
-    });
+    }));
     expect(operations).toHaveLength(0);
   });
 
@@ -3477,7 +3477,7 @@ Duplicate headings receive stable suffixes.
       path: "wiki/concepts/plugin-boundaries.md",
       contents: "# New Title\n",
       expectedHash: "stale",
-    });
+    }, { companyId: COMPANY_ID });
     await expect(staleWrite).rejects.toThrow("Refusing to overwrite");
 
     const result = await harness.executeTool<{ data?: { hash: string } }>("wiki_write_page", {
@@ -3485,7 +3485,7 @@ Duplicate headings receive stable suffixes.
       wikiId: "default",
       path: "wiki/concepts/plugin-boundaries.md",
       contents: "# Plugin Boundaries\n\nSee [Knowledge](wiki/areas/knowledge.md).",
-    });
+    }, { companyId: COMPANY_ID });
 
     expect(result.data?.hash).toHaveLength(64);
     expect(files.get("wiki/concepts/plugin-boundaries.md")).toContain("Plugin Boundaries");
@@ -3515,7 +3515,7 @@ Duplicate headings receive stable suffixes.
       wikiId: "default",
       path: "AGENTS.md",
       contents: "# LLM Wiki Maintainer\n\nCompromised instructions.\n",
-    })).rejects.toThrow("Refusing to overwrite protected wiki control file AGENTS.md");
+    }, { companyId: COMPANY_ID })).rejects.toThrow("Refusing to overwrite protected wiki control file AGENTS.md");
 
     const result = await harness.performAction<{ hash: string }>("write-page", {
       companyId: COMPANY_ID,
@@ -3668,7 +3668,11 @@ Duplicate headings receive stable suffixes.
   });
 
   it("starts query sessions, records run ids, and forwards session events to plugin streams", async () => {
-    const harness = createTestHarness({ manifest });
+    // A session-event callback runs outside any host invocation — the worker
+    // client dispatches `agents.sessions.event` without an invocation context —
+    // so the writes it makes are proactive and reach only the companies this
+    // plugin is configured for.
+    const harness = createTestHarness({ manifest, proactiveCompanyScopes: [COMPANY_ID] });
     harness.seed({ agents: [wikiMaintainerAgent()] });
     const streamEvents: unknown[] = [];
     harness.ctx.streams.emit = (_channel, event) => {

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -87,6 +87,176 @@ export class InvocationScopeDeniedError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Invocation company scope
+// ---------------------------------------------------------------------------
+
+/**
+ * The company a single worker→host call asks for, as the governed-access gate
+ * reads it off the JSON-RPC params.
+ *
+ * - `none` — the call references no company at all (instance-scoped state, an
+ *   unfiltered subscribe). Never gated.
+ * - `single` — one explicit company. Must match the invocation's company.
+ * - `all` — a wildcard read. Only `companies.list` may ask for it.
+ */
+export type CompanyScopeRequest =
+  | { kind: "none" }
+  | { kind: "single"; companyId: string }
+  | { kind: "all" };
+
+const NO_COMPANY_SCOPE: CompanyScopeRequest = { kind: "none" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Derive which company a worker→host call references, from the method name and
+ * its JSON-RPC params.
+ *
+ * This is the single definition of "is this call company-scoped" for the whole
+ * SDK. `requireInvocationCompanyScope` gates on it, `createTestHarness` mirrors
+ * it so a fake `ctx` refuses exactly what the host refuses, and the host's own
+ * proactive-scope resolver (`plugin-worker-manager.ts` `referencedCompanyId`)
+ * is documented as tracking it. Change it in one place only.
+ */
+export function requestedCompanyScope(
+  method: WorkerToHostMethodName,
+  params: unknown,
+): CompanyScopeRequest {
+  if (method === "companies.list") return { kind: "all" };
+  if (!isRecord(params)) return NO_COMPANY_SCOPE;
+
+  const companyId = readNonEmptyString(params.companyId);
+  if (companyId) return { kind: "single", companyId };
+
+  if (params.scopeKind === "company") {
+    const scopeId = readNonEmptyString(params.scopeId);
+    return scopeId ? { kind: "single", companyId: scopeId } : { kind: "all" };
+  }
+
+  if (method === "events.subscribe" && isRecord(params.filter)) {
+    const filterCompanyId = readNonEmptyString(params.filter.companyId);
+    if (filterCompanyId) return { kind: "single", companyId: filterCompanyId };
+  }
+
+  return NO_COMPANY_SCOPE;
+}
+
+/**
+ * Enforce that a worker→host call stays inside the company authorized for the
+ * current top-level plugin invocation.
+ *
+ * Exported so test doubles can enforce the same rule with the same messages. A
+ * fake host that skips this check does not merely fail to test the gate, it
+ * deletes the gate from the model under test — the plugin then passes its whole
+ * suite and is refused by the real host on its first company-scoped call.
+ *
+ * @param pluginId - Plugin the call belongs to, for the error message
+ * @param method - Worker→host method being called
+ * @param params - JSON-RPC params for the call
+ * @param context - Invocation scope the host resolved for this call
+ * @throws InvocationScopeDeniedError when the call leaves its invocation's company
+ */
+export function requireInvocationCompanyScope(
+  pluginId: string,
+  method: WorkerToHostMethodName,
+  params: unknown,
+  context?: WorkerHostCallContext,
+): void {
+  const requested = requestedCompanyScope(method, params);
+  if (requested.kind === "none") return;
+
+  if (context?.invalidInvocationScope) {
+    throw new InvocationScopeDeniedError(
+      pluginId,
+      method,
+      "the worker referenced a missing, expired, or unknown invocation scope",
+    );
+  }
+
+  const allowedCompanyId = readNonEmptyString(context?.invocationScope?.companyId);
+
+  if (requested.kind === "all") {
+    if (method === "companies.list") return;
+    if (!allowedCompanyId) {
+      throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
+    }
+    throw new InvocationScopeDeniedError(
+      pluginId,
+      method,
+      `the current invocation is scoped to company "${allowedCompanyId}"`,
+    );
+  }
+
+  if (!allowedCompanyId) {
+    throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
+  }
+
+  if (requested.companyId !== allowedCompanyId) {
+    throw new InvocationScopeDeniedError(
+      pluginId,
+      method,
+      `requested company "${requested.companyId}" but the current invocation is scoped to company "${allowedCompanyId}"`,
+    );
+  }
+}
+
+/**
+ * Resolve the single company a call must run against, for the methods that
+ * cannot proceed without one (`config.get`, `secrets.resolve`).
+ *
+ * Unlike `requireInvocationCompanyScope`, this also refuses a call that names
+ * no company at all: outside an invocation there is nothing to fall back to, so
+ * "no company anywhere" is `company context is required` rather than a pass.
+ *
+ * @param pluginId - Plugin the call belongs to, for the error message
+ * @param method - Worker→host method being called
+ * @param params - JSON-RPC params for the call
+ * @param context - Invocation scope the host resolved for this call
+ * @returns The company the call resolves to
+ * @throws InvocationScopeDeniedError when no company resolves, or the call leaves its own
+ */
+export function resolveRequiredCompanyId(
+  pluginId: string,
+  method: WorkerToHostMethodName,
+  params: unknown,
+  context?: WorkerHostCallContext,
+): string {
+  if (context?.invalidInvocationScope) {
+    throw new InvocationScopeDeniedError(
+      pluginId,
+      method,
+      "the worker referenced a missing, expired, or unknown invocation scope",
+    );
+  }
+
+  const requested = requestedCompanyScope(method, params);
+  const scopedCompanyId = readNonEmptyString(context?.invocationScope?.companyId);
+  if (requested.kind === "single") {
+    if (!scopedCompanyId) {
+      throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
+    }
+    if (requested.companyId !== scopedCompanyId) {
+      throw new InvocationScopeDeniedError(
+        pluginId,
+        method,
+        `requested company "${requested.companyId}" but the current invocation is scoped to company "${scopedCompanyId}"`,
+      );
+    }
+    return scopedCompanyId;
+  }
+
+  if (scopedCompanyId) return scopedCompanyId;
+
+  throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
+}
+
+// ---------------------------------------------------------------------------
 // Host service interfaces
 // ---------------------------------------------------------------------------
 
@@ -553,121 +723,6 @@ export function createHostClientHandlers(
   const { pluginId, services } = options;
   const capabilitySet = new Set<PluginCapability>(options.capabilities);
 
-  type CompanyScopeRequest =
-    | { kind: "none" }
-    | { kind: "single"; companyId: string }
-    | { kind: "all" };
-
-  const noCompanyScope: CompanyScopeRequest = { kind: "none" };
-
-  function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null && !Array.isArray(value);
-  }
-
-  function readNonEmptyString(value: unknown): string | null {
-    return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-  }
-
-  function requestedCompanyScope(
-    method: WorkerToHostMethodName,
-    params: unknown,
-  ): CompanyScopeRequest {
-    if (method === "companies.list") return { kind: "all" };
-    if (!isRecord(params)) return noCompanyScope;
-
-    const companyId = readNonEmptyString(params.companyId);
-    if (companyId) return { kind: "single", companyId };
-
-    if (params.scopeKind === "company") {
-      const scopeId = readNonEmptyString(params.scopeId);
-      return scopeId ? { kind: "single", companyId: scopeId } : { kind: "all" };
-    }
-
-    if (method === "events.subscribe" && isRecord(params.filter)) {
-      const filterCompanyId = readNonEmptyString(params.filter.companyId);
-      if (filterCompanyId) return { kind: "single", companyId: filterCompanyId };
-    }
-
-    return noCompanyScope;
-  }
-
-  function requireInvocationCompanyScope(
-    method: WorkerToHostMethodName,
-    params: unknown,
-    context?: WorkerHostCallContext,
-  ): void {
-    const requested = requestedCompanyScope(method, params);
-    if (requested.kind === "none") return;
-
-    if (context?.invalidInvocationScope) {
-      throw new InvocationScopeDeniedError(
-        pluginId,
-        method,
-        "the worker referenced a missing, expired, or unknown invocation scope",
-      );
-    }
-
-    const allowedCompanyId = readNonEmptyString(context?.invocationScope?.companyId);
-
-    if (requested.kind === "all") {
-      if (method === "companies.list") return;
-      if (!allowedCompanyId) {
-        throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
-      }
-      throw new InvocationScopeDeniedError(
-        pluginId,
-        method,
-        `the current invocation is scoped to company "${allowedCompanyId}"`,
-      );
-    }
-
-    if (!allowedCompanyId) {
-      throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
-    }
-
-    if (requested.companyId !== allowedCompanyId) {
-      throw new InvocationScopeDeniedError(
-        pluginId,
-        method,
-        `requested company "${requested.companyId}" but the current invocation is scoped to company "${allowedCompanyId}"`,
-      );
-    }
-  }
-
-  function resolveRequiredCompanyId(
-    method: WorkerToHostMethodName,
-    params: unknown,
-    context?: WorkerHostCallContext,
-  ): string {
-    if (context?.invalidInvocationScope) {
-      throw new InvocationScopeDeniedError(
-        pluginId,
-        method,
-        "the worker referenced a missing, expired, or unknown invocation scope",
-      );
-    }
-
-    const requested = requestedCompanyScope(method, params);
-    const scopedCompanyId = readNonEmptyString(context?.invocationScope?.companyId);
-    if (requested.kind === "single") {
-      if (!scopedCompanyId) {
-        throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
-      }
-      if (requested.companyId !== scopedCompanyId) {
-        throw new InvocationScopeDeniedError(
-          pluginId,
-          method,
-          `requested company "${requested.companyId}" but the current invocation is scoped to company "${scopedCompanyId}"`,
-        );
-      }
-      return scopedCompanyId;
-    }
-
-    if (scopedCompanyId) return scopedCompanyId;
-
-    throw new InvocationScopeDeniedError(pluginId, method, "company context is required");
-  }
-
   /**
    * Assert that the plugin has the required capability for a method.
    * Throws `CapabilityDeniedError` if the capability is missing.
@@ -694,7 +749,7 @@ export function createHostClientHandlers(
   ): HostHandler<M> {
     return async (params: WorkerToHostMethods[M][0], context?: WorkerHostCallContext) => {
       requireCapability(method);
-      requireInvocationCompanyScope(method, params, context);
+      requireInvocationCompanyScope(pluginId, method, params, context);
       return handler(params, context);
     };
   }
@@ -706,7 +761,7 @@ export function createHostClientHandlers(
   return {
     // Config
     "config.get": gated("config.get", async (params, context) => {
-      const companyId = resolveRequiredCompanyId("config.get", params, context);
+      const companyId = resolveRequiredCompanyId(pluginId, "config.get", params, context);
       return services.config.get({ ...params, companyId }, context);
     }),
 
@@ -776,7 +831,7 @@ export function createHostClientHandlers(
 
     // Secrets
     "secrets.resolve": gated("secrets.resolve", async (params, context) => {
-      const companyId = resolveRequiredCompanyId("secrets.resolve", params, context);
+      const companyId = resolveRequiredCompanyId(pluginId, "secrets.resolve", params, context);
       return services.secrets.resolve({ ...params, companyId }, context);
     }),
 

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -72,6 +72,12 @@ import type {
   PluginPerformActionActorContext,
   PluginPerformActionContext,
 } from "./protocol.js";
+import type { WorkerHostCallContext, WorkerToHostMethodName } from "./protocol.js";
+import {
+  requestedCompanyScope,
+  requireInvocationCompanyScope,
+  resolveRequiredCompanyId,
+} from "./host-client-factory.js";
 
 export interface TestHarnessOptions {
   /** Plugin manifest used to seed capability checks and metadata. */
@@ -80,6 +86,18 @@ export interface TestHarnessOptions {
   capabilities?: PluginCapability[];
   /** Initial config returned by `ctx.config.get(companyId)`. */
   config?: Record<string, unknown>;
+  /**
+   * Companies this plugin may act on from proactive (no-invocation) `ctx` calls
+   * — in production, exactly the companies the plugin is configured for.
+   *
+   * The host seeds the same set on the worker handle (`proactiveCompanyScopes`
+   * in `plugin-worker-manager.ts`) and refreshes it from `registry.listConfigs`
+   * on every config change, so a proactive loop can reach a configured company
+   * without a host-issued invocation. Leave it empty and every company-scoped
+   * `ctx` call outside an invocation is refused, which is what the host does for
+   * an unconfigured company.
+   */
+  proactiveCompanyScopes?: string[];
 }
 
 export interface TestHarnessLogEntry {
@@ -124,8 +142,18 @@ export interface TestHarness {
   setConfig(config: Record<string, unknown>): void;
   /** Dispatch a host or plugin event to registered handlers. */
   emit(eventType: PluginEventType | `plugin.${string}`, payload: unknown, base?: Partial<PluginEvent>): Promise<void>;
-  /** Execute a previously-registered scheduled job handler. */
-  runJob(jobKey: string, partial?: Partial<PluginJobContext>): Promise<void>;
+  /**
+   * Execute a previously-registered scheduled job handler.
+   *
+   * `companyId` sets the invocation company scope for the run, the way a
+   * company-scoped job declaration does in production. A job run without one is
+   * instance-scoped and every company-scoped `ctx` call inside it is refused,
+   * which is exactly what the host does.
+   */
+  runJob(
+    jobKey: string,
+    partial?: Partial<PluginJobContext> & { companyId?: string | null },
+  ): Promise<void>;
   /** Invoke a `ctx.data.register(...)` handler by key. */
   getData<T = unknown>(key: string, params?: Record<string, unknown>): Promise<T>;
   /** Invoke a `ctx.actions.register(...)` handler by key. */
@@ -136,6 +164,24 @@ export interface TestHarness {
   ): Promise<T>;
   /** Execute a registered tool handler via `ctx.tools.execute(...)`. */
   executeTool<T = ToolResult>(name: string, params: unknown, runCtx?: Partial<ToolRunContext>): Promise<T>;
+  /**
+   * Run `fn` with `companyId` as the active invocation company scope, for tests
+   * that drive `ctx` directly instead of through `emit`/`runJob`/`getData`/
+   * `performAction`/`executeTool`.
+   *
+   * Two cases need it: arranging or asserting host state straight off `ctx`, and
+   * calling a plugin lifecycle hook the harness does not wrap (`onApiRequest`,
+   * `onWebhook`), where the host mints the scope from the bridge call's own
+   * `companyId` before dispatching.
+   *
+   * This is not a bypass: the scope behaves exactly like one the host minted, so
+   * a call inside it that asks for a *different* company is still refused. Use
+   * it to state which company the test is acting as. If a call only passes once
+   * it is wrapped, and the plugin has no way to be inside that company's
+   * invocation in production, that is a finding about the plugin, not a reason
+   * to widen the wrapper.
+   */
+  withCompanyScope<T>(companyId: string | null, fn: () => Promise<T>): Promise<T>;
   /** Read raw in-memory state for assertions. */
   getState(input: ScopeKey): unknown;
   /** Simulate a streaming event arriving for an active session. */
@@ -439,6 +485,14 @@ function normalizeScope(input: ScopeKey): Required<Pick<ScopeKey, "scopeKind" | 
   };
 }
 
+/**
+ * The scope fields `worker-rpc-host.ts` puts on the wire for a `state.*` or
+ * `entities.*` call, so the harness gates on the same params the host sees.
+ */
+function scopeParams(input: { scopeKind: string; scopeId?: string }): { scopeKind: string; scopeId?: string } {
+  return { scopeKind: input.scopeKind, scopeId: input.scopeId };
+}
+
 function stateMapKey(input: ScopeKey): string {
   const normalized = normalizeScope(input);
   return `${normalized.scopeKind}|${normalized.scopeId ?? ""}|${normalized.namespace}|${normalized.stateKey}`;
@@ -455,11 +509,6 @@ function allowsEvent(filter: EventFilter | undefined, event: PluginEvent): boole
 function requireCapability(manifest: PaperclipPluginManifestV1, allowed: Set<PluginCapability>, capability: PluginCapability) {
   if (allowed.has(capability)) return;
   throw new Error(`Plugin '${manifest.id}' is missing required capability '${capability}' in test harness`);
-}
-
-function requireCompanyId(companyId?: string): string {
-  if (!companyId) throw new Error("companyId is required for this operation");
-  return companyId;
 }
 
 function isInCompany<T extends { companyId: string | null | undefined }>(
@@ -479,6 +528,88 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
   const manifest = options.manifest;
   const capabilitySet = new Set(options.capabilities ?? manifest.capabilities);
   let currentConfig = { ...(options.config ?? {}) };
+
+  // ---------------------------------------------------------------------
+  // Invocation company scope
+  //
+  // The host only lets a plugin touch company data on behalf of a company it
+  // minted a scope for. A fake `ctx` that answers every company-scoped call
+  // unconditionally does not merely fail to test that gate, it deletes the
+  // gate from the model under test: the plugin goes green on its whole suite
+  // and is refused by the real host on its first company-scoped call.
+  //
+  // The two branches below mirror `plugin-worker-manager.ts`
+  // `contextForWorkerMessage` exactly:
+  //
+  //   1. Inside a host-issued invocation (an event, job, action or tool run)
+  //      the call must name that invocation's company, or no company at all.
+  //   2. Outside one, the call is proactive. The host admits it only when it
+  //      names a company the plugin is *configured* for
+  //      (`proactiveCompanyScopes`, refreshed from `registry.listConfigs`), so
+  //      the harness admits exactly that set and nothing else.
+  //
+  // Whether a call is company-scoped at all is not decided here — it is read
+  // off the JSON-RPC params by `requestedCompanyScope`, the same function the
+  // real gate uses, so the two cannot drift.
+  // ---------------------------------------------------------------------
+  const proactiveCompanyScopes = new Set(options.proactiveCompanyScopes ?? []);
+  let invocationCompanyId: string | null = null;
+
+  function hostCallContext(method: WorkerToHostMethodName, params: unknown): WorkerHostCallContext {
+    if (invocationCompanyId) return { invocationScope: { companyId: invocationCompanyId } };
+    const requested = requestedCompanyScope(method, params);
+    if (requested.kind === "single" && proactiveCompanyScopes.has(requested.companyId)) {
+      return { invocationScope: { companyId: requested.companyId } };
+    }
+    return {};
+  }
+
+  /**
+   * Gate a fake `ctx` call the way the host gates the RPC it maps to. Pass the
+   * worker→host method name and the params the production client would send
+   * for it (`worker-rpc-host.ts`), so the check sees what the host would see.
+   */
+  function requireCompanyScope(method: WorkerToHostMethodName, params: unknown): void {
+    requireInvocationCompanyScope(manifest.id, method, params, hostCallContext(method, params));
+  }
+
+  /**
+   * Gate a call that cannot run without a company at all (`config.get`,
+   * `secrets.resolve`), and return the company it resolves to — from the
+   * params when given, otherwise from the active invocation.
+   */
+  function requireResolvedCompanyId(method: WorkerToHostMethodName, params: unknown): string {
+    return resolveRequiredCompanyId(manifest.id, method, params, hostCallContext(method, params));
+  }
+
+  /**
+   * Gate a call that takes a required `companyId` argument, then return it.
+   * Replaces the harness's old presence-only check — the argument being present
+   * was never the question the host asks.
+   */
+  function requireCompanyId(method: WorkerToHostMethodName, companyId?: string): string {
+    requireCompanyScope(method, { companyId });
+    if (!companyId) throw new Error("companyId is required for this operation");
+    return companyId;
+  }
+
+  async function withInvocationScope<T>(
+    companyId: string | null | undefined,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const previous = invocationCompanyId;
+    // A null scope is a real state, not "inherit": an instance-scoped job runs
+    // with no company, and nested calls inside it must be refused rather than
+    // borrow an outer scope.
+    invocationCompanyId = typeof companyId === "string" && companyId.trim().length > 0
+      ? companyId.trim()
+      : null;
+    try {
+      return await fn();
+    } finally {
+      invocationCompanyId = previous;
+    }
+  }
 
   const logs: TestHarnessLogEntry[] = [];
   const activity: TestHarness["activity"] = [];
@@ -738,7 +869,10 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
   const ctx: PluginContext = {
     manifest,
     config: {
-      async get() {
+      async get(companyId?: string) {
+        // The fake used to ignore the argument entirely, so it answered a call
+        // the host refuses outright when no company resolves.
+        requireResolvedCompanyId("config.get", companyId ? { companyId } : {});
         return { ...currentConfig };
       },
     },
@@ -748,6 +882,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async configure(input) {
         requireCapability(manifest, capabilitySet, "local.folders");
+        requireCompanyScope("localFolders.configure", { companyId: input.companyId });
         const status = {
           folderKey: input.folderKey,
           configured: true,
@@ -769,10 +904,12 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async status(companyId, folderKey) {
         requireCapability(manifest, capabilitySet, "local.folders");
+        requireCompanyScope("localFolders.status", { companyId });
         return localFolderStatuses.get(localFolderKey(companyId, folderKey)) ?? notConfiguredLocalFolderStatus(folderKey);
       },
       async list(companyId, folderKey, options) {
         requireCapability(manifest, capabilitySet, "local.folders");
+        requireCompanyScope("localFolders.list", { companyId });
         const status = localFolderStatuses.get(localFolderKey(companyId, folderKey));
         if (!status?.configured) throw new Error("Local folder is not configured");
         const prefix = normalizeLocalFolderRelativePath(options?.relativePath ?? "");
@@ -817,6 +954,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async readText(companyId, folderKey, relativePath) {
         requireCapability(manifest, capabilitySet, "local.folders");
+        requireCompanyScope("localFolders.readText", { companyId });
         const normalizedPath = normalizeLocalFolderRelativePath(relativePath);
         const contents = localFolderFiles.get(localFolderFileKey(companyId, folderKey, normalizedPath));
         if (contents === undefined) throw new Error(`Local folder file not found: ${relativePath}`);
@@ -824,6 +962,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async writeTextAtomic(companyId, folderKey, relativePath, contents) {
         requireCapability(manifest, capabilitySet, "local.folders");
+        requireCompanyScope("localFolders.writeTextAtomic", { companyId });
         const status = localFolderStatuses.get(localFolderKey(companyId, folderKey)) ?? {
           folderKey,
           configured: true,
@@ -849,6 +988,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async deleteFile(companyId, folderKey, relativePath) {
         requireCapability(manifest, capabilitySet, "local.folders");
+        requireCompanyScope("localFolders.deleteFile", { companyId });
         const status = localFolderStatuses.get(localFolderKey(companyId, folderKey)) ?? notConfiguredLocalFolderStatus(folderKey);
         if (status.configured && (status.access !== "readWrite" || !status.writable)) {
           throw new Error("Local folder is not configured for writes");
@@ -875,6 +1015,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async emit(name, companyId, payload) {
         requireCapability(manifest, capabilitySet, "events.emit");
+        requireCompanyScope("events.emit", { companyId });
         await harness.emit(`plugin.${manifest.id}.${name}`, payload, { companyId });
       },
     },
@@ -909,33 +1050,46 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
     },
     secrets: {
-      async resolve(secretRef) {
+      async resolve(secretRef, options) {
         requireCapability(manifest, capabilitySet, "secrets.read-ref");
+        // The fake used to drop `options` entirely, so a cross-company secret
+        // read the host refuses resolved cleanly here.
+        requireResolvedCompanyId(
+          "secrets.resolve",
+          options?.companyId ? { companyId: options.companyId } : {},
+        );
         return `resolved:${secretRef}`;
       },
     },
     activity: {
       async log(entry) {
         requireCapability(manifest, capabilitySet, "activity.log.write");
+        requireCompanyScope("activity.log", { companyId: entry.companyId });
         activity.push(entry);
       },
     },
     state: {
       async get(input) {
         requireCapability(manifest, capabilitySet, "plugin.state.read");
+        // State carries its company as `scopeKind: "company"` + `scopeId`, not
+        // a `companyId` field; `requestedCompanyScope` reads both shapes.
+        requireCompanyScope("state.get", scopeParams(input));
         return state.has(stateMapKey(input)) ? state.get(stateMapKey(input)) : null;
       },
       async set(input, value) {
         requireCapability(manifest, capabilitySet, "plugin.state.write");
+        requireCompanyScope("state.set", scopeParams(input));
         state.set(stateMapKey(input), value);
       },
       async delete(input) {
         requireCapability(manifest, capabilitySet, "plugin.state.write");
+        requireCompanyScope("state.delete", scopeParams(input));
         state.delete(stateMapKey(input));
       },
     },
     entities: {
       async upsert(input: PluginEntityUpsert) {
+        requireCompanyScope("entities.upsert", scopeParams(input));
         const externalKey = input.externalId
           ? `${input.entityType}|${input.scopeKind}|${input.scopeId ?? ""}|${input.externalId}`
           : null;
@@ -977,6 +1131,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         return record;
       },
       async list(query) {
+        requireCompanyScope("entities.list", { scopeKind: query.scopeKind, scopeId: query.scopeId });
         let out = [...entities.values()];
         if (query.entityType) out = out.filter((r) => r.entityType === query.entityType);
         if (query.scopeKind) out = out.filter((r) => r.scopeKind === query.scopeKind);
@@ -990,7 +1145,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     projects: {
       async list(input) {
         requireCapability(manifest, capabilitySet, "projects.read");
-        const companyId = requireCompanyId(input?.companyId);
+        const companyId = requireCompanyId("projects.list", input?.companyId);
         let out = [...projects.values()];
         out = out.filter((project) => project.companyId === companyId);
         if (input?.offset) out = out.slice(input.offset);
@@ -999,22 +1154,26 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async get(projectId, companyId) {
         requireCapability(manifest, capabilitySet, "projects.read");
+        requireCompanyScope("projects.get", { companyId });
         const project = projects.get(projectId);
         return isInCompany(project, companyId) ? project : null;
       },
       async listWorkspaces(projectId, companyId) {
         requireCapability(manifest, capabilitySet, "project.workspaces.read");
+        requireCompanyScope("projects.listWorkspaces", { companyId });
         if (!isInCompany(projects.get(projectId), companyId)) return [];
         return projectWorkspaces.get(projectId) ?? [];
       },
       async getPrimaryWorkspace(projectId, companyId) {
         requireCapability(manifest, capabilitySet, "project.workspaces.read");
+        requireCompanyScope("projects.getPrimaryWorkspace", { companyId });
         if (!isInCompany(projects.get(projectId), companyId)) return null;
         const workspaces = projectWorkspaces.get(projectId) ?? [];
         return workspaces.find((workspace) => workspace.isPrimary) ?? null;
       },
       async getWorkspaceForIssue(issueId, companyId) {
         requireCapability(manifest, capabilitySet, "project.workspaces.read");
+        requireCompanyScope("projects.getWorkspaceForIssue", { companyId });
         const issue = issues.get(issueId);
         if (!isInCompany(issue, companyId)) return null;
         const projectId = (issue as unknown as Record<string, unknown>)?.projectId as string | undefined;
@@ -1026,6 +1185,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       managed: {
         async get(projectKey, companyId) {
           requireCapability(manifest, capabilitySet, "projects.managed");
+          requireCompanyScope("projects.managed.get", { companyId });
           const declaration = manifest.projects?.find((project) => project.projectKey === projectKey);
           if (!declaration) {
             return {
@@ -1132,9 +1292,11 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           };
         },
         async reconcile(projectKey, companyId) {
+          requireCompanyScope("projects.managed.reconcile", { companyId });
           return this.get(projectKey, companyId);
         },
         async reset(projectKey, companyId) {
+          requireCompanyScope("projects.managed.reset", { companyId });
           const resolved = await this.get(projectKey, companyId);
           return { ...resolved, status: resolved.project ? "reset" : resolved.status };
         },
@@ -1143,6 +1305,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     executionWorkspaces: {
       async get(workspaceId, companyId) {
         requireCapability(manifest, capabilitySet, "execution.workspaces.read");
+        requireCompanyScope("executionWorkspaces.get", { companyId });
         const workspace = executionWorkspaces.get(workspaceId);
         return workspace?.companyId === companyId ? workspace : null;
       },
@@ -1151,6 +1314,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       managed: {
         async get(routineKey, companyId) {
           requireCapability(manifest, capabilitySet, "routines.managed");
+          requireCompanyScope("routines.managed.get", { companyId });
           const declaration = manifest.routines?.find((routine) => routine.routineKey === routineKey);
           if (!declaration) {
             return {
@@ -1196,6 +1360,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           } satisfies PluginManagedRoutineResolution;
         },
         async reconcile(routineKey, companyId, overrides) {
+          requireCompanyScope("routines.managed.reconcile", { companyId });
           const existing = await this.get(routineKey, companyId);
           if (existing.routine) return existing;
           const declaration = manifest.routines?.find((routine) => routine.routineKey === routineKey);
@@ -1298,10 +1463,12 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           } satisfies PluginManagedRoutineResolution;
         },
         async reset(routineKey, companyId, overrides) {
+          requireCompanyScope("routines.managed.reset", { companyId });
           const resolved = await this.reconcile(routineKey, companyId, overrides);
           return { ...resolved, status: resolved.routine ? "reset" : resolved.status } satisfies PluginManagedRoutineResolution;
         },
         async update(routineKey, companyId, patch) {
+          requireCompanyScope("routines.managed.update", { companyId });
           const resolved = await this.get(routineKey, companyId);
           if (!resolved.routine) throw new Error(`Managed routine not found: ${routineKey}`);
           const next = {
@@ -1313,6 +1480,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           return next;
         },
         async run(routineKey, companyId) {
+          requireCompanyScope("routines.managed.run", { companyId });
           const resolved = await this.get(routineKey, companyId);
           if (!resolved.routine) throw new Error(`Managed routine not found: ${routineKey}`);
           const now = new Date();
@@ -1349,6 +1517,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       managed: {
         async get(skillKey, companyId) {
           requireCapability(manifest, capabilitySet, "skills.managed");
+          requireCompanyScope("skills.managed.get", { companyId });
           const declaration = manifest.skills?.find((skill) => skill.skillKey === skillKey);
           if (!declaration) {
             return {
@@ -1394,6 +1563,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           } satisfies PluginManagedSkillResolution;
         },
         async reconcile(skillKey, companyId) {
+          requireCompanyScope("skills.managed.reconcile", { companyId });
           const existing = await this.get(skillKey, companyId);
           if (existing.skill) return existing;
           const declaration = manifest.skills?.find((skill) => skill.skillKey === skillKey);
@@ -1465,6 +1635,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async reset(skillKey, companyId) {
           requireCapability(manifest, capabilitySet, "skills.managed");
+          requireCompanyScope("skills.managed.reset", { companyId });
           const existing = await this.get(skillKey, companyId);
           const declaration = manifest.skills?.find((skill) => skill.skillKey === skillKey);
           if (!declaration) return existing;
@@ -1551,13 +1722,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async get(companyId) {
         requireCapability(manifest, capabilitySet, "companies.read");
+        requireCompanyScope("companies.get", { companyId });
         return companies.get(companyId) ?? null;
       },
     },
     issues: {
       async list(input) {
         requireCapability(manifest, capabilitySet, "issues.read");
-        const companyId = requireCompanyId(input?.companyId);
+        const companyId = requireCompanyId("issues.list", input?.companyId);
         let out = [...issues.values()];
         out = out.filter((issue) => issue.companyId === companyId);
         if (input?.projectId) out = out.filter((issue) => issue.projectId === input.projectId);
@@ -1580,11 +1752,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async get(issueId, companyId) {
         requireCapability(manifest, capabilitySet, "issues.read");
+        requireCompanyScope("issues.get", { companyId });
         const issue = issues.get(issueId);
         return isInCompany(issue, companyId) ? issue : null;
       },
       async create(input) {
         requireCapability(manifest, capabilitySet, "issues.create");
+        requireCompanyScope("issues.create", { companyId: input.companyId });
         const now = new Date();
         const originKind = normalizePluginOriginKind(
           input.surfaceVisibility === "plugin_operation" && !input.originKind
@@ -1637,6 +1811,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async update(issueId, patch, companyId) {
         requireCapability(manifest, capabilitySet, "issues.update");
+        requireCompanyScope("issues.update", { companyId });
         const record = issues.get(issueId);
         if (!isInCompany(record, companyId)) throw new Error(`Issue not found: ${issueId}`);
         const { blockedByIssueIds: nextBlockedByIssueIds, ...issuePatch } = patch;
@@ -1656,6 +1831,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async assertCheckoutOwner(input) {
         requireCapability(manifest, capabilitySet, "issues.checkout");
+        requireCompanyScope("issues.assertCheckoutOwner", { companyId: input.companyId });
         const record = issues.get(input.issueId);
         if (!isInCompany(record, input.companyId)) throw new Error(`Issue not found: ${input.issueId}`);
         if (
@@ -1675,6 +1851,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async requestWakeup(issueId, companyId) {
         requireCapability(manifest, capabilitySet, "issues.wakeup");
+        requireCompanyScope("issues.requestWakeup", { companyId });
         const record = issues.get(issueId);
         if (!isInCompany(record, companyId)) throw new Error(`Issue not found: ${issueId}`);
         if (!record.assigneeAgentId) throw new Error("Issue has no assigned agent to wake");
@@ -1687,6 +1864,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async requestWakeups(issueIds, companyId) {
         requireCapability(manifest, capabilitySet, "issues.wakeup");
+        requireCompanyScope("issues.requestWakeups", { companyId });
         const results = [];
         for (const issueId of issueIds) {
           const record = issues.get(issueId);
@@ -1703,6 +1881,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async listComments(issueId, companyId) {
         requireCapability(manifest, capabilitySet, "issue.comments.read");
+        requireCompanyScope("issues.listComments", { companyId });
         if (!isInCompany(issues.get(issueId), companyId)) return [];
         return (issueComments.get(issueId) ?? []).map((comment) =>
           comment.deletedAt ? { ...comment, body: "", presentation: null, metadata: null } : comment
@@ -1710,6 +1889,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async createComment(issueId, body, companyId, options) {
         requireCapability(manifest, capabilitySet, "issue.comments.create");
+        requireCompanyScope("issues.createComment", { companyId });
         if (options?.actorUserId) {
           requireCapability(manifest, capabilitySet, "issue.comments.create_human_attributed");
         }
@@ -1742,6 +1922,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async createInteraction(issueId, interaction, companyId, options) {
         requireCapability(manifest, capabilitySet, "issue.interactions.create");
+        requireCompanyScope("issues.createInteraction", { companyId });
         const parentIssue = issues.get(issueId);
         if (!isInCompany(parentIssue, companyId)) {
           throw new Error(`Issue not found: ${issueId}`);
@@ -1789,11 +1970,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async listInteractions(issueId, companyId) {
         requireCapability(manifest, capabilitySet, "issue.interactions.read");
+        requireCompanyScope("issues.listInteractions", { companyId });
         if (!isInCompany(issues.get(issueId), companyId)) return [];
         return issueInteractions.get(issueId) ?? [];
       },
       async respondInteraction(issueId, interactionId, input, companyId) {
         requireCapability(manifest, capabilitySet, "issue.interactions.respond");
+        requireCompanyScope("issues.respondInteraction", { companyId });
         const parentIssue = issues.get(issueId);
         if (!isInCompany(parentIssue, companyId)) {
           throw new Error(`Issue not found: ${issueId}`);
@@ -1824,11 +2007,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async listAttachments(issueId, companyId) {
         requireCapability(manifest, capabilitySet, "issue.attachments.read");
+        requireCompanyScope("issues.listAttachments", { companyId });
         if (!isInCompany(issues.get(issueId), companyId)) return [];
         return issueAttachments.get(issueId) ?? [];
       },
       async getAttachmentContent(attachmentId, companyId, options) {
         requireCapability(manifest, capabilitySet, "issue.attachments.read");
+        requireCompanyScope("issues.getAttachmentContent", { companyId });
         const attachment = [...issueAttachments.values()]
           .flat()
           .find((entry) => entry.id === attachmentId);
@@ -1850,6 +2035,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       documents: {
         async list(issueId, companyId) {
           requireCapability(manifest, capabilitySet, "issue.documents.read");
+          requireCompanyScope("issues.documents.list", { companyId });
           if (!isInCompany(issues.get(issueId), companyId)) return [];
           return [...issueDocuments.values()]
             .filter((document) => document.issueId === issueId && document.companyId === companyId)
@@ -1857,11 +2043,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async get(issueId, key, companyId) {
           requireCapability(manifest, capabilitySet, "issue.documents.read");
+          requireCompanyScope("issues.documents.get", { companyId });
           if (!isInCompany(issues.get(issueId), companyId)) return null;
           return issueDocuments.get(`${issueId}|${key}`) ?? null;
         },
         async upsert(input) {
           requireCapability(manifest, capabilitySet, "issue.documents.write");
+          requireCompanyScope("issues.documents.upsert", { companyId: input.companyId });
           const parentIssue = issues.get(input.issueId);
           if (!isInCompany(parentIssue, input.companyId)) {
             throw new Error(`Issue not found: ${input.issueId}`);
@@ -1893,6 +2081,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async delete(issueId, _key, companyId) {
           requireCapability(manifest, capabilitySet, "issue.documents.write");
+          requireCompanyScope("issues.documents.delete", { companyId });
           const parentIssue = issues.get(issueId);
           if (!isInCompany(parentIssue, companyId)) {
             throw new Error(`Issue not found: ${issueId}`);
@@ -1903,17 +2092,20 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       relations: {
         async get(issueId, companyId) {
           requireCapability(manifest, capabilitySet, "issue.relations.read");
+          requireCompanyScope("issues.relations.get", { companyId });
           if (!isInCompany(issues.get(issueId), companyId)) throw new Error(`Issue not found: ${issueId}`);
           return issueRelationSummary(issueId);
         },
         async setBlockedBy(issueId, nextBlockedByIssueIds, companyId) {
           requireCapability(manifest, capabilitySet, "issue.relations.write");
+          requireCompanyScope("issues.relations.setBlockedBy", { companyId });
           if (!isInCompany(issues.get(issueId), companyId)) throw new Error(`Issue not found: ${issueId}`);
           blockedByIssueIds.set(issueId, [...new Set(nextBlockedByIssueIds)]);
           return issueRelationSummary(issueId);
         },
         async addBlockers(issueId, blockerIssueIds, companyId) {
           requireCapability(manifest, capabilitySet, "issue.relations.write");
+          requireCompanyScope("issues.relations.addBlockers", { companyId });
           if (!isInCompany(issues.get(issueId), companyId)) throw new Error(`Issue not found: ${issueId}`);
           const next = new Set(blockedByIssueIds.get(issueId) ?? []);
           for (const blockerIssueId of blockerIssueIds) next.add(blockerIssueId);
@@ -1922,6 +2114,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async removeBlockers(issueId, blockerIssueIds, companyId) {
           requireCapability(manifest, capabilitySet, "issue.relations.write");
+          requireCompanyScope("issues.relations.removeBlockers", { companyId });
           if (!isInCompany(issues.get(issueId), companyId)) throw new Error(`Issue not found: ${issueId}`);
           const removals = new Set(blockerIssueIds);
           blockedByIssueIds.set(
@@ -1933,6 +2126,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async getSubtree(issueId, companyId, options) {
         requireCapability(manifest, capabilitySet, "issue.subtree.read");
+        requireCompanyScope("issues.getSubtree", { companyId });
         const root = issues.get(issueId);
         if (!isInCompany(root, companyId)) throw new Error(`Issue not found: ${issueId}`);
         const includeRoot = options?.includeRoot !== false;
@@ -1964,6 +2158,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       summaries: {
         async getOrchestration(input) {
           requireCapability(manifest, capabilitySet, "issues.orchestration.read");
+          requireCompanyScope("issues.summaries.getOrchestration", { companyId: input.companyId });
           const root = issues.get(input.issueId);
           if (!isInCompany(root, input.companyId)) throw new Error(`Issue not found: ${input.issueId}`);
           const subtreeIssueIds = [root.id];
@@ -2001,6 +2196,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     approvals: {
       async list(input) {
         requireCapability(manifest, capabilitySet, "approvals.read");
+        requireCompanyScope("approvals.list", { companyId: input.companyId });
         return [...approvals.values()].filter(
           (approval) =>
             approval.companyId === input.companyId
@@ -2009,12 +2205,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async get(approvalId, companyId) {
         requireCapability(manifest, capabilitySet, "approvals.read");
+        requireCompanyScope("approvals.get", { companyId });
         const approval = approvals.get(approvalId);
         if (!approval || approval.companyId !== companyId) return null;
         return approval;
       },
       async decide(approvalId, input, companyId) {
         requireCapability(manifest, capabilitySet, "approvals.respond");
+        requireCompanyScope("approvals.decide", { companyId });
         const approval = approvals.get(approvalId);
         if (!approval || approval.companyId !== companyId) {
           throw new Error(`Approval not found: ${approvalId}`);
@@ -2042,7 +2240,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     agents: {
       async list(input) {
         requireCapability(manifest, capabilitySet, "agents.read");
-        const companyId = requireCompanyId(input?.companyId);
+        const companyId = requireCompanyId("agents.list", input?.companyId);
         let out = [...agents.values()];
         out = out.filter((agent) => agent.companyId === companyId);
         if (input?.status) out = out.filter((agent) => agent.status === input.status);
@@ -2052,12 +2250,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async get(agentId, companyId) {
         requireCapability(manifest, capabilitySet, "agents.read");
+        requireCompanyScope("agents.get", { companyId });
         const agent = agents.get(agentId);
         return isInCompany(agent, companyId) ? agent : null;
       },
       async pause(agentId, companyId) {
         requireCapability(manifest, capabilitySet, "agents.pause");
-        const cid = requireCompanyId(companyId);
+        const cid = requireCompanyId("agents.pause", companyId);
         const agent = agents.get(agentId);
         if (!isInCompany(agent, cid)) throw new Error(`Agent not found: ${agentId}`);
         if (agent!.status === "terminated") throw new Error("Cannot pause terminated agent");
@@ -2067,7 +2266,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async resume(agentId, companyId) {
         requireCapability(manifest, capabilitySet, "agents.resume");
-        const cid = requireCompanyId(companyId);
+        const cid = requireCompanyId("agents.resume", companyId);
         const agent = agents.get(agentId);
         if (!isInCompany(agent, cid)) throw new Error(`Agent not found: ${agentId}`);
         if (agent!.status === "terminated") throw new Error("Cannot resume terminated agent");
@@ -2078,7 +2277,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async invoke(agentId, companyId, opts) {
         requireCapability(manifest, capabilitySet, "agents.invoke");
-        const cid = requireCompanyId(companyId);
+        const cid = requireCompanyId("agents.invoke", companyId);
         const agent = agents.get(agentId);
         if (!isInCompany(agent, cid)) throw new Error(`Agent not found: ${agentId}`);
         if (
@@ -2093,7 +2292,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       managed: {
         async get(agentKey, companyId) {
           requireCapability(manifest, capabilitySet, "agents.managed");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("agents.managed.get", companyId);
           managedAgentDeclaration(agentKey);
           const agent = [...agents.values()].find((candidate) =>
             candidate.companyId === cid &&
@@ -2104,7 +2303,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async reconcile(agentKey, companyId) {
           requireCapability(manifest, capabilitySet, "agents.managed");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("agents.managed.reconcile", companyId);
           const declaration = managedAgentDeclaration(agentKey);
           const existingAgent = [...agents.values()].find((candidate) =>
             candidate.companyId === cid &&
@@ -2146,7 +2345,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async reset(agentKey, companyId) {
           requireCapability(manifest, capabilitySet, "agents.managed");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("agents.managed.reset", companyId);
           const declaration = managedAgentDeclaration(agentKey);
           let agent = [...agents.values()].find((candidate) =>
             candidate.companyId === cid &&
@@ -2211,7 +2410,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       sessions: {
         async create(agentId, companyId, opts) {
           requireCapability(manifest, capabilitySet, "agent.sessions.create");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("agents.sessions.create", companyId);
           const agent = agents.get(agentId);
           if (!isInCompany(agent, cid)) throw new Error(`Agent not found: ${agentId}`);
           const session: AgentSession = {
@@ -2226,13 +2425,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async list(agentId, companyId) {
           requireCapability(manifest, capabilitySet, "agent.sessions.list");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("agents.sessions.list", companyId);
           return [...sessions.values()].filter(
             (s) => s.agentId === agentId && s.companyId === cid && s.status === "active",
           );
         },
         async sendMessage(sessionId, companyId, opts) {
           requireCapability(manifest, capabilitySet, "agent.sessions.send");
+          requireCompanyScope("agents.sessions.sendMessage", { companyId });
           const session = sessions.get(sessionId);
           if (!session || session.status !== "active") throw new Error(`Session not found or closed: ${sessionId}`);
           if (session.companyId !== companyId) throw new Error(`Session not found: ${sessionId}`);
@@ -2243,6 +2443,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async close(sessionId, companyId) {
           requireCapability(manifest, capabilitySet, "agent.sessions.close");
+          requireCompanyScope("agents.sessions.close", { companyId });
           const session = sessions.get(sessionId);
           if (!session) throw new Error(`Session not found: ${sessionId}`);
           if (session.companyId !== companyId) throw new Error(`Session not found: ${sessionId}`);
@@ -2254,7 +2455,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     goals: {
       async list(input) {
         requireCapability(manifest, capabilitySet, "goals.read");
-        const companyId = requireCompanyId(input?.companyId);
+        const companyId = requireCompanyId("goals.list", input?.companyId);
         let out = [...goals.values()];
         out = out.filter((goal) => goal.companyId === companyId);
         if (input?.level) out = out.filter((goal) => goal.level === input.level);
@@ -2265,11 +2466,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async get(goalId, companyId) {
         requireCapability(manifest, capabilitySet, "goals.read");
+        requireCompanyScope("goals.get", { companyId });
         const goal = goals.get(goalId);
         return isInCompany(goal, companyId) ? goal : null;
       },
       async create(input) {
         requireCapability(manifest, capabilitySet, "goals.create");
+        requireCompanyScope("goals.create", { companyId: input.companyId });
         const now = new Date();
         const record: Goal = {
           id: randomUUID(),
@@ -2288,6 +2491,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async update(goalId, patch, companyId) {
         requireCapability(manifest, capabilitySet, "goals.update");
+        requireCompanyScope("goals.update", { companyId });
         const record = goals.get(goalId);
         if (!isInCompany(record, companyId)) throw new Error(`Goal not found: ${goalId}`);
         const updated: Goal = {
@@ -2303,7 +2507,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       members: {
         async list(input) {
           requireCapability(manifest, capabilitySet, "access.members.read");
-          const cid = requireCompanyId(input.companyId);
+          const cid = requireCompanyId("access.members.list", input.companyId);
           const includeArchived = input.includeArchived === true;
           return [...accessMembers.values()]
             .filter((member) => member.companyId === cid)
@@ -2315,7 +2519,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async get(memberId, companyId) {
           requireCapability(manifest, capabilitySet, "access.members.read");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("access.members.get", companyId);
           const member = accessMembers.get(memberId);
           if (!member || member.companyId !== cid) return null;
           return {
@@ -2325,7 +2529,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async update(memberId, patch, companyId) {
           requireCapability(manifest, capabilitySet, "access.members.write");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("access.members.update", companyId);
           const member = accessMembers.get(memberId);
           if (!member || member.companyId !== cid) {
             throw new Error(`Membership not found: ${memberId}`);
@@ -2346,17 +2550,17 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       invites: {
         async list(input) {
           requireCapability(manifest, capabilitySet, "access.invites.read");
-          requireCompanyId(input.companyId);
+          requireCompanyId("access.invites.list", input.companyId);
           return { invites: [], nextOffset: null };
         },
         async create(input) {
           requireCapability(manifest, capabilitySet, "access.invites.write");
-          requireCompanyId(input.companyId);
+          requireCompanyId("access.invites.create", input.companyId);
           throw new Error("Invite creation is not implemented in the plugin test harness");
         },
         async revoke(inviteId, companyId) {
           requireCapability(manifest, capabilitySet, "access.invites.write");
-          requireCompanyId(companyId);
+          requireCompanyId("access.invites.revoke", companyId);
           throw new Error(`Invite not found: ${inviteId}`);
         },
       },
@@ -2365,7 +2569,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       grants: {
         async list(input) {
           requireCapability(manifest, capabilitySet, "authorization.grants.read");
-          const cid = requireCompanyId(input.companyId);
+          const cid = requireCompanyId("authorization.grants.list", input.companyId);
           if (input.principalType && input.principalId) {
             return getPrincipalGrants(cid, input.principalType, input.principalId);
           }
@@ -2382,14 +2586,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async set(input) {
           requireCapability(manifest, capabilitySet, "authorization.grants.write");
-          const cid = requireCompanyId(input.companyId);
+          const cid = requireCompanyId("authorization.grants.set", input.companyId);
           return setPrincipalGrants(cid, input.principalType, input.principalId, input.grants);
         },
       },
       policies: {
         async summary(companyId) {
           requireCapability(manifest, capabilitySet, "authorization.policies.read");
-          const cid = requireCompanyId(companyId);
+          const cid = requireCompanyId("authorization.policies.summary", companyId);
           const members = [...accessMembers.values()].filter((member) => member.companyId === cid);
           let grantCount = 0;
           for (const [key, grants] of principalGrants.entries()) {
@@ -2406,12 +2610,12 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async get(input) {
           requireCapability(manifest, capabilitySet, "authorization.policies.read");
-          requireCompanyId(input.companyId);
+          requireCompanyId("authorization.policies.get", input.companyId);
           return null;
         },
         async update(input) {
           requireCapability(manifest, capabilitySet, "authorization.policies.write");
-          const cid = requireCompanyId(input.companyId);
+          const cid = requireCompanyId("authorization.policies.update", input.companyId);
           return {
             companyId: cid,
             resourceType: input.resourceType,
@@ -2422,7 +2626,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async previewAssignment(input) {
           requireCapability(manifest, capabilitySet, "authorization.policies.read");
-          requireCompanyId(input.companyId);
+          requireCompanyId("authorization.policies.previewAssignment", input.companyId);
           return {
             allowed: true,
             action: "issue.assign",
@@ -2432,7 +2636,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         },
         async explainAssignment(input) {
           requireCapability(manifest, capabilitySet, "authorization.policies.read");
-          requireCompanyId(input.companyId);
+          requireCompanyId("authorization.policies.explainAssignment", input.companyId);
           return {
             allowed: true,
             action: "issue.assign",
@@ -2444,7 +2648,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       audit: {
         async search(input) {
           requireCapability(manifest, capabilitySet, "authorization.audit.read");
-          requireCompanyId(input.companyId);
+          requireCompanyId("authorization.audit.search", input.companyId);
           return [];
         },
       },
@@ -2581,30 +2785,47 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         payload,
       };
 
-      for (const handler of events) {
-        const exactMatch = handler.name === event.eventType;
-        const wildcardPluginAll = handler.name === "plugin.*" && String(event.eventType).startsWith("plugin.");
-        const wildcardPluginOne = String(handler.name).endsWith(".*")
-          && String(event.eventType).startsWith(String(handler.name).slice(0, -1));
-        if (!exactMatch && !wildcardPluginAll && !wildcardPluginOne) continue;
-        if (!allowsEvent(handler.filter, event)) continue;
-        await handler.fn(event);
-      }
+      // The host derives an event delivery's invocation scope from
+      // `params.event.companyId` (`deriveInvocationScope`), so the harness does
+      // the same: everything the handler does runs as that company.
+      await withInvocationScope(event.companyId, async () => {
+        for (const handler of events) {
+          const exactMatch = handler.name === event.eventType;
+          const wildcardPluginAll = handler.name === "plugin.*" && String(event.eventType).startsWith("plugin.");
+          const wildcardPluginOne = String(handler.name).endsWith(".*")
+            && String(event.eventType).startsWith(String(handler.name).slice(0, -1));
+          if (!exactMatch && !wildcardPluginAll && !wildcardPluginOne) continue;
+          if (!allowsEvent(handler.filter, event)) continue;
+          await handler.fn(event);
+        }
+      });
     },
     async runJob(jobKey, partial = {}) {
       const handler = jobs.get(jobKey);
       if (!handler) throw new Error(`No job handler registered for '${jobKey}'`);
-      await handler({
-        jobKey,
-        runId: partial.runId ?? randomUUID(),
-        trigger: partial.trigger ?? "manual",
-        scheduledAt: partial.scheduledAt ?? new Date().toISOString(),
+      // A job run is company-scoped only when the job declaration is. Without a
+      // company the run is instance-scoped and every company-scoped `ctx` call
+      // inside it is refused — the same as a job the host dispatched with no
+      // company on its context.
+      const companyId = stringOrNull((partial as { companyId?: unknown }).companyId);
+      await withInvocationScope(companyId, async () => {
+        await handler({
+          jobKey,
+          runId: partial.runId ?? randomUUID(),
+          trigger: partial.trigger ?? "manual",
+          scheduledAt: partial.scheduledAt ?? new Date().toISOString(),
+          ...(companyId ? { companyId } : {}),
+        } as PluginJobContext);
       });
     },
     async getData<T = unknown>(key: string, params: Record<string, unknown> = {}) {
       const handler = dataHandlers.get(key);
       if (!handler) throw new Error(`No data handler registered for '${key}'`);
-      return await handler(params) as T;
+      // A bridge read is company-scoped through `GetDataParams.companyId`, which
+      // the host authorizes and `handleGetData` merges over the UI's params — so
+      // by the time a data handler sees `params.companyId`, it is the host's.
+      return await withInvocationScope(stringOrNull(params.companyId), async () =>
+        await handler(params) as T);
     },
     async performAction<T = unknown>(
       key: string,
@@ -2614,7 +2835,10 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       const handler = actionHandlers.get(key);
       if (!handler) throw new Error(`No action handler registered for '${key}'`);
       const context = actionContextFor(params, options);
-      return await handler(paramsWithHostCompanyScope(params, context, options), context) as T;
+      // `deriveInvocationScope` reads a performAction's company off
+      // `params.actorContext.companyId`, which is what `actionContextFor` models.
+      return await withInvocationScope(context.companyId, async () =>
+        await handler(paramsWithHostCompanyScope(params, context, options), context) as T);
     },
     async executeTool<T = ToolResult>(name: string, params: unknown, runCtx: Partial<ToolRunContext> = {}) {
       const handler = toolHandlers.get(name);
@@ -2625,7 +2849,13 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         companyId: runCtx.companyId ?? "company-test",
         projectId: runCtx.projectId ?? "project-test",
       };
-      return await handler(params, ctxToPass) as T;
+      // `deriveInvocationScope` reads a tool run's company off
+      // `params.runContext.companyId`.
+      return await withInvocationScope(ctxToPass.companyId, async () =>
+        await handler(params, ctxToPass) as T);
+    },
+    async withCompanyScope<T>(companyId: string | null, fn: () => Promise<T>): Promise<T> {
+      return await withInvocationScope(companyId, fn);
     },
     getState(input) {
       return state.get(stateMapKey(input));

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -145,15 +145,19 @@ export interface TestHarness {
   /**
    * Execute a previously-registered scheduled job handler.
    *
-   * `companyId` sets the invocation company scope for the run, the way a
-   * company-scoped job declaration does in production. A job run without one is
-   * instance-scoped and every company-scoped `ctx` call inside it is refused,
-   * which is exactly what the host does.
+   * A job run carries **no** company scope, so every company-scoped `ctx` call
+   * inside the handler is refused. That is not a harness limitation: both
+   * dispatch paths in `plugin-job-scheduler.ts` call `runJob` with `{ job }`
+   * and no company, `deriveInvocationScope` has no `runJob` branch, and the
+   * host therefore refuses those calls in production too.
+   *
+   * Passing a `companyId` here throws rather than minting a scope the scheduler
+   * cannot mint — a harness that authorized one would be exactly the kind of
+   * over-permissive fake this enforcement exists to remove. To test a handler
+   * for the day the host does dispatch jobs per company, wrap the body in
+   * `withCompanyScope`.
    */
-  runJob(
-    jobKey: string,
-    partial?: Partial<PluginJobContext> & { companyId?: string | null },
-  ): Promise<void>;
+  runJob(jobKey: string, partial?: Partial<PluginJobContext>): Promise<void>;
   /** Invoke a `ctx.data.register(...)` handler by key. */
   getData<T = unknown>(key: string, params?: Record<string, unknown>): Promise<T>;
   /** Invoke a `ctx.actions.register(...)` handler by key. */
@@ -2803,19 +2807,25 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     async runJob(jobKey, partial = {}) {
       const handler = jobs.get(jobKey);
       if (!handler) throw new Error(`No job handler registered for '${jobKey}'`);
-      // A job run is company-scoped only when the job declaration is. Without a
-      // company the run is instance-scoped and every company-scoped `ctx` call
-      // inside it is refused — the same as a job the host dispatched with no
-      // company on its context.
-      const companyId = stringOrNull((partial as { companyId?: unknown }).companyId);
-      await withInvocationScope(companyId, async () => {
+      // A job run gets no company scope, because the scheduler dispatches
+      // `runJob` with `{ job }` and no company (`plugin-job-scheduler.ts`), and
+      // `deriveInvocationScope` has no `runJob` branch. Refuse to fake one:
+      // authorizing a scope the host cannot mint is the over-permissive fake
+      // this enforcement exists to remove.
+      if (stringOrNull((partial as { companyId?: unknown }).companyId)) {
+        throw new Error(
+          "runJob() cannot take a companyId: the host dispatches scheduled jobs with no company scope, "
+          + "so a company-scoped ctx call inside a job handler is refused in production. "
+          + "Wrap the handler body in harness.withCompanyScope(companyId, ...) to test the scoped path.",
+        );
+      }
+      await withInvocationScope(null, async () => {
         await handler({
           jobKey,
           runId: partial.runId ?? randomUUID(),
           trigger: partial.trigger ?? "manual",
           scheduledAt: partial.scheduledAt ?? new Date().toISOString(),
-          ...(companyId ? { companyId } : {}),
-        } as PluginJobContext);
+        });
       });
     },
     async getData<T = unknown>(key: string, params: Record<string, unknown> = {}) {

--- a/packages/plugins/sdk/tests/testing-actions.test.ts
+++ b/packages/plugins/sdk/tests/testing-actions.test.ts
@@ -88,7 +88,10 @@ describe("createTestHarness managed routines", () => {
       },
     });
 
-    const resolved = await harness.ctx.routines.managed.reconcile("quiet-watcher", "company-1");
+    // Driven straight off `ctx`, outside any host invocation, so the test has
+    // to say which company it is acting as — the host would refuse it otherwise.
+    const resolved = await harness.withCompanyScope("company-1", () =>
+      harness.ctx.routines.managed.reconcile("quiet-watcher", "company-1"));
 
     expect(resolved.routine).toMatchObject({
       activityGatePolicy: "require_external_activity",
@@ -103,12 +106,12 @@ describe("createTestHarness issue interactions", () => {
       manifest,
       capabilities: ["issues.create", "issue.interactions.create"],
     });
-    const issue = await harness.ctx.issues.create({
+    const issue = await harness.withCompanyScope("company-1", () => harness.ctx.issues.create({
       companyId: "company-1",
       title: "Pick files",
-    });
+    }));
 
-    const interaction = await harness.ctx.issues.requestCheckboxConfirmation(
+    const interaction = await harness.withCompanyScope("company-1", () => harness.ctx.issues.requestCheckboxConfirmation(
       issue.id,
       {
         idempotencyKey: "checkbox:files",
@@ -127,7 +130,7 @@ describe("createTestHarness issue interactions", () => {
       },
       "company-1",
       { authorAgentId: "agent-1" },
-    );
+    ));
 
     expect(interaction).toMatchObject({
       issueId: issue.id,

--- a/packages/plugins/sdk/tests/testing-harness-scope-parity.test.ts
+++ b/packages/plugins/sdk/tests/testing-harness-scope-parity.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Category safeguard: a company-scoped `ctx` method must not exist in the test
+ * harness without the invocation-scope gate the host applies to it.
+ *
+ * The instance bug was that `createTestHarness` modelled no invocation scope at
+ * all. The *class* of bug is that the fake `ctx` (`testing.ts`) and the real
+ * `ctx` (`worker-rpc-host.ts`) are two hand-written implementations of one
+ * interface, so a method added to both — or a gate added to only one — drifts
+ * silently, and the drift is invisible precisely because the fake is what the
+ * tests run against.
+ *
+ * This test derives the company-scoped method set from the REAL client and
+ * asserts the fake gates every one of them. Add a company-scoped `ctx` method
+ * without a gate and this fails, naming the method.
+ *
+ * It is a source scan, so it strips comments first — otherwise a method named
+ * only in a doc comment would satisfy it and the gate would be vacuous.
+ *
+ * Known blind spot: `events.subscribe` carries its company in `filter.companyId`,
+ * but the harness's `ctx.events.on` registers the handler locally and never makes
+ * a host call at all, so there is no fake-side call site to gate. The scan does
+ * not flag it because the client builds those params from a variable.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const workerClientSource = readFileSync(
+  fileURLToPath(new URL("../src/worker-rpc-host.ts", import.meta.url)),
+  "utf8",
+);
+const harnessSource = readFileSync(
+  fileURLToPath(new URL("../src/testing.ts", import.meta.url)),
+  "utf8",
+);
+
+/**
+ * Methods the harness deliberately does not gate, each with the reason. Every
+ * entry here is a hole in the safeguard, so it stays short and justified.
+ */
+const UNGATED: Record<string, string> = {
+  // Fire-and-forget notifications. The host does not throw on these — it drops
+  // the notification and logs (plugin-worker-manager.ts handleWorkerNotification).
+  // The harness's `ctx.streams.*` fakes record nothing observable, so modelling
+  // the drop would have no test-visible effect. Gate them when the fakes grow a
+  // recorder.
+  "streams.open": "notification; host drops rather than throws, and the fake records nothing",
+  "streams.emit": "notification; host drops rather than throws, and the fake records nothing",
+  "streams.close": "notification; host drops rather than throws, and the fake records nothing",
+};
+
+/** Strip line and block comments so a method named in prose cannot satisfy the scan. */
+function stripComments(source: string): string {
+  let out = "";
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+        if (source[i] === "\n") out += "\n";
+        i += 1;
+      }
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      out += ch;
+      i += 1;
+      while (i < source.length) {
+        if (source[i] === "\\") { out += source.slice(i, i + 2); i += 2; continue; }
+        out += source[i];
+        const closed = source[i] === ch;
+        i += 1;
+        if (closed) break;
+      }
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+/** Text of the argument list of `fn(` starting at `openParenIndex`, paren-matched. */
+function argumentText(source: string, openParenIndex: number): string {
+  let depth = 0;
+  for (let i = openParenIndex; i < source.length; i += 1) {
+    if (source[i] === "(") depth += 1;
+    else if (source[i] === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openParenIndex + 1, i);
+    }
+  }
+  return source.slice(openParenIndex + 1);
+}
+
+/**
+ * Every worker→host method the production client sends a company for — either a
+ * `companyId` field or a `scopeKind`/`scopeId` pair.
+ *
+ * A call that forwards a whole object (`callHost("x", input)`) counts too: the
+ * company is inside `input`, invisible to a text scan, and every such call in
+ * the client today is company-scoped. Counting it errs toward demanding a gate,
+ * which is the safe direction for a safeguard — a new one must be gated or
+ * appear in `UNGATED` with a reason.
+ */
+function companyScopedMethods(source: string): string[] {
+  const stripped = stripComments(source);
+  const found = new Set<string>();
+  const call = /\b(?:callHost|notifyHost)\s*\(\s*"([^"]+)"/g;
+  let match: RegExpExecArray | null;
+  while ((match = call.exec(stripped)) !== null) {
+    const method = match[1];
+    const openParen = stripped.indexOf("(", match.index);
+    const args = argumentText(stripped, openParen);
+    const params = args.slice(args.indexOf(",") + 1).trim();
+    const forwardsWholeObject = args.includes(",") && /^[A-Za-z_$][\w$]*$/.test(params);
+    if (/\bcompanyId\b/.test(args) || /\bscopeKind\b/.test(args) || forwardsWholeObject) {
+      found.add(method);
+    }
+  }
+  return [...found].sort();
+}
+
+/** Methods the harness passes to one of its invocation-scope gates. */
+function gatedMethods(source: string): Set<string> {
+  const stripped = stripComments(source);
+  const gates = /\b(?:requireCompanyScope|requireCompanyId|requireResolvedCompanyId)\s*\(\s*"([^"]+)"/g;
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = gates.exec(stripped)) !== null) found.add(match[1]);
+  return found;
+}
+
+describe("test harness / production client company-scope parity", () => {
+  const scoped = companyScopedMethods(workerClientSource);
+  const gated = gatedMethods(harnessSource);
+
+  it("finds the company-scoped methods in the production client", () => {
+    // Negative control: if the scan silently matches nothing, every assertion
+    // below passes vacuously.
+    expect(scoped.length).toBeGreaterThan(30);
+    expect(scoped).toContain("config.get");
+    expect(scoped).toContain("issues.createComment");
+    expect(scoped).toContain("state.get");
+  });
+
+  it("finds the harness's gates", () => {
+    expect(gated.size).toBeGreaterThan(30);
+  });
+
+  it("gates every company-scoped method the production client can send", () => {
+    const missing = scoped.filter((method) => !gated.has(method) && !(method in UNGATED));
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps the ungated allowlist honest", () => {
+    // An allowlist entry for a method that is no longer company-scoped is dead
+    // weight that hides the next real hole.
+    const stale = Object.keys(UNGATED).filter((method) => !scoped.includes(method));
+    expect(stale).toEqual([]);
+  });
+});

--- a/packages/plugins/sdk/tests/testing-invocation-scope.test.ts
+++ b/packages/plugins/sdk/tests/testing-invocation-scope.test.ts
@@ -1,0 +1,288 @@
+/**
+ * The test harness must refuse the company-scoped calls the host refuses.
+ *
+ * A fake `ctx` that answers whatever it is asked does not merely fail to test
+ * the host's governed-access gate — it deletes the gate from the model under
+ * test. The plugin then passes its whole suite and is refused by the real host
+ * on its first company-scoped call, which is how a merge-gate relay shipped
+ * with 185 green tests and could not arm a single pull request.
+ *
+ * Every expectation below is pinned to the *host's* error string
+ * (`host-client-factory.ts`), not to a harness-local message, so a divergence
+ * between the fake and the host fails here rather than in production.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createTestHarness } from "../src/testing.js";
+import type { PaperclipPluginManifestV1 } from "../src/types.js";
+
+const COMPANY_A = "company-a";
+const COMPANY_B = "company-b";
+
+const manifest = {
+  id: "paperclip.test-invocation-scope",
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Test Invocation Scope",
+  description: "Test plugin",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [
+    "issues.read",
+    "issues.write",
+    "plugin.state.read",
+    "plugin.state.write",
+    "activity.log.write",
+    "agent.tools.register",
+    "jobs.schedule",
+    "events.subscribe",
+  ],
+  entrypoints: {},
+} satisfies PaperclipPluginManifestV1;
+
+/** The host's message for a company-scoped call made outside any invocation. */
+const NO_SCOPE = /company context is required/;
+/** The host's message for a call that leaves its invocation's company. */
+const crossCompany = (requested: string, scoped: string) =>
+  new RegExp(`requested company "${requested}" but the current invocation is scoped to company "${scoped}"`);
+
+describe("createTestHarness invocation company scope", () => {
+  describe("runJob", () => {
+    it("refuses a company-scoped call from a job run with no company", async () => {
+      const harness = createTestHarness({ manifest });
+      let error: unknown;
+
+      harness.ctx.jobs.register("sweep", async () => {
+        try {
+          await harness.ctx.config.get(COMPANY_A);
+        } catch (err) {
+          error = err;
+        }
+      });
+
+      await harness.runJob("sweep");
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(NO_SCOPE);
+    });
+
+    it("allows the same call when the job run carries a company", async () => {
+      const harness = createTestHarness({ manifest, config: { token: "t" } });
+      let config: Record<string, unknown> | undefined;
+
+      harness.ctx.jobs.register("sweep", async () => {
+        config = await harness.ctx.config.get(COMPANY_A);
+      });
+
+      await harness.runJob("sweep", { companyId: COMPANY_A });
+
+      expect(config).toEqual({ token: "t" });
+    });
+
+    it("refuses a cross-company call from a company-scoped job run", async () => {
+      const harness = createTestHarness({ manifest });
+      let error: unknown;
+
+      harness.ctx.jobs.register("sweep", async () => {
+        try {
+          await harness.ctx.config.get(COMPANY_B);
+        } catch (err) {
+          error = err;
+        }
+      });
+
+      await harness.runJob("sweep", { companyId: COMPANY_A });
+
+      expect((error as Error).message).toMatch(crossCompany(COMPANY_B, COMPANY_A));
+    });
+
+    it("puts the company on the job context the handler receives", async () => {
+      const harness = createTestHarness({ manifest });
+      let seen: unknown;
+
+      harness.ctx.jobs.register("sweep", async (job) => {
+        seen = (job as { companyId?: unknown }).companyId;
+      });
+
+      await harness.runJob("sweep", { companyId: COMPANY_A });
+
+      expect(seen).toBe(COMPANY_A);
+    });
+
+    it("does not leak an outer scope into a nested instance-scoped job run", async () => {
+      const harness = createTestHarness({ manifest });
+      let error: unknown;
+
+      harness.ctx.jobs.register("inner", async () => {
+        try {
+          await harness.ctx.config.get(COMPANY_A);
+        } catch (err) {
+          error = err;
+        }
+      });
+      harness.ctx.jobs.register("outer", async () => {
+        await harness.runJob("inner");
+      });
+
+      await harness.runJob("outer", { companyId: COMPANY_A });
+
+      expect((error as Error).message).toMatch(NO_SCOPE);
+    });
+  });
+
+  describe("entry points that carry a company", () => {
+    it("scopes an event delivery to the event's company", async () => {
+      const harness = createTestHarness({ manifest });
+      harness.seed({
+        issues: [
+          { id: "issue-a", companyId: COMPANY_A, title: "A" },
+          { id: "issue-b", companyId: COMPANY_B, title: "B" },
+        ] as never,
+      });
+      const errors: string[] = [];
+      let own: unknown;
+
+      harness.ctx.events.on("issue.created", async () => {
+        own = await harness.ctx.issues.get("issue-a", COMPANY_A);
+        try {
+          await harness.ctx.issues.get("issue-b", COMPANY_B);
+        } catch (err) {
+          errors.push((err as Error).message);
+        }
+      });
+
+      await harness.emit("issue.created", {}, { companyId: COMPANY_A });
+
+      expect(own).toBeTruthy();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatch(crossCompany(COMPANY_B, COMPANY_A));
+    });
+
+    it("scopes an action to the host-authorized actor company", async () => {
+      const harness = createTestHarness({ manifest });
+      harness.ctx.actions.register("touch", async () => {
+        await harness.ctx.state.set(
+          { scopeKind: "company", scopeId: COMPANY_A, stateKey: "k" },
+          1,
+        );
+        return "ok";
+      });
+
+      await expect(harness.performAction("touch")).rejects.toThrow(NO_SCOPE);
+      await expect(harness.performAction("touch", {}, { companyId: COMPANY_A }))
+        .resolves.toBe("ok");
+    });
+
+    it("scopes a tool run to its run context company", async () => {
+      const harness = createTestHarness({ manifest });
+      harness.ctx.tools.register("write-state", {} as never, async () => {
+        await harness.ctx.state.set(
+          { scopeKind: "company", scopeId: COMPANY_A, stateKey: "k" },
+          1,
+        );
+        return { content: [] } as never;
+      });
+
+      await expect(harness.executeTool("write-state", {}, { companyId: COMPANY_B }))
+        .rejects.toThrow(crossCompany(COMPANY_A, COMPANY_B));
+      await expect(harness.executeTool("write-state", {}, { companyId: COMPANY_A }))
+        .resolves.toBeTruthy();
+    });
+  });
+
+  describe("what stays allowed", () => {
+    it("leaves instance-scoped state alone", async () => {
+      const harness = createTestHarness({ manifest });
+
+      await harness.ctx.state.set({ scopeKind: "instance", stateKey: "cursor" }, 7);
+
+      expect(harness.getState({ scopeKind: "instance", stateKey: "cursor" })).toBe(7);
+    });
+
+    it("admits a proactive call for a company the plugin is configured for", async () => {
+      const harness = createTestHarness({
+        manifest,
+        proactiveCompanyScopes: [COMPANY_A],
+      });
+
+      await harness.ctx.state.set(
+        { scopeKind: "company", scopeId: COMPANY_A, stateKey: "k" },
+        1,
+      );
+
+      await expect(
+        harness.ctx.state.set({ scopeKind: "company", scopeId: COMPANY_B, stateKey: "k" }, 1),
+      ).rejects.toThrow(NO_SCOPE);
+    });
+
+    it("does not let a proactive grant widen an active invocation", async () => {
+      const harness = createTestHarness({
+        manifest,
+        proactiveCompanyScopes: [COMPANY_A, COMPANY_B],
+      });
+      let error: unknown;
+
+      harness.ctx.jobs.register("sweep", async () => {
+        try {
+          await harness.ctx.state.set(
+            { scopeKind: "company", scopeId: COMPANY_B, stateKey: "k" },
+            1,
+          );
+        } catch (err) {
+          error = err;
+        }
+      });
+
+      await harness.runJob("sweep", { companyId: COMPANY_A });
+
+      expect((error as Error).message).toMatch(crossCompany(COMPANY_B, COMPANY_A));
+    });
+  });
+
+  describe("withCompanyScope", () => {
+    it("lets a test drive ctx directly as one company", async () => {
+      const harness = createTestHarness({ manifest, config: { token: "t" } });
+
+      await expect(harness.ctx.config.get(COMPANY_A)).rejects.toThrow(NO_SCOPE);
+
+      await harness.withCompanyScope(COMPANY_A, async () => {
+        await expect(harness.ctx.config.get(COMPANY_A)).resolves.toEqual({ token: "t" });
+      });
+    });
+
+    it("is a scope, not a bypass — another company is still refused inside it", async () => {
+      const harness = createTestHarness({ manifest });
+
+      await harness.withCompanyScope(COMPANY_A, async () => {
+        await expect(harness.ctx.config.get(COMPANY_B))
+          .rejects.toThrow(crossCompany(COMPANY_B, COMPANY_A));
+      });
+    });
+
+    it("restores the previous scope when it returns", async () => {
+      const harness = createTestHarness({ manifest });
+
+      await harness.withCompanyScope(COMPANY_A, async () => {
+        await harness.withCompanyScope(COMPANY_B, async () => {
+          await expect(harness.ctx.config.get(COMPANY_B)).resolves.toBeTruthy();
+        });
+        await expect(harness.ctx.config.get(COMPANY_A)).resolves.toBeTruthy();
+      });
+
+      await expect(harness.ctx.config.get(COMPANY_A)).rejects.toThrow(NO_SCOPE);
+    });
+
+    it("restores the previous scope when the body throws", async () => {
+      const harness = createTestHarness({ manifest });
+
+      await harness.withCompanyScope(COMPANY_A, async () => {
+        await expect(
+          harness.withCompanyScope(COMPANY_B, async () => {
+            throw new Error("boom");
+          }),
+        ).rejects.toThrow("boom");
+        await expect(harness.ctx.config.get(COMPANY_A)).resolves.toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/plugins/sdk/tests/testing-invocation-scope.test.ts
+++ b/packages/plugins/sdk/tests/testing-invocation-scope.test.ts
@@ -66,15 +66,17 @@ describe("createTestHarness invocation company scope", () => {
       expect((error as Error).message).toMatch(NO_SCOPE);
     });
 
-    it("allows the same call when the job run carries a company", async () => {
+    it("allows the same call when the job handler declares its company", async () => {
       const harness = createTestHarness({ manifest, config: { token: "t" } });
       let config: Record<string, unknown> | undefined;
 
       harness.ctx.jobs.register("sweep", async () => {
-        config = await harness.ctx.config.get(COMPANY_A);
+        await harness.withCompanyScope(COMPANY_A, async () => {
+          config = await harness.ctx.config.get(COMPANY_A);
+        });
       });
 
-      await harness.runJob("sweep", { companyId: COMPANY_A });
+      await harness.runJob("sweep");
 
       expect(config).toEqual({ token: "t" });
     });
@@ -84,32 +86,35 @@ describe("createTestHarness invocation company scope", () => {
       let error: unknown;
 
       harness.ctx.jobs.register("sweep", async () => {
-        try {
-          await harness.ctx.config.get(COMPANY_B);
-        } catch (err) {
-          error = err;
-        }
+        await harness.withCompanyScope(COMPANY_A, async () => {
+          try {
+            await harness.ctx.config.get(COMPANY_B);
+          } catch (err) {
+            error = err;
+          }
+        });
       });
 
-      await harness.runJob("sweep", { companyId: COMPANY_A });
+      await harness.runJob("sweep");
 
       expect((error as Error).message).toMatch(crossCompany(COMPANY_B, COMPANY_A));
     });
 
-    it("puts the company on the job context the handler receives", async () => {
+    it("refuses to fake a job company the scheduler cannot dispatch", async () => {
+      // Both dispatch paths in `plugin-job-scheduler.ts` call `runJob` with
+      // `{ job }` and no company, and `deriveInvocationScope` has no `runJob`
+      // branch. A harness that minted a scope here would authorize a call the
+      // real host refuses — the exact over-permissive fake this enforcement
+      // exists to remove.
       const harness = createTestHarness({ manifest });
-      let seen: unknown;
+      harness.ctx.jobs.register("sweep", async () => {});
 
-      harness.ctx.jobs.register("sweep", async (job) => {
-        seen = (job as { companyId?: unknown }).companyId;
-      });
-
-      await harness.runJob("sweep", { companyId: COMPANY_A });
-
-      expect(seen).toBe(COMPANY_A);
+      await expect(
+        (harness.runJob as (k: string, p: unknown) => Promise<void>)("sweep", { companyId: COMPANY_A }),
+      ).rejects.toThrow(/cannot take a companyId/);
     });
 
-    it("does not leak an outer scope into a nested instance-scoped job run", async () => {
+    it("does not leak an outer scope into a nested job run", async () => {
       const harness = createTestHarness({ manifest });
       let error: unknown;
 
@@ -121,10 +126,12 @@ describe("createTestHarness invocation company scope", () => {
         }
       });
       harness.ctx.jobs.register("outer", async () => {
-        await harness.runJob("inner");
+        await harness.withCompanyScope(COMPANY_A, async () => {
+          await harness.runJob("inner");
+        });
       });
 
-      await harness.runJob("outer", { companyId: COMPANY_A });
+      await harness.runJob("outer");
 
       expect((error as Error).message).toMatch(NO_SCOPE);
     });
@@ -223,17 +230,19 @@ describe("createTestHarness invocation company scope", () => {
       let error: unknown;
 
       harness.ctx.jobs.register("sweep", async () => {
-        try {
-          await harness.ctx.state.set(
-            { scopeKind: "company", scopeId: COMPANY_B, stateKey: "k" },
-            1,
-          );
-        } catch (err) {
-          error = err;
-        }
+        await harness.withCompanyScope(COMPANY_A, async () => {
+          try {
+            await harness.ctx.state.set(
+              { scopeKind: "company", scopeId: COMPANY_B, stateKey: "k" },
+              1,
+            );
+          } catch (err) {
+            error = err;
+          }
+        });
       });
 
-      await harness.runJob("sweep", { companyId: COMPANY_A });
+      await harness.runJob("sweep");
 
       expect((error as Error).message).toMatch(crossCompany(COMPANY_B, COMPANY_A));
     });

--- a/server/src/__tests__/plugin-sdk-orchestration-contract.test.ts
+++ b/server/src/__tests__/plugin-sdk-orchestration-contract.test.ts
@@ -67,22 +67,26 @@ describe("plugin SDK orchestration contract", () => {
       issues: [issue({ id: blockerIssueId, companyId, title: "Blocker" })],
     });
 
-    const created = await harness.ctx.issues.create({
-      companyId,
-      title: "Generated issue",
-      status: "todo",
-      assigneeUserId: "board-user",
-      billingCode: "mission:alpha",
-      originId: "mission-alpha",
-      blockedByIssueIds: [blockerIssueId],
-    });
+    const created = await harness.withCompanyScope(companyId, () =>
+      harness.ctx.issues.create({
+        companyId,
+        title: "Generated issue",
+        status: "todo",
+        assigneeUserId: "board-user",
+        billingCode: "mission:alpha",
+        originId: "mission-alpha",
+        blockedByIssueIds: [blockerIssueId],
+      }),
+    );
 
     expect(created.originKind).toBe("plugin:paperclip.test-orchestration");
     expect(created.originId).toBe("mission-alpha");
     expect(created.billingCode).toBe("mission:alpha");
     expect(created.assigneeUserId).toBe("board-user");
 
-    await expect(harness.ctx.issues.relations.get(created.id, companyId)).resolves.toEqual({
+    await expect(
+      harness.withCompanyScope(companyId, () => harness.ctx.issues.relations.get(created.id, companyId)),
+    ).resolves.toEqual({
       blockedBy: [
         expect.objectContaining({
           id: blockerIssueId,
@@ -92,18 +96,28 @@ describe("plugin SDK orchestration contract", () => {
       blocks: [],
     });
 
-    await expect(harness.ctx.issues.relations.removeBlockers(created.id, [blockerIssueId], companyId)).resolves.toEqual({
+    await expect(
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.relations.removeBlockers(created.id, [blockerIssueId], companyId),
+      ),
+    ).resolves.toEqual({
       blockedBy: [],
       blocks: [],
     });
 
-    await expect(harness.ctx.issues.relations.addBlockers(created.id, [blockerIssueId], companyId)).resolves.toEqual({
+    await expect(
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.relations.addBlockers(created.id, [blockerIssueId], companyId),
+      ),
+    ).resolves.toEqual({
       blockedBy: [expect.objectContaining({ id: blockerIssueId })],
       blocks: [],
     });
 
     await expect(
-      harness.ctx.issues.getSubtree(created.id, companyId, { includeRelations: true }),
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.getSubtree(created.id, companyId, { includeRelations: true }),
+      ),
     ).resolves.toMatchObject({
       rootIssueId: created.id,
       issueIds: [created.id],
@@ -121,31 +135,39 @@ describe("plugin SDK orchestration contract", () => {
       manifest: manifest(["issues.create", "issues.update", "issues.read"]),
     });
 
-    const created = await harness.ctx.issues.create({
-      companyId,
-      title: "Generated issue",
-      originKind: "plugin:paperclip.test-orchestration:feature",
-    });
+    const created = await harness.withCompanyScope(companyId, () =>
+      harness.ctx.issues.create({
+        companyId,
+        title: "Generated issue",
+        originKind: "plugin:paperclip.test-orchestration:feature",
+      }),
+    );
 
     expect(created.originKind).toBe("plugin:paperclip.test-orchestration:feature");
     await expect(
-      harness.ctx.issues.list({
-        companyId,
-        originKind: "plugin:paperclip.test-orchestration:feature",
-      }),
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.list({
+          companyId,
+          originKind: "plugin:paperclip.test-orchestration:feature",
+        }),
+      ),
     ).resolves.toHaveLength(1);
     await expect(
-      harness.ctx.issues.create({
-        companyId,
-        title: "Spoofed issue",
-        originKind: "plugin:other.plugin:feature",
-      }),
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.create({
+          companyId,
+          title: "Spoofed issue",
+          originKind: "plugin:other.plugin:feature",
+        }),
+      ),
     ).rejects.toThrow("Plugin may only use originKind values under plugin:paperclip.test-orchestration");
     await expect(
-      harness.ctx.issues.update(
-        created.id,
-        { originKind: "plugin:other.plugin:feature" },
-        companyId,
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.update(
+          created.id,
+          { originKind: "plugin:other.plugin:feature" },
+          companyId,
+        ),
       ),
     ).rejects.toThrow("Plugin may only use originKind values under plugin:paperclip.test-orchestration");
   });
@@ -156,12 +178,14 @@ describe("plugin SDK orchestration contract", () => {
       manifest: manifest(["issues.create"]),
     });
 
-    const created = await harness.ctx.issues.create({
-      companyId,
-      title: "Background operation",
-      surfaceVisibility: "plugin_operation",
-      originId: "operation-1",
-    });
+    const created = await harness.withCompanyScope(companyId, () =>
+      harness.ctx.issues.create({
+        companyId,
+        title: "Background operation",
+        surfaceVisibility: "plugin_operation",
+        originId: "operation-1",
+      }),
+    );
 
     expect(created.originKind).toBe("plugin:paperclip.test-orchestration:operation");
     expect(created.originId).toBe("operation-1");
@@ -189,28 +213,34 @@ describe("plugin SDK orchestration contract", () => {
     });
 
     await expect(
-      harness.ctx.issues.assertCheckoutOwner({
-        issueId: checkedOutIssueId,
-        companyId,
-        actorAgentId: agentId,
-        actorRunId: runId,
-      }),
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.assertCheckoutOwner({
+          issueId: checkedOutIssueId,
+          companyId,
+          actorAgentId: agentId,
+          actorRunId: runId,
+        }),
+      ),
     ).resolves.toMatchObject({
       issueId: checkedOutIssueId,
       checkoutRunId: runId,
     });
 
     await expect(
-      harness.ctx.issues.requestWakeup(checkedOutIssueId, companyId, {
-        reason: "mission_advance",
-      }),
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.requestWakeup(checkedOutIssueId, companyId, {
+          reason: "mission_advance",
+        }),
+      ),
     ).resolves.toMatchObject({ queued: true });
 
     await expect(
-      harness.ctx.issues.requestWakeups([checkedOutIssueId], companyId, {
-        reason: "mission_advance",
-        idempotencyKeyPrefix: "mission:alpha",
-      }),
+      harness.withCompanyScope(companyId, () =>
+        harness.ctx.issues.requestWakeups([checkedOutIssueId], companyId, {
+          reason: "mission_advance",
+          idempotencyKeyPrefix: "mission:alpha",
+        }),
+      ),
     ).resolves.toEqual([
       expect.objectContaining({
         issueId: checkedOutIssueId,
@@ -251,7 +281,7 @@ describe("plugin SDK orchestration contract", () => {
     });
 
     await expect(
-      harness.ctx.issues.requestWakeup(blockedIssueId, companyId),
+      harness.withCompanyScope(companyId, () => harness.ctx.issues.requestWakeup(blockedIssueId, companyId)),
     ).rejects.toThrow("Issue is blocked by unresolved blockers");
   });
 });

--- a/server/src/__tests__/plugin-sdk-testing.test.ts
+++ b/server/src/__tests__/plugin-sdk-testing.test.ts
@@ -32,13 +32,17 @@ describe("plugin SDK test harness", () => {
       }],
     });
 
-    await expect(harness.ctx.executionWorkspaces.get("workspace-1", "company-1")).resolves.toMatchObject({
+    await expect(
+      harness.withCompanyScope("company-1", () => harness.ctx.executionWorkspaces.get("workspace-1", "company-1")),
+    ).resolves.toMatchObject({
       id: "workspace-1",
       cwd: "/tmp/paperclip-test",
       branchName: "feature/test",
       providerMetadata: { sandboxId: "sandbox-1" },
     });
-    await expect(harness.ctx.executionWorkspaces.get("workspace-1", "company-2")).resolves.toBeNull();
+    await expect(
+      harness.withCompanyScope("company-2", () => harness.ctx.executionWorkspaces.get("workspace-1", "company-2")),
+    ).resolves.toBeNull();
   });
 
   it("requires execution.workspaces.read before returning workspace metadata", async () => {
@@ -147,7 +151,9 @@ describe("plugin SDK test harness", () => {
       }],
     });
 
-    const comments = await harness.ctx.issues.listComments("issue-1", "company-1");
+    const comments = await harness.withCompanyScope("company-1", () =>
+      harness.ctx.issues.listComments("issue-1", "company-1"),
+    );
 
     expect(comments).toHaveLength(1);
     expect(comments[0]).toMatchObject({
@@ -199,7 +205,9 @@ describe("plugin SDK test harness", () => {
     });
 
     await expect(
-      harness.ctx.issues.createComment("issue-1", "relayed reply", "company-1", { actorUserId: "user-1" }),
+      harness.withCompanyScope("company-1", () =>
+        harness.ctx.issues.createComment("issue-1", "relayed reply", "company-1", { actorUserId: "user-1" }),
+      ),
     ).rejects.toThrow('actorUserId "user-1" is not an active human member of this company');
   });
 
@@ -241,7 +249,9 @@ describe("plugin SDK test harness", () => {
     });
 
     await expect(
-      harness.ctx.issues.createComment("issue-1", "relayed reply", "company-1", { actorUserId: "user-1" }),
+      harness.withCompanyScope("company-1", () =>
+        harness.ctx.issues.createComment("issue-1", "relayed reply", "company-1", { actorUserId: "user-1" }),
+      ),
     ).rejects.toThrow("viewer (read-only) access");
   });
 
@@ -279,11 +289,13 @@ describe("plugin SDK test harness", () => {
       }],
     });
 
-    const comment = await harness.ctx.issues.createComment(
-      "issue-1",
-      "relayed reply",
-      "company-1",
-      { actorUserId: "user-1" },
+    const comment = await harness.withCompanyScope("company-1", () =>
+      harness.ctx.issues.createComment(
+        "issue-1",
+        "relayed reply",
+        "company-1",
+        { actorUserId: "user-1" },
+      ),
     );
 
     expect(comment).toMatchObject({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip runs plugin code in separate worker processes, and the host answers each worker-to-host call
> - The host refuses a company-scoped call unless it made an invocation scope for that company
> - The plugin SDK also gives plugin authors an in-memory test harness, `createTestHarness`
> - This harness did not model an invocation scope at all, so the fake context answered every company-scoped call
> - A fake that permits more than the host removes the gate from the code under test, and the plugin suite becomes green on a build that the host refuses
> - This pull request makes the harness enforce the same rule from the same code, and adds a test that keeps the two together
> - The benefit is that a plugin fails in its own test suite, not on its first call to the real host

## Linked Issues or Issue Description

No public issue exists for this. The problem, in the bug report format:

**What happened?**

`createTestHarness` in `packages/plugins/sdk/src/testing.ts` did not model an invocation company scope. `ctx.config.get(companyId)`, `ctx.secrets.resolve(secretRef, { companyId })`, `ctx.issues.createComment(issueId, body, companyId)` and every company-scoped `ctx.state.*` call gave a result. The real host refuses all of these unless it made a scope for that company, in `requireInvocationCompanyScope` in `packages/plugins/sdk/src/host-client-factory.ts`.

Two effects follow. A plugin can pass its full test suite and then fail on its first company-scoped call to the real host. A plugin can also read or write another company's data in its tests, which hides the cross-company case from the author.

**Expected behavior**

The test harness must refuse the calls the host refuses, and it must use the same error text. A test that needs to act as one company must say so.

**Steps to reproduce**

1. Make a plugin with `createTestHarness`.
2. Register a scheduled job with `ctx.jobs.register`.
3. In the job handler, call `ctx.config.get("some-company-id")`.
4. Run the job with `harness.runJob("job-key")`.
5. The call gives a result. The real host refuses the same call with `company context is required`.

Related pull requests found in a duplicate search. Neither one changes this behavior, and neither one conflicts with this change:

- Refs #10580 — adds `ctx.runtime.runProactively()` so a long-lived callback can leave a stale invocation scope. It adds a new API to the harness. It does not make the harness enforce the scope rule.
- Refs #11571 — adds company-scoped scheduled jobs to the host. This pull request does not depend on it, and does not anticipate it: a job run gets no company scope, which matches `master` today. When that pull request or a similar one lands, `runJob` can read the company off the job context.

## What Changed

- Move `requireInvocationCompanyScope`, `requestedCompanyScope` and `resolveRequiredCompanyId` from the `createHostClientHandlers` closure to module scope in `host-client-factory.ts`, and export them. There is now one definition of the rule for the host and the harness.
- Set an active invocation scope in the harness at the entry points that carry one in production. This mirrors `deriveInvocationScope` in `server/src/services/plugin-worker-manager.ts`: `emit` uses `event.companyId`, `getData` uses the host-authorized `GetDataParams.companyId`, `performAction` uses the actor context, and `executeTool` uses the run context.
- Give a scheduled job run no company scope, because the host gives it none. Both dispatch paths in `plugin-job-scheduler.ts` call `runJob` with `{ job }` and no company, and `deriveInvocationScope` has no `runJob` branch. `runJob` throws if a test gives it a company, and the message points to `withCompanyScope` for a test that wants the scoped path. A harness that made a scope here would permit more than the host, which is the fault this pull request removes.
- Mirror the proactive branch of `contextForWorkerMessage` for calls made outside an invocation. A new `proactiveCompanyScopes` harness option holds the companies the plugin is configured for. Only those companies are permitted, as in production.
- Add `requireCompanyScope` to about 90 company-scoped fake methods in the harness, each with the worker-to-host method name that the production client sends.
- Add `harness.withCompanyScope(companyId, fn)`. A test uses it to say which company it acts as when it drives `ctx` directly, or when it calls a lifecycle hook that the harness does not wrap. It is a scope and not a bypass: a call inside it for a different company is still refused.
- Add `packages/plugins/sdk/tests/testing-invocation-scope.test.ts` with 15 tests. Each expectation uses the host's error text, not a harness error text.
- Add `packages/plugins/sdk/tests/testing-harness-scope-parity.test.ts`. It reads the company-scoped method set from the production client `worker-rpc-host.ts` and asserts that the harness gates each one. This prevents the same gap from returning.
- Update the tests that the new rule stopped. Each change says which company the test acts as. No expected message was changed and no assertion was removed.

## Verification

Automatic tests:

- `pnpm --filter @paperclipai/plugin-sdk run typecheck` — clean.
- `pnpm --filter @paperclipai/server run typecheck` — clean.
- `packages/plugins/sdk` — 64 of 64 tests pass.
- `packages/plugins/plugin-llm-wiki` — 101 of 101 tests pass.
- `packages/plugins/plugin-workspace-diff` — 26 of 26 tests pass.
- `packages/plugins/examples/plugin-authoring-smoke-example` and `plugin-orchestration-smoke-example` — all tests pass.
- `server/src/__tests__/plugin-sdk-testing.test.ts`, `plugin-sdk-orchestration-contract.test.ts`, `plugin-worker-manager.test.ts` and `plugin-execution-workspace-bridge.test.ts` — 62 of 62 tests pass.

Manual checks of the new gates. Four changes were made to the source, and each one made a test fail:

1. Remove one `requireCompanyScope` call. The parity test fails and gives the name of the method.
2. Make the harness answer every company-scoped call again. Six scope tests fail.
3. Keep the scope after `withCompanyScope` returns. Two tests fail.
4. Remove the `runJob` company guard so the harness makes a scope the scheduler cannot make. One test fails.

Findings from the test changes. Each one is a real difference between the harness and the host:

- The `wiki_write_page` tool in `plugin-llm-wiki` reads its company from its own parameters, and not from `runContext.companyId`. The host refuses this call when the agent run belongs to a different company. The test now gives the run context company, so the difference is visible.
- A session event callback runs with no invocation scope. The worker client sends `agents.sessions.event` without `runNotification`, and `onEvent` uses it. Writes from a session callback are therefore proactive. The test now declares the configured company.

### Review response

The first review found that `runJob(jobKey, { companyId })` made an invocation scope that the production scheduler cannot make. The finding is correct. Both dispatch paths send `{ job }` with no company, so the same handler runs with no scope on the real host. The harness now carries no company on a job run, and it throws if a test gives it one.

## Risks

- Test-only behavior change. No production code path changes. The exported functions have the same logic as before, and the host calls them in the same order.
- Plugin test suites outside this repository can fail after this change. Each failure shows a call that the real host also refuses, so the failure is correct. The message names the method and the company, and `harness.withCompanyScope` gives a short fix for a test that drives the context directly.
- The harness models an invocation scope with one variable, because a test runs one entry point at a time. The host also tracks the identifier of each invocation. A test that runs two entry points at the same time is therefore not modelled.
- Stream notifications stay ungated. The host drops an out-of-scope stream notification and does not raise an error, and the harness stream fakes record nothing. The parity test lists them with the reason, so the hole is visible.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`), extended thinking, with tool use and code execution in an agent harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
