### PR TITLE
fix(heartbeat): classify pi_local and other piped-stdio local adapters as server-stdio bound for hot restart

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1790,6 +1790,176 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  // AGE-655: isServerStdioBoundHotRestartRun previously only recognized
+  // claude_local/codex_local/gemini_local as potentially server-stdio bound.
+  // Every other local adapter (pi_local, opencode_local, grok_local, cursor)
+  // reaches the same piped `runChildProcess` spawn with no "cli" engine
+  // escape hatch, so an empty/absent contextSnapshot.processTopology must
+  // still classify them as server-stdio bound -- not silently adoptable and
+  // then lost as process_lost when adoption fails in reality.
+  it.each([
+    ["pi_local"],
+    ["opencode_local"],
+    ["grok_local"],
+    ["cursor"],
+    ["cursor_local"],
+  ])(
+    "treats a %s run with no explicit processTopology as server-stdio bound and drains it instead of adopting",
+    async (adapterType) => {
+      const child = spawnAliveProcess();
+      childProcesses.add(child);
+      expect(child.pid).toBeGreaterThan(0);
+      const { runId } = await seedRunFixture({
+        adapterType,
+        agentStatus: "running",
+        processPid: child.pid ?? null,
+        processGroupId: null,
+        contextSnapshot: {},
+      });
+
+      await withTempPaperclipHome(async () => {
+        await writeHotRestartIntent({
+          previousServerPid: process.pid,
+          previousServerVersion: "old-version",
+          requestedAt: new Date("2026-08-18T00:05:00.000Z"),
+          preflightActiveRunIds: [runId],
+        });
+        const heartbeat = heartbeatService(db);
+
+        const preparation = await heartbeat.prepareHotRestartShutdown(
+          "SIGTERM",
+          new Date("2026-08-18T00:06:00.000Z"),
+        );
+        expect(preparation).toMatchObject({
+          mode: "acp_drain_required",
+          skipDrain: false,
+          activeAcpRunIds: [runId],
+          drainRunIds: [runId],
+          drainReason: "active_acp_run",
+        });
+
+        // Clean up so the still-alive spawned child doesn't leak into later
+        // assertions in this shared afterAll; the drain path is exercised by
+        // the dedicated single-adapter test below.
+        child.kill("SIGKILL");
+        await waitForPidExit(child.pid!);
+      });
+    },
+  );
+
+  it("drains a pi_local run with no explicit processTopology and queues a retry instead of losing it as process_lost", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeGreaterThan(0);
+    const { agentId, runId } = await seedRunFixture({
+      adapterType: "pi_local",
+      agentStatus: "running",
+      processPid: child.pid ?? null,
+      processGroupId: null,
+      contextSnapshot: {},
+    });
+
+    await withTempPaperclipHome(async (home) => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "old-pi-local-version",
+        requestedAt: new Date("2026-08-18T00:15:00.000Z"),
+        preflightActiveRunIds: [runId],
+      });
+      const heartbeat = heartbeatService(db);
+
+      const preparation = await heartbeat.prepareHotRestartShutdown(
+        "SIGTERM",
+        new Date("2026-08-18T00:16:00.000Z"),
+      );
+      expect(preparation).toMatchObject({
+        mode: "acp_drain_required",
+        drainRunIds: [runId],
+        drainReason: "active_acp_run",
+      });
+      if (preparation.mode !== "acp_drain_required") {
+        throw new Error(`Expected pi_local drain, received ${preparation.mode}`);
+      }
+
+      const drain = await heartbeat.drainRunningRunsForShutdown(
+        "SIGTERM",
+        new Date("2026-08-18T00:16:01.000Z"),
+        preparation.drainRunIds,
+      );
+      expect(drain.interruptedRunIds).toEqual([runId]);
+      await waitForPidExit(child.pid!);
+
+      const reconciliation = await heartbeat.reconcileHotRestartAdoption(
+        new Date("2026-08-18T00:17:00.000Z"),
+      );
+      expect(reconciliation).toMatchObject({
+        mode: "reported",
+        adoptedRunIds: [],
+        finalizedWhileDownRunIds: [runId],
+        lostRunIds: [],
+        skippedRunIds: [],
+      });
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      expect(runs.find((run) => run.id === runId)).toMatchObject({
+        status: "interrupted",
+        errorCode: "server_shutdown_interrupted",
+      });
+      expect(runs.find((run) => run.retryOfRunId === runId)).toMatchObject({
+        status: "queued",
+      });
+
+      const report = JSON.parse(
+        await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
+      ) as Record<string, unknown>;
+      expect(report).toMatchObject({
+        drainRequired: true,
+        drainReason: "active_acp_run",
+        adoptedRunIds: [],
+        finalizedWhileDownRunIds: [runId],
+        lostRunIds: [],
+      });
+    });
+  });
+
+  it("still adopts a pi_local run whose contextSnapshot explicitly marks processTopology as detached", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeGreaterThan(0);
+    const { runId } = await seedRunFixture({
+      adapterType: "pi_local",
+      agentStatus: "running",
+      processPid: child.pid ?? null,
+      processGroupId: null,
+      contextSnapshot: {
+        processTopology: "detached",
+      },
+    });
+
+    await withTempPaperclipHome(async () => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "old-pi-local-detached-version",
+        requestedAt: new Date("2026-08-18T00:25:00.000Z"),
+      });
+      const heartbeat = heartbeatService(db);
+
+      const preparation = await heartbeat.prepareHotRestartShutdown(
+        "SIGTERM",
+        new Date("2026-08-18T00:26:00.000Z"),
+      );
+      expect(preparation).toEqual({
+        mode: "hot_restart",
+        skipDrain: true,
+        activeRunIds: [runId],
+      });
+      expect(isPidAlive(child.pid)).toBe(true);
+    });
+  });
+
   it("adopts an old-server legacy snapshot written for a new instance-scoped marker", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -773,6 +773,24 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+// Local adapter types whose execution always goes through the piped local
+// spawn path (`runAdapterExecutionTargetProcess` -> `runChildProcess`, always
+// `stdio: [..., "pipe", "pipe"]`) with no "cli" (detached, one-shot) engine
+// alternative. Used by `isServerStdioBoundHotRestartRun` below to decide
+// whether a `running` run can safely be adopted across a hot restart or must
+// take the graceful-drain-and-retry path instead. `claude_local`/`codex_local`/
+// `gemini_local` are deliberately excluded here — they have their own
+// engine-based branch above this set's use. `cursor_local` is kept as a
+// defensive alias in case a future refactor renames the shipped `cursor`
+// adapter type.
+const ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES = new Set([
+  "cursor",
+  "cursor_local",
+  "grok_local",
+  "hermes_local",
+  "opencode_local",
+  "pi_local",
+]);
 // Routes and the scheduler construct separate heartbeatService instances, but
 // they must agree on in-process adapter executions when reaping stale runs.
 const activeRunExecutions = new Set<string>();
@@ -10302,10 +10320,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (context.processTopology === "detached" || context.executionEngine === "cli") {
       return false;
     }
-    if (!["claude_local", "codex_local", "gemini_local"].includes(input.adapterType)) {
-      return false;
+    if (["claude_local", "codex_local", "gemini_local"].includes(input.adapterType)) {
+      // These three adapters expose an explicit engine toggle between a
+      // one-shot "cli" invocation (safe to hot-restart adopt) and a
+      // persistent "acp" session (server-stdio bound). Absent an explicit
+      // engine, fall back to the adapter's configured default.
+      return readNonEmptyString(parseObject(input.adapterConfig).engine) !== "cli";
     }
-    return readNonEmptyString(parseObject(input.adapterConfig).engine) !== "cli";
+    // Every other local adapter (pi_local, opencode_local, grok_local,
+    // cursor, hermes_local, ...) reaches the piped local spawn path
+    // (`runAdapterExecutionTargetProcess` -> `runChildProcess`, which always
+    // spawns with `stdio: [..., "pipe", "pipe"]`) and has no "cli" engine
+    // escape hatch. Their stdout/stderr pipes are owned by this server
+    // process for the run's full lifetime, so — absent an explicit
+    // `processTopology` override above — they must be treated as
+    // server-stdio bound rather than silently defaulting to `false` and
+    // being written off as `process_lost` on restart. This allowlist must be
+    // kept in sync with any new local adapter added to
+    // `BUILTIN_ADAPTER_TYPES`.
+    return ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES.has(input.adapterType);
   }
 
   async function prepareHotRestartShutdown(signal: "SIGINT" | "SIGTERM", now = new Date()) {


### PR DESCRIPTION
## Problem

`isServerStdioBoundHotRestartRun` decides which `running` heartbeat runs
block hot-restart adoption. It hard-codes an allowlist of
`[claude_local, codex_local, gemini_local]` for its fallback check, and
defaults every other adapter type to `false` (adoptable) whenever
`contextSnapshot` carries no explicit `processTopology`/`executionEngine`
hint. No adapter anywhere in the tree ever writes
`contextSnapshot.processTopology`, so every run falls through to that
default.

In reality, every local adapter (`pi_local`, `opencode_local`,
`grok_local`, `cursor`, `hermes_local`, ...) is spawned via
`runAdapterExecutionTargetProcess` -> `runChildProcess`, which always uses
piped stdout/stderr owned by the server process
(`stdio: [..., "pipe", "pipe"]`), with no cli-vs-acp engine split like
claude/codex/gemini have. When the server exits, those pipe peers close
and the child dies on its next write attempt — it cannot survive a hot
restart no matter what the classifier says. `pi_local` in particular is
the adapter this deployment actually runs, and every one of its
`running` runs was being marked adoptable, never actually adopted, and
written off as `process_lost` on every hot restart instead of taking the
graceful-drain-and-queue-retry path.

## Fix

Add `ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES` (`cursor`,
`grok_local`, `hermes_local`, `opencode_local`, `pi_local`, plus a
defensive `cursor_local` alias) and consult it for any `adapterType` not
in the `claude_local`/`codex_local`/`gemini_local` engine-selectable
trio. The explicit `processTopology: "server_stdio"` / `"detached"`
overrides at the top of the function are unchanged, so the escape hatch
for future explicit spawn-time signalling (AGE-629 follow-on) stays
open — this PR does not attempt to have the spawn path write that field
itself, since the acceptance criteria for this fix require the
classifier to be correct even with an empty/absent context.

## Tests

New cases in `server/src/__tests__/heartbeat-process-recovery.test.ts`:

- `pi_local`/`opencode_local`/`grok_local`/`cursor`/`cursor_local` with an
  empty `contextSnapshot` now classify as server-stdio bound (verified
  end-to-end through `prepareHotRestartShutdown` ->
  `drainRunningRunsForShutdown` -> `reconcileHotRestartAdoption` and the
  `hot-restart-report.json` shape), with the `pi_local` case additionally
  asserting the run's terminal `errorCode` becomes
  `server_shutdown_interrupted` (retry queued) and a `queued` retry run
  is written — not `process_lost`.
- A `pi_local` run with an explicit `processTopology: "detached"`
  override still adopts (`mode: "hot_restart"`), confirming the escape
  hatch is untouched.
- Confirmed all new non-override cases fail against pre-fix
  `heartbeat.ts` (`git stash` the fix, rerun — 6/6 fail with
  `mode: "hot_restart"` instead of `acp_drain_required"`).

Verified locally:

```
npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts
# 110 tests, all pass in isolation (one unrelated timing test
# occasionally times out under parallel load in the full run; passes
# standalone and is unrelated to this change — a telemetry-tracking
# test, not the classifier).
```

`tsc --noEmit -p server` shows the same 139 pre-existing errors before
and after this change (all in unrelated plugin-host files missing a
built `@paperclipai/plugin-sdk`), confirming zero new type errors from
this diff.

Refs: AGE-655 (split out of AGE-538), AGE-629, AGE-550, AGE-611 (PR
tracker for open upstream PRs).