### PR TITLE
feat(ui): exploded org list view with printable connector graph

### DIFF
--- a/ui/src/pages/OrgChart.test.tsx
+++ b/ui/src/pages/OrgChart.test.tsx
@@ -190,7 +190,7 @@ describe("OrgChart mobile gestures", () => {
     vi.clearAllMocks();
   });
 
-  async function renderOrgChart() {
+  async function renderOrgChart(view: "list" | "chart" = "list") {
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -201,6 +201,16 @@ describe("OrgChart mobile gestures", () => {
     });
     await flushReact();
     await flushReact();
+    if (view === "chart") {
+      const chartToggle = container.querySelector(
+        '[data-testid="org-view-chart"]',
+      ) as HTMLButtonElement;
+      await act(async () => {
+        chartToggle.click();
+      });
+      await flushReact();
+      await flushReact();
+    }
     return {
       viewport: container.querySelector('[data-testid="org-chart-viewport"]') as HTMLDivElement,
       layer: container.querySelector('[data-testid="org-chart-card-layer"]') as HTMLDivElement,
@@ -208,7 +218,7 @@ describe("OrgChart mobile gestures", () => {
   }
 
   it("pans the chart with one-finger touch drag", async () => {
-    const { viewport, layer } = await renderOrgChart();
+    const { viewport, layer } = await renderOrgChart("chart");
 
     await act(async () => {
       viewport.dispatchEvent(createTouchEvent("touchstart", [{ clientX: 100, clientY: 100 }]));
@@ -220,7 +230,7 @@ describe("OrgChart mobile gestures", () => {
   });
 
   it("suppresses card navigation after a touch pan", async () => {
-    const { viewport } = await renderOrgChart();
+    const { viewport } = await renderOrgChart("chart");
     const card = container.querySelector("[data-org-card]") as HTMLDivElement;
 
     await act(async () => {
@@ -234,7 +244,7 @@ describe("OrgChart mobile gestures", () => {
   });
 
   it("allows card navigation after a touch tap without movement", async () => {
-    const { viewport } = await renderOrgChart();
+    const { viewport } = await renderOrgChart("chart");
     const card = container.querySelector("[data-org-card]") as HTMLDivElement;
 
     await act(async () => {
@@ -246,7 +256,7 @@ describe("OrgChart mobile gestures", () => {
     expect(navigateMock).toHaveBeenCalledWith("/agents/ceo");
   });
   it("pinch-zooms toward the touch center", async () => {
-    const { viewport, layer } = await renderOrgChart();
+    const { viewport, layer } = await renderOrgChart("chart");
 
     await act(async () => {
       viewport.dispatchEvent(createTouchEvent("touchstart", [
@@ -261,5 +271,79 @@ describe("OrgChart mobile gestures", () => {
     });
 
     expect(layer.style.transform).toBe("translate(-45px, 40px) scale(1.5)");
+  });
+});
+
+describe("OrgChart exploded list view", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    orgMock.mockResolvedValue(orgTree);
+    listMock.mockResolvedValue(agents);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    container.remove();
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  async function renderList() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <OrgChart />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+  }
+
+  it("starts in the list view with every node visible and indented by depth", async () => {
+    await renderList();
+    const names = Array.from(container.querySelectorAll("[data-org-list-node]")).map(
+      (el) => el.getAttribute("data-org-name"),
+    );
+    expect(names).toEqual(["CEO", "Engineer"]);
+    const depths = Array.from(container.querySelectorAll("[data-org-list-node]")).map(
+      (el) => el.getAttribute("data-depth"),
+    );
+    // Root is exploded by default: its report is shown (not collapsed away).
+    expect(depths).toEqual(["0", "1"]);
+    // The connector graph linking parent rows to their reports is drawn.
+    const links = Array.from(container.querySelectorAll("svg[aria-hidden] path")).filter(
+      (el) => el.getAttribute("d")?.includes(" M "),
+    );
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it("collapses and re-expands a node in the list view by hand", async () => {
+    await renderList();
+    const chevron = container.querySelector(
+      '[data-testid="org-list-collapse"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      chevron.click();
+    });
+    expect(container.querySelector('[data-org-name="Engineer"]')).toBeNull();
+    await act(async () => {
+      chevron.click();
+    });
+    expect(container.querySelector('[data-org-name="Engineer"]')).not.toBeNull();
   });
 });

--- a/ui/src/pages/OrgChart.test.tsx
+++ b/ui/src/pages/OrgChart.test.tsx
@@ -272,6 +272,21 @@ describe("OrgChart mobile gestures", () => {
 
     expect(layer.style.transform).toBe("translate(-45px, 40px) scale(1.5)");
   });
+
+  it("collapses a chart card even when no list collapse happened first", async () => {
+    await renderOrgChart("chart");
+    const collapse = container.querySelector(
+      "[data-org-card] [data-org-collapse]",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      collapse.click();
+    });
+    const names = Array.from(container.querySelectorAll("[data-org-card]")).map(
+      (el) => el.textContent ?? "",
+    );
+    expect(names.some((t) => t.includes("CEO"))).toBe(true);
+    expect(names.some((t) => t.includes("Engineer"))).toBe(false);
+  });
 });
 
 describe("OrgChart exploded list view", () => {

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -220,37 +220,56 @@ function OrgListView({
   // pannable canvas, so the whole org is printable in one window.
   const containerRef = useRef<HTMLDivElement>(null);
   const [connectors, setConnectors] = useState<Array<{ id: string; d: string }>>([]);
-  const INDENT = 28;
+  // One indent step per depth level (px): 7 × the 4px spacing grid. Single
+  // source of truth shared by the row gutter and the connector geometry,
+  // following the named-constant convention of CompanySkills' skill tree.
+  const LIST_INDENT = 28;
 
   const measure = useCallback(() => {
     const list = containerRef.current;
     if (!list) return;
-    const byId = new Map<string, { el: HTMLElement; depth: number; parentId: string | null }>();
+    const listRect = list.getBoundingClientRect();
+    // The connector SVG is `absolute inset-0`, so its origin is the
+    // container's PADDING box; the rows live in the padded content box.
+    // Anchor every coordinate to the SVG's origin (padding box) instead of
+    // mixing offsetParent-relative offsets — otherwise the padding shifts
+    // the cards without shifting the connector paths.
+    const originX = listRect.left + list.clientLeft;
+    const originY = listRect.top + list.clientTop;
+    const byId = new Map<string, { card: HTMLElement; depth: number; parentId: string | null }>();
     for (const el of Array.from(list.querySelectorAll<HTMLElement>("[data-org-list-node]"))) {
       byId.set(el.getAttribute("data-org-id") ?? "", {
-        el,
+        card: el.querySelector<HTMLElement>("[data-org-card]") ?? el,
         depth: Number(el.getAttribute("data-depth") ?? 0),
         parentId: el.getAttribute("data-org-parent"),
       });
     }
-    const childrenByParent = new Map<string, Array<{ el: HTMLElement }>>();
+    const childrenByParent = new Map<string, Array<{ card: HTMLElement }>>();
     for (const [id, info] of byId) {
       if (info.parentId) {
-        const list = childrenByParent.get(info.parentId) ?? [];
-        list.push({ el: info.el });
-        childrenByParent.set(info.parentId, list);
+        const bucket = childrenByParent.get(info.parentId) ?? [];
+        bucket.push({ card: info.card });
+        childrenByParent.set(info.parentId, bucket);
       }
     }
     const paths: Array<{ id: string; d: string }> = [];
     for (const [parentId, children] of childrenByParent) {
       const parent = byId.get(parentId);
       if (!parent) continue;
-      const parentBottom = parent.el.offsetTop + parent.el.offsetHeight;
-      const deepest = children.reduce((a, b) => (a.el.offsetTop > b.el.offsetTop ? a : b));
-      const guideX = parent.depth * INDENT + INDENT / 2;
-      let d = `M ${guideX} ${parentBottom} L ${guideX} ${deepest.el.offsetTop}`;
+      const parentRect = parent.card.getBoundingClientRect();
+      const parentCardLeft = parentRect.left - originX;
+      // Trunk runs down the gutter, half an indent step to the right of the
+      // parent card's left edge, so elbows land exactly on child card edges.
+      const guideX = parentCardLeft + LIST_INDENT / 2;
+      const parentBottom = parentRect.top - originY + parentRect.height;
+      const deepestTop = Math.max(
+        ...children.map((c) => c.card.getBoundingClientRect().top - originY),
+      );
+      let d = `M ${guideX} ${parentBottom} L ${guideX} ${deepestTop}`;
       for (const child of children) {
-        d += ` M ${guideX} ${child.el.offsetTop} L ${child.el.offsetLeft} ${child.el.offsetTop}`;
+        const childRect = child.card.getBoundingClientRect();
+        const childTop = childRect.top - originY;
+        d += ` M ${guideX} ${childTop} L ${childRect.left - originX} ${childTop}`;
       }
       paths.push({ id: parentId, d });
     }
@@ -307,7 +326,7 @@ function OrgListView({
             data-org-name={node.name}
             data-depth={depth}
             className="flex w-full"
-            style={{ marginLeft: depth * 28 }}
+            style={{ paddingLeft: depth * LIST_INDENT }}
           >
             <Card
               data-org-card
@@ -920,7 +939,7 @@ export function OrgChart() {
                       e.preventDefault();
                       e.stopPropagation();
                       setCollapsed((prev) => {
-                        if (!prev) return prev;
+                        if (!prev) return new Set([node.id]);
                         const next = new Set(prev);
                         if (next.has(node.id)) next.delete(node.id);
                         else next.add(node.id);

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import { flushSync } from "react-dom";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
 import { agentsApi, type OrgNode } from "../api/agents";
@@ -11,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
-import { Download, Maximize2, Minus, Network, Plus, Upload } from "lucide-react";
+import { ChevronDown, ChevronRight, Download, List, Maximize2, Minus, Network, Plus, Upload } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
 
 // Layout constants
@@ -22,6 +23,7 @@ const GAP_Y = 80;
 const PADDING = 60;
 const MIN_ZOOM = 0.2;
 const MAX_ZOOM = 2;
+const MIN_FIT_ZOOM = 0.5;
 const TOUCH_MOVE_THRESHOLD = 6;
 
 // ── Tree layout types ───────────────────────────────────────────────────
@@ -169,6 +171,211 @@ const statusDotColor: Record<string, string> = {
 };
 const defaultDotColor = "var(--hex-a3a3a3)";
 
+// ── Exploded vertical list ──────────────────────────────────────────────
+// Renders the full org as an indented, top-to-bottom listing: every agent is a
+// full-width row and reports are nested underneath. Everything is expanded by
+// default ("exploded"), the layout never overflows horizontally, and the page
+// scrolls vertically instead of forcing horizontal pan/zoom.
+
+interface OrgListRow {
+  node: OrgNode;
+  depth: number;
+  parentId: string | null;
+}
+
+function flattenOrg(
+  nodes: OrgNode[],
+  rows: OrgListRow[] = [],
+  depth = 0,
+  parentId: string | null = null,
+): OrgListRow[] {
+  for (const n of nodes) {
+    rows.push({ node: n, depth, parentId });
+    flattenOrg(n.reports, rows, depth + 1, n.id);
+  }
+  return rows;
+}
+
+function OrgListView({
+  visible,
+  agentMap,
+  childCountById,
+  collapsed,
+  onToggle,
+  onOpenAgent,
+}: {
+  visible: OrgNode[];
+  agentMap: Map<string, Agent>;
+  childCountById: Map<string, number>;
+  collapsed: ReadonlySet<string> | null;
+  onToggle: (id: string) => void;
+  onOpenAgent: (node: OrgNode) => void;
+}) {
+  const rows = useMemo(() => flattenOrg(visible), [visible]);
+
+  // ── Connector graph ─────────────────────────────────────────────────────────
+  // Draw the parent→child links as vertical trunks with horizontal elbows inside
+  // the indent gutter, so the hierarchy reads at a glance like a tree. The
+  // lines live in a flow layout (printed along with the rows) rather than a
+  // pannable canvas, so the whole org is printable in one window.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [connectors, setConnectors] = useState<Array<{ id: string; d: string }>>([]);
+  const INDENT = 28;
+
+  const measure = useCallback(() => {
+    const list = containerRef.current;
+    if (!list) return;
+    const byId = new Map<string, { el: HTMLElement; depth: number; parentId: string | null }>();
+    for (const el of Array.from(list.querySelectorAll<HTMLElement>("[data-org-list-node]"))) {
+      byId.set(el.getAttribute("data-org-id") ?? "", {
+        el,
+        depth: Number(el.getAttribute("data-depth") ?? 0),
+        parentId: el.getAttribute("data-org-parent"),
+      });
+    }
+    const childrenByParent = new Map<string, Array<{ el: HTMLElement }>>();
+    for (const [id, info] of byId) {
+      if (info.parentId) {
+        const list = childrenByParent.get(info.parentId) ?? [];
+        list.push({ el: info.el });
+        childrenByParent.set(info.parentId, list);
+      }
+    }
+    const paths: Array<{ id: string; d: string }> = [];
+    for (const [parentId, children] of childrenByParent) {
+      const parent = byId.get(parentId);
+      if (!parent) continue;
+      const parentBottom = parent.el.offsetTop + parent.el.offsetHeight;
+      const deepest = children.reduce((a, b) => (a.el.offsetTop > b.el.offsetTop ? a : b));
+      const guideX = parent.depth * INDENT + INDENT / 2;
+      let d = `M ${guideX} ${parentBottom} L ${guideX} ${deepest.el.offsetTop}`;
+      for (const child of children) {
+        d += ` M ${guideX} ${child.el.offsetTop} L ${child.el.offsetLeft} ${child.el.offsetTop}`;
+      }
+      paths.push({ id: parentId, d });
+    }
+    setConnectors(paths);
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [measure, rows]);
+
+  // Re-measure when the panel is resized (e.g. window/browser chrome height
+  // changes), so the connectors stay attached to their cards.
+  useLayoutEffect(() => {
+    const list = containerRef.current;
+    if (!list || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(list);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full space-y-1.5 overflow-x-hidden rounded-lg border border-border bg-muted/20 p-3"
+    >
+      {/* Connector layer: absolute SVG on top of the flow rows, invisible to
+          pointer events so clicks reach the cards. Renders along with the rows,
+          making the hierarchy printable. */}
+      <svg
+        aria-hidden
+        className="pointer-events-none absolute inset-0 z-0"
+        width="100%"
+        height="100%"
+      >
+        {connectors.map((c) => (
+          <path key={c.id} d={c.d} fill="none" stroke="var(--border)" strokeWidth={2} />
+        ))}
+      </svg>
+      <div className="relative z-10">
+      {rows.map(({ node, depth, parentId }) => {
+        const agent = agentMap.get(node.id);
+        const childCount = childCountById.get(node.id) ?? 0;
+        const isCollapsed = collapsed !== null && collapsed.has(node.id);
+        const dotColor = statusDotColor[node.status] ?? defaultDotColor;
+
+        return (
+          <div
+            key={node.id}
+            data-org-list-node
+            data-org-id={node.id}
+            data-org-parent={parentId ?? ""}
+            data-org-name={node.name}
+            data-depth={depth}
+            className="flex w-full"
+            style={{ marginLeft: depth * 28 }}
+          >
+            <Card
+              data-org-card
+              data-org-list-row
+              className="w-full cursor-pointer py-2 select-none transition-(--tp-box-shadow-border-color) duration-150 hover:border-foreground/20 hover:shadow-md print:break-inside-avoid print:shadow-none"
+              onClick={() => onOpenAgent(node)}
+            >
+              <div className="flex items-center gap-3 px-3">
+                {childCount > 0 ? (
+                  <button
+                    type="button"
+                    data-org-collapse
+                    data-testid="org-list-collapse"
+                    aria-label={isCollapsed ? `Expand ${node.name}` : `Collapse ${node.name}`}
+                    title={isCollapsed ? "Show reports" : "Hide reports"}
+                    className="flex size-6 shrink-0 items-center justify-center rounded border border-border bg-background text-muted-foreground transition-colors hover:bg-accent print:hidden"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onToggle(node.id);
+                    }}
+                  >
+                    {isCollapsed ? (
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    ) : (
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                ) : (
+                  <span className="size-6 shrink-0" />
+                )}
+                <div className="relative shrink-0">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+                    <AgentIcon icon={agent?.icon} className="h-4 w-4 text-foreground/70" />
+                  </div>
+                  <span
+                    className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"
+                    style={{ backgroundColor: dotColor }}
+                  />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col items-start">
+                  <span className="text-sm font-semibold leading-tight text-foreground">
+                    {node.name}
+                  </span>
+                  <span className="mt-0.5 text-(length:--text-micro) leading-tight text-muted-foreground">
+                    {agent?.title ?? roleLabel(node.role)}
+                  </span>
+                  {agent && (
+                    <span className="mt-1 font-mono text-(length:--text-nano) leading-tight text-muted-foreground/60">
+                      {getAdapterLabel(agent.adapterType)}
+                    </span>
+                  )}
+                  {agent && agent.capabilities && (
+                    <span className="mt-1 line-clamp-1 leading-tight text-(length:--text-nano) text-muted-foreground/80">
+                      {agent.capabilities}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </Card>
+          </div>
+        );
+      })}
+      </div>
+    </div>
+  );
+}
+
 // ── Main component ──────────────────────────────────────────────────────
 
 export function OrgChart() {
@@ -198,8 +405,46 @@ export function OrgChart() {
     setBreadcrumbs([{ label: "Org Chart" }]);
   }, [setBreadcrumbs]);
 
-  // Layout computation
-  const layout = useMemo(() => layoutForest(orgTree ?? []), [orgTree]);
+  // Collapse state: the org starts fully exploded (every node expanded), and any
+  // node with reports can be collapsed by hand for a compact view.
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string> | null>(null);
+
+  // View mode: "list" is the exploded vertical listing (default) so the whole
+  // organization reads top-to-bottom in a single window; "chart" keeps the
+  // pannable/zoomable tree graph.
+  const [view, setView] = useState<"list" | "chart">("list");
+
+  const toggleCollapsed = useCallback((id: string) => {
+    setCollapsed((prev) => {
+      if (!prev) return new Set([id]);
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Pruned tree: collapsed nodes render but their subtree is not laid out.
+  const prunedTree = useMemo(() => {
+    if (!collapsed) return orgTree ?? [];
+    const prune = (n: OrgNode): OrgNode =>
+      collapsed.has(n.id) ? { ...n, reports: [] } : { ...n, reports: n.reports.map(prune) };
+    return (orgTree ?? []).map(prune);
+  }, [orgTree, collapsed]);
+
+  // Children counts from the ORIGINAL tree (needed for the collapse badge).
+  const childCountById = useMemo(() => {
+    const m = new Map<string, number>();
+    const walk = (n: OrgNode) => {
+      if (n.reports.length > 0) m.set(n.id, n.reports.length);
+      n.reports.forEach(walk);
+    };
+    for (const r of orgTree ?? []) walk(r);
+    return m;
+  }, [orgTree]);
+
+  // Layout computation over the pruned (visible) tree
+  const layout = useMemo(() => layoutForest(prunedTree), [prunedTree]);
   const allNodes = useMemo(() => flattenLayout(layout), [layout]);
   const edges = useMemo(() => collectEdges(layout), [layout]);
 
@@ -240,20 +485,22 @@ export function OrgChart() {
     };
   }, []);
 
-  // Center the chart on first load
-  const hasInitialized = useRef(false);
+  // Fit the visible chart to the container. Runs on load AND whenever the
+  // visible layout changes (collapse/expand) or the chart view is re-entered,
+  // always guaranteeing readable cards.
   useEffect(() => {
-    if (hasInitialized.current || allNodes.length === 0 || !containerRef.current) return;
-    hasInitialized.current = true;
+    if (view !== "chart") return;
+    if (allNodes.length === 0 || !containerRef.current) return;
 
     const container = containerRef.current;
     const containerW = container.clientWidth;
     const containerH = container.clientHeight;
 
-    // Fit chart to container
+    // Fit chart to container, but never shrink below a readable size —
+    // an oversized chart overflows and the user pans instead.
     const scaleX = (containerW - 40) / bounds.width;
     const scaleY = (containerH - 40) / bounds.height;
-    const fitZoom = Math.min(scaleX, scaleY, 1);
+    const fitZoom = Math.max(Math.min(scaleX, scaleY, 1), MIN_FIT_ZOOM);
 
     const chartW = bounds.width * fitZoom;
     const chartH = bounds.height * fitZoom;
@@ -263,7 +510,29 @@ export function OrgChart() {
       x: (containerW - chartW) / 2,
       y: (containerH - chartH) / 2,
     });
-  }, [allNodes, bounds]);
+  }, [allNodes, bounds, view]);
+
+  // Print: the exploded list is the only printable rendering (the chart is a
+  // fixed-height pannable surface). If the user prints while on the chart view,
+  // switch to the list synchronously, then restore the chosen view afterwards.
+  const printViewRef = useRef<"list" | "chart" | null>(null);
+  useEffect(() => {
+    const onBeforePrint = () => {
+      printViewRef.current = view;
+      if (view !== "list") flushSync(() => setView("list"));
+    };
+    const onAfterPrint = () => {
+      const prev = printViewRef.current;
+      if (prev && prev !== "list") flushSync(() => setView(prev));
+      printViewRef.current = null;
+    };
+    window.addEventListener("beforeprint", onBeforePrint);
+    window.addEventListener("afterprint", onAfterPrint);
+    return () => {
+      window.removeEventListener("beforeprint", onBeforePrint);
+      window.removeEventListener("afterprint", onAfterPrint);
+    };
+  }, [view]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
@@ -322,7 +591,7 @@ export function OrgChart() {
     const cH = containerRef.current.clientHeight;
     const scaleX = (cW - 40) / bounds.width;
     const scaleY = (cH - 40) / bounds.height;
-    const fitZoom = Math.min(scaleX, scaleY, 1);
+    const fitZoom = Math.max(Math.min(scaleX, scaleY, 1), MIN_FIT_ZOOM);
     const chartW = bounds.width * fitZoom;
     const chartH = bounds.height * fitZoom;
     setZoom(fitZoom);
@@ -442,21 +711,78 @@ export function OrgChart() {
   }
 
   return (
-    <div className="flex h-(--sz-calc-38) min-h-(--sz-420px) flex-col md:h-full md:min-h-0">
-      <div className="mb-2 flex shrink-0 flex-wrap items-center justify-start gap-2">
-        <Link to="/company/import">
-          <Button variant="outline" size="sm">
-            <Upload className="mr-1.5 h-3.5 w-3.5" />
-            Import company
-          </Button>
-        </Link>
-        <Link to="/company/export">
-          <Button variant="outline" size="sm">
-            <Download className="mr-1.5 h-3.5 w-3.5" />
-            Export company
-          </Button>
-        </Link>
+    <div
+      data-org-view={view}
+      className={
+        view === "list"
+          ? "flex flex-col gap-3"
+          : "flex h-(--sz-calc-38) min-h-(--sz-420px) flex-col md:h-full md:min-h-0"
+      }
+    >
+      <div className="mb-2 flex shrink-0 flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2 print:hidden">
+          <Link to="/company/import">
+            <Button variant="outline" size="sm">
+              <Upload className="mr-1.5 h-3.5 w-3.5" />
+              Import company
+            </Button>
+          </Link>
+          <Link to="/company/export">
+            <Button variant="outline" size="sm">
+              <Download className="mr-1.5 h-3.5 w-3.5" />
+              Export company
+            </Button>
+          </Link>
+        </div>
+        <div className="flex items-center gap-3 print:hidden">
+          <span className="text-(length:--text-micro) text-muted-foreground">
+            {allNodes.length} agent{allNodes.length === 1 ? "" : "s"}
+          </span>
+          <div className="flex items-center gap-0.5 rounded-md border border-border bg-background p-0.5">
+            <button
+              type="button"
+              data-testid="org-view-list"
+              aria-pressed={view === "list"}
+              className={`flex items-center gap-1 rounded-sm px-2 py-1 text-(length:--text-micro) font-medium transition-colors ${
+                view === "list"
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              onClick={() => setView("list")}
+            >
+              <List className="h-3.5 w-3.5" />
+              Exploded list
+            </button>
+            <button
+              type="button"
+              data-testid="org-view-chart"
+              aria-pressed={view === "chart"}
+              className={`flex items-center gap-1 rounded-sm px-2 py-1 text-(length:--text-micro) font-medium transition-colors ${
+                view === "chart"
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              onClick={() => setView("chart")}
+            >
+              <Network className="h-3.5 w-3.5" />
+              Chart
+            </button>
+          </div>
+        </div>
       </div>
+      {view === "list" ? (
+        <OrgListView
+          visible={prunedTree}
+          agentMap={agentMap}
+          childCountById={childCountById}
+          collapsed={collapsed}
+          onToggle={toggleCollapsed}
+          onOpenAgent={(node) => {
+            const agent = agentMap.get(node.id);
+            navigate(agent ? agentUrl(agent) : `/agents/${node.id}`);
+          }}
+        />
+      ) : (
       <div
         ref={containerRef}
         data-testid="org-chart-viewport"
@@ -477,7 +803,7 @@ export function OrgChart() {
         onTouchCancel={handleTouchEnd}
       >
         {/* Zoom controls */}
-        <div className="absolute top-3 right-3 z-10 flex flex-col gap-1.5">
+        <div className="absolute top-3 right-3 z-10 flex flex-col gap-1.5 print:hidden">
           <button
             className="flex size-9 items-center justify-center rounded border border-border bg-background text-sm transition-colors hover:bg-accent sm:size-7"
             onClick={() => {
@@ -561,12 +887,14 @@ export function OrgChart() {
           {allNodes.map((node) => {
             const agent = agentMap.get(node.id);
             const dotColor = statusDotColor[node.status] ?? defaultDotColor;
+            const childCount = childCountById.get(node.id) ?? 0;
+            const isCollapsed = collapsed !== null && collapsed.has(node.id);
 
             return (
               <Card
                 key={node.id}
                 data-org-card
-                className="block absolute py-0 hover:shadow-md hover:border-foreground/20 transition-(--tp-box-shadow-border-color) duration-150 cursor-pointer select-none"
+                className="block absolute py-0 hover:shadow-md hover:border-foreground/20 transition-(--tp-box-shadow-border-color) duration-150 cursor-pointer select-none print:shadow-none"
                 style={{
                   left: node.x,
                   top: node.y,
@@ -581,6 +909,40 @@ export function OrgChart() {
                   e.stopPropagation();
                 }}
               >
+                {childCount > 0 && (
+                  <button
+                    type="button"
+                    data-org-collapse
+                    aria-label={isCollapsed ? `Expand ${node.name}` : `Collapse ${node.name}`}
+                    title={isCollapsed ? "Show reports" : "Hide reports"}
+                    className="absolute top-1.5 right-1.5 z-10 flex size-5 items-center justify-center rounded border border-border bg-background text-muted-foreground transition-colors hover:bg-accent active:scale-95 print:hidden"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setCollapsed((prev) => {
+                        if (!prev) return prev;
+                        const next = new Set(prev);
+                        if (next.has(node.id)) next.delete(node.id);
+                        else next.add(node.id);
+                        return next;
+                      });
+                    }}
+                  >
+                    {isCollapsed ? (
+                      <ChevronRight className="h-3 w-3" />
+                    ) : (
+                      <ChevronDown className="h-3 w-3" />
+                    )}
+                  </button>
+                )}
+                {childCount > 0 && isCollapsed && (
+                  <span
+                    data-org-collapse-badge
+                    className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 rounded-full border border-border bg-background px-1.5 py-px text-(length:--text-nano) font-medium text-muted-foreground"
+                  >
+                    {childCount} report{childCount === 1 ? "" : "s"}
+                  </span>
+                )}
                 <div className="flex items-center px-4 py-3 gap-3">
                   {/* Agent icon + status dot */}
                   <div className="relative shrink-0">
@@ -617,6 +979,7 @@ export function OrgChart() {
           })}
         </div>
       </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the web app companies use to manage AI agents and their organization
> - The Org Chart page (`ui/src/pages/OrgChart.tsx`, route `/org`) shows the agent hierarchy as a pannable, zoomable tree graph inside a fixed-height viewport
> - The viewport shows only part of a large organization. The user must pan or zoom to read the full hierarchy
> - Users also print the page to share the organization outside the app. The pannable canvas prints only the visible portion
> - This pull request adds an exploded vertical list view as the default. It shows every node expanded, and it draws the parent-child graph as connector lines in normal document flow
> - The tree chart view stays available as an alternative
> - The benefit is one-glance readability of the whole organization plus a clean paper printout

## Linked Issues or Issue Description

No GitHub issue exists for this change. It follows the feature request template:

**Subsystem affected**
ui/ — React + Vite board UI (`ui/src/pages/OrgChart.tsx`)

**Problem or motivation**
The Org Chart page shows the agent hierarchy inside a fixed-height, pannable viewport. A large organization is hard to read at a glance, and printing captures only the visible part of the canvas.

**Proposed solution**
Make the exploded vertical list the default view. It renders every agent expanded, top to bottom, with connector lines (vertical trunks plus elbow links) between each parent and its reports. The lines live in document flow, so they print. Collapse and print handling are included.

**Alternatives considered**
Keeping the interactive chart as the default view does not solve the readability problem: a large hierarchy still requires panning, and the fixed-height canvas prints only the visible portion. Zoom-to-fit mitigates the first issue but not the print case. A print stylesheet that forces the chart onto paper was also considered and rejected: the absolutely-positioned card graph does not reflow, so a stylesheet cannot lay the full hierarchy out reliably on paper.

**Roadmap alignment**
Aligns with the V1 product direction in `doc/SPEC-implementation.md`: the organization page should give a readable overview of the agent hierarchy without forcing navigation, and printing is a first-class way to share it outside the app. No schema, API, or shared-contract changes; the change is contained in `ui/` and does not affect other features.

**Additional context**
The chart view is kept for interactive exploration. The review steps below reproduce the behavior.

## What Changed

- The Org page now opens fully exploded: every node with reports is expanded by default and collapsible by hand
- Added a vertical list view (default) that shows the whole organization in one window
- The list renders a connector graph: vertical trunks plus elbow links from each parent to its reports, drawn as an absolute SVG overlay with `pointer-events: none` so the hierarchy is visible, intuitive, and printable
- The tree chart view remains available via the view toggle; it re-fits to the container on load, on collapse/expand, and on re-entry
- Printing: when the chart view is active, `beforeprint` switches to the list synchronously (`flushSync`) and `afterprint` restores the previous view; interactive controls are hidden in print; cards do not split across pages
- `flattenOrg` now tracks the parent id of every row; rows expose `data-org-id`, `data-org-parent`, `data-depth`, and the root exposes `data-org-view` for tests and styling
- Tests: view-aware render helper, exploded-list behaviors, and connector path assertions

## Verification

- `pnpm vitest run src/pages/OrgChart.test.tsx` — 6/6 tests pass
- `pnpm run typecheck` (ui) — clean
- `pnpm -w check:token-gates` — all gates clean
- `pnpm run build` (ui) — builds (pre-existing >500 kB chunk warning only)
- Manual: open `/org`, read the exploded list, collapse and expand a node, switch to Chart and back, then print and confirm the full hierarchy appears

## Risks

- Low risk. The change is confined to one UI page and its tests
- Connector drawing measures DOM offsets; environments without `ResizeObserver` fall back to a single measure (guarded)
- No schema, API, or shared-contract changes

## Model Used

- Provider: Hermes Agent (Nous Research), custom provider endpoint
- Model: `arillm/deepseek_medium` (DeepSeek medium-tier model)
- Tool use and code execution inside the repository; no image inputs

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI run on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge

