### PR TITLE
fix(cli): make -C/--company-id optional on client commands enforced via resolveCommandContext

### DIFF
--- a/cli/src/__tests__/company-id-option.test.ts
+++ b/cli/src/__tests__/company-id-option.test.ts
@@ -7,6 +7,11 @@ import { registerApprovalCommands } from "../commands/client/approval.js";
 import { registerActivityCommands } from "../commands/client/activity.js";
 import { registerDashboardCommands } from "../commands/client/dashboard.js";
 import { registerFeedbackCommands } from "../commands/client/feedback.js";
+import { registerGoalCommands } from "../commands/client/goal.js";
+import { registerPluginCommands } from "../commands/client/plugin.js";
+import { registerProjectCommands } from "../commands/client/project.js";
+import { registerSecretCommands } from "../commands/client/secrets.js";
+import { registerTokenCommands } from "../commands/client/token.js";
 
 interface CommandNode {
   path: string;
@@ -37,6 +42,11 @@ describe("--company-id option registration", () => {
     registerActivityCommands(program);
     registerDashboardCommands(program);
     registerFeedbackCommands(program);
+    registerGoalCommands(program);
+    registerPluginCommands(program);
+    registerProjectCommands(program);
+    registerSecretCommands(program);
+    registerTokenCommands(program);
 
     const nodes = walkCommands(program);
 
@@ -61,6 +71,11 @@ describe("--company-id option registration", () => {
     registerActivityCommands(program);
     registerDashboardCommands(program);
     registerFeedbackCommands(program);
+    registerGoalCommands(program);
+    registerPluginCommands(program);
+    registerProjectCommands(program);
+    registerSecretCommands(program);
+    registerTokenCommands(program);
 
     const nodes = walkCommands(program);
 

--- a/cli/src/__tests__/company-id-option.test.ts
+++ b/cli/src/__tests__/company-id-option.test.ts
@@ -1,0 +1,73 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerCompanyCommands } from "../commands/client/company.js";
+import { registerIssueCommands } from "../commands/client/issue.js";
+import { registerAgentCommands } from "../commands/client/agent.js";
+import { registerApprovalCommands } from "../commands/client/approval.js";
+import { registerActivityCommands } from "../commands/client/activity.js";
+import { registerDashboardCommands } from "../commands/client/dashboard.js";
+import { registerFeedbackCommands } from "../commands/client/feedback.js";
+
+interface CommandNode {
+  path: string;
+  command: Command;
+}
+
+/**
+ * Walk the full command tree (recursively, through all subcommands) and
+ * return every node along with its dotted path (e.g. "agent list").
+ */
+function walkCommands(command: Command, path: string[] = []): CommandNode[] {
+  const currentPath = [...path, command.name()].filter(Boolean).join(" ");
+  const nodes: CommandNode[] = [{ path: currentPath || "<root>", command }];
+  for (const sub of command.commands) {
+    nodes.push(...walkCommands(sub, [...path, command.name()].filter(Boolean)));
+  }
+  return nodes;
+}
+
+describe("--company-id option registration", () => {
+  it("never declares --company-id as a mandatory (required) option", () => {
+    const program = new Command();
+
+    registerCompanyCommands(program);
+    registerIssueCommands(program);
+    registerAgentCommands(program);
+    registerApprovalCommands(program);
+    registerActivityCommands(program);
+    registerDashboardCommands(program);
+    registerFeedbackCommands(program);
+
+    const nodes = walkCommands(program);
+
+    // Trap: commander's `option.required` merely reflects that the flag takes
+    // a value (`<id>`). The `.requiredOption` discriminator is
+    // `option.mandatory`. Asserting on `required` would pass on the broken
+    // (pre-fix) tree and is worthless.
+    const offenders = nodes
+      .filter((node) => node.command.options.some((option) => option.long === "--company-id" && option.mandatory === true))
+      .map((node) => node.path);
+
+    expect(offenders, `--company-id must never be mandatory; offending commands: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("never declares --company-id more than once on the same command", () => {
+    const program = new Command();
+
+    registerCompanyCommands(program);
+    registerIssueCommands(program);
+    registerAgentCommands(program);
+    registerApprovalCommands(program);
+    registerActivityCommands(program);
+    registerDashboardCommands(program);
+    registerFeedbackCommands(program);
+
+    const nodes = walkCommands(program);
+
+    const duplicates = nodes
+      .filter((node) => node.command.options.filter((option) => option.long === "--company-id").length > 1)
+      .map((node) => node.path);
+
+    expect(duplicates, `--company-id must not be declared more than once; offending commands: ${duplicates.join(", ")}`).toEqual([]);
+  });
+});

--- a/cli/src/commands/client/activity.ts
+++ b/cli/src/commands/client/activity.ts
@@ -25,7 +25,7 @@ export function registerActivityCommands(program: Command): void {
     activity
       .command("list")
       .description("List company activity log entries")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--agent-id <id>", "Filter by agent ID")
       .option("--entity-type <type>", "Filter by entity type")
       .option("--entity-id <id>", "Filter by entity ID")
@@ -75,7 +75,7 @@ export function registerActivityCommands(program: Command): void {
     activity
       .command("create")
       .description("Create a company activity log entry")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--payload-json <json>", "CreateActivity JSON payload")
       .action(async (opts: ActivityListOptions) => {
         try {

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -284,7 +284,7 @@ export function registerAgentCommands(program: Command): void {
     agent
       .command("list")
       .description("List agents for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (opts: AgentListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -767,7 +767,7 @@ export function registerAgentCommands(program: Command): void {
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",
       )
       .argument("<agentRef>", "Agent ID or shortname/url-key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--key-name <name>", "API key label", "local-cli")
       .option(
         "--no-install-skills",

--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -50,7 +50,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("list")
       .description("List approvals for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--status <status>", "Status filter")
       .action(async (opts: ApprovalListOptions) => {
         try {
@@ -111,7 +111,7 @@ export function registerApprovalCommands(program: Command): void {
     approval
       .command("create")
       .description("Create an approval request")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--type <type>", "Approval type (hire_agent|approve_ceo_strategy)")
       .requiredOption("--payload <json>", "Approval payload as JSON object")
       .option("--requested-by-agent-id <id>", "Requesting agent ID")

--- a/cli/src/commands/client/company.ts
+++ b/cli/src/commands/client/company.ts
@@ -1498,7 +1498,7 @@ export function registerCompanyCommands(program: Command): void {
     company
       .command("feedback:list")
       .description("List feedback traces for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--target-type <type>", "Filter by target type")
       .option("--vote <vote>", "Filter by vote value")
       .option("--status <status>", "Filter by trace status")
@@ -1540,7 +1540,7 @@ export function registerCompanyCommands(program: Command): void {
     company
       .command("feedback:export")
       .description("Export feedback traces for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--target-type <type>", "Filter by target type")
       .option("--vote <vote>", "Filter by vote value")
       .option("--status <status>", "Filter by trace status")

--- a/cli/src/commands/client/dashboard.ts
+++ b/cli/src/commands/client/dashboard.ts
@@ -20,7 +20,7 @@ export function registerDashboardCommands(program: Command): void {
     dashboard
       .command("get")
       .description("Get dashboard summary for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (opts: DashboardGetOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });

--- a/cli/src/commands/client/goal.ts
+++ b/cli/src/commands/client/goal.ts
@@ -95,7 +95,7 @@ export function registerGoalCommands(program: Command): void {
     goal
       .command("create")
       .description("Create a goal")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--title <title>", "Goal title")
       .option("--description <text>", "Goal description")
       .option("--level <level>", "Goal level")

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -276,7 +276,7 @@ export function registerIssueCommands(program: Command): void {
     issue
       .command("create")
       .description("Create an issue")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--title <title>", "Issue title")
       .option("--description <text>", "Issue description")
       .option("--status <status>", "Issue status")

--- a/cli/src/commands/client/plugin.ts
+++ b/cli/src/commands/client/plugin.ts
@@ -849,7 +849,7 @@ function addPluginLocalFolderGet(parent: Command, name: string, description: str
       .command(name)
       .description(description)
       .argument("<pluginId>", "Plugin ID or key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (pluginId: string, opts: PluginCompanyOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -869,7 +869,7 @@ function addPluginLocalFolderKeyGet(parent: Command, name: string, description: 
       .description(description)
       .argument("<pluginId>", "Plugin ID or key")
       .argument("<folderKey>", "Local folder key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (pluginId: string, folderKey: string, opts: PluginCompanyOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -892,7 +892,7 @@ function addPluginLocalFolderKeyPost(parent: Command, name: string, description:
       .description(description)
       .argument("<pluginId>", "Plugin ID or key")
       .argument("<folderKey>", "Local folder key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--payload-json <json>", "JSON payload", "{}")
       .action(async (pluginId: string, folderKey: string, opts: PluginCompanyOptions) => {
         try {
@@ -919,7 +919,7 @@ function addPluginLocalFolderKeyPut(parent: Command, name: string, description: 
       .description(description)
       .argument("<pluginId>", "Plugin ID or key")
       .argument("<folderKey>", "Local folder key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--payload-json <json>", "JSON payload")
       .action(async (pluginId: string, folderKey: string, opts: PluginCompanyOptions) => {
         try {

--- a/cli/src/commands/client/project.ts
+++ b/cli/src/commands/client/project.ts
@@ -107,7 +107,7 @@ export function registerProjectCommands(program: Command): void {
     project
       .command("create")
       .description("Create a project")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--name <name>", "Project name")
       .option("--description <text>", "Project description")
       .option("--status <status>", "Project status")

--- a/cli/src/commands/client/secrets.ts
+++ b/cli/src/commands/client/secrets.ts
@@ -371,7 +371,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("list")
       .description("List secret metadata for a company")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (opts: SecretListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -387,7 +387,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("declarations")
       .description("List portable env declarations emitted by company export")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--include <values>", "Comma-separated include set: company,agents,projects,issues,tasks,skills", "company,agents,projects")
       .option("--kind <kind>", "Filter declarations: all | secret | plain", "all")
       .action(async (opts: SecretDeclarationsOptions) => {
@@ -414,7 +414,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("create")
       .description("Create a Paperclip-managed secret")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--name <name>", "Secret display name")
       .option("--key <key>", "Portable secret key")
       .option("--provider <provider>", "Secret provider id")
@@ -442,7 +442,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("link")
       .description("Link an external provider-owned secret without storing its value in Paperclip")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--name <name>", "Secret display name")
       .requiredOption("--provider <provider>", "Secret provider id")
       .requiredOption("--external-ref <ref>", "Provider secret ARN/name/path/reference")
@@ -556,7 +556,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("doctor")
       .description("Run secret provider health checks through the Paperclip API")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (opts: SecretDoctorOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -574,7 +574,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("providers")
       .description("List configured secret provider descriptors")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (opts: SecretDoctorOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -592,7 +592,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("provider-configs")
       .description("List company secret provider vault configs")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .action(async (opts: SecretDoctorOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -622,7 +622,7 @@ export function registerSecretCommands(program: Command): void {
     secrets
       .command("migrate-inline-env")
       .description("Migrate inline sensitive agent env values into secret references")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .option("--apply", "Persist changes; default is a dry run", false)
       .action(async (opts: SecretMigrateInlineEnvOptions) => {
         try {
@@ -639,7 +639,7 @@ function addCompanySecretJsonPost(parent: Command, name: string, description: st
     parent
       .command(name)
       .description(description)
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--payload-json <json>", "JSON payload")
       .action(async (opts: SecretJsonOptions) => {
         try {

--- a/cli/src/commands/client/token.ts
+++ b/cli/src/commands/client/token.ts
@@ -66,7 +66,7 @@ export function registerTokenCommands(program: Command): void {
     agent
       .command("create")
       .description("Create an agent API key")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--agent <agent>", "Agent ID, shortname, or unambiguous name")
       .option("--name <name>", "API key label", "cli-agent")
       .action(async (opts: AgentTokenOptions) => {
@@ -96,7 +96,7 @@ export function registerTokenCommands(program: Command): void {
     agent
       .command("list")
       .description("List agent API keys")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--agent <agent>", "Agent ID, shortname, or unambiguous name")
       .action(async (opts: AgentTokenOptions) => {
         try {
@@ -123,7 +123,7 @@ export function registerTokenCommands(program: Command): void {
       .command("revoke")
       .description("Revoke an agent API key")
       .argument("<keyId>", "Agent API key ID")
-      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("-C, --company-id <id>", "Company ID (overrides context default)")
       .requiredOption("--agent <agent>", "Agent ID, shortname, or unambiguous name")
       .action(async (keyId: string, opts: AgentTokenOptions) => {
         try {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `paperclipai` CLI is how humans and other agents drive Paperclip from a terminal or script
> - Many `client/*` command files declare `-C, --company-id` with `.requiredOption(...)`, so commander aborts argument parsing before the command's action ever runs
> - Every one of those same actions calls `resolveCommandContext(opts, { requireCompany: true })`, which already resolves the company id from `--company-id` -> `PAPERCLIP_COMPANY_ID` -> the context profile, and throws a clear error only when all three are empty
> - So a command like `agent list` fails immediately on a bare parse error even when the caller has `PAPERCLIP_COMPANY_ID` exported or a context profile set, while a sibling command like `issue list` (no `requiredOption`) works fine from the same environment — same resolver, inconsistent enforcement point
> - This pull request replaces `.requiredOption("-C, --company-id <id>", ...)` with `.option(...)` at every site backed by `resolveCommandContext(..., { requireCompany: true })`, leaving `requireCompany: true` untouched so the resolver still enforces the requirement, just with its existing, more informative error message
> - The benefit is that `--company-id` behaves consistently across every client command: env var and context-profile fallback always work, and the error message when nothing is set comes from one place instead of commander's generic "required option not specified"

## Linked Issues or Issue Description

No public GitHub issue exists for this yet, so following the Enhancement proposal template inline:

**What existing behavior does this improve?**
The `-C, --company-id` option on CLI client commands under `cli/src/commands/client/`.

**Subsystem affected**
Unsure / cross-cutting within the CLI — this is not one of the listed subsystems (server/, ui/, packages/db, packages/shared, packages/adapters, packages/plugins); it is `cli/src/commands/client/**`.

**Current behavior**
28 commands across `cli/src/commands/client/{activity,agent,approval,company,goal,plugin,project,secrets,token}.ts` declare `-C, --company-id` via commander's `.requiredOption(...)`. Commander enforces that flag at argument-parse time and exits with a generic `error: required option '-C, --company-id <id>' not specified` before the command's action function runs — even though every one of those actions calls `resolveCommandContext(opts, { requireCompany: true })`, which is fully capable of resolving the company id from `PAPERCLIP_COMPANY_ID` or the context profile. Other commands in the same CLI (e.g. `issue list`) use `.option(...)` for the same flag and already work from env/profile. The result is an inconsistent, confusing failure mode depending on which command you call.

**Proposed behavior**
All 28 sites use `.option("-C, --company-id <id>", ...)` instead of `.requiredOption(...)`. `requireCompany: true` stays in `resolveCommandContext`, so a company id is still required end-to-end — it can now come from `--company-id`, `PAPERCLIP_COMPANY_ID`, or the context profile, uniformly, with one shared, descriptive error message when none of the three are set.

**Breaking changes**
None for correctly-configured callers. A caller that relied on commander's parse-time rejection (rather than the resolver's `Company ID is required...` message) would see a different error message, but the exit-code behavior (non-zero, no company id resolved) is unchanged. No response shape, output format, or successful-path behavior changes.

## What Changed

- Replaced `.requiredOption("-C, --company-id <id>", ...)` with `.option("-C, --company-id <id>", ...)` at all 28 call sites across `cli/src/commands/client/activity.ts`, `agent.ts`, `approval.ts`, `company.ts`, `goal.ts`, `plugin.ts`, `project.ts`, `secrets.ts`, and `token.ts`.
- Left `resolveCommandContext(opts, { requireCompany: true })` unchanged everywhere — enforcement still happens there, with its existing error message.
- Added `cli/src/__tests__/company-id-option.test.ts`, a regression test modelled on `auth-command-registration.test.ts` that registers every affected command family (`company`, `issue`, `agent`, `approval`, `activity`, `dashboard`, `feedback`, `goal`, `plugin`, `project`, `secrets`, `token`), walks the full command tree, and asserts `--company-id` is never `mandatory` (commander's `.requiredOption` discriminator) and never declared more than once on the same command.

## Verification

```
$ grep -rn 'requiredOption("-C' cli/src/commands/client/
# exit code 1, no matches
```

```
$ cd cli && pnpm exec vitest run src/__tests__/company-id-option.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Red on the unpatched tree (reverting only the fix files reproduces 9+ offending commands):

```
$ git stash push -- cli/src/commands/client/*.ts
$ pnpm exec vitest run src/__tests__/company-id-option.test.ts
 ❯ … 1 failed
AssertionError: --company-id must never be mandatory; offending commands: …
$ git stash pop
```

```
$ pnpm -C cli build
# green (tsc --noEmit at the repo root reports ~139 pre-existing errors in
# server/src/** from a missing built @paperclipai/plugin-sdk dist, present
# identically on the unpatched tree and unrelated to this diff;
# cli/src/commands/client/** itself has zero new type errors)
```

Behavioral check via `cli/src/index.ts`:

```
$ PAPERCLIP_COMPANY_ID=test-co-123 PAPERCLIP_API_KEY=fake pnpm exec tsx src/index.ts agent list --json
API error 401: Unauthorized
# past argument parsing, into an HTTP/auth error — this is the intended fix

$ pnpm exec tsx src/index.ts agent list --json --context /tmp/pc-empty-context.json
Company ID is required. Pass --company-id, set PAPERCLIP_COMPANY_ID, or set context profile companyId via `paperclipai context set`.
```

## Risks

Low risk. This only relaxes a commander-level parse constraint; the underlying requirement (`requireCompany: true`) is untouched, so every affected command still refuses to proceed without a resolvable company id. The main behavioral shift is the error message and the point at which the error surfaces (resolver instead of commander), which is strictly more informative. No API, schema, or persisted-data changes.

## Model Used

Claude (Anthropic), Claude Opus, extended thinking / chain-of-thought reasoning enabled, with tool use (repo grep/read/edit, test execution) throughout implementation and verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

## Related PRs found during duplicate search

- #4276 (`feat(cli): unify issue flag matrix (A+B) — -C optional + per-subcommand guards`) — open, overlapping intent (also makes `-C` optional) but scoped to `issue create` only plus a separate flag-hint feature; does not touch the other 27 sites this PR fixes. Not a duplicate.
- #2538 (`Refine CLI company commands behavior, tests`) — open, touches `company.ts` but for import-adapter validation, unrelated to `--company-id` enforcement. Not a duplicate.

No exact duplicate of this PR's scope (making `--company-id` a non-mandatory option across all 28 client-command call sites while keeping resolver-level enforcement) was found in the open or closed PR list.
