### PR TITLE
docs(skills): maintain the release-credits exclusion list

### DIFF
--- a/.agents/skills/release-changelog-discord-message/SKILL.md
+++ b/.agents/skills/release-changelog-discord-message/SKILL.md
@@ -163,7 +163,8 @@ Mimic this register; do not invent a "professional" tone.
   (follow the twitter, intros, beta sign-ups). No real ask → drop it.
 - **Community** is the same contributors list that's in the changelog file,
   fenced in a triple-backtick block, comma-separated `@username, @username`.
-  Exclude bots and Paperclip founders, same rules as the changelog skill.
+  Exclude bots, founders, and core contributors — same rules and the same
+  canonical exclusion list as the changelog skill.
 - **The "In Summary" mission line** evolves slowly. Use the most recent
   variant unless dotta tells you otherwise. Recent variants:
   - "PAPERCLIP IS THE AI ORCHESTRATOR FOR HUMANS TO ACCOMPLISH 100x MORE WORK"
@@ -444,7 +445,8 @@ https://github.com/paperclipai/paperclip/blob/master/releases/v2026.427.0.md
 Before handing off:
 
 1. Version + date match the matching `releases/vYYYY.MDD.P.md` exactly.
-2. Contributor list matches the changelog (same exclusions: bots, founders).
+2. Contributor list matches the changelog (same exclusions: bots, founders,
+   core contributors).
 3. Highlights are a subset of the changelog Highlights — same shipped features,
    not invented or pre-alpha work.
 4. `WHATS NEXT` and `What's on my mind` are pulled from real recent issues /

--- a/.agents/skills/release-changelog-discord-message/SKILL.md
+++ b/.agents/skills/release-changelog-discord-message/SKILL.md
@@ -163,8 +163,8 @@ Mimic this register; do not invent a "professional" tone.
   (follow the twitter, intros, beta sign-ups). No real ask → drop it.
 - **Community** is the same contributors list that's in the changelog file,
   fenced in a triple-backtick block, comma-separated `@username, @username`.
-  Exclude bots, founders, and core contributors — same rules and the same
-  canonical exclusion list as the changelog skill.
+  Exclude bots and the specific folks on the changelog skill's canonical
+  exclusion list — same rules.
 - **The "In Summary" mission line** evolves slowly. Use the most recent
   variant unless dotta tells you otherwise. Recent variants:
   - "PAPERCLIP IS THE AI ORCHESTRATOR FOR HUMANS TO ACCOMPLISH 100x MORE WORK"
@@ -445,8 +445,8 @@ https://github.com/paperclipai/paperclip/blob/master/releases/v2026.427.0.md
 Before handing off:
 
 1. Version + date match the matching `releases/vYYYY.MDD.P.md` exactly.
-2. Contributor list matches the changelog (same exclusions: bots, founders,
-   core contributors).
+2. Contributor list matches the changelog (same exclusions: bots and the
+   changelog skill's canonical excluded-folks list).
 3. Highlights are a subset of the changelog Highlights — same shipped features,
    not invented or pre-alpha work.
 4. `WHATS NEXT` and `What's on my mind` are pulled from real recent issues /

--- a/.agents/skills/release-changelog/SKILL.md
+++ b/.agents/skills/release-changelog/SKILL.md
@@ -184,7 +184,11 @@ real name or email). To find GitHub usernames:
 **Never expose contributor email addresses.** Use `@username` only.
 
 Exclude bot accounts (e.g. `lockfile-bot`, `dependabot`) from the list.
-Exclude Paperclip founders from the list (e.g. `cryppadotta`, `forgottendev`, `devinfoley`, `sockmonster`, `scotttong`)
+Exclude Paperclip founders and core contributors from the list — the
+Contributors section credits community contributors only. The canonical
+exclusion list (keep it here; the Discord skill defers to it):
+`cryppadotta`, `forgottendev`, `devinfoley`, `sockmonster`, `scotttong`,
+`nguyenm7`, `nickyleach`
 
 List contributors in alphabetical order by GitHub username (case-insensitive).
 

--- a/.agents/skills/release-changelog/SKILL.md
+++ b/.agents/skills/release-changelog/SKILL.md
@@ -184,11 +184,11 @@ real name or email). To find GitHub usernames:
 **Never expose contributor email addresses.** Use `@username` only.
 
 Exclude bot accounts (e.g. `lockfile-bot`, `dependabot`) from the list.
-Exclude Paperclip founders and core contributors from the list — the
-Contributors section credits community contributors only. The canonical
-exclusion list (keep it here; the Discord skill defers to it):
+Exclude specific folks from the list — the Contributors section credits
+community contributors only. The canonical exclusion list (keep it here;
+the Discord skill defers to it):
 `cryppadotta`, `forgottendev`, `devinfoley`, `sockmonster`, `scotttong`,
-`nguyenm7`, `nickyleach`
+`nguyenm7`, `nickyleach`, `tonio-alucema`
 
 List contributors in alphabetical order by GitHub username (case-insensitive).
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Stable release notes end with a Contributors section that credits community contributors
> - The release-changelog skill excluded founders from that list, but had no rule for non-founder core contributors
> - A release-notes draft therefore credited two core contributors as community contributors
> - This pull request makes the exclusion list canonical in the changelog skill and adds the core contributors
> - The benefit is that release credits consistently mean "community", with one list to maintain

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The Contributors rules in `.agents/skills/release-changelog/SKILL.md` and the Community-section rules in `.agents/skills/release-changelog-discord-message/SKILL.md`.

**Current behavior**

The changelog skill says to exclude "Paperclip founders (e.g. `cryppadotta`, `forgottendev`, `devinfoley`, `sockmonster`, `scotttong`)". Core contributors who are not founders are not covered, so drafts credit them in the community list. The Discord skill refers to "founders" in two places.

**Proposed behavior**

The changelog skill holds the canonical exclusion list of specific folks — now including `nguyenm7`, `nickyleach`, and `tonio-alucema` — and both Discord-skill references defer to that one list.

**Reason and benefit**

Release credits consistently mean community contributions, and there is exactly one place to update when the core team changes.

## What Changed

- `.agents/skills/release-changelog/SKILL.md`: the exclusion rule names specific folks, is the canonical list, and adds `nguyenm7`, `nickyleach`, and `tonio-alucema`.
- `.agents/skills/release-changelog-discord-message/SKILL.md`: both references ("Community" template note and the final checklist) defer to the changelog skill's canonical list.

## Verification

- Docs-only change; rendered and proofread. No workflow, script, or test surface is touched.

## Risks

- None beyond docs accuracy. If the canonical-list wording lands after #11567 (which touches other sections of the same files), Git merges them cleanly — the edited regions do not overlap.

## Model Used

Claude Fable 5 (Claude Code)

## Pre-submission checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template

