### PR TITLE
fix(server): honor project execution environments

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -298,6 +298,7 @@ describe("execution workspace policy helpers", () => {
     expect(
       parseProjectExecutionWorkspacePolicy({
         enabled: true,
+        environmentId: "22222222-2222-4222-8222-222222222222",
         sharedWorkspaceConcurrency: "serialize",
         defaultMode: "isolated",
         workspaceStrategy: {
@@ -310,6 +311,7 @@ describe("execution workspace policy helpers", () => {
       }),
     ).toEqual({
       enabled: true,
+      environmentId: "22222222-2222-4222-8222-222222222222",
       sharedWorkspaceConcurrency: "serialize",
       defaultMode: "isolated_workspace",
       workspaceStrategy: {
@@ -379,6 +381,38 @@ describe("execution workspace policy helpers", () => {
   it("prefers the agent default environment", () => {
     expect(
       resolveExecutionWorkspaceEnvironmentId({
+        agentDefaultEnvironmentId: "agent-env",
+        instanceDefaultEnvironmentId: "instance-env",
+        localDefaultEnvironmentId: "local-env",
+      }),
+    ).toEqual({
+      environmentId: "agent-env",
+      source: "agent",
+    });
+  });
+
+  it("prefers an enabled project environment before the agent default", () => {
+    expect(
+      resolveExecutionWorkspaceEnvironmentId({
+        projectPolicy: {
+          enabled: true,
+          environmentId: "project-env",
+        },
+        agentDefaultEnvironmentId: "agent-env",
+        instanceDefaultEnvironmentId: "instance-env",
+        localDefaultEnvironmentId: "local-env",
+      }),
+    ).toEqual({
+      environmentId: "project-env",
+      source: "project",
+    });
+
+    expect(
+      resolveExecutionWorkspaceEnvironmentId({
+        projectPolicy: {
+          enabled: false,
+          environmentId: "project-env",
+        },
         agentDefaultEnvironmentId: "agent-env",
         instanceDefaultEnvironmentId: "instance-env",
         localDefaultEnvironmentId: "local-env",

--- a/server/src/__tests__/heartbeat-plugin-environment.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-environment.test.ts
@@ -80,7 +80,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
     await stopDb?.();
   });
 
-  it("acquires plugin environment leases through the heartbeat execution path", async () => {
+  it("acquires the project policy environment through the heartbeat execution path", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();
     const workspaceId = randomUUID();
@@ -108,6 +108,10 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       }),
     } as unknown as PluginWorkerManager;
 
+    await instanceSettingsService(db).updateExperimental({
+      enableEnvironments: true,
+      enableIsolatedWorkspaces: true,
+    });
     await db.insert(companies).values({
       id: companyId,
       name: "Acme",
@@ -122,6 +126,10 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       companyId,
       name: "Plugin Environment Heartbeat",
       status: "active",
+      executionWorkspacePolicy: {
+        enabled: true,
+        environmentId,
+      },
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -189,7 +197,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       adapterType: "codex_local",
       adapterConfig: {},
       runtimeConfig: {},
-      defaultEnvironmentId: environmentId,
+      defaultEnvironmentId: null,
       permissions: {},
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -109,6 +109,10 @@ export function parseProjectExecutionWorkspacePolicy(raw: unknown): ProjectExecu
   const defaultMode = asString(parsed.defaultMode, "");
   const defaultProjectWorkspaceId =
     typeof parsed.defaultProjectWorkspaceId === "string" ? parsed.defaultProjectWorkspaceId : undefined;
+  const environmentId =
+    typeof parsed.environmentId === "string" || parsed.environmentId === null
+      ? parsed.environmentId
+      : undefined;
   const allowIssueOverride =
     typeof parsed.allowIssueOverride === "boolean" ? parsed.allowIssueOverride : undefined;
   const sharedWorkspaceConcurrency = parseSharedWorkspaceConcurrency(parsed.sharedWorkspaceConcurrency);
@@ -131,6 +135,7 @@ export function parseProjectExecutionWorkspacePolicy(raw: unknown): ProjectExecu
     ...(normalizedDefaultMode ? { defaultMode: normalizedDefaultMode } : {}),
     ...(allowIssueOverride !== undefined ? { allowIssueOverride } : {}),
     ...(defaultProjectWorkspaceId ? { defaultProjectWorkspaceId } : {}),
+    ...(environmentId !== undefined ? { environmentId } : {}),
     ...(workspaceStrategy ? { workspaceStrategy } : {}),
     ...(parsed.workspaceRuntime && typeof parsed.workspaceRuntime === "object" && !Array.isArray(parsed.workspaceRuntime)
       ? { workspaceRuntime: { ...(parsed.workspaceRuntime as Record<string, unknown>) } }
@@ -230,6 +235,7 @@ export function selectEnvironmentExecutionWorkspaceSettings(
 }
 
 export type ExecutionWorkspaceEnvironmentSource =
+  | "project"
   | "agent"
   | "instance"
   | "default"
@@ -252,6 +258,7 @@ export class ManagedSandboxUnavailableError extends Error {
 }
 
 export function resolveExecutionWorkspaceEnvironmentId(input: {
+  projectPolicy?: Pick<ProjectExecutionWorkspacePolicy, "enabled" | "environmentId"> | null;
   agentDefaultEnvironmentId: string | null;
   instanceDefaultEnvironmentId: string | null;
   localDefaultEnvironmentId: string;
@@ -267,6 +274,12 @@ export function resolveExecutionWorkspaceEnvironmentId(input: {
   managedSandboxEnvironmentId?: string | null;
 }): ExecutionWorkspaceEnvironmentResolution {
   const resolved = ((): ExecutionWorkspaceEnvironmentResolution => {
+    if (input.projectPolicy?.enabled && input.projectPolicy.environmentId) {
+      return {
+        environmentId: input.projectPolicy.environmentId,
+        source: "project",
+      };
+    }
     if (input.agentDefaultEnvironmentId) {
       return {
         environmentId: input.agentDefaultEnvironmentId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14365,6 +14365,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ? await environmentsSvc.findManagedSandboxEnvironment(agent.companyId)
       : null;
     const environmentResolution = resolveExecutionWorkspaceEnvironmentId({
+      projectPolicy: projectExecutionWorkspacePolicy,
       agentDefaultEnvironmentId: agent.defaultEnvironmentId,
       instanceDefaultEnvironmentId: resolvedInstanceSettings.defaultEnvironmentId ?? null,
       localDefaultEnvironmentId: localEnvironment.id,


### PR DESCRIPTION
## Thinking Path

- Paperclip stores a project execution environment in `executionWorkspacePolicy.environmentId`.
- `parseProjectExecutionWorkspacePolicy` dropped that stored field.
- Heartbeat resolution therefore skipped issue and project environment selections and fell through to agent or instance defaults.
- This patch preserves the field and restores the existing issue → project → agent → instance → local precedence.
- The patch is intentionally retained as a small downstream backport rather than expanded into provider-lease lifecycle architecture.

## Linked Issues or Issue Description

- Refs #11644
- Durable plugin lease acquisition architecture: #11656

## What Changed

- Preserve `environmentId` while parsing stored project execution workspace policy.
- Resolve issue and project environment IDs before agent and instance defaults.
- Add focused policy and heartbeat regression coverage.
- No provider lease, cleanup, schema, SDK, or driver lifecycle changes.

## Verification

- `pnpm exec vitest run server/src/__tests__/execution-workspace-policy.test.ts server/src/__tests__/heartbeat-plugin-environment.test.ts`
  - Passed 23 tests, 0 failures on commit `5e7a0f3a0`.

## Risks

- The routing patch is deliberately narrow and does not redesign plugin-provider lease acquisition or crash recovery.
- It is retained downstream for easy release reapplication; this PR is being closed without requesting merge.
- The general provider lifecycle recommendation is tracked separately in #11656.

## Model Used

- Provider: OpenAI Codex
- Model ID: `gpt-5.6-sol`
- Tool calls and code execution were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have searched for related issues and linked them above
- [x] The branch name describes the change
- [x] Focused tests pass
- [x] Tests were added for the changed behavior
- [x] Risks are documented
- [ ] All Paperclip CI gates are green
- [ ] This PR is requesting merge
