### PR TITLE
fix(heartbeat): classify pi_local and other piped-stdio local adapters as server-stdio bound for hot restart

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1792,17 +1792,19 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   // AGE-655: isServerStdioBoundHotRestartRun previously only recognized
   // claude_local/codex_local/gemini_local as potentially server-stdio bound.
-  // Every other local adapter (pi_local, opencode_local, grok_local, cursor)
-  // reaches the same piped `runChildProcess` spawn with no "cli" engine
-  // escape hatch, so an empty/absent contextSnapshot.processTopology must
-  // still classify them as server-stdio bound -- not silently adoptable and
-  // then lost as process_lost when adoption fails in reality.
+  // Every other local adapter (pi_local, opencode_local, grok_local, cursor,
+  // the generic "process" builtin adapter) reaches the same piped
+  // `runChildProcess` spawn with no "cli" engine escape hatch, so an
+  // empty/absent contextSnapshot.processTopology must still classify them as
+  // server-stdio bound -- not silently adoptable and then lost as
+  // process_lost when adoption fails in reality.
   it.each([
     ["pi_local"],
     ["opencode_local"],
     ["grok_local"],
     ["cursor"],
     ["cursor_local"],
+    ["process"],
   ])(
     "treats a %s run with no explicit processTopology as server-stdio bound and drains it instead of adopting",
     async (adapterType) => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1790,6 +1790,176 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  // AGE-655: isServerStdioBoundHotRestartRun previously only recognized
+  // claude_local/codex_local/gemini_local as potentially server-stdio bound.
+  // Every other local adapter (pi_local, opencode_local, grok_local, cursor)
+  // reaches the same piped `runChildProcess` spawn with no "cli" engine
+  // escape hatch, so an empty/absent contextSnapshot.processTopology must
+  // still classify them as server-stdio bound -- not silently adoptable and
+  // then lost as process_lost when adoption fails in reality.
+  it.each([
+    ["pi_local"],
+    ["opencode_local"],
+    ["grok_local"],
+    ["cursor"],
+    ["cursor_local"],
+  ])(
+    "treats a %s run with no explicit processTopology as server-stdio bound and drains it instead of adopting",
+    async (adapterType) => {
+      const child = spawnAliveProcess();
+      childProcesses.add(child);
+      expect(child.pid).toBeGreaterThan(0);
+      const { runId } = await seedRunFixture({
+        adapterType,
+        agentStatus: "running",
+        processPid: child.pid ?? null,
+        processGroupId: null,
+        contextSnapshot: {},
+      });
+
+      await withTempPaperclipHome(async () => {
+        await writeHotRestartIntent({
+          previousServerPid: process.pid,
+          previousServerVersion: "old-version",
+          requestedAt: new Date("2026-08-18T00:05:00.000Z"),
+          preflightActiveRunIds: [runId],
+        });
+        const heartbeat = heartbeatService(db);
+
+        const preparation = await heartbeat.prepareHotRestartShutdown(
+          "SIGTERM",
+          new Date("2026-08-18T00:06:00.000Z"),
+        );
+        expect(preparation).toMatchObject({
+          mode: "acp_drain_required",
+          skipDrain: false,
+          activeAcpRunIds: [runId],
+          drainRunIds: [runId],
+          drainReason: "active_acp_run",
+        });
+
+        // Clean up so the still-alive spawned child doesn't leak into later
+        // assertions in this shared afterAll; the drain path is exercised by
+        // the dedicated single-adapter test below.
+        child.kill("SIGKILL");
+        await waitForPidExit(child.pid!);
+      });
+    },
+  );
+
+  it("drains a pi_local run with no explicit processTopology and queues a retry instead of losing it as process_lost", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeGreaterThan(0);
+    const { agentId, runId } = await seedRunFixture({
+      adapterType: "pi_local",
+      agentStatus: "running",
+      processPid: child.pid ?? null,
+      processGroupId: null,
+      contextSnapshot: {},
+    });
+
+    await withTempPaperclipHome(async (home) => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "old-pi-local-version",
+        requestedAt: new Date("2026-08-18T00:15:00.000Z"),
+        preflightActiveRunIds: [runId],
+      });
+      const heartbeat = heartbeatService(db);
+
+      const preparation = await heartbeat.prepareHotRestartShutdown(
+        "SIGTERM",
+        new Date("2026-08-18T00:16:00.000Z"),
+      );
+      expect(preparation).toMatchObject({
+        mode: "acp_drain_required",
+        drainRunIds: [runId],
+        drainReason: "active_acp_run",
+      });
+      if (preparation.mode !== "acp_drain_required") {
+        throw new Error(`Expected pi_local drain, received ${preparation.mode}`);
+      }
+
+      const drain = await heartbeat.drainRunningRunsForShutdown(
+        "SIGTERM",
+        new Date("2026-08-18T00:16:01.000Z"),
+        preparation.drainRunIds,
+      );
+      expect(drain.interruptedRunIds).toEqual([runId]);
+      await waitForPidExit(child.pid!);
+
+      const reconciliation = await heartbeat.reconcileHotRestartAdoption(
+        new Date("2026-08-18T00:17:00.000Z"),
+      );
+      expect(reconciliation).toMatchObject({
+        mode: "reported",
+        adoptedRunIds: [],
+        finalizedWhileDownRunIds: [runId],
+        lostRunIds: [],
+        skippedRunIds: [],
+      });
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      expect(runs.find((run) => run.id === runId)).toMatchObject({
+        status: "interrupted",
+        errorCode: "server_shutdown_interrupted",
+      });
+      expect(runs.find((run) => run.retryOfRunId === runId)).toMatchObject({
+        status: "queued",
+      });
+
+      const report = JSON.parse(
+        await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
+      ) as Record<string, unknown>;
+      expect(report).toMatchObject({
+        drainRequired: true,
+        drainReason: "active_acp_run",
+        adoptedRunIds: [],
+        finalizedWhileDownRunIds: [runId],
+        lostRunIds: [],
+      });
+    });
+  });
+
+  it("still adopts a pi_local run whose contextSnapshot explicitly marks processTopology as detached", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeGreaterThan(0);
+    const { runId } = await seedRunFixture({
+      adapterType: "pi_local",
+      agentStatus: "running",
+      processPid: child.pid ?? null,
+      processGroupId: null,
+      contextSnapshot: {
+        processTopology: "detached",
+      },
+    });
+
+    await withTempPaperclipHome(async () => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "old-pi-local-detached-version",
+        requestedAt: new Date("2026-08-18T00:25:00.000Z"),
+      });
+      const heartbeat = heartbeatService(db);
+
+      const preparation = await heartbeat.prepareHotRestartShutdown(
+        "SIGTERM",
+        new Date("2026-08-18T00:26:00.000Z"),
+      );
+      expect(preparation).toEqual({
+        mode: "hot_restart",
+        skipDrain: true,
+        activeRunIds: [runId],
+      });
+      expect(isPidAlive(child.pid)).toBe(true);
+    });
+  });
+
   it("adopts an old-server legacy snapshot written for a new instance-scoped marker", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -773,6 +773,24 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+// Local adapter types whose execution always goes through the piped local
+// spawn path (`runAdapterExecutionTargetProcess` -> `runChildProcess`, always
+// `stdio: [..., "pipe", "pipe"]`) with no "cli" (detached, one-shot) engine
+// alternative. Used by `isServerStdioBoundHotRestartRun` below to decide
+// whether a `running` run can safely be adopted across a hot restart or must
+// take the graceful-drain-and-retry path instead. `claude_local`/`codex_local`/
+// `gemini_local` are deliberately excluded here — they have their own
+// engine-based branch above this set's use. `cursor_local` is kept as a
+// defensive alias in case a future refactor renames the shipped `cursor`
+// adapter type.
+const ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES = new Set([
+  "cursor",
+  "cursor_local",
+  "grok_local",
+  "hermes_local",
+  "opencode_local",
+  "pi_local",
+]);
 // Routes and the scheduler construct separate heartbeatService instances, but
 // they must agree on in-process adapter executions when reaping stale runs.
 const activeRunExecutions = new Set<string>();
@@ -10302,10 +10320,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (context.processTopology === "detached" || context.executionEngine === "cli") {
       return false;
     }
-    if (!["claude_local", "codex_local", "gemini_local"].includes(input.adapterType)) {
-      return false;
+    if (["claude_local", "codex_local", "gemini_local"].includes(input.adapterType)) {
+      // These three adapters expose an explicit engine toggle between a
+      // one-shot "cli" invocation (safe to hot-restart adopt) and a
+      // persistent "acp" session (server-stdio bound). Absent an explicit
+      // engine, fall back to the adapter's configured default.
+      return readNonEmptyString(parseObject(input.adapterConfig).engine) !== "cli";
     }
-    return readNonEmptyString(parseObject(input.adapterConfig).engine) !== "cli";
+    // Every other local adapter (pi_local, opencode_local, grok_local,
+    // cursor, hermes_local, ...) reaches the piped local spawn path
+    // (`runAdapterExecutionTargetProcess` -> `runChildProcess`, which always
+    // spawns with `stdio: [..., "pipe", "pipe"]`) and has no "cli" engine
+    // escape hatch. Their stdout/stderr pipes are owned by this server
+    // process for the run's full lifetime, so — absent an explicit
+    // `processTopology` override above — they must be treated as
+    // server-stdio bound rather than silently defaulting to `false` and
+    // being written off as `process_lost` on restart. This allowlist must be
+    // kept in sync with any new local adapter added to
+    // `BUILTIN_ADAPTER_TYPES`.
+    return ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES.has(input.adapterType);
   }
 
   async function prepareHotRestartShutdown(signal: "SIGINT" | "SIGTERM", now = new Date()) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -773,8 +773,8 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
-// Local adapter types whose execution always goes through the piped local
-// spawn path (`runAdapterExecutionTargetProcess` -> `runChildProcess`, always
+// Adapter types whose execution always goes through the piped local spawn
+// path (`runAdapterExecutionTargetProcess` -> `runChildProcess`, always
 // `stdio: [..., "pipe", "pipe"]`) with no "cli" (detached, one-shot) engine
 // alternative. Used by `isServerStdioBoundHotRestartRun` below to decide
 // whether a `running` run can safely be adopted across a hot restart or must
@@ -782,7 +782,9 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
 // `gemini_local` are deliberately excluded here — they have their own
 // engine-based branch above this set's use. `cursor_local` is kept as a
 // defensive alias in case a future refactor renames the shipped `cursor`
-// adapter type.
+// adapter type. `process` is the generic builtin adapter
+// (`server/src/adapters/process/execute.ts`) and spawns through the same
+// `runChildProcess` path as the named local adapters.
 const ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES = new Set([
   "cursor",
   "cursor_local",
@@ -790,6 +792,7 @@ const ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES = new Set([
   "hermes_local",
   "opencode_local",
   "pi_local",
+  "process",
 ]);
 // Routes and the scheduler construct separate heartbeatService instances, but
 // they must agree on in-process adapter executions when reaping stale runs.
@@ -10328,7 +10331,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return readNonEmptyString(parseObject(input.adapterConfig).engine) !== "cli";
     }
     // Every other local adapter (pi_local, opencode_local, grok_local,
-    // cursor, hermes_local, ...) reaches the piped local spawn path
+    // cursor, hermes_local, process, ...) reaches the piped local spawn path
     // (`runAdapterExecutionTargetProcess` -> `runChildProcess`, which always
     // spawns with `stdio: [..., "pipe", "pipe"]`) and has no "cli" engine
     // escape hatch. Their stdout/stderr pipes are owned by this server


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service tracks each agent invocation as a `heartbeatRuns` row and decides, on every hot restart of the Paperclip server, which `running` runs can be adopted by the new server process versus which must be gracefully drained and retried
> - `isServerStdioBoundHotRestartRun` makes that adopt-vs-drain decision from a hard-coded adapter allowlist (`claude_local`/`codex_local`/`gemini_local`) plus an unused `contextSnapshot.processTopology` escape hatch that no adapter ever writes
> - Every local adapter — `pi_local` included — is spawned through `runAdapterExecutionTargetProcess` -> `runChildProcess`, which always pipes stdout/stderr through the server process (`stdio: [..., "pipe", "pipe"]`); when the server exits those pipe peers close and the child dies on its next write, so these runs cannot actually survive a hot restart no matter what the classifier says
> - Because `pi_local` (and `opencode_local`/`grok_local`/`cursor`/`hermes_local`) were missing from the allowlist, their `running` runs were marked adoptable, were never actually adopted, and were written off as `process_lost` (no retry) on every hot restart instead of taking the graceful-drain-and-retry path (`server_shutdown_interrupted`, retry queued)
> - This pull request extends the classifier's fallback branch to cover every local adapter type that reaches the piped spawn, while leaving the explicit `processTopology`/`executionEngine` overrides untouched
> - The benefit is that `pi_local` runs in flight during a hot restart are drained and automatically retried instead of silently disappearing as lost work

## Linked Issues or Issue Description

**What happened?**
On every hot restart of a Paperclip server running `pi_local` agents, in-flight (`status: "running"`) heartbeat runs were classified by `isServerStdioBoundHotRestartRun` (`server/src/services/heartbeat.ts`) as adoptable across the restart, because the function's adapter allowlist only recognized `claude_local`, `codex_local`, and `gemini_local`, and no adapter ever writes the `contextSnapshot.processTopology` escape hatch the function also checks. In reality `pi_local` (like every other local adapter) is spawned with piped stdout/stderr owned by the server process, so the child dies as soon as the old server process exits and the "adoption" never actually happens. The run is then reported `process_lost` with no retry queued, instead of taking the existing graceful-drain-and-retry path that already exists for `acp`-engine runs.

**Expected behavior**
A `running` `pi_local` (or `opencode_local`/`grok_local`/`cursor`/`hermes_local`) run in flight during a hot restart should be classified as server-stdio bound, take the graceful drain path, and finish as `server_shutdown_interrupted` with an automatic retry queued — the same outcome already correctly produced for `acp`-engine runs.

**Steps to reproduce**
1. Start a Paperclip server with an agent configured on the `pi_local` adapter and start a run so a `heartbeatRuns` row exists with `status: "running"` and an empty/absent `contextSnapshot.processTopology`.
2. Trigger a hot restart (`paperclipai service restart`, or send `SIGTERM` with a hot-restart intent file present).
3. Observe `hot-restart-report.json`: the run is reported in `adoptedRunIds` (or silently missing from `lostRunIds`/drain), and the run later terminates with `errorCode: "process_lost"` instead of `server_shutdown_interrupted` with a queued retry.

## What Changed

- `server/src/services/heartbeat.ts`: added `ALWAYS_SERVER_STDIO_BOUND_LOCAL_ADAPTER_TYPES` (`cursor`, `grok_local`, `hermes_local`, `opencode_local`, `pi_local`, plus a defensive `cursor_local` alias) and consulted it from `isServerStdioBoundHotRestartRun` for any `adapterType` not in the `claude_local`/`codex_local`/`gemini_local` engine-selectable trio. The explicit `processTopology: "server_stdio"` / `"detached"` overrides at the top of the function are unchanged.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: added test coverage proving `pi_local`/`opencode_local`/`grok_local`/`cursor`/`cursor_local` runs with an empty `contextSnapshot` now drain-and-retry instead of silently adopting, that the `pi_local` run's terminal state is `server_shutdown_interrupted` with a queued retry (not `process_lost`), and that an explicit `processTopology: "detached"` override still adopts.

## Verification

```
npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts
```
All 110 tests pass in isolation (109/110 pass in a single full-file run; the one occasional failure, `tracks the first heartbeat with the agent role instead of adapter type`, is an unrelated telemetry-tracking test that times out only under parallel embedded-Postgres load and passes standalone — not touched by this change).

Confirmed the new test cases are a real regression guard: reverted just `heartbeat.ts` (`git stash` the fix) and reran the same test filter — 6/6 non-override cases fail with `mode: "hot_restart"` instead of `mode: "acp_drain_required"`.

`npx tsc --noEmit -p server` reports the same 139 pre-existing errors with and without this diff (all in unrelated plugin-host files missing a built `@paperclipai/plugin-sdk`) — zero new type errors introduced.

Searched open/closed PRs for `pi_local` + `process_lost` / hot restart: #631 (`fix: pi_local agents stuck as process_lost after server restart`) addresses a related but distinct root cause in a different subsystem — a startup-reap race and zombie-run `updatedAt` coalescing in `server/src/index.ts` — and does not touch `isServerStdioBoundHotRestartRun` or the hot-restart classifier at all, so it does not overlap with or duplicate this change.

## Risks

Low risk. The change only widens which `running` runs take the existing, already-tested graceful-drain-and-retry path; it does not change draining/retry mechanics themselves, and it does not touch `claude_local`/`codex_local`/`gemini_local` behavior at all. The main risk is over-classifying an adapter as server-stdio bound when it is not (extra drain+retry on restart, not data loss) versus the current under-classification (silent data/work loss reported as `process_lost`) — the safer direction to err in.

## Model Used

Claude (Anthropic), Sonnet-class model via the Paperclip control-plane `pi_local` adapter (`pi` CLI harness), agentic tool-use mode (file read/edit/bash), no extended-thinking flag exposed to this harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
