### PR TITLE
fix(server): merge duplicate credential bindings instead of failing with 500

### DIFF
--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -7007,6 +7007,191 @@ describeEmbeddedPostgres("tool access service", () => {
       expect.objectContaining({ targetType: "agent", targetId: agent.id }),
     ]));
   });
+
+  it("merges credentialRefs and credentialSecretRefs that bind one secret to the same config path", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secret = await secretService(db).create(company.id, {
+      provider: "local_encrypted",
+      name: `Authorization ${randomUUID()}`,
+      key: `authorization.${randomUUID()}`,
+      value: "token-value",
+    });
+
+    const connection = await service.createConnection(company.id, {
+      name: "Duplicate binding fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [{
+        secretId: secret.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+      credentialRefs: [{
+        name: "authorization",
+        secretId: secret.id,
+        version: "latest",
+        placement: "header",
+        key: "Authorization",
+        prefix: "Bearer ",
+      }],
+    });
+
+    const rows = await db
+      .select()
+      .from(companySecretBindings)
+      .where(and(
+        eq(companySecretBindings.targetType, "tool_connection"),
+        eq(companySecretBindings.targetId, connection.id),
+      ));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.configPath).toBe("credentials.authorization");
+    expect(rows[0]!.secretId).toBe(secret.id);
+  });
+
+  it("updates a connection that sends credentialRefs and credentialSecretRefs together", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secret = await secretService(db).create(company.id, {
+      provider: "local_encrypted",
+      name: `Authorization ${randomUUID()}`,
+      key: `authorization.${randomUUID()}`,
+      value: "token-value",
+    });
+    const connection = await service.createConnection(company.id, {
+      name: "Patch binding fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [{
+        secretId: secret.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+    });
+
+    const updated = await service.updateConnection(connection.id, {
+      credentialSecretRefs: [{
+        secretId: secret.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+      credentialRefs: [{
+        name: "authorization",
+        secretId: secret.id,
+        version: "latest",
+        placement: "header",
+        key: "Authorization",
+        prefix: "Bearer ",
+      }],
+    });
+
+    expect(updated.id).toBe(connection.id);
+    const rows = await db
+      .select()
+      .from(companySecretBindings)
+      .where(and(
+        eq(companySecretBindings.targetType, "tool_connection"),
+        eq(companySecretBindings.targetId, connection.id),
+      ));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("keeps the class-3 projection when a header ref merges into a declared secret ref", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secret = await secretService(db).create(company.id, {
+      provider: "local_encrypted",
+      name: `Slack bot token ${randomUUID()}`,
+      key: `slack.bot.${randomUUID()}`,
+      value: "xoxb-token-value",
+    });
+
+    const connection = await service.createConnection(company.id, {
+      name: "Class 3 binding fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [{
+        secretId: secret.id,
+        versionSelector: "latest",
+        configPath: "credentials.bot_token",
+        required: true,
+        projectionClass: "class_3_static_lease",
+        projectionAllowlistKey: "slack.bot_token",
+      }],
+      credentialRefs: [{
+        name: "bot_token",
+        secretId: secret.id,
+        version: "latest",
+        placement: "header",
+        key: "Authorization",
+        prefix: "Bearer ",
+      }],
+    });
+
+    const rows = await db
+      .select()
+      .from(companySecretBindings)
+      .where(and(
+        eq(companySecretBindings.targetType, "tool_connection"),
+        eq(companySecretBindings.targetId, connection.id),
+      ));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.projectionClass).toBe("class_3_static_lease");
+    expect(rows[0]!.projectionAllowlistKey).toBe("slack.bot_token");
+  });
+
+  it("rejects one config path bound to two different secrets", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secretService_ = secretService(db);
+    const first = await secretService_.create(company.id, {
+      provider: "local_encrypted",
+      name: `First ${randomUUID()}`,
+      key: `first.${randomUUID()}`,
+      value: "first-value",
+    });
+    const second = await secretService_.create(company.id, {
+      provider: "local_encrypted",
+      name: `Second ${randomUUID()}`,
+      key: `second.${randomUUID()}`,
+      value: "second-value",
+    });
+
+    await expect(service.createConnection(company.id, {
+      name: "Conflicting binding fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [{
+        secretId: first.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+      credentialRefs: [{
+        name: "authorization",
+        secretId: second.id,
+        version: "latest",
+        placement: "header",
+        key: "Authorization",
+        prefix: "Bearer ",
+      }],
+    })).rejects.toMatchObject({
+      status: 400,
+      details: { code: "duplicate_credential_binding", configPath: "credentials.authorization" },
+    });
+  });
+
 });
 
 describe("classifyRisk", () => {

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -7149,6 +7149,109 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(rows[0]!.projectionAllowlistKey).toBe("slack.bot_token");
   });
 
+  it("rejects two secret refs that declare different projections for one config path", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secret = await secretService(db).create(company.id, {
+      provider: "local_encrypted",
+      name: `Bot token ${randomUUID()}`,
+      key: `bot.token.${randomUUID()}`,
+      value: "bot-token-value",
+    });
+
+    // Both allowlist keys are valid for `credentials.bot_token`, so neither
+    // declaration is rejected earlier. The merge must not pick one by position.
+    await expect(service.createConnection(company.id, {
+      name: "Contradictory projection fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [
+        {
+          secretId: secret.id,
+          versionSelector: "latest",
+          configPath: "credentials.bot_token",
+          required: true,
+          projectionClass: "class_3_static_lease",
+          projectionAllowlistKey: "slack.bot_token",
+        },
+        {
+          secretId: secret.id,
+          versionSelector: "latest",
+          configPath: "credentials.bot_token",
+          required: true,
+          projectionClass: "class_3_static_lease",
+          projectionAllowlistKey: "discord.bot_token",
+        },
+      ],
+    })).rejects.toMatchObject({
+      status: 400,
+      details: { code: "conflicting_credential_projection", configPath: "credentials.bot_token" },
+    });
+  });
+
+  it("leaves the stored connection unchanged when an update cannot merge its bindings", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secrets = secretService(db);
+    const first = await secrets.create(company.id, {
+      provider: "local_encrypted",
+      name: `First ${randomUUID()}`,
+      key: `first.${randomUUID()}`,
+      value: "first-value",
+    });
+    const second = await secrets.create(company.id, {
+      provider: "local_encrypted",
+      name: `Second ${randomUUID()}`,
+      key: `second.${randomUUID()}`,
+      value: "second-value",
+    });
+    const connection = await service.createConnection(company.id, {
+      name: "Stable binding fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [{
+        secretId: first.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+    });
+
+    await expect(service.updateConnection(connection.id, {
+      credentialSecretRefs: [{
+        secretId: first.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+      credentialRefs: [{
+        name: "authorization",
+        secretId: second.id,
+        version: "latest",
+        placement: "header",
+        key: "Authorization",
+        prefix: "Bearer ",
+      }],
+    })).rejects.toMatchObject({ status: 400 });
+
+    const [row] = await db.select().from(toolConnections).where(eq(toolConnections.id, connection.id));
+    expect(row!.credentialRefs).toEqual([]);
+    expect(row!.credentialSecretRefs).toHaveLength(1);
+    const bindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(and(
+        eq(companySecretBindings.targetType, "tool_connection"),
+        eq(companySecretBindings.targetId, connection.id),
+      ));
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]!.secretId).toBe(first.id);
+  });
+
   it("rejects one config path bound to two different secrets", async () => {
     const company = await createCompany(db);
     const service = toolAccessService(db);

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -177,6 +177,8 @@ type CredentialBindingRow = {
   configPath: string;
   projectionClass: SecretProjectionClass;
   projectionAllowlistKey: string | null;
+  /** `header` rows come from `credentialRefs`, `declared` rows from `credentialSecretRefs`. */
+  source: "header" | "declared";
 };
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -1378,11 +1380,15 @@ function readStdioTemplateId(config: Record<string, unknown>): string {
 /**
  * `credentialRefs` and `credentialSecretRefs` can legitimately describe the
  * same credential: the first places the header, the second declares how the
- * secret projects. Both derive a `company_secret_bindings` row keyed by
- * config path, so an unmerged pair collided on
+ * secret projects. Both derive a `company_secret_bindings` row keyed by config
+ * path, so an unmerged pair collided on
  * `company_secret_bindings_target_path_uq` inside a single multi-row insert
- * and surfaced as a bare 500. Merge the rows that share a config path, and
- * reject only a true ambiguity: one path bound to two different secrets.
+ * and surfaced as a bare 500.
+ *
+ * A `header` row always carries the default projection, so a `declared` row
+ * owns the projection when the two merge. Two rows of the same kind must
+ * already agree; the merge never picks a winner between two declarations,
+ * which keeps the stored policy independent of array order.
  */
 function mergeCredentialBindingRows(rows: CredentialBindingRow[]): CredentialBindingRow[] {
   const byConfigPath = new Map<string, CredentialBindingRow>();
@@ -1398,20 +1404,66 @@ function mergeCredentialBindingRows(rows: CredentialBindingRow[]): CredentialBin
         { code: "duplicate_credential_binding", configPath: row.configPath },
       );
     }
-    // A `credentialRefs` row always carries the default projection, so keep
-    // the stricter class and the declared allowlist key. Otherwise the merge
-    // could silently downgrade an explicit `class_3_static_lease` binding.
-    byConfigPath.set(row.configPath, {
-      secretId: existing.secretId,
-      configPath: existing.configPath,
-      projectionClass:
-        existing.projectionClass === "class_3_static_lease" || row.projectionClass === "class_3_static_lease"
-          ? "class_3_static_lease"
-          : existing.projectionClass,
-      projectionAllowlistKey: existing.projectionAllowlistKey ?? row.projectionAllowlistKey,
-    });
+    if (existing.source === row.source) {
+      if (
+        existing.projectionClass !== row.projectionClass
+        || existing.projectionAllowlistKey !== row.projectionAllowlistKey
+      ) {
+        throw badRequest(
+          `Config path "${row.configPath}" declares two different projections. Declare it once.`,
+          { code: "conflicting_credential_projection", configPath: row.configPath },
+        );
+      }
+      continue;
+    }
+    byConfigPath.set(row.configPath, existing.source === "declared" ? existing : row);
   }
   return [...byConfigPath.values()];
+}
+
+/**
+ * Derives the binding rows a connection persists, and rejects a pair that
+ * cannot be merged. Call this before a connection row is written, so a
+ * rejected payload never leaves stored arrays and stored bindings out of step.
+ */
+function credentialBindingRowsFor(
+  credentialRefs: ReadonlyArray<{ name: string; secretId: string }>,
+  credentialSecretRefs: ReadonlyArray<{
+    secretId: string;
+    configPath: string;
+    projectionClass?: SecretProjectionClass | null;
+    projectionAllowlistKey?: string | null;
+  }>,
+): CredentialBindingRow[] {
+  return mergeCredentialBindingRows([
+    ...credentialRefs.map((ref): CredentialBindingRow => ({
+      secretId: ref.secretId,
+      configPath: `credentials.${ref.name}`,
+      projectionClass: "unclassified",
+      projectionAllowlistKey: null,
+      source: "header",
+    })),
+    ...credentialSecretRefs.map((ref): CredentialBindingRow => ({
+      secretId: ref.secretId,
+      configPath: ref.configPath,
+      projectionClass: ref.projectionClass ?? "unclassified",
+      projectionAllowlistKey: ref.projectionAllowlistKey ?? null,
+      source: "declared",
+    })),
+  ]);
+}
+
+/** Throws when the two credential arrays cannot merge into one binding set. */
+function assertCredentialBindingsMergeable(
+  credentialRefs: ReadonlyArray<{ name: string; secretId: string }>,
+  credentialSecretRefs: ReadonlyArray<{
+    secretId: string;
+    configPath: string;
+    projectionClass?: SecretProjectionClass | null;
+    projectionAllowlistKey?: string | null;
+  }>,
+): void {
+  credentialBindingRowsFor(credentialRefs, credentialSecretRefs);
 }
 
 export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}) {
@@ -2779,23 +2831,9 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   }
 
   async function syncCredentialBindings(connection: typeof toolConnections.$inferSelect) {
-    const declared: CredentialBindingRow[] = [
-      ...connection.credentialRefs.map((ref): CredentialBindingRow => ({
-        secretId: ref.secretId,
-        configPath: `credentials.${ref.name}`,
-        projectionClass: "unclassified",
-        projectionAllowlistKey: null,
-      })),
-      ...connection.credentialSecretRefs.map((ref): CredentialBindingRow => ({
-        secretId: ref.secretId,
-        configPath: ref.configPath,
-        projectionClass: ref.projectionClass ?? "unclassified",
-        projectionAllowlistKey: ref.projectionAllowlistKey ?? null,
-      })),
-    ];
     // Merge before the delete. A rejected payload must not leave the
     // connection with its bindings removed and nothing written back.
-    const bindings = mergeCredentialBindingRows(declared);
+    const bindings = credentialBindingRowsFor(connection.credentialRefs, connection.credentialSecretRefs);
     await db
       .delete(companySecretBindings)
       .where(
@@ -6384,6 +6422,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         applicationId = app.id;
       }
       await assertSecretRefs(companyId, [...(input.credentialRefs ?? []), ...(input.credentialSecretRefs ?? [])]);
+      assertCredentialBindingsMergeable(input.credentialRefs ?? [], input.credentialSecretRefs ?? []);
       const connectionId = randomUUID();
       const [row] = await db.insert(toolConnections).values({
         id: connectionId,
@@ -6603,6 +6642,10 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       assertLocalStdioCanBeEnabled(existing.transport, input.enabled ?? existing.enabled);
       await assertGoogleSheetsSpreadsheetOwnership(existing.companyId, config, { excludeConnectionId: existing.id });
       await assertSecretRefs(existing.companyId, [...(input.credentialRefs ?? existing.credentialRefs), ...(input.credentialSecretRefs ?? existing.credentialSecretRefs)]);
+      assertCredentialBindingsMergeable(
+        input.credentialRefs ?? existing.credentialRefs,
+        input.credentialSecretRefs ?? existing.credentialSecretRefs,
+      );
       const [row] = await db
         .update(toolConnections)
         .set({

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -100,6 +100,7 @@ import type {
   ToolRuntimeSlot,
   ToolStdioCommandTemplate,
   ReviewToolProfileNewTools,
+  SecretProjectionClass,
   UpdateToolApplication,
   UpdateToolConnection,
   PutToolConnectionInstalls,
@@ -169,6 +170,13 @@ type ToolAccessServiceOptions = {
   deploymentExposure?: DeploymentExposure;
   trustedLocalStdioRuntimeHost?: string | null;
   now?: () => Date;
+};
+
+type CredentialBindingRow = {
+  secretId: string;
+  configPath: string;
+  projectionClass: SecretProjectionClass;
+  projectionAllowlistKey: string | null;
 };
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -1365,6 +1373,45 @@ function readStdioTemplateId(config: Record<string, unknown>): string {
     throw badRequest("Local stdio MCP connections must use an approved templateId");
   }
   return templateId.trim();
+}
+
+/**
+ * `credentialRefs` and `credentialSecretRefs` can legitimately describe the
+ * same credential: the first places the header, the second declares how the
+ * secret projects. Both derive a `company_secret_bindings` row keyed by
+ * config path, so an unmerged pair collided on
+ * `company_secret_bindings_target_path_uq` inside a single multi-row insert
+ * and surfaced as a bare 500. Merge the rows that share a config path, and
+ * reject only a true ambiguity: one path bound to two different secrets.
+ */
+function mergeCredentialBindingRows(rows: CredentialBindingRow[]): CredentialBindingRow[] {
+  const byConfigPath = new Map<string, CredentialBindingRow>();
+  for (const row of rows) {
+    const existing = byConfigPath.get(row.configPath);
+    if (!existing) {
+      byConfigPath.set(row.configPath, row);
+      continue;
+    }
+    if (existing.secretId !== row.secretId) {
+      throw badRequest(
+        `Config path "${row.configPath}" is bound to two different secrets. Bind it once in credentialRefs or credentialSecretRefs.`,
+        { code: "duplicate_credential_binding", configPath: row.configPath },
+      );
+    }
+    // A `credentialRefs` row always carries the default projection, so keep
+    // the stricter class and the declared allowlist key. Otherwise the merge
+    // could silently downgrade an explicit `class_3_static_lease` binding.
+    byConfigPath.set(row.configPath, {
+      secretId: existing.secretId,
+      configPath: existing.configPath,
+      projectionClass:
+        existing.projectionClass === "class_3_static_lease" || row.projectionClass === "class_3_static_lease"
+          ? "class_3_static_lease"
+          : existing.projectionClass,
+      projectionAllowlistKey: existing.projectionAllowlistKey ?? row.projectionAllowlistKey,
+    });
+  }
+  return [...byConfigPath.values()];
 }
 
 export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}) {
@@ -2732,6 +2779,23 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   }
 
   async function syncCredentialBindings(connection: typeof toolConnections.$inferSelect) {
+    const declared: CredentialBindingRow[] = [
+      ...connection.credentialRefs.map((ref): CredentialBindingRow => ({
+        secretId: ref.secretId,
+        configPath: `credentials.${ref.name}`,
+        projectionClass: "unclassified",
+        projectionAllowlistKey: null,
+      })),
+      ...connection.credentialSecretRefs.map((ref): CredentialBindingRow => ({
+        secretId: ref.secretId,
+        configPath: ref.configPath,
+        projectionClass: ref.projectionClass ?? "unclassified",
+        projectionAllowlistKey: ref.projectionAllowlistKey ?? null,
+      })),
+    ];
+    // Merge before the delete. A rejected payload must not leave the
+    // connection with its bindings removed and nothing written back.
+    const bindings = mergeCredentialBindingRows(declared);
     await db
       .delete(companySecretBindings)
       .where(
@@ -2741,20 +2805,6 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
           eq(companySecretBindings.targetId, connection.id),
         ),
       );
-    const bindings = [
-      ...connection.credentialRefs.map((ref) => ({
-        secretId: ref.secretId,
-        configPath: `credentials.${ref.name}`,
-        projectionClass: "unclassified",
-        projectionAllowlistKey: null,
-      })),
-      ...connection.credentialSecretRefs.map((ref) => ({
-        secretId: ref.secretId,
-        configPath: ref.configPath,
-        projectionClass: ref.projectionClass ?? "unclassified",
-        projectionAllowlistKey: ref.projectionAllowlistKey ?? null,
-      })),
-    ];
     if (bindings.length === 0) return;
     await db.insert(companySecretBindings).values(bindings.map((ref) => ({
       companyId: connection.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach external systems through tool connections, and each connection binds its credentials to a secret in the company vault
> - A connection describes a credential in two places: `credentialRefs` places the value in a header, and `credentialSecretRefs` declares how the secret projects
> - `syncCredentialBindings` derives one `company_secret_bindings` row from each array, and both rows are keyed by config path
> - When the two describe the same credential, the rows collide on `company_secret_bindings_target_path_uq` inside one multi-row insert, so Postgres rejects the insert and the request answers a bare 500
> - This pull request merges the rows that share a config path before the insert, and rejects only a true ambiguity with a 400 that names the path
> - The benefit is that the natural way to configure a connection stops failing, and an operator who does send a contradictory payload gets a message that says what to correct

## Linked Issues or Issue Description

Fixes #11610 — `PATCH /api/tool-connections/{id}` answers `500 Internal server error` when the body carries `credentialRefs` and `credentialSecretRefs` for the same credential. The issue has the payload, the failing query, and the constraint name.

The reporter notes the workaround is two sequential requests, which is not discoverable. The field names suggest the two arrays are complementary, so the failing combination is the natural one to write.

I searched the open pull requests for `11610`, `credentialSecretRefs`, and `syncCredentialBindings`. No open pull request changes this path.

## What Changed

- `server/src/services/tool-access.ts`: `mergeCredentialBindingRows` merges the binding rows that share a config path. Each row carries its source — a `header` row comes from `credentialRefs`, a `declared` row from `credentialSecretRefs`.
- `server/src/services/tool-access.ts`: `credentialBindingRowsFor` derives the rows from the two arrays, and `assertCredentialBindingsMergeable` runs next to the existing `assertSecretRefs` call in `createConnection` and `updateConnection`, before the connection row is written.
- `server/src/services/tool-access.ts`: `syncCredentialBindings` merges before it deletes the existing rows.
- `server/src/__tests__/tool-access-service.test.ts`: six tests — create with both arrays, update with both arrays, projection kept on merge, conflicting secrets, conflicting projections, and a rejected update that changes no stored state.

The merge rejects two conditions with a 400 that names the config path:

- `duplicate_credential_binding` — one config path bound to two different secrets.
- `conflicting_credential_projection` — two rows of the same kind that declare different projections.

Two decisions differ from the fix suggested in the issue. Both are explained here so a reviewer can disagree with them directly.

1. **A `declared` row owns the projection, not the `credentialRefs` row.** The issue suggests preferring the `credentialRefs`-derived row. That row always carries `projectionClass: "unclassified"` and a null allowlist key, and the binding row does not carry header placement at all — `resolveCredentialHeaders` reads that from `credentialRefs` on the connection. Preferring it would drop an explicit `class_3_static_lease` projection and gain nothing. The source tag also keeps the result independent of array order: the merge never picks a winner between two declarations, it rejects them.
2. **The merge runs before the delete, and the validation runs before the write.** `syncCredentialBindings` deletes the existing rows and then inserts the new set, and `updateConnection` writes the connection row before it synchronizes bindings. Without both moves, a rejected payload could leave a connection with no bindings, or with stored arrays that the bindings do not match.

## Verification

- `npx vitest run --root server src/__tests__/tool-access-service.test.ts` — 132/132 pass, including the 6 new tests.
- Every new test fails when the change is removed: two with `duplicate key value violates unique constraint "company_secret_bindings_target_path_uq"`, the conflict tests because a raw Postgres error is not a 400, and the stored-state test because the rejected arrays were persisted.
- `pnpm typecheck` — clean across the workspace.

## Risks

Low. The merge only changes requests that could not succeed before.

- A payload that now merges previously threw a unique-constraint error, so no request that used to be stored is affected.
- A payload that now returns 400 previously returned 500 for the same input. The status and the message change; the outcome does not.
- `conflicting_credential_projection` is the one genuinely new rejection. Two declarations that disagree on one config path were previously collapsed by array position, so the stored policy depended on input order.
- `syncCredentialBindings` has ten call sites, and some run inside OAuth refresh paths that rebuild both arrays server-side. They gain the same merge. If such a path ever produced two secrets on one config path, it raised a database error before and raises a typed 400 now.
- The issue also reports that a connection configured with `credentialSecretRefs` alone sends no credential header, because `resolveCredentialHeaders` iterates only `credentialRefs`. That is a separate defect in a different function, so it stays out of this pull request to keep one logical change.

## Model Used

Claude Opus 5 (`claude-opus-5`, Anthropic) through Claude Code, with extended thinking and tool use. The model read the failing path, wrote the merge helper and the tests, and ran the test and typecheck commands. @Drizzy07x reviewed the change and submits it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable — no document describes this error path)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
