### PR TITLE
fix(server): report the real host version to the plugin loader

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import {
 import detectPort from "detect-port";
 import { createApp } from "./app.js";
 import { loadConfig } from "./config.js";
+import { serverVersion } from "./version.js";
 import { logger } from "./middleware/logger.js";
 import {
   getManagedInstanceConfig,
@@ -762,6 +763,9 @@ export async function startServer(): Promise<StartedServer> {
     pluginWorkerManager,
     decisionServiceOptions,
     managedPluginAutoInstall,
+    // Without this the plugin loader falls back to "0.0.0" and rejects every
+    // plugin that declares a `minimumHostVersion`, however new the host is.
+    hostVersion: serverVersion,
   });
   const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
 


### PR DESCRIPTION
## Problem

`createApp` accepts a `hostVersion` option and falls back to `"0.0.0"` when it is absent:

```ts
// server/src/app.ts
hostVersion: opts.hostVersion ?? "0.0.0",
```

The server entrypoint (`server/src/index.ts`) never passes it, so the fallback is always in effect.

Step 6 of `fetchAndValidate` in `server/src/services/plugin-loader.ts` rejects a plugin whose manifest declares a `minimumHostVersion` newer than the host. With the host reporting `0.0.0`, that comparison fails for **every** such plugin, regardless of how new the server actually is:

```
Plugin <id> requires host version 2026.525.0 or newer,
but this server is running 0.0.0
```

The message points at the plugin, so the real cause is easy to miss — the server in that example was running `2026.722.0`.

## Fix

Pass the resolved `serverVersion` from `./version.js`.

The check only runs from `installPlugin` and `upgradePlugin`, not from the boot/activation path, so this affects install and upgrade rather than already-installed plugins.

## How it was found

On a local instance, a plugin declaring `minimumHostVersion: 2026.525.0` could not be installed. With this change it installs and activates.

Verified against a running `2026.722.0` instance; `upstream/master` still has the gap at the time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Lh6cahAxWsLsdFzsGwkxj
