### PR TITLE
fix(server): name the missing credential header instead of a sign-in challenge

### DIFF
--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -7007,6 +7007,95 @@ describeEmbeddedPostgres("tool access service", () => {
       expect.objectContaining({ targetType: "agent", targetId: agent.id }),
     ]));
   });
+
+  it("reports the missing credential header when only credentialSecretRefs are configured", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secret = await secretService(db).create(company.id, {
+      provider: "local_encrypted",
+      name: `App key ${randomUUID()}`,
+      key: `app.key.${randomUUID()}`,
+      value: "app-key-value",
+    });
+    const connection = await service.createConnection(company.id, {
+      name: "Header-less fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      credentialSecretRefs: [{
+        secretId: secret.id,
+        versionSelector: "latest",
+        configPath: "credentials.authorization",
+        required: true,
+      }],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: (name: string) => name.toLowerCase() === "www-authenticate" ? "Bearer realm=\"app\"" : null },
+      text: async () => JSON.stringify({ error: "unauthorized" }),
+      json: async () => ({}),
+    } as unknown as Response);
+
+    await expect(service.refreshCatalog(connection.id, { actorType: "user", actorId: "board" }))
+      .rejects.toMatchObject({
+        status: 502,
+        details: expect.objectContaining({ code: "credential_header_missing" }),
+      });
+
+    const [row] = await db.select().from(toolConnections).where(eq(toolConnections.id, connection.id));
+    expect(row!.healthStatus).toBe("error");
+    expect(row!.healthMessage).toContain("no credential header");
+  });
+
+  it("still reports a sign-in challenge when the connection places a credential header", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const secret = await secretService(db).create(company.id, {
+      provider: "local_encrypted",
+      name: `App key ${randomUUID()}`,
+      key: `app.key.${randomUUID()}`,
+      value: "app-key-value",
+    });
+    const connection = await service.createConnection(company.id, {
+      name: "Header fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+      // A distinct config path keeps this fixture independent of the duplicate
+      // binding collision that #11610 reports for a shared path.
+      credentialSecretRefs: [{
+        secretId: secret.id,
+        versionSelector: "latest",
+        configPath: "credentials.extra",
+        required: true,
+      }],
+      credentialRefs: [{
+        name: "authorization",
+        secretId: secret.id,
+        version: "latest",
+        placement: "header",
+        key: "Authorization",
+        prefix: "Bearer ",
+      }],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: (name: string) => name.toLowerCase() === "www-authenticate" ? "Bearer realm=\"app\"" : null },
+      text: async () => JSON.stringify({ error: "unauthorized" }),
+      json: async () => ({}),
+    } as unknown as Response);
+
+    await expect(service.refreshCatalog(connection.id, { actorType: "user", actorId: "board" }))
+      .rejects.toMatchObject({
+        status: 502,
+        details: expect.objectContaining({ code: "oauth_challenge" }),
+      });
+  });
+
 });
 
 describe("classifyRisk", () => {

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -1306,6 +1306,13 @@ function sanitizeHttpFailure(error: unknown): { status: ToolConnectionHealthStat
         code: "oauth_challenge",
       };
     }
+    if (code === "credential_header_missing") {
+      return {
+        status: "error",
+        message: "This connection has secret references but no credential header. Add a credentialRefs entry that places the secret.",
+        code: "credential_header_missing",
+      };
+    }
     if (code === "oauth_refresh_missing") {
       return {
         status: "failed",
@@ -2880,6 +2887,24 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
     if (!response.ok) {
       const authenticate = response.headers.get("www-authenticate") ?? "";
       if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
+        // `credentialSecretRefs` declares how a secret projects; only a
+        // `credentialRefs` entry places it in a header. A connection that
+        // carries the first and not the second sends no credential at all, and
+        // the 401 that follows is not a sign-in problem. Report the real cause
+        // instead of the OAuth challenge, which points an api_key connection at
+        // a consent flow that does not exist.
+        if (
+          Object.keys(headers).length === 0
+          && connection.credentialSecretRefs.length > 0
+          && Object.keys(oauthConfig(connection)).length === 0
+        ) {
+          throw new HttpError(502, "This connection sent no credential header.", {
+            code: "credential_header_missing",
+            status: response.status,
+            setupUrl: connectionSetupUrl(connection),
+            credentialSecretRefCount: connection.credentialSecretRefs.length,
+          });
+        }
         const endpoints = await discoverOAuthEndpoints(connection, authenticate);
         if (endpoints) {
           const nextConfig = {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach external systems through tool connections, and a remote connection authenticates with a header that Paperclip attaches to every request
> - A connection declares its credentials in two arrays: `credentialRefs` places a value in a header, and `credentialSecretRefs` declares how a secret projects
> - Only `credentialRefs` can produce a header, because a secret ref carries no placement, key, or prefix
> - A connection that declares secret refs and no header ref therefore sends no credential, the app answers 401, and Paperclip reported that as `oauth_challenge` with "This app needs you to sign in."
> - For an api_key connection there is no sign-in to complete, so the operator is sent to a consent flow that does not exist while the real cause stays hidden
> - This pull request reports `credential_header_missing` for that exact shape and leaves the OAuth challenge unchanged everywhere else
> - The benefit is that the message names what to correct, instead of describing a problem the connection does not have

## Linked Issues or Issue Description

Refs #11610 — the reporter found this while diagnosing the duplicate binding 500 and recorded it as an adjacent papercut. No separate issue exists, so the fields below describe it.

**What happened?**
A remote tool connection configured with `credentialSecretRefs` and no `credentialRefs` sends no credential header. `resolveCredentialHeaders` builds headers from `credentialRefs` only. The upstream app answers 401, and `remoteTools` reports `code: "oauth_challenge"` with the message "This app needs you to sign in." The connection health shows the same message. For an api_key connection this is misleading, because no sign-in exists.

**Expected behavior**
The error names the real cause: the connection sent no credential header, and a `credentialRefs` entry is what places one.

**Steps to reproduce**
1. Create a remote MCP connection with one `credentialSecretRefs` entry and no `credentialRefs` entry.
2. Point it at an app that answers 401 with a `WWW-Authenticate: Bearer` header.
3. Refresh the catalog. The result is `oauth_challenge` and "This app needs you to sign in."

**Paperclip version or commit**
Reproduced on `master`. The reporter saw it on `v2026.817.0`.

**Deployment mode**
Self-hosted, reported by the author of #11610.

This pull request is independent of the fix for #11610 itself, which is in [#11678](https://github.com/paperclipai/paperclip/pull/11678). The two touch different functions. The second test here uses distinct config paths on purpose, so it does not depend on that fix.

I searched the open pull requests for `credential_header_missing`, `oauth_challenge`, and `resolveCredentialHeaders`. No open pull request changes this path.

## What Changed

- `server/src/services/tool-access.ts`: `remoteTools` throws `credential_header_missing` when a 401 arrives, the request carried no credential header, the connection declares `credentialSecretRefs`, and the connection has no OAuth config. The check runs before OAuth endpoint discovery, so a misconfigured connection does not persist discovered OAuth endpoints it cannot use.
- `server/src/services/tool-access.ts`: `sanitizeHttpFailure` maps the new code to a stable health message.
- `server/src/__tests__/tool-access-service.test.ts`: two tests — the new diagnostic, and a guard that a connection which places a header still reports `oauth_challenge`.

The condition is deliberately narrow. An OAuth connection stores its access token as a `credentialRefs` entry named `oauth.access_token`, so an OAuth connection that has never been connected still reports the sign-in challenge, which is correct for it.

## Verification

- `npx vitest run --root server src/__tests__/tool-access-service.test.ts` — 128/128 pass, including the 2 new tests.
- Without the change, the new diagnostic test fails with `oauth_challenge`, which is the reported symptom. The guard test passes before and after, so the OAuth path does not change.
- `pnpm typecheck` — clean across the workspace.

## Risks

Low. The change only rewrites an error that a failing request already produced.

- No success path is affected. The check runs inside the `!response.ok` branch, after a 401.
- A connection with an OAuth config keeps the sign-in message, because the condition excludes it.
- A connection with no `credentialSecretRefs` keeps the sign-in message, because the condition requires at least one.
- `credential_header_missing` is a new code. A client that switches on the old code sees `paperclip_error` semantics for this narrow case if it does not learn the new one; `sanitizeHttpFailure` returns a clear message either way.

## Model Used

Claude Opus 5 (`claude-opus-5`, Anthropic) through Claude Code, with extended thinking and tool use. The model traced the header resolution path, wrote the diagnostic and the tests, and ran the test and typecheck commands. @Drizzy07x reviewed the change and submits it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable — no document describes this error path)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
