### PR TITLE
fix(cli): honor DATABASE_URL in doctor database check

### DIFF
--- a/cli/src/__tests__/database-check.test.ts
+++ b/cli/src/__tests__/database-check.test.ts
@@ -1,17 +1,32 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createDb } from "@paperclipai/db";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { databaseCheck } from "../checks/database-check.js";
 import type { PaperclipConfig } from "../config/schema.js";
 
+vi.mock("@paperclipai/db", () => ({
+  createDb: vi.fn(() => ({ execute: vi.fn().mockResolvedValue(undefined) })),
+}));
+
 const created: string[] = [];
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
 const ORIGINAL_IN_WORKTREE = process.env.PAPERCLIP_IN_WORKTREE;
 
 function makeBase(): string {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-dbcheck-"));
   created.push(base);
   return base;
+}
+
+function postgresConfig(connectionString?: string): PaperclipConfig {
+  return {
+    database: {
+      mode: "postgres",
+      connectionString,
+    },
+  } as unknown as PaperclipConfig;
 }
 
 function embeddedConfig(dataDir: string): PaperclipConfig {
@@ -25,13 +40,28 @@ function embeddedConfig(dataDir: string): PaperclipConfig {
 }
 
 afterEach(() => {
+  vi.clearAllMocks();
   vi.restoreAllMocks();
+  if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
   if (ORIGINAL_IN_WORKTREE === undefined) delete process.env.PAPERCLIP_IN_WORKTREE;
   else process.env.PAPERCLIP_IN_WORKTREE = ORIGINAL_IN_WORKTREE;
   while (created.length > 0) {
     const dir = created.pop();
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe("databaseCheck — postgres connection string", () => {
+  it("uses DATABASE_URL when config has no connection string", async () => {
+    const connectionString = "postgres://env-user:env-pass@db.example.com:5432/paperclip";
+    process.env.DATABASE_URL = ` ${connectionString} `;
+
+    const result = await databaseCheck(postgresConfig());
+
+    expect(result.status).toBe("pass");
+    expect(createDb).toHaveBeenCalledWith(connectionString);
+  });
 });
 
 describe("databaseCheck — embedded postgres temp-dir guard", () => {

--- a/cli/src/__tests__/database-check.test.ts
+++ b/cli/src/__tests__/database-check.test.ts
@@ -60,7 +60,7 @@ describe("databaseCheck — postgres connection string", () => {
     const result = await databaseCheck(postgresConfig());
 
     expect(result.status).toBe("pass");
-    expect(createDb).toHaveBeenCalledWith(connectionString);
+    expect(createDb).toHaveBeenCalledWith(` ${connectionString} `);
   });
 });
 

--- a/cli/src/checks/database-check.ts
+++ b/cli/src/checks/database-check.ts
@@ -13,7 +13,9 @@ function isInsideOsTmpDir(targetPath: string): boolean {
 
 export async function databaseCheck(config: PaperclipConfig, configPath?: string): Promise<CheckResult> {
   if (config.database.mode === "postgres") {
-    if (!config.database.connectionString) {
+    const connectionString =
+      process.env.DATABASE_URL?.trim() || config.database.connectionString?.trim();
+    if (!connectionString) {
       return {
         name: "Database",
         status: "fail",
@@ -25,7 +27,7 @@ export async function databaseCheck(config: PaperclipConfig, configPath?: string
 
     try {
       const { createDb } = await import("@paperclipai/db");
-      const db = createDb(config.database.connectionString);
+      const db = createDb(connectionString);
       await db.execute("SELECT 1");
       return {
         name: "Database",

--- a/cli/src/checks/database-check.ts
+++ b/cli/src/checks/database-check.ts
@@ -13,8 +13,7 @@ function isInsideOsTmpDir(targetPath: string): boolean {
 
 export async function databaseCheck(config: PaperclipConfig, configPath?: string): Promise<CheckResult> {
   if (config.database.mode === "postgres") {
-    const connectionString =
-      process.env.DATABASE_URL?.trim() || config.database.connectionString?.trim();
+    const connectionString = process.env.DATABASE_URL || config.database.connectionString;
     if (!connectionString) {
       return {
         name: "Database",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI agent companies.
> - The CLI runs doctor checks before `paperclipai run` starts the server.
> - The CLI loads the instance `.env` file before it runs doctor.
> - The database runtime uses `DATABASE_URL` before `config.database.connectionString`.
> - The doctor database check only used the config value and blocked a valid Postgres setup.
> - This pull request makes the doctor check use the same environment-first priority and keeps the existing connection query.
> - The benefit is that operators can keep the Postgres credential in the instance `.env` file without blocking server startup.

## Linked Issues or Issue Description

Fixes: #11598

## What Changed

- Resolve the doctor Postgres connection string from `DATABASE_URL` first.
- Fall back to `config.database.connectionString` when the environment value is empty.
- Use the resolved value for the existing `SELECT 1` connection check.
- Add a regression test for an environment-only connection string.

## Verification

- `corepack pnpm exec vitest run cli/src/__tests__/database-check.test.ts`
- `corepack pnpm --filter paperclipai typecheck`

## Risks

- Low risk. The change only affects the doctor check for Postgres mode.
- The existing config fallback remains unchanged.
- Embedded PostgreSQL behavior remains unchanged.

## Model Used

OpenAI `gpt-5.6-sol`, with repository tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no update was needed because this aligns doctor with existing runtime behavior)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

