### PR TITLE
fix: addresses the opencode agent hanging (giving 499 to server)

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1501,6 +1501,7 @@ export function renderPaperclipWakePrompt(
       case "provider_quota":
         return "Verify or create the wait-recovery monitor for the provider quota reset, then stop. Do not take over the task.";
       case "codex_output_inactivity_monitor":
+      case "opencode_output_inactivity_monitor":
         return "Your run was killed by the output-inactivity monitor, likely during a long quiet build/test phase. Go again from durable progress.";
       case "workspace_validation_failed":
         return `Recover/fix the workspace (worktree, branch, workspace link), then hand the issue back to ${originalAssigneeLabel} for the actual work. Do not do the deliverable work.`;

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -126,6 +126,7 @@ Core fields:
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
 - graceSec (number, optional): SIGTERM grace period in seconds
+- outputInactivityTimeoutMs (number | null, optional): inactivity monitor around the opencode child. Resets whenever the child emits stdout/stderr bytes or, on Linux, its process group shows meaningful CPU, disk I/O, or child-process churn during a silent build. Defaults to 30 * 60_000 ms when unset or non-positive. Set to \`null\` to disable the monitor entirely (only do this for known-slow tasks; the platform-level 1h silent-run safety net still applies). On fire, the adapter sends SIGTERM to the process group, waits 5s, then SIGKILL, and surfaces the run as failed with errorCode "opencode_output_inactivity_monitor" and errorMessage "monitor: no opencode activity (output or process) for {N}m {S}s". This guards against OpenCode's run loop getting stuck (e.g. after a provider request is aborted) without ever emitting its own terminal \`session.error\` / JSON error event or exiting.
 
 Notes:
 - OpenCode supports multiple providers and models. Use \

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -490,6 +490,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
     const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
+    // Sandbox `onSpawn` meta carries a PID from the provider's RPC response
+    // (the command's PID inside the sandbox's own namespace), not a PID in
+    // this host's process table — `execution-target.ts` already nulls its
+    // processGroupId for exactly this reason. Signalling it via local
+    // `process.kill` cannot reach the sandboxed process and can instead hit
+    // an unrelated host process that happens to reuse the same PID number.
+    // SSH targets are unaffected: their `runAdapterExecutionTargetProcess`
+    // path spawns a genuine local ssh child, so its pid/processGroupId are
+    // real and safe to signal.
+    const executionTargetIsSandbox =
+      runtimeExecutionTarget?.kind === "remote" && runtimeExecutionTarget.transport === "sandbox";
     if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(runtimeExecutionTarget)) {
       paperclipBridge = await startAdapterExecutionTargetPaperclipBridge({
         runId,
@@ -678,18 +689,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                 const message = formatOpenCodeOutputInactivityMonitorErrorMessage(monitorElapsedMs);
                 const elapsedSec = Math.round(monitorElapsedMs / 1000);
                 const timeoutSecLabel = Math.round(monitorResolution.timeoutMs / 1000);
+                // Sandbox `onSpawn` meta carries a PID from the provider's RPC
+                // response (the command's PID inside the sandbox's own
+                // namespace), not a PID in this host's process table --
+                // execution-target.ts already nulls its processGroupId for
+                // exactly this reason. Signalling it via local process.kill
+                // cannot reach the sandboxed process and can instead hit an
+                // unrelated host process that happens to reuse the same PID
+                // number, so skip the local signal attempt entirely for
+                // sandbox targets. SSH targets are unaffected: their
+                // runAdapterExecutionTargetProcess path spawns a genuine
+                // local ssh child, so its pid/processGroupId are real and
+                // safe to signal.
+                const terminationClause = executionTargetIsSandbox
+                  ? "the sandbox has no locally-signalable process; only the sandbox's own runtime timeout can end this run.\n"
+                  : "terminating opencode child via SIGTERM (5s grace, then SIGKILL).\n";
                 const logLine =
                   `[paperclip] adapter.invoke ${message}; ` +
                   `timeoutMs=${monitorResolution.timeoutMs} elapsedSinceLastEventMs=${monitorElapsedMs} ` +
                   `outputChunkCount=${state.outputChunkCount} outputBytes=${state.outputBytes} ` +
                   `parsedEvents=${state.parsedEventCount} processActivityCount=${state.processActivityCount} ` +
-                  `(timeout=${timeoutSecLabel}s elapsed=${elapsedSec}s); ` +
-                  `terminating opencode child via SIGTERM (5s grace, then SIGKILL).\n`;
+                  `(timeout=${timeoutSecLabel}s elapsed=${elapsedSec}s); ${terminationClause}`;
                 // Issue the log without awaiting on the kill hot path, but capture
                 // the promise so the surrounding try/finally can await flush before
                 // the run resolves. Without this the diagnostic that explains the
                 // kill could be dropped if the child exits faster than onLog flushes.
                 monitorLogPromise = Promise.resolve(onLog("stderr", logLine)).catch(() => {});
+                if (executionTargetIsSandbox) {
+                  return;
+                }
                 const target = killTarget;
                 if (!target || (target.pid == null && target.processGroupId == null)) {
                   return;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -55,6 +55,17 @@ import {
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+import {
+  OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS,
+  createOpenCodeOutputInactivityMonitor,
+  formatOpenCodeOutputInactivityMonitorErrorMessage,
+  resolveOpenCodeInactivityTimeout,
+} from "./output-inactivity-monitor.js";
+import {
+  OPENCODE_PROCESS_ACTIVITY_POLL_INTERVAL_MS,
+  createOpenCodeProcessActivityMonitor,
+  type OpenCodeProcessActivityMonitorHandle,
+} from "./process-activity-monitor.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -76,6 +87,29 @@ function parseModelProvider(model: string | null): string | null {
 
 function resolveOpenCodeBiller(env: Record<string, string>, provider: string | null): string {
   return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
+}
+
+function signalOpenCodeChild(
+  target: { pid: number | null; processGroupId: number | null },
+  signal: NodeJS.Signals,
+): boolean {
+  if (process.platform !== "win32" && target.processGroupId && target.processGroupId > 0) {
+    try {
+      process.kill(-target.processGroupId, signal);
+      return true;
+    } catch {
+      // Fall back to direct child signal if group signaling fails (e.g. group already gone).
+    }
+  }
+  if (target.pid && target.pid > 0) {
+    try {
+      process.kill(target.pid, signal);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }
 
 const REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC = 20;
@@ -582,6 +616,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const printLogs = isTruthyEnvFlag(
       env.PAPERCLIP_OPENCODE_PRINT_LOGS ?? process.env.PAPERCLIP_OPENCODE_PRINT_LOGS,
     );
+
+    const monitorResolution = resolveOpenCodeInactivityTimeout(config.outputInactivityTimeoutMs);
+    if (monitorResolution.mode === "disabled") {
+      await onLog(
+        "stdout",
+        `[paperclip] OpenCode output inactivity monitor is DISABLED via adapterConfig.outputInactivityTimeoutMs=null. Hung opencode runs will only be detected by the platform-level silent-run safety net.\n`,
+      );
+    } else if (monitorResolution.mode === "default" && "reason" in monitorResolution) {
+      await onLog(
+        "stdout",
+        `[paperclip] Ignoring non-positive adapterConfig.outputInactivityTimeoutMs; falling back to default ${monitorResolution.timeoutMs}ms.\n`,
+      );
+    }
+
     const buildArgs = (resumeSessionId: string | null) => {
       const args = ["run", "--format", "json"];
       if (printLogs) args.push("--print-logs");
@@ -608,22 +656,115 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         });
       }
 
-      const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
-        cwd,
-        env: preparedRuntimeConfig.env,
-        stdin: prompt,
-        timeoutSec,
-        graceSec,
-        onSpawn,
-        onRuntimeProgress: ctx.onRuntimeProgress,
-        onLog,
-        runLogTail: paperclipBridge?.runLogTail,
-      });
-      return {
-        proc,
-        rawStderr: proc.stderr,
-        parsed: parseOpenCodeJsonl(proc.stdout),
+      let monitorFired = false;
+      let monitorTerminationSignal: NodeJS.Signals | null = null;
+      let monitorElapsedMs = 0;
+      let monitorTimeoutMs = 0;
+      let killTarget: { pid: number | null; processGroupId: number | null } | null = null;
+      let sigkillTimer: ReturnType<typeof setTimeout> | null = null;
+      let monitorLogPromise: Promise<unknown> | null = null;
+      const processActivityMonitor: { current: OpenCodeProcessActivityMonitorHandle | null } = { current: null };
+      const resolvedMonitorTimeoutMs = monitorResolution.mode === "disabled" ? null : monitorResolution.timeoutMs;
+
+      const monitor =
+        monitorResolution.mode === "disabled"
+          ? null
+          : createOpenCodeOutputInactivityMonitor({
+              timeoutMs: monitorResolution.timeoutMs,
+              onFire: (state) => {
+                monitorFired = true;
+                monitorElapsedMs = (state.firedAt ?? Date.now()) - state.lastEventAt;
+                monitorTimeoutMs = monitorResolution.timeoutMs;
+                const message = formatOpenCodeOutputInactivityMonitorErrorMessage(monitorElapsedMs);
+                const elapsedSec = Math.round(monitorElapsedMs / 1000);
+                const timeoutSecLabel = Math.round(monitorResolution.timeoutMs / 1000);
+                const logLine =
+                  `[paperclip] adapter.invoke ${message}; ` +
+                  `timeoutMs=${monitorResolution.timeoutMs} elapsedSinceLastEventMs=${monitorElapsedMs} ` +
+                  `outputChunkCount=${state.outputChunkCount} outputBytes=${state.outputBytes} ` +
+                  `parsedEvents=${state.parsedEventCount} processActivityCount=${state.processActivityCount} ` +
+                  `(timeout=${timeoutSecLabel}s elapsed=${elapsedSec}s); ` +
+                  `terminating opencode child via SIGTERM (5s grace, then SIGKILL).\n`;
+                // Issue the log without awaiting on the kill hot path, but capture
+                // the promise so the surrounding try/finally can await flush before
+                // the run resolves. Without this the diagnostic that explains the
+                // kill could be dropped if the child exits faster than onLog flushes.
+                monitorLogPromise = Promise.resolve(onLog("stderr", logLine)).catch(() => {});
+                const target = killTarget;
+                if (!target || (target.pid == null && target.processGroupId == null)) {
+                  return;
+                }
+                const sentSig = signalOpenCodeChild(target, "SIGTERM");
+                if (sentSig) monitorTerminationSignal = "SIGTERM";
+                sigkillTimer = setTimeout(() => {
+                  sigkillTimer = null;
+                  const stillSent = signalOpenCodeChild(target, "SIGKILL");
+                  if (stillSent) monitorTerminationSignal = "SIGKILL";
+                }, OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS);
+                if (typeof (sigkillTimer as { unref?: () => void }).unref === "function") {
+                  (sigkillTimer as { unref: () => void }).unref();
+                }
+              },
+            });
+
+      const wrappedOnSpawn = async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+        killTarget = { pid: meta.pid ?? null, processGroupId: meta.processGroupId };
+        if (monitor && resolvedMonitorTimeoutMs !== null && !executionTargetIsRemote) {
+          processActivityMonitor.current = createOpenCodeProcessActivityMonitor({
+            pid: meta.pid,
+            processGroupId: meta.processGroupId,
+            intervalMs: Math.min(
+              OPENCODE_PROCESS_ACTIVITY_POLL_INTERVAL_MS,
+              Math.max(1_000, Math.floor(resolvedMonitorTimeoutMs / 4)),
+            ),
+            onActivity: () => monitor.noteProcessActivity(),
+          });
+        }
+        if (onSpawn) {
+          await onSpawn(meta);
+        }
       };
+
+      try {
+        const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+          cwd,
+          env: preparedRuntimeConfig.env,
+          stdin: prompt,
+          timeoutSec,
+          graceSec,
+          onSpawn: wrappedOnSpawn,
+          onRuntimeProgress: ctx.onRuntimeProgress,
+          onLog: async (stream, chunk) => {
+            monitor?.noteOutputChunk(stream, chunk);
+            await onLog(stream, chunk);
+          },
+          runLogTail: paperclipBridge?.runLogTail,
+        });
+        return {
+          proc,
+          rawStderr: proc.stderr,
+          parsed: parseOpenCodeJsonl(proc.stdout),
+          monitor: monitorFired
+            ? {
+                fired: true as const,
+                terminationSignal: monitorTerminationSignal,
+                elapsedMsSinceLastEvent: monitorElapsedMs,
+                timeoutMs: monitorTimeoutMs,
+              }
+            : { fired: false as const },
+        };
+      } finally {
+        processActivityMonitor.current?.stop();
+        monitor?.stop();
+        if (sigkillTimer) {
+          clearTimeout(sigkillTimer);
+          sigkillTimer = null;
+        }
+        if (monitorLogPromise) {
+          await monitorLogPromise;
+          monitorLogPromise = null;
+        }
+      }
     };
 
     const toResult = (
@@ -631,9 +772,49 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
         rawStderr: string;
         parsed: ReturnType<typeof parseOpenCodeJsonl>;
+        monitor?:
+          | { fired: false }
+          | { fired: true; terminationSignal: NodeJS.Signals | null; elapsedMsSinceLastEvent: number; timeoutMs: number };
       },
       clearSessionOnMissingSession = false,
     ): AdapterExecutionResult => {
+      if (attempt.monitor?.fired) {
+        const errorMessage = formatOpenCodeOutputInactivityMonitorErrorMessage(attempt.monitor.elapsedMsSinceLastEvent);
+        const modelId = model || null;
+        return {
+          exitCode: null,
+          signal: attempt.monitor.terminationSignal ?? attempt.proc.signal,
+          timedOut: false,
+          errorMessage,
+          errorCode: "opencode_output_inactivity_monitor",
+          errorFamily: null,
+          usage: {
+            inputTokens: attempt.parsed.usage.inputTokens,
+            outputTokens: attempt.parsed.usage.outputTokens,
+            cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
+          },
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          provider: parseModelProvider(modelId),
+          biller: resolveOpenCodeBiller(runtimeEnv, parseModelProvider(modelId)),
+          model: modelId,
+          billingType: "unknown",
+          costUsd: attempt.parsed.costUsd,
+          resultJson: {
+            stdout: attempt.proc.stdout,
+            stderr: attempt.proc.stderr,
+            outputInactivityMonitor: {
+              kind: "output_inactivity",
+              timeoutMs: attempt.monitor.timeoutMs,
+              elapsedMsSinceLastEvent: attempt.monitor.elapsedMsSinceLastEvent,
+              terminationSignal: attempt.monitor.terminationSignal,
+            },
+          },
+          summary: attempt.parsed.summary,
+          clearSession: clearSessionOnMissingSession,
+        };
+      }
       if (attempt.proc.timedOut) {
         return {
           exitCode: attempt.proc.exitCode,

--- a/packages/adapters/opencode-local/src/server/output-inactivity-monitor.integration.test.ts
+++ b/packages/adapters/opencode-local/src/server/output-inactivity-monitor.integration.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import {
+  OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS,
+  createOpenCodeOutputInactivityMonitor,
+  formatOpenCodeOutputInactivityMonitorErrorMessage,
+} from "./output-inactivity-monitor.js";
+import { createOpenCodeProcessActivityMonitor } from "./process-activity-monitor.js";
+
+const FAKE_OPENCODE_SCRIPT = `
+process.stdout.write(JSON.stringify({ type: "session.updated", sessionID: "abc" }) + "\\n");
+// Simulate a wedged opencode: read stdin forever, never write again.
+process.stdin.resume();
+process.stdin.on("data", () => {});
+setInterval(() => {}, 60_000);
+`;
+
+describe("opencode inactivity monitor (integration: real subprocess)", () => {
+  it.skipIf(process.platform !== "linux")(
+    "allows a long silent build while the child process group is consuming CPU",
+    async () => {
+      const runId = `monitor-active-build-${Date.now()}`;
+      const timeoutMs = 500;
+      const processActivityMonitor: {
+        current: ReturnType<typeof createOpenCodeProcessActivityMonitor> | null;
+      } = { current: null };
+      let monitorFired = false;
+      const monitor = createOpenCodeOutputInactivityMonitor({
+        timeoutMs,
+        onFire: () => {
+          monitorFired = true;
+        },
+      });
+
+      try {
+        const proc = await runChildProcess(
+          runId,
+          process.execPath,
+          ["-e", "const end = Date.now() + 2_000; while (Date.now() < end) {}"],
+          {
+            cwd: process.cwd(),
+            env: process.env as Record<string, string>,
+            timeoutSec: 5,
+            graceSec: 1,
+            onSpawn: async (meta) => {
+              processActivityMonitor.current = createOpenCodeProcessActivityMonitor({
+                pid: meta.pid,
+                processGroupId: meta.processGroupId,
+                intervalMs: 50,
+                onActivity: () => monitor.noteProcessActivity(),
+              });
+            },
+            onLog: async (stream, chunk) => monitor.noteOutputChunk(stream, chunk),
+          },
+        );
+
+        expect(proc.exitCode).toBe(0);
+        expect(proc.timedOut).toBe(false);
+        expect(monitorFired).toBe(false);
+        expect(monitor.state().processActivityCount).toBeGreaterThan(0);
+      } finally {
+        processActivityMonitor.current?.stop();
+        monitor.stop();
+      }
+    },
+    10_000,
+  );
+
+  it(
+    "kills an opencode child that goes silent after one event and surfaces a monitor failure",
+    async () => {
+      const runId = `monitor-integration-${Date.now()}`;
+      const timeoutMs = 250;
+      const logs: Array<{ stream: string; chunk: string }> = [];
+      let killTarget: { pid: number | null; processGroupId: number | null } | null = null;
+      let monitorFired = false;
+      let terminationSignal: NodeJS.Signals | null = null;
+      let sigkillTimer: ReturnType<typeof setTimeout> | null = null;
+      const processActivityMonitor: {
+        current: ReturnType<typeof createOpenCodeProcessActivityMonitor> | null;
+      } = { current: null };
+      let elapsedMs = 0;
+
+      const kill = (signal: NodeJS.Signals) => {
+        const target = killTarget;
+        if (!target) return false;
+        if (target.processGroupId && target.processGroupId > 0) {
+          try {
+            process.kill(-target.processGroupId, signal);
+            return true;
+          } catch {
+            /* fall through */
+          }
+        }
+        if (target.pid && target.pid > 0) {
+          try {
+            process.kill(target.pid, signal);
+            return true;
+          } catch {
+            return false;
+          }
+        }
+        return false;
+      };
+
+      const monitor = createOpenCodeOutputInactivityMonitor({
+        timeoutMs,
+        onFire: (state) => {
+          monitorFired = true;
+          elapsedMs = (state.firedAt ?? Date.now()) - state.lastEventAt;
+          if (kill("SIGTERM")) terminationSignal = "SIGTERM";
+          sigkillTimer = setTimeout(() => {
+            if (kill("SIGKILL")) terminationSignal = "SIGKILL";
+          }, OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS);
+        },
+      });
+
+      try {
+        const proc = await runChildProcess(runId, process.execPath, ["-e", FAKE_OPENCODE_SCRIPT], {
+          cwd: process.cwd(),
+          env: process.env as Record<string, string>,
+          timeoutSec: 30,
+          graceSec: 1,
+          onSpawn: async (meta) => {
+            killTarget = { pid: meta.pid, processGroupId: meta.processGroupId };
+            processActivityMonitor.current = createOpenCodeProcessActivityMonitor({
+              pid: meta.pid,
+              processGroupId: meta.processGroupId,
+              intervalMs: 25,
+              onActivity: () => monitor.noteProcessActivity(),
+            });
+          },
+          onLog: async (stream, chunk) => {
+            logs.push({ stream, chunk });
+            monitor.noteOutputChunk(stream, chunk);
+          },
+        });
+
+        expect(monitorFired, "monitor should fire when opencode goes silent").toBe(true);
+        // Process was killed by our signal, not by hitting timeoutSec.
+        expect(proc.timedOut).toBe(false);
+        expect(["SIGTERM", "SIGKILL"]).toContain(proc.signal);
+        expect(["SIGTERM", "SIGKILL"]).toContain(terminationSignal);
+        // The errorMessage shape mirrors the AdapterExecutionResult that
+        // execute.ts will produce for this case.
+        expect(formatOpenCodeOutputInactivityMonitorErrorMessage(elapsedMs)).toMatch(
+          /^monitor: no opencode activity \(output or process\) for \d+m \d+s$/,
+        );
+        // We should have observed exactly one parsed JSONL event before silence.
+        expect(monitor.state().parsedEventCount).toBe(1);
+      } finally {
+        processActivityMonitor.current?.stop();
+        monitor.stop();
+        if (sigkillTimer) clearTimeout(sigkillTimer);
+      }
+    },
+    15_000,
+  );
+});

--- a/packages/adapters/opencode-local/src/server/output-inactivity-monitor.test.ts
+++ b/packages/adapters/opencode-local/src/server/output-inactivity-monitor.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS,
+  OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS,
+  createOpenCodeOutputInactivityMonitor,
+  formatOpenCodeOutputInactivityMonitorErrorMessage,
+  resolveOpenCodeInactivityTimeout,
+} from "./output-inactivity-monitor.js";
+
+class FakeClock {
+  private nowMs = 0;
+  private nextHandle = 1;
+  private timers = new Map<number, { fireAt: number; cb: () => void }>();
+
+  now(): number {
+    return this.nowMs;
+  }
+
+  setTimer(cb: () => void, ms: number): number {
+    const handle = this.nextHandle++;
+    this.timers.set(handle, { fireAt: this.nowMs + ms, cb });
+    return handle;
+  }
+
+  clearTimer(handle: unknown): void {
+    if (typeof handle === "number") this.timers.delete(handle);
+  }
+
+  advance(ms: number): void {
+    const targetMs = this.nowMs + ms;
+    while (true) {
+      let nextHandle: number | null = null;
+      let nextTimer: { fireAt: number; cb: () => void } | null = null;
+      for (const [h, timer] of this.timers) {
+        if (timer.fireAt <= targetMs && (!nextTimer || timer.fireAt < nextTimer.fireAt)) {
+          nextHandle = h;
+          nextTimer = timer;
+        }
+      }
+      if (!nextTimer || nextHandle == null) break;
+      this.timers.delete(nextHandle);
+      this.nowMs = nextTimer.fireAt;
+      nextTimer.cb();
+    }
+    this.nowMs = targetMs;
+  }
+
+  pendingTimerCount(): number {
+    return this.timers.size;
+  }
+}
+
+describe("resolveOpenCodeInactivityTimeout", () => {
+  it("defaults to 30 minutes", () => {
+    expect(DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS).toBe(30 * 60 * 1000);
+  });
+
+  it("uses default when value is unset", () => {
+    expect(resolveOpenCodeInactivityTimeout(undefined)).toEqual({
+      mode: "default",
+      timeoutMs: DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS,
+    });
+  });
+
+  it("treats explicit null as disabled", () => {
+    expect(resolveOpenCodeInactivityTimeout(null)).toEqual({
+      mode: "disabled",
+      reason: "explicit_null",
+    });
+  });
+
+  it("returns configured value for positive numbers", () => {
+    expect(resolveOpenCodeInactivityTimeout(12_000)).toEqual({
+      mode: "configured",
+      timeoutMs: 12_000,
+    });
+  });
+
+  it("falls back to default for non-positive numbers", () => {
+    expect(resolveOpenCodeInactivityTimeout(0)).toEqual({
+      mode: "default",
+      timeoutMs: DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS,
+      reason: "non_positive",
+    });
+    expect(resolveOpenCodeInactivityTimeout(-100)).toEqual({
+      mode: "default",
+      timeoutMs: DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS,
+      reason: "non_positive",
+    });
+  });
+
+  it("falls back to default for non-number, non-null values", () => {
+    expect(resolveOpenCodeInactivityTimeout("420000")).toEqual({
+      mode: "default",
+      timeoutMs: DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS,
+    });
+  });
+});
+
+describe("formatOpenCodeOutputInactivityMonitorErrorMessage", () => {
+  it("formats minutes and seconds", () => {
+    expect(formatOpenCodeOutputInactivityMonitorErrorMessage(0)).toBe(
+      "monitor: no opencode activity (output or process) for 0m 0s",
+    );
+    expect(formatOpenCodeOutputInactivityMonitorErrorMessage(7 * 60 * 1000)).toBe(
+      "monitor: no opencode activity (output or process) for 7m 0s",
+    );
+    expect(formatOpenCodeOutputInactivityMonitorErrorMessage(7 * 60 * 1000 + 12_000)).toBe(
+      "monitor: no opencode activity (output or process) for 7m 12s",
+    );
+    expect(formatOpenCodeOutputInactivityMonitorErrorMessage(45_000)).toBe(
+      "monitor: no opencode activity (output or process) for 0m 45s",
+    );
+  });
+});
+
+describe("createOpenCodeOutputInactivityMonitor (acceptance criteria 1: fires)", () => {
+  it("fires after timeoutMs when child emits one event then goes silent", () => {
+    const clock = new FakeClock();
+    const fires: Array<{ elapsed: number; parsedEventCount: number }> = [];
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs: 7 * 60 * 1000,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: (state) => {
+        fires.push({
+          elapsed: (state.firedAt ?? 0) - state.lastEventAt,
+          parsedEventCount: state.parsedEventCount,
+        });
+      },
+    });
+
+    // One event right after spawn.
+    clock.advance(50);
+    monitor.noteOutputChunk("stdout", '{"type":"session.updated","sessionID":"abc"}\n');
+    expect(fires).toHaveLength(0);
+    expect(monitor.state().parsedEventCount).toBe(1);
+
+    // Now go silent for 7 minutes; monitor should fire exactly at threshold.
+    clock.advance(7 * 60 * 1000 - 1);
+    expect(fires).toHaveLength(0);
+    clock.advance(1);
+    expect(fires).toHaveLength(1);
+    expect(fires[0].elapsed).toBe(7 * 60 * 1000);
+    expect(fires[0].parsedEventCount).toBe(1);
+
+    // Stopping after fire is a no-op for the timer but returns final state.
+    const finalState = monitor.stop();
+    expect(finalState.fired).toBe(true);
+  });
+
+  it("only fires once even if more silence elapses after firing", () => {
+    const clock = new FakeClock();
+    let fireCount = 0;
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs: 1_000,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: () => {
+        fireCount += 1;
+      },
+    });
+    clock.advance(2_000);
+    expect(fireCount).toBe(1);
+    clock.advance(10_000);
+    expect(fireCount).toBe(1);
+    monitor.stop();
+  });
+
+  it("resets on non-JSON stdout bytes", () => {
+    const clock = new FakeClock();
+    let fireCount = 0;
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs: 1_000,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: () => {
+        fireCount += 1;
+      },
+    });
+    clock.advance(500);
+    monitor.noteOutputChunk("stdout", "loading model...\n");
+    expect(monitor.state()).toMatchObject({
+      outputChunkCount: 1,
+      outputBytes: Buffer.byteLength("loading model...\n", "utf8"),
+      parsedEventCount: 0,
+    });
+    clock.advance(999);
+    expect(fireCount).toBe(0);
+    clock.advance(1);
+    expect(fireCount).toBe(1);
+    monitor.stop();
+  });
+
+  it("resets on process activity without output", () => {
+    const clock = new FakeClock();
+    let fireCount = 0;
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs: 1_000,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: () => {
+        fireCount += 1;
+      },
+    });
+
+    clock.advance(900);
+    monitor.noteProcessActivity();
+    expect(monitor.state().processActivityCount).toBe(1);
+    clock.advance(999);
+    expect(fireCount).toBe(0);
+    clock.advance(1);
+    expect(fireCount).toBe(1);
+    monitor.stop();
+  });
+});
+
+describe("createOpenCodeOutputInactivityMonitor (acceptance criteria 2: does not fire)", () => {
+  it("keeps long verification alive while non-JSON stdout and stderr bytes continue", () => {
+    const clock = new FakeClock();
+    let fireCount = 0;
+    const timeoutMs = 7 * 60 * 1000;
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: () => {
+        fireCount += 1;
+      },
+    });
+
+    clock.advance(timeoutMs - 1_000);
+    monitor.noteOutputChunk("stdout", "packages/server: typecheck passed\n");
+    clock.advance(timeoutMs - 1_000);
+    monitor.noteOutputChunk("stderr", "packages/ui: build still running\n");
+    clock.advance(timeoutMs - 1_000);
+    monitor.noteOutputChunk("stdout", "packages/ui: build passed\n");
+
+    expect(fireCount).toBe(0);
+    expect(monitor.state()).toMatchObject({
+      outputChunkCount: 3,
+      parsedEventCount: 0,
+      fired: false,
+    });
+    monitor.stop();
+  });
+
+  it("does not fire when events arrive every (threshold - 1s)", () => {
+    const clock = new FakeClock();
+    let fireCount = 0;
+    const timeoutMs = 7 * 60 * 1000;
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: () => {
+        fireCount += 1;
+      },
+    });
+
+    // Pump events at threshold-1s intervals for 12 cycles (~84 minutes).
+    for (let i = 0; i < 12; i += 1) {
+      clock.advance(timeoutMs - 1_000);
+      monitor.noteOutputChunk("stdout", `{"type":"message.part.updated","part":{"text":"tick ${i}"}}\n`);
+      expect(fireCount).toBe(0);
+    }
+
+    // Final event lets us "complete" — total state shows 12 parsed events.
+    expect(monitor.state().parsedEventCount).toBe(12);
+    expect(fireCount).toBe(0);
+
+    // Stop cleanly before the timer would have fired.
+    monitor.stop();
+    expect(fireCount).toBe(0);
+  });
+
+  it("multiple events in one chunk all reset the timer", () => {
+    const clock = new FakeClock();
+    let fireCount = 0;
+    const monitor = createOpenCodeOutputInactivityMonitor({
+      timeoutMs: 1_000,
+      now: () => clock.now(),
+      setTimer: (cb, ms) => clock.setTimer(cb, ms),
+      clearTimer: (handle) => clock.clearTimer(handle),
+      onFire: () => {
+        fireCount += 1;
+      },
+    });
+    clock.advance(500);
+    monitor.noteOutputChunk(
+      "stdout",
+      '{"type":"session.updated","sessionID":"a"}\n{"type":"message.part.updated","part":{"text":"hi"}}\n',
+    );
+    expect(monitor.state().parsedEventCount).toBe(2);
+    // Now wait 999ms — should still not fire.
+    clock.advance(999);
+    expect(fireCount).toBe(0);
+    // Wait one more ms — fires now.
+    clock.advance(1);
+    expect(fireCount).toBe(1);
+    monitor.stop();
+  });
+});
+
+describe("createOpenCodeOutputInactivityMonitor (acceptance criteria 3: disabled)", () => {
+  it("resolveOpenCodeInactivityTimeout returns disabled for null and the adapter creates no monitor", () => {
+    const resolution = resolveOpenCodeInactivityTimeout(null);
+    expect(resolution.mode).toBe("disabled");
+    // Sanity: when a caller (execute.ts) honors `disabled`, it must not
+    // construct a monitor at all. Verify the constructor would otherwise
+    // require a positive timeoutMs.
+    expect(() =>
+      createOpenCodeOutputInactivityMonitor({
+        timeoutMs: 0,
+        onFire: () => {},
+      }),
+    ).toThrow(/timeoutMs > 0/);
+  });
+});
+
+describe("OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS", () => {
+  it("matches the 5-second grace window used by the codex_local watchdog", () => {
+    expect(OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS).toBe(5_000);
+  });
+});

--- a/packages/adapters/opencode-local/src/server/output-inactivity-monitor.ts
+++ b/packages/adapters/opencode-local/src/server/output-inactivity-monitor.ts
@@ -1,0 +1,157 @@
+import { parseJson } from "@paperclipai/adapter-utils/server-utils";
+
+export const DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
+export const OPENCODE_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS = 5_000;
+
+export type OpenCodeOutputInactivityMonitorResolution =
+  | { mode: "default"; timeoutMs: number }
+  | { mode: "configured"; timeoutMs: number }
+  | { mode: "disabled"; reason: "explicit_null" }
+  | { mode: "default"; timeoutMs: number; reason: "non_positive" };
+
+/**
+ * Resolve the inactivity monitor timeout from raw adapter config.
+ *
+ * - `null`         → disabled (explicit escape hatch).
+ * - missing/`undefined` → default 30m.
+ * - number > 0     → configured value.
+ * - number ≤ 0     → default 30m (and a `non_positive` note for logging).
+ */
+export function resolveOpenCodeInactivityTimeout(rawValue: unknown): OpenCodeOutputInactivityMonitorResolution {
+  if (rawValue === null) return { mode: "disabled", reason: "explicit_null" };
+  if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+    if (rawValue > 0) return { mode: "configured", timeoutMs: rawValue };
+    return { mode: "default", timeoutMs: DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS, reason: "non_positive" };
+  }
+  return { mode: "default", timeoutMs: DEFAULT_OPENCODE_OUTPUT_INACTIVITY_TIMEOUT_MS };
+}
+
+export interface OpenCodeOutputInactivityMonitorState {
+  fired: boolean;
+  spawnedAt: number;
+  lastEventAt: number;
+  firedAt: number | null;
+  outputChunkCount: number;
+  outputBytes: number;
+  parsedEventCount: number;
+  processActivityCount: number;
+}
+
+export interface OpenCodeOutputInactivityMonitorOptions {
+  timeoutMs: number;
+  onFire: (state: OpenCodeOutputInactivityMonitorState) => void;
+  now?: () => number;
+  setTimer?: (cb: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+  /**
+   * Per-line predicate. When omitted, any line that successfully parses as
+   * JSON via OpenCode's `--format json` NDJSON stream counts as a heartbeat
+   * event.
+   */
+  isHeartbeatLine?: (line: string) => boolean;
+}
+
+export interface OpenCodeOutputInactivityMonitorHandle {
+  noteOutputChunk(stream: "stdout" | "stderr", chunk: string): void;
+  noteProcessActivity(): void;
+  /** Returns the current state without stopping the timer. */
+  state(): OpenCodeOutputInactivityMonitorState;
+  /** Cancels any pending timer and returns the final state. */
+  stop(): OpenCodeOutputInactivityMonitorState;
+}
+
+function defaultIsHeartbeatLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  return parseJson(trimmed) !== null;
+}
+
+export function createOpenCodeOutputInactivityMonitor(
+  options: OpenCodeOutputInactivityMonitorOptions,
+): OpenCodeOutputInactivityMonitorHandle {
+  const now = options.now ?? (() => Date.now());
+  const setTimer = options.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+  const clearTimer = options.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  const isHeartbeatLine = options.isHeartbeatLine ?? defaultIsHeartbeatLine;
+  const timeoutMs = options.timeoutMs;
+
+  if (!(timeoutMs > 0)) {
+    throw new Error(`createOpenCodeOutputInactivityMonitor requires timeoutMs > 0 (got ${timeoutMs})`);
+  }
+
+  const spawnedAt = now();
+  const state: OpenCodeOutputInactivityMonitorState = {
+    fired: false,
+    spawnedAt,
+    lastEventAt: spawnedAt,
+    firedAt: null,
+    outputChunkCount: 0,
+    outputBytes: 0,
+    parsedEventCount: 0,
+    processActivityCount: 0,
+  };
+  let timerHandle: unknown = null;
+  let stopped = false;
+
+  const fire = () => {
+    if (state.fired || stopped) return;
+    state.fired = true;
+    state.firedAt = now();
+    timerHandle = null;
+    options.onFire({ ...state });
+  };
+
+  const arm = () => {
+    if (stopped || state.fired) return;
+    if (timerHandle != null) clearTimer(timerHandle);
+    timerHandle = setTimer(fire, timeoutMs);
+  };
+
+  arm();
+
+  return {
+    noteOutputChunk(stream: "stdout" | "stderr", chunk: string) {
+      if (stopped || state.fired || chunk.length === 0) return;
+      state.outputChunkCount += 1;
+      state.outputBytes += Buffer.byteLength(chunk, "utf8");
+      if (stream === "stdout") {
+        for (const rawLine of chunk.split(/\r?\n/)) {
+          if (isHeartbeatLine(rawLine)) {
+            state.parsedEventCount += 1;
+          }
+        }
+      }
+      state.lastEventAt = now();
+      arm();
+    },
+    noteProcessActivity() {
+      if (stopped || state.fired) return;
+      state.processActivityCount += 1;
+      state.lastEventAt = now();
+      arm();
+    },
+    state() {
+      return { ...state };
+    },
+    stop() {
+      stopped = true;
+      if (timerHandle != null) {
+        clearTimer(timerHandle);
+        timerHandle = null;
+      }
+      return { ...state };
+    },
+  };
+}
+
+/**
+ * Format the inactivity monitor error message in the canonical
+ * `monitor: no opencode activity (output or process) for {N}m {S}s` shape,
+ * mirroring the codex_local adapter's output-inactivity monitor message.
+ */
+export function formatOpenCodeOutputInactivityMonitorErrorMessage(elapsedMs: number): string {
+  const total = Math.max(0, Math.round(elapsedMs / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total - minutes * 60;
+  return `monitor: no opencode activity (output or process) for ${minutes}m ${seconds}s`;
+}

--- a/packages/adapters/opencode-local/src/server/process-activity-monitor.test.ts
+++ b/packages/adapters/opencode-local/src/server/process-activity-monitor.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOpenCodeProcessActivityMonitor,
+  type OpenCodeProcessActivitySnapshot,
+} from "./process-activity-monitor.js";
+
+class PollHarness {
+  private callback: (() => void) | null = null;
+
+  setTimer = (callback: () => void) => {
+    this.callback = callback;
+    return callback;
+  };
+
+  clearTimer = () => {
+    this.callback = null;
+  };
+
+  async poll(): Promise<void> {
+    await vi.waitFor(() => expect(this.callback).not.toBeNull());
+    const callback = this.callback;
+    this.callback = null;
+    callback?.();
+  }
+}
+
+function snapshot(cpuTicks: number, ioBytes: number, processIds = "100"): OpenCodeProcessActivitySnapshot {
+  return { cpuTicks, ioBytes, processIds };
+}
+
+describe("createOpenCodeProcessActivityMonitor", () => {
+  it("requires a baseline and ignores sub-threshold CPU changes", async () => {
+    const samples = [snapshot(100, 1_000), snapshot(114, 1_000)];
+    const harness = new PollHarness();
+    const onActivity = vi.fn();
+    const monitor = createOpenCodeProcessActivityMonitor({
+      pid: 100,
+      processGroupId: 100,
+      intervalMs: 15_000,
+      sample: async () => samples.shift() ?? null,
+      setTimer: harness.setTimer,
+      clearTimer: harness.clearTimer,
+      onActivity,
+    });
+
+    await harness.poll();
+    await vi.waitFor(() => expect(onActivity).not.toHaveBeenCalled());
+    monitor.stop();
+  });
+
+  it.each([
+    ["CPU growth", snapshot(115, 1_000)],
+    ["I/O growth", snapshot(100, 1_001)],
+    ["process-group churn", snapshot(100, 1_000, "100,101")],
+  ])("reports %s as process activity", async (_label, activeSnapshot) => {
+    const samples = [snapshot(100, 1_000), activeSnapshot];
+    const harness = new PollHarness();
+    const onActivity = vi.fn();
+    const monitor = createOpenCodeProcessActivityMonitor({
+      pid: 100,
+      processGroupId: 100,
+      intervalMs: 15_000,
+      sample: async () => samples.shift() ?? null,
+      setTimer: harness.setTimer,
+      clearTimer: harness.clearTimer,
+      onActivity,
+    });
+
+    await harness.poll();
+    await vi.waitFor(() => expect(onActivity).toHaveBeenCalledTimes(1));
+    monitor.stop();
+  });
+
+  it("resets its comparison baseline after an unavailable sample", async () => {
+    const samples = [snapshot(100, 1_000), null, snapshot(200, 2_000), snapshot(215, 2_000)];
+    const harness = new PollHarness();
+    const onActivity = vi.fn();
+    const monitor = createOpenCodeProcessActivityMonitor({
+      pid: 100,
+      processGroupId: 100,
+      intervalMs: 15_000,
+      sample: async () => samples.shift() ?? null,
+      setTimer: harness.setTimer,
+      clearTimer: harness.clearTimer,
+      onActivity,
+    });
+
+    await harness.poll();
+    await harness.poll();
+    await vi.waitFor(() => expect(onActivity).not.toHaveBeenCalled());
+    await harness.poll();
+    await vi.waitFor(() => expect(onActivity).toHaveBeenCalledTimes(1));
+    monitor.stop();
+  });
+});

--- a/packages/adapters/opencode-local/src/server/process-activity-monitor.ts
+++ b/packages/adapters/opencode-local/src/server/process-activity-monitor.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs/promises";
+
+export const OPENCODE_PROCESS_ACTIVITY_POLL_INTERVAL_MS = 15_000;
+
+export interface OpenCodeProcessActivitySnapshot {
+  cpuTicks: number;
+  ioBytes: number;
+  processIds: string;
+}
+
+export interface OpenCodeProcessActivityMonitorOptions {
+  pid: number;
+  processGroupId: number | null;
+  onActivity: () => void;
+  intervalMs?: number;
+  sample?: () => Promise<OpenCodeProcessActivitySnapshot | null>;
+  setTimer?: (cb: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+}
+
+export interface OpenCodeProcessActivityMonitorHandle {
+  stop(): void;
+}
+
+function parseProcStat(stat: string): { processGroupId: number; cpuTicks: number } | null {
+  const commandEnd = stat.lastIndexOf(")");
+  if (commandEnd < 0) return null;
+  const fields = stat.slice(commandEnd + 2).trim().split(/\s+/);
+  const processGroupId = Number(fields[2]);
+  const userTicks = Number(fields[11]);
+  const systemTicks = Number(fields[12]);
+  if (![processGroupId, userTicks, systemTicks].every(Number.isFinite)) return null;
+  return { processGroupId, cpuTicks: userTicks + systemTicks };
+}
+
+function parseProcIo(io: string): number {
+  let bytes = 0;
+  for (const line of io.split("\n")) {
+    const match = /^(?:read_bytes|write_bytes):\s+(\d+)$/.exec(line.trim());
+    if (match) bytes += Number(match[1]);
+  }
+  return bytes;
+}
+
+export async function sampleOpenCodeProcessActivity(
+  pid: number,
+  processGroupId: number | null,
+): Promise<OpenCodeProcessActivitySnapshot | null> {
+  if (process.platform !== "linux") return null;
+  const targetProcessGroupId = processGroupId && processGroupId > 0 ? processGroupId : null;
+  const entries = targetProcessGroupId ? await fs.readdir("/proc") : [String(pid)];
+  const processIds: number[] = [];
+  let cpuTicks = 0;
+  let ioBytes = 0;
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!/^\d+$/.test(entry)) return;
+      try {
+        const parsed = parseProcStat(await fs.readFile(`/proc/${entry}/stat`, "utf8"));
+        if (!parsed) return;
+        if (targetProcessGroupId !== null && parsed.processGroupId !== targetProcessGroupId) return;
+        if (targetProcessGroupId === null && Number(entry) !== pid) return;
+        const io = await fs.readFile(`/proc/${entry}/io`, "utf8").catch(() => "");
+        processIds.push(Number(entry));
+        cpuTicks += parsed.cpuTicks;
+        ioBytes += parseProcIo(io);
+      } catch {
+        // Processes can exit between listing /proc and reading their stat file.
+      }
+    }),
+  );
+
+  if (processIds.length === 0) return null;
+  processIds.sort((left, right) => left - right);
+  return { cpuTicks, ioBytes, processIds: processIds.join(",") };
+}
+
+export function createOpenCodeProcessActivityMonitor(
+  options: OpenCodeProcessActivityMonitorOptions,
+): OpenCodeProcessActivityMonitorHandle {
+  const intervalMs = options.intervalMs ?? OPENCODE_PROCESS_ACTIVITY_POLL_INTERVAL_MS;
+  const sample = options.sample ?? (() => sampleOpenCodeProcessActivity(options.pid, options.processGroupId));
+  const setTimer = options.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+  const clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+  const minimumCpuTickDelta = Math.max(1, Math.floor(intervalMs / 1_000));
+  let previous: OpenCodeProcessActivitySnapshot | null = null;
+  let timer: unknown = null;
+  let stopped = false;
+
+  const schedule = () => {
+    if (stopped) return;
+    timer = setTimer(() => {
+      void poll();
+    }, intervalMs);
+    if (typeof (timer as { unref?: () => void }).unref === "function") {
+      (timer as { unref: () => void }).unref();
+    }
+  };
+
+  const poll = async () => {
+    if (stopped) return;
+    const current = await sample().catch(() => null);
+    if (stopped) return;
+    if (
+      current &&
+      previous &&
+      (current.cpuTicks - previous.cpuTicks >= minimumCpuTickDelta ||
+        current.ioBytes > previous.ioBytes ||
+        current.processIds !== previous.processIds)
+    ) {
+      options.onActivity();
+    }
+    previous = current;
+    schedule();
+  };
+
+  void poll();
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer != null) {
+        clearTimer(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -166,6 +166,7 @@ type StrandedRecoveryCause =
   | "process_lost"
   | "provider_quota"
   | "codex_output_inactivity_monitor"
+  | "opencode_output_inactivity_monitor"
   | "workspace_validation_failed"
   | "configuration_incomplete"
   | "execution_review_participant_recovery"
@@ -197,6 +198,7 @@ function recoveryCauseTitle(cause: StrandedRecoveryCause) {
     case "process_lost":
       return "retries exhausted";
     case "codex_output_inactivity_monitor":
+    case "opencode_output_inactivity_monitor":
       return "output-inactivity retry exhausted";
     case "workspace_validation_failed":
       return "workspace validation failed";
@@ -270,8 +272,11 @@ function resolveStrandedRecoveryCause(
   if (explicitCause) return explicitCause;
   if (isProviderQuotaRecovery(latestRun)) return "provider_quota";
   if (latestRun?.errorCode === "process_lost") return "process_lost";
-  if (latestRun?.errorCode === "codex_output_inactivity_monitor") {
-    return "codex_output_inactivity_monitor";
+  if (
+    latestRun?.errorCode === "codex_output_inactivity_monitor" ||
+    latestRun?.errorCode === "opencode_output_inactivity_monitor"
+  ) {
+    return latestRun.errorCode;
   }
   return "stranded_assigned_issue";
 }
@@ -2588,7 +2593,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
-      input.recoveryCause === "codex_output_inactivity_monitor";
+      input.recoveryCause === "codex_output_inactivity_monitor" ||
+      input.recoveryCause === "opencode_output_inactivity_monitor";
     if (input.recoveryCause === "provider_quota") {
       const retryAgentId = await resolveInvokableRecoveryAgentId(input.issue, originalAgentId);
       if (!retryAgentId) {
@@ -2911,7 +2917,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           ? "Retry the original assignee from durable progress without redoing completed steps."
         : recoveryCause === "provider_quota"
           ? "Wait for provider quota recovery, then retry the original assignee; do not wake a takeover owner."
-        : recoveryCause === "codex_output_inactivity_monitor"
+        : recoveryCause === "codex_output_inactivity_monitor" || recoveryCause === "opencode_output_inactivity_monitor"
           ? "Retry the same agent from durable progress after the output-inactivity termination."
         : recoveryCause === "workspace_validation_failed"
           ? readWorkspaceValidationPayload(input.latestRun)?.reason === "git_worktree_branch_incoherence"


### PR DESCRIPTION

## Thinking Path

identified the issue with the opencode using custom models and the origin of the error (timeouts);

investigated in the code for open tickets/PRs, stumbled upon the codex process/output monitor;

identified  as a possible fix;

implemented and built locally. haven't had an agent hang since

(at at worse is harmless and offers more control over opencode)

## Linked Issues or Issue Description

Fixes: #11615

## What Changed

- mimmicked the codex output-activity monitor for opencode;

- mimmicked the codex process-activity monitor for opencode;

- included the new opencode errors in the types/switch

## Verification

Added equivalent testing to codex's activity and process monitor;
Can't be 100% sure it fixed it since it maydepend on timeouts, server load, etc, but havent had an opencode agent hang since

-

## Risks

Low risk. worse case scenario you have a more roubust opencode adapter

## Model Used

  claude-opus-4-6


## Checklist

- [x ] I have included a thinking path that traces from project context to this change
- [ x] I have specified the model used (with version and capability details)
- [ x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ x] I have searched GitHub for duplicate or related PRs and linked them above
- [ x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ x] I have run tests locally and they pass
- [ x] I have added or updated tests where applicable
- [ x] I have updated relevant documentation to reflect my changes
- [x ] I have considered and documented any risks above
- [ x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ x] I will address all Greptile and reviewer comments before requesting merge