### PR TITLE
feat: add least-privilege agent invocation permission

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -90,6 +90,14 @@ Role-based human permission granularity is V1 — see the `humans-and-permission
 plan, the `principal_permission_grants` table, and the `PERMISSION_KEYS` set
 in `packages/shared/src/constants.ts`.
 
+Agent invocation uses a separate least-privilege permission. Board callers of
+`POST /api/agents/:id/wakeup` require the company-scoped `agents:invoke` grant;
+the grant does not authorize agent creation, configuration, login, or any other
+management action. An authenticated agent may invoke only itself. Cross-company
+targets retain the normal non-enumerating `404` boundary. The legacy
+`POST /api/agents/:id/heartbeat/invoke` endpoint keeps its historical
+`agents:create` authorization contract for compatibility.
+
 ## 6. Architecture
 
 ## 6.1 Runtime Components

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -996,6 +996,7 @@ export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
   "agents:create",
+  "agents:invoke",
   "agents:configure",
   "agents:suggest-changes",
   "skills:create",

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -83,6 +83,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getRun: vi.fn(),
   cancelRun: vi.fn(),
   cancelInvocationsForAgents: vi.fn(),
+  wakeup: vi.fn(),
 }));
 
 const mockIssueApprovalService = vi.hoisted(() => ({
@@ -333,6 +334,7 @@ describe.sequential("agent permission routes", () => {
     mockHeartbeatService.getRun.mockReset();
     mockHeartbeatService.cancelRun.mockReset();
     mockHeartbeatService.cancelInvocationsForAgents.mockReset();
+    mockHeartbeatService.wakeup.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
     mockIssueService.list.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
@@ -408,6 +410,14 @@ describe.sequential("agent permission routes", () => {
     mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(async (_companyId, config) => ({ config }));
     mockInstanceSettingsService.getGeneral.mockResolvedValue({
       censorUsernameInLogs: false,
+    });
+    mockHeartbeatService.wakeup.mockResolvedValue({
+      id: "run-1",
+      companyId,
+      agentId,
+      status: "queued",
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
     });
     mockLogActivity.mockResolvedValue(undefined);
   });
@@ -540,8 +550,12 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(403);
   });
 
-  it("blocks wakeups for authenticated company members without agent admin permission", async () => {
-    mockAccessService.canUser.mockResolvedValue(false);
+  it("blocks board wakeups without agents:invoke", async () => {
+    mockAccessService.decide.mockResolvedValue({
+      allowed: false,
+      reason: "deny_missing_grant",
+      explanation: "Missing permission: agents:invoke.",
+    });
 
     const app = await createApp({
       type: "board",
@@ -556,6 +570,138 @@ describe.sequential("agent permission routes", () => {
       .send({}));
 
     expect(res.status).toBe(403);
+    expect(res.body.error).toContain("agents:invoke");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "agents:invoke",
+      resource: { type: "company", companyId },
+    }));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("allows board wakeups with agents:invoke without agents:create", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: input.action === "agents:invoke",
+      reason: input.action === "agents:invoke" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "agents:invoke"
+        ? "Allowed by explicit grant agents:invoke."
+        : `Missing permission: ${input.action}.`,
+    }));
+
+    const app = await createApp({
+      type: "board",
+      userId: "dispatcher-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${agentId}/wakeup`)
+      .send({ source: "automation", reason: "dispatch_stage" }));
+
+    expect(res.status).toBe(202);
+    expect(mockAccessService.decide).toHaveBeenCalledTimes(1);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "agents:invoke",
+    }));
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(agentId, expect.objectContaining({
+      source: "automation",
+      reason: "dispatch_stage",
+      requestedByActorType: "user",
+      requestedByActorId: "dispatcher-user",
+    }));
+  });
+
+  it("keeps the legacy heartbeat invoke route on agents:create", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: input.action === "agents:create",
+      reason: input.action === "agents:create" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "agents:create"
+        ? "Allowed by explicit grant agents:create."
+        : `Missing permission: ${input.action}.`,
+    }));
+
+    const app = await createApp({
+      type: "board",
+      userId: "legacy-admin",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${agentId}/heartbeat/invoke`)
+      .send({}));
+
+    expect(res.status).toBe(202);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "agents:create",
+    }));
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({
+      action: "agents:invoke",
+    }));
+  });
+
+  it("allows an agent to wake only itself without agents:invoke", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${agentId}/wakeup`)
+      .send({ source: "on_demand" }));
+
+    expect(res.status).toBe(202);
+    expect(mockAccessService.decide).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(agentId, expect.objectContaining({
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    }));
+  });
+
+  it("blocks an agent from waking another agent", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${agentId}/wakeup`)
+      .send({ source: "on_demand" }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Agent can only invoke itself");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("hides cross-company wakeup targets before permission evaluation", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      companyId: "44444444-4444-4444-8444-444444444444",
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "dispatcher-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${agentId}/wakeup`)
+      .send({ source: "automation" }));
+
+    expect(res.status).toBe(404);
+    expect(mockAccessService.decide).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("blocks agent-authenticated self-updates that set host-executed workspace commands", async () => {

--- a/server/src/__tests__/invite-join-grants.test.ts
+++ b/server/src/__tests__/invite-join-grants.test.ts
@@ -68,6 +68,7 @@ describe("human invite roles", () => {
   it("maps owner to the full management grant set", () => {
     expect(grantsForHumanRole("owner")).toEqual([
       { permissionKey: "agents:create", scope: null },
+      { permissionKey: "agents:invoke", scope: null },
       { permissionKey: "agents:configure", scope: null },
       { permissionKey: "skills:create", scope: null },
       { permissionKey: "environments:manage", scope: null },
@@ -81,6 +82,7 @@ describe("human invite roles", () => {
   it("maps admin to management grants including environment management", () => {
     expect(grantsForHumanRole("admin")).toEqual([
       { permissionKey: "agents:create", scope: null },
+      { permissionKey: "agents:invoke", scope: null },
       { permissionKey: "agents:configure", scope: null },
       { permissionKey: "skills:create", scope: null },
       { permissionKey: "environments:manage", scope: null },

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1137,6 +1137,18 @@ export function agentRoutes(
     throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
   }
 
+  async function assertBoardCanInvokeAgentsForCompany(req: Request, companyId: string) {
+    assertBoard(req);
+    assertCompanyAccess(req, companyId);
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "agents:invoke",
+      resource: { type: "company", companyId },
+    });
+    if (decision.allowed) return;
+    throw forbidden(decision.explanation, authorizationDeniedDetails(decision));
+  }
+
   // The single owner-authorization helper for the three adapter login routes. It
   // requires a board actor, company access, and the same configuration
   // permission as the adapter Test route (`agents:create`). It returns the
@@ -4258,7 +4270,7 @@ export function agentRoutes(
         return;
       }
     } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
+      await assertBoardCanInvokeAgentsForCompany(req, agent.companyId);
     }
     if (agent.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2058,11 +2058,12 @@ registry.registerPath({
   path: "/api/agents/{id}/wakeup",
   tags: ["agents"],
   summary: "Wake up an agent",
+  description: "Board callers require the company-scoped `agents:invoke` permission. An agent may invoke only itself.",
   request: {
     params: z.object({ id: z.string() }),
     body: jsonBody(wakeAgentSchema),
   },
-  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+  responses: { 202: r.ok(), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
 });
 
 registry.registerPath({

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -28,6 +28,7 @@ export function grantsForHumanRole(
     case "owner":
       return [
         { permissionKey: "agents:create", scope: null },
+        { permissionKey: "agents:invoke", scope: null },
         { permissionKey: "agents:configure", scope: null },
         { permissionKey: "skills:create", scope: null },
         { permissionKey: "environments:manage", scope: null },
@@ -39,6 +40,7 @@ export function grantsForHumanRole(
     case "admin":
       return [
         { permissionKey: "agents:create", scope: null },
+        { permissionKey: "agents:invoke", scope: null },
         { permissionKey: "agents:configure", scope: null },
         { permissionKey: "skills:create", scope: null },
         { permissionKey: "environments:manage", scope: null },


### PR DESCRIPTION
## Summary

- add a company-scoped `agents:invoke` permission
- require it for board calls to `POST /api/agents/:id/wakeup`
- keep agent self-invocation and the legacy `/heartbeat/invoke` compatibility contract unchanged
- backfill the permission for existing owner/admin roles through the existing role-default grant sync
- document the least-privilege boundary and expose it in OpenAPI

## Why

The modern wakeup route reused `agents:create`, so an invoke-only dispatcher had to receive agent-creation authority. This prevented a least-privilege automation identity from waking an existing agent without also gaining unrelated management capability.

## Impact

Board callers can now be granted wakeup authority without permission to create or configure agents. Cross-company targets remain non-enumerating `404`s, and authenticated agents can still invoke only themselves.

## Validation

- `vitest` targeted route and role suite: 68 passed
- `vitest` access and OpenAPI suite: 14 passed
- `@paperclipai/shared` TypeScript check passed
- `@paperclipai/server` TypeScript check passed
- `git diff --check` passed