### PR TITLE
fix(heartbeat): persist mid-run observed session id so a process-lost retry can resume

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -188,6 +188,23 @@ export interface AdapterExecutionContext {
   onEvent?: (event: AdapterRuntimeEvent) => Promise<void>;
   onRuntimeProgress?: RuntimeStatusSink;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
+  /**
+   * Fired the first time an adapter observes the session id its underlying
+   * agent process is using, while that process is still running. This lets
+   * the server persist the task session mid-run so a `process_lost` retry
+   * (the process was killed before it returned an `AdapterExecutionResult`)
+   * can resume from the observed session instead of starting from zero. The
+   * terminal `AdapterExecutionResult.sessionId`/`sessionParams` write still
+   * happens as before and remains authoritative (it still honours
+   * `clearSession` / max-turns clearing); this callback only closes the gap
+   * for a run that never reaches that terminal write. Adapters should invoke
+   * this at most once per run.
+   */
+  onSessionObserved?: (meta: {
+    sessionId: string;
+    sessionParams?: Record<string, unknown>;
+    sessionDisplayId?: string;
+  }) => Promise<void>;
   authToken?: string;
   /**
    * The injected OpenTelemetry startup trace context (tracer + root

--- a/packages/adapters/claude-local/src/server/execute.session-recovery.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.session-recovery.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for the poisoned-session retry: the mid-run
+// session-observed tracker used to be created once for the whole run and
+// shared across the poisoned-session retry attempt, so it latched onto the
+// first (poisoned) session's init event and silently ignored the retry's
+// replacement session. A process loss during the retry then resumed the
+// poisoned session instead of the active replacement, losing conversation
+// context. See the Greptile review on PR #11585.
+const { runChildProcess, ensureCommandResolvable, resolveCommandForLogs } = vi.hoisted(() => {
+  let call = 0;
+  return {
+    runChildProcess: vi.fn(async (_runId: string, _command: string, _args: string[], options: Record<string, unknown>) => {
+      call += 1;
+      const onLog = options.onLog as (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+      if (call === 1) {
+        // First attempt: resumes "claude-session-poisoned" and observes its
+        // init event mid-run, then fails with a poisoned previous_message_id.
+        await onLog(
+          "stdout",
+          `${JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-poisoned", model: "claude-sonnet" })}\n`,
+        );
+        return {
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          stdout: JSON.stringify({
+            type: "result",
+            session_id: "claude-session-poisoned",
+            is_error: true,
+            result: "Error: diagnostics.previous_message_id starts with `msg_`",
+          }),
+          stderr: "",
+          pid: 123,
+          startedAt: new Date().toISOString(),
+        };
+      }
+      // Retry attempt: starts a brand new session and must be observed too.
+      await onLog(
+        "stdout",
+        `${JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-replacement", model: "claude-sonnet" })}\n`,
+      );
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-replacement", model: "claude-sonnet" }),
+          JSON.stringify({
+            type: "assistant",
+            session_id: "claude-session-replacement",
+            message: { content: [{ type: "text", text: "hello" }] },
+          }),
+          JSON.stringify({
+            type: "result",
+            session_id: "claude-session-replacement",
+            result: "hello",
+            usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+          }),
+        ].join("\n"),
+        stderr: "",
+        pid: 124,
+        startedAt: new Date().toISOString(),
+      };
+    }),
+    ensureCommandResolvable: vi.fn(async () => undefined),
+    resolveCommandForLogs: vi.fn(async () => "claude"),
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+describe("claude_local poisoned-session retry", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("observes the replacement session's init event, not just the poisoned session's", async () => {
+    const onSessionObserved = vi.fn(async () => {});
+
+    const result = await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "12345678-1234-4abc-9def-123456789012",
+        sessionParams: { sessionId: "12345678-1234-4abc-9def-123456789012" },
+        sessionDisplayId: "12345678-1234-4abc-9def-123456789012",
+        taskKey: null,
+      },
+      config: { engine: "cli" },
+      context: {},
+      onLog: async () => {},
+      onSessionObserved,
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(runChildProcess).toHaveBeenCalledTimes(2);
+
+    // Both the poisoned session and its replacement must have been reported,
+    // in order, so a process loss mid-retry resumes the replacement instead
+    // of the discarded poisoned session.
+    expect(onSessionObserved).toHaveBeenCalledTimes(2);
+    expect(onSessionObserved).toHaveBeenNthCalledWith(1, { sessionId: "claude-session-poisoned" });
+    expect(onSessionObserved).toHaveBeenNthCalledWith(2, { sessionId: "claude-session-replacement" });
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -411,22 +411,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
 
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
-  // Wrap the raw process stdout log handler (not the general onLog used for
-  // command notes/text throughout this function) so the server can persist
-  // the task session as soon as the underlying `claude` process reports its
-  // session id, before the process finishes or is killed. Built once at this
-  // outer scope (not inside runAttempt) so a poisoned-session retry attempt
-  // shares the same tracker and `onSessionObserved` still fires at most once
-  // per run, even across attempts.
-  const sessionObservedTracker = ctx.onSessionObserved
-    ? createClaudeSessionObservedStdoutTracker(ctx.onSessionObserved)
-    : null;
-  const onProcessLog = sessionObservedTracker
-    ? async (stream: "stdout" | "stderr", chunk: string) => {
-        if (stream === "stdout") await sessionObservedTracker.feed(chunk);
-        await onLog(stream, chunk);
-      }
-    : onLog;
+  // Build a fresh mid-run session-observed tracker for each attempt (not once
+  // for the whole run): a poisoned-session retry starts a brand new Claude
+  // session with its own `init` event, and a tracker shared across attempts
+  // would have already latched onto the first (now-discarded) session and
+  // ignore the replacement's init event, leaving recovery pointed at the
+  // poisoned session if the retry process is then lost. Each attempt's own
+  // tracker still fires `onSessionObserved` at most once for that attempt.
+  const createOnProcessLog = () => {
+    const sessionObservedTracker = ctx.onSessionObserved
+      ? createClaudeSessionObservedStdoutTracker(ctx.onSessionObserved)
+      : null;
+    return sessionObservedTracker
+      ? async (stream: "stdout" | "stderr", chunk: string) => {
+          if (stream === "stdout") await sessionObservedTracker.feed(chunk);
+          await onLog(stream, chunk);
+        }
+      : onLog;
+  };
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
@@ -899,6 +901,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   const runAttempt = async (resumeSessionId: string | null) => {
+    const onProcessLog = createOnProcessLog();
     const attemptInstructionsFilePath = resumeSessionId ? undefined : effectiveInstructionsFilePath;
     const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath);
     const commandNotes: string[] = [];

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -58,6 +58,7 @@ import {
 import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
+  createClaudeSessionObservedStdoutTracker,
   describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
@@ -410,6 +411,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
 
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  // Wrap the raw process stdout log handler (not the general onLog used for
+  // command notes/text throughout this function) so the server can persist
+  // the task session as soon as the underlying `claude` process reports its
+  // session id, before the process finishes or is killed. Built once at this
+  // outer scope (not inside runAttempt) so a poisoned-session retry attempt
+  // shares the same tracker and `onSessionObserved` still fires at most once
+  // per run, even across attempts.
+  const sessionObservedTracker = ctx.onSessionObserved
+    ? createClaudeSessionObservedStdoutTracker(ctx.onSessionObserved)
+    : null;
+  const onProcessLog = sessionObservedTracker
+    ? async (stream: "stdout" | "stderr", chunk: string) => {
+        if (stream === "stdout") await sessionObservedTracker.feed(chunk);
+        await onLog(stream, chunk);
+      }
+    : onLog;
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
@@ -925,7 +942,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       graceSec,
       onSpawn,
       onRuntimeProgress: ctx.onRuntimeProgress,
-      onLog,
+      onLog: onProcessLog,
       runLogTail: paperclipBridge?.runLogTail,
       terminalResultCleanup: {
         graceMs: terminalResultCleanupGraceMs,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
+  createClaudeSessionObservedStdoutTracker,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeProviderQuotaError,
@@ -553,5 +554,61 @@ describe("parseClaudeStreamJson usage extraction", () => {
       cachedInputTokens: 20,
     });
     expect(parsed.usageBasis).toBe("per_run");
+  });
+});
+
+describe("createClaudeSessionObservedStdoutTracker", () => {
+  it("calls onSessionObserved exactly once with the session id from the init event", async () => {
+    const observed: string[] = [];
+    const tracker = createClaudeSessionObservedStdoutTracker(async (meta) => {
+      observed.push(meta.sessionId);
+    });
+
+    await tracker.feed(
+      `{"type":"system","subtype":"init","session_id":"abc123"}\n`,
+    );
+
+    expect(observed).toEqual(["abc123"]);
+  });
+
+  it("does not re-call onSessionObserved for a second session_id line", async () => {
+    const observed: string[] = [];
+    const tracker = createClaudeSessionObservedStdoutTracker(async (meta) => {
+      observed.push(meta.sessionId);
+    });
+
+    await tracker.feed(`{"type":"system","subtype":"init","session_id":"abc123"}\n`);
+    await tracker.feed(`{"type":"system","subtype":"init","session_id":"def456"}\n`);
+    await tracker.feed(`{"type":"assistant","session_id":"ghi789"}\n`);
+
+    expect(observed).toEqual(["abc123"]);
+  });
+
+  it("buffers a session_id line split across multiple stdout chunks", async () => {
+    const observed: string[] = [];
+    const tracker = createClaudeSessionObservedStdoutTracker(async (meta) => {
+      observed.push(meta.sessionId);
+    });
+
+    const line = `{"type":"system","subtype":"init","session_id":"split-session"}\n`;
+    const mid = Math.floor(line.length / 2);
+    await tracker.feed(line.slice(0, mid));
+    await tracker.feed(line.slice(mid));
+
+    expect(observed).toEqual(["split-session"]);
+  });
+
+  it("ignores non-init system events and non-JSON lines", async () => {
+    const observed: string[] = [];
+    const tracker = createClaudeSessionObservedStdoutTracker(async (meta) => {
+      observed.push(meta.sessionId);
+    });
+
+    await tracker.feed("not json\n");
+    await tracker.feed(`{"type":"system","subtype":"hook_started","session_id":"nope"}\n`);
+    expect(observed).toEqual([]);
+
+    await tracker.feed(`{"type":"system","subtype":"init","session_id":"real-session"}\n`);
+    expect(observed).toEqual(["real-session"]);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -54,6 +54,57 @@ export function claudeModelUsageTotals(modelUsage: unknown): UsageSummary | null
   return { inputTokens, outputTokens, cachedInputTokens };
 }
 
+/**
+ * Incrementally scans raw stdout chunks from a running `claude --print
+ * --output-format stream-json` process for the first `{"type":"system",
+ * "subtype":"init","session_id":...}` line and invokes `onSessionObserved`
+ * exactly once with that session id, while the process is still alive. This
+ * lets the server persist the task session mid-run so a killed process
+ * (`process_lost`) can resume from the observed session instead of losing
+ * all accumulated context. See parseClaudeStreamJson for the equivalent
+ * end-of-run parse over the fully accumulated stdout.
+ *
+ * Chunks arrive as raw `data` events off the child process stdout stream and
+ * are not guaranteed to align with line boundaries, so this buffers partial
+ * lines across `feed` calls.
+ */
+export function createClaudeSessionObservedStdoutTracker(
+  onSessionObserved: (meta: { sessionId: string }) => Promise<void>,
+) {
+  let buffer = "";
+  let observed = false;
+
+  return {
+    async feed(chunk: string): Promise<void> {
+      if (observed || !chunk) return;
+      buffer += chunk;
+
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (observed) return;
+        if (line) {
+          const event = parseJson(line);
+          if (
+            event &&
+            asString(event.type, "") === "system" &&
+            asString(event.subtype, "") === "init"
+          ) {
+            const sessionId = asString(event.session_id, "");
+            if (sessionId) {
+              observed = true;
+              await onSessionObserved({ sessionId });
+              return;
+            }
+          }
+        }
+        newlineIndex = buffer.indexOf("\n");
+      }
+    },
+  };
+}
+
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
   let model = "";

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -9,6 +9,7 @@ import {
   activityLog,
   agents,
   agentRuntimeState,
+  agentTaskSessions,
   agentWakeupRequests,
   authUsers,
   budgetPolicies,
@@ -414,6 +415,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(activityLog);
       await db.delete(heartbeatRunEvents);
+      // agent_task_sessions.last_run_id FK-references heartbeat_runs; clear it
+      // first so a mid-run session persisted by the process-lost mid-run
+      // session-observed wiring never blocks the heartbeat_runs teardown below.
+      await db.delete(agentTaskSessions);
       try {
         await db.delete(heartbeatRuns);
         break;
@@ -1370,6 +1375,123 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
+  });
+
+  it("persists a mid-run observed session id so a process-lost retry resumes instead of restarting from zero", async () => {
+    // Regression test: previously `upsertTaskSession` was only
+    // reachable after the adapter returned a result (see the terminal write
+    // in heartbeat.ts), so a process killed mid-run (SIGKILL/OOM/cgroup
+    // sweep) never persisted a task-session row, and the automatic
+    // process_lost retry always resumed with `sessionIdBefore: null` —
+    // losing all accumulated context. This test must fail on unmodified
+    // master (no `onSessionObserved` wiring) because the task-session row
+    // and the retry's `sessionIdBefore` would both be absent/null.
+    const observedSessionId = "claude-session-mid-run-observed";
+    let releaseAdapter: (() => void) | null = null;
+    const adapterObservedSession = new Promise<void>((resolve) => {
+      mockAdapterExecute.mockImplementationOnce(async (rawInput?: unknown) => {
+        const input = rawInput as {
+          onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
+          onSessionObserved?: (meta: { sessionId: string }) => Promise<void>;
+        };
+        const child = spawnAliveProcess();
+        childProcesses.add(child);
+        if (!child.pid) throw new Error("Test child did not expose a pid");
+        await input.onSpawn?.({
+          pid: child.pid,
+          processGroupId: null,
+          startedAt: new Date("2026-03-19T00:00:00.000Z").toISOString(),
+        });
+        // The adapter observes its session id early in the run, well before
+        // it would ever return an AdapterExecutionResult.
+        await input.onSessionObserved?.({ sessionId: observedSessionId });
+        resolve();
+        // Simulate the run staying alive (mid-turn) until it is killed from
+        // outside this test, exactly like the real SIGKILL/OOM scenario: the
+        // adapter's returned promise never settles here.
+        await new Promise<void>((release) => {
+          releaseAdapter = release;
+        });
+        return {
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          errorMessage: null,
+          summary: "unreachable in this test — the process is reaped before this would resolve",
+          provider: "test",
+          model: "test-model",
+        };
+      });
+    });
+
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      adapterType: "claude_local",
+      agentStatus: "idle",
+      runStatus: "queued",
+      processPid: null,
+      processGroupId: null,
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+    await Promise.race([
+      adapterObservedSession,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("Timed out waiting for adapter to observe a session id")), 3_000);
+      }),
+    ]);
+
+    // The mid-run write must already be visible while the run is still
+    // "running" — before any retry/kill machinery ever runs.
+    const taskSession = await waitForValue(async () =>
+      db
+        .select()
+        .from(agentTaskSessions)
+        .where(
+          and(
+            eq(agentTaskSessions.companyId, companyId),
+            eq(agentTaskSessions.agentId, agentId),
+            eq(agentTaskSessions.taskKey, issueId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null),
+    );
+    expect(taskSession).toMatchObject({ sessionDisplayId: observedSessionId });
+    expect(taskSession?.sessionParamsJson).toMatchObject({ sessionId: observedSessionId });
+
+    const runBeforeLoss = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(runBeforeLoss?.status).toBe("running");
+
+    // Simulate the process being lost mid-run: this drains the still-"running"
+    // run and hands it to the same process-loss retry path
+    // (`enqueueProcessLossRetry`) that `reapOrphanedRuns` uses at startup
+    // reconciliation, exercising `resolveSessionBeforeForWakeup` against the
+    // row the mid-run write above just created.
+    const drain = await heartbeat.drainRunningRunsForShutdown(
+      "SIGTERM",
+      new Date("2026-03-19T00:05:00.000Z"),
+    );
+    expect(drain.interruptedRunIds).toEqual([runId]);
+
+    const retryRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)))
+      .then((rows) => rows[0] ?? null);
+
+    expect(retryRun).toBeTruthy();
+    expect(retryRun?.contextSnapshot).toMatchObject({ retryReason: "process_lost" });
+    // The crux of the fix: without the mid-run `onSessionObserved` write above,
+    // `sessionIdBefore` would be null here and the retry would start from zero.
+    expect(retryRun?.sessionIdBefore).toBe(observedSessionId);
+
+    if (!releaseAdapter) throw new Error("Adapter release handle was not captured");
+    releaseAdapter();
+    await waitForRunToSettle(heartbeat, runId, 5_000).catch(() => null);
   });
 
   it("restores one lost monitor dispatch before escalating a second process loss", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16008,6 +16008,54 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               startedAt: meta.startedAt,
             });
           },
+          // Persist the task session as soon as the adapter observes a
+          // session id, while the underlying agent process is still
+          // running. If the process is later killed (SIGKILL, OOM, cgroup
+          // sweep) before the adapter returns an AdapterExecutionResult, the
+          // terminal `upsertTaskSession` write below never runs and the
+          // process_lost retry path (`resolveSessionBeforeForWakeup`) would
+          // otherwise find no task-session row and resume from zero. This is
+          // best-effort and never authoritative: the terminal write after a
+          // clean finish still runs unconditionally and still wins (it still
+          // honours `adapterResult.clearSession` / max-turns clearing), so a
+          // mid-run write here can never prevent the terminal path from
+          // clearing a poisoned session.
+          onSessionObserved: taskKey
+            ? async (meta) => {
+                try {
+                  const observedParams = normalizeSessionParams(
+                    sessionCodec.serialize(
+                      normalizeSessionParams(meta.sessionParams ?? { sessionId: meta.sessionId }) ?? null,
+                    ),
+                  );
+                  const observedDisplayId = truncateDisplayId(
+                    meta.sessionDisplayId ??
+                      (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(observedParams) : null) ??
+                      readNonEmptyString(observedParams?.sessionId) ??
+                      meta.sessionId,
+                  );
+                  await upsertTaskSession({
+                    companyId: agent.companyId,
+                    agentId: agent.id,
+                    adapterType: agent.adapterType,
+                    taskKey,
+                    sessionParamsJson: attachPaperclipSessionMetadataToSessionParams(
+                      observedParams,
+                      configuredModel,
+                      sessionConfigMetadata,
+                    ),
+                    sessionDisplayId: observedDisplayId,
+                    lastRunId: run.id,
+                    lastError: null,
+                  });
+                } catch (err) {
+                  logger.warn(
+                    { err, runId: run.id, agentId: agent.id, taskKey },
+                    "failed to persist mid-run observed session id; process_lost retry may resume from zero for this run",
+                  );
+                }
+              }
+            : undefined,
           authToken: authToken ?? undefined,
         });
         // Adapter returned cleanly, which means its workspace-restore finally


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - When an agent's underlying process is killed mid-run (OOM, cgroup sweep, `kill -9`), the server relies on an automatic `process_lost` retry to recover the run
> - That retry reads the last-known session id (`sessionIdBefore`) so the resumed run can pick up where it left off instead of starting a brand-new session
> - The session id was only ever persisted after the adapter returned an `AdapterExecutionResult` — a process that never returns one (because it was killed) leaves no session row behind
> - So every `process_lost` retry today resumes with `sessionIdBefore: null`, discarding all accumulated context, even though the underlying agent CLI (`claude --resume <session>`) can recover that context perfectly well
> - This PR adds an optional `onSessionObserved` adapter callback fired the moment the adapter learns its session id, while the process is still alive, and wires the server to persist the task session at that point instead of waiting for a terminal result
> - The benefit is a `process_lost` retry resumes the real prior conversation instead of losing it

## Linked Issues or Issue Description

**What happened?**

When a run's agent process is killed (SIGKILL from a systemd cgroup sweep, OOM, or `kill -9`), the adapter never returns an `AdapterExecutionResult`, so the server's `upsertTaskSession` write (which only runs after a result is returned, see `server/src/services/heartbeat.ts`) never happens. The automatic `process_lost` retry (`enqueueProcessLossRetry` → `resolveSessionBeforeForWakeup`) then finds no persisted task-session row and starts the retry with `sessionIdBefore: null`, i.e. from a brand-new session, discarding everything the killed run had already done.

**Expected behavior**

The server should persist the session id as soon as the adapter learns it (while the process is still running), not only after the process exits cleanly. A `process_lost` retry should then resume the same underlying session (e.g. `claude --resume <session_id>`) instead of starting over.

**Steps to reproduce**

1. Start a `claude_local`-style run and let it produce a couple of turns (or read the `session_id` from the stream-json `init` event).
2. `kill -9` the `claude` process mid-turn, before it can print a terminal `result` event.
3. Observe that on `master`, no `agent_task_sessions` row exists for that run, so a `process_lost` retry's `sessionIdBefore` is `null`.
4. Separately confirm the underlying CLI *can* recover the pre-kill context: `claude --print - --output-format stream-json --resume <session_id>` with a prompt like "what were we just working on?" returns the pre-kill context correctly — the resumability exists, the server just never captures the session id in time to use it.

I verified step 4 manually before writing any code (see Verification below): a real `claude` CLI session, killed with `SIGKILL` mid-turn (confirmed no `result` event was ever emitted), fully recovered a fact told to it in an earlier turn once resumed via `--resume <session_id>`. This is the basis for the fix below.

## What Changed

- `packages/adapter-utils/src/types.ts`: add an optional `AdapterExecutionContext.onSessionObserved?: (meta: { sessionId, sessionParams?, sessionDisplayId? }) => Promise<void>`, documented alongside the existing `onSpawn` callback.
- `packages/adapters/claude-local/src/server/parse.ts`: add `createClaudeSessionObservedStdoutTracker`, a small incremental line-buffering scanner that watches raw stdout chunks for the first `{"type":"system","subtype":"init","session_id":...}` line and invokes a callback exactly once.
- `packages/adapters/claude-local/src/server/execute.ts`: wrap the process-level stdout log handler with the tracker (built once per run, shared across a poisoned-session retry attempt so `onSessionObserved` still fires at most once per run) and call `ctx.onSessionObserved` the first time a session id is observed.
- `server/src/services/heartbeat.ts`: wire `onSessionObserved` into the adapter dispatch. It calls the same `upsertTaskSession` helper the terminal path already uses, keyed by the same `taskKey`/`sessionCodec`/`configuredModel`/`sessionConfigMetadata` already in scope. The terminal write after a clean finish is unchanged and still authoritative — it still honours `adapterResult.clearSession` and empty-session clearing, so this mid-run write can never block the terminal path from clearing a poisoned session. Best-effort: a failure to persist here is logged and does not fail the run.
- Scope: `claude-local` only in this PR. `pi-local` / `codex-local` / `gemini-local` / `cursor-local` / `opencode-local` / `copilot-local` are unchanged; they can adopt the shared callback in follow-up PRs.

## Verification

Manual CLI experiment (done first, before any code change, to prove the premise):

```
$ claude --print "Remember this fact for later: the secret code word is BANANA77..." --output-format stream-json --verbose > turn1.jsonl
# captured session_id from the "init" event

$ nohup claude --print "Write a detailed 2000-word essay..." --output-format stream-json --verbose --resume "$SID" > turn2.jsonl &
$ sleep 4 && kill -9 <claude pid>
$ grep -c '"type":"result"' turn2.jsonl   # => 0, confirms it was killed mid-turn, no terminal event ever written

$ claude --print "Forget the essay. What was the secret code word...?" --output-format stream-json --verbose --resume "$SID"
# => "BANANA77." — the resumed session recovered the pre-kill context cleanly
```

Automated tests:

```
$ pnpm --filter @paperclipai/adapter-claude-local exec vitest run --exclude "**/execute.acp-fallback.test.ts"
 Test Files  13 passed | 1 skipped (14)
      Tests  221 passed | 1 skipped (222)
```
(`execute.acp-fallback.test.ts` has one pre-existing failure caused by ambient env vars in this sandbox — confirmed identical on unmodified `master` before this change; unrelated to this PR.)

```
$ npx vitest run packages/adapter-utils
 Test Files  29 passed (29)
      Tests  571 passed | 4 skipped (575)
```

```
$ pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts
 Test Files  1 passed (1)
      Tests  104 passed (104)
```

New regression test (`heartbeat-process-recovery.test.ts`): a run whose mocked adapter calls `onSessionObserved` and is then drained as a lost/interrupted run leaves an `agent_task_sessions` row with the observed session id, and the resulting `process_lost` retry run's `sessionIdBefore` is non-null. I confirmed this test **fails on unmodified `heartbeat.ts`** (reverted only the implementation files, kept the test) with:

```
AssertionError: expected null to match object { Object (sessionDisplayId) }
```

then passes again once the implementation is restored.

New unit tests (`parse.test.ts`): `createClaudeSessionObservedStdoutTracker` calls back exactly once for an `init` session_id line, ignores a second `session_id` line, buffers a line split across chunks, and ignores non-init/non-JSON lines.

## Risks

- Low risk. The new callback is additive and optional (`onSessionObserved?`); no existing adapter or call site is required to implement it.
- The mid-run write is best-effort: a failure there is caught and logged, and never throws out of the adapter callback, so it cannot turn a healthy run into a failure.
- The terminal write path is untouched, so existing "clear session on `clearSession`/max-turns" behavior is unaffected — verified by the existing `heartbeat-process-recovery.test.ts` suite staying green.
- Scope is intentionally limited to `claude-local`; other local adapters do not get this behavior yet and still resume from zero after a mid-run kill until they adopt the same callback in a follow-up.

## Model Used

Claude (Anthropic), model `claude-opus-4-8` via Claude Code CLI, 1M context window, extended/interleaved thinking enabled, with tool use (Bash, file edit, grep) for implementation, testing, and the manual CLI verification above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found; #678 is a related-but-different session-clearing fix, not a duplicate)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs cover this internal recovery mechanism)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — verified with `gh pr checks 11585`: every required build/test gate passes; only the Greptile gate (tracked separately below) is red.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — currently 4/5. Open finding: the poisoned-session replacement path must persist its new session ID before this is safe to merge. Not yet fixed; tracked as follow-up branch work, not a description issue.
- [x] I will address all Greptile and reviewer comments before requesting merge

