### PR TITLE
fix(recovery): stop terminal-run recovery from stranding, flapping, and destroying live monitors

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5897,6 +5897,57 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     )).toBe(true);
   });
 
+  it("gives assigned todo work one fresh dispatch instead of re-escalating a stale run after a manual blocked-to-todo reset (AGE-691)", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+      runErrorCode: "process_lost",
+    });
+    // Mirrors what classifySourceRecoveryRevalidation records when a human/agent
+    // manually resets `blocked` -> `todo` via a plain issue PATCH (not the
+    // dedicated recovery-actions resolve endpoint): the previously active
+    // recovery action is cancelled, but the stale failed `latestRun` above is
+    // untouched by that reset.
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "cancelled",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      cause: "process_lost",
+      fingerprint: `manual-reset:${issueId}`,
+      nextAction: "Resume source work",
+      outcome: "cancelled",
+      resolutionNote: "Recovery action became stale because the source issue was manually moved from blocked to todo.",
+      resolvedAt: new Date("2026-03-19T00:06:00.000Z"),
+      createdAt: new Date("2026-03-19T00:01:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:06:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.dispatchRequeued).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect((retryRun?.contextSnapshot as Record<string, unknown>)?.retryReason).toBe("assignment_recovery");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",
@@ -6965,6 +7016,43 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
+      livenessState: "advanced",
+      monitorNextCheckAt: new Date("2026-03-19T01:00:00.000Z"),
+      resultJson: {
+        summary: "Waiting for the deploy to settle; monitor is scheduled.",
+        externalWait: { kind: "issue_monitor", durable: true },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.monitorNextCheckAt?.toISOString()).toBe("2026-03-19T01:00:00.000Z");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
+  it("preserves a persisted issue monitor when the run that scheduled it crashed instead of succeeding (AGE-691)", async () => {
+    // Mirrors AGE-602: the assignee's run scheduled a durable external_service
+    // monitor (e.g. to read back a CI run) and then the *run process itself*
+    // terminated abnormally (crashed/timed out) rather than reporting
+    // `succeeded`. Terminal-run recovery must not treat that as stranding and
+    // clear the monitor — the monitor is the live wake path, regardless of
+    // how the run that scheduled it ended.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
       livenessState: "advanced",
       monitorNextCheckAt: new Date("2026-03-19T01:00:00.000Z"),
       resultJson: {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -2283,6 +2283,37 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       expect(action?.lastAttemptAt?.getTime()).toBeGreaterThan(Date.now() - 60_000);
     });
 
+    it("claims the retry slot atomically so two overlapping sweeps enqueue exactly one wake (AGE-709)", async () => {
+      // The periodic reconciliation tick is fire-and-forget with no in-flight
+      // guard, so two `reconcileOrphanedBlockedRecoveryActions` passes can
+      // overlap and both read the same pre-claim action row. Without a
+      // compare-and-set claim on the retry-slot UPDATE, both would enqueue a
+      // wake and both would write the same absolute `attemptCount + 1`,
+      // consuming two owner runs for one recorded retry.
+      const { companyId, managerId, sourceIssueId } = await seedCompany();
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      const actionId = await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt: new Date(Date.now() - 60 * 60 * 1000),
+        attemptCount: 0,
+      });
+      const enqueueWakeup = vi.fn(async () => ({ id: randomUUID() } as never));
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const [first, second] = await Promise.all([
+        recovery.reconcileOrphanedBlockedRecoveryActions(),
+        recovery.reconcileOrphanedBlockedRecoveryActions(),
+      ]);
+
+      expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+      expect(first.rewoken + second.rewoken).toBe(1);
+      expect(first.skipped + second.skipped).toBeGreaterThanOrEqual(1);
+      const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, actionId));
+      expect(action?.attemptCount).toBe(1);
+    });
+
     it("stops re-waking once maxAttempts is exhausted", async () => {
       const { companyId, managerId, sourceIssueId } = await seedCompany();
       await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -2153,7 +2153,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         lastAttemptAt: new Date(Date.now() - 60 * 60 * 1000),
         attemptCount: 1,
       });
-      const enqueueWakeup = vi.fn(async () => null);
+      const enqueueWakeup = vi.fn(async () => ({ id: randomUUID() } as never));
       const recovery = recoveryService(db, { enqueueWakeup });
 
       const result = await recovery.reconcileStrandedAssignedIssues();
@@ -2166,6 +2166,40 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       );
       const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, actionId));
       expect(action?.attemptCount).toBe(2);
+      const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(updatedIssue?.status).toBe("blocked");
+    });
+
+    it("does not consume the retry attempt or backoff window when enqueueWakeup does not create a wake (AGE-691)", async () => {
+      // `enqueueWakeup` can return `null` without throwing (idempotency
+      // dedupe, budget block). Recording the retry attempt regardless would
+      // silently burn this issue's bounded recovery budget and backoff
+      // window on a tick that never actually woke the owner.
+      const { companyId, managerId, sourceIssueId } = await seedCompany();
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      const lastAttemptAt = new Date(Date.now() - 60 * 60 * 1000);
+      const actionId = await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt,
+        attemptCount: 1,
+      });
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.reconcileStrandedAssignedIssues();
+
+      expect(result.orphanedBlockedRecoveryRewoken).toBe(0);
+      expect(result.orphanedBlockedRecoveryReminded).toBe(0);
+      expect(result.skipped).toBeGreaterThanOrEqual(1);
+      expect(enqueueWakeup).toHaveBeenCalledWith(
+        managerId,
+        expect.objectContaining({ reason: "source_scoped_recovery_action" }),
+      );
+      const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, actionId));
+      expect(action?.attemptCount).toBe(1);
+      expect(action?.lastAttemptAt?.getTime()).toBe(lastAttemptAt.getTime());
       const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
       expect(updatedIssue?.status).toBe("blocked");
     });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -2107,4 +2107,167 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       .where(eq(issueRecoveryActions.id, action.id));
     expect(actionRow?.status).toBe("active");
   });
+
+  // AGE-691 — a `blocked` issue with an active recovery action but zero
+  // first-class blockedByIssueIds relations has no monitor (ineligible on
+  // `blocked`) and is excluded from the todo/in_progress/in_review
+  // reconciliation scan above, so a single failed recovery wake parked it
+  // forever before this backstop existed.
+  describe("orphaned blocked recovery actions (AGE-691)", () => {
+    async function seedOrphanedBlockedAction(input: {
+      companyId: string;
+      sourceIssueId: string;
+      ownerAgentId: string;
+      lastAttemptAt: Date;
+      maxAttempts?: number | null;
+      attemptCount?: number;
+    }) {
+      const actionId = randomUUID();
+      await db.insert(issueRecoveryActions).values({
+        id: actionId,
+        companyId: input.companyId,
+        sourceIssueId: input.sourceIssueId,
+        kind: "stranded_assigned_issue",
+        status: "active",
+        ownerType: "agent",
+        ownerAgentId: input.ownerAgentId,
+        cause: "stranded_assigned_issue",
+        fingerprint: `stranded_assigned_issue:${input.sourceIssueId}`,
+        evidence: {},
+        nextAction: "Restore a live execution path.",
+        wakePolicy: { type: "wake_owner", ownerAgentId: input.ownerAgentId },
+        attemptCount: input.attemptCount ?? 1,
+        maxAttempts: input.maxAttempts ?? null,
+        lastAttemptAt: input.lastAttemptAt,
+      });
+      return actionId;
+    }
+
+    it("re-wakes the recovery owner once the retry backoff has elapsed", async () => {
+      const { companyId, managerId, sourceIssueId } = await seedCompany();
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      const actionId = await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt: new Date(Date.now() - 60 * 60 * 1000),
+        attemptCount: 1,
+      });
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.reconcileStrandedAssignedIssues();
+
+      expect(result.orphanedBlockedRecoveryRewoken).toBe(1);
+      expect(result.orphanedBlockedRecoveryReminded).toBe(0);
+      expect(enqueueWakeup).toHaveBeenCalledWith(
+        managerId,
+        expect.objectContaining({ reason: "source_scoped_recovery_action" }),
+      );
+      const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, actionId));
+      expect(action?.attemptCount).toBe(2);
+      const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(updatedIssue?.status).toBe("blocked");
+    });
+
+    it("does not re-wake before the retry backoff elapses", async () => {
+      const { companyId, managerId, sourceIssueId } = await seedCompany();
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt: new Date(),
+      });
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.reconcileStrandedAssignedIssues();
+
+      expect(result.orphanedBlockedRecoveryRewoken).toBe(0);
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+    });
+
+    it("skips a blocked issue that already has a real blockedByIssueIds relation", async () => {
+      const { companyId, managerId, sourceIssueId, prefix } = await seedCompany();
+      const blockerIssueId = randomUUID();
+      await db.insert(issues).values({
+        id: blockerIssueId,
+        companyId,
+        title: "Real blocker",
+        status: "todo",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: `${prefix}-2`,
+      });
+      await db.insert(issueRelations).values({
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: sourceIssueId,
+        type: "blocks",
+      });
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.reconcileStrandedAssignedIssues();
+
+      expect(result.orphanedBlockedRecoveryRewoken).toBe(0);
+      expect(result.orphanedBlockedRecoveryReminded).toBe(0);
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+    });
+
+    it("leaves a bounded-frequency reminder instead of a silent stall when no invokable owner remains", async () => {
+      const { companyId, managerId, sourceIssueId } = await seedCompany();
+      await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      const actionId = await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt: new Date(Date.now() - 60 * 60 * 1000),
+        attemptCount: 3,
+      });
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.reconcileStrandedAssignedIssues();
+
+      expect(result.orphanedBlockedRecoveryRewoken).toBe(0);
+      expect(result.orphanedBlockedRecoveryReminded).toBe(1);
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+      const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssueId));
+      expect(comments.some((comment) => comment.body?.includes(actionId))).toBe(true);
+      const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, actionId));
+      expect(action?.attemptCount).toBe(3);
+      expect(action?.lastAttemptAt?.getTime()).toBeGreaterThan(Date.now() - 60_000);
+    });
+
+    it("stops re-waking once maxAttempts is exhausted", async () => {
+      const { companyId, managerId, sourceIssueId } = await seedCompany();
+      await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+      await seedOrphanedBlockedAction({
+        companyId,
+        sourceIssueId,
+        ownerAgentId: managerId,
+        lastAttemptAt: new Date(Date.now() - 60 * 60 * 1000),
+        attemptCount: 3,
+        maxAttempts: 3,
+      });
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      const result = await recovery.reconcileStrandedAssignedIssues();
+
+      expect(result.orphanedBlockedRecoveryRewoken).toBe(0);
+      expect(result.orphanedBlockedRecoveryReminded).toBe(1);
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3801,16 +3801,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
-      await db
-        .update(issueRecoveryActions)
-        .set({
-          attemptCount: action.attemptCount + 1,
-          lastAttemptAt: now,
-          updatedAt: now,
-        })
-        .where(eq(issueRecoveryActions.id, action.id));
-
-      await deps.enqueueWakeup(ownerAgentId!, {
+      // Enqueue the wake before recording the retry attempt: `enqueueWakeup`
+      // can return `null` (idempotency dedupe, budget block) without
+      // throwing. Bumping `attemptCount`/`lastAttemptAt` first would consume
+      // this issue's bounded retry budget and backoff window even when no
+      // wake was actually created, silently losing a retry instead of
+      // re-checking on the next tick.
+      const wakeRun = await deps.enqueueWakeup(ownerAgentId!, {
         source: "assignment",
         triggerDetail: "system",
         reason: "source_scoped_recovery_action",
@@ -3832,6 +3829,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sourceIssueId: issue.id,
         },
       });
+      if (!wakeRun) {
+        result.skipped += 1;
+        continue;
+      }
+
+      await db
+        .update(issueRecoveryActions)
+        .set({
+          attemptCount: action.attemptCount + 1,
+          lastAttemptAt: now,
+          updatedAt: now,
+        })
+        .where(eq(issueRecoveryActions.id, action.id));
 
       result.rewoken += 1;
       result.issueIds.push(issue.id);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -997,6 +997,44 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  // AGE-691 — `didAutomaticRecoveryFail` classifies the *latest* run as an
+  // already-failed automatic recovery attempt purely from that run's own
+  // retryReason/status. It never asks whether anyone has acted on the issue
+  // since that run finished. A manual `blocked` -> `todo`/`in_progress`/
+  // `in_review` reset (or the dedicated recovery-actions resolve endpoint)
+  // always resolves/cancels the active recovery action
+  // (`classifySourceRecoveryRevalidation`'s `blockedToTodoRecovery` and
+  // `assigneeAgentId`-with-agent-owner branches), but the stale `latestRun`
+  // this sweep reads is unchanged by that reset. Without this check, the very
+  // next sweep tick re-derives the same "automatic recovery already failed"
+  // verdict from that same stale run and re-blocks the issue within minutes
+  // of a correct manual unblock, destroying whatever the human/agent just did.
+  // Any resolved/cancelled recovery action recorded after the run finished
+  // means someone already acted on this exact evidence — give the issue one
+  // fresh recovery-retry dispatch instead of re-escalating on it again.
+  async function wasRecoveryActionResolvedSinceRun(
+    issue: typeof issues.$inferSelect,
+    latestRun: LatestIssueRun,
+  ) {
+    if (!latestRun) return false;
+    const runFinishedAt = latestRun.startedAt ?? latestRun.createdAt;
+    if (!runFinishedAt) return false;
+
+    return db
+      .select({ id: issueRecoveryActions.id })
+      .from(issueRecoveryActions)
+      .where(
+        and(
+          eq(issueRecoveryActions.companyId, issue.companyId),
+          eq(issueRecoveryActions.sourceIssueId, issue.id),
+          inArray(issueRecoveryActions.status, ["resolved", "cancelled"]),
+          gte(issueRecoveryActions.resolvedAt, runFinishedAt),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
   async function hasQueuedIssueWake(companyId: string, issueId: string, agentId?: string | null) {
     return db
       .select({ id: agentWakeupRequests.id })
@@ -3892,6 +3930,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         result.skipped += 1;
         continue;
       }
+      // AGE-691 — the check above only ever covered a *succeeded* run (e.g. a
+      // clean successful-run handoff that legitimately left a monitor/blocker
+      // as its resume path). Terminal-run recovery's own subject — a run
+      // that crashed/timed out *after* it had already scheduled a monitor —
+      // was never covered: escalation ran unconditionally on any unsuccessful
+      // terminal run, silently clearing the very monitor the assignee had
+      // correctly armed, because `applyMonitorTransition` clears
+      // `monitorNextCheckAt` on any status change away from
+      // in_progress/in_review. Extend the exemption to a persisted monitor on
+      // any terminal run so it is never destroyed by recovery, regardless of
+      // why the run that scheduled it ultimately ended. This is
+      // deliberately narrower than `hasPersistedDurableWaitPath` (monitor
+      // only, not the delegated-blocker-relation check) so it does not
+      // shadow the more specific waiting-on-review blocker conversion below,
+      // which formalizes an existing blocking relation into a real `blocked`
+      // status + `blockedByIssueIds` rather than silently skipping.
+      if (
+        latestRun &&
+        isUnsuccessfulTerminalIssueRun(latestRun) &&
+        issue.monitorNextCheckAt
+      ) {
+        result.skipped += 1;
+        continue;
+      }
       const recoveryNow = new Date();
       const participantLatestRunForRecovery = issue.status === "in_review" && participantAgentId
         ? await getLatestIssueRunForAgent(issue.companyId, issue.id, participantAgentId)
@@ -4150,7 +4212,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
-        if (didAutomaticRecoveryFail(participantLatestRun, EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON)) {
+        if (
+          didAutomaticRecoveryFail(participantLatestRun, EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON) &&
+          !(await wasRecoveryActionResolvedSinceRun(issue, participantLatestRun))
+        ) {
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "in_review",
@@ -4231,7 +4296,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
-        if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
+        if (
+          didAutomaticRecoveryFail(latestRun, "assignment_recovery") &&
+          !(await wasRecoveryActionResolvedSinceRun(issue, latestRun))
+        ) {
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "todo",
@@ -4402,7 +4470,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
-        if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
+        if (
+          didAutomaticRecoveryFail(latestRun, "issue_continuation_needed") &&
+          !(await wasRecoveryActionResolvedSinceRun(issue, latestRun))
+        ) {
           const { consecutive, latestFinishedAt } = await summarizeRecentContinuationRetries(
             issue.companyId,
             issue.id,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3801,12 +3801,32 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
-      // Enqueue the wake before recording the retry attempt: `enqueueWakeup`
-      // can return `null` (idempotency dedupe, budget block) without
-      // throwing. Bumping `attemptCount`/`lastAttemptAt` first would consume
-      // this issue's bounded retry budget and backoff window even when no
-      // wake was actually created, silently losing a retry instead of
-      // re-checking on the next tick.
+      // Claim the retry slot before enqueueing with a compare-and-set UPDATE:
+      // two overlapping sweeps can both read this same action row (no
+      // in-flight guard on the periodic reconciliation tick), so bumping
+      // `attemptCount`/`lastAttemptAt` unconditionally would let both sweeps
+      // enqueue a wake against one recorded retry. Guarding the UPDATE on the
+      // action's pre-read `attemptCount`/`lastAttemptAt` makes only the first
+      // writer win the claim; the loser sees zero affected rows and skips.
+      const claimed = await db
+        .update(issueRecoveryActions)
+        .set({ attemptCount: action.attemptCount + 1, lastAttemptAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(issueRecoveryActions.id, action.id),
+            eq(issueRecoveryActions.attemptCount, action.attemptCount),
+            action.lastAttemptAt
+              ? eq(issueRecoveryActions.lastAttemptAt, action.lastAttemptAt)
+              : isNull(issueRecoveryActions.lastAttemptAt),
+          ),
+        )
+        .returning({ id: issueRecoveryActions.id });
+      if (claimed.length === 0) {
+        // Another sweep already won the claim on this action this tick.
+        result.skipped += 1;
+        continue;
+      }
+
       const wakeRun = await deps.enqueueWakeup(ownerAgentId!, {
         source: "assignment",
         triggerDetail: "system",
@@ -3830,18 +3850,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         },
       });
       if (!wakeRun) {
+        // `enqueueWakeup` can return `null` (idempotency dedupe, budget block)
+        // without throwing. Release the claim so a failed enqueue does not
+        // consume this issue's bounded retry budget and backoff window.
+        await db
+          .update(issueRecoveryActions)
+          .set({ attemptCount: action.attemptCount, lastAttemptAt: action.lastAttemptAt, updatedAt: new Date() })
+          .where(eq(issueRecoveryActions.id, action.id));
         result.skipped += 1;
         continue;
       }
-
-      await db
-        .update(issueRecoveryActions)
-        .set({
-          attemptCount: action.attemptCount + 1,
-          lastAttemptAt: now,
-          updatedAt: now,
-        })
-        .where(eq(issueRecoveryActions.id, action.id));
 
       result.rewoken += 1;
       result.issueIds.push(issue.id);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -369,6 +369,17 @@ const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
+// AGE-691 — terminal-run recovery escalates a stranded assigned issue to
+// `blocked` and hands ownership to a recovery action's owner agent, but that
+// escalation is a one-shot wake. If the owner's own run also terminates badly,
+// the source issue is stuck in `blocked` with no first-class blockedByIssueIds
+// relation (recovery actions are not issues) and no monitor is eligible on a
+// `blocked` status, so it is invisible to every other reconciliation pass and
+// permanently unwakeable. `reconcileOrphanedBlockedRecoveryActions` re-checks
+// exactly that state on the same interval `reconcileStrandedAssignedIssues`
+// already runs on, bounded by this backoff and the action's own `maxAttempts`.
+export const ORPHANED_BLOCKED_RECOVERY_ACTION_RETRY_INTERVAL_MS = 15 * 60 * 1000;
+
 const PROVIDER_QUOTA_ERROR_RE =
   /(?:you(?:'|’)ve hit your usage limit|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
@@ -3639,6 +3650,158 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       readNonEmptyString(monitor.externalRef) === latestRun.id;
   }
 
+  // AGE-691 backstop: re-drive (or, absent an owner, keep visibly and
+  // repeatedly reminding about) a `blocked` issue whose only recovery path is
+  // an active `issueRecoveryActions` row, when that issue has zero first-class
+  // blockedByIssueIds relations. Without this, such an issue is invisible to
+  // every other reconciliation pass (they all scope to todo/in_progress/
+  // in_review, or to blockers that actually resolve) and to issue monitors
+  // (never eligible on `blocked`), so a single failed recovery wake parks it
+  // forever. Scoped narrowly to recovery-caused blocks (identified by the
+  // active recovery action) so it never touches a human-authored `blocked`
+  // issue that was deliberately left without a blocker relation.
+  async function reconcileOrphanedBlockedRecoveryActions(opts?: {
+    issueCreatedAtGte?: Date | null;
+    excludeIssueIds?: string[];
+  }) {
+    const result = {
+      rewoken: 0,
+      boardEscalationReminded: 0,
+      skipped: 0,
+      issueIds: [] as string[],
+    };
+
+    const excludeIssueIds = [...new Set(opts?.excludeIssueIds ?? [])];
+
+    const candidates = await db
+      .select({ issue: issues, action: issueRecoveryActions })
+      .from(issueRecoveryActions)
+      .innerJoin(
+        issues,
+        and(
+          eq(issues.id, issueRecoveryActions.sourceIssueId),
+          eq(issues.companyId, issueRecoveryActions.companyId),
+        ),
+      )
+      .where(
+        and(
+          inArray(issueRecoveryActions.status, ["active", "escalated"]),
+          eq(issues.status, "blocked"),
+          isNull(issues.assigneeUserId),
+          opts?.issueCreatedAtGte ? gte(issues.createdAt, opts.issueCreatedAtGte) : undefined,
+          // Exclude issues this same reconciliation pass already escalated to
+          // `blocked` moments ago — they were just given a fresh recovery
+          // action and are inside the retry backoff by construction, so there
+          // is nothing new for this backstop to do on this tick.
+          excludeIssueIds.length > 0 ? notInArray(issues.id, excludeIssueIds) : undefined,
+        ),
+      );
+
+    const now = new Date();
+
+    for (const { issue, action } of candidates) {
+      const blockerIds = await existingUnresolvedBlockerIssueIds(issue.companyId, issue.id);
+      if (blockerIds.length > 0) {
+        // A real blockedByIssueIds relation already gives this issue a wake
+        // path (issue_blockers_resolved, or the resolved-dependency backstop).
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasQueuedIssueWake(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const lastAttemptMs = action.lastAttemptAt ? action.lastAttemptAt.getTime() : 0;
+      if (now.getTime() - lastAttemptMs < ORPHANED_BLOCKED_RECOVERY_ACTION_RETRY_INTERVAL_MS) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const attemptsExhausted = action.maxAttempts !== null && action.attemptCount >= action.maxAttempts;
+      const ownerAgentId = !attemptsExhausted ? action.ownerAgentId ?? issue.assigneeAgentId : null;
+      const ownerAgent = ownerAgentId ? await getAgent(ownerAgentId) : null;
+      const ownerInvokable = Boolean(
+        ownerAgent && ownerAgent.companyId === issue.companyId && (await isAgentInvokable(ownerAgent)),
+      );
+
+      if (!ownerInvokable || (ownerAgentId && await isInvocationBudgetBlocked(issue, ownerAgentId))) {
+        // No invokable, budget-available owner to re-wake. Still visible on the
+        // board (status stays `blocked`, comment names the gap), but leave a
+        // fresh, bounded-frequency marker so a periodic sweep of
+        // `unresolvedBlockerCount === 0` blocked issues can page a human
+        // instead of this ticket sitting silently with a stale one-shot note.
+        await db
+          .update(issueRecoveryActions)
+          .set({ lastAttemptAt: now, updatedAt: now })
+          .where(eq(issueRecoveryActions.id, action.id));
+        await issuesSvc.addComment(
+          issue.id,
+          [
+            "Paperclip re-checked this recovery-blocked issue and it still has no live execution path " +
+              "(no invokable/budget-available recovery owner). It remains `blocked` with no automatic wake; " +
+              "a board operator should assign an invokable recovery owner or record an intentional manual resolution.",
+            "",
+            `- Recovery action: \`${action.id}\``,
+            `- Attempt: ${action.attemptCount}${action.maxAttempts !== null ? ` / ${action.maxAttempts}` : ""}`,
+          ].join("\n"),
+          {},
+        );
+        result.boardEscalationReminded += 1;
+        result.issueIds.push(issue.id);
+        continue;
+      }
+
+      await db
+        .update(issueRecoveryActions)
+        .set({
+          attemptCount: action.attemptCount + 1,
+          lastAttemptAt: now,
+          updatedAt: now,
+        })
+        .where(eq(issueRecoveryActions.id, action.id));
+
+      await deps.enqueueWakeup(ownerAgentId!, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "source_scoped_recovery_action",
+        idempotencyKey: `source_scoped_recovery_action:${action.id}:${action.attemptCount + 1}`,
+        payload: {
+          issueId: issue.id,
+          sourceIssueId: issue.id,
+          recoveryActionId: action.id,
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: {
+          issueId: issue.id,
+          taskId: issue.id,
+          wakeReason: "source_scoped_recovery_action",
+          skipIssueComment: true,
+          source: "issue_recovery_action_orphaned_blocked_backstop",
+          recoveryActionId: action.id,
+          sourceIssueId: issue.id,
+        },
+      });
+
+      result.rewoken += 1;
+      result.issueIds.push(issue.id);
+    }
+
+    return result;
+  }
+
   async function reconcileStrandedAssignedIssues(opts?: { issueCreatedAtGte?: Date | null }) {
     const candidates = await db
       .select()
@@ -3669,6 +3832,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       providerQuotaMonitored: 0,
       recentProgressExempted: 0,
       operatorCancelExempted: 0,
+      orphanedBlockedRecoveryRewoken: 0,
+      orphanedBlockedRecoveryReminded: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
@@ -4305,6 +4470,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     result.orphanBlockersAssigned = orphanBlockerRecovery.assigned;
     result.skipped += orphanBlockerRecovery.skipped;
     result.issueIds.push(...orphanBlockerRecovery.issueIds);
+
+    const orphanedBlockedRecovery = await reconcileOrphanedBlockedRecoveryActions({
+      ...opts,
+      excludeIssueIds: result.issueIds,
+    });
+    result.orphanedBlockedRecoveryRewoken = orphanedBlockedRecovery.rewoken;
+    result.orphanedBlockedRecoveryReminded = orphanedBlockedRecovery.boardEscalationReminded;
+    result.skipped += orphanedBlockedRecovery.skipped;
+    result.issueIds.push(...orphanedBlockedRecovery.issueIds);
 
     return result;
   }
@@ -5809,6 +5983,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recordWatchdogDecision,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
+    reconcileOrphanedBlockedRecoveryActions,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileResolvedDependencyWakeBackstop,


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat recovery service watches assigned issues and escalates them to `blocked` when an agent run stops responding
> - That escalation service has three gaps: (1) a `blocked` issue with an orphaned recovery action has no monitor and no first-class blocker, so it can never wake again; (2) escalation re-derives its "already failed" verdict from a stale run even after a human already fixed the issue, so a manual unblock gets undone within minutes; (3) escalation clears any scheduled issue monitor unconditionally, even when the run that scheduled it merely crashed afterward
> - Left unaddressed, agents and operators lose real recovery work: fixes get silently reverted, and monitors that would have read back a completed external check (for example a CI run) never fire
> - This pull request adds a periodic re-wake path for orphaned blocked recovery actions, gates the "already failed" escalation checks on whether the recovery action was already resolved since the run finished, and narrows the monitor-clearing behavior so a scheduled monitor survives an unsuccessful terminal run
> - The benefit is that a `blocked` issue always has a real wake path, a manual fix is not undone by the next reconciliation tick, and a scheduled monitor is never silently destroyed

## Linked Issues or Issue Description

**What happened?**
`server/src/services/recovery/service.ts`'s `reconcileStrandedAssignedIssues` sweep has three related defects around its automatic `blocked` escalation path:
1. When an issue is escalated to `blocked` and its recovery-action owner's own run also terminates badly, the issue has zero first-class `blockedByIssueIds` (recovery actions are rows in `issue_recovery_actions`, not issues, so they can never populate that field) and monitors are not eligible on a `blocked` status. The issue becomes permanently unwakeable outside a human reading the board.
2. `didAutomaticRecoveryFail` classifies the *latest* run as an already-failed automatic recovery attempt purely from that run's own `retryReason`/status. It never checks whether the recovery action has since been resolved (for example by a manual `blocked` -> `todo` reset). The very next sweep tick re-derives the same verdict from the same stale run and re-blocks the issue within minutes of a correct manual unblock.
3. The sweep's only durable-wait-path exemption (skip escalation when a monitor/blocker is already scheduled) covered a *succeeded* run only. A run that crashed or timed out *after* it had already scheduled a real `executionState.monitor` was never exempted, so escalation cleared the monitor anyway.

**Expected behavior**
- A `blocked` issue caused by recovery always has either a first-class blocker, a re-armed wake, or a bounded, clearly-labeled operator escalation comment — never a silent permanent stall.
- A manually-resolved recovery action is not immediately re-escalated using the same stale run evidence; the issue gets one fresh recovery-retry dispatch first.
- A scheduled issue monitor survives an unsuccessful terminal run and is never cleared by escalation.

**Steps to reproduce**
1. Assign an issue to an agent and let its run terminate unsuccessfully (crash/timeout) so the sweep escalates it to `blocked` with a source-scoped recovery action.
2. Have that recovery-action owner's own run also terminate unsuccessfully -> the issue stays `blocked` forever with no blocker relation and no monitor.
3. Separately, manually reset a `blocked` issue back to `todo`/`in_progress` (a plain status PATCH, not the dedicated recovery-actions resolve endpoint) while its last run is still an unsuccessful "already-retried" run -> the next `reconcileStrandedAssignedIssues` tick re-escalates it to `blocked` within minutes, using the same stale run.
4. Separately, have an in-progress run schedule an `executionState.monitor` (for example to poll a CI run) and then crash/time out -> the next sweep tick escalates to `blocked` and silently clears the monitor.

## What Changed

- Added `reconcileOrphanedBlockedRecoveryActions`, wired into the existing `reconcileStrandedAssignedIssues` sweep (reuses its interval, no new timer). Each tick it finds `blocked` issues with an active recovery action and zero first-class blocker relations, then either re-wakes the recovery owner (bounded 15-minute backoff + the action's own `maxAttempts`) or leaves a fresh, bounded-frequency comment when no invokable owner remains.
- Added `wasRecoveryActionResolvedSinceRun` and gated all three `didAutomaticRecoveryFail` escalation call sites (assignment_recovery / issue_continuation_needed / execution_review_participant_recovery) on it: a recovery action resolved/cancelled after the run finished now buys the issue one fresh recovery-retry dispatch instead of an immediate re-escalation on the same stale evidence.
- Added a monitor-only durable-wait-path exemption for any terminal run (not just succeeded), deliberately narrower than the existing `hasPersistedDurableWaitPath` helper so it does not shadow the separate waiting-on-review blocker-conversion path.

## Verification

- `cd server && npx tsc --noEmit -p .` — clean.
- `cd server && npx vitest run src/__tests__/heartbeat-process-recovery.test.ts` — 105/105 passed (includes 2 new tests: one proving a manually-reset `todo` issue gets a fresh dispatch instead of re-escalating, one proving a scheduled monitor survives an unsuccessful terminal run).
- `cd server && npx vitest run src/__tests__/issue-recovery-actions.test.ts` — 49/49 passed (5 tests added for the orphaned-blocked re-wake path: re-wake after backoff, no re-wake inside backoff, skip when a real blocker exists, bounded-frequency reminder with no invokable owner, stop re-waking once `maxAttempts` is exhausted).
- `cd server && npx vitest run src/__tests__/server-startup-feedback-export.test.ts` — 16/16 passed.

## Risks

- Behavioral change, not a schema/migration change — no rollback beyond reverting the commit.
- The new orphaned-blocked re-wake path is scoped narrowly to recovery-caused blocks (identified by an active `issue_recovery_actions` row), so it should never touch a human-authored `blocked` issue that intentionally has no blocker relation.
- The `wasRecoveryActionResolvedSinceRun` guard only *widens* when escalation is skipped in favor of one fresh retry dispatch; it never escalates in a case that previously would not have. Existing escalation tests for the unmodified paths (no recent resolution recorded) are unchanged and still pass.
- The monitor-preservation exemption is deliberately scoped to `monitorNextCheckAt` truthiness only (matching the existing succeeded-run exemption's semantics), not the broader `hasPersistedDurableWaitPath` (which also checks delegated-blocker relations) — broadening to the full helper regressed the waiting-on-review blocker-conversion test during review of this change; narrowing it fixed that regression while still covering the reported monitor-destruction case.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Sonnet 4.5 (claude-sonnet-4-5), extended/agentic tool-use mode, editing and running the repository's own test suite (embedded PostgreSQL) locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Note: the branch name (`fix/age-691-orphaned-blocked-recovery-actions`) was created before this checklist requirement and predates this update; renaming it now would require opening a fresh PR. Flagging rather than silently unchecking.
