### PR TITLE
fix(tools): include local stdio in runtime MCP delivery

### DIFF
--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -348,7 +348,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       transport: "local_stdio",
       status: "active",
       enabled: true,
-      config: { templateId: stdioTemplateKey },
+      config: { templateId: ` ${stdioTemplateKey} ` },
     }).returning();
     const [profile] = await db.insert(toolProfiles).values({
       companyId: company!.id,

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -16,6 +16,7 @@ import {
   toolProfileBindings,
   toolProfileEntries,
   toolProfiles,
+  toolStdioCommandTemplates,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -48,6 +49,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     await db.delete(toolProfileBindings);
     await db.delete(toolProfileEntries);
     await db.delete(toolProfiles);
+    await db.delete(toolStdioCommandTemplates);
     await db.delete(toolConnections);
     await db.delete(toolApplications);
     await db.delete(agents);
@@ -78,7 +80,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       type: "mcp_http",
       status: "active",
     }).returning();
-    const [installedConnection, uninstalledConnection] = await db.insert(toolConnections).values([
+    const [installedConnection, unpermittedConnection] = await db.insert(toolConnections).values([
       {
         companyId: company!.id,
         applicationId: application!.id,
@@ -92,7 +94,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       {
         companyId: company!.id,
         applicationId: application!.id,
-        name: "Uninstalled MCP",
+        name: "Unpermitted MCP",
         uid: `test/${randomUUID()}`,
         transport: "mcp_remote",
         status: "active",
@@ -138,7 +140,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
       token: expect.stringMatching(/^pcgw_/),
     });
-    expect(first.some((server) => server.connectionId === uninstalledConnection!.id)).toBe(false);
+    expect(first.some((server) => server.connectionId === unpermittedConnection!.id)).toBe(false);
     expect(second).toHaveLength(1);
 
     const gateways = await db.select().from(toolMcpGateways);
@@ -184,6 +186,23 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       enabled: true,
       config: { url: "https://zapier.example.test/mcp" },
     }).returning();
+    const [stdioApplication] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `runtime-diagnostic-stdio-${randomUUID().slice(0, 8)}`,
+      name: "Local stdio",
+      type: "mcp_stdio",
+      status: "active",
+    }).returning();
+    const [stdioConnection] = await db.insert(toolConnections).values({
+      companyId: company!.id,
+      applicationId: stdioApplication!.id,
+      name: "Local stdio",
+      uid: `test/${randomUUID()}`,
+      transport: "local_stdio",
+      status: "active",
+      enabled: true,
+      config: { templateId: "local.uninstalled" },
+    }).returning();
     const [profile] = await db.insert(toolProfiles).values({
       companyId: company!.id,
       profileKey: `app:${connection!.id}`,
@@ -201,6 +220,26 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     await db.insert(toolProfileBindings).values({
       companyId: company!.id,
       profileId: profile!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    const [stdioProfile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${stdioConnection!.id}`,
+      name: "Local stdio",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
+      selectorType: "connection",
+      effect: "include",
+      applicationId: stdioApplication!.id,
+      connectionId: stdioConnection!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
       targetType: "agent",
       targetId: agent!.id,
     });
@@ -227,8 +266,11 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       details: expect.objectContaining({
         reasonCode: "permitted_connections_not_installed",
         deliveredServerCount: 0,
-        permittedNotInstalledCount: 1,
-        permittedNotInstalledConnections: [{ id: connection!.id, name: "Zapier" }],
+        permittedNotInstalledCount: 2,
+        permittedNotInstalledConnections: [
+          { id: stdioConnection!.id, name: "Local stdio" },
+          { id: connection!.id, name: "Zapier" },
+        ],
       }),
     });
     const [audit] = await db.select().from(toolAccessAuditEvents);
@@ -268,7 +310,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       type: "mcp_stdio",
       status: "active",
     }).returning();
-    const [installedConnection, uninstalledConnection] = await db.insert(toolConnections).values([
+    const [installedConnection, unpermittedConnection] = await db.insert(toolConnections).values([
       {
         companyId: company!.id,
         applicationId: application!.id,
@@ -282,7 +324,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       {
         companyId: company!.id,
         applicationId: application!.id,
-        name: "Uninstalled MCP",
+        name: "Unpermitted MCP",
         uid: `test/${randomUUID()}`,
         transport: "mcp_remote",
         status: "active",
@@ -290,6 +332,14 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
         config: { url: "https://uninstalled.example.test/mcp" },
       },
     ]).returning();
+    const stdioTemplateKey = `test.${randomUUID()}`;
+    await db.insert(toolStdioCommandTemplates).values({
+      companyId: company!.id,
+      templateKey: stdioTemplateKey,
+      name: "Installed stdio MCP",
+      command: "node",
+      args: ["server.js"],
+    });
     const [stdioConnection] = await db.insert(toolConnections).values({
       companyId: company!.id,
       applicationId: stdioApplication!.id,
@@ -298,7 +348,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       transport: "local_stdio",
       status: "active",
       enabled: true,
-      config: { templateId: randomUUID() },
+      config: { templateId: stdioTemplateKey },
     }).returning();
     const [profile] = await db.insert(toolProfiles).values({
       companyId: company!.id,
@@ -370,7 +420,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
       token: expect.stringMatching(/^pcgw_/),
     }));
-    expect(first.some((server) => server.connectionId === uninstalledConnection!.id)).toBe(false);
+    expect(first.some((server) => server.connectionId === unpermittedConnection!.id)).toBe(false);
     expect(second).toHaveLength(2);
 
     const gateways = await db.select().from(toolMcpGateways);
@@ -388,6 +438,14 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       expect(token.expiresAt!.getTime()).toBeLessThanOrEqual(Date.now() + 61 * 60 * 1000);
     }
     expect(JSON.stringify(tokens)).not.toContain(first[0]!.token);
+
+    await db
+      .update(toolStdioCommandTemplates)
+      .set({ status: "disabled", disabledAt: new Date() })
+      .where(eq(toolStdioCommandTemplates.templateKey, stdioTemplateKey));
+    const afterDisable = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
+    expect(afterDisable).toHaveLength(1);
+    expect(afterDisable[0]).toMatchObject({ connectionId: installedConnection!.id });
   });
 
 });

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -240,4 +240,154 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       details: expect.objectContaining({ runId, deliveredServerCount: 0 }),
     });
   });
+
+  it("provisions gateways for installed remote and local stdio connections", async () => {
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    const [company] = await db.insert(companies).values({
+      name: `Runtime MCP ${randomUUID()}`,
+      issuePrefix: `RM${randomUUID().slice(0, 5).toUpperCase()}`,
+    }).returning();
+    const [agent] = await db.insert(agents).values({
+      companyId: company!.id,
+      name: "Runtime MCP Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    }).returning();
+    const [application] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `runtime-${randomUUID().slice(0, 8)}`,
+      name: "Runtime MCP App",
+      type: "mcp_http",
+      status: "active",
+    }).returning();
+    const [stdioApplication] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `runtime-stdio-${randomUUID().slice(0, 8)}`,
+      name: "Runtime stdio MCP App",
+      type: "mcp_stdio",
+      status: "active",
+    }).returning();
+    const [installedConnection, uninstalledConnection] = await db.insert(toolConnections).values([
+      {
+        companyId: company!.id,
+        applicationId: application!.id,
+        name: "Installed MCP",
+        uid: `test/${randomUUID()}`,
+        transport: "mcp_remote",
+        status: "active",
+        enabled: true,
+        config: { url: "https://installed.example.test/mcp" },
+      },
+      {
+        companyId: company!.id,
+        applicationId: application!.id,
+        name: "Uninstalled MCP",
+        uid: `test/${randomUUID()}`,
+        transport: "mcp_remote",
+        status: "active",
+        enabled: true,
+        config: { url: "https://uninstalled.example.test/mcp" },
+      },
+    ]).returning();
+    const [stdioConnection] = await db.insert(toolConnections).values({
+      companyId: company!.id,
+      applicationId: stdioApplication!.id,
+      name: "Installed stdio MCP",
+      uid: `test/${randomUUID()}`,
+      transport: "local_stdio",
+      status: "active",
+      enabled: true,
+      config: { templateId: randomUUID() },
+    }).returning();
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${installedConnection!.id}`,
+      name: "Installed MCP",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: profile!.id,
+      selectorType: "connection",
+      effect: "include",
+      applicationId: application!.id,
+      connectionId: installedConnection!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: profile!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    const [stdioProfile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${stdioConnection!.id}`,
+      name: "Installed stdio MCP",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
+      selectorType: "connection",
+      effect: "include",
+      applicationId: stdioApplication!.id,
+      connectionId: stdioConnection!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id,
+      connectionId: installedConnection!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id,
+      connectionId: stdioConnection!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+
+    const before = Date.now();
+    const first = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
+    const second = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
+
+    expect(first).toHaveLength(2);
+    expect(first).toContainEqual(expect.objectContaining({
+      name: "Installed MCP",
+      connectionId: installedConnection!.id,
+      url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
+      token: expect.stringMatching(/^pcgw_/),
+    }));
+    expect(first).toContainEqual(expect.objectContaining({
+      name: "Installed stdio MCP",
+      connectionId: stdioConnection!.id,
+      url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
+      token: expect.stringMatching(/^pcgw_/),
+    }));
+    expect(first.some((server) => server.connectionId === uninstalledConnection!.id)).toBe(false);
+    expect(second).toHaveLength(2);
+
+    const gateways = await db.select().from(toolMcpGateways);
+    expect(gateways).toHaveLength(2);
+    expect(gateways.map((gateway) => gateway.metadata)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ managedRuntimeConnectionId: installedConnection!.id }),
+      expect.objectContaining({ managedRuntimeConnectionId: stdioConnection!.id }),
+    ]));
+    const tokens = await db.select().from(toolMcpGatewayTokens);
+    expect(tokens).toHaveLength(4);
+    for (const token of tokens) {
+      expect(token.subjectType).toBe("heartbeat_run");
+      expect(token.subjectId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(token.expiresAt!.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+      expect(token.expiresAt!.getTime()).toBeLessThanOrEqual(Date.now() + 61 * 60 * 1000);
+    }
+    expect(JSON.stringify(tokens)).not.toContain(first[0]!.token);
+  });
+
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3411,7 +3411,9 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     const templateId = connection.config && typeof connection.config === "object"
       ? (connection.config as Record<string, unknown>).templateId
       : null;
-    return typeof templateId === "string" && !disabledStdioTemplateKeys.has(templateId);
+    return typeof templateId === "string"
+      && templateId.trim().length > 0
+      && !disabledStdioTemplateKeys.has(templateId.trim());
   });
   const service = createToolGatewayService(input.db);
   if (uniqueConnections.length === 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -67,6 +67,7 @@ import {
   toolMcpGatewayTokens,
   toolConnections,
   toolProfiles,
+  toolStdioCommandTemplates,
   workspaceOperations,
 } from "@paperclipai/db";
 import { conflict, HttpError, notFound } from "../errors.js";
@@ -3391,12 +3392,27 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     )
     .map(({ id, name }) => ({ id, name }))
     .sort((a, b) => a.name.localeCompare(b.name));
-  const uniqueConnections = effective.installedConnections.filter((connection) =>
-    permittedConnectionIds.has(connection.id)
-    && connection.status === "active"
-    && connection.enabled
-    && (connection.transport === "mcp_remote" || connection.transport === "local_stdio")
+  const disabledStdioTemplateKeys = new Set(
+    (await input.db
+      .select({ templateKey: toolStdioCommandTemplates.templateKey })
+      .from(toolStdioCommandTemplates)
+      .where(and(
+        eq(toolStdioCommandTemplates.companyId, input.agent.companyId),
+        eq(toolStdioCommandTemplates.status, "disabled"),
+      )))
+      .map((template) => template.templateKey),
   );
+  const uniqueConnections = effective.installedConnections.filter((connection) => {
+    if (!permittedConnectionIds.has(connection.id) || connection.status !== "active" || !connection.enabled) {
+      return false;
+    }
+    if (connection.transport === "mcp_remote") return true;
+    if (connection.transport !== "local_stdio") return false;
+    const templateId = connection.config && typeof connection.config === "object"
+      ? (connection.config as Record<string, unknown>).templateId
+      : null;
+    return typeof templateId === "string" && !disabledStdioTemplateKeys.has(templateId);
+  });
   const service = createToolGatewayService(input.db);
   if (uniqueConnections.length === 0) {
     await service.recordRuntimeMcpDeliveryDiagnostic({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3385,14 +3385,17 @@ export async function buildPaperclipRuntimeMcpServers(input: {
       ))
     : [];
   const permittedNotInstalledConnections = permittedConnections
-    .filter((connection) => connection.transport === "mcp_remote" && !installedConnectionIds.has(connection.id))
+    .filter((connection) =>
+      (connection.transport === "mcp_remote" || connection.transport === "local_stdio")
+      && !installedConnectionIds.has(connection.id)
+    )
     .map(({ id, name }) => ({ id, name }))
     .sort((a, b) => a.name.localeCompare(b.name));
   const uniqueConnections = effective.installedConnections.filter((connection) =>
     permittedConnectionIds.has(connection.id)
     && connection.status === "active"
     && connection.enabled
-    && connection.transport === "mcp_remote"
+    && (connection.transport === "mcp_remote" || connection.transport === "local_stdio")
   );
   const service = createToolGatewayService(input.db);
   if (uniqueConnections.length === 0) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages governed tools for AI agent runs.
> - The heartbeat service selects the MCP connections for each run.
> - The service delivered only remote MCP connections.
> - Installed local stdio connections therefore disappeared from fresh agent runtimes.
> - Cortex Memory and Project Memory use local stdio connections in this deployment.
> - This pull request includes installed and permitted local stdio connections in the existing gateway path.
> - The benefit is stable tool delivery without direct credential injection.

## Linked Issues or Issue Description

Related: #11568

**Describe the bug**

Installed and permitted local stdio MCP connections do not appear in fresh agent runtimes.

**To Reproduce**

Configure an agent with an installed local stdio MCP connection and an access profile. Start a heartbeat. The runtime MCP server list omits the connection.

**Expected behavior**

The heartbeat gateway delivers installed and permitted remote and local stdio MCP connections.

## What Changed

- Include `local_stdio` in runtime MCP delivery selection.
- Include uninstalled local stdio connections in delivery diagnostics.
- Add a database-backed regression test for remote and local stdio delivery across two runs.

## Verification

- `pnpm --filter @paperclipai/server test -- src/__tests__/heartbeat-runtime-mcp-servers.test.ts`
- `git diff --check origin/master...HEAD`

## Risks

- Low risk. The change uses the existing access profile, install, active, and enabled checks.
- The gateway remains the credential and policy boundary.

> This fix does not add a core feature. It completes the existing governed runtime MCP delivery path.

## Model Used

- OpenAI Codex, GPT-5.6, agentic code execution and repository tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
