### PR TITLE
fix(issues): put a copy-pasteable agent handoff payload in the in_review 422

### DIFF
--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -325,43 +325,15 @@ describe("issue execution policy routes", () => {
       missing: "review_path",
     });
     expect(mockIssueService.update).not.toHaveBeenCalled();
-  });
 
-  // This 422 is the only text an agent is guaranteed to be reading at the moment
-  // it is stuck. Naming a mechanism is demonstrably not enough: the message already
-  // listed "set a typed executionState.currentParticipant through an execution
-  // policy" and agents still fell back to `blocked`, which wakes nobody. The
-  // example must stay copy-pasteable, so assert it parses and keeps its shape
-  // rather than just asserting a substring that could drift into nonsense.
-  it("carries a copy-pasteable agent-to-agent handoff payload in the 422 body", async () => {
-    const issue = {
-      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-      companyId: "company-1",
-      status: "todo",
-      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-      assigneeUserId: null,
-      createdByUserId: "local-board",
-      identifier: "PAP-1003",
-      title: "Missing review path",
-      executionPolicy: null,
-      executionState: null,
-    };
-    mockIssueService.getById.mockResolvedValue(issue);
-
-    const res = await request(await createApp({
-      type: "agent",
-      agentId: "33333333-3333-4333-8333-333333333333",
-      companyId: "company-1",
-      runId: "run-1",
-    }))
-      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
-      .send({ status: "in_review" });
-
-    expect(res.status).toBe(422);
-
-    // Delimited rather than brace-counted: a regex that counts closing braces
-    // breaks the moment the example gains a field, which is exactly when the
-    // assertion is most needed.
+    // This 422 is the only text an agent is guaranteed to be reading at the
+    // moment it is stuck, so it must carry a payload it can copy rather than
+    // the name of a mechanism. Naming alone demonstrably was not enough: the
+    // message already listed "set a typed executionState.currentParticipant
+    // through an execution policy" and agents still fell back to `blocked`,
+    // which wakes nobody. Extract by delimiter and parse, rather than assert a
+    // substring, so the example cannot drift into something malformed while
+    // still matching. (A brace-counting regex was tried first and was wrong.)
     const example = res.body.error.match(/needed: (\{.*?\}) - Paperclip/)?.[1];
     expect(example, "the 422 must embed a JSON handoff example").toBeTruthy();
 
@@ -371,9 +343,6 @@ describe("issue execution policy routes", () => {
     expect(stage.type).toBe("review");
     expect(stage.participants[0].type).toBe("agent");
     expect(stage.participants[0]).toHaveProperty("agentId");
-
-    // `blocked` is the wrong answer here and the message must say so, since that
-    // is the fallback agents actually reached for.
     expect(res.body.error).toContain("blocked");
   });
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -327,6 +327,56 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  // This 422 is the only text an agent is guaranteed to be reading at the moment
+  // it is stuck. Naming a mechanism is demonstrably not enough: the message already
+  // listed "set a typed executionState.currentParticipant through an execution
+  // policy" and agents still fell back to `blocked`, which wakes nobody. The
+  // example must stay copy-pasteable, so assert it parses and keeps its shape
+  // rather than just asserting a substring that could drift into nonsense.
+  it("carries a copy-pasteable agent-to-agent handoff payload in the 422 body", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1003",
+      title: "Missing review path",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review" });
+
+    expect(res.status).toBe(422);
+
+    // Delimited rather than brace-counted: a regex that counts closing braces
+    // breaks the moment the example gains a field, which is exactly when the
+    // assertion is most needed.
+    const example = res.body.error.match(/needed: (\{.*?\}) - Paperclip/)?.[1];
+    expect(example, "the 422 must embed a JSON handoff example").toBeTruthy();
+
+    const parsed = JSON.parse(example as string);
+    expect(parsed.status).toBe("in_review");
+    const stage = parsed.executionPolicy.stages[0];
+    expect(stage.type).toBe("review");
+    expect(stage.participants[0].type).toBe("agent");
+    expect(stage.participants[0]).toHaveProperty("agentId");
+
+    // `blocked` is the wrong answer here and the message must say so, since that
+    // is the fallback agents actually reached for.
+    expect(res.body.error).toContain("blocked");
+  });
+
   it("allows an agent-authored in_review transition with a pending confirmation interaction", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1646,7 +1646,10 @@ const INVALID_AGENT_IN_REVIEW_DISPOSITION_MESSAGE =
   "This request would leave the issue in_review without anyone or anything owning the next action. " +
   "Keep working instead of moving to review, create a request_confirmation or ask_user_questions interaction, " +
   "link or request a pending approval, assign a human reviewer with assigneeUserId, set a typed executionState.currentParticipant through an execution policy, " +
-  "or schedule an issue monitor for an external review/check. After creating one of those review paths, retry the status update.";
+  "or schedule an issue monitor for an external review/check. After creating one of those review paths, retry the status update. " +
+  "To hand off to another agent, send the execution policy in this same request - no separate setup call is needed: " +
+  '{"status":"in_review","executionPolicy":{"stages":[{"type":"review","approvalsNeeded":1,"participants":[{"type":"agent","agentId":"<their-agent-id>"}]}]}} ' +
+  "- Paperclip reassigns the issue to that agent and wakes them. Do not use blocked for this; blocked is for first-class blockedByIssueIds and wakes nobody.";
 
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,


### PR DESCRIPTION
The `invalid_issue_disposition` 422 already lists `typed_execution_state_current_participant` as a valid review path, and already tells agents to "set a typed `executionState.currentParticipant` through an execution policy."

In practice that is not enough. Agents read that sentence, do not know what to send, and fall back to `status: blocked` — which has no wake attached. The issue then stalls silently and indefinitely, because `issue_blockers_resolved` only fires when first-class `blockedByIssueIds` resolve, and a self-declared block has none.

## The capability was never missing

- `IssueExecutionStagePrincipal.type` is `"agent" | "user"` (`packages/shared/src/types/issue.ts:589`)
- `patchForPrincipal` maps an agent principal to `assigneeAgentId` (`server/src/services/issue-execution-policy.ts:480`)
- `Object.assign(updateFields, transition.patch)` runs *before* `assertAgentInReviewReviewPath` (`server/src/routes/issues.ts`), so a single PATCH carrying an `executionPolicy` whose review stage names another agent derives a `currentParticipant` and passes the check

Verified against a running instance, not just read: the handoff reassigned the issue to the target agent and woke it, on an agent that had been idle with no assigned work.

## What this changes

Embeds the working payload in the message itself, and states plainly that `blocked` is the wrong answer:

```json
{"status":"in_review","executionPolicy":{"stages":[{"type":"review","approvalsNeeded":1,"participants":[{"type":"agent","agentId":"<their-agent-id>"}]}]}}
```

This is the one text an agent is guaranteed to be reading at the moment it is stuck. A skill section it may have loaded hours earlier and dropped; this it definitely read.

## Test

Extracts the example by delimiter and `JSON.parse`s it, asserting the parsed shape, rather than asserting a substring — so the example cannot drift into something malformed while still matching. A brace-counting regex was tried first and was wrong; that is precisely the failure mode being guarded against.

## Scope

Server-only. A companion change to `skills/paperclip/SKILL.md` follows separately, since `skills/**` is CODEOWNERS-gated and this fix should not wait on that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198HFSvnatHmEd1tZh2paC8