### PR TITLE
fix(work-products): refresh managed runtime links

### DIFF
--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { workProductService } from "../services/work-products.ts";
+import type { IssueWorkProduct } from "@paperclipai/shared";
+import {
+  resolveRuntimeServiceWorkProductState,
+  workProductService,
+} from "../services/work-products.ts";
 
-function createWorkProductRow(overrides: Partial<Record<string, unknown>> = {}) {
+function createWorkProductRow(overrides: Partial<IssueWorkProduct> = {}): IssueWorkProduct {
   const now = new Date("2026-03-17T00:00:00.000Z");
   return {
     id: "work-product-1",
@@ -29,6 +33,167 @@ function createWorkProductRow(overrides: Partial<Record<string, unknown>> = {}) 
 }
 
 describe("workProductService", () => {
+  it("refreshes a runtime work product from its current managed service row", () => {
+    const product = createWorkProductRow({
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "runtime-1",
+      type: "runtime_service",
+      provider: "paperclip",
+      externalId: "runtime-1",
+      title: "Managed dev server",
+      url: "https://paperclip.example.test:42001",
+      status: "active",
+      healthStatus: "healthy",
+      metadata: { serviceName: "paperclip-dev" },
+    });
+
+    const resolved = resolveRuntimeServiceWorkProductState(product, [{
+      id: "runtime-1",
+      companyId: "company-1",
+      executionWorkspaceId: "workspace-1",
+      serviceName: "paperclip-dev",
+      status: "running",
+      port: 42013,
+      url: "https://paperclip.example.test:42013",
+      healthStatus: "healthy",
+      updatedAt: new Date("2026-08-18T18:02:54.000Z"),
+    }]);
+
+    expect(resolved).toMatchObject({
+      runtimeServiceId: "runtime-1",
+      externalId: "runtime-1",
+      url: "https://paperclip.example.test:42013",
+      status: "active",
+      healthStatus: "healthy",
+      metadata: {
+        serviceName: "paperclip-dev",
+        runtimeService: {
+          id: "runtime-1",
+          serviceName: "paperclip-dev",
+          status: "running",
+          port: 42013,
+        },
+      },
+    });
+  });
+
+  it("follows a replacement runtime row for the same workspace service", () => {
+    const product = createWorkProductRow({
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "runtime-stopped",
+      type: "runtime_service",
+      provider: "paperclip",
+      externalId: "runtime-stopped",
+      url: "https://paperclip.example.test:42001",
+      status: "active",
+      healthStatus: "healthy",
+      metadata: { serviceName: "paperclip-dev" },
+    });
+    const runtimeBase = {
+      companyId: "company-1",
+      executionWorkspaceId: "workspace-1",
+      serviceName: "paperclip-dev",
+      port: 42001,
+      url: null,
+      healthStatus: "unknown",
+      updatedAt: new Date("2026-08-18T12:04:25.000Z"),
+    };
+
+    const resolved = resolveRuntimeServiceWorkProductState(product, [
+      { ...runtimeBase, id: "runtime-stopped", status: "stopped" },
+      {
+        ...runtimeBase,
+        id: "runtime-current",
+        status: "running",
+        port: 42013,
+        url: "https://paperclip.example.test:42013",
+        healthStatus: "healthy",
+        updatedAt: new Date("2026-08-18T18:02:54.000Z"),
+      },
+    ]);
+
+    expect(resolved).toMatchObject({
+      runtimeServiceId: "runtime-current",
+      externalId: "runtime-current",
+      url: "https://paperclip.example.test:42013",
+      status: "active",
+      healthStatus: "healthy",
+    });
+  });
+
+  it("removes a dead URL when no replacement runtime is active", () => {
+    const product = createWorkProductRow({
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "runtime-stopped",
+      type: "runtime_service",
+      provider: "paperclip",
+      url: "https://paperclip.example.test:42001",
+      status: "active",
+      healthStatus: "healthy",
+    });
+
+    const resolved = resolveRuntimeServiceWorkProductState(product, [{
+      id: "runtime-stopped",
+      companyId: "company-1",
+      executionWorkspaceId: "workspace-1",
+      serviceName: "paperclip-dev",
+      status: "stopped",
+      port: 42001,
+      url: null,
+      healthStatus: "unknown",
+      updatedAt: new Date("2026-08-18T12:04:25.000Z"),
+    }]);
+
+    expect(resolved).toMatchObject({
+      runtimeServiceId: "runtime-stopped",
+      url: null,
+      status: "archived",
+      healthStatus: "unknown",
+    });
+  });
+
+  it("hydrates runtime state when listing work products", async () => {
+    const staleProduct = createWorkProductRow({
+      executionWorkspaceId: "workspace-1",
+      runtimeServiceId: "runtime-1",
+      type: "runtime_service",
+      provider: "paperclip",
+      externalId: "runtime-1",
+      url: "https://paperclip.example.test:42001",
+      status: "active",
+      healthStatus: "healthy",
+      metadata: { serviceName: "paperclip-dev" },
+    });
+    const productOrderBy = vi.fn(async () => [staleProduct]);
+    const productWhere = vi.fn(() => ({ orderBy: productOrderBy }));
+    const productFrom = vi.fn(() => ({ where: productWhere }));
+    const runtimeWhere = vi.fn(async () => [{
+      id: "runtime-1",
+      companyId: "company-1",
+      executionWorkspaceId: "workspace-1",
+      serviceName: "paperclip-dev",
+      status: "running",
+      port: 42013,
+      url: "https://paperclip.example.test:42013",
+      healthStatus: "healthy",
+      updatedAt: new Date("2026-08-18T18:02:54.000Z"),
+    }]);
+    const runtimeFrom = vi.fn(() => ({ where: runtimeWhere }));
+    const select = vi.fn()
+      .mockReturnValueOnce({ from: productFrom })
+      .mockReturnValueOnce({ from: runtimeFrom });
+
+    const result = await workProductService({ select } as any).listForIssue("issue-1");
+
+    expect(result[0]).toMatchObject({
+      runtimeServiceId: "runtime-1",
+      url: "https://paperclip.example.test:42013",
+      status: "active",
+      healthStatus: "healthy",
+    });
+    expect(select).toHaveBeenCalledTimes(2);
+  });
+
   it("uses a transaction when creating a new primary work product", async () => {
     const updatedWhere = vi.fn(async () => undefined);
     const updateSet = vi.fn(() => ({ where: updatedWhere }));

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -56,7 +56,6 @@ describe("workProductService", () => {
       port: 42013,
       url: "https://paperclip.example.test:42013",
       healthStatus: "healthy",
-      updatedAt: new Date("2026-08-18T18:02:54.000Z"),
     }]);
 
     expect(resolved).toMatchObject({
@@ -77,7 +76,7 @@ describe("workProductService", () => {
     });
   });
 
-  it("follows a replacement runtime row for the same workspace service", () => {
+  it("does not substitute a different same-name runtime row", () => {
     const product = createWorkProductRow({
       executionWorkspaceId: "workspace-1",
       runtimeServiceId: "runtime-stopped",
@@ -96,7 +95,6 @@ describe("workProductService", () => {
       port: 42001,
       url: null,
       healthStatus: "unknown",
-      updatedAt: new Date("2026-08-18T12:04:25.000Z"),
     };
 
     const resolved = resolveRuntimeServiceWorkProductState(product, [
@@ -108,16 +106,15 @@ describe("workProductService", () => {
         port: 42013,
         url: "https://paperclip.example.test:42013",
         healthStatus: "healthy",
-        updatedAt: new Date("2026-08-18T18:02:54.000Z"),
       },
     ]);
 
     expect(resolved).toMatchObject({
-      runtimeServiceId: "runtime-current",
-      externalId: "runtime-current",
-      url: "https://paperclip.example.test:42013",
-      status: "active",
-      healthStatus: "healthy",
+      runtimeServiceId: "runtime-stopped",
+      externalId: "runtime-stopped",
+      url: null,
+      status: "archived",
+      healthStatus: "unknown",
     });
   });
 
@@ -141,7 +138,6 @@ describe("workProductService", () => {
       port: 42001,
       url: null,
       healthStatus: "unknown",
-      updatedAt: new Date("2026-08-18T12:04:25.000Z"),
     }]);
 
     expect(resolved).toMatchObject({
@@ -176,7 +172,6 @@ describe("workProductService", () => {
       port: 42013,
       url: "https://paperclip.example.test:42013",
       healthStatus: "healthy",
-      updatedAt: new Date("2026-08-18T18:02:54.000Z"),
     }]);
     const runtimeFrom = vi.fn(() => ({ where: runtimeWhere }));
     const select = vi.fn()

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { issueWorkProducts, workspaceRuntimeServices } from "@paperclipai/db";
 import type { IssueWorkProduct } from "@paperclipai/shared";
@@ -16,10 +16,7 @@ export interface RuntimeServiceWorkProductState {
   port: number | null;
   url: string | null;
   healthStatus: string;
-  updatedAt: Date;
 }
-
-const ACTIVE_RUNTIME_SERVICE_STATUSES = new Set(["provisioning", "starting", "running"]);
 
 function runtimeServiceWorkProductStatus(status: string): IssueWorkProduct["status"] | null {
   if (status === "running") return "active";
@@ -33,12 +30,6 @@ function runtimeServiceHealthStatus(status: string): IssueWorkProduct["healthSta
   return status === "healthy" || status === "unhealthy" ? status : "unknown";
 }
 
-function compareRuntimeServiceRecency(left: RuntimeServiceWorkProductState, right: RuntimeServiceWorkProductState) {
-  const statusRank = (status: string) => status === "running" ? 0 : status === "starting" ? 1 : status === "provisioning" ? 2 : 3;
-  return statusRank(left.status) - statusRank(right.status)
-    || right.updatedAt.getTime() - left.updatedAt.getTime();
-}
-
 /**
  * Runtime-service work products are durable pointers, not snapshots. Resolve
  * their user-facing state from the managed runtime row so a restart that moves
@@ -50,30 +41,9 @@ export function resolveRuntimeServiceWorkProductState(
 ): IssueWorkProduct {
   if (product.type !== "runtime_service") return product;
 
-  const exact = product.runtimeServiceId
+  const resolved = product.runtimeServiceId
     ? runtimeServices.find((service) => service.id === product.runtimeServiceId && service.companyId === product.companyId)
     : null;
-  let current = exact && ACTIVE_RUNTIME_SERVICE_STATUSES.has(exact.status) ? exact : null;
-
-  if (!current && product.executionWorkspaceId) {
-    const activeInWorkspace = runtimeServices
-      .filter((service) => (
-        service.companyId === product.companyId
-        && service.executionWorkspaceId === product.executionWorkspaceId
-        && ACTIVE_RUNTIME_SERVICE_STATUSES.has(service.status)
-      ));
-    const serviceName = typeof product.metadata?.serviceName === "string"
-      ? product.metadata.serviceName.trim()
-      : "";
-    const matchingServices = serviceName
-      ? activeInWorkspace.filter((service) => service.serviceName === serviceName)
-      : activeInWorkspace;
-    if (matchingServices.length > 0 && (serviceName || matchingServices.length === 1)) {
-      current = [...matchingServices].sort(compareRuntimeServiceRecency)[0] ?? null;
-    }
-  }
-
-  const resolved = current ?? exact;
   if (!resolved) return product;
   const resolvedStatus = runtimeServiceWorkProductStatus(resolved.status);
 
@@ -127,7 +97,7 @@ export function workProductService(db: Db) {
   const resolveRuntimeServiceState = async (products: IssueWorkProduct[]) => {
     const runtimeProducts = products.filter((product) => (
       product.type === "runtime_service"
-      && (product.runtimeServiceId || product.executionWorkspaceId)
+      && product.runtimeServiceId
     ));
     if (runtimeProducts.length === 0) return products;
 
@@ -135,18 +105,6 @@ export function workProductService(db: Db) {
     const runtimeServiceIds = [
       ...new Set(runtimeProducts.flatMap((product) => product.runtimeServiceId ? [product.runtimeServiceId] : [])),
     ];
-    const executionWorkspaceIds = [
-      ...new Set(runtimeProducts.flatMap((product) => product.executionWorkspaceId ? [product.executionWorkspaceId] : [])),
-    ];
-    const runtimeReferenceCondition = runtimeServiceIds.length > 0
-      ? executionWorkspaceIds.length > 0
-        ? or(
-            inArray(workspaceRuntimeServices.id, runtimeServiceIds),
-            inArray(workspaceRuntimeServices.executionWorkspaceId, executionWorkspaceIds),
-          )
-        : inArray(workspaceRuntimeServices.id, runtimeServiceIds)
-      : inArray(workspaceRuntimeServices.executionWorkspaceId, executionWorkspaceIds);
-    if (!runtimeReferenceCondition) return products;
     const runtimeServices = await db
       .select({
         id: workspaceRuntimeServices.id,
@@ -157,10 +115,12 @@ export function workProductService(db: Db) {
         port: workspaceRuntimeServices.port,
         url: workspaceRuntimeServices.url,
         healthStatus: workspaceRuntimeServices.healthStatus,
-        updatedAt: workspaceRuntimeServices.updatedAt,
       })
       .from(workspaceRuntimeServices)
-      .where(and(inArray(workspaceRuntimeServices.companyId, companyIds), runtimeReferenceCondition));
+      .where(and(
+        inArray(workspaceRuntimeServices.companyId, companyIds),
+        inArray(workspaceRuntimeServices.id, runtimeServiceIds),
+      ));
 
     return products.map((product) => resolveRuntimeServiceWorkProductState(product, runtimeServices));
   };

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -1,11 +1,101 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray, or } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { issueWorkProducts } from "@paperclipai/db";
+import { issueWorkProducts, workspaceRuntimeServices } from "@paperclipai/db";
 import type { IssueWorkProduct } from "@paperclipai/shared";
 import { insertRowsInChunks } from "./batch-insert.js";
 import type { ImportIssueWorkProductRow } from "./import-write-types.js";
 
 type IssueWorkProductRow = typeof issueWorkProducts.$inferSelect;
+
+export interface RuntimeServiceWorkProductState {
+  id: string;
+  companyId: string;
+  executionWorkspaceId: string | null;
+  serviceName: string;
+  status: string;
+  port: number | null;
+  url: string | null;
+  healthStatus: string;
+  updatedAt: Date;
+}
+
+const ACTIVE_RUNTIME_SERVICE_STATUSES = new Set(["provisioning", "starting", "running"]);
+
+function runtimeServiceWorkProductStatus(status: string): IssueWorkProduct["status"] | null {
+  if (status === "running") return "active";
+  if (status === "provisioning" || status === "starting") return "draft";
+  if (status === "failed") return "failed";
+  if (status === "stopped") return "archived";
+  return null;
+}
+
+function runtimeServiceHealthStatus(status: string): IssueWorkProduct["healthStatus"] {
+  return status === "healthy" || status === "unhealthy" ? status : "unknown";
+}
+
+function compareRuntimeServiceRecency(left: RuntimeServiceWorkProductState, right: RuntimeServiceWorkProductState) {
+  const statusRank = (status: string) => status === "running" ? 0 : status === "starting" ? 1 : status === "provisioning" ? 2 : 3;
+  return statusRank(left.status) - statusRank(right.status)
+    || right.updatedAt.getTime() - left.updatedAt.getTime();
+}
+
+/**
+ * Runtime-service work products are durable pointers, not snapshots. Resolve
+ * their user-facing state from the managed runtime row so a restart that moves
+ * or replaces the service cannot leave a dead URL presented as healthy.
+ */
+export function resolveRuntimeServiceWorkProductState(
+  product: IssueWorkProduct,
+  runtimeServices: RuntimeServiceWorkProductState[],
+): IssueWorkProduct {
+  if (product.type !== "runtime_service") return product;
+
+  const exact = product.runtimeServiceId
+    ? runtimeServices.find((service) => service.id === product.runtimeServiceId && service.companyId === product.companyId)
+    : null;
+  let current = exact && ACTIVE_RUNTIME_SERVICE_STATUSES.has(exact.status) ? exact : null;
+
+  if (!current && product.executionWorkspaceId) {
+    const activeInWorkspace = runtimeServices
+      .filter((service) => (
+        service.companyId === product.companyId
+        && service.executionWorkspaceId === product.executionWorkspaceId
+        && ACTIVE_RUNTIME_SERVICE_STATUSES.has(service.status)
+      ));
+    const serviceName = typeof product.metadata?.serviceName === "string"
+      ? product.metadata.serviceName.trim()
+      : "";
+    const matchingServices = serviceName
+      ? activeInWorkspace.filter((service) => service.serviceName === serviceName)
+      : activeInWorkspace;
+    if (matchingServices.length > 0 && (serviceName || matchingServices.length === 1)) {
+      current = [...matchingServices].sort(compareRuntimeServiceRecency)[0] ?? null;
+    }
+  }
+
+  const resolved = current ?? exact;
+  if (!resolved) return product;
+  const resolvedStatus = runtimeServiceWorkProductStatus(resolved.status);
+
+  return {
+    ...product,
+    runtimeServiceId: resolved.id,
+    externalId: product.provider === "paperclip" ? resolved.id : product.externalId,
+    url: resolved.url,
+    status: resolvedStatus ?? product.status,
+    healthStatus: runtimeServiceHealthStatus(resolved.healthStatus),
+    metadata: {
+      ...(product.metadata ?? {}),
+      runtimeService: {
+        id: resolved.id,
+        serviceName: resolved.serviceName,
+        status: resolved.status,
+        healthStatus: resolved.healthStatus,
+        port: resolved.port,
+      },
+    },
+  };
+}
 
 function toIssueWorkProduct(row: IssueWorkProductRow): IssueWorkProduct {
   return {
@@ -34,6 +124,47 @@ function toIssueWorkProduct(row: IssueWorkProductRow): IssueWorkProduct {
 }
 
 export function workProductService(db: Db) {
+  const resolveRuntimeServiceState = async (products: IssueWorkProduct[]) => {
+    const runtimeProducts = products.filter((product) => (
+      product.type === "runtime_service"
+      && (product.runtimeServiceId || product.executionWorkspaceId)
+    ));
+    if (runtimeProducts.length === 0) return products;
+
+    const companyIds = [...new Set(runtimeProducts.map((product) => product.companyId))];
+    const runtimeServiceIds = [
+      ...new Set(runtimeProducts.flatMap((product) => product.runtimeServiceId ? [product.runtimeServiceId] : [])),
+    ];
+    const executionWorkspaceIds = [
+      ...new Set(runtimeProducts.flatMap((product) => product.executionWorkspaceId ? [product.executionWorkspaceId] : [])),
+    ];
+    const runtimeReferenceCondition = runtimeServiceIds.length > 0
+      ? executionWorkspaceIds.length > 0
+        ? or(
+            inArray(workspaceRuntimeServices.id, runtimeServiceIds),
+            inArray(workspaceRuntimeServices.executionWorkspaceId, executionWorkspaceIds),
+          )
+        : inArray(workspaceRuntimeServices.id, runtimeServiceIds)
+      : inArray(workspaceRuntimeServices.executionWorkspaceId, executionWorkspaceIds);
+    if (!runtimeReferenceCondition) return products;
+    const runtimeServices = await db
+      .select({
+        id: workspaceRuntimeServices.id,
+        companyId: workspaceRuntimeServices.companyId,
+        executionWorkspaceId: workspaceRuntimeServices.executionWorkspaceId,
+        serviceName: workspaceRuntimeServices.serviceName,
+        status: workspaceRuntimeServices.status,
+        port: workspaceRuntimeServices.port,
+        url: workspaceRuntimeServices.url,
+        healthStatus: workspaceRuntimeServices.healthStatus,
+        updatedAt: workspaceRuntimeServices.updatedAt,
+      })
+      .from(workspaceRuntimeServices)
+      .where(and(inArray(workspaceRuntimeServices.companyId, companyIds), runtimeReferenceCondition));
+
+    return products.map((product) => resolveRuntimeServiceWorkProductState(product, runtimeServices));
+  };
+
   return {
     listForIssue: async (issueId: string) => {
       const rows = await db
@@ -41,7 +172,7 @@ export function workProductService(db: Db) {
         .from(issueWorkProducts)
         .where(eq(issueWorkProducts.issueId, issueId))
         .orderBy(desc(issueWorkProducts.isPrimary), desc(issueWorkProducts.updatedAt));
-      return rows.map(toIssueWorkProduct);
+      return await resolveRuntimeServiceState(rows.map(toIssueWorkProduct));
     },
 
     getById: async (id: string) => {
@@ -50,7 +181,8 @@ export function workProductService(db: Db) {
         .from(issueWorkProducts)
         .where(eq(issueWorkProducts.id, id))
         .then((rows) => rows[0] ?? null);
-      return row ? toIssueWorkProduct(row) : null;
+      if (!row) return null;
+      return (await resolveRuntimeServiceState([toIssueWorkProduct(row)]))[0] ?? null;
     },
 
     createForIssue: async (issueId: string, companyId: string, data: Omit<typeof issueWorkProducts.$inferInsert, "issueId" | "companyId">) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip records work products so operators can open the current output of an issue
> - A runtime-service work product can outlive one managed service process or port assignment
> - The work-product read path returned its stored URL even after the runtime manager moved or replaced the service
> - The stored URL could then report a dead port as active and healthy
> - This pull request resolves runtime-service work products from the current managed runtime state on each read
> - The benefit is that operators receive the live service URL and do not need to repair stale links by hand

## Linked Issues or Issue Description

Refs #11526

Refs #11337

No public GitHub issue exists. This section follows the bug report template.

**What happened?**

A managed worktree service moved to a new port during safe port mediation. Its runtime-service work product kept the old URL and still reported an active and healthy state. The old URL returned an upstream failure even though the managed service was healthy on its new port.

**Expected behavior**

A runtime-service work product must show the URL, status, and health of its referenced managed service. It must keep the runtime foreign key authoritative so another same-name service cannot replace its identity. It must remove a dead URL when the referenced service stops.

**Steps to reproduce**

1. Create a runtime-service work product for a managed workspace service.
2. Restart the service after its old port becomes unavailable.
3. Let the runtime manager move the service to a safe port while it keeps the same runtime row.
4. Read the issue work products.
5. Observe that the stored work-product URL still uses the old port before this fix.

**Paperclip version or commit**

Reproduced on `120ae5428fa2` from `master`.

**Deployment mode**

Local development mode with a managed execution worktree service.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

Not adapter-specific. This is a core work-product read-model bug.

## What Changed

- Resolve runtime-service work products from current company-scoped managed runtime rows.
- Keep the referenced runtime foreign key authoritative when same-name services exist.
- Clear dead URLs and project current status, health, port, and service metadata.
- Add focused tests for port changes, same-name service isolation, stopped services, and the list read path.

## Verification

- `pnpm exec vitest run server/src/__tests__/work-products.test.ts` — 6 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `pnpm test:run` — 4,300 tests passed and 5 tests skipped. Ten tests in `workspace-runtime-exposure.test.ts` failed because this development host has active listeners on the fixed `42000/52000` fixture pair. PR #11526 documents this host-only limitation. CI runs on a clean host.
- Fresh browser smoke — email sign-in returned HTTP 200, the user interface did not show `Load failed`, and cloned company, project, and issue data loaded.

## Risks

- Runtime-service work-product reads add one bounded runtime-row query when an issue has this work-product type.
- Runtime rows are selected only by the stored runtime foreign key and company. A same-name service cannot take over the link.
- The change modifies only the read model. It adds no migration and makes no stored-data rewrite.

> I checked `ROADMAP.md`. This focused bug fix completes the existing work-products and managed-runtime capabilities. It does not duplicate planned core work.

## Model Used

OpenAI Codex with the exact `gpt-5.6-sol` model assisted this change. The runtime did not expose its context window size or reasoning setting. Repository tool use, code execution, browser automation, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
