### PR TITLE
Inbox: show live, waiting and nested state without opening a task (mobile especially)

### DIFF
--- a/ui/src/components/IssueColumns.tsx
+++ b/ui/src/components/IssueColumns.tsx
@@ -175,12 +175,14 @@ export function InboxIssueMetaLeading({
       ) : null}
       {isLive && (
         <Badge variant="ghost"
+          data-testid="issue-live-badge"
+          title="An agent run is executing on this task right now."
           className={cn(
-            "px-1.5 sm:gap-1.5 sm:px-2",
+            "gap-1 px-1.5 sm:gap-1.5 sm:px-2",
             "bg-blue-500/10",
           )}
         >
-          <span className="relative flex h-2 w-2">
+          <span className="relative flex h-2 w-2 shrink-0">
             <span className="absolute inline-flex h-full w-full animate-pulse rounded-full bg-blue-400 opacity-75" />
             <span
               className={cn(
@@ -189,9 +191,14 @@ export function InboxIssueMetaLeading({
               )}
             />
           </span>
+          {/* The label is readable at every width. It used to be `hidden
+              sm:inline`, which left phones with a bare blue dot indistinguish-
+              able from every other coloured dot in the row — the list then read
+              as "no live marker at all" on the device the board is mostly
+              checked from. */}
           <span
             className={cn(
-              "hidden text-(length:--text-micro) font-medium sm:inline",
+              "text-(length:--text-micro) font-medium",
               "text-blue-600 dark:text-blue-400",
             )}
           >
@@ -201,8 +208,9 @@ export function InboxIssueMetaLeading({
       )}
       {showSubtreeLiveChip && !isLive && subtreeLiveCount > 0 && (
         <Badge variant="outline"
+          data-testid="issue-subtree-live-badge"
           className={cn(
-            "px-1.5 sm:gap-1.5 sm:px-2",
+            "gap-1 px-1.5 sm:gap-1.5 sm:px-2",
             "border-border bg-transparent",
           )}
           title={`${subtreeLiveCount} sub-task${subtreeLiveCount === 1 ? "" : "s"} running below`}
@@ -214,8 +222,9 @@ export function InboxIssueMetaLeading({
             )}
             aria-hidden="true"
           />
-          <span className="hidden text-(length:--text-micro) font-medium text-muted-foreground sm:inline">
-            {subtreeLiveCount} live below
+          <span className="text-(length:--text-micro) font-medium text-muted-foreground">
+            <span className="sm:hidden">{subtreeLiveCount}</span>
+            <span className="hidden sm:inline">{subtreeLiveCount} live below</span>
           </span>
         </Badge>
       )}

--- a/ui/src/components/IssueRow.test.tsx
+++ b/ui/src/components/IssueRow.test.tsx
@@ -7,6 +7,7 @@ import type { Issue } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IssueRow } from "./IssueRow";
 import { StatusIcon } from "./StatusIcon";
+import { IssueSignalsContext } from "../context/IssueSignalsContext";
 
 vi.mock("@/lib/router", () => ({
   Link: ({
@@ -95,6 +96,63 @@ describe("IssueRow", () => {
 
   afterEach(() => {
     container.remove();
+  });
+
+  it("shows no awaiting-response dot without an IssueSignalsProvider", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<IssueRow issue={createIssue()} />);
+    });
+
+    expect(container.querySelectorAll('[data-testid="issue-row-awaiting-response"]').length).toBe(0);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("marks a task that has a pending issue-thread interaction", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueSignalsContext.Provider value={new Map([["issue-1", 2]])}>
+          <IssueRow issue={createIssue({ id: "issue-1" })} />
+        </IssueSignalsContext.Provider>,
+      );
+    });
+
+    // Once for mobile, once for desktop — each side of the row is visibility-
+    // gated by a Tailwind breakpoint, so both must carry the marker.
+    const dots = container.querySelectorAll('[data-testid="issue-row-awaiting-response"]');
+    expect(dots.length).toBe(2);
+    dots.forEach((dot) => {
+      expect(dot.getAttribute("data-awaiting-count")).toBe("2");
+      expect(dot.getAttribute("aria-label")).toBe("2 questions are waiting for your answer");
+    });
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("leaves rows without a pending interaction unmarked", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueSignalsContext.Provider value={new Map([["other-issue", 1]])}>
+          <IssueRow issue={createIssue({ id: "issue-1" })} />
+        </IssueSignalsContext.Provider>,
+      );
+    });
+
+    expect(container.querySelectorAll('[data-testid="issue-row-awaiting-response"]').length).toBe(0);
+
+    act(() => {
+      root.unmount();
+    });
   });
 
   it("renders the list status glyph at md (16px)", () => {

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -18,6 +18,7 @@ import { productivityReviewTriggerLabel } from "./ProductivityReviewBadge";
 import { hasAssignedBacklogBlocker } from "../lib/issue-blockers";
 import { ExternalObjectStatusSummary } from "./ExternalObjectStatusSummary";
 import { Badge } from "@/components/ui/badge";
+import { useIssueSignals } from "../context/IssueSignalsContext";
 
 type UnreadState = "hidden" | "visible" | "fading";
 
@@ -192,6 +193,39 @@ export function IssueRow({
       Blocked by parked work
     </Badge>
   ) : null;
+  // Pending issue-thread interactions, served from one company-wide query held
+  // by IssueSignalsProvider. Inert in any tree without the provider — unit
+  // tests and Storybook included.
+  const signals = useIssueSignals(issue.id);
+  // The "waiting on a human" dot. Deliberately red and deliberately NOT the
+  // same control as the blue unread dot: unread means "you have not looked at
+  // this", this means "this task cannot move until you answer".
+  const awaitingIndicator = signals.awaiting ? (
+    <span
+      data-testid="issue-row-awaiting-response"
+      data-awaiting-count={signals.awaitingCount}
+      role="status"
+      aria-label={
+        signals.awaitingCount > 1
+          ? `${signals.awaitingCount} questions are waiting for your answer`
+          : "A question is waiting for your answer"
+      }
+      title={
+        signals.awaitingCount > 1
+          ? `${signals.awaitingCount} pending requests are waiting for your answer — open the task to reply.`
+          : "A pending request is waiting for your answer — open the task to reply."
+      }
+      className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "block h-2 w-2 rounded-full ring-2 ring-red-500/25",
+          selected ? "bg-muted-foreground ring-muted-foreground/25" : "bg-red-500 dark:bg-red-400",
+        )}
+      />
+    </span>
+  ) : null;
 
   return (
     <div
@@ -231,6 +265,7 @@ export function IssueRow({
         <span className="sr-only">Open {identifier}: {issue.title}</span>
       </Link>
       <span className="flex shrink-0 items-center gap-1 pt-px sm:hidden">
+        {awaitingIndicator}
         {mobileLeading ?? <StatusIcon status={issue.status} blockerAttention={issue.blockerAttention} size="md" className={selectedStatusClass} />}
         {productivityReviewIndicator}
         {parkedBlockerIndicator}
@@ -296,6 +331,9 @@ export function IssueRow({
             : null}
           {desktopLeadingSpacer ? (
             <span className="hidden w-3.5 shrink-0 sm:block" />
+          ) : null}
+          {awaitingIndicator ? (
+            <span className="hidden shrink-0 items-center sm:inline-flex">{awaitingIndicator}</span>
           ) : null}
           {desktopMetaLeading ?? (
             <>

--- a/ui/src/context/IssueSignalsContext.test.ts
+++ b/ui/src/context/IssueSignalsContext.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildAwaitingCounts } from "./IssueSignalsContext";
+
+describe("buildAwaitingCounts", () => {
+  it("counts pending issue-thread interactions per issue", () => {
+    const counts = buildAwaitingCounts([
+      {
+        sourceKind: "issue_thread_interaction",
+        subject: { kind: "interaction", id: "int-1" },
+        relatedIssue: { kind: "issue", id: "issue-1" },
+      },
+      {
+        sourceKind: "issue_thread_interaction",
+        subject: { kind: "interaction", id: "int-2" },
+        relatedIssue: { kind: "issue", id: "issue-1" },
+      },
+      {
+        sourceKind: "issue_thread_interaction",
+        subject: { kind: "interaction", id: "int-3" },
+        relatedIssue: { kind: "issue", id: "issue-2" },
+      },
+    ]);
+
+    expect(counts.get("issue-1")).toBe(2);
+    expect(counts.get("issue-2")).toBe(1);
+  });
+
+  it("falls back to the subject when it is the issue itself", () => {
+    const counts = buildAwaitingCounts([
+      {
+        sourceKind: "issue_thread_interaction",
+        subject: { kind: "issue", id: "issue-9" },
+        relatedIssue: null,
+      },
+    ]);
+
+    expect(counts.get("issue-9")).toBe(1);
+  });
+
+  it("ignores every other attention source", () => {
+    // Approvals, reviews, failed runs and blockers each have their own inbox
+    // row and their own affordance. Folding them into the same dot would make
+    // the dot mean "something, somewhere" instead of "answer this question".
+    const counts = buildAwaitingCounts([
+      { sourceKind: "approval", relatedIssue: { kind: "issue", id: "issue-1" } },
+      { sourceKind: "review", relatedIssue: { kind: "issue", id: "issue-1" } },
+      { sourceKind: "failed_run", relatedIssue: { kind: "issue", id: "issue-1" } },
+      { sourceKind: "blocker_attention", relatedIssue: { kind: "issue", id: "issue-1" } },
+    ]);
+
+    expect(counts.size).toBe(0);
+  });
+
+  it("skips interactions that resolve to no issue", () => {
+    const counts = buildAwaitingCounts([
+      { sourceKind: "issue_thread_interaction", subject: { kind: "interaction", id: "int-1" }, relatedIssue: null },
+      { sourceKind: "issue_thread_interaction", relatedIssue: { kind: "issue", id: null } },
+    ]);
+
+    expect(counts.size).toBe(0);
+  });
+
+  it("returns an empty map for an absent feed", () => {
+    expect(buildAwaitingCounts(undefined).size).toBe(0);
+  });
+});

--- a/ui/src/context/IssueSignalsContext.tsx
+++ b/ui/src/context/IssueSignalsContext.tsx
@@ -1,0 +1,93 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { attentionApi } from "../api/attention";
+import { queryKeys } from "../lib/queryKeys";
+import { useCompany } from "./CompanyContext";
+
+/**
+ * The one per-issue signal a list row needs that no list already carries:
+ * "this task has a pending issue-thread interaction and cannot move until a
+ * human answers it" (ask_user_questions / request_confirmation /
+ * suggest_tasks).
+ *
+ * Live runs are deliberately NOT here — lists already receive `liveIssueIds`
+ * and render the Live badge through `InboxIssueMetaLeading`.
+ *
+ * The data comes from the company-wide attention feed that the sidebar already
+ * calls (`GET /companies/:id/attention`), reusing the same query key so the two
+ * consumers share one request. Every row then reads a map instead of fetching.
+ *
+ * The context defaults to "no signals", so `IssueRow` renders unchanged in unit
+ * tests, in Storybook, and in any tree that does not mount the provider.
+ */
+export interface IssueSignals {
+  awaiting: boolean;
+  awaitingCount: number;
+}
+
+export const NO_ISSUE_SIGNALS: IssueSignals = { awaiting: false, awaitingCount: 0 };
+
+/**
+ * Exported so tests and Storybook can inject a map directly instead of
+ * standing up a QueryClient and a company.
+ */
+export const IssueSignalsContext = createContext<ReadonlyMap<string, number>>(new Map<string, number>());
+
+/**
+ * Counts pending issue-thread interactions per issue.
+ *
+ * The attention feed unions many sources; only `issue_thread_interaction`
+ * means "an agent is asking a human a question on this task". Approvals,
+ * reviews and failed runs already have their own inbox rows and their own
+ * affordances, so folding them into the same dot would make the dot mean
+ * nothing in particular.
+ */
+export function buildAwaitingCounts(
+  items: ReadonlyArray<{
+    sourceKind?: string;
+    subject?: { kind?: string; id?: string | null } | null;
+    relatedIssue?: { kind?: string; id?: string | null } | null;
+  }> | undefined,
+): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const item of items ?? []) {
+    if (item.sourceKind !== "issue_thread_interaction") continue;
+    const issueId = item.relatedIssue?.kind === "issue"
+      ? item.relatedIssue.id
+      : item.subject?.kind === "issue"
+        ? item.subject.id
+        : null;
+    if (!issueId) continue;
+    out.set(issueId, (out.get(issueId) ?? 0) + 1);
+  }
+  return out;
+}
+
+export function IssueSignalsProvider({ children }: { children: ReactNode }) {
+  const { selectedCompanyId } = useCompany();
+
+  // Same key + queryFn as the sidebar's Decisions badge, so React Query serves
+  // both from one request. Enabled without the Decisions experimental flag:
+  // the pending-interaction dot is not part of that surface, it is the plain
+  // "this task is waiting on you" marker.
+  const { data: attentionFeed } = useQuery({
+    queryKey: queryKeys.attention(selectedCompanyId!),
+    queryFn: () => attentionApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 60_000,
+  });
+
+  const value = useMemo(() => buildAwaitingCounts(attentionFeed?.items), [attentionFeed]);
+
+  return <IssueSignalsContext.Provider value={value}>{children}</IssueSignalsContext.Provider>;
+}
+
+export function useIssueSignals(issueId: string | null | undefined): IssueSignals {
+  const awaitingCountByIssueId = useContext(IssueSignalsContext);
+  return useMemo(() => {
+    if (!issueId) return NO_ISSUE_SIGNALS;
+    const awaitingCount = awaitingCountByIssueId.get(issueId) ?? 0;
+    if (awaitingCount === 0) return NO_ISSUE_SIGNALS;
+    return { awaiting: true, awaitingCount };
+  }, [issueId, awaitingCountByIssueId]);
+}

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -1198,8 +1198,10 @@ describe("inbox helpers", () => {
     expect(resolveInboxNestingEnabled(true, false)).toBe(true);
   });
 
-  it("forces nesting off on mobile even when the saved preference is on", () => {
-    expect(resolveInboxNestingEnabled(true, true)).toBe(false);
+  it("keeps nesting enabled on mobile when the saved preference is on", () => {
+    // Mobile used to be forced flat, which hid every sub-task on a phone and
+    // gave no way to reveal them — the nesting toggle was desktop-only.
+    expect(resolveInboxNestingEnabled(true, true)).toBe(true);
   });
 
   it("keeps nesting off when the saved preference is off", () => {

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -670,8 +670,21 @@ export function saveInboxNesting(enabled: boolean) {
   }
 }
 
-export function resolveInboxNestingEnabled(preferenceEnabled: boolean, isMobile: boolean): boolean {
-  return preferenceEnabled && !isMobile;
+/**
+ * Whether the inbox nests sub-tasks under their parent.
+ *
+ * This used to return `false` on mobile unconditionally, so a phone inbox
+ * showed a flat list and a parent's sub-tasks were simply not there — with no
+ * way to reveal them, since the nesting toggle is itself a desktop-only
+ * control. Mobile now nests like desktop: rows carry a per-depth left indent
+ * in place of the desktop tree guides, and the collapse chevron already has a
+ * mobile affordance (`mobileLeading` in Inbox.tsx).
+ *
+ * `isMobile` stays in the signature: callers pass it, and keeping it documents
+ * that the mobile behaviour is a decision rather than an oversight.
+ */
+export function resolveInboxNestingEnabled(preferenceEnabled: boolean, _isMobile: boolean): boolean {
+  return preferenceEnabled;
 }
 
 export function loadLastInboxTab(): InboxTab {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -8,6 +8,7 @@ import { App } from "./App";
 import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { CompanyProvider, useCompany } from "./context/CompanyContext";
 import { LiveUpdatesProvider } from "./context/LiveUpdatesProvider";
+import { IssueSignalsProvider } from "./context/IssueSignalsContext";
 import { BreadcrumbProvider } from "./context/BreadcrumbContext";
 import { PanelProvider } from "./context/PanelContext";
 import { SidebarProvider } from "./context/SidebarContext";
@@ -63,19 +64,21 @@ createRoot(document.getElementById("root")!).render(
               <EditorAutocompleteProvider>
                 <ToastProvider>
                   <LiveUpdatesProvider>
-                    <TooltipProvider>
-                      <CompanyAwareBreadcrumbProvider>
-                        <SidebarProvider>
-                          <PanelProvider>
-                            <PluginLauncherProvider>
-                              <DialogProvider>
-                                <App />
-                              </DialogProvider>
-                            </PluginLauncherProvider>
-                          </PanelProvider>
-                        </SidebarProvider>
-                      </CompanyAwareBreadcrumbProvider>
-                    </TooltipProvider>
+                    <IssueSignalsProvider>
+                      <TooltipProvider>
+                        <CompanyAwareBreadcrumbProvider>
+                          <SidebarProvider>
+                            <PanelProvider>
+                              <PluginLauncherProvider>
+                                <DialogProvider>
+                                  <App />
+                                </DialogProvider>
+                              </PluginLauncherProvider>
+                            </PanelProvider>
+                          </SidebarProvider>
+                        </CompanyAwareBreadcrumbProvider>
+                      </TooltipProvider>
+                    </IssueSignalsProvider>
                   </LiveUpdatesProvider>
                 </ToastProvider>
               </EditorAutocompleteProvider>

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -182,6 +182,16 @@ import {
   type InboxOrderPin,
 } from "../lib/inboxOrderPin";
 
+/**
+ * Mobile-only indent for nested inbox rows. Desktop shows depth through
+ * `IssueRow`'s tree guides, which are `sm:` only, so without this a nested row
+ * on a phone is indistinguishable from a root row.
+ *
+ * Margin, not padding: `IssueRow` sets its own `pl-*` (including the reserved
+ * unread-dot gutter) and tailwind-merge would let a `pl-*` here silently win.
+ */
+const MOBILE_INBOX_TREE_INDENT = ["", "ml-4 sm:ml-0", "ml-8 sm:ml-0", "ml-12 sm:ml-0", "ml-16 sm:ml-0"];
+
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
 const INBOX_HOT_PATH_STALE_MS = 30_000;
@@ -2294,7 +2304,15 @@ export function Inbox() {
         </div>
         <div className="flex flex-wrap items-center justify-between gap-2">
         <Tabs value={tab} onValueChange={(value) => navigate(`/inbox/${value}`)}>
+          {/* `value` + `onValueChange` are what switch PageTabBar to its compact
+              mobile <select>. Without them the full five-tab list renders at a
+              fixed ~311px inside a ~358px toolbar; the icon group no longer fits
+              beside it and the `flex-wrap` container breaks onto a second row,
+              doubling its height (36px -> 88px) and leaving the dead gap Simon
+              sees on iPhone. Desktop is unchanged — it still renders TabsList. */}
           <PageTabBar
+            value={tab}
+            onValueChange={(value) => navigate(`/inbox/${value}`)}
             items={[
               {
                 value: "mine",
@@ -2434,7 +2452,10 @@ export function Inbox() {
                 type="button"
                 variant="outline"
                 size="icon"
-                className={cn("hidden h-8 w-8 shrink-0 sm:inline-flex", nestingEnabled && "bg-accent")}
+                // Reachable on mobile too, now that the inbox nests there:
+                // leaving it desktop-only made nesting a setting phones could
+                // be subject to but never change.
+                className={cn("inline-flex h-8 w-8 shrink-0", nestingEnabled && "bg-accent")}
                 onClick={toggleNesting}
                 title={nestingEnabled ? "Disable parent-child nesting" : "Enable parent-child nesting"}
               >
@@ -2502,15 +2523,25 @@ export function Inbox() {
               />
               {canMarkAllRead && (
                 <>
+                  {/* Icon-only on mobile. At 390px the label is 132px wide and
+                      pushed this whole action group onto a second toolbar row
+                      (99px tabs + 292px actions > 358px available), which is the
+                      dead band Simon reads as "grosses espaces". Icon-only the
+                      group is ~192px and the toolbar stays one row. */}
                   <Button
                     type="button"
                     variant="outline"
                     size="sm"
-                    className="h-8 shrink-0"
+                    className="h-8 w-8 shrink-0 px-0 sm:w-auto sm:px-3"
                     onClick={() => setShowMarkAllReadConfirm(true)}
                     disabled={markAllReadMutation.isPending}
+                    title="Mark all as read"
+                    aria-label="Mark all as read"
                   >
-                    {markAllReadMutation.isPending ? "Marking…" : "Mark all as read"}
+                    <Check className="h-4 w-4 sm:hidden" aria-hidden />
+                    <span className="hidden sm:inline">
+                      {markAllReadMutation.isPending ? "Marking…" : "Mark all as read"}
+                    </span>
                   </Button>
                   <Dialog open={showMarkAllReadConfirm} onOpenChange={setShowMarkAllReadConfirm}>
                     <DialogContent className="sm:max-w-md">
@@ -2688,11 +2719,16 @@ export function Inbox() {
                       issueLinkState={issueLinkState}
                       treeGuides={depth}
                       selected={selected}
-                      className={
+                      className={cn(
                         isArchiving
                           ? "pointer-events-none -translate-x-4 scale-(--s-0_98) opacity-0 transition-all duration-200 ease-out"
-                          : "transition-all duration-200 ease-out"
-                      }
+                          : "transition-all duration-200 ease-out",
+                        // Mobile has no tree guides (those are `sm:` only), so
+                        // depth reads as a plain left indent instead.
+                        nestingEnabled
+                          ? MOBILE_INBOX_TREE_INDENT[Math.min(depth, MOBILE_INBOX_TREE_INDENT.length - 1)]
+                          : null,
+                      )}
                       desktopMetaLeading={
                         <>
                           {nestingEnabled ? (


### PR DESCRIPTION
## Why

On a phone the inbox does not answer the two questions you open it to answer: *what is running right now* and *what is blocked waiting on me*. Both are rendered on the issue detail page but not in the list, so you have to open tasks one by one to find them. A pending `ask_user_questions` / `request_confirmation` can sit unanswered for days this way.

Four independent defects, four small fixes. Each is verifiable on its own.

## What

**1. The toolbar wraps on iPhone.** `PageTabBar` already ships a compact `<select>` for mobile, but it only engages when `value` and `onValueChange` are passed, and `Inbox.tsx` passed neither (it wrapped the bar in `<Tabs>` instead). The five-tab `TabsList` therefore rendered at a fixed ~311px inside a ~358px `flex-wrap` toolbar, the action group no longer fit beside it, and the container broke onto a second row.

Passing the props — the same call shape `Search.tsx` already uses — plus making "Mark all as read" icon-only below `sm`, keeps it one row.

At 390x844: toolbar **88px → 44px**, first task at **228px → 184px**, **7 → 8** tasks visible. Desktop is untouched and still renders `TabsList`.

**2. Sub-tasks are invisible on mobile.** `resolveInboxNestingEnabled` forced nesting off below `sm`, and the toggle that could turn it back on was itself `hidden sm:inline-flex`, so it could not be reached. Nesting now applies at every width, with a per-depth left margin standing in for the desktop tree guides (which are `sm:` only), and the toggle is reachable on mobile.

**3. The Live badge is invisible on mobile.** The badge existed, but its label was `hidden sm:inline` — leaving a bare blue dot indistinguishable from the other coloured dots in the row, which reads as no live marker at all. The label now renders at every width; the sibling "N live below" chip degrades to "N" instead of vanishing.

**4. Nothing marks a task that is waiting on a human.** New `IssueSignalsProvider` counts pending `issue_thread_interaction` items from the company attention feed and `IssueRow` renders a red dot for them. It reuses the sidebar's existing query key, so the two consumers share one request rather than adding a per-row fetch. The context defaults to "no signals", so any tree that does not mount the provider — unit tests, Storybook — renders exactly as before.

Only `issue_thread_interaction` counts toward the dot. Approvals, reviews and failed runs already have their own inbox rows and affordances; folding them in would make the dot mean nothing in particular.

## Verification

Verified in a real browser at a **390x844** iPhone viewport against live data, not a devtools window resize. That distinction matters here: at 500px wide the toolbar does **not** wrap, so defect 1 is invisible unless you emulate the true viewport.

Measured on the running page after the change: toolbar one row at 44px, 2 Live badges rendering their label, 8 awaiting dots with `aria-label` "A question is waiting for your answer", 20 indented nested rows.

`ui` typecheck clean. Touched-area tests pass (111). Full `ui` suite: 3876 passed, with 4 pre-existing failures (timezone- and clipboard-dependent) that fail identically on a clean tree at this base.

## Notes

The dot is deliberately not the blue unread dot: unread means "you have not looked at this", the red dot means "this cannot move until you answer".
