### PR TITLE
fix(server): create hire approvals for pending managed agents with declared instructions

### DIFF
--- a/server/src/__tests__/plugin-managed-agents.test.ts
+++ b/server/src/__tests__/plugin-managed-agents.test.ts
@@ -362,4 +362,76 @@ describeEmbeddedPostgres("plugin-managed agents", () => {
       managedResourceKey: "wiki-maintainer",
     });
   });
+
+  it("creates the hire approval when a pending managed agent declares instructions", async () => {
+    const previousHome = process.env.PAPERCLIP_HOME;
+    const previousInstance = process.env.PAPERCLIP_INSTANCE_ID;
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-managed-agent-home-"));
+    process.env.PAPERCLIP_HOME = tempHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test";
+    try {
+      const pluginManifest = manifest();
+      pluginManifest.agents![0].instructions = {
+        entryFile: "AGENTS.md",
+        content: "Maintain the wiki.",
+      };
+      const { companyId, services } = await seedCompanyAndPlugin({
+        requireApproval: true,
+        manifest: pluginManifest,
+      });
+
+      const created = await services.agents.managedReconcile({ companyId, agentKey: "wiki-maintainer" });
+
+      expect(created.status).toBe("created");
+      expect(created.agent?.status).toBe("pending_approval");
+      expect(created.approvalId).toBeTruthy();
+
+      const [approval] = await db.select().from(approvals).where(eq(approvals.id, created.approvalId!));
+      expect(approval).toMatchObject({ type: "hire_agent", status: "pending" });
+      expect(approval?.payload).toMatchObject({ agentId: created.agentId });
+    } finally {
+      process.env.PAPERCLIP_HOME = previousHome;
+      process.env.PAPERCLIP_INSTANCE_ID = previousInstance;
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("backfills a missing hire approval for an orphaned pending managed agent", async () => {
+    const { companyId, pluginId, pluginManifest, services } = await seedCompanyAndPlugin({ requireApproval: true });
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Wiki Maintainer",
+      role: "engineer",
+      status: "pending_approval",
+      adapterType: "process",
+      adapterConfig: { command: "pnpm wiki:maintain" },
+      runtimeConfig: {},
+      permissions: {},
+      metadata: {
+        paperclipManagedResource: {
+          pluginId,
+          pluginKey: pluginManifest.id,
+          resourceKind: "agent",
+          resourceKey: "wiki-maintainer",
+        },
+      },
+    });
+
+    const relinked = await services.agents.managedReconcile({ companyId, agentKey: "wiki-maintainer" });
+    expect(relinked.status).toBe("relinked");
+    expect(relinked.agentId).toBe(agentId);
+    expect(relinked.approvalId).toBeTruthy();
+
+    const [approval] = await db.select().from(approvals).where(eq(approvals.id, relinked.approvalId!));
+    expect(approval).toMatchObject({ type: "hire_agent", status: "pending" });
+    expect(approval?.payload).toMatchObject({ agentId });
+
+    // A second reconcile must reuse the open approval, not create a duplicate.
+    const again = await services.agents.managedReconcile({ companyId, agentKey: "wiki-maintainer" });
+    expect(again.approvalId).toBe(relinked.approvalId);
+    const rows = await db.select().from(approvals);
+    expect(rows).toHaveLength(1);
+  });
 });

--- a/server/src/services/plugin-managed-agents.ts
+++ b/server/src/services/plugin-managed-agents.ts
@@ -326,7 +326,7 @@ export function pluginManagedAgentService(
     companyId: string,
     agent: Agent,
     declaration: PluginManagedAgentDeclaration,
-    materializeOptions: { replaceExisting: boolean },
+    materializeOptions: { replaceExisting: boolean; allowPendingApprovalConfigUpdate?: boolean },
   ): Promise<Agent> {
     const variables = await optionsForInstructionVariables(companyId);
     const declared = declaredInstructionFiles(declaration, variables);
@@ -347,6 +347,7 @@ export function pluginManagedAgentService(
       recordRevision: {
         source: `plugin:${optionsForRevisionSource()}:managed-agent-instructions`,
       },
+      allowPendingApprovalConfigUpdate: materializeOptions.allowPendingApprovalConfigUpdate,
     });
     return (updated as Agent | null) ?? { ...agent, adapterConfig: materialized.adapterConfig };
   }
@@ -406,6 +407,71 @@ export function pluginManagedAgentService(
     };
   }
 
+  async function createHireApproval(
+    companyId: string,
+    declaration: PluginManagedAgentDeclaration,
+    agent: Agent,
+  ) {
+    const approval = await approvalSvc.create(companyId, {
+      type: "hire_agent",
+      requestedByAgentId: null,
+      requestedByUserId: null,
+      status: "pending",
+      payload: {
+        name: agent.name,
+        role: agent.role,
+        title: agent.title,
+        icon: agent.icon,
+        reportsTo: agent.reportsTo,
+        capabilities: agent.capabilities,
+        adapterType: agent.adapterType,
+        adapterConfig: agent.adapterConfig,
+        runtimeConfig: agent.runtimeConfig,
+        budgetMonthlyCents: agent.budgetMonthlyCents,
+        metadata: agent.metadata,
+        agentId: agent.id,
+        sourcePluginId: options.pluginId,
+        sourcePluginKey: options.pluginKey,
+        managedResourceKey: declaration.agentKey,
+      },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      updatedAt: new Date(),
+    });
+    await logActivity(db, {
+      companyId,
+      actorType: "plugin",
+      actorId: options.pluginId,
+      action: "approval.created",
+      entityType: "approval",
+      entityId: approval.id,
+      details: {
+        type: "hire_agent",
+        linkedAgentId: agent.id,
+        sourcePluginKey: options.pluginKey,
+        managedResourceKey: declaration.agentKey,
+      },
+    });
+    return approval.id;
+  }
+
+  /**
+   * A pending-approval managed agent must always have an open hire approval in
+   * the board inbox; earlier builds could crash between agent creation and
+   * approval creation, leaving the agent orphaned with nothing to approve.
+   */
+  async function ensureHireApprovalForPendingAgent(
+    companyId: string,
+    declaration: PluginManagedAgentDeclaration,
+    agent: Agent,
+  ): Promise<string | null> {
+    if (agent.status !== "pending_approval") return null;
+    const existing = await approvalSvc.findOpenHireApprovalForAgent(companyId, agent.id);
+    if (existing) return existing.id;
+    return createHireApproval(companyId, declaration, agent);
+  }
+
   async function createManagedAgent(companyId: string, declaration: PluginManagedAgentDeclaration) {
     const company = await db
       .select()
@@ -423,52 +489,14 @@ export function pluginManagedAgentService(
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,
     }) as Agent;
-    created = await materializeDeclaredInstructions(companyId, created, declaration, { replaceExisting: true });
+    created = await materializeDeclaredInstructions(companyId, created, declaration, {
+      replaceExisting: true,
+      allowPendingApprovalConfigUpdate: requiresApproval,
+    });
 
     let approvalId: string | null = null;
     if (requiresApproval) {
-      const approval = await approvalSvc.create(companyId, {
-        type: "hire_agent",
-        requestedByAgentId: null,
-        requestedByUserId: null,
-        status: "pending",
-        payload: {
-          name: created.name,
-          role: created.role,
-          title: created.title,
-          icon: created.icon,
-          reportsTo: created.reportsTo,
-          capabilities: created.capabilities,
-          adapterType: created.adapterType,
-          adapterConfig: created.adapterConfig,
-          runtimeConfig: created.runtimeConfig,
-          budgetMonthlyCents: created.budgetMonthlyCents,
-          metadata: created.metadata,
-          agentId: created.id,
-          sourcePluginId: options.pluginId,
-          sourcePluginKey: options.pluginKey,
-          managedResourceKey: declaration.agentKey,
-        },
-        decisionNote: null,
-        decidedByUserId: null,
-        decidedAt: null,
-        updatedAt: new Date(),
-      });
-      approvalId = approval.id;
-      await logActivity(db, {
-        companyId,
-        actorType: "plugin",
-        actorId: options.pluginId,
-        action: "approval.created",
-        entityType: "approval",
-        entityId: approval.id,
-        details: {
-          type: "hire_agent",
-          linkedAgentId: created.id,
-          sourcePluginKey: options.pluginKey,
-          managedResourceKey: declaration.agentKey,
-        },
-      });
+      approvalId = await createHireApproval(companyId, declaration, created);
     }
 
     await upsertBinding(companyId, declaration, created.id, { approvalId }, adapterType);
@@ -507,14 +535,16 @@ export function pluginManagedAgentService(
       const current = await get(agentKey, companyId);
       if (current.agent) {
         await upsertBinding(companyId, declaration, current.agent.id);
-        return current;
+        const approvalId = await ensureHireApprovalForPendingAgent(companyId, declaration, current.agent);
+        return approvalId ? { ...current, approvalId } : current;
       }
 
       const relinkCandidate = await findRelinkCandidate(companyId, declaration);
       if (relinkCandidate) {
         await upsertBinding(companyId, declaration, relinkCandidate.id);
         const agent = await agentSvc.getById(relinkCandidate.id);
-        return resolution(companyId, declaration, agent as Agent, "relinked");
+        const approvalId = await ensureHireApprovalForPendingAgent(companyId, declaration, agent as Agent);
+        return resolution(companyId, declaration, agent as Agent, "relinked", approvalId);
       }
 
       return createManagedAgent(companyId, declaration);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins can declare managed agents. The server creates these agents through `plugin-managed-agents.ts`.
> - A company can require board approval for new agents. New agents then start in the `pending_approval` status. A `hire_agent` approval must appear in the board inbox.
> - Creation of a managed agent with declared `instructions` fails partway. The agent row exists, but the approval is never created. The board sees a pending agent with nothing to approve.
> - The cause is the pending-approval config freeze guard. The creation flow trips its own guard when it materializes the declared instructions.
> - This pull request lets the creation flow bypass its own guard, and makes reconcile backfill missing hire approvals.
> - The benefit is that every pending managed agent always has an approval item in the board inbox.

## Linked Issues or Issue Description

No existing issue covers this defect. I searched open and closed issues for "pending approval inbox managed agent" and "pending_approval_agent_config_frozen" and found none. Description per the bug report template:

**What happened?**

A plugin with `requireBoardApprovalForNewAgents` enabled declared managed agents with `instructions`. The reconcile call failed with `Pending approval agent configuration cannot be changed before board approval` (`pending_approval_agent_config_frozen`). The agent rows were created in the `pending_approval` status, but no `hire_agent` approval, no `plugin_managed_resources` binding, and no activity-log entries were written. The agent detail page shows "This agent is pending board approval and cannot be invoked yet", but the board inbox shows nothing to approve. The plugin action that triggered the reconcile returned a 502.

**Expected behavior**

Each managed agent created in the `pending_approval` status has one open `hire_agent` approval in the board inbox. The board can approve or reject it from the inbox.

**Steps to reproduce**

1. Enable **Require board approval for new agents** on a company.
2. Install a plugin whose manifest declares a managed agent with an `instructions` block (`entryFile` + `content`).
3. Make the plugin call `agents.managed.reconcile` for that agent key.
4. Observe the error in the server log, the orphaned `pending_approval` agent, and the empty approvals inbox.

**Paperclip version or commit**

Reproduced on `master` at 0e9b038.

**Deployment mode**

Local development instance (embedded Postgres).

**Installation method**

Source checkout, `pnpm` workspace.

## What Changed

- `materializeDeclaredInstructions` accepts an `allowPendingApprovalConfigUpdate` option and forwards it to `agentSvc.update`.
- `createManagedAgent` sets that option when the company requires approval. The creation flow no longer trips its own freeze guard. The approval payload still snapshots the fully materialized config.
- The inline approval-creation block moved into a `createHireApproval` helper.
- New `ensureHireApprovalForPendingAgent` helper: if a managed agent is in `pending_approval` and has no open hire approval, it creates one. It reuses an existing open approval and never duplicates.
- `reconcile` calls the helper on both the resolved-agent path and the relink path. Agents orphaned by earlier builds get their approval backfilled on the next reconcile.
- Two new tests in `plugin-managed-agents.test.ts` cover the regression and the backfill.

## Verification

- `cd server && npx vitest run src/__tests__/plugin-managed-agents.test.ts` — 8/8 pass with the fix.
- I confirmed the new regression test fails on unpatched `master` with the exact production error (`Pending approval agent configuration cannot be changed before board approval`) and passes with the fix.
- `npx tsc --noEmit` introduces no new errors in the touched files.
- Manual: with the fix, retrying the plugin action creates the five missing inbox approvals for the previously orphaned agents on a real instance.

## Risks

- Low risk. The bypass applies only inside the managed-agent creation flow, before the approval snapshot is taken. Config changes on pending agents from any other path stay frozen.
- The backfill in `reconcile` is idempotent (it checks `findOpenHireApprovalForAgent` first), so repeated reconciles cannot create duplicate approvals.
- No schema changes and no migrations.

## Model Used

Claude Fable 5 (Anthropic, model ID `claude-fable-5`) via Claude Code, with extended thinking and tool use (shell, file edits, Postgres inspection, test execution). The human operator reviewed the diagnosis and the diff.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no docs describe this internal flow; code comments added)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Related (not duplicates), found while searching the PR list: Refs #7337 (import path mints `pending_approval` agents), Refs #10983 (agents withdraw pending approvals).
