### PR TITLE
fix(worktrees): quarantine cloned runtime services

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -11,11 +11,14 @@ import {
   authUsers,
   companies,
   createDb,
+  executionWorkspaces,
   issueComments,
   issues,
+  projectWorkspaces,
   projects,
   routines,
   routineTriggers,
+  workspaceRuntimeServices,
 } from "@paperclipai/db";
 import {
   copyGitHooksToWorktreeGitDir,
@@ -434,6 +437,9 @@ describe("worktree helpers", () => {
           quarantinedInProgressIssues: 1,
           unassignedTodoIssues: 1,
           unassignedReviewIssues: 1,
+          stoppedProjectWorkspaceRuntimes: 0,
+          stoppedExecutionWorkspaceRuntimes: 0,
+          stoppedRuntimeServices: 0,
         },
         reboundWorkspaces: [],
       });
@@ -540,6 +546,9 @@ describe("worktree helpers", () => {
             quarantinedInProgressIssues: 0,
             unassignedTodoIssues: 0,
             unassignedReviewIssues: 0,
+            stoppedProjectWorkspaceRuntimes: 0,
+            stoppedExecutionWorkspaceRuntimes: 0,
+            stoppedRuntimeServices: 0,
           },
           reboundWorkspaces: [],
         };
@@ -599,6 +608,10 @@ describe("worktree helpers", () => {
     const todoIssueId = randomUUID();
     const reviewIssueId = randomUUID();
     const userIssueId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const runtimeServiceId = randomUUID();
 
     try {
       await db.insert(companies).values({
@@ -634,6 +647,64 @@ describe("worktree helpers", () => {
           permissions: {},
         },
       ]);
+      await db.insert(projects).values({
+        id: projectId,
+        companyId,
+        name: "Runtime quarantine",
+        status: "in_progress",
+      });
+      await db.insert(projectWorkspaces).values({
+        id: projectWorkspaceId,
+        companyId,
+        projectId,
+        name: "Primary workspace",
+        cwd: "/source/project",
+        metadata: {
+          keep: "project-metadata",
+          runtimeConfig: {
+            workspaceRuntime: { services: [{ name: "paperclip-dev" }] },
+            desiredState: "running",
+            serviceStates: { "0": "running", "1": "manual" },
+          },
+        },
+      });
+      await db.insert(executionWorkspaces).values({
+        id: executionWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "Copied runtime workspace",
+        cwd: "/source/worktree",
+        providerType: "git_worktree",
+        metadata: {
+          keep: "execution-metadata",
+          config: {
+            environmentId: "environment-1",
+            desiredState: "running",
+            serviceStates: { "0": "running" },
+          },
+        },
+      });
+      await db.insert(workspaceRuntimeServices).values({
+        id: runtimeServiceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        executionWorkspaceId,
+        scopeType: "project_workspace",
+        scopeId: projectWorkspaceId,
+        serviceName: "paperclip-dev",
+        status: "running",
+        lifecycle: "shared",
+        provider: "local_process",
+        providerRef: "12345",
+        ownerAgentId: agentId,
+        port: 42013,
+        url: "https://paperclip-dev.example.test:42013",
+        healthStatus: "healthy",
+      });
       await db.insert(issues).values([
         {
           id: inProgressIssueId,
@@ -685,6 +756,9 @@ describe("worktree helpers", () => {
         quarantinedInProgressIssues: 1,
         unassignedTodoIssues: 1,
         unassignedReviewIssues: 1,
+        stoppedProjectWorkspaceRuntimes: 1,
+        stoppedExecutionWorkspaceRuntimes: 1,
+        stoppedRuntimeServices: 1,
       });
 
       const [quarantinedAgent] = await db.select().from(agents).where(eq(agents.id, agentId));
@@ -715,6 +789,47 @@ describe("worktree helpers", () => {
       const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, inProgressIssueId));
       expect(comments).toHaveLength(1);
       expect(comments[0]?.body).toContain("Quarantined during worktree seed");
+
+      const [projectWorkspace] = await db
+        .select()
+        .from(projectWorkspaces)
+        .where(eq(projectWorkspaces.id, projectWorkspaceId));
+      expect(projectWorkspace?.metadata).toEqual({
+        keep: "project-metadata",
+        runtimeConfig: {
+          workspaceRuntime: { services: [{ name: "paperclip-dev" }] },
+          desiredState: "stopped",
+          serviceStates: { "0": "stopped", "1": "manual" },
+        },
+      });
+
+      const [executionWorkspace] = await db
+        .select()
+        .from(executionWorkspaces)
+        .where(eq(executionWorkspaces.id, executionWorkspaceId));
+      expect(executionWorkspace?.metadata).toEqual({
+        keep: "execution-metadata",
+        config: {
+          environmentId: "environment-1",
+          desiredState: "stopped",
+          serviceStates: { "0": "stopped" },
+        },
+      });
+
+      const [runtimeService] = await db
+        .select()
+        .from(workspaceRuntimeServices)
+        .where(eq(workspaceRuntimeServices.id, runtimeServiceId));
+      expect(runtimeService).toMatchObject({
+        status: "stopped",
+        healthStatus: "unknown",
+        providerRef: null,
+        ownerAgentId: null,
+        startedByRunId: null,
+        port: null,
+        url: null,
+      });
+      expect(runtimeService?.stoppedAt).toBeInstanceOf(Date);
     } finally {
       await db.$client?.end?.({ timeout: 5 }).catch(() => undefined);
       await tempDb.cleanup();

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -30,6 +30,7 @@ import {
   documentRevisions,
   documents,
   ensurePostgresDatabase,
+  executionWorkspaces,
   formatDatabaseBackupResult,
   goals,
   heartbeatRuns,
@@ -45,6 +46,7 @@ import {
   runDatabaseBackup,
   runDatabaseRestore,
   resetPostgresDatabase,
+  workspaceRuntimeServices,
   createEmbeddedPostgresLogBuffer,
   formatEmbeddedPostgresError,
   prepareEmbeddedPostgresNativeRuntime,
@@ -233,6 +235,9 @@ export type SeededWorktreeExecutionQuarantineSummary = {
   quarantinedInProgressIssues: number;
   unassignedTodoIssues: number;
   unassignedReviewIssues: number;
+  stoppedProjectWorkspaceRuntimes: number;
+  stoppedExecutionWorkspaceRuntimes: number;
+  stoppedRuntimeServices: number;
 };
 
 function nonEmpty(value: string | null | undefined): string | null {
@@ -256,6 +261,9 @@ function formatSeededWorktreeExecutionQuarantineSummary(
     `quarantined in-progress issues: ${summary.quarantinedInProgressIssues}`,
     `unassigned todo issues: ${summary.unassignedTodoIssues}`,
     `unassigned review issues: ${summary.unassignedReviewIssues}`,
+    `stopped project workspace runtimes: ${summary.stoppedProjectWorkspaceRuntimes}`,
+    `stopped execution workspace runtimes: ${summary.stoppedExecutionWorkspaceRuntimes}`,
+    `stopped runtime services: ${summary.stoppedRuntimeServices}`,
   ].join(", ");
 }
 
@@ -1187,6 +1195,9 @@ const EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY: SeededWorktreeExecutio
   quarantinedInProgressIssues: 0,
   unassignedTodoIssues: 0,
   unassignedReviewIssues: 0,
+  stoppedProjectWorkspaceRuntimes: 0,
+  stoppedExecutionWorkspaceRuntimes: 0,
+  stoppedRuntimeServices: 0,
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1216,6 +1227,36 @@ function normalizeWorktreeRuntimeConfig(runtimeConfig: unknown): {
   }
 
   return { runtimeConfig: nextRuntimeConfig, disabledTimerHeartbeat: false, changed: false };
+}
+
+function stopSeededWorkspaceRuntime(
+  metadata: unknown,
+  configKey: "config" | "runtimeConfig",
+): { metadata: Record<string, unknown>; changed: boolean } {
+  const nextMetadata = isRecord(metadata) ? { ...metadata } : {};
+  const currentConfig = isRecord(nextMetadata[configKey])
+    ? { ...(nextMetadata[configKey] as Record<string, unknown>) }
+    : null;
+  if (!currentConfig) return { metadata: nextMetadata, changed: false };
+
+  let changed = false;
+  if (currentConfig.desiredState === "running") {
+    currentConfig.desiredState = "stopped";
+    changed = true;
+  }
+
+  if (isRecord(currentConfig.serviceStates)) {
+    const nextServiceStates = { ...currentConfig.serviceStates };
+    for (const [serviceIndex, state] of Object.entries(nextServiceStates)) {
+      if (state !== "running") continue;
+      nextServiceStates[serviceIndex] = "stopped";
+      changed = true;
+    }
+    if (changed) currentConfig.serviceStates = nextServiceStates;
+  }
+
+  if (changed) nextMetadata[configKey] = currentConfig;
+  return { metadata: nextMetadata, changed };
 }
 
 export async function quarantineSeededWorktreeExecutionState(
@@ -1300,6 +1341,50 @@ export async function quarantineSeededWorktreeExecutionState(
           summary.unassignedReviewIssues += 1;
         }
       }
+
+      const seededProjectWorkspaces = await tx
+        .select({ id: projectWorkspaces.id, metadata: projectWorkspaces.metadata })
+        .from(projectWorkspaces);
+      for (const workspace of seededProjectWorkspaces) {
+        const stopped = stopSeededWorkspaceRuntime(workspace.metadata, "runtimeConfig");
+        if (!stopped.changed) continue;
+        await tx
+          .update(projectWorkspaces)
+          .set({ metadata: stopped.metadata, updatedAt: new Date() })
+          .where(eq(projectWorkspaces.id, workspace.id));
+        summary.stoppedProjectWorkspaceRuntimes += 1;
+      }
+
+      const seededExecutionWorkspaces = await tx
+        .select({ id: executionWorkspaces.id, metadata: executionWorkspaces.metadata })
+        .from(executionWorkspaces);
+      for (const workspace of seededExecutionWorkspaces) {
+        const stopped = stopSeededWorkspaceRuntime(workspace.metadata, "config");
+        if (!stopped.changed) continue;
+        await tx
+          .update(executionWorkspaces)
+          .set({ metadata: stopped.metadata, updatedAt: new Date() })
+          .where(eq(executionWorkspaces.id, workspace.id));
+        summary.stoppedExecutionWorkspaceRuntimes += 1;
+      }
+
+      const now = new Date();
+      const stoppedRuntimeServices = await tx
+        .update(workspaceRuntimeServices)
+        .set({
+          status: "stopped",
+          healthStatus: "unknown",
+          providerRef: null,
+          ownerAgentId: null,
+          startedByRunId: null,
+          port: null,
+          url: null,
+          stoppedAt: now,
+          lastUsedAt: now,
+          updatedAt: now,
+        })
+        .returning({ id: workspaceRuntimeServices.id });
+      summary.stoppedRuntimeServices = stoppedRuntimeServices.length;
     });
 
     return summary;
@@ -3593,7 +3678,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Do not quarantine copied agent work or workspace runtime services in the seeded worktree", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeMakeCommand);
@@ -3610,7 +3695,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--server-port <port>", "Preferred server port", (value) => Number(value))
     .option("--db-port <port>", "Preferred embedded Postgres port", (value) => Number(value))
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Do not quarantine copied agent work or workspace runtime services in the seeded worktree", false)
     .option("--no-seed", "Skip database seeding from the source instance")
     .option("--force", "Replace existing repo-local config and isolated instance data", false)
     .action(worktreeInitCommand);
@@ -3629,7 +3714,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-config <path>", "Source config.json to seed from (defaults to the seed-pending marker)")
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues", false)
+    .option("--preserve-live-work", "Do not quarantine copied agent work or workspace runtime services", false)
     .action(worktreeEnsureSeededCommand);
 
   program
@@ -3660,7 +3745,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config")
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: full)", "full")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Do not quarantine copied agent work or workspace runtime services in the seeded worktree", false)
     .option("--yes", "Skip the destructive confirmation prompt", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeReseedCommand);
@@ -3674,7 +3759,7 @@ export function registerWorktreeCommands(program: Command): void {
     .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
     .option("--from-instance <id>", "Source instance id when deriving the source config (default: default)")
     .option("--seed-mode <mode>", "Seed profile: minimal or full (default: minimal)", "minimal")
-    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues in the seeded worktree", false)
+    .option("--preserve-live-work", "Do not quarantine copied agent work or workspace runtime services in the seeded worktree", false)
     .option("--no-seed", "Repair metadata only and skip reseeding when bootstrapping a missing worktree config", false)
     .option("--allow-live-target", "Override the guard that requires the target worktree DB to be stopped first", false)
     .action(worktreeRepairCommand);

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -469,6 +469,8 @@ Seed modes:
 
 Seeded worktree instances quarantine copied live execution by default for both `minimal` and `full` seeds. During restore, Paperclip disables copied agent timer heartbeats, resets copied `running` agents to `idle`, blocks and unassigns copied agent-owned `in_progress` issues, and unassigns copied agent-owned `todo`/`in_review` issues. This keeps a freshly booted worktree from starting agents for work already owned by the source instance. Pass `--preserve-live-work` only when you intentionally want the isolated worktree to resume copied assignments.
 
+The same quarantine stops copied project/execution-workspace runtime desired states and clears copied runtime process claims. Without this reset, booting the cloned Paperclip database could restart a source workspace's dev service from the isolated instance, creating duplicate runners, port reassignment, and stale public URLs.
+
 After `worktree init`, both the server and the CLI auto-load the repo-local `.paperclip/.env` when run inside that worktree, so normal commands like `pnpm dev`, `paperclipai doctor`, and `paperclipai db:backup` stay scoped to the worktree instance.
 
 `pnpm dev` now fails fast in a linked git worktree when `.paperclip/.env` is missing, instead of silently booting against the default instance/port. If that happens, run `paperclipai worktree init` in the worktree first.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip can create a worktree and seed it with data from another instance.
> - A full seed copied active runtime state and live process claims into the new database.
> - The copied state could make the new instance restart or adopt services that belong to the source instance.
> - A stale process identifier, port, or URL could then make the worktree page fail to load after a restart.
> - This pull request makes cloned runtime state inactive before the new instance starts.
> - The benefit is that each instance starts with clear service ownership and no stale live claims.

## Linked Issues or Issue Description

- [x] I searched open and closed issues and pull requests. I found no duplicate report.

**What happened?**

`paperclipai worktree init --full` copied project and execution workspace runtime records without changing their active state. The new database could contain `running` desired state, `running` service state, and provider references that identify processes from the source instance. After a host restart, the cloned instance could try to recover services that it did not own. The browser then showed a load failure at a stale or moved service URL.

**Expected behavior**

A cloned database must not claim that source-instance runtime processes are live. Project and execution workspace services must start as stopped in the clone. An operator can start them explicitly after the clone is ready.

**Steps to reproduce**

1. Start a managed worktree runtime in a source Paperclip instance.
2. Create a full worktree seed from that instance.
3. Start Paperclip with the seeded database.
4. Observe that the copied database can retain active desired state and live process, port, and URL claims.

**Paperclip version or commit**

Reproduced on `master` at `d1cd9c37f4`.

**Deployment mode**

Local development with managed worktree services.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

Not adapter-specific. This is a core worktree seed bug.

**Database mode**

External PostgreSQL source data copied into the isolated worktree database.

**Access context**

Board operator.

**Privacy checklist**

I reviewed this description and removed private instance URLs, internal task identifiers, credentials, and user paths.

## What Changed

- Stop cloned project and execution workspace runtime desired state during a full or minimal seed.
- Change copied service states from `running` to `stopped`.
- Clear copied process, provider, port, URL, owner, and starter claims.
- Keep unrelated runtime metadata intact.
- Add regression tests for project services, execution workspace services, unrelated metadata, and the live-work preservation option.
- Document runtime quarantine in the worktree development guide.

## Verification

- `pnpm exec vitest run cli/src/__tests__/worktree.test.ts` passes 43 tests.
- `pnpm -r typecheck` passes.
- `pnpm build` passes.
- `pnpm test:run` passes 4,304 tests. One unrelated timing test timed out during the loaded run and passed alone. Ten unrelated exposure tests could not use their fixed ports because host Tailscale listeners already owned ports 42000 and 52000.
- A managed worktree restart completes with a healthy source runtime and one authoritative service owner.
- An authenticated clone inspection shows the copied runtime as stopped with no live provider, process, port, or URL claim.

## Risks

- A cloned service no longer starts only because the source service was running. An operator must start the cloned service explicitly. This is the intended ownership boundary.
- `--preserve-live-work` keeps the old behavior for operators who explicitly request live runtime state.
- The change does not alter schema or source-instance runtime records.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5. The runtime does not expose a more specific deployment ID or context-window size. The model used high-reasoning mode, repository tools, code execution, and GitHub review tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
