### PR TITLE
fix(heartbeat): gate issue_continuation_waiting_on_review on real review state

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1515,7 +1515,10 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(1);
   });
 
-  it("cancels queued continuation recovery when the continuation summary parks executor work for review", async () => {
+  it("cancels queued continuation recovery when the continuation summary parks executor work AND a real review posture (executionState.reviewRequest) still exists", async () => {
+    // AGE-671 regression guard: the stale-summary text alone must never be
+    // sufficient. This case additionally carries a live executionState.reviewRequest,
+    // so cancellation with issue_continuation_waiting_on_review remains correct.
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();
     await db.insert(issues).values({
@@ -1525,6 +1528,18 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       status: "in_progress",
       priority: "medium",
       assigneeAgentId: agentId,
+      executionState: {
+        status: "pending",
+        currentStageId: randomUUID(),
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: null,
+        returnAssignee: { type: "agent", agentId, userId: null },
+        reviewRequest: { instructions: "Please review the diff before I continue." },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
     });
     await seedContinuationSummary({
       companyId,
@@ -1584,6 +1599,70 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(wakeup?.status).toBe("skipped");
     expect(wakeup?.error).toContain("continuation summary says the executor should wait");
     expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("AGE-671: does not cancel queued continuation recovery on stale summary text when no real review posture exists", async () => {
+    // Reproduces the strand from AGE-671: the continuation summary's "Next
+    // Action" says to wait for reviewer feedback (written while the issue was
+    // briefly in_review), but the issue has no live executionState.reviewRequest,
+    // no pending issue-thread interaction, and no open approval. The queued
+    // continuation must be allowed to run instead of being cancelled with
+    // issue_continuation_waiting_on_review. This must fail against unfixed
+    // master, which cancels here purely on the stale summary text.
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale review text with no live reviewer",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await seedContinuationSummary({
+      companyId,
+      issueId,
+      agentId,
+      body: [
+        "# Continuation Summary",
+        "",
+        "## Next Action",
+        "",
+        "- Wait for reviewer feedback or approval before continuing executor work.",
+      ].join("\n"),
+    });
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_continuation_needed",
+      invocationSource: "automation",
+      contextExtras: {
+        retryReason: "issue_continuation_needed",
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded" || run?.status === "cancelled";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
   });
 
   it("runs accepted-interaction continuation recovery despite a pre-acceptance review park", async () => {

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -4,12 +4,14 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import {
   agents,
   agentWakeupRequests,
+  approvals,
   companies,
   costEvents,
   createDb,
   documentRevisions,
   documents,
   heartbeatRuns,
+  issueApprovals,
   issueComments,
   issueDocuments,
   issues,
@@ -1516,7 +1518,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
   });
 
   it("cancels queued continuation recovery when the continuation summary parks executor work AND a real review posture (executionState.reviewRequest) still exists", async () => {
-    // AGE-671 regression guard: the stale-summary text alone must never be
+    // Regression guard: the stale-summary text alone must never be
     // sufficient. This case additionally carries a live executionState.reviewRequest,
     // so cancellation with issue_continuation_waiting_on_review remains correct.
     const { companyId, agentId } = await seedCompanyAndAgent();
@@ -1601,12 +1603,12 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
-  it("AGE-671: does not cancel queued continuation recovery on stale summary text when no real review posture exists", async () => {
-    // Reproduces the strand from AGE-671: the continuation summary's "Next
-    // Action" says to wait for reviewer feedback (written while the issue was
-    // briefly in_review), but the issue has no live executionState.reviewRequest,
-    // no pending issue-thread interaction, and no open approval. The queued
-    // continuation must be allowed to run instead of being cancelled with
+  it("does not cancel queued continuation recovery on stale summary text when no real review posture exists", async () => {
+    // The continuation summary's "Next Action" says to wait for reviewer
+    // feedback (written while the issue was briefly in_review), but the issue
+    // has no live executionState.reviewRequest, no pending issue-thread
+    // interaction, and no open approval. The queued continuation must be
+    // allowed to run instead of being cancelled with
     // issue_continuation_waiting_on_review. This must fail against unfixed
     // master, which cancels here purely on the stale summary text.
     const { companyId, agentId } = await seedCompanyAndAgent();
@@ -1663,6 +1665,169 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(run?.status).toBe("succeeded");
     expect(run?.errorCode).toBeNull();
     expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+
+  it("does not cancel queued continuation recovery when the only open approval is unrelated to review of this issue's work (hire_agent)", async () => {
+    // An issue can be linked to an approval purely for provenance -- e.g. the
+    // agent working the issue also requested hiring a teammate, and the new
+    // hire approval was linked back to the source issue. That approval says
+    // nothing about whether this issue's own work is under review, so it must
+    // not gate this issue's continuation.
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale review text with an unrelated pending hire_agent approval",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await seedContinuationSummary({
+      companyId,
+      issueId,
+      agentId,
+      body: [
+        "# Continuation Summary",
+        "",
+        "## Next Action",
+        "",
+        "- Wait for reviewer feedback or approval before continuing executor work.",
+      ].join("\n"),
+    });
+
+    const [approval] = await db
+      .insert(approvals)
+      .values({
+        companyId,
+        type: "hire_agent",
+        requestedByAgentId: agentId,
+        status: "pending",
+        payload: { name: "New teammate" },
+      })
+      .returning();
+    await db.insert(issueApprovals).values({
+      companyId,
+      issueId,
+      approvalId: approval.id,
+    });
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_continuation_needed",
+      invocationSource: "automation",
+      contextExtras: {
+        retryReason: "issue_continuation_needed",
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded" || run?.status === "cancelled";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+
+  it("cancels queued continuation recovery when a pending request_board_approval reviews this issue's own work", async () => {
+    // Unlike hire_agent, request_board_approval is raised while executing this
+    // issue's own high-risk tool action and blocks that same work until a
+    // human decides -- this is genuine live review posture and must continue
+    // to gate the continuation.
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Implementation parked pending a high-risk tool approval",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await seedContinuationSummary({
+      companyId,
+      issueId,
+      agentId,
+      body: [
+        "# Continuation Summary",
+        "",
+        "## Next Action",
+        "",
+        "- Wait for reviewer feedback or approval before continuing executor work.",
+      ].join("\n"),
+    });
+
+    const [approval] = await db
+      .insert(approvals)
+      .values({
+        companyId,
+        type: "request_board_approval",
+        requestedByAgentId: agentId,
+        status: "pending",
+        payload: { title: "Approve high-risk tool action" },
+      })
+      .returning();
+    await db.insert(issueApprovals).values({
+      companyId,
+      issueId,
+      approvalId: approval.id,
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_continuation_needed",
+      invocationSource: "automation",
+      contextExtras: {
+        retryReason: "issue_continuation_needed",
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_continuation_waiting_on_review");
+    expect(wakeup?.status).toBe("skipped");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
   it("runs accepted-interaction continuation recovery despite a pre-acceptance review park", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12688,6 +12688,52 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return cancelled;
   }
 
+  // AGE-671: the continuation summary's "Next Action" text is an LLM-authored
+  // hint, not ground truth about review posture. It is written once (often
+  // while the issue is briefly `in_review`) and can outlive the state that
+  // produced it, so it must never be the sole reason a queued continuation is
+  // cancelled. Only cancel when a *real* review posture still exists:
+  // executionState.reviewRequest, a pending issue-thread interaction, or an
+  // open approval linked to the issue.
+  async function hasLiveIssueReviewPosture(issue: {
+    id: string;
+    companyId: string;
+    executionState: unknown;
+  }): Promise<boolean> {
+    const executionState = parseIssueExecutionState(issue.executionState);
+    if (executionState?.reviewRequest) return true;
+
+    const [pendingInteraction, pendingApproval] = await Promise.all([
+      db
+        .select({ id: issueThreadInteractions.id })
+        .from(issueThreadInteractions)
+        .where(
+          and(
+            eq(issueThreadInteractions.companyId, issue.companyId),
+            eq(issueThreadInteractions.issueId, issue.id),
+            eq(issueThreadInteractions.status, "pending"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: issueApprovals.approvalId })
+        .from(issueApprovals)
+        .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+        .where(
+          and(
+            eq(issueApprovals.companyId, issue.companyId),
+            eq(issueApprovals.issueId, issue.id),
+            inArray(approvals.status, ["pending", "revision_requested"]),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    return Boolean(pendingInteraction || pendingApproval);
+  }
+
   type QueuedRunStaleness =
     | { stale: false }
     | {
@@ -12752,7 +12798,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? null
         : await getIssueContinuationSummaryDocument(db, issueId);
       const continuationSummaryBody = queuedContinuationSummary ?? currentContinuationSummary?.body ?? null;
-      if (continuationSummaryParksExecutor(continuationSummaryBody)) {
+      if (
+        continuationSummaryParksExecutor(continuationSummaryBody) &&
+        (await hasLiveIssueReviewPosture({ id: issue.id, companyId: run.companyId, executionState: issue.executionState }))
+      ) {
         return {
           stale: true,
           errorCode: "issue_continuation_waiting_on_review",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12688,13 +12688,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return cancelled;
   }
 
-  // AGE-671: the continuation summary's "Next Action" text is an LLM-authored
-  // hint, not ground truth about review posture. It is written once (often
-  // while the issue is briefly `in_review`) and can outlive the state that
+  // Approval kinds that represent review of *this issue's own current work*
+  // -- as opposed to an approval that is merely linked to the issue for
+  // provenance while concerning something else entirely (hiring another
+  // agent, a budget hard-stop override, a credential grant). Only these
+  // kinds may gate a queued continuation on "waiting for review".
+  const ISSUE_WORK_REVIEW_APPROVAL_TYPES = ["request_board_approval"];
+
+  // The continuation summary's "Next Action" text is an LLM-authored hint,
+  // not ground truth about review posture. It is written once (often while
+  // the issue is briefly `in_review`) and can outlive the state that
   // produced it, so it must never be the sole reason a queued continuation is
   // cancelled. Only cancel when a *real* review posture still exists:
   // executionState.reviewRequest, a pending issue-thread interaction, or an
-  // open approval linked to the issue.
+  // open approval that represents review of *this issue's own work* --
+  // linked via issue_approvals and restricted to approval kinds in
+  // ISSUE_WORK_REVIEW_APPROVAL_TYPES. Approvals that merely happen to be
+  // linked to the issue for provenance (hiring another agent, a budget
+  // hard-stop override, a credential grant) are not review of this issue's
+  // work and must never gate its continuation.
   async function hasLiveIssueReviewPosture(issue: {
     id: string;
     companyId: string;
@@ -12725,6 +12737,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             eq(issueApprovals.companyId, issue.companyId),
             eq(issueApprovals.issueId, issue.id),
             inArray(approvals.status, ["pending", "revision_requested"]),
+            inArray(approvals.type, ISSUE_WORK_REVIEW_APPROVAL_TYPES),
           ),
         )
         .limit(1)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat scheduler decides whether a queued continuation run for an issue is still safe to execute, or must be cancelled and re-queued
> - A prior fix taught that scheduler to require a *real* review posture (a live `reviewRequest`, a pending thread interaction, or an open approval linked to the issue) before cancelling a continuation on stale "wait for review" summary text
> - That check treated *any* open approval linked to the issue as review posture, including approval kinds that have nothing to do with reviewing the issue's own work — e.g. an approval to hire a new teammate that happens to be linked back to the issue that requested the hire
> - So an issue with a pending `hire_agent` approval (or a budget override approval) and no reviewer at all still had its queued continuation cancelled with `issue_continuation_waiting_on_review`, reproducing the exact stranding class the prior fix was meant to remove
> - This pull request narrows the approval check to only the approval kinds that represent review of the issue's own current work, and leaves every other open approval kind (hiring, budget overrides, credential grants) out of the gate
> - The benefit is that an issue can no longer be strand-cancelled by an approval that concerns something unrelated to its own work, while an issue genuinely waiting on review of its own work is still held correctly

## Linked Issues or Issue Description

**What happened?**
The heartbeat scheduler's `hasLiveIssueReviewPosture()` check (in `evaluateQueuedRunStaleness()`) queries `issue_approvals` joined to `approvals` and treats *any* row with `status` in `("pending", "revision_requested")` as evidence that the issue is under live review. It does not filter on the approval's `type`. An issue that has an open `hire_agent` approval linked to it (for example, because the agent working the issue also requested hiring a teammate and the hire approval was linked back to the source issue) is treated the same as an issue that is genuinely waiting on a reviewer, and its queued continuation is cancelled with `issue_continuation_waiting_on_review` even though nothing about the issue's own work is under review.

**Expected behavior**
Only approval kinds that represent review of the issue's own current work should gate the continuation. `hire_agent`, `budget_override_required`, and any other approval kind that is merely linked to the issue for provenance should never cancel a continuation on this reason.

**Steps to reproduce**
1. Create an issue in `in_progress` with a queued continuation run and a continuation-summary document whose "Next Action" text says to wait for reviewer feedback.
2. Insert an `approvals` row with `type: "hire_agent"` and `status: "pending"`, and link it to the issue via `issue_approvals`.
3. Run the heartbeat scheduler's `resumeQueuedRuns()`.
4. Observe the queued run is cancelled with `issue_continuation_waiting_on_review`, even though the pending approval has nothing to do with review of the issue's own work.

## What Changed

- Added `ISSUE_WORK_REVIEW_APPROVAL_TYPES` (currently `["request_board_approval"]`) in `server/src/services/heartbeat.ts`.
- `hasLiveIssueReviewPosture()` now additionally filters the open-approval query on `inArray(approvals.type, ISSUE_WORK_REVIEW_APPROVAL_TYPES)`, so only approvals of a review-relevant kind can satisfy the "open approval" branch of the check. `hire_agent` and `budget_override_required` approvals no longer count.
- Added a test proving a pending `hire_agent` approval linked to the issue no longer cancels the continuation.
- Added a test proving a pending `request_board_approval` linked to the issue still cancels the continuation (the narrowing does not remove legitimate gating).

## Verification

- `cd server && npx vitest run src/__tests__/heartbeat-stale-queue-invalidation.test.ts` — 27/27 passing, including the two new cases.
- `npx tsc -p server/tsconfig.json --noEmit` — clean.

## Risks

- Low risk. The change only narrows an existing predicate (fewer cancellations), it does not add a new cancellation path. The one currently known approval kind that should still gate continuations (`request_board_approval`, used for high-risk tool-action sign-off) is covered by a passing regression test, so the narrowing does not silently disable legitimate review gating.
- If a future approval kind is added that should also represent review of an issue's own work, it must be added to `ISSUE_WORK_REVIEW_APPROVAL_TYPES` explicitly — this is an allowlist, so the safe failure mode for an unrecognized kind is "does not gate", not "gates when it shouldn't".

## Model Used

Claude (claude-sonnet-4-5), no extended thinking, agent tool use via Pi CLI harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
