### PR TITLE
fix(server): return 404 instead of 500 for non-UUID project refs

### DIFF
--- a/server/src/__tests__/project-non-uuid-ref-routes.test.ts
+++ b/server/src/__tests__/project-non-uuid-ref-routes.test.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, projects } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { projectRoutes } from "../routes/projects.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres project non-UUID ref tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+function boardActor(companyId: string): Express.Request["actor"] {
+  return {
+    type: "board",
+    userId: "user-1",
+    source: "session",
+    isInstanceAdmin: true,
+    companyIds: [companyId],
+    memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+  };
+}
+
+function createApp(db: ReturnType<typeof createDb>, actor: Express.Request["actor"]) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use("/api", projectRoutes(db));
+  app.use(errorHandler);
+  return app;
+}
+
+describeEmbeddedPostgres("project route refs that are not UUIDs", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-project-non-uuid-ref-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Demo Project",
+      status: "in_progress",
+    });
+
+    return { companyId, projectId };
+  }
+
+  it("resolves a project shortname when the company scope is known", async () => {
+    const { companyId, projectId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const res = await request(app).get(`/api/projects/demo-project?companyId=${companyId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(projectId);
+  });
+
+  it("keeps returning the project for a UUID ref", async () => {
+    const { companyId, projectId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const res = await request(app).get(`/api/projects/${projectId}?companyId=${companyId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(projectId);
+  });
+
+  it("returns 404 for a ref that matches no shortname", async () => {
+    const { companyId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const res = await request(app).get(`/api/projects/not-a-project?companyId=${companyId}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a shortname that has no company scope", async () => {
+    const { companyId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const res = await request(app).get("/api/projects/demo-project");
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -576,6 +576,12 @@ export function projectService(db: Db) {
   };
 
   const getProjectById = async (id: string): Promise<ProjectWithGoals | null> => {
+    // Non-UUID refs (for example a project shortname the route could not
+    // resolve) previously reached the uuid-typed query and threw a
+    // DrizzleQueryError ("invalid input syntax for type uuid"), surfacing as
+    // HTTP 500 from GET /api/projects/:id. Treat them as not-found so the
+    // route returns 404.
+    if (!isUuidLike(id)) return null;
     const row = await db
       .select()
       .from(projects)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators, agents, and the `paperclipai` CLI read project state through the board REST API
> - `GET /api/projects/:id` accepts a project reference in the path, and the CLI help text promises "Project ID or shortname"
> - The route normalizes a shortname to a UUID only when it can find a company scope and a unique match; in every other case it passes the raw reference on
> - The raw reference then reaches the uuid-typed `projects.id` column, and Postgres throws `invalid input syntax for type uuid`, which surfaces as HTTP 500
> - This pull request guards `getProjectById` with a UUID check, so a reference that cannot match a row resolves to `null` and the route returns its existing 404 path
> - The benefit is correct HTTP semantics for bad input, quieter server logs, and one less misleading 500 for self-hosters to diagnose

## Linked Issues or Issue Description

Fixes #11660 — `GET /api/projects/:id` returns 500 (`invalid input syntax for type uuid`) for a shortname that the route cannot resolve, instead of 404. The issue has the full repro and the server stack trace.

Related, not changed here:

- #9962 — the same failure on `GET /api/companies/:companyId`. It is closed by PR #9959, which used the same guard in `companyService.getById`. This PR applies that accepted pattern to the projects service.
- #7489 — the same failure shape on `GET /issues?parentId=<identifier>`. It is still open and stays out of scope, because one PR must be one logical change.

I searched the open pull requests for `11660`, `projects`, and `uuid`. No open pull request changes this path.

## What Changed

- `server/src/services/projects.ts`: `getProjectById` returns `null` for a reference that is not a UUID. It no longer sends the reference to the uuid-typed query.
- `server/src/__tests__/project-non-uuid-ref-routes.test.ts`: new regression test at the route level. It covers shortname resolution, UUID lookup, an unknown reference, and a shortname with no company scope.

## Verification

- `npx vitest run --root server src/__tests__/project-non-uuid-ref-routes.test.ts` — 4/4 pass.
- The two new 404 cases fail with `expected 500 to be 404` when I remove the guard. This confirms the test catches the regression.
- `npx vitest run --root server src/__tests__/project` — 7 files, 23 tests pass. No other project test changes behavior.
- `pnpm typecheck` — clean.
- Manual: `GET /api/projects/not-a-project?companyId=<uuid>` returns 404 (it returned 500). `GET /api/projects/<uuid>?companyId=<uuid>` returns 200, and `GET /api/projects/demo-project?companyId=<uuid>` still resolves the shortname.

## Risks

Low. The guard is pure input validation on one read path, and UUID lookups do not change. The only behavior change is 500 to 404 for a reference that could never match a row.

`GET`, `PATCH`, and `DELETE` on `/projects/:id` all gate on `svc.getById` first, so they all return 404 instead of 500 for such a reference. This is the same correction, not an extra one. The plugin host services also call `projects.getById`; they already handle a `null` result as "not found".

## Model Used

Claude Opus 5 (`claude-opus-5`, Anthropic) through Claude Code, with extended thinking and tool use. The model located the failing query, found the merged precedent in `companyService.getById` (PR #9959), wrote the guard and the test, and ran the test and typecheck commands. @Drizzy07x reviewed the change and submits it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable — no document describes this error path)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

