### PR TITLE
fix(server): re-resolve managed instructions root at heartbeat config-assembly

### DIFF
--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { agentInstructionsService } from "../services/agent-instructions.js";
+import { agentInstructionsService, resolveHeartbeatManagedInstructionsPatch } from "../services/agent-instructions.js";
 
 type TestAgent = {
   id: string;
@@ -357,5 +357,144 @@ describe("agent instructions service", () => {
       "Recovered managed instructions entry file from disk as AGENTS.md; previous entry docs/MISSING.md was missing.",
     ]);
     expect(exported.files).toEqual({ "AGENTS.md": "# Managed Agent\n" });
+  });
+});
+
+describe("resolveHeartbeatManagedInstructionsPatch", () => {
+  const originalPaperclipHome = process.env.PAPERCLIP_HOME;
+  const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+  const cleanupDirs = new Set<string>();
+
+  afterEach(async () => {
+    if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalPaperclipHome;
+    if (originalPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+    else process.env.PAPERCLIP_INSTANCE_ID = originalPaperclipInstanceId;
+
+    await Promise.all([...cleanupDirs].map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+      cleanupDirs.delete(dir);
+    }));
+  });
+
+  function managedRootFor(paperclipHome: string, instanceId: string) {
+    return path.join(
+      paperclipHome,
+      "instances",
+      instanceId,
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+  }
+
+  it("re-resolves the managed root when the data dir moved out from under a managed config (AGE-168 repro)", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-move-");
+    cleanupDirs.add(paperclipHome);
+
+    // Step 1: agent is configured in managed mode under data-dir A.
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+    const rootA = managedRootFor(paperclipHome, "instance-a");
+    await fs.mkdir(rootA, { recursive: true });
+    await fs.writeFile(path.join(rootA, "AGENTS.md"), "# Instance A Agent\n", "utf8");
+
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: rootA,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(rootA, "AGENTS.md"),
+    });
+
+    // Sanity: with data-dir A still current, nothing needs correcting.
+    await expect(resolveHeartbeatManagedInstructionsPatch(agent)).resolves.toEqual({});
+
+    // Step 2: the data dir is moved to B (`--data-dir ~/B`, no symlink shim), and the real
+    // instructions file lives under the *current* resolveManagedInstructionsRoot(agent) for root B.
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-b";
+    const rootB = managedRootFor(paperclipHome, "instance-b");
+    cleanupDirs.add(rootB);
+    await fs.mkdir(rootB, { recursive: true });
+    await fs.writeFile(path.join(rootB, "AGENTS.md"), "# Instance B Agent\n", "utf8");
+
+    // The agent's persisted adapterConfig still points at stale root A; a heartbeat must resolve
+    // the current root and load the correct instructions file, not the stale persisted absolute path.
+    const patch = await resolveHeartbeatManagedInstructionsPatch(agent);
+
+    expect(patch).toMatchObject({
+      instructionsRootPath: rootB,
+      instructionsFilePath: path.join(rootB, "AGENTS.md"),
+      instructionsEntryFile: "AGENTS.md",
+    });
+    expect((patch as { warnings: string[] }).warnings).toEqual([
+      `Recovered managed instructions from disk at ${rootB}; ignoring stale configured root ${rootA}.`,
+    ]);
+  });
+
+  it("also corrects a stale instructionsEntryFile (fingerprint resolution prefers entryFile over instructionsFilePath)", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-entry-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+
+    // The configured entry file (docs/MISSING.md) no longer exists on disk; only AGENTS.md does,
+    // so recovery must fall back to it as the recovered entry file.
+    const managedRoot = managedRootFor(paperclipHome, "instance-a");
+    await fs.mkdir(managedRoot, { recursive: true });
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Recovered Agent\n", "utf8");
+
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: managedRoot,
+      instructionsEntryFile: "docs/MISSING.md",
+      instructionsFilePath: path.join(managedRoot, "docs", "MISSING.md"),
+    });
+
+    const patch = await resolveHeartbeatManagedInstructionsPatch(agent);
+
+    expect(patch).toMatchObject({
+      instructionsRootPath: managedRoot,
+      instructionsFilePath: path.join(managedRoot, "AGENTS.md"),
+      instructionsEntryFile: "AGENTS.md",
+    });
+  });
+
+  it("returns {} for an external-mode config, even if it points at a nonexistent path", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-external-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+
+    const externalRoot = "/nonexistent/external/root";
+    const agent = makeAgent({
+      instructionsBundleMode: "external",
+      instructionsRootPath: externalRoot,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(externalRoot, "AGENTS.md"),
+    });
+
+    await expect(resolveHeartbeatManagedInstructionsPatch(agent)).resolves.toEqual({});
+  });
+
+  it("returns {} when the managed config is already correct", async () => {
+    const paperclipHome = await makeTempDir("paperclip-heartbeat-instructions-correct-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+
+    const rootA = managedRootFor(paperclipHome, "instance-a");
+    await fs.mkdir(rootA, { recursive: true });
+    await fs.writeFile(path.join(rootA, "AGENTS.md"), "# Instance A Agent\n", "utf8");
+
+    const agent = makeAgent({
+      instructionsBundleMode: "managed",
+      instructionsRootPath: rootA,
+      instructionsEntryFile: "AGENTS.md",
+      instructionsFilePath: path.join(rootA, "AGENTS.md"),
+    });
+
+    await expect(resolveHeartbeatManagedInstructionsPatch(agent)).resolves.toEqual({});
   });
 });

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execute } from "@paperclipai/adapter-pi-local/server";
+import { resolveHeartbeatManagedInstructionsPatch } from "../services/agent-instructions.js";
 
 async function writeFakePiCommand(commandPath: string): Promise<void> {
   const script = `#!/usr/bin/env node
@@ -204,6 +205,136 @@ describe("pi_local execute", () => {
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("consumes a heartbeat-corrected config.instructionsFilePath end-to-end (AGE-168)", async () => {
+    // This proves resolveHeartbeatManagedInstructionsPatch's corrected instructionsFilePath actually
+    // reaches the injected system prompt in a real pi-local execute() run -- not just that the
+    // resolver function returns the right value in isolation (agent-instructions-service.test.ts
+    // covers that in isolation already).
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-instructions-patch-"));
+    const paperclipHome = path.join(root, "paperclip-home");
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "pi");
+    const systemPromptDumpPath = path.join(root, "captured-system-prompt.txt");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(paperclipHome, { recursive: true });
+
+    const captureSystemPromptScript = `#!/usr/bin/env node
+const fs = require("node:fs");
+if (process.argv.includes("--list-models")) {
+  console.log("provider  model");
+  console.log("google    gemini-3-flash-preview");
+  process.exit(0);
+}
+const flagIndex = process.argv.indexOf("--append-system-prompt");
+const systemPrompt = flagIndex >= 0 ? process.argv[flagIndex + 1] : "";
+fs.writeFileSync(${JSON.stringify(systemPromptDumpPath)}, systemPrompt);
+console.log(JSON.stringify({ type: "agent_start" }));
+console.log(JSON.stringify({ type: "turn_start" }));
+console.log(JSON.stringify({ type: "turn_end", message: { role: "assistant", content: "" }, toolResults: [] }));
+console.log(JSON.stringify({ type: "agent_end", messages: [] }));
+process.exit(0);
+`;
+    await fs.writeFile(commandPath, captureSystemPromptScript, "utf8");
+    await fs.chmod(commandPath, 0o755);
+
+    const previousHome = process.env.HOME;
+    const previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    const previousPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+    process.env.HOME = root;
+
+    try {
+      // Step 1: agent is configured in managed mode while the data dir is instance "a".
+      process.env.PAPERCLIP_HOME = paperclipHome;
+      process.env.PAPERCLIP_INSTANCE_ID = "instance-a";
+      const rootA = path.join(
+        paperclipHome,
+        "instances",
+        "instance-a",
+        "companies",
+        "company-instructions-patch",
+        "agents",
+        "agent-instructions-patch",
+        "instructions",
+      );
+      await fs.mkdir(rootA, { recursive: true });
+      await fs.writeFile(path.join(rootA, "AGENTS.md"), "# Stale Instance A Instructions\n", "utf8");
+
+      const agent = {
+        id: "agent-instructions-patch",
+        companyId: "company-instructions-patch",
+        name: "Pi Agent",
+        adapterConfig: {
+          instructionsBundleMode: "managed" as const,
+          instructionsRootPath: rootA,
+          instructionsEntryFile: "AGENTS.md",
+          instructionsFilePath: path.join(rootA, "AGENTS.md"),
+        },
+      };
+
+      // Step 2: the data dir moves to instance "b" (no symlink shim) -- the agent's persisted
+      // adapterConfig still points at stale root A, but the real instructions now live under B.
+      process.env.PAPERCLIP_INSTANCE_ID = "instance-b";
+      const rootB = path.join(
+        paperclipHome,
+        "instances",
+        "instance-b",
+        "companies",
+        "company-instructions-patch",
+        "agents",
+        "agent-instructions-patch",
+        "instructions",
+      );
+      await fs.mkdir(rootB, { recursive: true });
+      await fs.writeFile(path.join(rootB, "AGENTS.md"), "# Recovered Instance B Instructions\n", "utf8");
+
+      // This is the same correction heartbeat.ts applies to `config` before it flows into
+      // buildExecutionWorkspaceAdapterConfig / the runtime config an adapter executes with.
+      const patch = await resolveHeartbeatManagedInstructionsPatch(agent);
+      expect(patch).toMatchObject({ instructionsFilePath: path.join(rootB, "AGENTS.md") });
+      const correctedConfig = { ...agent.adapterConfig, ...patch };
+
+      await execute({
+        runId: "run-pi-instructions-patch",
+        agent: {
+          id: agent.id,
+          companyId: agent.companyId,
+          name: agent.name,
+          adapterType: "pi_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "google/gemini-3-flash-preview",
+          promptTemplate: "Keep working.",
+          ...correctedConfig,
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      const capturedSystemPrompt = await fs.readFile(systemPromptDumpPath, "utf8");
+      expect(capturedSystemPrompt).toContain("# Recovered Instance B Instructions");
+      expect(capturedSystemPrompt).not.toContain("Stale Instance A Instructions");
+      expect(capturedSystemPrompt).toContain(path.join(rootB, "AGENTS.md"));
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+      if (previousPaperclipInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+      else process.env.PAPERCLIP_INSTANCE_ID = previousPaperclipInstanceId;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -451,6 +451,64 @@ export function syncInstructionsBundleConfigFromFilePath(
   return applyBundleConfig(next, { mode, rootPath, entryFile });
 }
 
+/**
+ * Re-resolves the managed instructions root/entry file/file path for a `mode: "managed"` agent
+ * at run-dispatch time, instead of trusting whatever absolute path was persisted into
+ * `adapterConfig.instructionsRootPath`/`instructionsFilePath` the last time the bundle was written.
+ *
+ * `applyBundleConfig` persists an absolute path computed from `resolveManagedInstructionsRoot(agent)`
+ * at config-write time (see above). That path is derived from the current Paperclip instance root
+ * (`PAPERCLIP_HOME`/`PAPERCLIP_INSTANCE_ID`), so moving the data dir without a symlink shim silently
+ * orphans every managed agent's persisted config even though `deriveBundleState` +
+ * `recoverManagedBundleState` already know how to self-heal it -- those helpers only run on the
+ * bundle read/list HTTP API path today, not on the path that assembles the config actually handed
+ * to an adapter's `execute()`.
+ *
+ * This composes the same `deriveBundleState` + `recoverManagedBundleState` helpers used by the
+ * bundle API and returns a patch to apply to `config` before it flows into
+ * `buildExecutionWorkspaceAdapterConfig`/the runtime config an adapter executes with. Returns `{}`
+ * when there is nothing to correct: the bundle is in `external` mode, or the currently configured
+ * managed root/entry file already match what recovery finds on disk.
+ *
+ * Otherwise returns `{ instructionsRootPath, instructionsFilePath, instructionsEntryFile, warnings }`
+ * where `warnings` carries only the warning strings newly produced by this recovery pass (e.g.
+ * "Recovered managed instructions from disk ... ignoring stale configured root"). `instructionsEntryFile`
+ * is included alongside the resolved file path because `resolveInstructionsConfigFingerprintMetadata`
+ * in heartbeat.ts resolves the session-freshness fingerprint path from `config.instructionsEntryFile`
+ * *in preference to* `config.instructionsFilePath` -- leaving the stale entry file name in place would
+ * silently defeat the path correction for that fingerprint even though the adapter's own
+ * `instructionsFilePath` read is fixed.
+ */
+export async function resolveHeartbeatManagedInstructionsPatch(
+  agent: AgentLike,
+): Promise<
+  | Record<string, never>
+  | {
+      instructionsRootPath: string;
+      instructionsFilePath: string;
+      instructionsEntryFile: string;
+      warnings: string[];
+    }
+> {
+  const derived = deriveBundleState(agent);
+  const recovered = await recoverManagedBundleState(agent, derived);
+
+  if (recovered.mode !== "managed" || !recovered.rootPath || !recovered.resolvedEntryPath) return {};
+
+  const rootUnchanged = derived.rootPath ? path.resolve(derived.rootPath) === path.resolve(recovered.rootPath) : false;
+  const entryUnchanged = derived.entryFile === recovered.entryFile;
+  if (rootUnchanged && entryUnchanged) return {};
+
+  const newWarnings = recovered.warnings.filter((warning) => !derived.warnings.includes(warning));
+
+  return {
+    instructionsRootPath: recovered.rootPath,
+    instructionsFilePath: recovered.resolvedEntryPath,
+    instructionsEntryFile: recovered.entryFile,
+    warnings: newWarnings,
+  };
+}
+
 export function agentInstructionsService() {
   async function getBundle(agent: AgentLike): Promise<AgentInstructionsBundle> {
     const state = await recoverManagedBundleState(agent, deriveBundleState(agent));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -151,6 +151,7 @@ import {
   WORKTREE_INSTANCE_ROOT_METADATA_KEY,
 } from "./workspace-instance-cleanup.js";
 import { issueService } from "./issues.js";
+import { resolveHeartbeatManagedInstructionsPatch } from "./agent-instructions.js";
 import { projectService } from "./projects.js";
 import { authorizationService, type AuthorizationActor } from "./authorization.js";
 import { createToolGatewayService } from "./tool-gateway.js";
@@ -14052,7 +14053,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         : null,
     });
-    const config = parseObject(agent.adapterConfig);
+    const config = { ...parseObject(agent.adapterConfig) };
+    const managedInstructionsPatch = await resolveHeartbeatManagedInstructionsPatch(agent);
+    if (Object.keys(managedInstructionsPatch).length > 0) {
+      logger.info(
+        {
+          companyId: agent.companyId,
+          agentId: agent.id,
+          previousInstructionsRootPath: config.instructionsRootPath ?? null,
+          previousInstructionsFilePath: config.instructionsFilePath ?? null,
+          previousInstructionsEntryFile: config.instructionsEntryFile ?? null,
+          instructionsRootPath: managedInstructionsPatch.instructionsRootPath,
+          instructionsFilePath: managedInstructionsPatch.instructionsFilePath,
+          instructionsEntryFile: managedInstructionsPatch.instructionsEntryFile,
+          warnings: managedInstructionsPatch.warnings,
+        },
+        "Corrected stale managed instructions root at heartbeat config-assembly",
+      );
+      config.instructionsRootPath = managedInstructionsPatch.instructionsRootPath;
+      config.instructionsFilePath = managedInstructionsPatch.instructionsFilePath;
+      // Session-freshness fingerprinting (resolveInstructionsConfigFingerprintMetadata below) prefers
+      // instructionsEntryFile over instructionsFilePath, so this must be corrected too or the
+      // fingerprint would keep resolving against the stale entry file name.
+      config.instructionsEntryFile = managedInstructionsPatch.instructionsEntryFile;
+    }
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;


### PR DESCRIPTION
## What

`applyBundleConfig()` in `server/services/agent-instructions.ts` persists an absolute path (`path.resolve(rootPath, entryFile)`) into `adapterConfig.instructionsFilePath`/`instructionsRootPath` at config-write time. `deriveBundleState()` + `recoverManagedBundleState()` already re-resolve and self-heal this on the bundle read/list HTTP API path, but nothing re-ran that recovery before the config reached an adapter's `execute()` — so moving the Paperclip data dir silently orphaned every managed agent's runtime instructions even though the API already knew the config was stale.

Upstream issue: https://github.com/paperclipai/paperclip/issues/11391 (part 2).

## Fix

Instead of touching each of the 9 adapter packages individually, this fixes it once at the single choke point where every run's `adapterConfig` is assembled: `heartbeat.ts`, right after `parseObject(agent.adapterConfig)`.

- `agent-instructions.ts`: exports `resolveHeartbeatManagedInstructionsPatch`, which composes the existing `deriveBundleState` + `recoverManagedBundleState` and returns `{}` (external mode, or an already-correct managed config) or a `{ instructionsRootPath, instructionsFilePath, instructionsEntryFile, warnings }` patch reflecting the current on-disk managed root.
- `heartbeat.ts`: applies that patch to a copy of `config` before it flows into `buildExecutionWorkspaceAdapterConfig` / `mergedConfig` / `resolvedConfig` / `runtimeConfig`, and logs any correction via the existing pino logger with `agentId`/`companyId` and old+new paths. `instructionsEntryFile` is corrected too, since `resolveInstructionsConfigFingerprintMetadata` prefers it over `instructionsFilePath` when resolving the session-freshness fingerprint path.

## Deviation from the linked ticket, flagged explicitly

The internal ticket driving this PR asked for the fix in "the adapter execution path" (each adapter's `execute()`). This PR instead fixes it once at `heartbeat.ts` config-assembly, upstream of every adapter, so the adapter package never sees a stale path in the first place — avoiding a 9-package duplicate of the same correction. The reproduction steps in that ticket ("start with one data dir, move state to another, trigger a heartbeat, confirm the heartbeat resolves the current root") are heartbeat-specific, which this satisfies. A reviewer who prefers the literal per-adapter approach should say so; happy to duplicate the correction into `packages/adapters/*/src/server/execute.ts` instead/also.

Out of scope for this PR (flagging to maintainers as a follow-up major-version cleanup): never persisting an absolute path at all — store only `mode` + `entryFile` and resolve the root at every read.

## Tests

- `server/src/__tests__/agent-instructions-service.test.ts`: repro for `resolveHeartbeatManagedInstructionsPatch` — managed config recorded under data-dir A, data-dir re-pointed to B via `PAPERCLIP_HOME`/`PAPERCLIP_INSTANCE_ID` swap (no symlink shim), function returns the corrected root/path for B. Plus entry-file correction and no-op cases.
- `server/src/__tests__/pi-local-execute.test.ts`: integration test proving the corrected `instructionsFilePath` is actually consumed end-to-end by a real `@paperclipai/adapter-pi-local` `execute()` run (captured `--append-system-prompt` contains the recovered file's contents, not the stale one).

## Verified

```
pnpm --filter @paperclipai/server run typecheck   # exits 0
npx vitest run src/__tests__/agent-instructions-service.test.ts   # 12/12 pass
npx vitest run src/__tests__/pi-local-execute.test.ts             # 4/4 pass
npx vitest run src/__tests__/heartbeat-*.test.ts                  # 609 tests, 607 pass
```

The 2 failures in `heartbeat-workspace-branch-containment.test.ts` are pre-existing macOS `/var` vs `/private/var` tmpdir-symlink string-equality flakes in a `providerRef` assertion, unrelated to this change (no instructions-related code in that test file's path).
