### PR TITLE
fix(tools): apply issue-scoped profiles to runtime MCP

### DIFF
--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -348,7 +348,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       transport: "local_stdio",
       status: "active",
       enabled: true,
-      config: { templateId: stdioTemplateKey },
+      config: { templateId: ` ${stdioTemplateKey} ` },
     }).returning();
     const [profile] = await db.insert(toolProfiles).values({
       companyId: company!.id,

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -16,6 +16,7 @@ import {
   toolProfileBindings,
   toolProfileEntries,
   toolProfiles,
+  toolStdioCommandTemplates,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -48,6 +49,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     await db.delete(toolProfileBindings);
     await db.delete(toolProfileEntries);
     await db.delete(toolProfiles);
+    await db.delete(toolStdioCommandTemplates);
     await db.delete(toolConnections);
     await db.delete(toolApplications);
     await db.delete(agents);
@@ -78,7 +80,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       type: "mcp_http",
       status: "active",
     }).returning();
-    const [installedConnection, uninstalledConnection] = await db.insert(toolConnections).values([
+    const [installedConnection, unpermittedConnection] = await db.insert(toolConnections).values([
       {
         companyId: company!.id,
         applicationId: application!.id,
@@ -92,7 +94,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       {
         companyId: company!.id,
         applicationId: application!.id,
-        name: "Uninstalled MCP",
+        name: "Unpermitted MCP",
         uid: `test/${randomUUID()}`,
         transport: "mcp_remote",
         status: "active",
@@ -138,7 +140,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
       token: expect.stringMatching(/^pcgw_/),
     });
-    expect(first.some((server) => server.connectionId === uninstalledConnection!.id)).toBe(false);
+    expect(first.some((server) => server.connectionId === unpermittedConnection!.id)).toBe(false);
     expect(second).toHaveLength(1);
 
     const gateways = await db.select().from(toolMcpGateways);
@@ -184,6 +186,23 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       enabled: true,
       config: { url: "https://zapier.example.test/mcp" },
     }).returning();
+    const [stdioApplication] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `runtime-diagnostic-stdio-${randomUUID().slice(0, 8)}`,
+      name: "Local stdio",
+      type: "mcp_stdio",
+      status: "active",
+    }).returning();
+    const [stdioConnection] = await db.insert(toolConnections).values({
+      companyId: company!.id,
+      applicationId: stdioApplication!.id,
+      name: "Local stdio",
+      uid: `test/${randomUUID()}`,
+      transport: "local_stdio",
+      status: "active",
+      enabled: true,
+      config: { templateId: "local.uninstalled" },
+    }).returning();
     const [profile] = await db.insert(toolProfiles).values({
       companyId: company!.id,
       profileKey: `app:${connection!.id}`,
@@ -201,6 +220,26 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     await db.insert(toolProfileBindings).values({
       companyId: company!.id,
       profileId: profile!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    const [stdioProfile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${stdioConnection!.id}`,
+      name: "Local stdio",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
+      selectorType: "connection",
+      effect: "include",
+      applicationId: stdioApplication!.id,
+      connectionId: stdioConnection!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
       targetType: "agent",
       targetId: agent!.id,
     });
@@ -227,8 +266,11 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       details: expect.objectContaining({
         reasonCode: "permitted_connections_not_installed",
         deliveredServerCount: 0,
-        permittedNotInstalledCount: 1,
-        permittedNotInstalledConnections: [{ id: connection!.id, name: "Zapier" }],
+        permittedNotInstalledCount: 2,
+        permittedNotInstalledConnections: [
+          { id: stdioConnection!.id, name: "Local stdio" },
+          { id: connection!.id, name: "Zapier" },
+        ],
       }),
     });
     const [audit] = await db.select().from(toolAccessAuditEvents);
@@ -268,7 +310,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       type: "mcp_stdio",
       status: "active",
     }).returning();
-    const [installedConnection, uninstalledConnection] = await db.insert(toolConnections).values([
+    const [installedConnection, unpermittedConnection] = await db.insert(toolConnections).values([
       {
         companyId: company!.id,
         applicationId: application!.id,
@@ -282,7 +324,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       {
         companyId: company!.id,
         applicationId: application!.id,
-        name: "Uninstalled MCP",
+        name: "Unpermitted MCP",
         uid: `test/${randomUUID()}`,
         transport: "mcp_remote",
         status: "active",
@@ -290,6 +332,14 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
         config: { url: "https://uninstalled.example.test/mcp" },
       },
     ]).returning();
+    const stdioTemplateKey = `test.${randomUUID()}`;
+    await db.insert(toolStdioCommandTemplates).values({
+      companyId: company!.id,
+      templateKey: stdioTemplateKey,
+      name: "Installed stdio MCP",
+      command: "node",
+      args: ["server.js"],
+    });
     const [stdioConnection] = await db.insert(toolConnections).values({
       companyId: company!.id,
       applicationId: stdioApplication!.id,
@@ -298,7 +348,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       transport: "local_stdio",
       status: "active",
       enabled: true,
-      config: { templateId: randomUUID() },
+      config: { templateId: stdioTemplateKey },
     }).returning();
     const [profile] = await db.insert(toolProfiles).values({
       companyId: company!.id,
@@ -370,7 +420,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
       token: expect.stringMatching(/^pcgw_/),
     }));
-    expect(first.some((server) => server.connectionId === uninstalledConnection!.id)).toBe(false);
+    expect(first.some((server) => server.connectionId === unpermittedConnection!.id)).toBe(false);
     expect(second).toHaveLength(2);
 
     const gateways = await db.select().from(toolMcpGateways);
@@ -388,6 +438,14 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       expect(token.expiresAt!.getTime()).toBeLessThanOrEqual(Date.now() + 61 * 60 * 1000);
     }
     expect(JSON.stringify(tokens)).not.toContain(first[0]!.token);
+
+    await db
+      .update(toolStdioCommandTemplates)
+      .set({ status: "disabled", disabledAt: new Date() })
+      .where(eq(toolStdioCommandTemplates.templateKey, stdioTemplateKey));
+    const afterDisable = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
+    expect(afterDisable).toHaveLength(1);
+    expect(afterDisable[0]).toMatchObject({ connectionId: installedConnection!.id });
   });
 
 });

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -7,8 +7,11 @@ import {
   companies,
   createDb,
   heartbeatRuns,
+  issues,
+  projects,
   toolAccessAuditEvents,
   toolApplications,
+  toolCatalogEntries,
   toolConnectionInstalls,
   toolConnections,
   toolMcpGateways,
@@ -26,6 +29,148 @@ import { buildPaperclipRuntimeMcpServers } from "../services/heartbeat.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function createScopedRuntimeFixture(input: {
+  db: ReturnType<typeof createDb>;
+  broadTargetType: "agent" | "company";
+  exactTargetType: "issue" | "project";
+}) {
+  const { db } = input;
+  const [company] = await db.insert(companies).values({
+    name: `Scoped runtime MCP ${randomUUID()}`,
+    issuePrefix: `SR${randomUUID().slice(0, 5).toUpperCase()}`,
+  }).returning();
+  const [agent] = await db.insert(agents).values({
+    companyId: company!.id,
+    name: "Scoped Runtime MCP Agent",
+    role: "engineer",
+    adapterType: "codex_local",
+    adapterConfig: {},
+  }).returning();
+  const [project] = await db.insert(projects).values({
+    companyId: company!.id,
+    name: `Scoped runtime project ${randomUUID()}`,
+  }).returning();
+  const [issue] = await db.insert(issues).values({
+    companyId: company!.id,
+    projectId: project!.id,
+    title: "GOB-70 exact runtime allowlist",
+    status: "todo",
+  }).returning();
+
+  const toolNames = [
+    "workflow_status_remote",
+    "workflow_status_local",
+    "get_profiles",
+    "get_brand_colors",
+    "get_me",
+    "broad_extra_tool",
+  ] as const;
+  const connections: Array<typeof toolConnections.$inferSelect> = [];
+  const catalogEntries: Array<typeof toolCatalogEntries.$inferSelect> = [];
+
+  for (const [index, toolName] of toolNames.entries()) {
+    const localStdio = index === 1;
+    const templateKey = `test.scoped-runtime.${randomUUID()}`;
+    if (localStdio) {
+      await db.insert(toolStdioCommandTemplates).values({
+        companyId: company!.id,
+        templateKey,
+        name: "Scoped runtime local stdio",
+        command: "node",
+        args: ["server.js"],
+      });
+    }
+    const [application] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `scoped-runtime-${index}-${randomUUID().slice(0, 8)}`,
+      name: `Scoped runtime app ${index + 1}`,
+      type: localStdio ? "mcp_stdio" : "mcp_http",
+      status: "active",
+    }).returning();
+    const [connection] = await db.insert(toolConnections).values({
+      companyId: company!.id,
+      applicationId: application!.id,
+      name: `Scoped runtime connection ${index + 1}`,
+      uid: `test/${randomUUID()}`,
+      transport: localStdio ? "local_stdio" : "mcp_remote",
+      status: "active",
+      enabled: true,
+      config: localStdio
+        ? { templateId: templateKey }
+        : { url: `https://scoped-${index + 1}.example.test/mcp` },
+    }).returning();
+    const [catalogEntry] = await db.insert(toolCatalogEntries).values({
+      companyId: company!.id,
+      applicationId: application!.id,
+      connectionId: connection!.id,
+      name: toolName,
+      toolName,
+      riskLevel: "read",
+      versionHash: randomUUID(),
+      schemaHash: randomUUID(),
+    }).returning();
+    const [broadProfile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${connection!.id}`,
+      name: `Broad app profile ${index + 1}`,
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: broadProfile!.id,
+      selectorType: "catalog_entry",
+      effect: "include",
+      applicationId: application!.id,
+      connectionId: connection!.id,
+      catalogEntryId: catalogEntry!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: broadProfile!.id,
+      targetType: input.broadTargetType,
+      targetId: input.broadTargetType === "agent" ? agent!.id : company!.id,
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id,
+      connectionId: connection!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    connections.push(connection!);
+    catalogEntries.push(catalogEntry!);
+  }
+
+  const [exactProfile] = await db.insert(toolProfiles).values({
+    companyId: company!.id,
+    profileKey: `exact-five-${randomUUID()}`,
+    name: "GOB-70 exact five read-only tools",
+    defaultAction: "deny",
+  }).returning();
+  await db.insert(toolProfileEntries).values(catalogEntries.slice(0, 5).map((catalogEntry) => ({
+    companyId: company!.id,
+    profileId: exactProfile!.id,
+    selectorType: "catalog_entry" as const,
+    effect: "include" as const,
+    applicationId: catalogEntry.applicationId,
+    connectionId: catalogEntry.connectionId,
+    catalogEntryId: catalogEntry.id,
+  })));
+  await db.insert(toolProfileBindings).values({
+    companyId: company!.id,
+    profileId: exactProfile!.id,
+    targetType: input.exactTargetType,
+    targetId: input.exactTargetType === "issue" ? issue!.id : project!.id,
+  });
+
+  return {
+    agent: agent!,
+    project: project!,
+    issue: issue!,
+    allowedConnectionIds: connections.slice(0, 5).map((connection) => connection.id).sort(),
+    extraConnectionId: connections[5]!.id,
+  };
+}
 
 describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
   let db!: ReturnType<typeof createDb>;
@@ -49,9 +194,12 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     await db.delete(toolProfileBindings);
     await db.delete(toolProfileEntries);
     await db.delete(toolProfiles);
+    await db.delete(toolCatalogEntries);
     await db.delete(toolStdioCommandTemplates);
     await db.delete(toolConnections);
     await db.delete(toolApplications);
+    await db.delete(issues);
+    await db.delete(projects);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -446,6 +594,45 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     const afterDisable = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
     expect(afterDisable).toHaveLength(1);
     expect(afterDisable[0]).toMatchObject({ connectionId: installedConnection!.id });
+  });
+
+  it("delivers exactly the five issue-bound tools instead of broad agent access", async () => {
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    const fixture = await createScopedRuntimeFixture({
+      db,
+      broadTargetType: "agent",
+      exactTargetType: "issue",
+    });
+
+    const servers = await buildPaperclipRuntimeMcpServers({
+      db,
+      agent: fixture.agent,
+      runId: randomUUID(),
+      issueId: fixture.issue.id,
+      projectId: fixture.project.id,
+    });
+
+    expect(servers.map((server) => server.connectionId).sort()).toEqual(fixture.allowedConnectionIds);
+    expect(servers.some((server) => server.connectionId === fixture.extraConnectionId)).toBe(false);
+  });
+
+  it("delivers project-bound tools instead of broader company access", async () => {
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    const fixture = await createScopedRuntimeFixture({
+      db,
+      broadTargetType: "company",
+      exactTargetType: "project",
+    });
+
+    const servers = await buildPaperclipRuntimeMcpServers({
+      db,
+      agent: fixture.agent,
+      runId: randomUUID(),
+      projectId: fixture.project.id,
+    });
+
+    expect(servers.map((server) => server.connectionId).sort()).toEqual(fixture.allowedConnectionIds);
+    expect(servers.some((server) => server.connectionId === fixture.extraConnectionId)).toBe(false);
   });
 
 });

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -240,4 +240,154 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       details: expect.objectContaining({ runId, deliveredServerCount: 0 }),
     });
   });
+
+  it("provisions gateways for installed remote and local stdio connections", async () => {
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    const [company] = await db.insert(companies).values({
+      name: `Runtime MCP ${randomUUID()}`,
+      issuePrefix: `RM${randomUUID().slice(0, 5).toUpperCase()}`,
+    }).returning();
+    const [agent] = await db.insert(agents).values({
+      companyId: company!.id,
+      name: "Runtime MCP Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    }).returning();
+    const [application] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `runtime-${randomUUID().slice(0, 8)}`,
+      name: "Runtime MCP App",
+      type: "mcp_http",
+      status: "active",
+    }).returning();
+    const [stdioApplication] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `runtime-stdio-${randomUUID().slice(0, 8)}`,
+      name: "Runtime stdio MCP App",
+      type: "mcp_stdio",
+      status: "active",
+    }).returning();
+    const [installedConnection, uninstalledConnection] = await db.insert(toolConnections).values([
+      {
+        companyId: company!.id,
+        applicationId: application!.id,
+        name: "Installed MCP",
+        uid: `test/${randomUUID()}`,
+        transport: "mcp_remote",
+        status: "active",
+        enabled: true,
+        config: { url: "https://installed.example.test/mcp" },
+      },
+      {
+        companyId: company!.id,
+        applicationId: application!.id,
+        name: "Uninstalled MCP",
+        uid: `test/${randomUUID()}`,
+        transport: "mcp_remote",
+        status: "active",
+        enabled: true,
+        config: { url: "https://uninstalled.example.test/mcp" },
+      },
+    ]).returning();
+    const [stdioConnection] = await db.insert(toolConnections).values({
+      companyId: company!.id,
+      applicationId: stdioApplication!.id,
+      name: "Installed stdio MCP",
+      uid: `test/${randomUUID()}`,
+      transport: "local_stdio",
+      status: "active",
+      enabled: true,
+      config: { templateId: randomUUID() },
+    }).returning();
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${installedConnection!.id}`,
+      name: "Installed MCP",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: profile!.id,
+      selectorType: "connection",
+      effect: "include",
+      applicationId: application!.id,
+      connectionId: installedConnection!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: profile!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    const [stdioProfile] = await db.insert(toolProfiles).values({
+      companyId: company!.id,
+      profileKey: `app:${stdioConnection!.id}`,
+      name: "Installed stdio MCP",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
+      selectorType: "connection",
+      effect: "include",
+      applicationId: stdioApplication!.id,
+      connectionId: stdioConnection!.id,
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id,
+      profileId: stdioProfile!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id,
+      connectionId: installedConnection!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id,
+      connectionId: stdioConnection!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+
+    const before = Date.now();
+    const first = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
+    const second = await buildPaperclipRuntimeMcpServers({ db, agent: agent!, runId: randomUUID() });
+
+    expect(first).toHaveLength(2);
+    expect(first).toContainEqual(expect.objectContaining({
+      name: "Installed MCP",
+      connectionId: installedConnection!.id,
+      url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
+      token: expect.stringMatching(/^pcgw_/),
+    }));
+    expect(first).toContainEqual(expect.objectContaining({
+      name: "Installed stdio MCP",
+      connectionId: stdioConnection!.id,
+      url: expect.stringMatching(/^https:\/\/paperclip\.example\.test\/api\/tool-gateway\/gateways\/.+\/mcp$/),
+      token: expect.stringMatching(/^pcgw_/),
+    }));
+    expect(first.some((server) => server.connectionId === uninstalledConnection!.id)).toBe(false);
+    expect(second).toHaveLength(2);
+
+    const gateways = await db.select().from(toolMcpGateways);
+    expect(gateways).toHaveLength(2);
+    expect(gateways.map((gateway) => gateway.metadata)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ managedRuntimeConnectionId: installedConnection!.id }),
+      expect.objectContaining({ managedRuntimeConnectionId: stdioConnection!.id }),
+    ]));
+    const tokens = await db.select().from(toolMcpGatewayTokens);
+    expect(tokens).toHaveLength(4);
+    for (const token of tokens) {
+      expect(token.subjectType).toBe("heartbeat_run");
+      expect(token.subjectId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(token.expiresAt!.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+      expect(token.expiresAt!.getTime()).toBeLessThanOrEqual(Date.now() + 61 * 60 * 1000);
+    }
+    expect(JSON.stringify(tokens)).not.toContain(first[0]!.token);
+  });
+
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3313,14 +3313,17 @@ export async function buildPaperclipRuntimeMcpServers(input: {
       ))
     : [];
   const permittedNotInstalledConnections = permittedConnections
-    .filter((connection) => connection.transport === "mcp_remote" && !installedConnectionIds.has(connection.id))
+    .filter((connection) =>
+      (connection.transport === "mcp_remote" || connection.transport === "local_stdio")
+      && !installedConnectionIds.has(connection.id)
+    )
     .map(({ id, name }) => ({ id, name }))
     .sort((a, b) => a.name.localeCompare(b.name));
   const uniqueConnections = effective.installedConnections.filter((connection) =>
     permittedConnectionIds.has(connection.id)
     && connection.status === "active"
     && connection.enabled
-    && connection.transport === "mcp_remote"
+    && (connection.transport === "mcp_remote" || connection.transport === "local_stdio")
   );
   const service = createToolGatewayService(input.db);
   if (uniqueConnections.length === 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3288,10 +3288,13 @@ export async function buildPaperclipRuntimeMcpServers(input: {
   db: Db;
   agent: Pick<typeof agents.$inferSelect, "id" | "companyId" | "name">;
   runId: string;
+  issueId?: string | null;
+  projectId?: string | null;
 }): Promise<AdapterRuntimeMcpServer[]> {
   const effective = await toolAccessService(input.db).getEffectiveProfilesForAgent(
     input.agent.companyId,
     input.agent.id,
+    { issueId: input.issueId, projectId: input.projectId },
   );
   const permittedConnectionIds = new Set([
     ...effective.entries
@@ -15983,6 +15986,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           db,
           agent,
           runId: run.id,
+          issueId: issueRef?.id ?? null,
+          projectId: issueRef?.projectId ?? readNonEmptyString(context.projectId),
         });
         const runtimeMcp = createAdapterRuntimeMcpAccess(runtimeMcpServers);
         const managedMcpConfig = await createManagedMcpRunConfig({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -66,6 +66,7 @@ import {
   toolMcpGatewayTokens,
   toolConnections,
   toolProfiles,
+  toolStdioCommandTemplates,
   workspaceOperations,
 } from "@paperclipai/db";
 import { conflict, HttpError, notFound } from "../errors.js";
@@ -3319,12 +3320,27 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     )
     .map(({ id, name }) => ({ id, name }))
     .sort((a, b) => a.name.localeCompare(b.name));
-  const uniqueConnections = effective.installedConnections.filter((connection) =>
-    permittedConnectionIds.has(connection.id)
-    && connection.status === "active"
-    && connection.enabled
-    && (connection.transport === "mcp_remote" || connection.transport === "local_stdio")
+  const disabledStdioTemplateKeys = new Set(
+    (await input.db
+      .select({ templateKey: toolStdioCommandTemplates.templateKey })
+      .from(toolStdioCommandTemplates)
+      .where(and(
+        eq(toolStdioCommandTemplates.companyId, input.agent.companyId),
+        eq(toolStdioCommandTemplates.status, "disabled"),
+      )))
+      .map((template) => template.templateKey),
   );
+  const uniqueConnections = effective.installedConnections.filter((connection) => {
+    if (!permittedConnectionIds.has(connection.id) || connection.status !== "active" || !connection.enabled) {
+      return false;
+    }
+    if (connection.transport === "mcp_remote") return true;
+    if (connection.transport !== "local_stdio") return false;
+    const templateId = connection.config && typeof connection.config === "object"
+      ? (connection.config as Record<string, unknown>).templateId
+      : null;
+    return typeof templateId === "string" && !disabledStdioTemplateKeys.has(templateId);
+  });
   const service = createToolGatewayService(input.db);
   if (uniqueConnections.length === 0) {
     await service.recordRuntimeMcpDeliveryDiagnostic({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3339,7 +3339,9 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     const templateId = connection.config && typeof connection.config === "object"
       ? (connection.config as Record<string, unknown>).templateId
       : null;
-    return typeof templateId === "string" && !disabledStdioTemplateKeys.has(templateId);
+    return typeof templateId === "string"
+      && templateId.trim().length > 0
+      && !disabledStdioTemplateKeys.has(templateId.trim());
   });
   const service = createToolGatewayService(input.db);
   if (uniqueConnections.length === 0) {

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -7170,7 +7170,11 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       return { unbound: rows.length };
     },
 
-    getEffectiveProfilesForAgent: async (companyId: string, agentId: string): Promise<ToolProfileEffectiveSummary> => {
+    getEffectiveProfilesForAgent: async (
+      companyId: string,
+      agentId: string,
+      context?: { issueId?: string | null; projectId?: string | null },
+    ): Promise<ToolProfileEffectiveSummary> => {
       await assertOptionalAgent(companyId, agentId, "Tool profile effective agent");
       const allBindings = await db
         .select()
@@ -7180,6 +7184,8 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       const bindings = narrowestScopeBindings(allBindings.filter((binding) =>
         (binding.targetType === "company" && binding.targetId === companyId)
         || (binding.targetType === "agent" && binding.targetId === agentId)
+        || (binding.targetType === "issue" && binding.targetId === context?.issueId)
+        || (binding.targetType === "project" && binding.targetId === context?.projectId)
       ));
       if (bindings.length === 0) {
         return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their governed tool access.
> - The heartbeat runtime builds the MCP server list for each agent run.
> - The runtime profile resolver used only company and agent bindings.
> - An issue or project profile could therefore fail to restrict a broader agent profile.
> - PR #11605 adds local stdio connections to the same runtime delivery path.
> - This pull request adds the missing run context to profile resolution.
> - The benefit is an exact, narrow runtime tool list for issue-scoped and project-scoped work.

## Linked Issues or Issue Description

Refs #11605

**What happened?**

A heartbeat run with an issue-scoped deny-by-default tool profile received the broader agent tool list. The regression fixture returned six installed connections instead of the five connections allowed by the issue profile.

**Expected behavior**

The runtime must use the narrowest matching profile. An issue profile must take priority over agent, project, and company profiles. A project profile must take priority over broader company profiles.

**Steps to reproduce**

1. Install six tool connections for one agent.
2. Bind broad profiles for all six connections to the agent or company.
3. Bind a deny-by-default profile with five included connections to the run issue or project.
4. Build the heartbeat runtime MCP server list with the issue and project context.
5. Observe that the old code returns all six connections.

**Paperclip version or commit**

Parent commit `9ecc4ce2fa7ba9091e6640f1006b00fd436ce5a8` from #11605.

**Deployment mode**

Local development from source with embedded Postgres tests.

## What Changed

- Pass the run issue ID and project ID to runtime MCP profile resolution.
- Match issue and project profile bindings in `getEffectiveProfilesForAgent`.
- Reuse the existing narrowest-scope precedence function.
- Add real-database regressions for issue-over-agent and project-over-company precedence.
- Keep the local stdio delivery behavior from #11605.

## Verification

- RED: the two new regressions failed with six returned connections instead of five.
- GREEN: `npx -y pnpm@9.15.4 exec vitest run server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts` passed 5 of 5 tests.
- `npx -y pnpm@9.15.4 exec vitest run server/src/__tests__/tool-access-policy-service.test.ts` passed 35 of 35 tests.
- `npx -y pnpm@9.15.4 --filter @paperclipai/server typecheck` passed.
- `git diff --check 9ecc4ce2fa7ba9091e6640f1006b00fd436ce5a8...HEAD` passed.
- The candidate worktree was clean after verification.

## Risks

- This is a dependent draft. It contains the commits from #11605 until that pull request merges.
- The optional project ID fallback uses trusted heartbeat run context. The primary issue path uses the database-backed issue and project IDs.
- A narrower issue or project profile now intentionally removes tools granted only by broader profiles.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with `gpt-5.6-sol` in high-reasoning mode. The agent used repository tools, Git, code execution, real-database tests, and an independent verification pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation change is required
- [x] I have considered and documented the risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge