### PR TITLE
feat(markdown): syntax colors for code blocks, and fix the surfaces beneath them

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,9 @@ importers:
       react-router-dom:
         specifier: ^7.18.1
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1862,11 +1865,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -6596,17 +6599,27 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  highlight.js@11.11.2:
+    resolution: {integrity: sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.13.2:
     resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
@@ -6965,6 +6978,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -7817,6 +7833,9 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -8322,6 +8341,9 @@ packages:
 
   unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -14408,6 +14430,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -14442,11 +14468,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
 
   help-me@5.0.0: {}
+
+  highlight.js@11.11.2: {}
 
   hono@4.13.2: {}
 
@@ -14769,6 +14804,12 @@ snapshots:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.2
 
   lru-cache@10.4.3: {}
 
@@ -16082,6 +16123,14 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -16743,6 +16792,11 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
     optional: true
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,9 +1005,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.1
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      rehype-highlight:
-        specifier: ^7.0.2
-        version: 7.0.2
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1865,11 +1862,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -6599,27 +6596,17 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hast-util-is-element@3.0.0:
-    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
-
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
-  hast-util-to-text@4.0.2:
-    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
-
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-
-  highlight.js@11.11.2:
-    resolution: {integrity: sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==}
-    engines: {node: '>=12.0.0'}
 
   hono@4.13.2:
     resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
@@ -6978,9 +6965,6 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
-  lowlight@3.3.0:
-    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -7833,9 +7817,6 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
-  rehype-highlight@7.0.2:
-    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
-
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -8341,9 +8322,6 @@ packages:
 
   unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
-
-  unist-util-find-after@5.0.0:
-    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -14430,10 +14408,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-is-element@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -14468,20 +14442,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-text@4.0.2:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      hast-util-is-element: 3.0.0
-      unist-util-find-after: 5.0.0
-
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
 
   help-me@5.0.0: {}
-
-  highlight.js@11.11.2: {}
 
   hono@4.13.2: {}
 
@@ -14804,12 +14769,6 @@ snapshots:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
-
-  lowlight@3.3.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      devlop: 1.1.0
-      highlight.js: 11.11.2
 
   lru-cache@10.4.3: {}
 
@@ -16123,14 +16082,6 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  rehype-highlight@7.0.2:
-    dependencies:
-      '@types/hast': 3.0.4
-      hast-util-to-text: 4.0.2
-      lowlight: 3.3.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -16792,11 +16743,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
     optional: true
-
-  unist-util-find-after@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,6 +66,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.2",
     "react-router-dom": "^7.18.1",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0"
   },

--- a/ui/src/components/MarkdownBody.test.tsx
+++ b/ui/src/components/MarkdownBody.test.tsx
@@ -668,3 +668,46 @@ describe("MarkdownBody", () => {
   });
 
 });
+
+describe("code block syntax highlighting", () => {
+  it("tokenizes a fenced block that declares its language", () => {
+    const html = renderMarkdown(['```typescript', 'const status = "blocked";', '```'].join("\n"));
+
+    // rehype-highlight marks the code element and wraps each token.
+    expect(html).toContain("hljs");
+    expect(html).toContain("hljs-keyword");
+    expect(html).toContain("hljs-string");
+  });
+
+  it("tokenizes an untagged fence, because most agent-authored fences carry no language", () => {
+    const html = renderMarkdown(
+      ['```', 'export function run() {', '  return "ok";', '}', '```'].join("\n"),
+    );
+
+    expect(html).toContain("hljs-");
+  });
+
+  it("marks added and removed lines in a diff fence", () => {
+    const html = renderMarkdown(
+      ['```diff', '-  const a = 1;', '+  const a = 2;', '```'].join("\n"),
+    );
+
+    expect(html).toContain("hljs-deletion");
+    expect(html).toContain("hljs-addition");
+  });
+
+  it("does not throw on a fence whose language is unknown", () => {
+    expect(() =>
+      renderMarkdown(['```notalanguage', 'some text', '```'].join("\n")),
+    ).not.toThrow();
+  });
+
+  it("leaves inline code untokenized", () => {
+    // rehype-highlight only visits `pre > code`. Inline code keeps the
+    // chip treatment and must not pick up a syntax colour.
+    const html = renderMarkdown("Set `status` to blocked.");
+
+    expect(html).toContain(">status</code>");
+    expect(html).not.toContain("hljs");
+  });
+});

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Check, Copy, ExternalLink, Github, WrapText } from "lucide-react";
 import Markdown, { defaultUrlTransform, type Components, type Options } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
 import { cn } from "../lib/utils";
 import { Link, useCaseHref } from "@/lib/router";
 import { useTheme } from "../context/ThemeContext";
@@ -221,6 +222,37 @@ const scrollableBlockStyle: React.CSSProperties = {
   maxWidth: "100%",
   overflowX: "auto",
 };
+
+/* Syntax highlighting for fenced code blocks.
+
+   `subset` is deliberate. highlight.js auto-detection is unreliable on the
+   short snippets that appear in task chat, and a wrong guess colours the
+   whole block wrongly. Restricting detection to the languages agents
+   actually post makes the guess reliable. `detect` stays on because most
+   agent-authored fences carry no language tag, and without it those blocks
+   would never highlight.
+
+   Defined at module scope so the array identity is stable. react-markdown
+   remounts the rendered tree when its plugin array changes identity, which
+   discards scroll position and selection — the same hazard the
+   `remarkPlugins` memo below guards against. */
+const HIGHLIGHT_LANGUAGE_SUBSET = [
+  "bash",
+  "diff",
+  "json",
+  "typescript",
+  "javascript",
+  "yaml",
+  "sql",
+  "python",
+  "css",
+  "xml",
+  "markdown",
+];
+
+const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
+  [rehypeHighlight, { detect: true, subset: HIGHLIGHT_LANGUAGE_SUBSET, ignoreMissing: true }],
+];
 
 const codeBlockActionsStyle: React.CSSProperties = {
   position: "absolute",
@@ -942,6 +974,7 @@ function MarkdownBodyImpl({
     >
       <Markdown
         remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
         components={components}
         urlTransform={safeMarkdownUrlTransform}
       >

--- a/ui/src/components/MarkdownCodeBlockStyles.test.ts
+++ b/ui/src/components/MarkdownCodeBlockStyles.test.ts
@@ -28,7 +28,7 @@ describe("markdown code block styles", () => {
   it("rides theme tokens for the rendered code block surface", () => {
     const block = cssBlock(".paperclip-markdown pre");
 
-    expect(block).toContain("background-color: var(--muted)");
+    expect(block).toContain("background-color: var(--code-surface)");
     expect(block).toContain("color: var(--foreground)");
     expect(block).toContain("border: 1px solid var(--border)");
     expect(block).toContain("border-radius: var(--radius-lg)");
@@ -37,7 +37,7 @@ describe("markdown code block styles", () => {
   it("rides theme tokens for the editor content code block surface", () => {
     const block = cssBlock(".paperclip-mdxeditor-content pre");
 
-    expect(block).toContain("background: var(--muted)");
+    expect(block).toContain("background: var(--code-surface)");
     expect(block).toContain("color: var(--foreground)");
     expect(block).toContain("border: 1px solid var(--border)");
     expect(block).toContain("border-radius: var(--radius-lg)");
@@ -46,9 +46,9 @@ describe("markdown code block styles", () => {
   it("points the normal and inverted prose variables at the same tokens", () => {
     const block = cssBlock(".paperclip-markdown");
 
-    expect(block).toContain("--tw-prose-pre-bg: var(--muted)");
+    expect(block).toContain("--tw-prose-pre-bg: var(--code-surface)");
     expect(block).toContain("--tw-prose-pre-code: var(--foreground)");
-    expect(block).toContain("--tw-prose-invert-pre-bg: var(--muted)");
+    expect(block).toContain("--tw-prose-invert-pre-bg: var(--code-surface)");
     expect(block).toContain("--tw-prose-invert-pre-code: var(--foreground)");
   });
 
@@ -108,5 +108,24 @@ describe("code syntax palette", () => {
     ]) {
       expect(stylesheet, `${cls} must be mapped`).toContain(cls);
     }
+  });
+});
+
+describe("code block surface separation", () => {
+  it("defines the surface as a translucent tint in both modes", () => {
+    // A fixed token cannot work: --bubble-agent is oklch(0.97 0 0) in light,
+    // identical to --muted, and its "hairline" variant is var(--background).
+    // A tint shifts whatever is beneath it, so it separates everywhere.
+    expect(stylesheet).toMatch(/--code-surface:\s*color-mix\(in oklab, var\(--foreground\) \d+%, transparent\)/);
+
+    const darkBlock = stylesheet.slice(stylesheet.indexOf(".dark {"));
+    expect(darkBlock).toContain("--code-surface:");
+  });
+
+  it("never pins the code surface to the agent bubble fill", () => {
+    const preBlock = cssBlock(".paperclip-markdown pre");
+
+    expect(preBlock).not.toContain("var(--muted)");
+    expect(preBlock).not.toContain("var(--bubble-agent)");
   });
 });

--- a/ui/src/components/MarkdownCodeBlockStyles.test.ts
+++ b/ui/src/components/MarkdownCodeBlockStyles.test.ts
@@ -68,3 +68,45 @@ describe("markdown code block styles", () => {
     expect(codeBlockActionStyle.backgroundColor).not.toContain("--muted");
   });
 });
+
+describe("code syntax palette", () => {
+  const aliases = [
+    "--code-syntax-keyword",
+    "--code-syntax-string",
+    "--code-syntax-number",
+    "--code-syntax-identifier",
+    "--code-syntax-punctuation",
+    "--code-syntax-comment",
+    "--code-syntax-added",
+    "--code-syntax-removed",
+  ];
+
+  it("defines every syntax role as an alias of an existing token", () => {
+    for (const alias of aliases) {
+      const declaration = new RegExp(`${alias}:\\s*var\\(--[a-z0-9_-]+\\)`, "i");
+      expect(stylesheet, `${alias} must be defined as var(--existing-token)`).toMatch(declaration);
+    }
+  });
+
+  it("holds the borrowed-token coupling in the alias layer only", () => {
+    // The syntax rules must reference the aliases, never the borrowed tokens
+    // directly. That keeps repointing to a real palette a one-block edit.
+    const syntaxRules = stylesheet.slice(stylesheet.indexOf(".paperclip-markdown :is(pre, code)"));
+
+    expect(syntaxRules).not.toContain("--status-task-icon-");
+    expect(syntaxRules).not.toContain("--chip-match-title-fg");
+  });
+
+  it("maps the highlight.js token classes the renderer emits", () => {
+    for (const cls of [
+      ".hljs-keyword",
+      ".hljs-string",
+      ".hljs-number",
+      ".hljs-comment",
+      ".hljs-addition",
+      ".hljs-deletion",
+    ]) {
+      expect(stylesheet, `${cls} must be mapped`).toContain(cls);
+    }
+  });
+});

--- a/ui/src/components/task-chat/TaskChatDescriptionBubble.test.tsx
+++ b/ui/src/components/task-chat/TaskChatDescriptionBubble.test.tsx
@@ -95,8 +95,16 @@ describe("TaskChatDescriptionBubble (PAP-375)", () => {
     expect(bubble?.className).toContain("items-start");
     expect(bubble?.querySelector('[data-testid="task-chat-agent-avatar"]')).not.toBeNull();
     expect(bubble?.textContent).toContain("CEO");
-    expect(bubble?.querySelector(".bg-\\(--bubble-agent\\)")).not.toBeNull();
+    // PAP-501: agent prose sits on the page surface. The description is agent
+    // prose when an agent opened the task, so it carries no card fill, no
+    // rounding and no width cap — matching TaskChatBubble's agent branch.
+    expect(bubble?.querySelector(".bg-\\(--bubble-agent\\)")).toBeNull();
     expect(bubble?.querySelector(".bg-\\(--liveness-blue\\)")).toBeNull();
+    const agentBody = bubble?.querySelector(".bg-transparent");
+    expect(agentBody).not.toBeNull();
+    expect(agentBody?.className).toContain("w-full");
+    expect(agentBody?.className).not.toContain("rounded-2xl");
+    expect(agentBody?.className).not.toContain("max-w-(--pct-85)");
   });
 
   it("renders the live description — a new value shows without remount", () => {

--- a/ui/src/components/task-chat/TaskChatDescriptionBubble.tsx
+++ b/ui/src/components/task-chat/TaskChatDescriptionBubble.tsx
@@ -135,11 +135,17 @@ export function TaskChatDescriptionBubble({ brief }: TaskChatDescriptionBubblePr
         )}
       >
         <div
+          // PAP-501 put agent prose on the page surface: no card fill, no
+          // rounding, full width. TaskChatBubble already does this for agent
+          // messages. The description is agent prose too when an agent opened
+          // the task, so it follows the same rule rather than keeping a
+          // --bubble-agent card that no other agent text still uses. The human
+          // side keeps its accent bubble.
           className={cn(
-            "max-w-(--pct-85) break-words px-3.5 py-2 text-sm",
+            "break-words py-2 text-sm",
             isHuman
-              ? "rounded-2xl rounded-br-sm bg-(--liveness-blue) text-white"
-              : "rounded-2xl rounded-bl-sm bg-(--bubble-agent) text-foreground",
+              ? "max-w-(--pct-85) rounded-2xl rounded-br-sm bg-(--liveness-blue) px-3.5 text-white"
+              : "w-full bg-transparent px-1 text-foreground",
           )}
         >
           <FoldCurtain

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1408,7 +1408,7 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
   padding: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: var(--muted);
+  background: var(--code-surface);
   color: var(--foreground);
   overflow-x: auto;
 }
@@ -1487,16 +1487,16 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
    both modes. Override prose CSS variables so prose-invert can't revert to
    defaults. */
 .paperclip-markdown {
-  --tw-prose-pre-bg: var(--muted);
+  --tw-prose-pre-bg: var(--code-surface);
   --tw-prose-pre-code: var(--foreground);
-  --tw-prose-invert-pre-bg: var(--muted);
+  --tw-prose-invert-pre-bg: var(--code-surface);
   --tw-prose-invert-pre-code: var(--foreground);
 }
 
 .paperclip-markdown pre {
   border: 1px solid var(--border) !important;
   border-radius: var(--radius-lg) !important;
-  background-color: var(--muted) !important;
+  background-color: var(--code-surface) !important;
   color: var(--foreground) !important;
   padding: 0.5rem 0.65rem !important;
   margin: 0.4rem 0 !important;
@@ -1508,6 +1508,25 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
 .paperclip-markdown code {
   font-family: var(--font-mono);
   font-size: 1em;
+}
+
+/* ── Code block surface ──
+   The block must separate from whatever it sits on, and that is not always
+   the page. It also renders inside agent bubbles, whose fill --bubble-agent
+   is oklch(0.97 0 0) in light — the same value as --muted, which made the
+   block vanish into the bubble and read as one flat slab. The bubble fill
+   also changes per variant, and the "hairline" variant IS var(--background),
+   so no fixed token separates in every case.
+
+   A translucent tint shifts whatever is beneath it instead of replacing it,
+   so one value holds on the page and in every bubble variant, in both modes.
+   Light darkens toward the ink; dark lifts toward it. */
+:root {
+  --code-surface: color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.dark {
+  --code-surface: color-mix(in oklab, var(--foreground) 9%, transparent);
 }
 
 /* ── Code syntax roles ──

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1510,6 +1510,73 @@ a.paperclip-mention-chip[data-mention-kind="agent"]::before {
   font-size: 1em;
 }
 
+/* ── Code syntax roles ──
+   Each alias points at a token that already exists and already carries a
+   `.dark` override, so one definition covers both modes. A custom property
+   resolves at its use site, so `.dark` swaps these automatically.
+
+   The mapping is BORROWED. `--status-task-icon-*` and `--chip-match-title-fg`
+   name task-status and search-chip concerns, not syntax roles. Paperclip has
+   no syntax palette, and these were the only hues carrying a real per-mode
+   value: the fixed `--status-task-*` hues go dim on the dark code surface.
+   The coupling is deliberate and confined to this one block. To mint a real
+   palette later, repoint these eight aliases — no rule below changes. */
+:root {
+  --code-syntax-keyword: var(--status-task-icon-in_review);
+  --code-syntax-string: var(--status-task-icon-done);
+  --code-syntax-number: var(--chip-match-title-fg);
+  --code-syntax-identifier: var(--foreground);
+  --code-syntax-punctuation: var(--muted-foreground);
+  --code-syntax-comment: var(--muted-foreground);
+  --code-syntax-added: var(--status-task-icon-done);
+  --code-syntax-removed: var(--destructive);
+}
+
+/* highlight.js token classes, emitted by rehype-highlight. No highlight.js
+   stylesheet is imported, so these rules are the only source of colour. */
+.paperclip-markdown :is(pre, code) :is(.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type, .hljs-meta, .hljs-selector-tag) {
+  color: var(--code-syntax-keyword);
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-string, .hljs-regexp, .hljs-symbol, .hljs-char, .hljs-quote) {
+  color: var(--code-syntax-string);
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-number, .hljs-title, .hljs-name, .hljs-section, .hljs-link, .hljs-attr, .hljs-attribute, .hljs-selector-id, .hljs-selector-class) {
+  color: var(--code-syntax-number);
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-variable, .hljs-params, .hljs-property, .hljs-subst, .hljs-template-variable) {
+  color: var(--code-syntax-identifier);
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-operator, .hljs-punctuation, .hljs-tag, .hljs-bullet) {
+  color: var(--code-syntax-punctuation);
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-comment, .hljs-doctag) {
+  color: var(--code-syntax-comment);
+  font-style: italic;
+}
+
+/* ```diff fences. The row tinting from the design is not implemented, so
+   the +/- lines are carried by colour alone here. */
+.paperclip-markdown :is(pre, code) .hljs-addition {
+  color: var(--code-syntax-added);
+}
+
+.paperclip-markdown :is(pre, code) .hljs-deletion {
+  color: var(--code-syntax-removed);
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-emphasis) {
+  font-style: italic;
+}
+
+.paperclip-markdown :is(pre, code) :is(.hljs-strong) {
+  font-weight: 600;
+}
+
 .paperclip-markdown pre code {
   font-size: inherit;
   color: inherit;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents report their work in task chat, so a fenced code block is one of the most frequent things a person reads in the product
> - A previous change made the block follow the light and dark theme, but every token inside it stayed one colour, so a shell command and a JSON payload read the same
> - The design that was approved for that work also specifies syntax colours, taken only from tokens that already exist
> - Applying those colours exposed two surface defects: the block fill matched the agent bubble fill in light mode, and the agent-authored description still used a card that the rest of the product dropped
> - This pull request adds the syntax colours and fixes both surfaces
> - The benefit is that code in task chat is readable at a glance, and an agent message looks the same whether it is the first message or the tenth

## Linked Issues or Issue Description

No public issue exists. The problems are described below.

**What happened?**
Three defects, all in rendered markdown in task chat.

1. A fenced code block has no syntax colour. Every token uses the same foreground, so a keyword, a string and a comment are indistinguishable.
2. In light mode a code block is invisible inside an agent bubble. The block used `--muted`, which is `oklch(0.97 0 0)`. The agent bubble fill `--bubble-agent` is also `oklch(0.97 0 0)`. The two paint the same colour, so the comment reads as one flat grey slab. Dark mode hides the fault, because the bubble is `oklch(0.185 0 0)` and the block `oklch(0.269 0 0)`.
3. An agent-authored task description renders in a `--bubble-agent` card. Agent prose moved onto the page surface in an earlier change, and `TaskChatBubble` follows that rule, but `TaskChatDescriptionBubble` was not updated. The first message in a thread therefore sits in a grey card while every later agent message sits on the page.

**Expected behavior**
1. A fenced code block shows syntax colour, in both themes.
2. A code block is visible against every surface it can sit on.
3. An agent message looks the same whether it is the description or a later comment.

**Steps to reproduce**
1. Open a task whose chat contains a fenced code block, opened by an agent.
2. Set the theme to light.
3. The description sits in a grey card. The code block inside it is the same grey and has no visible edge.
4. Every token in the block is the same colour.

**Paperclip version or commit**
Reproduced on `master` at `a1278e6de`.

**Agent adapter(s) involved**
Not adapter-specific (core bug). All three defects are in the UI render path.

**Deployment mode**
Local development server.

## What Changed

Syntax colour:

- Add `rehype-highlight` to `ui/package.json` and pass it to react-markdown. The repository had no highlighter. The plugin array is declared at module scope, because react-markdown remounts the rendered tree when its plugin array changes identity, which discards scroll position and text selection.
- Enable `detect`, because most agent-authored fences carry no language tag and would never highlight without it. Restrict it with `subset` to eleven languages. highlight.js guesses badly on short snippets, and a wrong guess colours the whole block wrongly.
- Add eight `--code-syntax-*` aliases in `ui/src/index.css` and map the highlight.js token classes to them.

Code block surface:

- Add `--code-surface`, a translucent tint: 5% toward the foreground in light, 9% in dark. A tint shifts whatever is beneath it instead of replacing it.
- Point `.paperclip-markdown pre`, `.paperclip-mdxeditor-content pre` and the four `--tw-prose-*-pre-*` variables at it.

Agent prose surface:

- Give the agent branch of `TaskChatDescriptionBubble` the same classes `TaskChatBubble` already uses for agent messages: `w-full bg-transparent px-1 text-foreground`. The human branch keeps its accent bubble.

Tests:

- Assert the syntax rules never reference the borrowed tokens directly.
- Assert the surface is a `color-mix` tint defined in both modes, and that the block never pins itself to `--muted` or `--bubble-agent`.
- Assert a tagged fence, an untagged fence and a `diff` fence each tokenize, that an unknown language does not throw, and that inline code stays untokenized.
- Update the `TaskChatDescriptionBubble` test, which asserted the old card.

## Verification

Automated:

```bash
cd ui && npx vitest run --config vitest.config.ts src/components/task-chat src/components/MarkdownCodeBlockStyles.test.ts src/components/MarkdownBody.test.tsx src/components/MarkdownBody.wrap.test.tsx src/components/MarkdownAccentStyles.test.ts
```

302 tests pass. `npx tsc --noEmit -p ui/tsconfig.json` is clean.

Manual. Open a task whose chat has a fenced code block. Read the computed styles in the browser. The measured values are:

| Property | Light | Dark |
| --- | --- | --- |
| code block fill | `oklab(0.145 0 0 / 0.05)` | `oklab(0.985 0 0 / 0.09)` |
| surface beneath it | `oklch(0.97 0 0)` | `oklch(0.185 0 0)` |
| keyword | `#7c3aed` | `#9474f0` |
| function and number | `oklch(0.4 0.13 265)` | `oklch(0.78 0.1 265)` |
| identifier | `oklch(0.145 0 0)` | `oklch(0.985 0 0)` |
| comment | `oklch(0.556 0 0)` | `oklch(0.708 0 0)` |

Toggle the theme and confirm the block stays visible against the surface behind it.

## Risks

Medium. Read the two notes below before approving.

1. **A new dependency.** `rehype-highlight` adds five transitive packages: `lowlight`, `highlight.js`, `hast-util-is-element`, `hast-util-to-text`, `unist-util-find-after`. The lockfile diff is 56 lines and contains nothing else. `shiki` is already resolved in the lockfile, but only as an optional peer of another package, so using it would be a phantom dependency. `rehype-highlight` is the standard react-markdown pairing and is synchronous, so it needs no async render path.

2. **The syntax palette borrows tokens.** Paperclip has no syntax palette. `--status-task-icon-*` and `--chip-match-title-fg` name task-status and search-chip concerns, not syntax roles. They were chosen because they are the only hues that carry a real per-mode value; the fixed `--status-task-*` hues go dim on the dark code surface. This means recolouring the review violet also recolours every keyword. The coupling is deliberate and is confined to the eight aliases, and a test stops any rule from reaching past them. Minting a real `--code-syntax-*` palette later is an eight-line edit and changes no rule. Reviewers who want that done first should say so.

Lower risk, but worth knowing:

- Auto-detection can mislabel a very short snippet. The language subset limits the damage to a plausible neighbour.
- The CodeMirror theme inside the MDXEditor still uses its own literals. That surface is an editor, not a rendered snippet, and changing it needs a full light CodeMirror theme.
- The change to `TaskChatDescriptionBubble` is a judgment call. It treats the description as agent prose because an agent wrote it. If the opening brief should stay visually distinct regardless of author, drop that one commit; the other two stand alone.

## Model Used

Claude Opus 5 (`claude-opus-5`), via Claude Code. Extended thinking was on. Tool use was on, with file edit, shell, browser automation and the Paper design tool. The colour values were read back from the design tool and verified against computed styles in a running browser, not taken from screenshots.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

The two unchecked boxes are the CI and review gates, which have not run at the time of opening.
