### PR TITLE
fix(ui): add retry action to stranded task notices

### DIFF
--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -456,6 +456,7 @@ interface IssueChatThreadProps {
   scheduledRetry?: IssueScheduledRetry | null;
   recoveryAction?: IssueRecoveryAction | null;
   onResolveRecoveryAction?: (outcome: RecoveryResolveOutcome) => void;
+  recoveryActionPending?: boolean;
   onReissueIsolatedRecoveryAction?: (request: RecoveryReissueRequest) => void;
   reissueIsolatedRecoveryActionPending?: boolean;
   onReconcileForwardRecoveryAction?: () => void;

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -455,7 +455,7 @@ interface IssueChatThreadProps {
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
   scheduledRetry?: IssueScheduledRetry | null;
   recoveryAction?: IssueRecoveryAction | null;
-  onResolveRecoveryAction?: (outcome: RecoveryResolveOutcome) => void;
+  onResolveRecoveryAction?: (outcome: RecoveryResolveOutcome) => Promise<void> | void;
   recoveryActionPending?: boolean;
   onReissueIsolatedRecoveryAction?: (request: RecoveryReissueRequest) => void;
   reissueIsolatedRecoveryActionPending?: boolean;

--- a/ui/src/components/TaskChatThread.test.tsx
+++ b/ui/src/components/TaskChatThread.test.tsx
@@ -233,6 +233,29 @@ describe("TaskChatThread recovery actions", () => {
 
     expect(container.querySelector('[data-testid="task-chat-recovery-try-again"]')).toBeNull();
   });
+
+  it("disables Try again while recovery resolution is pending", () => {
+    const onResolveRecoveryAction = vi.fn();
+    render(
+      <TaskChatThread
+        comments={[recoveryComment]}
+        onAdd={async () => {}}
+        issueId="issue-1"
+        issueStatus="blocked"
+        recoveryAction={recoveryAction}
+        onResolveRecoveryAction={onResolveRecoveryAction}
+        recoveryActionPending
+      />,
+    );
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-recovery-try-again"]',
+    )!;
+    expect(retry.disabled).toBe(true);
+
+    flushSync(() => retry.click());
+    expect(onResolveRecoveryAction).not.toHaveBeenCalled();
+  });
 });
 
 describe("TaskChatThread composer alignment (PAP-498)", () => {

--- a/ui/src/components/TaskChatThread.test.tsx
+++ b/ui/src/components/TaskChatThread.test.tsx
@@ -196,17 +196,13 @@ describe("TaskChatThread recovery actions", () => {
     expect(disclosure.getAttribute("aria-expanded")).toBe("false");
     expect(retry.textContent).toBe("Try again");
 
-    flushSync(() => retry.click());
-    expect(onResolveRecoveryAction).toHaveBeenLastCalledWith("todo");
-    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
-
     flushSync(() => disclosure.click());
     expect(disclosure.getAttribute("aria-expanded")).toBe("true");
     expect(container.querySelector('[data-testid="task-chat-system-notice-details"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="task-chat-recovery-try-again"]')).not.toBeNull();
 
     flushSync(() => retry.click());
-    expect(onResolveRecoveryAction).toHaveBeenCalledTimes(2);
+    expect(onResolveRecoveryAction).toHaveBeenCalledTimes(1);
     expect(onResolveRecoveryAction).toHaveBeenLastCalledWith("todo");
   });
 
@@ -255,6 +251,31 @@ describe("TaskChatThread recovery actions", () => {
 
     flushSync(() => retry.click());
     expect(onResolveRecoveryAction).not.toHaveBeenCalled();
+  });
+
+  it("submits only once across rapid clicks before pending state renders", () => {
+    const onResolveRecoveryAction = vi.fn(() => new Promise<void>(() => {}));
+    render(
+      <TaskChatThread
+        comments={[recoveryComment]}
+        onAdd={async () => {}}
+        issueId="issue-1"
+        issueStatus="blocked"
+        recoveryAction={recoveryAction}
+        onResolveRecoveryAction={onResolveRecoveryAction}
+      />,
+    );
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-recovery-try-again"]',
+    )!;
+    flushSync(() => {
+      retry.click();
+      retry.click();
+    });
+
+    expect(onResolveRecoveryAction).toHaveBeenCalledTimes(1);
+    expect(retry.disabled).toBe(true);
   });
 });
 

--- a/ui/src/components/TaskChatThread.test.tsx
+++ b/ui/src/components/TaskChatThread.test.tsx
@@ -116,6 +116,125 @@ describe("TaskChatThread draft pass-through", () => {
   });
 });
 
+describe("TaskChatThread recovery actions", () => {
+  const recoveryAction = {
+    id: "recovery-action-1",
+    companyId: "company-1",
+    sourceIssueId: "issue-1",
+    recoveryIssueId: null,
+    kind: "stranded_assigned_issue" as const,
+    status: "active" as const,
+    ownerType: "agent" as const,
+    ownerAgentId: "agent-2",
+    ownerUserId: null,
+    previousOwnerAgentId: "agent-1",
+    returnOwnerAgentId: "agent-1",
+    cause: "issue_continuation_needed",
+    fingerprint: "stranded-issue-1",
+    evidence: { sourceRunId: "run-1" },
+    nextAction: "Restore a live execution path.",
+    wakePolicy: null,
+    monitorPolicy: null,
+    attemptCount: 1,
+    maxAttempts: 3,
+    timeoutAt: null,
+    lastAttemptAt: null,
+    outcome: null,
+    resolutionNote: null,
+    resolvedAt: null,
+    createdAt: "2026-08-18T10:00:00.000Z",
+    updatedAt: "2026-08-18T10:00:00.000Z",
+  };
+
+  const recoveryComment = {
+    id: "comment-recovery",
+    companyId: "company-1",
+    issueId: "issue-1",
+    authorType: "system" as const,
+    authorAgentId: null,
+    authorUserId: null,
+    body:
+      "Paperclip automatically retried continuation for this assigned `in_progress` issue after its live execution disappeared, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
+    presentation: {
+      kind: "system_notice" as const,
+      tone: "danger" as const,
+      title: "No live execution path",
+      detailsDefaultOpen: false,
+    },
+    metadata: {
+      version: 1 as const,
+      sourceRunId: "run-1",
+      sections: [{
+        title: "Recovery",
+        rows: [{ type: "key_value" as const, label: "Recovery action", value: recoveryAction.id }],
+      }],
+    },
+    createdAt: new Date("2026-08-18T10:00:00.000Z"),
+    updatedAt: new Date("2026-08-18T10:00:00.000Z"),
+  };
+
+  it("keeps Try again visible in folded and expanded recovery notices and resolves to todo", () => {
+    const onResolveRecoveryAction = vi.fn();
+    render(
+      <TaskChatThread
+        comments={[recoveryComment]}
+        onAdd={async () => {}}
+        issueId="issue-1"
+        issueStatus="blocked"
+        recoveryAction={recoveryAction}
+        onResolveRecoveryAction={onResolveRecoveryAction}
+      />,
+    );
+
+    const disclosure = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-system-notice"] button[aria-controls]',
+    )!;
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-recovery-try-again"]',
+    )!;
+
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(retry.textContent).toBe("Try again");
+
+    flushSync(() => retry.click());
+    expect(onResolveRecoveryAction).toHaveBeenLastCalledWith("todo");
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+
+    flushSync(() => disclosure.click());
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector('[data-testid="task-chat-system-notice-details"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="task-chat-recovery-try-again"]')).not.toBeNull();
+
+    flushSync(() => retry.click());
+    expect(onResolveRecoveryAction).toHaveBeenCalledTimes(2);
+    expect(onResolveRecoveryAction).toHaveBeenLastCalledWith("todo");
+  });
+
+  it("does not attach the active action to a stale recovery notice", () => {
+    render(
+      <TaskChatThread
+        comments={[{
+          ...recoveryComment,
+          metadata: {
+            ...recoveryComment.metadata,
+            sections: [{
+              title: "Recovery",
+              rows: [{ type: "key_value" as const, label: "Recovery action", value: "older-action" }],
+            }],
+          },
+        }]}
+        onAdd={async () => {}}
+        issueId="issue-1"
+        issueStatus="blocked"
+        recoveryAction={recoveryAction}
+        onResolveRecoveryAction={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('[data-testid="task-chat-recovery-try-again"]')).toBeNull();
+  });
+});
+
 describe("TaskChatThread composer alignment (PAP-498)", () => {
   it("matches the thread width on mobile and stays narrower on larger screens", () => {
     render(<TaskChatThread comments={[]} onAdd={async () => {}} />);

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -149,6 +149,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     liveIssueIds,
     recoveryAction,
     onResolveRecoveryAction,
+    recoveryActionPending,
   } = props;
 
   const liveWorkLinks = useMemo(
@@ -644,13 +645,14 @@ export function TaskChatThread(props: TaskChatThreadProps) {
           variant="outline"
           size="xs"
           data-testid="task-chat-recovery-try-again"
+          disabled={recoveryActionPending}
           onClick={() => onResolveRecoveryAction("todo")}
         >
           Try again
         </Button>
       );
     },
-    [onResolveRecoveryAction, recoveryAction],
+    [onResolveRecoveryAction, recoveryAction, recoveryActionPending],
   );
 
   const renderInteraction = useCallback(

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -101,6 +101,8 @@ export type TaskChatThreadProps = ComponentProps<typeof IssueChatThread>;
  * folded row. flag-OFF remains byte-for-byte IssueChatThread.
  */
 export function TaskChatThread(props: TaskChatThreadProps) {
+  const recoveryRetryInFlightRef = useRef(false);
+  const [recoveryRetryInFlight, setRecoveryRetryInFlight] = useState(false);
   const {
     comments,
     interactions,
@@ -626,6 +628,22 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     [interruptingQueuedRunId, onInterruptQueued],
   );
 
+  const handleRecoveryTryAgain = useCallback(() => {
+    if (!onResolveRecoveryAction || recoveryRetryInFlightRef.current) return;
+    recoveryRetryInFlightRef.current = true;
+    setRecoveryRetryInFlight(true);
+    void (async () => {
+      try {
+        await onResolveRecoveryAction("todo");
+      } catch {
+        // The mutation owns user-visible error reporting.
+      } finally {
+        recoveryRetryInFlightRef.current = false;
+        setRecoveryRetryInFlight(false);
+      }
+    })();
+  }, [onResolveRecoveryAction]);
+
   const renderSystemNoticeAction = useCallback(
     (item: TaskChatMessageItem) => {
       if (
@@ -645,14 +663,20 @@ export function TaskChatThread(props: TaskChatThreadProps) {
           variant="outline"
           size="xs"
           data-testid="task-chat-recovery-try-again"
-          disabled={recoveryActionPending}
-          onClick={() => onResolveRecoveryAction("todo")}
+          disabled={recoveryActionPending || recoveryRetryInFlight}
+          onClick={handleRecoveryTryAgain}
         >
           Try again
         </Button>
       );
     },
-    [onResolveRecoveryAction, recoveryAction, recoveryActionPending],
+    [
+      handleRecoveryTryAgain,
+      onResolveRecoveryAction,
+      recoveryAction,
+      recoveryActionPending,
+      recoveryRetryInFlight,
+    ],
   );
 
   const renderInteraction = useCallback(

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -65,6 +65,17 @@ function toMs(value: Date | string | null | undefined): number {
 const SETTLING_TAIL_MAX_MS = 15_000;
 const EMPTY_LIVE_ISSUE_IDS: ReadonlySet<string> = new Set<string>();
 
+function systemNoticeReferencesRecoveryAction(item: TaskChatMessageItem, actionId: string): boolean {
+  if (item.author !== "system") return false;
+  return item.metadata?.sections.some((section) =>
+    section.rows.some((row) =>
+      row.type === "key_value" &&
+      row.label.trim().toLowerCase() === "recovery action" &&
+      row.value === actionId,
+    ),
+  ) ?? false;
+}
+
 export type TaskChatThreadProps = ComponentProps<typeof IssueChatThread>;
 
 /**
@@ -136,6 +147,8 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     blockedBy = [],
     blockerAttention,
     liveIssueIds,
+    recoveryAction,
+    onResolveRecoveryAction,
   } = props;
 
   const liveWorkLinks = useMemo(
@@ -612,6 +625,34 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     [interruptingQueuedRunId, onInterruptQueued],
   );
 
+  const renderSystemNoticeAction = useCallback(
+    (item: TaskChatMessageItem) => {
+      if (
+        !recoveryAction ||
+        recoveryAction.kind !== "stranded_assigned_issue" ||
+        recoveryAction.status === "resolved" ||
+        recoveryAction.status === "cancelled" ||
+        !onResolveRecoveryAction ||
+        !systemNoticeReferencesRecoveryAction(item, recoveryAction.id)
+      ) {
+        return null;
+      }
+
+      return (
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          data-testid="task-chat-recovery-try-again"
+          onClick={() => onResolveRecoveryAction("todo")}
+        >
+          Try again
+        </Button>
+      );
+    },
+    [onResolveRecoveryAction, recoveryAction],
+  );
+
   const renderInteraction = useCallback(
     (item: TaskChatInteractionItem) => (
       <TaskChatInteractionCard
@@ -680,6 +721,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
             renderInteraction={renderInteraction}
             renderBrief={issueBrief ? () => <TaskChatDescriptionBubble brief={issueBrief} /> : undefined}
             renderMessageActions={renderMessageActions}
+            renderSystemNoticeAction={renderSystemNoticeAction}
             renderQueuedAction={renderQueuedAction}
             tail={tailRunId || bottomBlockerLinks ? (
               <>

--- a/ui/src/components/task-chat/TaskChatBubble.tsx
+++ b/ui/src/components/task-chat/TaskChatBubble.tsx
@@ -20,6 +20,8 @@ import type { TaskChatMessageItem } from "./task-chat-model";
 
 interface TaskChatBubbleProps {
   item: TaskChatMessageItem;
+  /** Action rendered beside a system notice's disclosure control. */
+  systemNoticeAction?: ReactNode;
   /** Action shown beside the queued state for an interruptible message. */
   queuedAction?: ReactNode;
   /**
@@ -63,7 +65,13 @@ function galleryItemForImage(src: string, name?: string): GalleryMediaItem {
   };
 }
 
-export function TaskChatBubble({ item, queuedAction, attachedTurn, actions }: TaskChatBubbleProps) {
+export function TaskChatBubble({
+  item,
+  queuedAction,
+  attachedTurn,
+  actions,
+  systemNoticeAction,
+}: TaskChatBubbleProps) {
   // Clicking an embedded image opens the full-screen lightbox (with download);
   // arrow keys walk across the other images in the same bubble.
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
@@ -77,7 +85,7 @@ export function TaskChatBubble({ item, queuedAction, attachedTurn, actions }: Ta
 
   if (item.author === "system") {
     // Collapsed humanized one-liner, expandable to the full detail (PAP-443).
-    return <TaskChatSystemNotice item={item} />;
+    return <TaskChatSystemNotice item={item} action={systemNoticeAction} />;
   }
 
   const isHuman = item.author === "human";

--- a/ui/src/components/task-chat/TaskChatSystemNotice.tsx
+++ b/ui/src/components/task-chat/TaskChatSystemNotice.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useId, useState, type ReactNode } from "react";
 import {
   ChevronDown,
   CircleCheck,
@@ -42,7 +42,14 @@ const TONE_ICON_CLASS: Record<SystemNoticeTone, string> = {
  * markdown-rendered body plus any structured metadata sections; nothing is
  * suppressed, only folded.
  */
-export function TaskChatSystemNotice({ item }: { item: TaskChatMessageItem }) {
+export function TaskChatSystemNotice({
+  item,
+  action,
+}: {
+  item: TaskChatMessageItem;
+  /** Optional action that remains reachable whether the notice is folded or expanded. */
+  action?: ReactNode;
+}) {
   const [open, setOpen] = useState(Boolean(item.presentation?.detailsDefaultOpen));
   const detailsId = useId();
   const { title, tone, detail } = humanizeSystemNotice({
@@ -57,26 +64,29 @@ export function TaskChatSystemNotice({ item }: { item: TaskChatMessageItem }) {
 
   return (
     <div className="tc-enter-bubble flex flex-col items-center py-1" data-testid="task-chat-system-notice">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-controls={detailsId}
-        className={cn(
-          "flex max-w-(--pct-85) items-center gap-1.5 rounded-md px-2 py-0.5 text-xs text-muted-foreground",
-          "hover:bg-muted/50 hover:text-foreground",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-        )}
-      >
-        <ToneIcon className={cn("h-3.5 w-3.5 shrink-0", TONE_ICON_CLASS[tone])} aria-hidden />
-        <span className="truncate font-medium">{title}</span>
-        {detail ? <span className="hidden truncate sm:inline">· {detail}</span> : null}
-        {relative ? <span className="shrink-0 text-muted-foreground/70">· {relative}</span> : null}
-        <ChevronDown
-          className={cn("tc-notice-chevron h-3.5 w-3.5 shrink-0 transition-transform", open && "rotate-180")}
-          aria-hidden
-        />
-      </button>
+      <div className="flex max-w-(--pct-85) items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls={detailsId}
+          className={cn(
+            "flex min-w-0 items-center gap-1.5 rounded-md px-2 py-0.5 text-xs text-muted-foreground",
+            "hover:bg-muted/50 hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          )}
+        >
+          <ToneIcon className={cn("h-3.5 w-3.5 shrink-0", TONE_ICON_CLASS[tone])} aria-hidden />
+          <span className="truncate font-medium">{title}</span>
+          {detail ? <span className="hidden truncate sm:inline">· {detail}</span> : null}
+          {relative ? <span className="shrink-0 text-muted-foreground/70">· {relative}</span> : null}
+          <ChevronDown
+            className={cn("tc-notice-chevron h-3.5 w-3.5 shrink-0 transition-transform", open && "rotate-180")}
+            aria-hidden
+          />
+        </button>
+        {action}
+      </div>
       {open ? (
         <div
           id={detailsId}

--- a/ui/src/components/task-chat/TaskChatThreadView.tsx
+++ b/ui/src/components/task-chat/TaskChatThreadView.tsx
@@ -41,6 +41,8 @@ interface TaskChatThreadViewProps {
    * fixtures omit it and the bubbles render actionless.
    */
   renderMessageActions?: (item: TaskChatMessageItem) => ReactNode;
+  /** Renders an action beside a system notice's disclosure control. */
+  renderSystemNoticeAction?: (item: TaskChatMessageItem) => ReactNode;
   /** Renders an interrupt action beside a queued human message. */
   renderQueuedAction?: (item: TaskChatMessageItem) => ReactNode;
   /** Content appended inside the transcript scroller after the settled thread. */
@@ -58,6 +60,7 @@ function renderItem(
   renderInteraction?: (item: TaskChatInteractionItem) => ReactNode,
   renderBrief?: () => ReactNode,
   renderMessageActions?: (item: TaskChatMessageItem) => ReactNode,
+  renderSystemNoticeAction?: (item: TaskChatMessageItem) => ReactNode,
   renderQueuedAction?: (item: TaskChatMessageItem) => ReactNode,
 ) {
   switch (item.kind) {
@@ -72,6 +75,7 @@ function renderItem(
         <TaskChatBubble
           item={item}
           actions={actions}
+          systemNoticeAction={renderSystemNoticeAction?.(item)}
           queuedAction={renderQueuedAction?.(item)}
           attachedTurn={
             item.attachedTurn ? (
@@ -139,6 +143,7 @@ export function TaskChatThreadView({
   renderInteraction,
   renderBrief,
   renderMessageActions,
+  renderSystemNoticeAction,
   renderQueuedAction,
   tail,
   contentKey,
@@ -160,6 +165,7 @@ export function TaskChatThreadView({
             renderInteraction,
             renderBrief,
             renderMessageActions,
+            renderSystemNoticeAction,
             renderQueuedAction,
           )}
         </div>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -961,6 +961,7 @@ type IssueDetailChatTabProps = {
   scheduledRetry: Issue["scheduledRetry"] | null;
   recoveryAction: Issue["activeRecoveryAction"];
   onResolveRecoveryAction?: (outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome) => void;
+  recoveryActionPending?: boolean;
   onReissueIsolatedRecoveryAction?: (request: import("../components/IssueRecoveryActionCard").RecoveryReissueRequest) => void;
   reissueIsolatedRecoveryActionPending?: boolean;
   onReconcileForwardRecoveryAction?: () => void;
@@ -1067,6 +1068,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   scheduledRetry,
   recoveryAction,
   onResolveRecoveryAction,
+  recoveryActionPending,
   onReissueIsolatedRecoveryAction,
   reissueIsolatedRecoveryActionPending,
   onReconcileForwardRecoveryAction,
@@ -1342,6 +1344,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
         scheduledRetry={scheduledRetry}
         recoveryAction={recoveryAction ?? null}
         onResolveRecoveryAction={onResolveRecoveryAction}
+        recoveryActionPending={recoveryActionPending}
         onReissueIsolatedRecoveryAction={onReissueIsolatedRecoveryAction}
         reissueIsolatedRecoveryActionPending={reissueIsolatedRecoveryActionPending}
         onReconcileForwardRecoveryAction={onReconcileForwardRecoveryAction}
@@ -5285,6 +5288,7 @@ export function IssueDetail() {
               scheduledRetry={issue.scheduledRetry ?? null}
               recoveryAction={issue.activeRecoveryAction ?? null}
               onResolveRecoveryAction={handleResolveRecoveryAction}
+              recoveryActionPending={resolveRecoveryAction.isPending}
               onReissueIsolatedRecoveryAction={handleReissueIsolatedRecoveryAction}
               reissueIsolatedRecoveryActionPending={reissueIsolatedRecoveryAction.isPending}
               onReconcileForwardRecoveryAction={handleReconcileForwardRecoveryAction}

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -960,7 +960,7 @@ type IssueDetailChatTabProps = {
   successfulRunHandoff: Issue["successfulRunHandoff"] | null;
   scheduledRetry: Issue["scheduledRetry"] | null;
   recoveryAction: Issue["activeRecoveryAction"];
-  onResolveRecoveryAction?: (outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome) => void;
+  onResolveRecoveryAction?: (outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome) => Promise<void> | void;
   recoveryActionPending?: boolean;
   onReissueIsolatedRecoveryAction?: (request: import("../components/IssueRecoveryActionCard").RecoveryReissueRequest) => void;
   reissueIsolatedRecoveryActionPending?: boolean;
@@ -4068,25 +4068,29 @@ export function IssueDetail() {
   }, [updateIssue.mutateAsync]);
   const activeRecoveryActionId = issue?.activeRecoveryAction?.id;
   const handleResolveRecoveryAction = useCallback(
-    (outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome) => {
+    async (outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome) => {
       const actionId = activeRecoveryActionId;
       if (!actionId) return;
-      switch (outcome) {
-        case "todo":
-          void resolveRecoveryAction.mutateAsync({ actionId, outcome: "restored", sourceIssueStatus: "todo" });
-          return;
-        case "done":
-          void resolveRecoveryAction.mutateAsync({ actionId, outcome: "restored", sourceIssueStatus: "done" });
-          return;
-        case "in_review":
-          void resolveRecoveryAction.mutateAsync({ actionId, outcome: "restored", sourceIssueStatus: "in_review" });
-          return;
-        case "false_positive_done":
-          void resolveRecoveryAction.mutateAsync({ actionId, outcome: "false_positive", sourceIssueStatus: "done" });
-          return;
-        case "false_positive_in_review":
-          void resolveRecoveryAction.mutateAsync({ actionId, outcome: "false_positive", sourceIssueStatus: "in_review" });
-          return;
+      try {
+        switch (outcome) {
+          case "todo":
+            await resolveRecoveryAction.mutateAsync({ actionId, outcome: "restored", sourceIssueStatus: "todo" });
+            return;
+          case "done":
+            await resolveRecoveryAction.mutateAsync({ actionId, outcome: "restored", sourceIssueStatus: "done" });
+            return;
+          case "in_review":
+            await resolveRecoveryAction.mutateAsync({ actionId, outcome: "restored", sourceIssueStatus: "in_review" });
+            return;
+          case "false_positive_done":
+            await resolveRecoveryAction.mutateAsync({ actionId, outcome: "false_positive", sourceIssueStatus: "done" });
+            return;
+          case "false_positive_in_review":
+            await resolveRecoveryAction.mutateAsync({ actionId, outcome: "false_positive", sourceIssueStatus: "in_review" });
+            return;
+        }
+      } catch {
+        // The mutation's onError handler surfaces the failure.
       }
     },
     [activeRecoveryActionId, resolveRecoveryAction.mutateAsync],


### PR DESCRIPTION
## Thinking Path

> - Paperclip helps operators manage work done by AI agents.
> - The task chat shows system notices for recovery events.
> - A stranded task notice starts in a folded state.
> - The folded notice did not expose the recovery action.
> - Operators had to open the classic task view and use its recovery menu.
> - This pull request adds the same recovery action to the folded and expanded chat notice.
> - The benefit is that operators can restart the task from the view where they see the failure.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The new task chat folds recovery system notices by default. This change improves the action path for a stranded assigned task.

**Subsystem affected**

ui/ — React and Vite board UI.

**Current behavior**

The notice explains that a task has no live execution path. The new task view does not show the available recovery action. The operator must use the classic task view.

**Proposed behavior**

Show a Try again button next to the matching recovery notice. Keep the button visible when the notice is folded and when it is expanded. Use the existing recovery-action API path to return the task to todo.

**Reason and benefit**

The action appears with the failure that it resolves. The operator can restart work without changing views or finding a separate menu.

**Breaking changes**

None. The change reuses the existing recovery action and does not change an API or data contract.

**Additional context**

Related recovery context: #8458.

## What Changed

- Added a Try again action beside stranded-task system notices in the task chat.
- Matched the active recovery action to its system notice so stale notices stay inactive.
- Kept the action outside the disclosure content so it stays visible in both notice states.
- Prevented pending and same-frame repeated clicks from sending duplicate recovery requests.
- Added regression tests for folded, expanded, stale-notice, pending, and rapid-click behavior.

## Verification

- `pnpm exec vitest run ui/src/components/TaskChatThread.test.tsx` — 19 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:token-gates` — all token gates passed.
- GitHub CI — all latest-head checks passed. The Storybook visual job was intentionally skipped by its path filter.
- Greptile — 5/5 with zero unresolved threads.

## Risks

- Low risk. The action only renders for the active stranded-assigned recovery action and its matching system notice.
- A malformed notice without the recovery action identifier does not show the button.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5. The runtime does not expose a more specific model ID, context-window size, or reasoning mode. The model used tool calls and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge