### PR TITLE
fix: strip systemd service-manager env vars from spawned agent processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
 COPY packages/mcp-server/package.json packages/mcp-server/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
+COPY packages/adapters/copilot-local/package.json packages/adapters/copilot-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/

--- a/cli/package.json
+++ b/cli/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@clack/prompts": "^0.10.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -1,5 +1,6 @@
 import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
+import { printCopilotStreamEvent } from "@paperclipai/adapter-copilot-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
@@ -17,6 +18,11 @@ const claudeLocalCLIAdapter: CLIAdapterModule = {
 const codexLocalCLIAdapter: CLIAdapterModule = {
   type: "codex_local",
   formatStdoutEvent: printCodexStreamEvent,
+};
+
+const copilotLocalCLIAdapter: CLIAdapterModule = {
+  type: "copilot_local",
+  formatStdoutEvent: printCopilotStreamEvent,
 };
 
 const openCodeLocalCLIAdapter: CLIAdapterModule = {
@@ -47,6 +53,7 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
+    copilotLocalCLIAdapter,
     codexLocalCLIAdapter,
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -92,6 +92,49 @@ describe("runChildProcess", () => {
     expect(finishedAt - startedAt).toBeGreaterThanOrEqual(spawnDelayMs);
   });
 
+  it("strips systemd service-manager vars (NOTIFY_SOCKET/LISTEN_FDS/LISTEN_PID/LISTEN_FDNAMES) from both inherited and caller-supplied env", async () => {
+    const SERVICE_MANAGER_VARS = ["NOTIFY_SOCKET", "LISTEN_FDS", "LISTEN_PID", "LISTEN_FDNAMES"] as const;
+    const originalValues: Record<string, string | undefined> = {};
+    for (const key of SERVICE_MANAGER_VARS) {
+      originalValues[key] = process.env[key];
+      process.env[key] = `inherited-${key}`;
+    }
+
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", "process.stdout.write(JSON.stringify(process.env))"],
+        {
+          cwd: process.cwd(),
+          env: {
+            NOTIFY_SOCKET: "/run/caller-supplied.sock",
+            LISTEN_FDS: "1",
+            LISTEN_PID: "12345",
+            LISTEN_FDNAMES: "caller",
+          },
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const childEnv = JSON.parse(result.stdout) as Record<string, string | undefined>;
+      for (const key of SERVICE_MANAGER_VARS) {
+        expect(childEnv[key]).toBeUndefined();
+      }
+    } finally {
+      for (const key of SERVICE_MANAGER_VARS) {
+        if (originalValues[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = originalValues[key];
+        }
+      }
+    }
+  });
+
   it.skipIf(process.platform === "win32")("kills descendant processes on timeout via the process group", async () => {
     let descendantPid: number | null = null;
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1494,6 +1494,22 @@ export async function runChildProcess(
       delete rawMerged[key];
     }
 
+    // Strip systemd service-manager vars so the spawned agent process can't
+    // reach the Paperclip server's own readiness/socket-activation channel.
+    // NOTIFY_SOCKET in particular lets any process with it in its env call
+    // sd_notify on the server's readiness socket; systemd only accepts
+    // notifications from the service's registered main PID, so an agent
+    // subprocess inheriting it just spams "reception only permitted for
+    // main PID" warnings, but it's still an unintended channel and must not
+    // be handed to child processes. These vars can arrive either via
+    // process.env (systemd sets them on the server process) or via
+    // opts.env (adapters that build their env as `{ ...process.env, ... }`),
+    // so strip them after the merge, not just from the process.env side.
+    const SERVICE_MANAGER_VARS = ["NOTIFY_SOCKET", "LISTEN_FDS", "LISTEN_PID", "LISTEN_FDNAMES"] as const;
+    for (const key of SERVICE_MANAGER_VARS) {
+      delete rawMerged[key];
+    }
+
     const mergedEnv = ensurePathInEnv(rawMerged);
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {
       remoteExecution: opts.remoteExecution ?? null,

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -38,6 +38,7 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
   "claude_local",
+  "copilot_local",
   "codex_local",
   "cursor",
   "gemini_local",
@@ -51,6 +52,11 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
     supportsSessionResume: true,
     nativeContextManagement: "confirmed",
     defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+  },
+  copilot_local: {
+    supportsSessionResume: true,
+    nativeContextManagement: "unknown",
+    defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
   },
   codex_local: {
     supportsSessionResume: true,

--- a/packages/adapters/copilot-local/package.json
+++ b/packages/adapters/copilot-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-copilot-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/copilot-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./cli": "./src/cli/index.ts",
+    "./ui": "./src/ui/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/copilot-local/src/cli/format-event.ts
+++ b/packages/adapters/copilot-local/src/cli/format-event.ts
@@ -1,0 +1,190 @@
+import pc from "picocolors";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asPayload(record: Record<string, unknown>): Record<string, unknown> {
+  const payload = asRecord(record.data);
+  return payload && Object.keys(payload).length > 0 ? payload : record;
+}
+
+function eventType(record: Record<string, unknown>, payload: Record<string, unknown>): string {
+  return normalizeText(record.type || payload.type).toLowerCase();
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function extractErrorText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const record = asRecord(value);
+  if (!record) return "";
+  return (
+    normalizeText(record.message) ||
+    normalizeText(record.error) ||
+    normalizeText(record.code) ||
+    stringifyUnknown(value).trim()
+  );
+}
+
+function extractSessionId(record: Record<string, unknown>, payload: Record<string, unknown>): string {
+  const direct =
+    normalizeText(payload.sessionId) ||
+    normalizeText(payload.session_id) ||
+    normalizeText(payload.sessionID) ||
+    normalizeText(record.sessionId) ||
+    normalizeText(record.session_id) ||
+    normalizeText(record.sessionID);
+  if (direct) return direct;
+  const payloadSession = asRecord(payload.session);
+  const recordSession = asRecord(record.session);
+  return (
+    normalizeText(payloadSession?.id) ||
+    normalizeText(payloadSession?.sessionId) ||
+    normalizeText(recordSession?.id) ||
+    normalizeText(recordSession?.sessionId)
+  );
+}
+
+export function printCopilotStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    console.log(line);
+    return;
+  }
+
+  const payload = asPayload(parsed);
+  const type = eventType(parsed, payload);
+  const sessionId = extractSessionId(parsed, payload);
+
+  if (type.startsWith("session.")) {
+    if (type === "session.tools_updated") {
+      const model = normalizeText(payload.model) || normalizeText(parsed.model);
+      if (model) console.log(pc.blue(`model: ${model}`));
+    } else if (debug) {
+      console.log(pc.gray(type));
+    }
+    if (sessionId && debug) {
+      console.log(pc.blue(`session: ${sessionId}`));
+    }
+    return;
+  }
+
+  if (type === "assistant.turn_start" || type === "assistant.turn_end") {
+    if (debug) console.log(pc.gray(type));
+    return;
+  }
+
+  if (type === "assistant.reasoning") {
+    const text = normalizeText(payload.content) || normalizeText(payload.text);
+    if (text) console.log(pc.gray(`thinking: ${text}`));
+    return;
+  }
+
+  if (type === "assistant.message") {
+    const text =
+      normalizeText(payload.content) ||
+      normalizeText(payload.text) ||
+      normalizeText(asRecord(payload.message)?.content);
+    if (text) console.log(pc.green(`assistant: ${text}`));
+    return;
+  }
+
+  if (type === "tool.execution_start") {
+    const toolName = normalizeText(payload.toolName) || normalizeText(payload.name) || "tool";
+    const args = payload.arguments ?? payload.input;
+    console.log(pc.yellow(`tool_call: ${toolName}`));
+    if (args !== undefined && debug) {
+      console.log(pc.gray(stringifyUnknown(args)));
+    }
+    return;
+  }
+
+  if (type === "tool.execution_complete") {
+    const toolName = normalizeText(payload.toolName) || normalizeText(payload.name) || "tool";
+    const success = asBoolean(payload.success, true);
+    const result = asRecord(payload.result);
+    const content =
+      normalizeText(result?.content) ||
+      normalizeText(result?.detailedContent) ||
+      normalizeText(result?.summary) ||
+      normalizeText(payload.message) ||
+      stringifyUnknown(result).trim() ||
+      `${toolName} ${success ? "completed" : "failed"}`;
+    console.log((success ? pc.cyan : pc.red)(`tool_result: ${toolName}${success ? "" : " (error)"}`));
+    if (content) console.log((success ? pc.gray : pc.red)(content));
+    return;
+  }
+
+  if (type === "result") {
+    const usage = asRecord(payload.usage) ?? asRecord(parsed.usage);
+    const input = asNumber(
+      usage?.input_tokens,
+      asNumber(usage?.inputTokens, asNumber(usage?.prompt_tokens, asNumber(usage?.promptTokens, 0))),
+    );
+    const output = asNumber(
+      usage?.output_tokens,
+      asNumber(
+        usage?.outputTokens,
+        asNumber(usage?.completion_tokens, asNumber(usage?.completionTokens, 0)),
+      ),
+    );
+    const cached = asNumber(
+      usage?.cached_input_tokens,
+      asNumber(usage?.cachedInputTokens, 0),
+    );
+    const cost = asNumber(
+      payload.costUsd,
+      asNumber(payload.cost_usd, asNumber(payload.cost, asNumber(parsed.costUsd, asNumber(parsed.cost, 0)))),
+    );
+    const exitCode = asNumber(payload.exitCode, asNumber(parsed.exitCode, 0));
+    if (sessionId) console.log(pc.blue(`session: ${sessionId}`));
+    console.log(pc.blue(`tokens: in=${input} out=${output} cached=${cached} cost=$${cost.toFixed(6)}`));
+    console.log((exitCode === 0 ? pc.blue : pc.red)(`result: exit_code=${exitCode}`));
+    return;
+  }
+
+  if (type.includes("error")) {
+    const error = extractErrorText(payload.error ?? parsed.error ?? payload.message ?? parsed.message);
+    if (error) console.log(pc.red(`error: ${error}`));
+    return;
+  }
+
+  if (debug) console.log(line);
+}

--- a/packages/adapters/copilot-local/src/cli/index.ts
+++ b/packages/adapters/copilot-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printCopilotStreamEvent } from "./format-event.js";

--- a/packages/adapters/copilot-local/src/index.ts
+++ b/packages/adapters/copilot-local/src/index.ts
@@ -1,0 +1,46 @@
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+
+export const type = "copilot_local";
+export const label = "GitHub Copilot CLI";
+export const DEFAULT_COPILOT_LOCAL_MODEL = "claude-sonnet-4.6";
+
+export const models: AdapterModel[] = [
+  { id: DEFAULT_COPILOT_LOCAL_MODEL, label: "Claude Sonnet 4.6" },
+  { id: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+  { id: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
+  { id: "claude-opus-4.7", label: "Claude Opus 4.7" },
+  { id: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  { id: "claude-opus-4.6-fast", label: "Claude Opus 4.6 Fast" },
+  { id: "claude-opus-4.6-1m", label: "Claude Opus 4.6 1M" },
+  { id: "claude-opus-4.5", label: "Claude Opus 4.5" },
+  { id: "claude-sonnet-4", label: "Claude Sonnet 4" },
+  { id: "gpt-5.4", label: "GPT-5.4" },
+  { id: "gpt-5.5", label: "GPT-5.5" },
+  { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+  { id: "gpt-5.2-codex", label: "GPT-5.2 Codex" },
+  { id: "gpt-5.2", label: "GPT-5.2" },
+  { id: "gpt-5.1", label: "GPT-5.1" },
+  { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+  { id: "gpt-5-mini", label: "GPT-5 Mini" },
+  { id: "gpt-4.1", label: "GPT-4.1" },
+  { id: "auto", label: "Auto (default)" },
+];
+
+export const agentConfigurationDoc = `# copilot_local agent configuration
+
+Adapter: copilot_local (GitHub Copilot CLI)
+
+Core fields:
+- cwd (string, optional): absolute working directory fallback for the agent process
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- promptTemplate (string, optional): run prompt template
+- model (string, optional): model id (default: claude-sonnet-4.6)
+- effort (string, optional): reasoning effort level (low, medium, high, xhigh)
+- command (string, optional): defaults to "copilot"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+`;

--- a/packages/adapters/copilot-local/src/server/auth-env.ts
+++ b/packages/adapters/copilot-local/src/server/auth-env.ts
@@ -1,0 +1,12 @@
+/**
+ * Maps COPILOT_GITHUB_TOKEN to GH_TOKEN and GITHUB_TOKEN when the latter
+ * are not already set.  This lets users configure a single token variable
+ * that is automatically propagated to the GitHub-auth env vars expected by
+ * the Copilot CLI at runtime.
+ */
+export function applyCopilotAuthEnvAliases(env: Record<string, string>): void {
+  const token = env.COPILOT_GITHUB_TOKEN?.trim();
+  if (!token) return;
+  if (!env.GH_TOKEN?.trim()) env.GH_TOKEN = token;
+  if (!env.GITHUB_TOKEN?.trim()) env.GITHUB_TOKEN = token;
+}

--- a/packages/adapters/copilot-local/src/server/execute.ts
+++ b/packages/adapters/copilot-local/src/server/execute.ts
@@ -1,0 +1,384 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  asStringArray,
+  buildInvocationEnvForLogs,
+  buildPaperclipEnv,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  joinPromptSections,
+  parseObject,
+  renderPaperclipWakePrompt,
+  renderTemplate,
+  stringifyPaperclipWakePayload,
+  resolveCommandForLogs,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { isCopilotUnknownSessionError, parseCopilotJsonOutput } from "./parse.js";
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+import { applyCopilotAuthEnvAliases } from "./auth-env.js";
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
+  );
+  const command = asString(config.command, "copilot");
+  const model = asString(config.model, "").trim() || null;
+  const effort =
+    asString(config.effort, asString(config.reasoningEffort, asString(config.modelReasoningEffort, ""))).trim() || "";
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServiceIntents = Array.isArray(context.paperclipRuntimeServiceIntents)
+    ? context.paperclipRuntimeServiceIntents.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimeServices = Array.isArray(context.paperclipRuntimeServices)
+    ? context.paperclipRuntimeServices.filter(
+        (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
+
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  if (effectiveWorkspaceCwd) env.PAPERCLIP_WORKSPACE_CWD = effectiveWorkspaceCwd;
+  if (workspaceSource) env.PAPERCLIP_WORKSPACE_SOURCE = workspaceSource;
+  if (workspaceId) env.PAPERCLIP_WORKSPACE_ID = workspaceId;
+  if (workspaceRepoUrl) env.PAPERCLIP_WORKSPACE_REPO_URL = workspaceRepoUrl;
+  if (workspaceRepoRef) env.PAPERCLIP_WORKSPACE_REPO_REF = workspaceRepoRef;
+  if (agentHome) env.AGENT_HOME = agentHome;
+  if (workspaceHints.length > 0) env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaceHints);
+  if (runtimeServiceIntents.length > 0) env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(runtimeServiceIntents);
+  if (runtimeServices.length > 0) env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(runtimeServices);
+  if (runtimePrimaryUrl) env.PAPERCLIP_RUNTIME_PRIMARY_URL = runtimePrimaryUrl;
+
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  applyCopilotAuthEnvAliases(env);
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = Object.fromEntries(
+    Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  await ensureCommandResolvable(command, cwd, runtimeEnv);
+  const resolvedCommand = await resolveCommandForLogs(command, cwd, runtimeEnv);
+  const loggedEnv = buildInvocationEnvForLogs(env, {
+    runtimeEnv,
+    includeRuntimeKeys: ["HOME"],
+    resolvedCommand,
+  });
+
+  const timeoutSec = asNumber(config.timeoutSec, 0);
+  const graceSec = asNumber(config.graceSec, 20);
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Copilot session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const resolvedInstructionsFilePath = instructionsFilePath ? path.resolve(cwd, instructionsFilePath) : "";
+  const instructionsDir = resolvedInstructionsFilePath ? `${path.dirname(resolvedInstructionsFilePath)}/` : "";
+  let instructionsPrefix = "";
+  if (resolvedInstructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(resolvedInstructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${resolvedInstructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stdout",
+        `[paperclip] Warning: could not read agent instructions file "${resolvedInstructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+  const commandNotesBase = (() => {
+    const notes: string[] = [];
+    if (!resolvedInstructionsFilePath) return notes;
+    if (instructionsPrefix.length > 0) {
+      notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
+      notes.push(
+        `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
+      );
+      return notes;
+    }
+    notes.push(
+      `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+    );
+    return notes;
+  })();
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+
+  const buildPromptForAttempt = (resumeSessionId: string | null) => {
+    const resumedSession = Boolean(resumeSessionId);
+    const renderedBootstrapPrompt =
+      !resumedSession && bootstrapPromptTemplate.trim().length > 0
+        ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+        : "";
+    const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession });
+    const shouldUseResumeDeltaPrompt = resumedSession && wakePrompt.length > 0;
+    const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
+    const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
+    const prompt = joinPromptSections([
+      promptInstructionsPrefix,
+      renderedBootstrapPrompt,
+      wakePrompt,
+      sessionHandoffNote,
+      renderedPrompt,
+    ]);
+    const promptMetrics = {
+      promptChars: prompt.length,
+      instructionsChars: promptInstructionsPrefix.length,
+      bootstrapPromptChars: renderedBootstrapPrompt.length,
+      wakePromptChars: wakePrompt.length,
+      sessionHandoffChars: sessionHandoffNote.length,
+      heartbeatPromptChars: renderedPrompt.length,
+    };
+
+    return {
+      prompt,
+      promptMetrics,
+      shouldUseResumeDeltaPrompt,
+    };
+  };
+
+  const buildArgs = (resumeSessionId: string | null, prompt: string) => {
+    const args = ["--allow-all-tools", "--output-format", "json", "--stream", "off"];
+    if (resumeSessionId) args.push(`--resume=${resumeSessionId}`);
+    if (model) args.push("--model", model);
+    if (effort) args.push("--effort", effort);
+    if (extraArgs.length > 0) args.push(...extraArgs);
+    args.push("-p", prompt);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const { prompt, promptMetrics, shouldUseResumeDeltaPrompt } = buildPromptForAttempt(resumeSessionId);
+    const args = buildArgs(resumeSessionId, prompt);
+    const commandNotes = [
+      ...commandNotesBase,
+      resumeSessionId
+        ? `Resuming Copilot session ${resumeSessionId}.`
+        : "Starting a fresh Copilot session.",
+      shouldUseResumeDeltaPrompt && instructionsPrefix.length > 0
+        ? "Skipped instruction reinjection while resuming an existing Copilot session with wake delta."
+        : null,
+      shouldUseResumeDeltaPrompt
+        ? "Resumed session with wake delta prompt (base prompt template omitted)."
+        : "Prompt includes full base prompt template.",
+    ].filter((note): note is string => typeof note === "string" && note.length > 0);
+
+    if (onMeta) {
+      await onMeta({
+        adapterType: "copilot_local",
+        command: resolvedCommand,
+        cwd,
+        commandNotes,
+        commandArgs: args.map((value, idx) => (idx === args.length - 1 ? `<prompt ${prompt.length} chars>` : value)),
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runChildProcess(runId, command, args, {
+      cwd,
+      env: runtimeEnv,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onLog,
+    });
+    return {
+      proc,
+      rawStderr: proc.stderr,
+      parsed: parseCopilotJsonOutput(proc.stdout, proc.stderr),
+    };
+  };
+
+  const toResult = (
+    attempt: {
+      proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
+      rawStderr: string;
+      parsed: ReturnType<typeof parseCopilotJsonOutput>;
+    },
+    clearSessionOnMissingSession = false,
+  ): AdapterExecutionResult => {
+    if (attempt.proc.timedOut) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
+
+    const resolvedSessionId =
+      attempt.parsed.sessionId ??
+      (clearSessionOnMissingSession ? null : runtimeSessionId ?? runtime.sessionId ?? null);
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+          sessionId: resolvedSessionId,
+          cwd,
+          ...(workspaceId ? { workspaceId } : {}),
+          ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+          ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        } as Record<string, unknown>)
+      : null;
+    const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
+    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stdoutLine = firstNonEmptyLine(attempt.proc.stdout);
+    const rawExitCode = attempt.proc.exitCode;
+    const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
+    const fallbackErrorMessage =
+      parsedError ||
+      stderrLine ||
+      stdoutLine ||
+      `Copilot exited with code ${synthesizedExitCode ?? -1}`;
+
+    return {
+      exitCode: synthesizedExitCode,
+      signal: attempt.proc.signal,
+      timedOut: false,
+      errorMessage: (synthesizedExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+      usage: attempt.parsed.usage,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "github-copilot",
+      biller: "github-copilot",
+      model,
+      billingType: "unknown",
+      costUsd: attempt.parsed.costUsd,
+      resultJson: {
+        stdout: attempt.proc.stdout,
+        stderr: attempt.proc.stderr,
+      },
+      summary: attempt.parsed.summary,
+      clearSession: Boolean(clearSessionOnMissingSession),
+    };
+  };
+
+  const initial = await runAttempt(sessionId);
+  const initialFailed =
+    !initial.proc.timedOut && ((initial.proc.exitCode ?? 0) !== 0 || Boolean(initial.parsed.errorMessage));
+  if (
+    sessionId &&
+    initialFailed &&
+    isCopilotUnknownSessionError(initial.proc.stdout, initial.rawStderr)
+  ) {
+    await onLog(
+      "stdout",
+      `[paperclip] Copilot session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+    );
+    const retry = await runAttempt(null);
+    return toResult(retry, true);
+  }
+
+  return toResult(initial);
+}

--- a/packages/adapters/copilot-local/src/server/index.ts
+++ b/packages/adapters/copilot-local/src/server/index.ts
@@ -1,0 +1,67 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+import { listCopilotModels } from "./models.js";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID)
+    );
+  },
+};
+
+export { execute } from "./execute.js";
+export { listCopilotModels };
+export { parseCopilotJsonOutput, isCopilotUnknownSessionError } from "./parse.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/copilot-local/src/server/models.test.ts
+++ b/packages/adapters/copilot-local/src/server/models.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_COPILOT_LOCAL_MODEL, models as staticCopilotModels } from "../index.js";
+import { labelForModelId, listCopilotModels, resetCopilotModelsCacheForTests } from "./models.js";
+
+function sortedUniqueIds(models: { id: string }[]): string[] {
+  return [...new Set(models.map((model) => model.id.trim()).filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b, "en", { numeric: true, sensitivity: "base" }),
+  );
+}
+
+describe("copilot models", () => {
+  const originalPath = process.env.PATH;
+  const originalCommand = process.env.PAPERCLIP_COPILOT_COMMAND;
+
+  afterEach(() => {
+    if (typeof originalPath === "string") process.env.PATH = originalPath;
+    else delete process.env.PATH;
+
+    if (typeof originalCommand === "string") process.env.PAPERCLIP_COPILOT_COMMAND = originalCommand;
+    else delete process.env.PAPERCLIP_COPILOT_COMMAND;
+
+    resetCopilotModelsCacheForTests();
+  });
+
+  it("formats copilot model ids into readable labels", () => {
+    expect(labelForModelId("claude-sonnet-4.6")).toBe("Claude Sonnet 4.6");
+    expect(labelForModelId("claude-opus-4.6-1m")).toBe("Claude Opus 4.6 1M");
+    expect(labelForModelId("gpt-5.5")).toBe("GPT-5.5");
+    expect(labelForModelId("gpt-5.3-codex")).toBe("GPT-5.3 Codex");
+    expect(labelForModelId("auto")).toBe("Auto (default)");
+  });
+
+  it("falls back to static adapter models when runtime discovery is unavailable", async () => {
+    process.env.PATH = "__paperclip_missing_path__";
+    process.env.PAPERCLIP_COPILOT_COMMAND = "/__paperclip_missing_copilot_command__";
+
+    const listed = await listCopilotModels();
+    const expectedIds = sortedUniqueIds(staticCopilotModels);
+
+    expect(listed.map((model) => model.id)).toEqual(expectedIds);
+    expect(listed.find((model) => model.id === DEFAULT_COPILOT_LOCAL_MODEL)?.label).toBe("Claude Sonnet 4.6");
+    expect(listed.some((model) => model.id === "auto")).toBe(true);
+  });
+
+  it("always returns unique, sorted models with stable defaults", async () => {
+    const listed = await listCopilotModels();
+    const ids = listed.map((model) => model.id);
+
+    expect(listed.length).toBeGreaterThan(0);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(sortedUniqueIds(listed));
+    expect(ids).toContain(DEFAULT_COPILOT_LOCAL_MODEL);
+    expect(ids).toContain("auto");
+  });
+});

--- a/packages/adapters/copilot-local/src/server/models.ts
+++ b/packages/adapters/copilot-local/src/server/models.ts
@@ -1,0 +1,299 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import { ensurePathInEnv, resolveCommandForLogs } from "@paperclipai/adapter-utils/server-utils";
+import { models as staticCopilotModels } from "../index.js";
+
+const execFileAsync = promisify(execFile);
+const MODELS_CACHE_TTL_MS = 1_800 * 1_000;
+const NPM_DISCOVERY_TIMEOUT_MS = 4_000;
+
+const FALLBACK_MODELS: AdapterModel[] = sortModels(
+  dedupeModels(staticCopilotModels.map((model) => ({ id: model.id, label: model.label }))),
+);
+
+let discoveryCache: { expiresAt: number; models: AdapterModel[] } | null = null;
+
+function firstToken(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.split(/\s+/)[0] ?? "";
+}
+
+function dedupeModels(models: AdapterModel[]): AdapterModel[] {
+  const seen = new Set<string>();
+  const deduped: AdapterModel[] = [];
+  for (const model of models) {
+    const id = model.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    deduped.push({ id, label: model.label.trim() || id });
+  }
+  return deduped;
+}
+
+function sortModels(models: AdapterModel[]): AdapterModel[] {
+  return [...models].sort((a, b) =>
+    a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }),
+  );
+}
+
+function titleCaseToken(token: string): string {
+  const normalized = token.trim().toLowerCase();
+  if (!normalized) return "";
+  if (/^\d+(\.\d+)?$/.test(normalized)) return normalized;
+  if (/^\d+[a-z]+$/.test(normalized)) return normalized.replace(/[a-z]+$/g, (suffix) => suffix.toUpperCase());
+  if (normalized === "gpt") return "GPT";
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+export function labelForModelId(modelId: string): string {
+  const id = modelId.trim();
+  if (!id) return modelId;
+  if (id === "auto") return "Auto (default)";
+
+  const tokens = id.split("-").map((token) => token.trim()).filter(Boolean);
+  if (tokens.length === 0) return id;
+
+  if (tokens[0] === "gpt") {
+    if (tokens.length > 1 && /^\d+(\.\d+)?$/.test(tokens[1])) {
+      const suffix = tokens.slice(2).map(titleCaseToken).filter(Boolean).join(" ");
+      return suffix ? `GPT-${tokens[1]} ${suffix}` : `GPT-${tokens[1]}`;
+    }
+    return ["GPT", ...tokens.slice(1).map(titleCaseToken).filter(Boolean)].join(" ");
+  }
+
+  if (tokens[0] === "claude") {
+    return ["Claude", ...tokens.slice(1).map(titleCaseToken).filter(Boolean)].join(" ");
+  }
+
+  return tokens.map(titleCaseToken).filter(Boolean).join(" ");
+}
+
+function toModelList(ids: Iterable<string>): AdapterModel[] {
+  const parsed: AdapterModel[] = [];
+  for (const raw of ids) {
+    const id = raw.trim();
+    if (!id) continue;
+    parsed.push({ id, label: labelForModelId(id) });
+  }
+  return sortModels(dedupeModels(parsed));
+}
+
+function mergeWithFallbackModels(models: AdapterModel[]): AdapterModel[] {
+  return sortModels(dedupeModels([...models, ...FALLBACK_MODELS]));
+}
+
+function extractSupportedModelIds(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.flatMap((entry) => {
+      if (typeof entry === "string") return [entry];
+      if (typeof entry !== "object" || entry === null) return [];
+      const record = entry as Record<string, unknown>;
+      return typeof record.id === "string" ? [record.id] : [];
+    });
+  }
+  if (typeof raw === "object" && raw !== null) {
+    const record = raw as Record<string, unknown>;
+    const idsFromValues = Object.values(record).flatMap((value) => {
+      if (typeof value === "string") return [value];
+      if (typeof value !== "object" || value === null) return [];
+      const model = value as Record<string, unknown>;
+      return typeof model.id === "string" ? [model.id] : [];
+    });
+    const idsFromKeys = Object.keys(record).filter((key) => key.includes("-"));
+    return [...idsFromValues, ...idsFromKeys];
+  }
+  return [];
+}
+
+function extractSupportedModelIdsFromModule(moduleValue: unknown): string[] {
+  if (typeof moduleValue !== "object" || moduleValue === null) return [];
+  const record = moduleValue as Record<string, unknown>;
+  const defaultRecord =
+    typeof record.default === "object" && record.default !== null
+      ? (record.default as Record<string, unknown>)
+      : null;
+  const root = defaultRecord ?? record;
+  const visible = extractSupportedModelIds(root.HELP_VISIBLE_MODELS ?? record.HELP_VISIBLE_MODELS);
+  const supported = extractSupportedModelIds(root.SUPPORTED_MODELS ?? record.SUPPORTED_MODELS);
+  const hidden = new Set(extractSupportedModelIds(root.HIDDEN_MODELS ?? record.HIDDEN_MODELS));
+  const excluded = new Set(extractSupportedModelIds(root.EXCLUDED_MODELS ?? record.EXCLUDED_MODELS));
+  const selected = visible.length > 0 ? visible : supported;
+  return selected.filter((id) => !hidden.has(id) && !excluded.has(id));
+}
+
+/** Candidate relative paths from a @github/copilot package root to the SDK entry. */
+const SDK_RELATIVE_PATHS = [
+  "sdk/index.js",
+  "dist/sdk/index.js",
+  "lib/sdk/index.js",
+  "dist/sdk.js",
+] as const;
+
+/**
+ * Try to load the SDK module directly via dynamic import (bypasses CJS exports restrictions).
+ * Falls back to createRequire for older package layouts that support CJS.
+ */
+async function loadSupportedModelIdsFromNodeModules(nodeModulesDir: string): Promise<string[]> {
+  const copilotPkgDir = path.join(nodeModulesDir, "@github", "copilot");
+
+  // Strategy 1: Direct file import — handles packages that only export ESM via `exports`.
+  for (const relPath of SDK_RELATIVE_PATHS) {
+    const candidate = path.join(copilotPkgDir, relPath);
+    try {
+      await fs.promises.access(candidate, fs.constants.R_OK);
+      const moduleValue = await import(pathToFileURL(candidate).href);
+      const ids = extractSupportedModelIdsFromModule(moduleValue);
+      if (ids.length > 0) return ids;
+    } catch {
+      // Continue to next candidate path.
+    }
+  }
+
+  // Strategy 2: createRequire — works for packages that expose CJS or have a `require` export condition.
+  const requireFrom = createRequire(path.join(nodeModulesDir, "__paperclip_copilot_models__.js"));
+  const cjsSpecifiers = [
+    "@github/copilot",
+    "@github/copilot/sdk",
+    "@github/copilot/dist/sdk",
+    "@github/copilot/models",
+  ] as const;
+  for (const specifier of cjsSpecifiers) {
+    try {
+      const moduleValue = requireFrom(specifier);
+      const ids = extractSupportedModelIdsFromModule(moduleValue);
+      if (ids.length > 0) return ids;
+    } catch {
+      // Continue to next specifier.
+    }
+  }
+
+  return [];
+}
+
+async function resolveNpmGlobalRoot(): Promise<string | null> {
+  try {
+    const env = ensurePathInEnv({ ...process.env });
+    const { stdout } = await execFileAsync("npm", ["root", "-g"], {
+      cwd: process.cwd(),
+      env,
+      timeout: NPM_DISCOVERY_TIMEOUT_MS,
+    });
+    const root = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return root ? path.resolve(root) : null;
+  } catch {
+    return null;
+  }
+}
+
+function deriveNodeModulesCandidatesFromCommandPath(commandPath: string): string[] {
+  const resolved = path.resolve(commandPath);
+  const candidates = new Set<string>();
+
+  // If the resolved path is inside node_modules (e.g. .../lib/node_modules/@github/copilot/npm-loader.js),
+  // extract the node_modules root directly — this is the most reliable candidate.
+  const segments = resolved.split(path.sep);
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i] === "node_modules") {
+      candidates.add(segments.slice(0, i + 1).join(path.sep));
+      break;
+    }
+  }
+
+  // Walk up from the command directory looking for node_modules directories.
+  let cursor = path.dirname(resolved);
+  while (true) {
+    if (path.basename(cursor) === "node_modules") {
+      candidates.add(cursor);
+    } else {
+      candidates.add(path.join(cursor, "node_modules"));
+    }
+    const parent = path.dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  return [...candidates];
+}
+
+async function resolveCommandCandidates(): Promise<string[]> {
+  const command = firstToken(
+    typeof process.env.PAPERCLIP_COPILOT_COMMAND === "string" && process.env.PAPERCLIP_COPILOT_COMMAND.trim().length > 0
+      ? process.env.PAPERCLIP_COPILOT_COMMAND
+      : "copilot",
+  );
+  if (!command) return [];
+
+  const env = ensurePathInEnv({ ...process.env });
+  const resolved = await resolveCommandForLogs(command, process.cwd(), env);
+  const candidates = new Set<string>();
+  if (path.isAbsolute(resolved)) {
+    candidates.add(resolved);
+    // Follow symlinks to find the real install location (e.g. Homebrew, nvm).
+    try {
+      const realPath = await fs.promises.realpath(resolved);
+      if (realPath !== resolved) candidates.add(realPath);
+    } catch {
+      // realpath may fail if the target doesn't exist; ignore.
+    }
+  }
+  if (command.includes("/") || command.includes("\\")) {
+    candidates.add(path.resolve(process.cwd(), command));
+  }
+  return [...candidates];
+}
+
+async function discoverNodeModulesCandidates(): Promise<string[]> {
+  const candidates = new Set<string>();
+  const npmGlobalRoot = await resolveNpmGlobalRoot();
+  if (npmGlobalRoot) candidates.add(npmGlobalRoot);
+
+  const commandCandidates = await resolveCommandCandidates();
+  for (const commandPath of commandCandidates) {
+    candidates.add(path.dirname(commandPath));
+    for (const nodeModulesPath of deriveNodeModulesCandidatesFromCommandPath(commandPath)) {
+      candidates.add(nodeModulesPath);
+    }
+  }
+
+  return [...candidates];
+}
+
+async function discoverSupportedModelsFromSdk(): Promise<AdapterModel[] | null> {
+  const nodeModulesCandidates = await discoverNodeModulesCandidates();
+  for (const candidate of nodeModulesCandidates) {
+    try {
+      const ids = await loadSupportedModelIdsFromNodeModules(candidate);
+      if (ids.length > 0) return toModelList(ids);
+    } catch {
+      // Best-effort discovery; continue to next candidate.
+    }
+  }
+  return null;
+}
+
+export async function listCopilotModels(): Promise<AdapterModel[]> {
+  const now = Date.now();
+  if (discoveryCache && discoveryCache.expiresAt > now) return discoveryCache.models;
+
+  try {
+    const discovered = await discoverSupportedModelsFromSdk();
+    const models = discovered && discovered.length > 0 ? mergeWithFallbackModels(discovered) : FALLBACK_MODELS;
+    discoveryCache = { expiresAt: now + MODELS_CACHE_TTL_MS, models };
+    return models;
+  } catch {
+    discoveryCache = { expiresAt: now + MODELS_CACHE_TTL_MS, models: FALLBACK_MODELS };
+    return FALLBACK_MODELS;
+  }
+}
+
+export function resetCopilotModelsCacheForTests() {
+  discoveryCache = null;
+}

--- a/packages/adapters/copilot-local/src/server/parse.test.ts
+++ b/packages/adapters/copilot-local/src/server/parse.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { isCopilotUnknownSessionError, parseCopilotJsonOutput } from "./parse.js";
+
+describe("parseCopilotJsonOutput", () => {
+  it("parses wrapped Copilot JSON events with assistant summary and session id", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "session.tools_updated",
+        data: { model: "claude-sonnet-4.6" },
+      }),
+      JSON.stringify({
+        type: "assistant.message",
+        data: {
+          content: "",
+          outputTokens: 134,
+          toolRequests: [{ id: "toolu_1", toolName: "bash", arguments: "pwd" }],
+        },
+      }),
+      JSON.stringify({
+        type: "tool.execution_start",
+        data: { toolCallId: "toolu_1", toolName: "bash", arguments: "pwd" },
+      }),
+      JSON.stringify({
+        type: "tool.execution_complete",
+        data: {
+          toolCallId: "toolu_1",
+          toolName: "bash",
+          success: true,
+          result: { content: "/workspace/repo" },
+        },
+      }),
+      JSON.stringify({
+        type: "assistant.message",
+        data: {
+          content: "Done. Updated adapter wiring.",
+          outputTokens: 182,
+        },
+      }),
+      JSON.stringify({
+        type: "result",
+        sessionId: "copilot-session-1",
+        exitCode: 0,
+        usage: {
+          premiumRequests: 3,
+        },
+      }),
+    ].join("\n");
+
+    expect(parseCopilotJsonOutput(stdout)).toEqual({
+      sessionId: "copilot-session-1",
+      summary: "Done. Updated adapter wiring.",
+      usage: {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 182,
+      },
+      costUsd: null,
+      errorMessage: null,
+    });
+  });
+
+  it("treats plain-text error output as an error message", () => {
+    const stdout =
+      "Error: invalid value 'task-123' for '--resume [<SESSION_ID>]': value is not a valid uuid";
+
+    expect(parseCopilotJsonOutput(stdout)).toEqual({
+      sessionId: null,
+      summary: "",
+      usage: {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      costUsd: null,
+      errorMessage:
+        "Error: invalid value 'task-123' for '--resume [<SESSION_ID>]': value is not a valid uuid",
+    });
+  });
+
+  it("ignores benign stderr session notices", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      sessionId: "copilot-session-1",
+      exitCode: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+      },
+    });
+
+    expect(
+      parseCopilotJsonOutput(stdout, "Session created: copilot-session-1"),
+    ).toEqual({
+      sessionId: "copilot-session-1",
+      summary: "",
+      usage: {
+        inputTokens: 1,
+        cachedInputTokens: 0,
+        outputTokens: 1,
+      },
+      costUsd: null,
+      errorMessage: null,
+    });
+  });
+});
+
+describe("isCopilotUnknownSessionError", () => {
+  it("detects stale/unknown resume session errors from Copilot", () => {
+    expect(
+      isCopilotUnknownSessionError("", "Error: unknown session id abc"),
+    ).toBe(true);
+    expect(
+      isCopilotUnknownSessionError("", "resume failed: session not found"),
+    ).toBe(true);
+    expect(
+      isCopilotUnknownSessionError("", "No session or task matched for '--resume=9d3f...'"),
+    ).toBe(true);
+    expect(
+      isCopilotUnknownSessionError(
+        "",
+        "Error: invalid value 'task-123' for '--resume [<SESSION_ID>]': value is not a valid uuid",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated errors as session misses", () => {
+    expect(
+      isCopilotUnknownSessionError("", "Error: network timeout"),
+    ).toBe(false);
+  });
+});

--- a/packages/adapters/copilot-local/src/server/parse.ts
+++ b/packages/adapters/copilot-local/src/server/parse.ts
@@ -1,0 +1,350 @@
+import { asBoolean, asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+const STDERR_ERROR_RE =
+  /(error|failed|not\s+logged\s+in|unauthorized|forbidden|invalid|resume failed|session not found|unknown session|denied|timed\s*out)/i;
+
+function parseStderrFallback(stderr: string): string | null {
+  const first = firstNonEmptyLine(stderr);
+  if (!first) return null;
+  return STDERR_ERROR_RE.test(first) ? first : null;
+}
+
+function extractPayload(record: Record<string, unknown>): Record<string, unknown> {
+  const payload = parseObject(record.data);
+  return Object.keys(payload).length > 0 ? payload : record;
+}
+
+function extractType(record: Record<string, unknown>, payload: Record<string, unknown>): string {
+  return normalizeText(record.type || payload.type).toLowerCase();
+}
+
+function extractSessionId(record: Record<string, unknown>, payload: Record<string, unknown>): string | null {
+  const direct =
+    normalizeText(payload.sessionId) ||
+    normalizeText(payload.session_id) ||
+    normalizeText(payload.sessionID) ||
+    normalizeText(record.sessionId) ||
+    normalizeText(record.session_id) ||
+    normalizeText(record.sessionID);
+  if (direct) return direct;
+  const payloadSession = parseObject(payload.session);
+  const recordSession = parseObject(record.session);
+  const nested =
+    normalizeText(payloadSession.id) ||
+    normalizeText(payloadSession.sessionId) ||
+    normalizeText(recordSession.id) ||
+    normalizeText(recordSession.sessionId);
+  return nested || null;
+}
+
+function extractAssistantText(
+  type: string,
+  record: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): string {
+  if (type.includes("error")) return "";
+  if (type.startsWith("session.") || type === "user.message" || type === "assistant.turn_start" || type === "assistant.turn_end") {
+    return "";
+  }
+  if (type === "assistant.reasoning") return "";
+  if (type.startsWith("tool.execution_")) return "";
+
+  const direct =
+    normalizeText(payload.content) ||
+    normalizeText(payload.summary) ||
+    normalizeText(payload.output_text) ||
+    normalizeText(payload.text) ||
+    normalizeText(record.summary) ||
+    normalizeText(record.output_text) ||
+    normalizeText(record.text);
+  if (direct) return direct;
+
+  const payloadMessage = parseObject(payload.message);
+  const recordMessage = parseObject(record.message);
+  const message = Object.keys(payloadMessage).length > 0 ? payloadMessage : recordMessage;
+  const messageRole = normalizeText(message.role).toLowerCase();
+  if (!messageRole || messageRole === "assistant") {
+    const content = normalizeText(message.content) || normalizeText(message.text);
+    if (content) return content;
+  }
+
+  const payloadResponse = parseObject(payload.response);
+  const recordResponse = parseObject(record.response);
+  const response = Object.keys(payloadResponse).length > 0 ? payloadResponse : recordResponse;
+  const responseOutputText = normalizeText(response.output_text);
+  if (responseOutputText) return responseOutputText;
+
+  const choices = Array.isArray(payload.choices)
+    ? payload.choices
+    : Array.isArray(record.choices)
+      ? record.choices
+      : [];
+  for (const rawChoice of choices) {
+    const choice = parseObject(rawChoice);
+    const choiceMessage = parseObject(choice.message);
+    const content =
+      normalizeText(choiceMessage.content) ||
+      normalizeText(choiceMessage.text) ||
+      normalizeText(choice.text);
+    if (content) return content;
+  }
+
+  return "";
+}
+
+function readErrorValue(value: unknown): string {
+  const direct = normalizeText(value);
+  if (direct) return direct;
+  const record = parseObject(value);
+  const message =
+    normalizeText(record.message) ||
+    normalizeText(record.error) ||
+    normalizeText(record.code) ||
+    normalizeText(record.reason) ||
+    normalizeText(record.content);
+  if (message) return message;
+  return safeStringify(value);
+}
+
+function extractError(
+  type: string,
+  record: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): string {
+  const directError =
+    readErrorValue(payload.error) ||
+    readErrorValue(record.error);
+  if (directError) return directError;
+
+  if (type === "tool.execution_complete") {
+    const success = asBoolean(payload.success, true);
+    if (!success) {
+      return (
+        readErrorValue(payload.result) ||
+        readErrorValue(payload.message) ||
+        "Tool execution failed."
+      );
+    }
+  }
+
+  if (type === "result") {
+    const exitCode = asNumber(payload.exitCode, asNumber(record.exitCode, 0));
+    if (exitCode !== 0) {
+      return readErrorValue(payload.message) || `Copilot exited with code ${exitCode}`;
+    }
+  }
+
+  if (type.includes("error")) {
+    return (
+      readErrorValue(payload.message) ||
+      readErrorValue(record.message) ||
+      safeStringify(payload) ||
+      safeStringify(record)
+    );
+  }
+
+  return "";
+}
+
+function applyUsageObject(
+  usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number },
+  usageObj: Record<string, unknown>,
+) {
+  const promptTokens = asNumber(usageObj.prompt_tokens, asNumber(usageObj.promptTokens, 0));
+  const inputTokens = asNumber(
+    usageObj.input_tokens,
+    asNumber(usageObj.inputTokens, promptTokens),
+  );
+  const outputTokens = asNumber(
+    usageObj.output_tokens,
+    asNumber(
+      usageObj.outputTokens,
+      asNumber(usageObj.completion_tokens, asNumber(usageObj.completionTokens, 0)),
+    ),
+  );
+  const cachedDetails = parseObject(usageObj.prompt_tokens_details);
+  const cachedInputTokens = asNumber(
+    usageObj.cached_input_tokens,
+    asNumber(
+      usageObj.cachedInputTokens,
+      asNumber(cachedDetails.cached_tokens, asNumber(cachedDetails.cachedTokens, 0)),
+    ),
+  );
+
+  usage.inputTokens = Math.max(usage.inputTokens, inputTokens);
+  usage.outputTokens = Math.max(usage.outputTokens, outputTokens);
+  usage.cachedInputTokens = Math.max(usage.cachedInputTokens, cachedInputTokens);
+}
+
+function applyUsage(
+  usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number },
+  record: Record<string, unknown>,
+  payload: Record<string, unknown>,
+) {
+  const payloadUsage = parseObject(payload.usage);
+  const recordUsage = parseObject(record.usage);
+  const payloadResultUsage = parseObject(parseObject(payload.result).usage);
+  const recordResultUsage = parseObject(parseObject(record.result).usage);
+
+  if (Object.keys(payloadUsage).length > 0) applyUsageObject(usage, payloadUsage);
+  if (Object.keys(recordUsage).length > 0) applyUsageObject(usage, recordUsage);
+  if (Object.keys(payloadResultUsage).length > 0) applyUsageObject(usage, payloadResultUsage);
+  if (Object.keys(recordResultUsage).length > 0) applyUsageObject(usage, recordResultUsage);
+
+  const inlineInputTokens = asNumber(
+    payload.inputTokens,
+    asNumber(payload.input_tokens, asNumber(record.inputTokens, asNumber(record.input_tokens, 0))),
+  );
+  const inlineOutputTokens = asNumber(
+    payload.outputTokens,
+    asNumber(payload.output_tokens, asNumber(record.outputTokens, asNumber(record.output_tokens, 0))),
+  );
+  const inlineCachedInputTokens = asNumber(
+    payload.cachedInputTokens,
+    asNumber(
+      payload.cached_input_tokens,
+      asNumber(record.cachedInputTokens, asNumber(record.cached_input_tokens, 0)),
+    ),
+  );
+
+  usage.inputTokens = Math.max(usage.inputTokens, inlineInputTokens);
+  usage.outputTokens = Math.max(usage.outputTokens, inlineOutputTokens);
+  usage.cachedInputTokens = Math.max(usage.cachedInputTokens, inlineCachedInputTokens);
+}
+
+function extractCost(record: Record<string, unknown>, payload: Record<string, unknown>): number | null {
+  const candidate = asNumber(
+    payload.costUsd,
+    asNumber(
+      payload.cost_usd,
+      asNumber(
+        payload.cost,
+        asNumber(record.costUsd, asNumber(record.cost_usd, asNumber(record.cost, Number.NaN))),
+      ),
+    ),
+  );
+  return Number.isFinite(candidate) ? candidate : null;
+}
+
+function parseObjects(stdout: string): Record<string, unknown>[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+  const value = parseJson(trimmed);
+  if (value && typeof value === "object") {
+    if (!Array.isArray(value)) return [value as Record<string, unknown>];
+    const entries: Record<string, unknown>[] = [];
+    for (const item of value) {
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        entries.push(item as Record<string, unknown>);
+      }
+    }
+    if (entries.length > 0) return entries;
+  }
+  const parsed: Record<string, unknown>[] = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const lineValue = parseJson(line);
+    if (!lineValue || typeof lineValue !== "object" || Array.isArray(lineValue)) continue;
+    parsed.push(lineValue as Record<string, unknown>);
+  }
+  return parsed;
+}
+
+export function parseCopilotJsonOutput(stdout: string, stderr = "") {
+  let sessionId: string | null = null;
+  const messages: string[] = [];
+  const errors: string[] = [];
+  const usage = {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+  };
+  let costUsd: number | null = null;
+  const records = parseObjects(stdout);
+
+  if (records.length === 0) {
+    const trimmed = stdout.trim();
+    if (!trimmed) {
+      return {
+        sessionId,
+        summary: "",
+        usage,
+        costUsd,
+        errorMessage: parseStderrFallback(stderr),
+      };
+    }
+
+    const first = firstNonEmptyLine(trimmed);
+    const looksLikeError =
+      /(error|failed|not\s+logged\s+in|unauthorized|forbidden|invalid|resume\s+failed|invalid\s+resume|session\s+not\s+found|unknown\s+session|no\s+such\s+session)/i.test(first);
+    return {
+      sessionId,
+      summary: looksLikeError ? "" : trimmed,
+      usage,
+      costUsd,
+      errorMessage: looksLikeError ? first : null,
+    };
+  }
+
+  for (const record of records) {
+    const payload = extractPayload(record);
+    const type = extractType(record, payload);
+    const nextSessionId = extractSessionId(record, payload);
+    if (nextSessionId) sessionId = nextSessionId;
+
+    const text = extractAssistantText(type, record, payload);
+    if (text) messages.push(text);
+
+    const error = extractError(type, record, payload);
+    if (error) errors.push(error);
+
+    applyUsage(usage, record, payload);
+
+    const nextCost = extractCost(record, payload);
+    if (nextCost !== null) {
+      costUsd = costUsd === null ? nextCost : Math.max(costUsd, nextCost);
+    }
+  }
+
+  return {
+    sessionId,
+    summary: messages.join("\n\n").trim(),
+    usage,
+    costUsd,
+    errorMessage: errors.length > 0 ? errors.join("\n") : parseStderrFallback(stderr),
+  };
+}
+
+export function isCopilotUnknownSessionError(stdout: string, stderr: string): boolean {
+  const haystack = `${stdout}\n${stderr}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+
+  return /unknown\s+session|session\b.*\bnot\s+found|invalid\s+resume|resume\b.*\bfailed|stale\s+session|no\s+such\s+session|no\s+session\s+or\s+task\s+matched|invalid\s+value.+--resume/i.test(
+    haystack,
+  );
+}

--- a/packages/adapters/copilot-local/src/server/test.ts
+++ b/packages/adapters/copilot-local/src/server/test.ts
@@ -1,0 +1,158 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  ensureAbsoluteDirectory,
+  ensureCommandResolvable,
+  ensurePathInEnv,
+  parseObject,
+  runChildProcess,
+} from "@paperclipai/adapter-utils/server-utils";
+import { parseCopilotJsonOutput } from "./parse.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
+  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+const COPILOT_AUTH_REQUIRED_RE =
+  /(?:auth(?:entication)?\s+required|not\s+logged\s+in|please\s+run\s+copilot\s+(?:auth|login)|unauthorized|forbidden|token\s+expired)/i;
+
+import { applyCopilotAuthEnvAliases } from "./auth-env.js";
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "copilot");
+  const cwd = asString(config.cwd, process.cwd());
+
+  try {
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+    checks.push({
+      code: "copilot_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "copilot_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  applyCopilotAuthEnvAliases(env);
+  const runtimeEnv = Object.fromEntries(
+    Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+
+  try {
+    await ensureCommandResolvable(command, cwd, runtimeEnv);
+    checks.push({
+      code: "copilot_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "copilot_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "copilot_cwd_invalid" && check.code !== "copilot_command_unresolvable");
+  if (canRunProbe) {
+    const probe = await runChildProcess(
+      `copilot-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command,
+      ["--allow-all-tools", "--output-format", "json", "--stream", "off", "-p", "Respond with hello."],
+      {
+        cwd,
+        env: runtimeEnv,
+        timeoutSec: 45,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+    const parsed = parseCopilotJsonOutput(probe.stdout, probe.stderr);
+    const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
+    const authEvidence = `${parsed.errorMessage ?? ""}\n${probe.stdout}\n${probe.stderr}`.trim();
+
+    if (probe.timedOut) {
+      checks.push({
+        code: "copilot_hello_probe_timed_out",
+        level: "warn",
+        message: "Copilot hello probe timed out.",
+        hint: "Retry the probe. If this persists, run the copilot command manually in this working directory.",
+      });
+    } else if ((probe.exitCode ?? 1) === 0 && !parsed.errorMessage) {
+      const summary = parsed.summary.trim();
+      const hasHello = /\bhello\b/i.test(summary);
+      checks.push({
+        code: hasHello ? "copilot_hello_probe_passed" : "copilot_hello_probe_unexpected_output",
+        level: hasHello ? "info" : "warn",
+        message: hasHello
+          ? "Copilot hello probe succeeded."
+          : "Copilot probe ran but did not return `hello` as expected.",
+        ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+      });
+    } else if (COPILOT_AUTH_REQUIRED_RE.test(authEvidence)) {
+      checks.push({
+        code: "copilot_hello_probe_auth_required",
+        level: "warn",
+        message: "Copilot CLI is installed, but authentication is not ready.",
+        ...(detail ? { detail } : {}),
+        hint: "Run `copilot login` (or configure credentials) and retry.",
+      });
+    } else {
+      checks.push({
+        code: "copilot_hello_probe_failed",
+        level: "error",
+        message: "Copilot hello probe failed.",
+        ...(detail ? { detail } : {}),
+        hint: "Run the copilot command manually with --output-format json to inspect output.",
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/copilot-local/src/ui/build-config.test.ts
+++ b/packages/adapters/copilot-local/src/ui/build-config.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { buildCopilotLocalConfig } from "./build-config.js";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "copilot_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: true,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    ...overrides,
+  };
+}
+
+describe("buildCopilotLocalConfig", () => {
+  it("builds config with merged env vars and defaults", () => {
+    const config = buildCopilotLocalConfig(
+      makeValues({
+        cwd: "/workspace/repo",
+        instructionsFilePath: ".paperclip/AGENTS.md",
+        promptTemplate: "Do work",
+        bootstrapPrompt: "Bootstrap",
+        command: "copilot",
+        extraArgs: "--trace, --jsonl",
+        envVars: "OPENAI_API_KEY=abc\nINVALID-KEY=ignored",
+      }),
+    );
+
+    expect(config).toMatchObject({
+      cwd: "/workspace/repo",
+      instructionsFilePath: ".paperclip/AGENTS.md",
+      promptTemplate: "Do work",
+      bootstrapPromptTemplate: "Bootstrap",
+      model: "claude-sonnet-4.6",
+      command: "copilot",
+      extraArgs: ["--trace", "--jsonl"],
+      timeoutSec: 0,
+      graceSec: 15,
+      env: {
+        OPENAI_API_KEY: { type: "plain", value: "abc" },
+      },
+    });
+  });
+
+  it("includes copilot-specific fields from the create form", () => {
+    const config = buildCopilotLocalConfig(
+      makeValues({
+        model: "gpt-4.1",
+        thinkingEffort: "xhigh",
+        dangerouslyBypassSandbox: true,
+        workspaceStrategyType: "git_worktree",
+        workspaceBaseRef: "main",
+        workspaceBranchTemplate: "paperclip/{{issue.number}}",
+        worktreeParentDir: "/worktrees",
+        runtimeServicesJson: JSON.stringify({ services: [{ name: "db", command: "docker compose up db" }] }),
+      }),
+    );
+
+    expect(config).toMatchObject({
+      model: "gpt-4.1",
+      effort: "xhigh",
+      dangerouslyBypassApprovalsAndSandbox: true,
+      workspaceStrategy: {
+        type: "git_worktree",
+        baseRef: "main",
+        branchTemplate: "paperclip/{{issue.number}}",
+        worktreeParentDir: "/worktrees",
+      },
+      workspaceRuntime: {
+        services: [{ name: "db", command: "docker compose up db" }],
+      },
+    });
+  });
+});

--- a/packages/adapters/copilot-local/src/ui/build-config.ts
+++ b/packages/adapters/copilot-local/src/ui/build-config.ts
@@ -1,0 +1,102 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_COPILOT_LOCAL_MODEL } from "../index.js";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function buildCopilotLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  if (v.bootstrapPrompt) ac.bootstrapPromptTemplate = v.bootstrapPrompt;
+  ac.model = v.model || DEFAULT_COPILOT_LOCAL_MODEL;
+  if (v.thinkingEffort) ac.effort = v.thinkingEffort;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  if (typeof v.dangerouslyBypassSandbox === "boolean") {
+    ac.dangerouslyBypassApprovalsAndSandbox = v.dangerouslyBypassSandbox;
+  }
+  if (v.workspaceStrategyType === "git_worktree") {
+    ac.workspaceStrategy = {
+      type: "git_worktree",
+      ...(v.workspaceBaseRef ? { baseRef: v.workspaceBaseRef } : {}),
+      ...(v.workspaceBranchTemplate ? { branchTemplate: v.workspaceBranchTemplate } : {}),
+      ...(v.worktreeParentDir ? { worktreeParentDir: v.worktreeParentDir } : {}),
+    };
+  }
+  const runtimeServices = parseJsonObject(v.runtimeServicesJson ?? "");
+  if (runtimeServices && Array.isArray(runtimeServices.services)) {
+    ac.workspaceRuntime = runtimeServices;
+  }
+  return ac;
+}

--- a/packages/adapters/copilot-local/src/ui/index.ts
+++ b/packages/adapters/copilot-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { createCopilotStdoutParser, parseCopilotStdoutLine } from "./parse-stdout.js";
+export { buildCopilotLocalConfig } from "./build-config.js";

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { createCopilotStdoutParser, parseCopilotStdoutLine } from "./parse-stdout.js";
+
+const ts = "2026-04-23T00:00:00.000Z";
+
+describe("parseCopilotStdoutLine", () => {
+  it("parses assistant message events from nested data payload", () => {
+    const line = JSON.stringify({
+      type: "assistant.message",
+      data: { content: "hello from copilot" },
+    });
+
+    expect(parseCopilotStdoutLine(line, ts)).toEqual([
+      { kind: "assistant", ts, text: "hello from copilot" },
+    ]);
+  });
+
+  it("parses tool execution start/complete events", () => {
+    const start = JSON.stringify({
+      type: "tool.execution_start",
+      data: { toolCallId: "toolu_1", toolName: "bash", arguments: "pwd" },
+    });
+    const complete = JSON.stringify({
+      type: "tool.execution_complete",
+      data: {
+        toolCallId: "toolu_1",
+        toolName: "bash",
+        success: true,
+        result: { content: "/workspace/repo" },
+      },
+    });
+
+    expect(parseCopilotStdoutLine(start, ts)).toEqual([
+      { kind: "tool_call", ts, toolUseId: "toolu_1", name: "bash", input: "pwd" },
+    ]);
+    expect(parseCopilotStdoutLine(complete, ts)).toEqual([
+      {
+        kind: "tool_result",
+        ts,
+        toolUseId: "toolu_1",
+        toolName: "bash",
+        content: "/workspace/repo",
+        isError: false,
+      },
+    ]);
+  });
+
+  it("parses result events with init metadata and usage", () => {
+    const line = JSON.stringify({
+      type: "result",
+      sessionId: "copilot-session-1",
+      exitCode: 0,
+      usage: {
+        input_tokens: 120,
+        output_tokens: 40,
+        cached_input_tokens: 5,
+      },
+    });
+
+    expect(parseCopilotStdoutLine(line, ts)).toEqual([
+      {
+        kind: "init",
+        ts,
+        model: "copilot",
+        sessionId: "copilot-session-1",
+      },
+      {
+        kind: "result",
+        ts,
+        text: "completed",
+        inputTokens: 120,
+        outputTokens: 40,
+        cachedTokens: 5,
+        costUsd: 0,
+        subtype: "completed",
+        isError: false,
+        errors: [],
+      },
+    ]);
+  });
+
+  it("suppresses noisy session events", () => {
+    const line = JSON.stringify({
+      type: "session.skills_loaded",
+      data: { skills: [] },
+    });
+
+    expect(parseCopilotStdoutLine(line, ts)).toEqual([]);
+  });
+
+  it("carries session.tools_updated model into the later result init entry", () => {
+    const parser = createCopilotStdoutParser();
+
+    expect(
+      parser.parseLine(
+        JSON.stringify({
+          type: "session.tools_updated",
+          data: { model: "claude-sonnet-4.6" },
+        }),
+        ts,
+      ),
+    ).toEqual([]);
+
+    expect(
+      parser.parseLine(
+        JSON.stringify({
+          type: "result",
+          sessionId: "copilot-session-1",
+          exitCode: 0,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        ts,
+      ),
+    ).toEqual([
+      {
+        kind: "init",
+        ts,
+        model: "claude-sonnet-4.6",
+        sessionId: "copilot-session-1",
+      },
+      {
+        kind: "result",
+        ts,
+        text: "completed",
+        inputTokens: 1,
+        outputTokens: 1,
+        cachedTokens: 0,
+        costUsd: 0,
+        subtype: "completed",
+        isError: false,
+        errors: [],
+      },
+    ]);
+  });
+
+  it("emits stderr entries for explicit error events", () => {
+    const line = JSON.stringify({
+      type: "error",
+      data: { message: "authentication required" },
+    });
+
+    expect(parseCopilotStdoutLine(line, ts)).toEqual([
+      { kind: "stderr", ts, text: "authentication required" },
+    ]);
+  });
+});

--- a/packages/adapters/copilot-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/copilot-local/src/ui/parse-stdout.ts
@@ -1,0 +1,247 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asPayload(record: Record<string, unknown>): Record<string, unknown> {
+  const payload = asRecord(record.data);
+  return payload && Object.keys(payload).length > 0 ? payload : record;
+}
+
+function eventType(record: Record<string, unknown>, payload: Record<string, unknown>): string {
+  return normalizeText(record.type || payload.type).toLowerCase();
+}
+
+function extractSessionId(record: Record<string, unknown>, payload: Record<string, unknown>): string {
+  const direct =
+    normalizeText(payload.sessionId) ||
+    normalizeText(payload.session_id) ||
+    normalizeText(payload.sessionID) ||
+    normalizeText(record.sessionId) ||
+    normalizeText(record.session_id) ||
+    normalizeText(record.sessionID);
+  if (direct) return direct;
+  const payloadSession = asRecord(payload.session);
+  const recordSession = asRecord(record.session);
+  return (
+    normalizeText(payloadSession?.id) ||
+    normalizeText(payloadSession?.sessionId) ||
+    normalizeText(recordSession?.id) ||
+    normalizeText(recordSession?.sessionId)
+  );
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function extractErrorText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const record = asRecord(value);
+  if (!record) return "";
+  return (
+    normalizeText(record.message) ||
+    normalizeText(record.error) ||
+    normalizeText(record.code) ||
+    stringifyUnknown(value).trim()
+  );
+}
+
+type CopilotParserState = { pendingModel: string };
+
+function nextCopilotEntries(
+  line: string,
+  ts: string,
+  state: CopilotParserState,
+): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) return [{ kind: "stdout", ts, text: line }];
+
+  const payload = asPayload(parsed);
+  const type = eventType(parsed, payload);
+
+  if (type.startsWith("session.")) {
+    const model = normalizeText(payload.model) || normalizeText(parsed.model);
+    if (model) state.pendingModel = model;
+    return [];
+  }
+
+  if (type === "assistant.turn_start" || type === "assistant.turn_end") {
+    return [];
+  }
+
+  if (type === "user.message") {
+    const text = normalizeText(payload.content) || normalizeText(parsed.content);
+    return text ? [{ kind: "user", ts, text }] : [];
+  }
+
+  if (type === "assistant.reasoning") {
+    const text = normalizeText(payload.content) || normalizeText(payload.text);
+    return text ? [{ kind: "thinking", ts, text }] : [];
+  }
+
+  if (type === "assistant.message") {
+    const text =
+      normalizeText(payload.content) ||
+      normalizeText(payload.text) ||
+      normalizeText(asRecord(payload.message)?.content);
+    return text ? [{ kind: "assistant", ts, text }] : [];
+  }
+
+  if (type === "tool.execution_start") {
+    const toolName = normalizeText(payload.toolName) || normalizeText(payload.name) || "tool";
+    const toolUseId =
+      normalizeText(payload.toolCallId) ||
+      normalizeText(payload.tool_use_id) ||
+      normalizeText(payload.id) ||
+      toolName;
+    const input = payload.arguments ?? payload.input ?? {};
+    return [{ kind: "tool_call", ts, name: toolName, toolUseId, input }];
+  }
+
+  if (type === "tool.execution_complete") {
+    const toolName = normalizeText(payload.toolName) || normalizeText(payload.name) || "tool";
+    const toolUseId =
+      normalizeText(payload.toolCallId) ||
+      normalizeText(payload.tool_use_id) ||
+      normalizeText(payload.id) ||
+      toolName;
+    const result = asRecord(payload.result);
+    const content =
+      normalizeText(result?.content) ||
+      normalizeText(result?.detailedContent) ||
+      normalizeText(result?.summary) ||
+      normalizeText(payload.message) ||
+      stringifyUnknown(result).trim() ||
+      `${toolName} ${asBoolean(payload.success, true) ? "completed" : "failed"}`;
+
+    return [{
+      kind: "tool_result",
+      ts,
+      toolUseId,
+      toolName,
+      content,
+      isError: !asBoolean(payload.success, true),
+    }];
+  }
+
+  if (type === "result") {
+    const usageObj = asRecord(payload.usage) ?? asRecord(parsed.usage);
+    const inputTokens = asNumber(
+      usageObj?.input_tokens,
+      asNumber(usageObj?.inputTokens, asNumber(usageObj?.prompt_tokens, asNumber(usageObj?.promptTokens, 0))),
+    );
+    const outputTokens = asNumber(
+      usageObj?.output_tokens,
+      asNumber(
+        usageObj?.outputTokens,
+        asNumber(usageObj?.completion_tokens, asNumber(usageObj?.completionTokens, 0)),
+      ),
+    );
+    const cachedTokens = asNumber(
+      usageObj?.cached_input_tokens,
+      asNumber(usageObj?.cachedInputTokens, 0),
+    );
+    const costUsd = asNumber(
+      payload.costUsd,
+      asNumber(payload.cost_usd, asNumber(payload.cost, asNumber(parsed.costUsd, asNumber(parsed.cost, 0)))),
+    );
+    const exitCode = asNumber(payload.exitCode, asNumber(parsed.exitCode, 0));
+    const errorText = extractErrorText(payload.error ?? parsed.error ?? payload.message ?? parsed.message);
+    const text =
+      normalizeText(payload.summary) ||
+      normalizeText(parsed.summary) ||
+      (exitCode === 0 ? "completed" : "failed");
+    const sessionId = extractSessionId(parsed, payload);
+    const entries: TranscriptEntry[] = [];
+    if (sessionId) {
+      const model =
+        normalizeText(payload.model) ||
+        normalizeText(parsed.model) ||
+        state.pendingModel;
+      entries.push({
+        kind: "init",
+        ts,
+        model: model || "copilot",
+        sessionId,
+      });
+      state.pendingModel = "";
+    }
+    entries.push({
+      kind: "result",
+      ts,
+      text,
+      inputTokens,
+      outputTokens,
+      cachedTokens,
+      costUsd,
+      subtype: exitCode === 0 ? "completed" : "failed",
+      isError: exitCode !== 0 || errorText.length > 0,
+      errors: errorText ? [errorText] : [],
+    });
+    return entries;
+  }
+
+  if (type.includes("error")) {
+    const text = extractErrorText(payload.error ?? parsed.error ?? payload.message ?? parsed.message);
+    return [{ kind: "stderr", ts, text: text || line }];
+  }
+
+  const legacySummary =
+    normalizeText(parsed.summary) ||
+    normalizeText(parsed.output_text) ||
+    normalizeText(parsed.text);
+  if (legacySummary) {
+    return [{ kind: "assistant", ts, text: legacySummary }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}
+
+export function createCopilotStdoutParser() {
+  const state: CopilotParserState = { pendingModel: "" };
+  return {
+    parseLine(line: string, ts: string) {
+      return nextCopilotEntries(line, ts, state);
+    },
+    reset() {
+      state.pendingModel = "";
+    },
+  };
+}
+
+export function parseCopilotStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  return nextCopilotEntries(line, ts, { pendingModel: "" });
+}

--- a/packages/adapters/copilot-local/tsconfig.json
+++ b/packages/adapters/copilot-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/copilot-local/vitest.config.ts
+++ b/packages/adapters/copilot-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -3,7 +3,7 @@ import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
 export const type = "opencode_local";
 export const label = "OpenCode (local)";
 
-export const DEFAULT_OPENCODE_LOCAL_MODEL = "openai/gpt-5.2-codex";
+export const DEFAULT_OPENCODE_LOCAL_MODEL = "github-copilot/gpt-5.3-codex";
 
 export const models: Array<{ id: string; label: string }> = [
   { id: DEFAULT_OPENCODE_LOCAL_MODEL, label: DEFAULT_OPENCODE_LOCAL_MODEL },
@@ -11,6 +11,13 @@ export const models: Array<{ id: string; label: string }> = [
   { id: "openai/gpt-5.2", label: "openai/gpt-5.2" },
   { id: "openai/gpt-5.1-codex-max", label: "openai/gpt-5.1-codex-max" },
   { id: "openai/gpt-5.1-codex-mini", label: "openai/gpt-5.1-codex-mini" },
+  { id: "github-copilot/gpt-5.3-codex", label: "github-copilot/gpt-5.3-codex" },
+  { id: "github-copilot/gpt-5.2-codex", label: "github-copilot/gpt-5.2-codex" },
+  { id: "github-copilot/claude-opus-4.7", label: "github-copilot/claude-opus-4.7" },
+  { id: "github-copilot/claude-opus-4.6", label: "github-copilot/claude-opus-4.6" },
+  { id: "github-copilot/claude-sonnet-4.6", label: "github-copilot/claude-sonnet-4.6" },
+  { id: "github-copilot/claude-haiku-4.5", label: "github-copilot/claude-haiku-4.5" },
+  { id: "github-copilot/gemini-3-pro-preview", label: "github-copilot/gemini-3-pro-preview" },
 ];
 
 export const modelProfiles: AdapterModelProfileDefinition[] = [

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "process",
   "http",
   "claude_local",
+  "copilot_local",
   "codex_local",
   "gemini_local",
   "opencode_local",

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
+import { models as copilotFallbackModels } from "@paperclipai/adapter-copilot-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
 import { models as opencodeFallbackModels } from "@paperclipai/adapter-opencode-local";
 import { resetOpenCodeModelsCacheForTests } from "@paperclipai/adapter-opencode-local/server";
@@ -29,6 +30,11 @@ describe("adapter model listing", () => {
 
     expect(models).toEqual(codexFallbackModels);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns copilot fallback models", async () => {
+    const models = await listAdapterModels("copilot_local");
+    expect(models).toEqual(copilotFallbackModels);
   });
 
   it("loads codex models dynamically and merges fallback options", async () => {

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { sessionCodec as claudeSessionCodec } from "@paperclipai/adapter-claude-local/server";
+import {
+  sessionCodec as copilotSessionCodec,
+  isCopilotUnknownSessionError,
+} from "@paperclipai/adapter-copilot-local/server";
 import { sessionCodec as codexSessionCodec, isCodexUnknownSessionError } from "@paperclipai/adapter-codex-local/server";
 import {
   sessionCodec as cursorSessionCodec,
@@ -52,6 +56,24 @@ describe("adapter session codecs", () => {
       cwd: "/tmp/codex",
     });
     expect(codexSessionCodec.getDisplayId?.(serialized ?? null)).toBe("codex-session-1");
+  });
+
+  it("normalizes copilot session params with cwd", () => {
+    const parsed = copilotSessionCodec.deserialize({
+      sessionID: "copilot-session-1",
+      cwd: "/tmp/copilot",
+    });
+    expect(parsed).toEqual({
+      sessionId: "copilot-session-1",
+      cwd: "/tmp/copilot",
+    });
+
+    const serialized = copilotSessionCodec.serialize(parsed);
+    expect(serialized).toEqual({
+      sessionId: "copilot-session-1",
+      cwd: "/tmp/copilot",
+    });
+    expect(copilotSessionCodec.getDisplayId?.(serialized ?? null)).toBe("copilot-session-1");
   });
 
   it("normalizes opencode session params with cwd", () => {
@@ -126,6 +148,23 @@ describe("codex resume recovery detection", () => {
     expect(
       isCodexUnknownSessionError(
         '{"type":"result","ok":true}',
+        "",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("copilot resume recovery detection", () => {
+  it("detects unknown session errors from copilot output", () => {
+    expect(
+      isCopilotUnknownSessionError(
+        "",
+        "resume failed: session not found",
+      ),
+    ).toBe(true);
+    expect(
+      isCopilotUnknownSessionError(
+        "{\"type\":\"result\",\"ok\":true}",
         "",
       ),
     ).toBe(false);

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -3,6 +3,7 @@
  */
 export const BUILTIN_ADAPTER_TYPES = new Set([
   "claude_local",
+  "copilot_local",
   "codex_local",
   "cursor",
   "gemini_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -15,6 +15,13 @@ import {
   modelProfiles as claudeModelProfiles,
 } from "@paperclipai/adapter-claude-local";
 import {
+  execute as copilotExecute,
+  testEnvironment as copilotTestEnvironment,
+  sessionCodec as copilotSessionCodec,
+  listCopilotModels,
+} from "@paperclipai/adapter-copilot-local/server";
+import { agentConfigurationDoc as copilotAgentConfigurationDoc, models as copilotModels } from "@paperclipai/adapter-copilot-local";
+import {
   execute as codexExecute,
   listCodexSkills,
   syncCodexSkills,
@@ -172,6 +179,21 @@ const codexLocalAdapter: ServerAdapterModule = {
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: codexAgentConfigurationDoc,
   getQuotaWindows: codexGetQuotaWindows,
+};
+
+const copilotLocalAdapter: ServerAdapterModule = {
+  type: "copilot_local",
+  execute: copilotExecute,
+  testEnvironment: copilotTestEnvironment,
+  sessionCodec: copilotSessionCodec,
+  sessionManagement: getAdapterSessionManagement("copilot_local") ?? undefined,
+  models: copilotModels,
+  listModels: listCopilotModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: copilotAgentConfigurationDoc,
 };
 
 const cursorLocalAdapter: ServerAdapterModule = {
@@ -336,6 +358,7 @@ const pausedOverrides = new Set<string>();
 function registerBuiltInAdapters() {
   for (const adapter of [
     claudeLocalAdapter,
+    copilotLocalAdapter,
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -72,6 +72,7 @@ import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { runClaudeLogin } from "@paperclipai/adapter-claude-local/server";
+import { DEFAULT_COPILOT_LOCAL_MODEL } from "@paperclipai/adapter-copilot-local";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
@@ -111,6 +112,7 @@ export function agentRoutes(
   // declare capability flags explicitly.
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
     claude_local: "instructionsFilePath",
+    copilot_local: "instructionsFilePath",
     codex_local: "instructionsFilePath",
     droid_local: "instructionsFilePath",
     gemini_local: "instructionsFilePath",
@@ -840,6 +842,10 @@ export function agentRoutes(
     }
     if (adapterType === "gemini_local" && !asNonEmptyString(next.model)) {
       next.model = DEFAULT_GEMINI_LOCAL_MODEL;
+      return ensureGatewayDeviceKey(adapterType, next);
+    }
+    if (adapterType === "copilot_local" && !asNonEmptyString(next.model)) {
+      next.model = DEFAULT_COPILOT_LOCAL_MODEL;
       return ensureGatewayDeviceKey(adapterType, next);
     }
     // OpenCode requires explicit model selection — no default

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -595,6 +595,10 @@ const RUNTIME_DEFAULT_RULES: Array<{ path: string[]; value: unknown }> = [
 ];
 
 const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; value: unknown }>> = {
+  copilot_local: [
+    { path: ["timeoutSec"], value: 0 },
+    { path: ["graceSec"], value: 15 },
+  ],
   codex_local: [
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -250,6 +250,7 @@ function mergeAdapterRecoveryMetadata(input: {
 const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved"]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
+  "copilot_local",
   "codex_local",
   "cursor",
   "gemini_local",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "./packages/shared" },
     { "path": "./packages/db" },
     { "path": "./packages/adapters/claude-local" },
+    { "path": "./packages/adapters/copilot-local" },
     { "path": "./packages/adapters/codex-local" },
     { "path": "./packages/adapters/cursor-local" },
     { "path": "./packages/adapters/droid-local" },

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "@lexical/link": "0.35.0",
     "@mdxeditor/editor": "^3.52.4",
     "@paperclipai/adapter-claude-local": "workspace:*",
+    "@paperclipai/adapter-copilot-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.test.ts
+++ b/ui/src/adapters/adapter-display-registry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { Code, Cpu } from "lucide-react";
+import {
+  getAdapterDisplay,
+  getAdapterLabel,
+} from "./adapter-display-registry";
+
+describe("adapter display registry", () => {
+  it("returns copilot-local display metadata", () => {
+    expect(getAdapterLabel("copilot_local")).toBe("Copilot (local)");
+    expect(getAdapterDisplay("copilot_local")).toMatchObject({
+      label: "Copilot",
+      description: "Local GitHub Copilot CLI agent",
+      icon: Code,
+    });
+  });
+
+  it("falls back for unknown adapters", () => {
+    expect(getAdapterLabel("custom_local")).toBe("Custom (local)");
+    expect(getAdapterDisplay("custom_local")).toMatchObject({
+      label: "Custom (local)",
+      description: "External local adapter",
+      icon: Cpu,
+    });
+  });
+});

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -64,6 +64,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     icon: Code,
     recommended: true,
   },
+  copilot_local: {
+    label: "Copilot",
+    description: "Local GitHub Copilot CLI agent",
+    icon: Code,
+  },
   gemini_local: {
     label: "Gemini CLI",
     description: "Local Gemini agent",

--- a/ui/src/adapters/copilot-local/config-fields.tsx
+++ b/ui/src/adapters/copilot-local/config-fields.tsx
@@ -1,0 +1,49 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  Field,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime. Authenticate with `copilot login` (or provide tokens in precedence order: COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN).";
+
+export function CopilotLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  if (hideInstructionsFile) return null;
+  return (
+    <Field label="Agent instructions file" hint={instructionsFileHint}>
+      <div className="flex items-center gap-2">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.instructionsFilePath ?? ""
+              : eff(
+                  "adapterConfig",
+                  "instructionsFilePath",
+                  String(config.instructionsFilePath ?? ""),
+                )
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="/absolute/path/to/AGENTS.md"
+        />
+        <ChoosePathButton />
+      </div>
+    </Field>
+  );
+}

--- a/ui/src/adapters/copilot-local/index.ts
+++ b/ui/src/adapters/copilot-local/index.ts
@@ -1,0 +1,16 @@
+import type { UIAdapterModule } from "../types";
+import {
+  buildCopilotLocalConfig,
+  createCopilotStdoutParser,
+  parseCopilotStdoutLine,
+} from "@paperclipai/adapter-copilot-local/ui";
+import { CopilotLocalConfigFields } from "./config-fields";
+
+export const copilotLocalUIAdapter: UIAdapterModule = {
+  type: "copilot_local",
+  label: "GitHub Copilot CLI (local)",
+  parseStdoutLine: parseCopilotStdoutLine,
+  createStdoutParser: createCopilotStdoutParser,
+  ConfigFields: CopilotLocalConfigFields,
+  buildAdapterConfig: buildCopilotLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -1,5 +1,6 @@
 import type { UIAdapterModule } from "./types";
 import { claudeLocalUIAdapter } from "./claude-local";
+import { copilotLocalUIAdapter } from "./copilot-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
@@ -51,6 +52,7 @@ function registerBuiltInUIAdapters() {
   for (const adapter of [
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
+    copilotLocalUIAdapter,
     geminiLocalUIAdapter,
     hermesLocalUIAdapter,
     openCodeLocalUIAdapter,

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -18,6 +18,8 @@ const ALL_FALSE: AdapterCapabilities = {
 const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   claude_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: true },
   codex_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: true },
+  // copilot_local does not expose listSkills/syncSkills in server registry.
+  copilot_local: { supportsInstructionsBundle: true, supportsSkills: false, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false },
   cursor: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   gemini_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   opencode_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -18,6 +18,7 @@ import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
 } from "@paperclipai/adapter-codex-local";
+import { DEFAULT_COPILOT_LOCAL_MODEL } from "@paperclipai/adapter-copilot-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import {
@@ -795,6 +796,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
                       nextValues.dangerouslyBypassSandbox =
                         DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+                    } else if (t === "copilot_local") {
+                      nextValues.model = DEFAULT_COPILOT_LOCAL_MODEL;
                     } else if (t === "gemini_local") {
                       nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
                     } else if (t === "cursor") {
@@ -814,6 +817,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                         model:
                           t === "codex_local"
                             ? DEFAULT_CODEX_LOCAL_MODEL
+                            : t === "copilot_local"
+                              ? DEFAULT_COPILOT_LOCAL_MODEL
                             : t === "gemini_local"
                               ? DEFAULT_GEMINI_LOCAL_MODEL
                             : t === "cursor"
@@ -913,6 +918,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     ({
                       claude_local: "claude",
                       codex_local: "codex",
+                      copilot_local: "copilot",
                       gemini_local: "gemini",
                       pi_local: "pi",
                       cursor: "agent",

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -100,11 +100,16 @@ import {
   ISSUE_OVERRIDE_ADAPTER_TYPES,
   type IssueModelLane,
 } from "../lib/issue-assignee-overrides";
-
 const STAGED_FILE_ACCEPT = "image/*,application/pdf,text/plain,text/markdown,application/json,text/csv,text/html,.md,.markdown";
 
 const ISSUE_THINKING_EFFORT_OPTIONS = {
   claude_local: [
+    { value: "", label: "Default" },
+    { value: "low", label: "Low" },
+    { value: "medium", label: "Medium" },
+    { value: "high", label: "High" },
+  ],
+  copilot_local: [
     { value: "", label: "Default" },
     { value: "low", label: "Low" },
     { value: "medium", label: "Medium" },
@@ -791,6 +796,8 @@ export function NewIssueDialog() {
         ? ISSUE_THINKING_EFFORT_OPTIONS.codex_local
         : assigneeAdapterType === "opencode_local"
           ? ISSUE_THINKING_EFFORT_OPTIONS.opencode_local
+          : assigneeAdapterType === "copilot_local"
+            ? ISSUE_THINKING_EFFORT_OPTIONS.copilot_local
           : ISSUE_THINKING_EFFORT_OPTIONS.claude_local;
     if (!validThinkingValues.some((option) => option.value === assigneeThinkingEffort)) {
       setAssigneeThinkingEffort("");
@@ -1027,8 +1034,10 @@ export function NewIssueDialog() {
   const assigneeOptionsTitle =
     assigneeAdapterType === "claude_local"
       ? "Claude options"
-      : assigneeAdapterType === "codex_local"
-        ? "Codex options"
+        : assigneeAdapterType === "codex_local"
+          ? "Codex options"
+        : assigneeAdapterType === "copilot_local"
+          ? "Copilot options"
         : assigneeAdapterType === "opencode_local"
           ? "OpenCode options"
         : "Agent options";
@@ -1037,6 +1046,8 @@ export function NewIssueDialog() {
       ? ISSUE_THINKING_EFFORT_OPTIONS.codex_local
       : assigneeAdapterType === "opencode_local"
         ? ISSUE_THINKING_EFFORT_OPTIONS.opencode_local
+      : assigneeAdapterType === "copilot_local"
+        ? ISSUE_THINKING_EFFORT_OPTIONS.copilot_local
       : ISSUE_THINKING_EFFORT_OPTIONS.claude_local;
   const recentAssigneeIds = useMemo(() => getRecentAssigneeIds(), [newIssueOpen]);
   const recentAssigneeOptionIds = useMemo(

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -40,6 +40,7 @@ import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL
 } from "@paperclipai/adapter-codex-local";
+import { DEFAULT_COPILOT_LOCAL_MODEL } from "@paperclipai/adapter-copilot-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
@@ -220,6 +221,7 @@ export function OnboardingWizard() {
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
     claude_local: "claude",
     codex_local: "codex",
+    copilot_local: "copilot",
     gemini_local: "gemini",
     pi_local: "pi",
     cursor: "agent",
@@ -321,6 +323,8 @@ export function OnboardingWizard() {
       model:
         adapterType === "codex_local"
           ? model || DEFAULT_CODEX_LOCAL_MODEL
+          : adapterType === "copilot_local"
+            ? model || DEFAULT_COPILOT_LOCAL_MODEL
           : adapterType === "gemini_local"
             ? model || DEFAULT_GEMINI_LOCAL_MODEL
           : adapterType === "cursor"
@@ -774,8 +778,13 @@ export function OnboardingWizard() {
                             setAdapterType(nextType);
                             if (nextType === "codex_local" && !model) {
                               setModel(DEFAULT_CODEX_LOCAL_MODEL);
+                              return;
                             }
-                            if (nextType !== "codex_local") {
+                            if (nextType === "copilot_local") {
+                              setModel(DEFAULT_COPILOT_LOCAL_MODEL);
+                              return;
+                            }
+                            if (nextType !== "codex_local" && nextType !== "copilot_local") {
                               setModel("");
                             }
                           }}
@@ -829,13 +838,17 @@ export function OnboardingWizard() {
                                 setModel(DEFAULT_GEMINI_LOCAL_MODEL);
                                 return;
                               }
-                              if (nextType === "cursor" && !model) {
-                                setModel(DEFAULT_CURSOR_LOCAL_MODEL);
-                                return;
-                              }
-                              if (nextType === "opencode_local") {
-                                if (!model.includes("/")) {
-                                  setModel("");
+                               if (nextType === "cursor" && !model) {
+                                 setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+                                 return;
+                               }
+                                if (nextType === "copilot_local") {
+                                  setModel(DEFAULT_COPILOT_LOCAL_MODEL);
+                                  return;
+                                }
+                               if (nextType === "opencode_local") {
+                                 if (!model.includes("/")) {
+                                   setModel("");
                                 }
                                 return;
                               }
@@ -1028,7 +1041,9 @@ export function OnboardingWizard() {
                             {adapterType === "cursor"
                               ? `${effectiveAdapterCommand} -p --mode ask --output-format json \"Respond with hello.\"`
                               : adapterType === "codex_local"
-                              ? `${effectiveAdapterCommand} exec --json -`
+                                ? `${effectiveAdapterCommand} exec --json -`
+                              : adapterType === "copilot_local"
+                                ? `${effectiveAdapterCommand} --allow-all-tools --output-format json --stream off -p "Respond with hello."`
                               : adapterType === "gemini_local"
                                 ? `${effectiveAdapterCommand} --output-format json "Respond with hello."`
                               : adapterType === "opencode_local"
@@ -1041,26 +1056,31 @@ export function OnboardingWizard() {
                           </p>
                           {adapterType === "cursor" ||
                           adapterType === "codex_local" ||
+                          adapterType === "copilot_local" ||
                           adapterType === "gemini_local" ||
                           adapterType === "opencode_local" ? (
                             <p className="text-muted-foreground">
                               If auth fails, set{" "}
-                              <span className="font-mono">
-                                {adapterType === "cursor"
-                                  ? "CURSOR_API_KEY"
-                                  : adapterType === "gemini_local"
-                                    ? "GEMINI_API_KEY"
+                                <span className="font-mono">
+                                   {adapterType === "cursor"
+                                     ? "CURSOR_API_KEY"
+                                   : adapterType === "copilot_local"
+                                       ? "COPILOT_GITHUB_TOKEN, GH_TOKEN, then GITHUB_TOKEN (in that order)"
+                                    : adapterType === "gemini_local"
+                                      ? "GEMINI_API_KEY"
                                     : "OPENAI_API_KEY"}
-                              </span>{" "}
+                                </span>{" "}
                               in env or run{" "}
                               <span className="font-mono">
                                 {adapterType === "cursor"
                                   ? "agent login"
-                                  : adapterType === "codex_local"
-                                    ? "codex login"
-                                    : adapterType === "gemini_local"
-                                      ? "gemini auth"
-                                      : "opencode auth login"}
+                                    : adapterType === "codex_local"
+                                      ? "codex login"
+                                    : adapterType === "copilot_local"
+                                      ? "copilot login"
+                                     : adapterType === "gemini_local"
+                                       ? "gemini auth"
+                                    : "opencode auth login"}
                               </span>
                               .
                             </p>

--- a/ui/src/lib/issue-assignee-overrides.ts
+++ b/ui/src/lib/issue-assignee-overrides.ts
@@ -1,5 +1,6 @@
 export const ISSUE_OVERRIDE_ADAPTER_TYPES = new Set([
   "claude_local",
+  "copilot_local",
   "codex_local",
   "opencode_local",
 ]);
@@ -47,7 +48,7 @@ export function buildAssigneeAdapterOverrides(
       adapterConfig.modelReasoningEffort = input.thinkingEffortOverride;
     } else if (adapterType === "opencode_local") {
       adapterConfig.variant = input.thinkingEffortOverride;
-    } else if (adapterType === "claude_local") {
+    } else if (adapterType === "claude_local" || adapterType === "copilot_local") {
       adapterConfig.effort = input.thinkingEffortOverride;
     }
   }

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -22,6 +22,7 @@ const joinAdapterOptions: AgentAdapterType[] = [...AGENT_ADAPTER_TYPES];
 const ENABLED_INVITE_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
+  "copilot_local",
   "gemini_local",
   "opencode_local",
   "pi_local",

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -32,6 +32,7 @@ import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
   DEFAULT_CODEX_LOCAL_MODEL,
 } from "@paperclipai/adapter-codex-local";
+import { DEFAULT_COPILOT_LOCAL_MODEL } from "@paperclipai/adapter-copilot-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 
@@ -44,6 +45,8 @@ function createValuesForAdapterType(
     nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
     nextValues.dangerouslyBypassSandbox =
       DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+  } else if (adapterType === "copilot_local") {
+    nextValues.model = DEFAULT_COPILOT_LOCAL_MODEL;
   } else if (adapterType === "gemini_local") {
     nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
   } else if (adapterType === "cursor") {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/db",
       "packages/adapter-utils",
       "packages/adapters/claude-local",
+      "packages/adapters/copilot-local",
       "packages/adapters/codex-local",
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",


### PR DESCRIPTION
## Problem

Agent child processes spawned by `runChildProcess` inherit the paperclip
server's systemd readiness socket (`NOTIFY_SOCKET`) and socket-activation
vars (`LISTEN_FDS`/`LISTEN_PID`/`LISTEN_FDNAMES`), so an agent subprocess can
reach the service's own readiness channel. Every boot then logs `Got
notification message from PID N, but reception only permitted for main PID M`.

## Fix

In `runChildProcess` (`packages/adapter-utils/src/server-utils.ts`), in the
same block that already strips the Claude Code nesting-guard vars, strip
`NOTIFY_SOCKET` / `LISTEN_FDS` / `LISTEN_PID` / `LISTEN_FDNAMES` from the
**merged** env (`process.env` + `opts.env`) after the merge — not just from
the `process.env` side — since every local adapter builds `opts.env` as
`{ ...process.env, ...env }` and would otherwise re-leak these vars even
after `sanitizeInheritedPaperclipEnv` strips `PAPERCLIP_*` keys from the
`process.env` copy.

This is a single chokepoint fix covering all local adapters (pi-local,
claude-local, codex-local, cursor-local, gemini-local, opencode-local,
copilot-local, acpx-local). Remote/sandbox execution targets bypass
`runChildProcess` and are unaffected.

Scope: env-strip only, per the linked issue. Does not include the
systemd-cgroup escape work tracked separately.

## Testing

New unit test in `packages/adapter-utils/src/server-utils.test.ts`:
sets `NOTIFY_SOCKET`/`LISTEN_FDS`/`LISTEN_PID`/`LISTEN_FDNAMES` in **both**
`process.env` and the caller's `opts.env`, spawns a child that echoes its
own `process.env` as JSON, and asserts none of the four vars are present.

Confirmed the test fails on unmodified master (red) and passes with the
fix applied (green):

```
$ npx vitest run --project @paperclipai/adapter-utils src/server-utils.test.ts
 ✓ |@paperclipai/adapter-utils| src/server-utils.test.ts (19 tests)
```

(No per-package `test` script exists in `packages/adapter-utils/package.json`
or any sibling adapter package — tests run via the root vitest `projects`
config, so `--project @paperclipai/adapter-utils` is the equivalent of
`pnpm --filter @paperclipai/adapter-utils test`.)

`pnpm --filter @paperclipai/adapter-utils typecheck` is clean.

Paperclip: AGE-551