### PR TITLE
docs: point section 11 at the renamed implementation plan

### DIFF
--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -173,7 +173,7 @@ future public-hosted setup design explicitly changes this policy.
 
 ## 11. Relationship to Other Docs
 
-- implementation plan: `doc/plans/deployment-auth-mode-consolidation.md`
+- implementation plan: `doc/plans/2026-02-23-deployment-auth-mode-consolidation.md`
 - V1 contract: `doc/SPEC-implementation.md`
 - operator workflows: `doc/DEVELOPING.md` and `doc/CLI.md`
 - invite/join state map: `doc/spec/invite-flow.md`


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `doc/` tree is how a contributor learns the system
> - Section 11 of `doc/DEPLOYMENT-MODES.md` is a map to the other documents
> - One entry on that map points at a file that is not there
> - Commit `9c7d9ded1` moved every plan into `doc/plans/` with a date prefix, and this link kept the old name
> - This pull request updates the link to the current file name
> - The benefit is that a reader who follows the map arrives at the plan

## Linked Issues or Issue Description

No issue exists. The problem is below.

**Issue type**

Docs. A link points at a file name that changed.

**Where is the issue?**

`doc/DEPLOYMENT-MODES.md`, line 176, in section 11 "Relationship to Other Docs".

**What's wrong?**

The line reads:

```
- implementation plan: `doc/plans/deployment-auth-mode-consolidation.md`
```

That file is not in the repository. Commit `9c7d9ded1` ("docs: organize plans into doc/plans
with date prefixes") renamed it to `doc/plans/2026-02-23-deployment-auth-mode-consolidation.md`.
The renamed file is there today. The link text was not updated.

The other four entries in section 11 are correct. I checked each one:
`doc/SPEC-implementation.md`, `doc/DEVELOPING.md`, `doc/CLI.md` and `doc/spec/invite-flow.md`
all exist.

**Suggested fix**

Use the new file name in the link. That is what this pull request does.

## What Changed

- `doc/DEPLOYMENT-MODES.md` line 176 now names `doc/plans/2026-02-23-deployment-auth-mode-consolidation.md`

## Verification

Run this command. It prints the file, so the new name is correct:

```
ls doc/plans/2026-02-23-deployment-auth-mode-consolidation.md
```

Run this command. It prints nothing, so the old name is wrong:

```
ls doc/plans/deployment-auth-mode-consolidation.md
```

## Risks

Low risk. The change is one file name in one line of documentation. No code changes.

## Model Used

Claude (Anthropic), model ID `claude-opus-5`, 1M context window, extended thinking, with tool
use and code execution.

The path was found by [docproof](https://github.com/melbinjp/docproof), an open source
checker that compares what documentation claims against what the repository contains. A
person then read the document, checked the rename in `git log`, and confirmed the other four
links in the same section.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

One box stays unticked and I would rather say so than tick it. I did not run the test suite
locally, because the change is one line of prose and no test reads it.

The other two were unticked when this opened, because CI and Greptile had not run yet. Both
have now. **29 checks pass and 2 report `skipping`** (Contributor trust, Storybook visual
regression); none fail. Greptile returned **5/5** with no P2s: *"The documentation-only change
appears safe to merge. The new path exists ... and replaces an obsolete path that no longer
exists."*
