### PR TITLE
fix(db): make auto backup fallback restorable

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -451,7 +451,7 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
   );
 
   it(
-    "restores fallback COPY data when child tables are dumped before parent tables",
+    "restores auto fallback data without pg_dump or psql when child tables are dumped first",
     async () => {
       const sourceConnectionString = await createTempDatabase();
       const restoreConnectionString = await createSiblingDatabase(
@@ -462,7 +462,9 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
       const sourceSql = postgres(sourceConnectionString, { max: 1, onnotice: () => {} });
       const restoreSql = postgres(restoreConnectionString, { max: 1, onnotice: () => {} });
       const originalPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      const originalPsqlPath = process.env.PAPERCLIP_PSQL_PATH;
       process.env.PAPERCLIP_PG_DUMP_PATH = "/bin/false";
+      process.env.PAPERCLIP_PSQL_PATH = "/bin/false";
 
       try {
         await sourceSql.unsafe(`
@@ -498,6 +500,8 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
         expect(backupSql.indexOf("-- Data for: public.aaa_child_records")).toBeLessThan(
           backupSql.indexOf("-- Data for: public.zzz_parent_records"),
         );
+        expect(backupSql).not.toContain('COPY "public"."aaa_child_records"');
+        expect(backupSql).toContain('INSERT INTO "public"."aaa_child_records"');
 
         await runDatabaseRestore({
           connectionString: restoreConnectionString,
@@ -515,6 +519,11 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
           delete process.env.PAPERCLIP_PG_DUMP_PATH;
         } else {
           process.env.PAPERCLIP_PG_DUMP_PATH = originalPgDumpPath;
+        }
+        if (originalPsqlPath === undefined) {
+          delete process.env.PAPERCLIP_PSQL_PATH;
+        } else {
+          process.env.PAPERCLIP_PSQL_PATH = originalPsqlPath;
         }
         await sourceSql.end();
         await restoreSql.end();

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -529,6 +529,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const retention = opts.retention;
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
   const backupEngine = opts.backupEngine ?? "auto";
+  // `auto` returns immediately when pg_dump succeeds. If pg_dump is absent or
+  // fails, the remaining path must emit statements that the JavaScript
+  // restore engine can execute without requiring psql.
+  const useJavaScriptDataRows = backupEngine !== "pg_dump";
   const canUsePgDump = !hasBackupTransforms(opts);
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
@@ -902,7 +906,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       emit(`-- Data for: ${schema_name}.${tablename} (${count[0]!.n} rows)`);
 
       const nullifiedColumns = nullifiedColumnsByTable.get(currentTableKey) ?? new Set<string>();
-      if (backupEngine !== "javascript" && nullifiedColumns.size === 0) {
+      if (!useJavaScriptDataRows && nullifiedColumns.size === 0) {
         emit(`COPY ${qualifiedTableName} (${colNames}) FROM stdin;`);
         await writer.writeRaw("\n");
         const copySql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip creates database backups for recovery and migration.
> - The automatic backup mode first tries `pg_dump`.
> - The automatic mode uses the JavaScript backup path when `pg_dump` is not available.
> - The old fallback path still wrote `COPY` data blocks.
> - The JavaScript restore path cannot execute these `COPY` blocks when `psql` is not available.
> - This pull request writes executable `INSERT` statements in the automatic fallback path.
> - The benefit is a backup that the matching JavaScript restore path can restore without PostgreSQL client tools.

## Linked Issues or Issue Description

**What happened?**

The automatic database backup mode used the JavaScript fallback when `pg_dump` failed. The fallback still wrote table data as `COPY` blocks. A restore without `psql` then used the JavaScript statement reader, which cannot execute `COPY` blocks.

**Expected behavior**

The automatic fallback backup must use SQL statements that the JavaScript restore engine can execute. The primary `pg_dump` path must keep its current behavior.

**Steps to reproduce**

1. Run a database backup with `backupEngine: "auto"`.
2. Make `pg_dump` unavailable so that Paperclip uses the fallback backup path.
3. Make `psql` unavailable so that Paperclip uses the JavaScript restore path.
4. Restore a backup that contains child-table data before parent-table data.
5. Observe that the old backup contains `COPY` blocks that the JavaScript restore path cannot execute.

**Paperclip version or commit**

`6b8e4216`

**Deployment mode**

Local development from source.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

Not adapter-specific. This is a core database backup bug.

**Database mode**

Embedded test database. The affected backup logic also handles external PostgreSQL connections.

## What Changed

- Treat the automatic fallback as a JavaScript-compatible data writer.
- Keep `COPY` output for the explicit `pg_dump` engine path.
- Add a regression test that disables both `pg_dump` and `psql`.
- Verify that the fallback writes `INSERT` statements and restores related rows.
- No documentation change is required because this restores the documented fallback behavior.

## Verification

- `corepack pnpm exec vitest run packages/db/src/backup-lib.test.ts --reporter=verbose` — 7 tests passed.
- `corepack pnpm --filter @paperclipai/db exec tsx src/check-migration-numbering.ts` — passed.
- `corepack pnpm --filter @paperclipai/db exec tsx src/check-migration-safety.ts` — passed.
- `corepack pnpm --filter @paperclipai/db exec tsc --noEmit` — passed.
- The new regression test fails on the base code and passes with this change.

## Risks

- Low risk. The change only affects the automatic fallback after `pg_dump` is unavailable or fails.
- Fallback files can be larger because they use `INSERT` statements instead of `COPY` blocks.
- The successful `pg_dump` path does not change.
- The explicit JavaScript backup path does not change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with model `gpt-5.6-sol`. The model used agentic reasoning, repository tools, shell execution, and local test execution. The Codex app did not expose the context window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
