### PR TITLE
Fix direct-manager issue comment authorization

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -556,7 +556,7 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("shared default-open");
   });
 
-  it("allows standard-trust agents to comment on and update visible peer-owned issues", async () => {
+  it("keeps standard-trust peer issue mutations default-open but denies peer comments", async () => {
     const company = await createCompany(db, "DefaultOpenPeerWrites");
     const actorAgent = await createAgent(db, company.id);
     const ownerAgent = await createAgent(db, company.id);
@@ -576,15 +576,75 @@ describeEmbeddedPostgres("authorization service", () => {
     };
     const authorization = authorizationService(db);
 
-    for (const action of ["issue:comment", "issue:mutate"] as const) {
-      await expect(authorization.decide({ actor, action, resource })).resolves.toMatchObject({
-        allowed: true,
-        reason: "allow_visible_issue_write",
-      });
-    }
+    await expect(authorization.decide({ actor, action: "issue:comment", resource })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+    await expect(authorization.decide({ actor, action: "issue:mutate", resource })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_visible_issue_write",
+    });
   });
 
-  it("keeps the responsible-user ceiling on every default-open peer write", async () => {
+  it("allows only direct same-company managers to comment on assigned issues", async () => {
+    const company = await createCompany(db, "DirectManagerComment");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const managerAgent = await createAgent(db, company.id, { reportsTo: ceoAgent.id });
+    const directReport = await createAgent(db, company.id, { reportsTo: managerAgent.id });
+    const peerAgent = await createAgent(db, company.id, { reportsTo: ceoAgent.id });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: directReport.id });
+    const unassignedIssue = await createIssue(db, company.id);
+    const otherCompany = await createCompany(db, "CrossCompanyManagerComment");
+    const otherAgent = await createAgent(db, otherCompany.id);
+    const otherIssue = await createIssue(db, otherCompany.id, { assigneeAgentId: otherAgent.id });
+    const authorization = authorizationService(db);
+    const actorFor = (agentId: string, companyId = company.id) => ({
+      type: "agent" as const,
+      agentId,
+      companyId,
+      source: "agent_jwt" as const,
+    });
+    const resourceFor = (targetIssue: typeof issue) => ({
+      type: "issue" as const,
+      companyId: targetIssue.companyId,
+      issueId: targetIssue.id,
+      assigneeAgentId: targetIssue.assigneeAgentId,
+      status: targetIssue.status,
+    });
+
+    await expect(authorization.decide({
+      actor: actorFor(managerAgent.id),
+      action: "issue:comment",
+      resource: resourceFor(issue),
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+    await expect(authorization.decide({
+      actor: actorFor(ceoAgent.id),
+      action: "issue:comment",
+      resource: resourceFor(issue),
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    await expect(authorization.decide({
+      actor: actorFor(peerAgent.id),
+      action: "issue:comment",
+      resource: resourceFor(issue),
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    await expect(authorization.decide({
+      actor: actorFor(managerAgent.id),
+      action: "issue:comment",
+      resource: resourceFor(unassignedIssue),
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    await expect(authorization.decide({
+      actor: actorFor(managerAgent.id),
+      action: "issue:comment",
+      resource: resourceFor(otherIssue),
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_company_boundary" });
+    await expect(authorization.decide({
+      actor: actorFor(managerAgent.id),
+      action: "issue:mutate",
+      resource: resourceFor(issue),
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_visible_issue_write" });
+  });
+
+  it("keeps the responsible-user ceiling on default-open peer mutations", async () => {
     const company = await createCompany(db, "DefaultOpenPeerWriteCeiling");
     const actorAgent = await createAgent(db, company.id);
     const ownerAgent = await createAgent(db, company.id);
@@ -606,13 +666,15 @@ describeEmbeddedPostgres("authorization service", () => {
     };
     const authorization = authorizationService(db);
 
-    for (const action of ["issue:comment", "issue:mutate"] as const) {
-      await expect(authorization.decide({ actor, action, resource })).resolves.toMatchObject({
-        allowed: false,
-        code: "RESPONSIBLE_USER_UNAVAILABLE",
-        reason: "deny_missing_membership",
-      });
-    }
+    await expect(authorization.decide({ actor, action: "issue:comment", resource })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+    await expect(authorization.decide({ actor, action: "issue:mutate", resource })).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+      reason: "deny_missing_membership",
+    });
   });
 
   it("structurally keeps default-open comments inside issue visibility", async () => {
@@ -666,7 +728,7 @@ describeEmbeddedPostgres("authorization service", () => {
     }
   });
 
-  it("does not let default-open non-assignee comments mint mention grants", async () => {
+  it("does not let denied non-assignee comments mint mention grants", async () => {
     const company = await createCompany(db, "DefaultOpenMentionNonTransitive");
     const ownerAgent = await createAgent(db, company.id);
     const commentingAgent = await createAgent(db, company.id);
@@ -694,10 +756,7 @@ describeEmbeddedPostgres("authorization service", () => {
         assigneeAgentId: ownerAgent.id,
         status: issue.status,
       },
-    })).resolves.toMatchObject({
-      allowed: true,
-      reason: "allow_visible_issue_write",
-    });
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
   });
 
   it("denies delegated protected assignment when the responsible user lacks matching authority", async () => {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1908,7 +1908,7 @@ export function authorizationService(db: Db) {
 
     const visibleIssueWriteDecision =
       trustResolution.kind === "standard" &&
-      (input.action === "issue:comment" || input.action === "issue:mutate")
+      input.action === "issue:mutate"
         ? await decideVisibleIssueWrite()
         : null;
     if (visibleIssueWriteDecision && !visibleIssueWriteDecision.allowed) {
@@ -2148,12 +2148,22 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the actor owns the assigned issue.",
         });
       }
-      if (!resource?.assigneeAgentId) {
+      if (!resource?.assigneeAgentId && input.action === "issue:mutate") {
         return allow({
           action: input.action,
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
         });
+      }
+      if (input.action === "issue:comment" && resource?.assigneeAgentId) {
+        const assignee = await loadAgent(resource.assigneeAgentId);
+        if (assignee?.companyId === companyId && assignee.reportsTo === actorAgentId) {
+          return allow({
+            action: input.action,
+            reason: "allow_manager_chain",
+            explanation: "Allowed because the issue assignee reports directly to the actor.",
+          });
+        }
       }
       if (
         input.action === "issue:comment" &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip decides whether an agent can read, comment on, or change an issue.
> - A manager must be able to comment on an issue assigned to a direct report in the same company.
> - This access must not extend to peers, indirect reports, other companies, or unassigned issues.
> - The grant must apply only to comments.
> - This pull request applies that narrow rule and adds tests for each boundary.

## Linked Issues or Issue Description

Refs #9707.

This pull request supersedes #9707. The old pull request uses a fork branch that rejects maintainer writes. Its head also conflicts with current `master`.

### What happened?

A manager could not post a required comment to an issue assigned to a direct report. The existing standard-trust path also allowed comments more broadly than this rule permits.

### Expected behavior

A same-company direct manager can comment on a direct report's assigned issue. Peers, indirect managers, cross-company agents, and comments on unassigned issues remain denied unless another valid grant applies.

## What Changed

- Remove `issue:comment` from the standard default-open issue write path.
- Allow a comment when the assignee reports directly to the actor in the same company.
- Keep self-comment and valid mention grants.
- Keep existing `issue:mutate` behavior.
- Add focused allow and deny tests.

## Verification

The implementation owner ran these checks on commit `355a80d5c906067047bab2ad66f00696c1858a91`:

- `pnpm exec vitest run server/src/__tests__/authorization-service.test.ts` — 62 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.

The two changed files on current `master` matched this commit's parent before the successor branch was published.

## Carried Review Finding

The old pull request had one resolved P2 note about a redundant assignee guard. That guard is not copied. The successor checks the assignee only on the comment path where an unassigned comment can still reach the check.

The old 5/5 automated result does not approve this successor. Fresh checks and review are required for this head.

## Risks

This changes an authorization boundary. The focused tests cover the direct-manager allow case and the named deny cases. No schema, dependency, route, or configuration changes are included.

## Model Used

OpenAI GPT-5 Codex, with repository inspection, code editing, and local test execution.

## Checklist

- [x] I included the reasoning path and the user-visible benefit.
- [x] I described the bug in this pull request and linked the superseded pull request.
- [x] I have searched GitHub for duplicate or related PRs and linked them above.
- [x] I used a branch name with no private issue identifier.
- [x] The implementation owner ran the focused tests and type check.
- [x] I carried forward the applicable review finding from #9707.
- [ ] All required checks are green on this head.
- [ ] Fresh review is complete on this head.
