### PR TITLE
fix(heartbeat): never process_lost/retry a hot-restart-adopted run after its process exits

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -33,6 +33,7 @@ export type {
   AdapterRuntimeCommandSpec,
   AcpTargetDescriptor,
   ServerAdapterModule,
+  AdoptedRunOutcomeRecovery,
   QuotaWindow,
   ProviderQuotaResult,
   TranscriptEntry,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -500,6 +500,32 @@ export interface ServerAdapterModule {
    * and provisioned in fresh remote environments such as sandboxes.
    */
   getRuntimeCommandSpec?: (config: Record<string, unknown>) => AdapterRuntimeCommandSpec | null;
+
+  /**
+   * Optional (AGE-697): recover the real terminal outcome of a local child
+   * process from its persisted stdout/stderr log content. Used only when a
+   * run's process was adopted across a hot restart (AGE-656) and later exits
+   * without this server observing the exit live -- at that point the process
+   * is gone and its in-memory exit code was never captured, so the only
+   * remaining evidence is whatever the adapter itself already wrote to its
+   * log files.
+   *
+   * Returns `null` when no terminal result is present in the given output;
+   * the caller then finalizes the run with an explicit unknown-outcome state
+   * instead of guessing at success/failure. This deliberately reuses the same
+   * terminal-result detection an adapter already performs live via
+   * `runChildProcess`'s `terminalResultCleanup.hasTerminalResult`
+   * (packages/adapter-utils/src/server-utils.ts) -- an adapter that doesn't
+   * wire that live detection also doesn't implement this hook and simply
+   * falls back to the unknown-outcome floor.
+   */
+  recoverAdoptedRunOutcome?: (output: { stdout: string; stderr: string }) => AdoptedRunOutcomeRecovery | null;
+}
+
+export interface AdoptedRunOutcomeRecovery {
+  outcome: "succeeded" | "failed";
+  errorMessage?: string | null;
+  summary?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -47,7 +47,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { runningProcesses } from "../adapters/index.ts";
+import { runningProcesses, getServerAdapter } from "../adapters/index.ts";
 const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
 const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
 const mockTerminateLocalService = vi.hoisted(() => vi.fn());
@@ -2180,6 +2180,122 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         },
       });
     });
+  });
+
+  it("recovers the real outcome from a hot-restart-adopted run's persisted log once its process has fully exited", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_997,
+      processGroupId: null,
+      contextSnapshot: {
+        stdoutLogFilePath: "/nonexistent/does-not-matter-for-this-test.log",
+      },
+    });
+    // Adoption metadata is normally written by `reconcileHotRestartAdoption`;
+    // seeded directly here since this test only exercises `reapOrphanedRuns`.
+    await db
+      .update(heartbeatRuns)
+      .set({
+        resultJson: {
+          hotRestart: {
+            adopted: true,
+            adoptedAt: "2026-03-19T00:00:30.000Z",
+            previousServerPid: 1,
+            newServerPid: process.pid,
+            previousServerVersion: "old-version",
+            processPid: 999_999_997,
+            processGroupId: null,
+          },
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    vi.mocked(getServerAdapter).mockReturnValueOnce({
+      type: "codex_local",
+      execute: mockAdapterExecute,
+      testEnvironment: async () => ({
+        adapterType: "codex_local",
+        status: "ok",
+        testedAt: new Date().toISOString(),
+        checks: [],
+      }),
+      recoverAdoptedRunOutcome: () => ({ outcome: "succeeded" }),
+    } as unknown as ReturnType<typeof getServerAdapter>);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    // Recovering a real outcome must not enqueue a retry: exactly one row.
+    expect(runs).toHaveLength(1);
+
+    const finalized = runs.find((row) => row.id === runId);
+    expect(finalized?.status).toBe("succeeded");
+    expect(finalized?.errorCode).not.toBe("process_lost");
+    expect(finalized?.errorCode).toBeNull();
+    expect(finalized?.resultJson).toMatchObject({
+      adoptedRunLogEvidence: {
+        stdoutLogFilePath: "/nonexistent/does-not-matter-for-this-test.log",
+      },
+    });
+
+    const issue = await db
+      .select({ executionRunId: issues.executionRunId, checkoutRunId: issues.checkoutRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+    expect(issue?.checkoutRunId).toBeNull();
+  });
+
+  it("finalizes a hot-restart-adopted run as unknown-outcome (never process_lost, never retried) once its process has fully exited with no recoverable terminal result", async () => {
+    const { agentId, runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_996,
+      processGroupId: null,
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        resultJson: {
+          hotRestart: {
+            adopted: true,
+            adoptedAt: "2026-03-19T00:00:30.000Z",
+            previousServerPid: 1,
+            newServerPid: process.pid,
+            previousServerVersion: "old-version",
+            processPid: 999_999_996,
+            processGroupId: null,
+          },
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // No log file path was ever persisted for this run (or the adapter has no
+    // `recoverAdoptedRunOutcome`), so the default mocked adapter (no such hook)
+    // applies -- nothing to override here.
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    // The unknown-outcome floor must never enqueue a retry: exactly one row.
+    expect(runs).toHaveLength(1);
+
+    const finalized = runs.find((row) => row.id === runId);
+    expect(finalized?.status).toBe("failed");
+    expect(finalized?.errorCode).not.toBe("process_lost");
+    expect(finalized?.errorCode).toBe("adopted_run_outcome_unknown");
   });
 
   it("interrupts running runs on graceful shutdown and queues restart recovery without recording a failure", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -113,6 +113,7 @@ import {
   writeHotRestartIntent,
 } from "../services/hot-restart.ts";
 import { secretService } from "../services/secrets.ts";
+import { getRunLogStore } from "../services/run-log-store.ts";
 import {
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
@@ -2296,6 +2297,114 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(finalized?.status).toBe("failed");
     expect(finalized?.errorCode).not.toBe("process_lost");
     expect(finalized?.errorCode).toBe("adopted_run_outcome_unknown");
+  });
+
+  it("recovers a hot-restart-adopted run's outcome from the general-purpose run transcript log when no direct log-file path was ever persisted", async () => {
+    // This is the path that is already reachable in production TODAY,
+    // independent of the sibling file-backed-local-run-output change: every
+    // run writes its stdout/stderr through `runLogStore` right now, so
+    // recovery must be able to reconstruct a terminal result from that NDJSON
+    // transcript alone -- not only from `contextSnapshot.stdoutLogFilePath`.
+    const { companyId, agentId, runId } = await seedRunFixture({
+      adapterType: "claude_local",
+      agentStatus: "running",
+      processPid: 999_999_995,
+      processGroupId: null,
+    });
+
+    const runLogStore = getRunLogStore();
+    const handle = await runLogStore.begin({ companyId, agentId, runId });
+    // Split the terminal Claude "result" event across two appends to also
+    // exercise the reconstruction's cross-page leftover-line buffering.
+    const resultLine = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      session_id: "sess-1",
+      result: "All done.",
+    });
+    await runLogStore.append(handle, {
+      stream: "stdout",
+      chunk: `${resultLine.slice(0, 20)}`,
+      ts: "2026-03-19T00:00:10.000Z",
+      seq: 1,
+    });
+    await runLogStore.append(handle, {
+      stream: "stdout",
+      chunk: `${resultLine.slice(20)}\n`,
+      ts: "2026-03-19T00:00:11.000Z",
+      seq: 2,
+    });
+    await runLogStore.append(handle, {
+      stream: "stderr",
+      chunk: "warning: ignored\n",
+      ts: "2026-03-19T00:00:11.500Z",
+      seq: 3,
+    });
+    await runLogStore.finalize(handle);
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        logStore: handle.store,
+        logRef: handle.logRef,
+        resultJson: {
+          hotRestart: {
+            adopted: true,
+            adoptedAt: "2026-03-19T00:00:30.000Z",
+            previousServerPid: 1,
+            newServerPid: process.pid,
+            previousServerVersion: "old-version",
+            processPid: 999_999_995,
+            processGroupId: null,
+          },
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    vi.mocked(getServerAdapter).mockReturnValueOnce({
+      type: "claude_local",
+      execute: mockAdapterExecute,
+      testEnvironment: async () => ({
+        adapterType: "claude_local",
+        status: "ok",
+        testedAt: new Date().toISOString(),
+        checks: [],
+      }),
+      // Mirrors the shape of the real claude_local wiring in
+      // server/src/adapters/registry.ts without importing the real package,
+      // so this test isolates the NDJSON-transcript reconstruction from
+      // claude-specific parsing (covered separately by parse.test.ts).
+      recoverAdoptedRunOutcome: ({ stdout }) => {
+        for (const line of stdout.split("\n")) {
+          if (!line.trim()) continue;
+          const event = JSON.parse(line) as { type?: string; is_error?: boolean };
+          if (event.type === "result") {
+            return event.is_error ? { outcome: "failed" as const } : { outcome: "succeeded" as const };
+          }
+        }
+        return null;
+      },
+    } as unknown as ReturnType<typeof getServerAdapter>);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const finalized = runs.find((row) => row.id === runId);
+    expect(finalized?.status).toBe("succeeded");
+    expect(finalized?.errorCode).not.toBe("process_lost");
+    expect(finalized?.errorCode).toBeNull();
+    expect(finalized?.resultJson).toMatchObject({
+      adoptedRunLogEvidence: { recoverySource: "run_log_store" },
+    });
   });
 
   it("interrupts running runs on graceful shutdown and queues restart recovery without recording a failure", async () => {

--- a/server/src/__tests__/run-log-store.test.ts
+++ b/server/src/__tests__/run-log-store.test.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDurableRunLogStore } from "../services/run-log-store.js";
+
+// AGE-697: `readTail` is what makes adopted-run terminal-result recovery in
+// heartbeat.ts's `reconstructRunLogStreamsTail` correct for a large
+// transcript -- unlike forward pagination via `read` (bounded by a scan cap),
+// it always reaches the true end of the log in a fixed number of requests
+// regardless of total size. These tests exercise `readTail` directly against
+// a real on-disk store, independent of heartbeat.ts's fixed production scan
+// size, so a small `maxBytes` here still proves the tail-vs-truncation
+// behavior a multi-megabyte transcript in production relies on.
+//
+// The NDJSON transcript escapes each event's `chunk` field (it is JSON
+// stringified along with `ts`/`stream`/`seq`), so a raw terminal-result
+// string embedded in a chunk never appears byte-for-byte in the file -- its
+// quotes are backslash-escaped. `reconstructedStdout` below parses each line
+// and concatenates `chunk` the same way production code does, so assertions
+// run against the same reconstructed text a terminal-result parser would see.
+function reconstructedStdout(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        const event = JSON.parse(line) as { stream?: unknown; chunk?: unknown };
+        return event.stream === "stdout" && typeof event.chunk === "string" ? [event.chunk] : [];
+      } catch {
+        return [];
+      }
+    })
+    .join("");
+}
+
+describe("run-log-store readTail", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true }).catch(() => undefined)),
+    );
+  });
+
+  async function makeStore() {
+    const basePath = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-store-test-"));
+    tempDirs.push(basePath);
+    return createDurableRunLogStore({ basePath });
+  }
+
+  it("returns the whole log with truncatedAtStart=false when it fits within maxBytes", async () => {
+    const store = await makeStore();
+    const handle = await store.begin({ companyId: "co", agentId: "agent", runId: randomUUID() });
+    await store.append(handle, { stream: "stdout", chunk: "first\n", ts: "2026-01-01T00:00:00.000Z", seq: 1 });
+    await store.append(handle, { stream: "stdout", chunk: "second\n", ts: "2026-01-01T00:00:01.000Z", seq: 2 });
+    await store.finalize(handle);
+
+    const tail = await store.readTail!(handle, { maxBytes: 10_000 });
+    expect(tail.truncatedAtStart).toBe(false);
+    expect(reconstructedStdout(tail.content)).toBe("first\nsecond\n");
+  });
+
+  it("reaches the true tail (not just a bounded forward scan) of a log far larger than maxBytes", async () => {
+    const store = await makeStore();
+    const handle = await store.begin({ companyId: "co", agentId: "agent", runId: randomUUID() });
+    // Write enough lines that the log is unambiguously larger than the small
+    // maxBytes used below -- this stands in for a multi-megabyte production
+    // transcript without actually writing megabytes in a test.
+    for (let i = 0; i < 200; i++) {
+      await store.append(handle, {
+        stream: "stdout",
+        chunk: `padding-line-${i}-${"x".repeat(40)}\n`,
+        ts: "2026-01-01T00:00:00.000Z",
+        seq: i,
+      });
+    }
+    const terminalMarker = JSON.stringify({ type: "result", subtype: "success", is_error: false });
+    await store.append(handle, {
+      stream: "stdout",
+      chunk: `${terminalMarker}\n`,
+      ts: "2026-01-01T00:01:00.000Z",
+      seq: 1_000,
+    });
+    await store.finalize(handle);
+
+    const maxBytes = 300;
+    const tail = await store.readTail!(handle, { maxBytes });
+    expect(tail.truncatedAtStart).toBe(true);
+    expect(tail.content.length).toBeLessThanOrEqual(maxBytes);
+    const reconstructed = reconstructedStdout(tail.content);
+    // The tail read is clamped to maxBytes -- it must not contain the log's
+    // very first written line (proves this is a true tail, not a bounded
+    // forward scan from offset 0 that happened to stop early).
+    expect(reconstructed).not.toContain("padding-line-0-");
+    // But it must still reach the terminal marker near the true end,
+    // regardless of how much padding precedes it in the file.
+    expect(reconstructed).toContain(terminalMarker);
+  });
+
+  it("falls back to the S3-backed tail when the local file is gone (pod-roll simulation)", async () => {
+    const basePath = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-store-test-"));
+    tempDirs.push(basePath);
+    let putBody: string | null = null;
+    const fakeS3 = {
+      provider: {
+        async putObject(input: { objectKey: string; body: NodeJS.ReadableStream }) {
+          const chunks: Buffer[] = [];
+          await new Promise<void>((resolve, reject) => {
+            input.body.on("data", (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+            input.body.on("error", reject);
+            input.body.on("end", () => resolve());
+          });
+          putBody = Buffer.concat(chunks).toString("utf8");
+        },
+        async headObject() {
+          return putBody === null
+            ? { exists: false }
+            : { exists: true, contentLength: Buffer.byteLength(putBody, "utf8") };
+        },
+        async getObject(input: { range?: { start: number; end: number } }) {
+          const { Readable } = await import("node:stream");
+          const body = putBody ?? "";
+          const sliced = input.range ? body.slice(input.range.start, input.range.end + 1) : body;
+          return { stream: Readable.from([Buffer.from(sliced, "utf8")]) };
+        },
+      },
+    };
+    const store = createDurableRunLogStore({
+      basePath,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      s3: fakeS3 as any,
+    });
+    const handle = await store.begin({ companyId: "co", agentId: "agent", runId: randomUUID() });
+    const terminalMarker = JSON.stringify({ type: "result", is_error: false });
+    await store.append(handle, { stream: "stdout", chunk: `${terminalMarker}\n`, ts: "2026-01-01T00:00:00.000Z", seq: 1 });
+    await store.finalize(handle);
+
+    // Simulate the pod-roll: the local emptyDir is gone, only the S3 mirror remains.
+    await fs.rm(path.join(basePath, handle.logRef), { force: true });
+
+    const tail = await store.readTail!(handle, { maxBytes: 10_000 });
+    expect(reconstructedStdout(tail.content)).toContain(terminalMarker);
+  });
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -218,19 +218,25 @@ const claudeLocalAdapter: ServerAdapterModule = {
   // the exact same terminal-result presence check (`resultJson !== null`)
   // that `runChildProcess`'s `terminalResultCleanup.hasTerminalResult` already
   // performs live for this adapter (packages/adapters/claude-local/src/server/execute.ts).
-  // `exitCode` is unavailable here (the process is already gone), so success is
-  // judged purely from the parsed result event: the CLI reports `subtype:
-  // "success"` with `is_error: false` on success, and anything else --
-  // including a missing terminal result -- is failure/unknown at the caller.
+  //
+  // Success/failure mirrors the live classification in execute.ts's
+  // `toAdapterResult` as closely as possible given what is actually knowable
+  // post-exit: live code computes `failed = !parsedSucceeded && (exitCode !==
+  // 0 || is_error)`, i.e. a non-"success" subtype with a clean exit (e.g.
+  // `model_refusal`, `error_max_turns`) is NOT treated as failed. `exitCode`
+  // is unavailable here (the process is already gone, which is the whole
+  // reason recovery is needed), so this can only key off `is_error` -- the
+  // one live-failure signal that doesn't depend on exit code. Matching this
+  // (rather than requiring `subtype === "success"`) avoids recording a
+  // spurious `adopted_run_recovered_failure` for a run that live execution
+  // would have called successful.
   recoverAdoptedRunOutcome: ({ stdout }) => {
     const parsed = parseClaudeStreamJson(stdout).resultJson;
     if (!parsed) return null;
     const isError = asBoolean(parsed.is_error, false);
-    const subtype = typeof parsed.subtype === "string" ? parsed.subtype.trim().toLowerCase() : "";
-    const succeeded = subtype === "success" && !isError;
-    return succeeded
-      ? { outcome: "succeeded" }
-      : { outcome: "failed", errorMessage: describeClaudeFailure(parsed) ?? "Claude reported a non-success result" };
+    return isError
+      ? { outcome: "failed", errorMessage: describeClaudeFailure(parsed) ?? "Claude reported an error result" }
+      : { outcome: "succeeded" };
   },
 };
 

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -9,6 +9,7 @@ import {
   buildSandboxNpmInstallCommand,
   getAdapterSessionManagement,
 } from "@paperclipai/adapter-utils";
+import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
 import {
   execute as claudeExecute,
   listClaudeSkills,
@@ -19,6 +20,8 @@ import {
   sessionCodec as claudeSessionCodec,
   getQuotaWindows as claudeGetQuotaWindows,
   getConfigSchema as getClaudeConfigSchema,
+  parseClaudeStreamJson,
+  describeClaudeFailure,
 } from "@paperclipai/adapter-claude-local/server";
 import {
   agentConfigurationDoc as claudeAgentConfigurationDoc,
@@ -210,6 +213,25 @@ const claudeLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: claudeAgentConfigurationDoc,
   getConfigSchema: getClaudeConfigSchema,
   getQuotaWindows: claudeGetQuotaWindows,
+  // AGE-697: recover the real outcome of a hot-restart-adopted run whose
+  // process later exited without this server observing the exit live. Reuses
+  // the exact same terminal-result presence check (`resultJson !== null`)
+  // that `runChildProcess`'s `terminalResultCleanup.hasTerminalResult` already
+  // performs live for this adapter (packages/adapters/claude-local/src/server/execute.ts).
+  // `exitCode` is unavailable here (the process is already gone), so success is
+  // judged purely from the parsed result event: the CLI reports `subtype:
+  // "success"` with `is_error: false` on success, and anything else --
+  // including a missing terminal result -- is failure/unknown at the caller.
+  recoverAdoptedRunOutcome: ({ stdout }) => {
+    const parsed = parseClaudeStreamJson(stdout).resultJson;
+    if (!parsed) return null;
+    const isError = asBoolean(parsed.is_error, false);
+    const subtype = typeof parsed.subtype === "string" ? parsed.subtype.trim().toLowerCase() : "";
+    const succeeded = subtype === "success" && !isError;
+    return succeeded
+      ? { outcome: "succeeded" }
+      : { outcome: "failed", errorMessage: describeClaudeFailure(parsed) ?? "Claude reported a non-success result" };
+  },
 };
 
 const acpxLocalAdapter: ServerAdapterModule = {

--- a/server/src/adapters/types.ts
+++ b/server/src/adapters/types.ts
@@ -32,4 +32,5 @@ export type {
   AdapterConfigSchema,
   AdapterRuntimeCommandSpec,
   ServerAdapterModule,
+  AdoptedRunOutcomeRecovery,
 } from "@paperclipai/adapter-utils";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -372,6 +372,15 @@ const ADOPTED_RUN_OUTCOME_UNKNOWN_ERROR_CODE = "adopted_run_outcome_unknown";
 // itself a failure. Also never auto-retried (see above) -- the run already
 // ran to completion, so this is a real failure outcome, not a lost process.
 const ADOPTED_RUN_RECOVERED_FAILURE_ERROR_CODE = "adopted_run_recovered_failure";
+// AGE-697: pagination size for reconstructing a run's stdout/stderr text from
+// the general-purpose NDJSON run transcript log (see
+// `reconstructRunLogStreamsTail`). Large enough to keep round trips low for a
+// typical run log without holding an unreasonable amount in memory per page.
+const RUN_LOG_STREAM_PAGE_BYTES = 512 * 1024;
+// Safety valve on the total bytes scanned while reconstructing a run's
+// transcript tail: bounds the I/O cost for a pathologically large log. This
+// only runs for a rare adopted-and-now-dead reap tick, not on every heartbeat.
+const RUN_LOG_STREAM_SCAN_MAX_BYTES = 32 * 1024 * 1024;
 // The reaper sweeps at most this many pending_cleanup leases per tick.
 const PENDING_CLEANUP_SWEEP_PAGE_SIZE = 20;
 // The reaper stops retrying a pending_cleanup lease after this many attempts.
@@ -13502,6 +13511,89 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
   }
 
+  // AGE-697: fallback reconstruction of a run's stdout/stderr text from the
+  // general-purpose run transcript log (`run.logStore`/`run.logRef`), which
+  // EVERY run already writes today via `runLogStore` -- unlike the raw
+  // file-backed stdout/stderr paths on `contextSnapshot`, which only exist
+  // once the sibling file-backed-local-run-output change lands. This is what
+  // makes real-outcome recovery actually reachable in production before that
+  // change ships, instead of always falling through to the unknown-outcome
+  // floor.
+  //
+  // The transcript is NDJSON: each line is `{ts, stream, chunk, seq}`, not raw
+  // adapter stdout, so this reads it page by page (oldest-to-newest, since the
+  // store's `read` only supports forward pagination from a byte offset) and
+  // reconstructs the stdout/stderr streams by concatenating each line's
+  // `chunk` in order, keeping only the last `MAX_CAPTURE_BYTES` of each stream
+  // so a terminal-result parser sees the same tail-shaped input it would from
+  // the direct-file path above. A `RUN_LOG_STREAM_SCAN_MAX_BYTES` safety valve
+  // bounds the total scan for a pathologically large log; this only runs for
+  // a rare adopted-and-now-dead reap tick, so the extra I/O is an acceptable
+  // trade for correctness over the direct-file path's single read.
+  async function reconstructRunLogStreamsTail(
+    run: typeof heartbeatRuns.$inferSelect,
+  ): Promise<{ stdout: string; stderr: string } | null> {
+    if (!run.logStore || !run.logRef) return null;
+    const runLogStore = getRunLogStore();
+    const handle: RunLogHandle = { store: run.logStore as RunLogHandle["store"], logRef: run.logRef };
+    const trimToCap = (parts: string[]): string[] => {
+      const joined = parts.join("");
+      return joined.length > MAX_CAPTURE_BYTES ? [joined.slice(-MAX_CAPTURE_BYTES)] : parts;
+    };
+    let stdoutParts: string[] = [];
+    let stderrParts: string[] = [];
+    let offset = 0;
+    let scanned = 0;
+    let leftover = "";
+    for (;;) {
+      let page: Awaited<ReturnType<typeof runLogStore.read>> | null = null;
+      try {
+        page = await runLogStore.read(handle, { offset, limitBytes: RUN_LOG_STREAM_PAGE_BYTES });
+      } catch {
+        break;
+      }
+      if (!page || !page.content) break;
+      scanned += Buffer.byteLength(page.content, "utf8");
+      const combined = leftover + page.content;
+      const lines = combined.split("\n");
+      leftover = page.nextOffset ? (lines.pop() ?? "") : "";
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+        let event: { stream?: unknown; chunk?: unknown } | null = null;
+        try {
+          event = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const chunk = typeof event?.chunk === "string" ? event.chunk : "";
+        if (!chunk) continue;
+        if (event?.stream === "stdout") {
+          stdoutParts.push(chunk);
+          stdoutParts = trimToCap(stdoutParts);
+        } else if (event?.stream === "stderr") {
+          stderrParts.push(chunk);
+          stderrParts = trimToCap(stderrParts);
+        }
+      }
+      if (!page.nextOffset || scanned >= RUN_LOG_STREAM_SCAN_MAX_BYTES) break;
+      offset = page.nextOffset;
+    }
+    if (leftover.trim()) {
+      try {
+        const event = JSON.parse(leftover.trim()) as { stream?: unknown; chunk?: unknown };
+        const chunk = typeof event.chunk === "string" ? event.chunk : "";
+        if (chunk) {
+          if (event.stream === "stdout") stdoutParts = trimToCap([...stdoutParts, chunk]);
+          else if (event.stream === "stderr") stderrParts = trimToCap([...stderrParts, chunk]);
+        }
+      } catch {
+        // Trailing partial line with no closing newline yet -- drop it.
+      }
+    }
+    return { stdout: stdoutParts.join(""), stderr: stderrParts.join("") };
+  }
+
   // AGE-697: finalize a hot-restart-adopted run once its process (pid AND
   // process group) is confirmed dead. This path is deliberately separate from
   // the generic `process_lost` finalization below it: an adopted run may
@@ -13523,17 +13615,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const recoverOutcome = getServerAdapter(agentInfo.adapterType).recoverAdoptedRunOutcome;
 
     let recovered: ReturnType<NonNullable<typeof recoverOutcome>> = null;
+    let recoverySource: "log_file" | "run_log_store" | null = null;
     if (recoverOutcome && stdoutLogFilePath) {
+      // Preferred: the raw file-backed stdout/stderr this run's own process
+      // wrote to directly (see the sibling file-backed-local-run-output
+      // change). A single tail read, and the content an adapter's terminal-
+      // result parser expects with no reconstruction needed.
       const [stdout, stderr] = await Promise.all([
         readAdoptedRunOutputLogTail(stdoutLogFilePath),
         stderrLogFilePath ? readAdoptedRunOutputLogTail(stderrLogFilePath) : Promise.resolve(""),
       ]);
       recovered = recoverOutcome({ stdout, stderr });
+      if (recovered) recoverySource = "log_file";
+    }
+    if (!recovered && recoverOutcome) {
+      // Fallback: every run already writes its general-purpose NDJSON
+      // transcript via `runLogStore` today, independent of whether the
+      // direct-file path above has ever been persisted for this run. This is
+      // what makes recovery reachable right now rather than only once the
+      // sibling change ships.
+      const reconstructed = await reconstructRunLogStreamsTail(run);
+      if (reconstructed) {
+        recovered = recoverOutcome(reconstructed);
+        if (recovered) recoverySource = "run_log_store";
+      }
     }
 
     const logEvidence = {
       stdoutLogFilePath: stdoutLogFilePath ?? null,
       stderrLogFilePath: stderrLogFilePath ?? null,
+      runLogStore: run.logStore ?? null,
+      runLogRef: run.logRef ?? null,
+      recoverySource,
     };
 
     let finalizedRun: typeof heartbeatRuns.$inferSelect | null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -95,7 +95,7 @@ import type {
   UsageSummary,
 } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
-import { parseObject, asBoolean, asNumber, appendWithByteCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
+import { parseObject, asBoolean, asNumber, appendWithByteCap, MAX_EXCERPT_BYTES, MAX_CAPTURE_BYTES } from "../adapters/utils.js";
 import { costService } from "./costs.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
@@ -357,6 +357,21 @@ const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_AGENT_MESSAGE_KEY = "paperclipAgentMessage";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+// AGE-697: a hot-restart-adopted run whose process later exited without this
+// server observing the exit live, and whose persisted log content contained
+// no adapter terminal result. Distinct from "process_lost" on purpose: this
+// run is NOT eligible for the automatic process-loss retry, because the
+// adopted process may already have completed its real side effects (posted
+// comments, patched issues, opened PRs) before it exited, and retrying would
+// duplicate them. See the AGE-656/AGE-697 decision: recover the real outcome
+// from the persisted run log when possible, and finalize with this distinct,
+// non-retrying "unknown outcome" state as the floor when it isn't.
+const ADOPTED_RUN_OUTCOME_UNKNOWN_ERROR_CODE = "adopted_run_outcome_unknown";
+// AGE-697: a hot-restart-adopted run whose process exited and whose
+// persisted log DID contain an adapter terminal result, but that result was
+// itself a failure. Also never auto-retried (see above) -- the run already
+// ran to completion, so this is a real failure outcome, not a lost process.
+const ADOPTED_RUN_RECOVERED_FAILURE_ERROR_CODE = "adopted_run_recovered_failure";
 // The reaper sweeps at most this many pending_cleanup leases per tick.
 const PENDING_CLEANUP_SWEEP_PAGE_SIZE = 20;
 // The reaper stops retrying a pending_cleanup lease after this many attempts.
@@ -13461,6 +13476,155 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { swept: rows.length, destroyed, capped };
   }
 
+  // AGE-697: read the tail of a run's persisted stdout/stderr log file so an
+  // adopted-and-now-exited run's real outcome can be recovered from it. Reads
+  // at most `MAX_CAPTURE_BYTES` from the end of the file, matching the cap a
+  // live `runChildProcess` capture already enforces (packages/adapter-utils/src/server-utils.ts),
+  // so an adapter's terminal-result parser sees comparable input either way.
+  // Any read failure (missing file, permission error, path never persisted)
+  // is treated as "no evidence found" rather than a hard failure -- the
+  // caller falls back to the unknown-outcome floor, which is always safe.
+  async function readAdoptedRunOutputLogTail(logFilePath: string): Promise<string> {
+    let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
+    try {
+      handle = await fs.open(logFilePath, "r");
+      const stat = await handle.stat();
+      const start = Math.max(0, stat.size - MAX_CAPTURE_BYTES);
+      const length = stat.size - start;
+      if (length <= 0) return "";
+      const buffer = Buffer.alloc(length);
+      await handle.read(buffer, 0, length, start);
+      return buffer.toString("utf8");
+    } catch {
+      return "";
+    } finally {
+      await handle?.close().catch(() => undefined);
+    }
+  }
+
+  // AGE-697: finalize a hot-restart-adopted run once its process (pid AND
+  // process group) is confirmed dead. This path is deliberately separate from
+  // the generic `process_lost` finalization below it: an adopted run may
+  // already have completed all of its real side effects (posted comments,
+  // patched issues, opened PRs) before this server ever observed it, so it
+  // must never be labeled `process_lost` and must never auto-enqueue a
+  // process-loss retry -- doing either risks duplicating that work. See the
+  // AGE-656/AGE-697 decision: recover the real outcome from the persisted run
+  // log when possible, and finalize with a distinct, non-retrying "unknown
+  // outcome" state as the floor when it isn't.
+  async function finalizeAdoptedRunAfterProcessExit(
+    run: typeof heartbeatRuns.$inferSelect,
+    agentInfo: Pick<typeof agents.$inferSelect, "adapterType" | "adapterConfig">,
+    now: Date,
+  ): Promise<string | null> {
+    const runContext = parseObject(run.contextSnapshot);
+    const stdoutLogFilePath = readNonEmptyString(runContext.stdoutLogFilePath);
+    const stderrLogFilePath = readNonEmptyString(runContext.stderrLogFilePath);
+    const recoverOutcome = getServerAdapter(agentInfo.adapterType).recoverAdoptedRunOutcome;
+
+    let recovered: ReturnType<NonNullable<typeof recoverOutcome>> = null;
+    if (recoverOutcome && stdoutLogFilePath) {
+      const [stdout, stderr] = await Promise.all([
+        readAdoptedRunOutputLogTail(stdoutLogFilePath),
+        stderrLogFilePath ? readAdoptedRunOutputLogTail(stderrLogFilePath) : Promise.resolve(""),
+      ]);
+      recovered = recoverOutcome({ stdout, stderr });
+    }
+
+    const logEvidence = {
+      stdoutLogFilePath: stdoutLogFilePath ?? null,
+      stderrLogFilePath: stderrLogFilePath ?? null,
+    };
+
+    let finalizedRun: typeof heartbeatRuns.$inferSelect | null;
+    let message: string;
+    if (recovered) {
+      const succeeded = recovered.outcome === "succeeded";
+      message = succeeded
+        ? "Adopted run's process exited after a hot restart; recovered a successful terminal result from its persisted output"
+        : (recovered.errorMessage ??
+          "Adopted run's process exited after a hot restart; recovered a failed terminal result from its persisted output");
+      finalizedRun = await setRunStatus(run.id, succeeded ? "succeeded" : "failed", {
+        error: succeeded ? null : message,
+        errorCode: succeeded ? null : ADOPTED_RUN_RECOVERED_FAILURE_ERROR_CODE,
+        finishedAt: now,
+        resultJson: {
+          ...mergeRunStopMetadataForAgent(agentInfo, succeeded ? "succeeded" : "failed", {
+            resultJson: parseObject(run.resultJson),
+            errorCode: succeeded ? null : ADOPTED_RUN_RECOVERED_FAILURE_ERROR_CODE,
+            errorMessage: succeeded ? null : message,
+          }),
+          adoptedRunLogEvidence: logEvidence,
+        },
+      });
+    } else {
+      message =
+        "Adopted run's process exited after a hot restart, but no terminal result could be recovered from its persisted output";
+      finalizedRun = await setRunStatus(run.id, "failed", {
+        error: message,
+        errorCode: ADOPTED_RUN_OUTCOME_UNKNOWN_ERROR_CODE,
+        finishedAt: now,
+        resultJson: {
+          ...mergeRunStopMetadataForAgent(agentInfo, "failed", {
+            resultJson: parseObject(run.resultJson),
+            errorCode: ADOPTED_RUN_OUTCOME_UNKNOWN_ERROR_CODE,
+            errorMessage: message,
+          }),
+          adoptedRunLogEvidence: logEvidence,
+        },
+      });
+    }
+    await setWakeupStatus(run.wakeupRequestId, recovered?.outcome === "succeeded" ? "completed" : "failed", {
+      finishedAt: now,
+      error: recovered?.outcome === "succeeded" ? null : message,
+    });
+    if (!finalizedRun) finalizedRun = await getRun(run.id);
+    if (!finalizedRun) return null;
+    finalizedRun =
+      (await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson))) ?? finalizedRun;
+    await releaseEnvironmentLeasesForRun({
+      runId: finalizedRun.id,
+      companyId: finalizedRun.companyId,
+      agentId: finalizedRun.agentId,
+      status: finalizedRun.status,
+      failureReason: finalizedRun.error ?? undefined,
+    });
+
+    // Never auto-retry from this path (AGE-697): an adopted run may already
+    // have produced real side effects before it exited, whether or not this
+    // reap tick could recover its outcome, so retrying here risks duplicating
+    // them. `suppressImmediateRecovery` also blocks `releaseIssueExecutionAndPromote`'s
+    // own "queue a continuation run" path for a failed/unknown-outcome issue --
+    // that path is a second, independent auto-retry mechanism (see the
+    // `issueNeedsImmediateRecovery` / `issueNeedsReviewParticipantRecovery`
+    // branches below) and is just as capable of duplicating an adopted run's
+    // side effects as the process-loss retry this function replaces.
+    await releaseIssueExecutionAndPromote(finalizedRun, { suppressImmediateRecovery: true });
+
+    await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: recovered?.outcome === "succeeded" ? "info" : "error",
+      message,
+      payload: {
+        ...(run.processPid ? { processPid: run.processPid } : {}),
+        ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
+        adoptedRunOutcomeRecovered: Boolean(recovered),
+        ...logEvidence,
+      },
+    });
+
+    await finalizeAgentStatus(
+      finalizedRun.agentId,
+      finalizedRun.status === "succeeded" ? "succeeded" : "failed",
+      message,
+      { wasFirstHeartbeat: timerClaimWasFirstHeartbeat(run) },
+    );
+    await startNextQueuedRunForAgent(finalizedRun.agentId);
+    runningProcesses.delete(run.id);
+    return finalizedRun.id;
+  }
+
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
@@ -13538,6 +13702,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             });
           }
         }
+        continue;
+      }
+
+      // AGE-697: the run carries hot-restart adoption metadata but its
+      // process is now confirmed dead (both the guard above and the
+      // `processPidAlive` branch above already ruled out "still alive").
+      // Never fall through to the unconditional `process_lost` finalization
+      // below for this run -- see `finalizeAdoptedRunAfterProcessExit`.
+      if (readHotRestartAdoptionMetadata(parseObject(run.resultJson))) {
+        const finalizedRunId = await finalizeAdoptedRunAfterProcessExit(
+          run,
+          { adapterType, adapterConfig },
+          now,
+        );
+        if (finalizedRunId) reaped.push(finalizedRunId);
         continue;
       }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13521,15 +13521,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   // floor.
   //
   // The transcript is NDJSON: each line is `{ts, stream, chunk, seq}`, not raw
-  // adapter stdout, so this reads it page by page (oldest-to-newest, since the
-  // store's `read` only supports forward pagination from a byte offset) and
-  // reconstructs the stdout/stderr streams by concatenating each line's
-  // `chunk` in order, keeping only the last `MAX_CAPTURE_BYTES` of each stream
-  // so a terminal-result parser sees the same tail-shaped input it would from
-  // the direct-file path above. A `RUN_LOG_STREAM_SCAN_MAX_BYTES` safety valve
-  // bounds the total scan for a pathologically large log; this only runs for
-  // a rare adopted-and-now-dead reap tick, so the extra I/O is an acceptable
-  // trade for correctness over the direct-file path's single read.
+  // adapter stdout, so this reconstructs the stdout/stderr streams by
+  // concatenating each line's `chunk` in order (by stream tag), keeping only
+  // the last `MAX_CAPTURE_BYTES` of each stream so a terminal-result parser
+  // sees the same tail-shaped input it would from the direct-file path above.
+  //
+  // Prefers `runLogStore.readTail`, a true O(1)-request tail read regardless
+  // of total log size, so a terminal result near the end of a large
+  // transcript is always reachable. Falls back to forward pagination via
+  // `read` (bounded by `RUN_LOG_STREAM_SCAN_MAX_BYTES`) only for a store
+  // implementation that hasn't implemented `readTail` (e.g. a test fake) --
+  // that fallback CAN miss a terminal result past the scan cap on a
+  // pathologically large transcript, which is why `readTail` is preferred.
   async function reconstructRunLogStreamsTail(
     run: typeof heartbeatRuns.$inferSelect,
   ): Promise<{ stdout: string; stderr: string } | null> {
@@ -13542,6 +13545,50 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
     let stdoutParts: string[] = [];
     let stderrParts: string[] = [];
+
+    const consumeLine = (rawLine: string) => {
+      const line = rawLine.trim();
+      if (!line) return;
+      let event: { stream?: unknown; chunk?: unknown } | null = null;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        return;
+      }
+      const chunk = typeof event?.chunk === "string" ? event.chunk : "";
+      if (!chunk) return;
+      if (event?.stream === "stdout") {
+        stdoutParts.push(chunk);
+        stdoutParts = trimToCap(stdoutParts);
+      } else if (event?.stream === "stderr") {
+        stderrParts.push(chunk);
+        stderrParts = trimToCap(stderrParts);
+      }
+    };
+
+    if (runLogStore.readTail) {
+      let tail: Awaited<ReturnType<NonNullable<typeof runLogStore.readTail>>> | null = null;
+      try {
+        tail = await runLogStore.readTail(handle, { maxBytes: RUN_LOG_STREAM_SCAN_MAX_BYTES });
+      } catch {
+        return null;
+      }
+      if (!tail || !tail.content) return { stdout: "", stderr: "" };
+      const lines = tail.content.split("\n");
+      // The read window was clamped to the tail, so its first line may be a
+      // record truncated mid-JSON by the clamp -- drop it rather than risk a
+      // parse of a corrupted fragment. Only skip it when the window did NOT
+      // start at the true beginning of the file (see `truncatedAtStart`).
+      if (tail.truncatedAtStart) lines.shift();
+      for (const rawLine of lines) consumeLine(rawLine);
+      return { stdout: stdoutParts.join(""), stderr: stderrParts.join("") };
+    }
+
+    // Fallback: forward pagination from the start. Bounded by
+    // `RUN_LOG_STREAM_SCAN_MAX_BYTES`, so a transcript larger than that cap
+    // can still miss a terminal result near the true end -- acceptable only
+    // because this path is exercised solely by a store implementation that
+    // hasn't implemented `readTail` (a test fake), never in production.
     let offset = 0;
     let scanned = 0;
     let leftover = "";
@@ -13557,40 +13604,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const combined = leftover + page.content;
       const lines = combined.split("\n");
       leftover = page.nextOffset ? (lines.pop() ?? "") : "";
-      for (const rawLine of lines) {
-        const line = rawLine.trim();
-        if (!line) continue;
-        let event: { stream?: unknown; chunk?: unknown } | null = null;
-        try {
-          event = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        const chunk = typeof event?.chunk === "string" ? event.chunk : "";
-        if (!chunk) continue;
-        if (event?.stream === "stdout") {
-          stdoutParts.push(chunk);
-          stdoutParts = trimToCap(stdoutParts);
-        } else if (event?.stream === "stderr") {
-          stderrParts.push(chunk);
-          stderrParts = trimToCap(stderrParts);
-        }
-      }
+      for (const rawLine of lines) consumeLine(rawLine);
       if (!page.nextOffset || scanned >= RUN_LOG_STREAM_SCAN_MAX_BYTES) break;
       offset = page.nextOffset;
     }
-    if (leftover.trim()) {
-      try {
-        const event = JSON.parse(leftover.trim()) as { stream?: unknown; chunk?: unknown };
-        const chunk = typeof event.chunk === "string" ? event.chunk : "";
-        if (chunk) {
-          if (event.stream === "stdout") stdoutParts = trimToCap([...stdoutParts, chunk]);
-          else if (event.stream === "stderr") stderrParts = trimToCap([...stderrParts, chunk]);
-        }
-      } catch {
-        // Trailing partial line with no closing newline yet -- drop it.
-      }
-    }
+    if (leftover.trim()) consumeLine(leftover);
     return { stdout: stdoutParts.join(""), stderr: stderrParts.join("") };
   }
 

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -29,6 +29,16 @@ export interface RunLogFinalizeSummary {
   compressed: boolean;
 }
 
+export interface RunLogTailReadResult {
+  content: string;
+  // True when the returned content starts partway into the log (the read
+  // window was clamped to the last `maxBytes`), so the caller's first parsed
+  // line/record may be truncated mid-record and should be discarded rather
+  // than parsed. False only when the whole file fit in the window, in which
+  // case the first line is genuinely complete.
+  truncatedAtStart: boolean;
+}
+
 export interface RunLogStore {
   begin(input: { companyId: string; agentId: string; runId: string }): Promise<RunLogHandle>;
   append(
@@ -37,6 +47,12 @@ export interface RunLogStore {
   ): Promise<number>;
   finalize(handle: RunLogHandle): Promise<RunLogFinalizeSummary>;
   read(handle: RunLogHandle, opts?: RunLogReadOptions): Promise<RunLogReadResult>;
+  // Optional so existing fakes/fixtures keep compiling: read the last
+  // `maxBytes` of the log directly (a true tail, O(1) requests regardless of
+  // total log size), for a caller that only needs to look for a marker near
+  // the end -- e.g. AGE-697's adopted-run terminal-result recovery. Falls
+  // back to forward pagination via `read` when unimplemented.
+  readTail?(handle: RunLogHandle, opts?: { maxBytes?: number }): Promise<RunLogTailReadResult>;
   // Optional so existing fakes/fixtures keep compiling: uploads every dirty
   // in-flight mirror immediately (graceful-shutdown path). No-op when the
   // in-flight mirror is not enabled.
@@ -345,6 +361,29 @@ export function createDurableRunLogStore(options: DurableRunLogStoreOptions): Ru
       if (local) return local;
       // Local file gone (pod rolled) -> serve from the S3 mirror if configured.
       return readS3Range(handle.logRef, offset, limitBytes);
+    },
+
+    async readTail(handle, opts) {
+      if (handle.store !== "local_file") throw notFound("Run log not found");
+      const maxBytes = opts?.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : 256_000;
+      const absPath = resolveWithin(basePath, handle.logRef);
+      const stat = await fs.stat(absPath).catch(() => null);
+      if (stat) {
+        const start = Math.max(0, stat.size - maxBytes);
+        const length = stat.size - start;
+        const local = length > 0 ? await readLocalRange(absPath, start, length) : { content: "" };
+        if (local) return { content: local.content, truncatedAtStart: start > 0 };
+      }
+      // Local file gone (pod rolled) or stat failed -> serve from the S3 mirror.
+      if (!s3) throw notFound("Run log not found");
+      const key = s3Key(handle.logRef);
+      const head = await s3.provider.headObject({ objectKey: key });
+      if (!head.exists) throw notFound("Run log not found");
+      const total = head.contentLength ?? 0;
+      const start = Math.max(0, total - maxBytes);
+      const length = Math.max(1, total - start);
+      const remote = await readS3Range(handle.logRef, start, length);
+      return { content: remote.content, truncatedAtStart: start > 0 };
     },
 
     async flushInflightMirrors() {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service's orphaned-run reaper (`reapOrphanedRuns`) recovers a run whose child process died, including a run this server *adopted* from a previous process across a hot restart
> - The adoption guard only protects an adopted run while its process is still alive. The instant the adopted process (and its process group) exits, the guard's own condition goes false and the run falls into the generic "process lost" path
> - That generic path can label the run `process_lost` and auto-enqueue a retry, even though an adopted run may already have finished its real work (posted comments, patched issues, opened PRs) before this server ever observed it. Retrying it duplicates that work
> - This pull request adds a dedicated finalization path for exactly this case: never `process_lost`, never auto-retried, and — when a persisted stdout/stderr log is available — the real success/failure outcome is recovered from it instead of guessing
> - The benefit is no more duplicate side effects from a completed run that happened to be adopted across a restart, with an explicit "unknown outcome" floor (also non-retrying) when the real outcome can't be recovered

## Linked Issues or Issue Description

**What happened?**
`reapOrphanedRuns` computes `processPidAlive`/`processGroupAlive` and only skips reaping an adopted run while `(processPidAlive || processGroupAlive) && readHotRestartAdoptionMetadata(...)` is true. Once the adopted process and its process group both exit, that condition is false and the run falls straight into the unconditional `process_lost` finalization further down the function, which can set `shouldRetry = true` and enqueue an automatic retry of a run that may have already completed all of its real side effects.

**Expected behavior**
A run carrying hot-restart adoption metadata should never be finalized as `process_lost` and should never be auto-retried once adopted, regardless of whether its process is still alive. When possible, its real terminal outcome should be recovered from its persisted output log; otherwise it should land in an explicit, non-retrying "unknown outcome" state.

**Steps to reproduce**
1. Start a local-adapter run and let the server hot-restart while it is running, so the new process adopts it (recorded via `resultJson.hotRestart.adopted = true`).
2. Let the adopted process (and its process group) exit on its own, without the new server process ever observing that exit live.
3. Let the heartbeat's `reapOrphanedRuns` sweep run.
4. Observe the run is finalized `errorCode: "process_lost"` and, if `processLossRetryCount < 1`, a retry run is auto-enqueued for an agent/task that may have already produced real comments/PRs/issue updates.

## What Changed

- Added `finalizeAdoptedRunAfterProcessExit` in `server/src/services/heartbeat.ts`: a dedicated finalization path in `reapOrphanedRuns` for a run carrying hot-restart adoption metadata whose process (pid AND process group) is confirmed dead. It never uses `errorCode: "process_lost"` and never auto-enqueues a retry.
- The new path also passes `suppressImmediateRecovery: true` to `releaseIssueExecutionAndPromote`, which has its own independent "queue a continuation run" auto-retry mechanism keyed only on `run.status === "failed"` — without this, that second mechanism would still duplicate the adopted run's work even though the process-loss retry path was closed.
- Added an optional adapter capability, `recoverAdoptedRunOutcome`, on `ServerAdapterModule` (`packages/adapter-utils/src/types.ts`). It recovers the real outcome from a run's persisted stdout/stderr log content, reusing the same terminal-result presence check (`resultJson !== null`) that `runChildProcess`'s existing `terminalResultCleanup.hasTerminalResult` already performs live (`packages/adapter-utils/src/server-utils.ts`).
- Wired `recoverAdoptedRunOutcome` for the `claude_local` adapter (`server/src/adapters/registry.ts`) using the adapter's own `parseClaudeStreamJson`/`describeClaudeFailure` parsers.
- When a terminal result is recovered, the run finalizes with the real success/failure outcome. When it isn't (no log path persisted, adapter has no hook, or no terminal result in the log), the run finalizes with a distinct, non-retrying `errorCode: "adopted_run_outcome_unknown"`.
- Added `readAdoptedRunOutputLogTail` to read the tail of a log file (capped at the same `MAX_CAPTURE_BYTES` a live run capture already enforces).
- Added two tests to `server/src/__tests__/heartbeat-process-recovery.test.ts` covering both the recovered-outcome and unknown-outcome branches, and verified no regression to the existing adoption-still-alive and process_lost-retry tests.

## Verification

```
cd server
pnpm exec vitest run src/__tests__/heartbeat-process-recovery.test.ts
# 105 passed (105)
```

- New test: "recovers the real outcome from a hot-restart-adopted run's persisted log once its process has fully exited" — mocks the adapter's `recoverAdoptedRunOutcome` to report success; asserts the run finalizes `succeeded`, `errorCode` is not `process_lost`, and exactly one row exists (no retry). Fails against `master`.
- New test: "finalizes a hot-restart-adopted run as unknown-outcome (never process_lost, never retried) once its process has fully exited with no recoverable terminal result" — no adapter hook available; asserts `errorCode: "adopted_run_outcome_unknown"` and exactly one row exists (no retry). Fails against `master`.
- Pre-existing tests re-verified green: "queues exactly one retry when the recorded local pid is dead" (non-adopted `process_lost` path, unchanged behavior), "reports adopted hot-restart runs before startup reap can mark them process_lost", and "keeps process-group-only hot-restart adoptions out of process_lost reaping" (adoption-still-alive guard, unchanged).
- `pnpm --filter @paperclipai/server run typecheck` — clean.
- `packages/adapter-utils` typecheck — clean; `packages/adapter-utils/src/server-utils.test.ts` — 92/92 passing.
- `packages/adapters/claude-local/src/server/parse.test.ts` — 46/46 passing.
- One pre-existing, unrelated failure in `packages/adapters/claude-local/src/server/execute.acp-fallback.test.ts` reproduces identically on an unmodified checkout at the same base commit — not touched by this change.

## Risks

- Behavioral shift: an adopted run whose process later exits with no recoverable log evidence now finalizes as `adopted_run_outcome_unknown` (failed, non-retrying) instead of `process_lost` (failed, retried once). This is intentional — the whole point of this change is to stop the automatic retry for this case — but any downstream code or dashboard that specifically filters on `errorCode: "process_lost"` will no longer see these runs under that code. `dashboard-service.test.ts`'s existing `process_lost` bucket assertions still pass unaffected, since they cover a different run shape.
- `recoverAdoptedRunOutcome` is currently wired for exactly one adapter (`claude_local`). Every other local adapter safely falls through to the non-retrying unknown-outcome floor rather than silently guessing — no adapter regresses to worse behavior than before.
- Low risk otherwise: the change is additive (a new capability field, a new finalization function) and does not alter the existing "still alive" adoption guard or the existing non-adopted `process_lost` retry path, both of which are covered by pre-existing, still-green tests.

## Model Used

Claude (Anthropic), via the `pi` coding agent harness — extended reasoning/thinking mode enabled, with tool use (file read/edit/bash) and no code execution beyond the local test/typecheck runs listed above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
