### PR TITLE
fix(workspace-runtime): keep the real readiness failure when the deadline-clamped probe aborts

### DIFF
--- a/server/src/__tests__/workspace-runtime-start-terminality.test.ts
+++ b/server/src/__tests__/workspace-runtime-start-terminality.test.ts
@@ -99,6 +99,44 @@ describe("managed runtime start terminality", () => {
     expect(probes).toBeLessThan(12);
   });
 
+  it("preserves the last HTTP failure when the deadline-clamped probe aborts", async () => {
+    // The readiness budget (1s) is smaller than the per-probe timeout, so every probe is bounded
+    // by the deadline. The first probe observes the real failure (503); the second is admitted
+    // with 1ms left and aborts immediately. That abort says the budget ran out, not that the
+    // service misbehaved, so it must not overwrite the 503 in the thrown message.
+    let nowMs = 0;
+    let probes = 0;
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+      probes += 1;
+      if (probes === 1) {
+        nowMs = 999;
+        return new Response(null, { status: 503 });
+      }
+      return await new Promise<Response>((_resolve, reject) => {
+        const rejectOnAbort = () => {
+          nowMs = 1_000;
+          reject(new Error("The operation was aborted"));
+        };
+        if (init?.signal?.aborted) {
+          rejectOnAbort();
+          return;
+        }
+        init?.signal?.addEventListener("abort", rejectOnAbort, { once: true });
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      waitForRuntimeServiceReadiness({
+        service: { readiness: { type: "http", timeoutSec: 1, intervalMs: 100 } },
+        url: "http://127.0.0.1:45439/",
+        readinessUrl: null,
+        fetchImpl,
+        now: () => nowMs,
+      }),
+    ).rejects.toThrow("Readiness check failed for http://127.0.0.1:45439/: received HTTP 503");
+    expect(probes).toBe(2);
+  });
+
   it("hands two concurrent starts distinct ports even when the kernel repeats a candidate", async () => {
     // The kernel really does hand the same ephemeral port to two `listen(0)` probes once the
     // first probe socket has closed, which is exactly the reallocation collision in the report.

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -5116,14 +5116,26 @@ export async function waitForRuntimeServiceReadiness(input: {
   const intervalMs = Math.max(100, asNumber(readiness.intervalMs, 500));
   const deadline = now() + timeoutSec * 1000;
   let lastError = "service did not become ready";
+  let sawServiceFailure = false;
   while (now() < deadline) {
-    const probeBudgetMs = Math.max(1, Math.min(RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS, deadline - now()));
+    const remainingMs = deadline - now();
+    // When the readiness budget is what bounds this probe, aborting it only means we ran out of
+    // time — it is not an observation about the service, so it must not replace one we already have.
+    const boundedByDeadline = remainingMs <= RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS;
+    const probeBudgetMs = Math.max(1, Math.min(RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS, remainingMs));
+    let probeSignal: AbortSignal | undefined;
     try {
-      const response = await fetchImpl(readinessUrl, { signal: AbortSignal.timeout(probeBudgetMs) });
+      probeSignal = AbortSignal.timeout(probeBudgetMs);
+      const response = await fetchImpl(readinessUrl, { signal: probeSignal });
       if (response.ok) return;
       lastError = `received HTTP ${response.status}`;
+      sawServiceFailure = true;
     } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
+      const abortedByDeadline = Boolean(probeSignal?.aborted) && boundedByDeadline;
+      if (!abortedByDeadline || !sawServiceFailure) {
+        lastError = err instanceof Error ? err.message : String(err);
+        sawServiceFailure = true;
+      }
     }
     if (now() >= deadline) break;
     await delay(Math.min(intervalMs, Math.max(0, deadline - now())));

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -4599,14 +4599,26 @@ export async function waitForRuntimeServiceReadiness(input: {
   const intervalMs = Math.max(100, asNumber(readiness.intervalMs, 500));
   const deadline = now() + timeoutSec * 1000;
   let lastError = "service did not become ready";
+  let sawServiceFailure = false;
   while (now() < deadline) {
-    const probeBudgetMs = Math.max(1, Math.min(RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS, deadline - now()));
+    const remainingMs = deadline - now();
+    // When the readiness budget is what bounds this probe, aborting it only means we ran out of
+    // time — it is not an observation about the service, so it must not replace one we already have.
+    const boundedByDeadline = remainingMs <= RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS;
+    const probeBudgetMs = Math.max(1, Math.min(RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS, remainingMs));
+    let probeSignal: AbortSignal | undefined;
     try {
-      const response = await fetchImpl(readinessUrl, { signal: AbortSignal.timeout(probeBudgetMs) });
+      probeSignal = AbortSignal.timeout(probeBudgetMs);
+      const response = await fetchImpl(readinessUrl, { signal: probeSignal });
       if (response.ok) return;
       lastError = `received HTTP ${response.status}`;
+      sawServiceFailure = true;
     } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
+      const abortedByDeadline = Boolean(probeSignal?.aborted) && boundedByDeadline;
+      if (!abortedByDeadline || !sawServiceFailure) {
+        lastError = err instanceof Error ? err.message : String(err);
+        sawServiceFailure = true;
+      }
     }
     if (now() >= deadline) break;
     await delay(Math.min(intervalMs, Math.max(0, deadline - now())));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - An agent run can start workspace runtime services, and the run waits for each service's HTTP readiness check before proceeding
> - When that wait fails, the thrown message is the only thing the operator sees, so it has to name the failure that actually happened
> - `waitForRuntimeServiceReadiness` admits a loop iteration whenever *any* time remains before the deadline, and clamps that probe's `AbortSignal` to the time left
> - A probe admitted with a millisecond to spare therefore aborts straight away and overwrites `lastError`, discarding the HTTP status an earlier probe genuinely observed
> - This pull request stops a deadline-caused abort from replacing a real observation, and nothing else
> - The benefit is that a readiness failure reports the reason the service was not ready, instead of the fact that the clock ran out

## Linked Issues or Issue Description

No filed issue — found while diagnosing a readiness failure whose reported cause did not match the service's actual behaviour.

Related PRs: #11525 introduced the bounded probe this fixes the reporting for, and #11494 (closed) added a regression test locking that probe bound. Neither touches which failure is reported, and no other open or closed PR addresses the reporting defect.

The bounded probe was introduced with the readiness timeout work in #11525. That change is correct in what it set out to do: it stops an unresponsive service from parking the wait forever. The reporting path is the part that was left behind.

In `server/src/services/workspace-runtime.ts`, the loop is entered while any time remains:

```js
while (now() < deadline) {
  const probeBudgetMs = Math.max(1, Math.min(RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS, deadline - now()));
  try {
    const response = await fetchImpl(readinessUrl, { signal: AbortSignal.timeout(probeBudgetMs) });
    if (response.ok) return;
    lastError = `received HTTP ${response.status}`;
  } catch (err) {
    lastError = err instanceof Error ? err.message : String(err);   // <- clobbers the real reason
  }
```

`Math.max(1, ...)` means the final admitted probe can be given roughly a millisecond, so it aborts almost immediately. The `catch` then unconditionally replaces `lastError`, so a service that has been returning `503` for the whole budget is reported as `The operation was aborted`.

Whether this happens depends on where the last iteration lands relative to the deadline, which is why it surfaces as an intermittent test failure rather than a constant one. It shows up in the wild on the existing `requires Paperclip dev runtime services to pass /api/health readiness` test, which asserts `received HTTP 503` and intermittently observes the abort text instead ([CI log](https://github.com/paperclipai/paperclip/actions/runs/32046138886/job/95434615824)).

## What Changed

`server/src/services/workspace-runtime.ts` — an abort is ignored for reporting purposes when all three hold:

- the probe's own signal is what aborted,
- that probe was bounded by the readiness deadline rather than by `RUNTIME_SERVICE_READINESS_PROBE_TIMEOUT_MS`, and
- an earlier probe already recorded a real failure.

Otherwise the error is recorded exactly as before, so the first failure, connection errors, and genuine per-probe timeouts on a long budget all still surface.

This is a reporting-only change. Probe scheduling, the probe budget, the interval, the deadline, and the number of requests issued are all untouched.

I deliberately did not add a minimum-budget floor that would skip a probe with little time left. That would change probing behaviour — a service becoming ready in the final milliseconds would start being reported as not ready — and it would not fix the misreporting anyway.

## Verification

New test in `server/src/__tests__/workspace-runtime-start-terminality.test.ts`, alongside the bounded-probe tests from #11525. It drives the loop with an injected clock and `fetchImpl`: the first probe returns `503` and advances the clock to 999ms of a 1000ms budget, so the second is admitted with 1ms and aborts. Deterministic — no reliance on real timing.

Before this change, on unmodified master:

```
× preserves the last HTTP failure when the deadline-clamped probe aborts

Expected: "Readiness check failed for http://127.0.0.1:45439/: received HTTP 503"
Received: "Readiness check failed for http://127.0.0.1:45439/: The operation was aborted"

Tests  1 failed | 8 skipped (9)
```

After:

```
Test Files  1 passed (1)
      Tests  9 passed (9)
```

`server/src/__tests__/workspace-runtime.test.ts` — 120 passed, 2 failed. Both failures (`records teardown and cleanup operations when a recorder is provided`, `adopts a live auto-port shared service after runtime state is reset`) reproduce identically on unmodified master and are unrelated to this change.

`pnpm typecheck` in `server` — clean.

## Risks

Low, and confined to the text of an error that is already being thrown.

The one behavioural consequence worth stating plainly: if a service returns a real failure and *then* starts hanging, the reported reason is now the earlier failure rather than the abort. That is the intended trade — the earlier failure is something the service actually did, while the abort only reflects the budget expiring.

The condition is narrow enough that a hang with no prior failure, which is the case #11525 was written for, still reports the abort exactly as it does today. The negative-control and probe-count tests from #11525 continue to pass unchanged.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5`, used via Claude Code with extended thinking and tool use (repository search, file editing, and local test execution). The diagnosis was independently cross-checked with GPT-5.6 (OpenAI) via Codex CLI, which reproduced the failure on unmodified master. The fix and the test were produced with model assistance and verified locally by running the test suites and typechecker as described in Verification.

## Checklist

- [x] Tests added for the fixed behaviour
- [x] Existing tests in the touched files pass, with pre-existing failures verified against unmodified master
- [x] Typecheck clean
- [x] No behavioural change to probing, only to which failure is reported
- [x] I have searched GitHub for duplicate or related PRs and linked them above

