### PR TITLE
feat: enable routine-safe summary refresh writes

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -258,6 +258,8 @@ These browser suites are intended for targeted local verification and CI, not th
 
 For normal issue work, start with the smallest targeted check that proves the change. Reserve repo-wide typecheck/build/test runs for PR-ready handoff or changes broad enough that narrow checks do not cover the risk.
 
+Summary refresh routines use `POST /api/companies/{companyId}/summary-slots/routine-refresh/claim` before writing. The claim is company-scoped, accepts only the checked-out built-in Summarizer routine task, selects changed stale slots, and binds that task as each selected slot's active generator. Subsequent writes still use the normal summary-slot `PUT` with the returned `latestRevisionId` as `baseRevisionId`.
+
 ## One-Command Local Run
 
 For a first-time local install, you can bootstrap and run in one command:

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -1125,7 +1125,7 @@ Behavior:
 
 ## 11.5 Recovery Model Profiles
 
-The optional `modelProfiles.cheap` lane is not a retry worker lane. Paperclip may request the cheap profile only for status-only recovery coordination, and those wakes must include guard context that prevents deliverable work and document/plan updates (`allowDeliverableWork: false`, `allowDocumentUpdates: false`, `resumeRequiresNormalModel: true`).
+The optional `modelProfiles.cheap` lane is not a retry worker lane. Paperclip may request the cheap profile for status-only recovery coordination, and those wakes must include guard context that prevents deliverable work and document/plan updates (`allowDeliverableWork: false`, `allowDocumentUpdates: false`, `resumeRequiresNormalModel: true`). The built-in Summarizer refresh routine is the narrow reporting exception: its execution issue requests an enabled low-cost `cheap` profile, remains read-and-report only, and may mutate only summary revisions that its checked-out routine task first claimed through the company-scoped routine-refresh endpoint.
 
 Failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, and downstream source-work child/requeue/resume contexts must use the normal/original model lane. If cheap recovery repairs liveness while actual work remains, the next live continuation path must be a separate normal-model worker run with cheap hints scrubbed.
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -28,6 +28,7 @@ export const API = {
   summarySlot: `${API_PREFIX}/companies/:companyId/summary-slots/:scopeKind/:slotKey`,
   summarySlotRevisions: `${API_PREFIX}/companies/:companyId/summary-slots/:scopeKind/:slotKey/revisions`,
   summarySlotGenerate: `${API_PREFIX}/companies/:companyId/summary-slots/:scopeKind/:slotKey/generate`,
+  summarySlotRoutineRefreshClaim: `${API_PREFIX}/companies/:companyId/summary-slots/routine-refresh/claim`,
   goals: `${API_PREFIX}/goals`,
   approvals: `${API_PREFIX}/approvals`,
   secrets: `${API_PREFIX}/secrets`,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -595,6 +595,7 @@ export {
 } from "./constants.js";
 
 export {
+  claimRoutineSummaryRefreshSlotsSchema,
   generateSummarySlotSchema,
   summarySlotKeySchema,
   summarySlotQuerySchema,
@@ -602,6 +603,7 @@ export {
   summarySlotScopeSelectorSchema,
   summarySlotStatusSchema,
   writeSummarySlotSchema,
+  type ClaimRoutineSummaryRefreshSlotsInput,
   type GenerateSummarySlotInput,
   type SummarySlotScopeSelectorInput,
   type WriteSummarySlotInput,
@@ -627,6 +629,9 @@ export {
 } from "./environment-custom-images.js";
 
 export type {
+  ClaimedRoutineSummaryRefreshSlot,
+  ClaimRoutineSummaryRefreshSlotsRequest,
+  ClaimRoutineSummaryRefreshSlotsResponse,
   Company,
   InteractionResolverGovernance,
   InteractionResolverKindGovernance,

--- a/packages/shared/src/summary-slot.test.ts
+++ b/packages/shared/src/summary-slot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { API } from "./api.js";
 import {
+  claimRoutineSummaryRefreshSlotsSchema,
   summarySlotScopeSelectorSchema,
   writeSummarySlotSchema,
 } from "./validators/summary-slot.js";
@@ -17,6 +18,9 @@ describe("summary slot shared contract", () => {
     );
     expect(API.summarySlotGenerate).toBe(
       "/api/companies/:companyId/summary-slots/:scopeKind/:slotKey/generate",
+    );
+    expect(API.summarySlotRoutineRefreshClaim).toBe(
+      "/api/companies/:companyId/summary-slots/routine-refresh/claim",
     );
   });
 
@@ -88,5 +92,25 @@ describe("summary slot shared contract", () => {
     });
 
     expect(() => writeSummarySlotSchema.parse({ markdown: "   " })).toThrow();
+  });
+
+  it("bounds routine refresh claims", () => {
+    expect(claimRoutineSummaryRefreshSlotsSchema.parse({
+      generationIssueId: issueId,
+      staleAfterHours: 24,
+      maxSlots: 10,
+      scopeKinds: "project",
+    })).toEqual({
+      generationIssueId: issueId,
+      staleAfterHours: 24,
+      maxSlots: 10,
+      scopeKinds: "project",
+    });
+    expect(() => claimRoutineSummaryRefreshSlotsSchema.parse({
+      generationIssueId: issueId,
+      staleAfterHours: 24,
+      maxSlots: 51,
+      scopeKinds: "all",
+    })).toThrow();
   });
 });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -5,6 +5,9 @@ export type {
   InteractionResolverKindGovernance,
 } from "./company.js";
 export type {
+  ClaimedRoutineSummaryRefreshSlot,
+  ClaimRoutineSummaryRefreshSlotsRequest,
+  ClaimRoutineSummaryRefreshSlotsResponse,
   GenerateSummarySlotRequest,
   GenerateSummarySlotResponse,
   GetSummarySlotResponse,

--- a/packages/shared/src/types/summary-slot.ts
+++ b/packages/shared/src/types/summary-slot.ts
@@ -89,6 +89,22 @@ export interface GenerateSummarySlotResponse {
   alreadyGenerating: boolean;
 }
 
+export interface ClaimRoutineSummaryRefreshSlotsRequest {
+  generationIssueId: string;
+  staleAfterHours: number;
+  maxSlots: number;
+  scopeKinds: SummarySlotScopeKind | "all";
+}
+
+export interface ClaimedRoutineSummaryRefreshSlot {
+  slot: SummarySlot;
+  document: SummarySlotDocument;
+}
+
+export interface ClaimRoutineSummaryRefreshSlotsResponse {
+  slots: ClaimedRoutineSummaryRefreshSlot[];
+}
+
 export interface WriteSummarySlotRequest {
   scopeId?: string | null;
   markdown: string;

--- a/packages/shared/src/validators/summary-slot.ts
+++ b/packages/shared/src/validators/summary-slot.ts
@@ -47,6 +47,15 @@ export const summarySlotQuerySchema = z
 
 export const generateSummarySlotSchema = summarySlotQuerySchema;
 
+export const claimRoutineSummaryRefreshSlotsSchema = z
+  .object({
+    generationIssueId: z.string().uuid(),
+    staleAfterHours: z.number().finite().positive().max(24 * 365),
+    maxSlots: z.number().int().positive().max(50),
+    scopeKinds: z.union([z.literal("all"), summarySlotScopeKindSchema]),
+  })
+  .strict();
+
 export const writeSummarySlotSchema = z
   .object({
     scopeId: optionalScopeIdSchema,
@@ -61,4 +70,5 @@ export const writeSummarySlotSchema = z
 
 export type SummarySlotScopeSelectorInput = z.infer<typeof summarySlotScopeSelectorSchema>;
 export type GenerateSummarySlotInput = z.infer<typeof generateSummarySlotSchema>;
+export type ClaimRoutineSummaryRefreshSlotsInput = z.infer<typeof claimRoutineSummaryRefreshSlotsSchema>;
 export type WriteSummarySlotInput = z.infer<typeof writeSummarySlotSchema>;

--- a/packages/skills-catalog/catalog/bundled/paperclip-operations/summarize-status/SKILL.md
+++ b/packages/skills-catalog/catalog/bundled/paperclip-operations/summarize-status/SKILL.md
@@ -57,6 +57,7 @@ Use these routes directly. Do not guess unscoped `/api/issues` or alternate summ
 - Gather project issues: `GET /api/companies/{companyId}/issues?projectId=...`
 - Gather execution-workspace issues: `GET /api/companies/{companyId}/issues?executionWorkspaceId=...`
 - Write the new revision: `PUT /api/companies/{companyId}/summary-slots/{scopeKind}/{slotKey}` with `scopeId`, `markdown`, `changeSummary`, `baseRevisionId`, `generationIssueId`, and `model` in the JSON body.
+- Routine refresh only: first claim the bounded changed/stale set with `POST /api/companies/{companyId}/summary-slots/routine-refresh/claim`. Use the returned document revision as each write's `baseRevisionId`; the routine task can write only the slots that endpoint bound to it.
 
 For `workspaces_overview`, omit `scopeId` from the read query and send it as `null` in the write body. All calls use the run-scoped Paperclip API URL and bearer token already present in the environment.
 

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-08-07T20:30:29.973Z",
+  "generatedAt": "2026-08-12T05:24:16.136Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -172,11 +172,11 @@
         {
           "path": "SKILL.md",
           "kind": "skill",
-          "sizeBytes": 8877,
-          "sha256": "4cb3d177f5d16e3cc2052d2f80e7fb245ab95e79c1e947abdc84cd4ee3d8c61e"
+          "sizeBytes": 9157,
+          "sha256": "74a9b3dc0a178e0990c09433c80a1dc86435c2b2df71a56db379b67ea2b32265"
         }
       ],
-      "contentHash": "sha256:3e49ee2b8d83d1371fb0f59197bb96c46b64f722540405f46d4a5a756fbe1b89"
+      "contentHash": "sha256:e4a75c820cd4b70ac4d17b7c9269ed94d0aa2dc9a258bb434e827f7b6809d0f5"
     },
     {
       "id": "paperclipai:bundled:paperclip-operations:task-planning",

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -174,8 +174,12 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(summarizer).toMatchObject({
       defaultAdapterType: "claude_local",
       defaultAdapterConfig: { model: "claude-haiku-4-5" },
+      defaultRuntimeConfig: {
+        modelProfiles: {
+          cheap: { enabled: true, adapterConfig: { model: "claude-haiku-4-5" } },
+        },
+      },
     });
-    expect(summarizer?.defaultRuntimeConfig).toBeUndefined();
     expect(() => validateBuiltInAgentDefinitions([
       {
         key: "briefs",
@@ -1209,7 +1213,15 @@ describeEmbeddedPostgres("built-in agents", () => {
       featureKeys: ["summarizer"],
     });
 
-    expect(state.agent?.runtimeConfig).not.toHaveProperty("modelProfiles.cheap");
+    expect(state.agent?.runtimeConfig).toMatchObject({
+      modelProfiles: {
+        cheap: {
+          enabled: true,
+          label: "Cheap",
+          adapterConfig: { model: "claude-haiku-4-5" },
+        },
+      },
+    });
 
     expect(state.resources.map((resource) => [resource.resourceKind, resource.stockStatus])).toEqual([
       ["instructions", "stock_current"],
@@ -1245,6 +1257,14 @@ describeEmbeddedPostgres("built-in agents", () => {
       cronExpression: "0 8 * * *",
       timezone: "UTC",
     });
+    const [routineBinding] = await db.select().from(builtInManagedResources).where(and(
+      eq(builtInManagedResources.companyId, companyId),
+      eq(builtInManagedResources.resourceKind, "routine"),
+      eq(builtInManagedResources.resourceId, routine!.id),
+    ));
+    expect(routineBinding?.defaultsJson).toMatchObject({
+      issueTemplate: { modelProfile: "cheap" },
+    });
   });
 
   it("keeps the Summarizer not-configured until an adapter model is set", async () => {
@@ -1266,7 +1286,7 @@ describeEmbeddedPostgres("built-in agents", () => {
     });
   });
 
-  it("preserves an operator-overridden cheap summariser model across reconcile", async () => {
+  it("enables the Summarizer cheap lane while preserving an operator-overridden low-cost model", async () => {
     const companyId = await seedCompany();
     const builtIns = builtInAgentService(db);
     const created = await builtIns.ensure(companyId, "summarizer");
@@ -1274,13 +1294,13 @@ describeEmbeddedPostgres("built-in agents", () => {
     // Operator overrides the cheap lane with a provider-specific low-cost model.
     await agentService(db).update(created.agentId!, {
       runtimeConfig: {
-        modelProfiles: { cheap: { enabled: true, label: "Cheap", adapterConfig: { model: "haiku-cheap" } } },
+        modelProfiles: { cheap: { enabled: false, label: "Cheap", adapterConfig: { model: "haiku-cheap" } } },
       },
     }, { allowBuiltInAgentMetadata: true });
 
     const reconciled = await builtIns.ensure(companyId, "summarizer");
     expect(reconciled.agent?.runtimeConfig).toMatchObject({
-      modelProfiles: { cheap: { adapterConfig: { model: "haiku-cheap" } } },
+      modelProfiles: { cheap: { enabled: true, adapterConfig: { model: "haiku-cheap" } } },
     });
   });
 

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import {
   activityLog,
   agents,
+  builtInManagedResources,
   companies,
   companySecretBindings,
   companySecrets,
@@ -62,6 +63,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       process.env.PAPERCLIP_SECRETS_PROVIDER = originalSecretsProviderEnv;
     }
     await db.delete(activityLog);
+    await db.delete(builtInManagedResources);
     await db.delete(issueInboxArchives);
     await db.delete(secretAccessEvents);
     await db.delete(companySecretBindings);
@@ -1043,6 +1045,28 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
         },
       },
     ]);
+  });
+
+  it("applies a built-in routine's cheap model profile to its execution issue", async () => {
+    const { companyId, routine, svc } = await seedFixture();
+    await db.insert(builtInManagedResources).values({
+      companyId,
+      bundleKey: "summarizer",
+      resourceKind: "routine",
+      resourceKey: "refresh-stale-summaries",
+      resourceId: routine.id,
+      stockVersion: "test",
+      stockHash: "test",
+      defaultsJson: { issueTemplate: { modelProfile: "cheap" } },
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    const [executionIssue] = await db
+      .select({ assigneeAdapterOverrides: issues.assigneeAdapterOverrides })
+      .from(issues)
+      .where(eq(issues.id, run.linkedIssueId!));
+
+    expect(executionIssue?.assigneeAdapterOverrides).toEqual({ modelProfile: "cheap" });
   });
 
   it("records the manual board runner on fresh routine issues so they appear in that user's inbox", async () => {

--- a/server/src/__tests__/summary-slot-routes.test.ts
+++ b/server/src/__tests__/summary-slot-routes.test.ts
@@ -22,6 +22,7 @@ const mockSummarySlotService = vi.hoisted(() => ({
   getSlot: vi.fn(),
   listRevisions: vi.fn(),
   generate: vi.fn(),
+  claimRoutineRefreshSlots: vi.fn(),
   write: vi.fn(),
 }));
 
@@ -120,6 +121,12 @@ describe("summary slot routes", () => {
       slot: slot({ status: "generating", generatingIssueId }),
       generatingIssue: generatingIssue(),
       alreadyGenerating: false,
+    });
+    mockSummarySlotService.claimRoutineRefreshSlots.mockResolvedValue({
+      slots: [{
+        slot: slot({ status: "generating", generatingIssueId }),
+        document: { id: "doc-1", companyId, latestRevisionId: "rev-1", format: "markdown", body: "# Old" },
+      }],
     });
     mockSummarySlotService.write.mockResolvedValue({
       slot: slot({ documentId: "doc-1", status: "idle" }),
@@ -244,6 +251,36 @@ describe("summary slot routes", () => {
       ).send({});
       expect(res.status, JSON.stringify(res.body)).toBe(404);
       expect(mockSummarySlotService.generate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("routine refresh claim route", () => {
+    it("lets an agent routine claim a bounded changed-stale set and logs each binding", async () => {
+      const app = await createApp(agentActor);
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/summary-slots/routine-refresh/claim`)
+        .send({ generationIssueId: generatingIssueId, staleAfterHours: 24, maxSlots: 10, scopeKinds: "project" });
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockSummarySlotService.claimRoutineRefreshSlots).toHaveBeenCalledWith({
+        companyId,
+        generationIssueId: generatingIssueId,
+        staleAfterHours: 24,
+        maxSlots: 10,
+        scopeKinds: "project",
+      }, { agentId, runId: "run-123" });
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ action: "summary_slot.routine_refresh_claimed", entityId: slotId }),
+      );
+    });
+
+    it("rejects board actors before claiming routine slots", async () => {
+      const app = await createApp(boardActor);
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/summary-slots/routine-refresh/claim`)
+        .send({ generationIssueId: generatingIssueId, staleAfterHours: 24, maxSlots: 10, scopeKinds: "all" });
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(mockSummarySlotService.claimRoutineRefreshSlots).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/__tests__/summary-slots.test.ts
+++ b/server/src/__tests__/summary-slots.test.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import {
   activityLog,
   agents,
+  builtInManagedResources,
   companies,
   createDb,
   documentRevisions,
@@ -13,6 +14,7 @@ import {
   issues,
   projectWorkspaces,
   projects,
+  routines,
   summarySlots,
 } from "@paperclipai/db";
 import {
@@ -47,10 +49,12 @@ describeEmbeddedPostgres("summary slot service", () => {
 
   afterEach(async () => {
     await db.delete(summarySlots);
+    await db.delete(builtInManagedResources);
     await db.delete(documentRevisions);
     await db.delete(documents);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
+    await db.delete(routines);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -631,6 +635,106 @@ describeEmbeddedPostgres("summary slot service", () => {
           { agentId: summarizerAgentId, runId: randomUUID() },
         ),
       ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it("lets a checked-out refresh routine claim and update a changed stale slot but rejects an unrelated slot", async () => {
+      const companyId = await seedCompany();
+      const changedProjectId = await seedProject(companyId);
+      const unrelatedProjectId = await seedProject(companyId);
+      const summarizerAgentId = await seedSummarizer(companyId);
+      const svc = summarySlotService(db);
+
+      const seedSummary = async (projectId: string) => {
+        const generated = await svc.generate(projectSelector(companyId, projectId), { userId: "board-user" });
+        const runId = await seedRun(companyId, summarizerAgentId);
+        await db.update(issues).set({ checkoutRunId: runId }).where(eq(issues.id, generated.generatingIssue.id));
+        return svc.write(
+          { ...projectSelector(companyId, projectId), markdown: "# Previous summary", generationIssueId: generated.generatingIssue.id },
+          { agentId: summarizerAgentId, runId },
+        );
+      };
+      const changedPrevious = await seedSummary(changedProjectId);
+      await seedSummary(unrelatedProjectId);
+      const staleAt = new Date(Date.now() - 48 * 60 * 60 * 1_000);
+      await db.update(summarySlots).set({ lastGeneratedAt: staleAt }).where(eq(summarySlots.companyId, companyId));
+      await db.update(projects).set({ updatedAt: new Date(staleAt.getTime() - 60 * 60 * 1_000) }).where(eq(projects.companyId, companyId));
+      await db.update(issues).set({ updatedAt: new Date(staleAt.getTime() - 60 * 60 * 1_000) }).where(eq(issues.companyId, companyId));
+      await db.insert(issues).values({
+        companyId,
+        projectId: changedProjectId,
+        title: "Changed after the previous summary",
+        status: "in_progress",
+        priority: "medium",
+        updatedAt: new Date(),
+      });
+
+      const [routine] = await db.insert(routines).values({
+        companyId,
+        title: "Refresh stale summary slots",
+        assigneeAgentId: summarizerAgentId,
+        status: "paused",
+      }).returning();
+      await db.insert(builtInManagedResources).values({
+        companyId,
+        bundleKey: "summarizer",
+        resourceKind: "routine",
+        resourceKey: "refresh-stale-summaries",
+        resourceId: routine!.id,
+        stockVersion: "test",
+        stockHash: "test",
+        defaultsJson: { issueTemplate: { modelProfile: "cheap" } },
+      });
+      const routineRunId = await seedRun(companyId, summarizerAgentId);
+      const [routineIssue] = await db.insert(issues).values({
+        companyId,
+        title: "Refresh stale summary slots",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: summarizerAgentId,
+        checkoutRunId: routineRunId,
+        originKind: "routine_execution",
+        originId: routine!.id,
+      }).returning();
+
+      const claimed = await svc.claimRoutineRefreshSlots({
+        companyId,
+        generationIssueId: routineIssue!.id,
+        staleAfterHours: 24,
+        maxSlots: 10,
+        scopeKinds: "project",
+      }, { agentId: summarizerAgentId, runId: routineRunId });
+
+      expect(claimed.slots).toHaveLength(1);
+      expect(claimed.slots[0]).toMatchObject({
+        slot: {
+          scopeId: changedProjectId,
+          status: "generating",
+          generatingIssueId: routineIssue!.id,
+        },
+        document: { latestRevisionId: changedPrevious.revision.id },
+      });
+      await expect(svc.write({
+        ...projectSelector(companyId, unrelatedProjectId),
+        markdown: "# Unauthorized refresh",
+        generationIssueId: routineIssue!.id,
+      }, { agentId: summarizerAgentId, runId: routineRunId })).rejects.toMatchObject({ status: 403 });
+
+      await expect(svc.write({
+        ...projectSelector(companyId, changedProjectId),
+        markdown: "# Stale write",
+        baseRevisionId: randomUUID(),
+        generationIssueId: routineIssue!.id,
+      }, { agentId: summarizerAgentId, runId: routineRunId })).rejects.toMatchObject({ status: 409 });
+
+      const refreshed = await svc.write({
+        ...projectSelector(companyId, changedProjectId),
+        markdown: "# Refreshed summary",
+        baseRevisionId: changedPrevious.revision.id,
+        generationIssueId: routineIssue!.id,
+        model: "claude-haiku-4-5",
+      }, { agentId: summarizerAgentId, runId: routineRunId });
+      expect(refreshed.revision.revisionNumber).toBe(2);
+      expect(refreshed.slot).toMatchObject({ status: "idle", generatingIssueId: null });
     });
   });
 });

--- a/server/src/built-ins/agents/summarizer/routines/refresh-stale-summaries.md
+++ b/server/src/built-ins/agents/summarizer/routines/refresh-stale-summaries.md
@@ -51,15 +51,15 @@ This routine is **paused by default** and spends no tokens until an operator ena
 
 ## What this run must do
 
-1. Select summary slots whose scope has changed since their last revision and whose `lastGeneratedAt` is older than `{{staleAfterHours}}` hours. Restrict to `{{scopeKinds}}` when a specific kind is chosen. Cap the set at `{{maxSlots}}`, most-stale first.
-2. For each selected slot, run the `summarize-status` skill as the operating procedure: read the current revision, read the company-scoped state you need to understand where things are, and write one new Markdown revision back to the slot.
+1. Claim the bounded refresh set with `POST /api/companies/{companyId}/summary-slots/routine-refresh/claim`, sending this routine execution issue id as `generationIssueId` plus `staleAfterHours: {{staleAfterHours}}`, `maxSlots: {{maxSlots}}`, and `scopeKinds: "{{scopeKinds}}"`. The endpoint returns only stale slots whose scope changed, most-stale first, and binds this checked-out routine task as their active generator.
+2. For each claimed slot, run the `summarize-status` skill as the operating procedure: use the returned document and `latestRevisionId`, read the company-scoped state you need to understand where things are, and write one new Markdown revision back to that exact slot with this routine issue as `generationIssueId`.
 3. Skip slots with no meaningful change since their last revision — do not spend tokens rewriting an unchanged summary.
 
 ## Hard limits for this routine
 
 - Read-and-report only. This routine must never change issues, workspaces, code, or agent configuration — its only write is the summary revision.
 - Keep every read company-scoped. Do not cross company boundaries.
-- Run on the low-cost model profile lane (`cheap`). Keep each summary short.
+- Run on the enabled low-cost model profile lane (`cheap`). The stock Summarizer maps this lane to Claude Haiku 4.5; an operator may replace it with another approved low-cost model. Keep each summary short.
 - Never fabricate status and never surface secrets from issue bodies or configs.
 
 ## Output

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -12,6 +12,7 @@ import {
   createAgentKeySchema,
   builtInAgentEmptyMutationSchema,
   builtInAgentProvisionSchema,
+  claimRoutineSummaryRefreshSlotsSchema,
   generateSummarySlotSchema,
   writeSummarySlotSchema,
   createStatusCardSchema,
@@ -1512,6 +1513,25 @@ registry.registerPath({
   summary: "List dated revisions for a summary slot",
   request: { params: summarySlotParams },
   responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound, 422: r.unprocessable },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/companies/{companyId}/summary-slots/routine-refresh/claim",
+  tags: ["summaries"],
+  summary: "Claim changed stale summary slots for the checked-out Summarizer routine task",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    body: jsonBody(claimRoutineSummaryRefreshSlotsSchema),
+  },
+  responses: {
+    200: r.ok(),
+    400: r.badRequest,
+    401: r.unauthorized,
+    403: r.forbidden,
+    404: r.notFound,
+    422: r.unprocessable,
+  },
 });
 
 registry.registerPath({

--- a/server/src/routes/summary-slots.ts
+++ b/server/src/routes/summary-slots.ts
@@ -1,6 +1,10 @@
 import { Router, type Request } from "express";
 import type { Db } from "@paperclipai/db";
-import { generateSummarySlotSchema, writeSummarySlotSchema } from "@paperclipai/shared";
+import {
+  claimRoutineSummaryRefreshSlotsSchema,
+  generateSummarySlotSchema,
+  writeSummarySlotSchema,
+} from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { forbidden, notFound } from "../errors.js";
 import { accessService, heartbeatService, instanceSettingsService, logActivity } from "../services/index.js";
@@ -54,7 +58,7 @@ export function summarySlotRoutes(db: Db) {
     req: Request,
     input: {
       companyId: string;
-      action: "summary_slot.generate_requested" | "summary_slot.write";
+      action: "summary_slot.generate_requested" | "summary_slot.routine_refresh_claimed" | "summary_slot.write";
       slotId: string;
       details: Record<string, unknown>;
     },
@@ -98,6 +102,45 @@ export function summarySlotRoutes(db: Db) {
     });
     res.json(result);
   });
+
+  router.post(
+    "/companies/:companyId/summary-slots/routine-refresh/claim",
+    validate(claimRoutineSummaryRefreshSlotsSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      await assertSummariesEnabled();
+      if (req.actor.type !== "agent") {
+        throw forbidden("Only the Summarizer refresh routine may claim summary slots");
+      }
+      const actor = getActorInfo(req);
+      const result = await svc.claimRoutineRefreshSlots(
+        {
+          companyId,
+          generationIssueId: req.body.generationIssueId,
+          staleAfterHours: req.body.staleAfterHours,
+          maxSlots: req.body.maxSlots,
+          scopeKinds: req.body.scopeKinds,
+        },
+        { agentId: actor.agentId, runId: actor.runId ?? null },
+      );
+      for (const claimed of result.slots) {
+        await logSummaryMutation(req, {
+          companyId,
+          action: "summary_slot.routine_refresh_claimed",
+          slotId: claimed.slot.id,
+          details: {
+            scopeKind: claimed.slot.scopeKind,
+            scopeId: claimed.slot.scopeId,
+            slotKey: claimed.slot.slotKey,
+            generatingIssueId: req.body.generationIssueId,
+            baseRevisionId: claimed.document.latestRevisionId,
+          },
+        });
+      }
+      res.json(result);
+    },
+  );
 
   router.post(
     "/companies/:companyId/summary-slots/:scopeKind/:slotKey/generate",

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -117,6 +117,9 @@ export interface BuiltInAgentBundleDefinition {
     priority: "critical" | "high" | "medium" | "low";
     concurrencyPolicy: "always_enqueue" | "coalesce_if_active" | "skip_if_active";
     catchUpPolicy: "enqueue_missed_with_cap" | "skip_missed";
+    issueTemplate?: {
+      modelProfile?: "cheap";
+    };
     variables: RoutineVariable[];
     triggers: Array<{
       kind: "schedule";
@@ -417,9 +420,18 @@ const DEFINITIONS = validateBuiltInAgentDefinitions([
     defaultAdapterConfig: {
       model: "claude-haiku-4-5",
     },
+    defaultRuntimeConfig: {
+      modelProfiles: {
+        cheap: {
+          enabled: true,
+          label: "Cheap",
+          adapterConfig: { model: "claude-haiku-4-5" },
+        },
+      },
+    },
     defaultBudgetMonthlyCents: 0,
     bundle: {
-      stockVersion: "2026-08-02",
+      stockVersion: "2026-08-12",
       instructions: {
         entryFile: "AGENTS.md",
         files: {
@@ -443,6 +455,7 @@ const DEFINITIONS = validateBuiltInAgentDefinitions([
         priority: "medium",
         concurrencyPolicy: "coalesce_if_active",
         catchUpPolicy: "skip_missed",
+        issueTemplate: { modelProfile: "cheap" },
         variables: [
           { name: "staleAfterHours", label: "Refresh slots older than (hours)", type: "number", defaultValue: 24, required: true, options: [] },
           { name: "maxSlots", label: "Max slots to refresh per run", type: "number", defaultValue: 10, required: true, options: [] },
@@ -736,6 +749,35 @@ function definitionPatch(definition: BuiltInAgentDefinition, input: BuiltInAgent
     permissions: definition.defaultPermissions ?? {},
     budgetMonthlyCents: input.budgetMonthlyCents ?? definition.defaultBudgetMonthlyCents ?? 0,
   };
+}
+
+function mergeBuiltInRuntimeDefaults(
+  current: Record<string, unknown> | null | undefined,
+  defaults: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const next = { ...(current ?? {}) };
+  if (!defaults) return next;
+  const defaultProfiles = isPlainRecord(defaults.modelProfiles) ? defaults.modelProfiles : {};
+  const currentProfiles = isPlainRecord(next.modelProfiles) ? next.modelProfiles : {};
+  const mergedProfiles = { ...currentProfiles };
+  for (const [key, value] of Object.entries(defaultProfiles)) {
+    const defaultProfile = isPlainRecord(value) ? value : null;
+    const currentProfile = isPlainRecord(mergedProfiles[key]) ? mergedProfiles[key] as Record<string, unknown> : null;
+    if (!currentProfile || !defaultProfile) {
+      if (!Object.prototype.hasOwnProperty.call(mergedProfiles, key)) mergedProfiles[key] = value;
+      continue;
+    }
+    mergedProfiles[key] = {
+      ...defaultProfile,
+      ...currentProfile,
+      ...(defaultProfile.enabled === true ? { enabled: true } : {}),
+      adapterConfig: isPlainRecord(currentProfile.adapterConfig)
+        ? currentProfile.adapterConfig
+        : defaultProfile.adapterConfig,
+    };
+  }
+  if (Object.keys(mergedProfiles).length > 0) next.modelProfiles = mergedProfiles;
+  return next;
 }
 
 async function assertKnownBuiltInAgentModel(
@@ -1395,6 +1437,7 @@ export function builtInAgentService(db: Db) {
         title: bundle.routine.title,
         status: bundle.routine.status,
         triggerCount: bundle.routine.triggers.length,
+        ...(bundle.routine.issueTemplate ? { issueTemplate: bundle.routine.issueTemplate } : {}),
       },
     });
     const next = await getRoutineByBinding(agent.companyId, definition);
@@ -1619,6 +1662,13 @@ export function builtInAgentService(db: Db) {
       const patch: Partial<typeof agents.$inferInsert> = {
         metadata: builtInMetadata(definition, existing.metadata),
       };
+      const runtimeConfig = mergeBuiltInRuntimeDefaults(
+        existing.runtimeConfig,
+        definition.defaultRuntimeConfig,
+      );
+      if (stableJson(runtimeConfig) !== stableJson(existing.runtimeConfig ?? {})) {
+        patch.runtimeConfig = runtimeConfig;
+      }
       if (
         !existingPendingApproval
         && (resolvedInput.adapterType !== undefined || resolvedInput.adapterConfig !== undefined)

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -4,6 +4,7 @@ import type { Db } from "@paperclipai/db";
 import {
   agents,
   activityLog,
+  builtInManagedResources,
   companies,
   companyMemberships,
   companySecretBindings,
@@ -484,6 +485,7 @@ function createRoutineDispatchFingerprint(input: {
   executionWorkspaceSettings?: Record<string, unknown> | null;
   title: string;
   description: string | null;
+  modelProfile: "cheap" | null;
 }) {
   const canonical = JSON.stringify(normalizeRoutineDispatchFingerprintValue(input));
   return crypto.createHash("sha256").update(canonical).digest("hex");
@@ -501,6 +503,7 @@ function readManagedRoutineIssueTemplate(defaultsJson: Record<string, unknown> |
     surfaceVisibility: typeof value.surfaceVisibility === "string" ? value.surfaceVisibility : null,
     originId: typeof value.originId === "string" && value.originId.trim() ? value.originId.trim() : null,
     billingCode: typeof value.billingCode === "string" && value.billingCode.trim() ? value.billingCode.trim() : null,
+    modelProfile: value.modelProfile === "cheap" ? "cheap" as const : null,
   };
 }
 
@@ -645,7 +648,7 @@ export function routineService(
   }
 
   async function getManagedRoutineBinding(routine: typeof routines.$inferSelect) {
-    return db
+    const pluginBinding = await db
       .select({
         pluginKey: pluginManagedResources.pluginKey,
         defaultsJson: pluginManagedResources.defaultsJson,
@@ -661,6 +664,18 @@ export function routineService(
         ),
       )
       .then((rows) => rows[0] ?? null);
+    if (pluginBinding) return pluginBinding;
+    return db
+      .select({ defaultsJson: builtInManagedResources.defaultsJson })
+      .from(builtInManagedResources)
+      .where(and(
+        eq(builtInManagedResources.companyId, routine.companyId),
+        eq(builtInManagedResources.resourceKind, "routine"),
+        eq(builtInManagedResources.resourceId, routine.id),
+      ))
+      .then((rows) => rows[0]
+        ? { pluginKey: null, manifestJson: null, defaultsJson: rows[0].defaultsJson }
+        : null);
   }
 
   async function listManagedRoutineMetadata(routineIds: string[]) {
@@ -1663,11 +1678,12 @@ export function routineService(
     const triggerPayload = mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables });
     const managedRoutineBinding = await getManagedRoutineBinding(input.routine);
     const managedIssueTemplate = readManagedRoutineIssueTemplate(managedRoutineBinding?.defaultsJson);
-    const issueOriginKind = managedIssueTemplate?.surfaceVisibility === "plugin_operation" && managedRoutineBinding
+    const issueOriginKind = managedIssueTemplate?.surfaceVisibility === "plugin_operation" && managedRoutineBinding?.pluginKey
       ? pluginOperationIssueOriginKind(managedRoutineBinding.pluginKey)
       : "routine_execution";
     const issueOriginId = managedIssueTemplate?.originId ?? input.routine.id;
     const issueBillingCode = managedIssueTemplate?.billingCode ?? null;
+    const issueModelProfile = managedIssueTemplate?.modelProfile ?? null;
     const dispatchFingerprint = createRoutineDispatchFingerprint({
       payload: triggerPayload,
       projectId,
@@ -1680,6 +1696,7 @@ export function routineService(
       executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
       title,
       description,
+      modelProfile: issueModelProfile,
     });
     const run = await db.transaction(async (tx) => {
       const txDb = tx as unknown as Db;
@@ -1804,6 +1821,7 @@ export function routineService(
             originRunId: createdRun.id,
             originFingerprint: dispatchFingerprint,
             billingCode: issueBillingCode,
+            assigneeAdapterOverrides: issueModelProfile ? { modelProfile: issueModelProfile } : null,
             executionWorkspaceId: input.executionWorkspaceId ?? null,
             executionWorkspacePreference: input.executionWorkspacePreference ?? null,
             executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,

--- a/server/src/services/summary-slots.ts
+++ b/server/src/services/summary-slots.ts
@@ -1,15 +1,18 @@
-import { and, desc, eq, gte, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   documentRevisions,
   documents,
+  builtInManagedResources,
   executionWorkspaces,
   issues,
   projectWorkspaces,
   projects,
+  routines,
   summarySlots,
 } from "@paperclipai/db";
 import {
+  type ClaimRoutineSummaryRefreshSlotsResponse,
   type GenerateSummarySlotResponse,
   type GetSummarySlotResponse,
   type IssueStatus,
@@ -31,6 +34,7 @@ import { issueService } from "./issues.js";
 
 /** Built-in agent key for the Summarizer bundle (see PAP-13920). */
 export const SUMMARIZER_BUILT_IN_KEY = "summarizer";
+export const SUMMARIZER_REFRESH_ROUTINE_KEY = "refresh-stale-summaries";
 
 /** Generation issues in these statuses are no longer active and can be superseded. */
 const TERMINAL_ISSUE_STATUSES = new Set<IssueStatus>(["done", "cancelled"]);
@@ -580,6 +584,18 @@ export function summarySlotService(db: Db) {
     if (!issueRef.row) {
       throw forbidden("Linked generation task not found");
     }
+    if (issueRef.row.assigneeAgentId !== actor.agentId) {
+      throw forbidden("Generation task is not assigned to this agent");
+    }
+    const runId = actor.runId ?? null;
+    const runMatches =
+      !!runId && (issueRef.row.checkoutRunId === runId || issueRef.row.executionRunId === runId);
+    if (!runMatches) {
+      throw forbidden("Summary write must run from the linked generation task");
+    }
+
+    if (await isSummarizerRefreshRoutineIssue(sel.companyId, issueRef.row)) return;
+
     const payloadMatch = issueRef.row.description?.match(/```json\n([\s\S]*?)\n```/);
     let payload: Record<string, unknown> | null = null;
     try {
@@ -595,15 +611,186 @@ export function summarySlotService(db: Db) {
     ) {
       throw forbidden("Generation task does not target this summary slot");
     }
-    if (issueRef.row.assigneeAgentId !== actor.agentId) {
-      throw forbidden("Generation task is not assigned to this agent");
+  }
+
+  async function isSummarizerRefreshRoutineIssue(
+    companyId: string,
+    issueRow: typeof issues.$inferSelect,
+  ): Promise<boolean> {
+    if (issueRow.originKind !== "routine_execution" || !issueRow.originId) return false;
+    const row = await db
+      .select({ routineId: routines.id })
+      .from(routines)
+      .innerJoin(
+        builtInManagedResources,
+        and(
+          eq(builtInManagedResources.companyId, routines.companyId),
+          eq(builtInManagedResources.resourceId, routines.id),
+          eq(builtInManagedResources.bundleKey, SUMMARIZER_BUILT_IN_KEY),
+          eq(builtInManagedResources.resourceKind, "routine"),
+          eq(builtInManagedResources.resourceKey, SUMMARIZER_REFRESH_ROUTINE_KEY),
+        ),
+      )
+      .where(
+        and(
+          eq(routines.id, issueRow.originId),
+          eq(routines.companyId, companyId),
+          eq(routines.assigneeAgentId, issueRow.assigneeAgentId!),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    return !!row;
+  }
+
+  async function assertRoutineRefreshWriter(
+    companyId: string,
+    generationIssueId: string,
+    actor: SummaryWriteActor,
+  ): Promise<typeof issues.$inferSelect> {
+    if (!actor.agentId) throw forbidden("Only the Summarizer refresh routine may claim summary slots");
+    const agent = await agents.getById(actor.agentId);
+    if (
+      !agent ||
+      agent.companyId !== companyId ||
+      readBuiltInAgentMarker(agent.metadata)?.key !== SUMMARIZER_BUILT_IN_KEY
+    ) {
+      throw forbidden("Only the Summarizer refresh routine may claim summary slots");
+    }
+    const issueRow = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.id, generationIssueId), eq(issues.companyId, companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (
+      !issueRow ||
+      issueRow.status !== "in_progress" ||
+      issueRow.assigneeAgentId !== actor.agentId ||
+      !(await isSummarizerRefreshRoutineIssue(companyId, issueRow))
+    ) {
+      throw forbidden("Summary refresh claims require the checked-out Summarizer routine task");
     }
     const runId = actor.runId ?? null;
-    const runMatches =
-      !!runId && (issueRef.row.checkoutRunId === runId || issueRef.row.executionRunId === runId);
-    if (!runMatches) {
-      throw forbidden("Summary write must run from the linked generation task");
+    if (!runId || (issueRow.checkoutRunId !== runId && issueRow.executionRunId !== runId)) {
+      throw forbidden("Summary refresh claims must run from the checked-out routine task");
     }
+    return issueRow;
+  }
+
+  async function hasMeaningfulScopeChange(
+    executor: Db,
+    slotRow: SummarySlotRow,
+  ): Promise<boolean> {
+    const since = slotRow.lastGeneratedAt;
+    if (!since) return false;
+    const changedIssue = async (conditions: ReturnType<typeof eq>[]) =>
+      executor
+        .select({ id: issues.id })
+        .from(issues)
+        .where(and(eq(issues.companyId, slotRow.companyId), isNull(issues.hiddenAt), gt(issues.updatedAt, since), ...conditions))
+        .limit(1)
+        .then((rows) => rows.length > 0);
+
+    if (slotRow.scopeKind === "project" && slotRow.scopeId) {
+      const [targetChanged, issueChanged] = await Promise.all([
+        executor.select({ id: projects.id }).from(projects).where(and(
+          eq(projects.id, slotRow.scopeId),
+          eq(projects.companyId, slotRow.companyId),
+          gt(projects.updatedAt, since),
+        )).limit(1).then((rows) => rows.length > 0),
+        changedIssue([eq(issues.projectId, slotRow.scopeId)]),
+      ]);
+      return targetChanged || issueChanged;
+    }
+    if (slotRow.scopeKind === "project_workspace" && slotRow.scopeId) {
+      const [targetChanged, issueChanged] = await Promise.all([
+        executor.select({ id: projectWorkspaces.id }).from(projectWorkspaces).where(and(
+          eq(projectWorkspaces.id, slotRow.scopeId),
+          eq(projectWorkspaces.companyId, slotRow.companyId),
+          gt(projectWorkspaces.updatedAt, since),
+        )).limit(1).then((rows) => rows.length > 0),
+        changedIssue([eq(issues.projectWorkspaceId, slotRow.scopeId)]),
+      ]);
+      return targetChanged || issueChanged;
+    }
+    if (slotRow.scopeKind === "execution_workspace" && slotRow.scopeId) {
+      const [targetChanged, issueChanged] = await Promise.all([
+        executor.select({ id: executionWorkspaces.id }).from(executionWorkspaces).where(and(
+          eq(executionWorkspaces.id, slotRow.scopeId),
+          eq(executionWorkspaces.companyId, slotRow.companyId),
+          gt(executionWorkspaces.updatedAt, since),
+        )).limit(1).then((rows) => rows.length > 0),
+        changedIssue([eq(issues.executionWorkspaceId, slotRow.scopeId)]),
+      ]);
+      return targetChanged || issueChanged;
+    }
+    if (slotRow.scopeKind === "workspaces_overview") {
+      const [projectWorkspaceChanged, executionWorkspaceChanged, issueChanged] = await Promise.all([
+        executor.select({ id: projectWorkspaces.id }).from(projectWorkspaces).where(and(
+          eq(projectWorkspaces.companyId, slotRow.companyId),
+          gt(projectWorkspaces.updatedAt, since),
+        )).limit(1).then((rows) => rows.length > 0),
+        executor.select({ id: executionWorkspaces.id }).from(executionWorkspaces).where(and(
+          eq(executionWorkspaces.companyId, slotRow.companyId),
+          gt(executionWorkspaces.updatedAt, since),
+        )).limit(1).then((rows) => rows.length > 0),
+        changedIssue([or(isNotNull(issues.projectWorkspaceId), isNotNull(issues.executionWorkspaceId))!]),
+      ]);
+      return projectWorkspaceChanged || executionWorkspaceChanged || issueChanged;
+    }
+    return false;
+  }
+
+  async function claimRoutineRefreshSlots(
+    input: {
+      companyId: string;
+      generationIssueId: string;
+      staleAfterHours: number;
+      maxSlots: number;
+      scopeKinds: SummarySlotScopeKind | "all";
+    },
+    actor: SummaryWriteActor,
+  ): Promise<ClaimRoutineSummaryRefreshSlotsResponse> {
+    await assertRoutineRefreshWriter(input.companyId, input.generationIssueId, actor);
+    const cutoff = new Date(Date.now() - input.staleAfterHours * 60 * 60 * 1_000);
+    return db.transaction(async (tx) => {
+      const txDb = tx as unknown as Db;
+      const candidates = await txDb
+        .select()
+        .from(summarySlots)
+        .where(and(
+          eq(summarySlots.companyId, input.companyId),
+          inArray(summarySlots.status, ["idle", "failed"]),
+          isNotNull(summarySlots.documentId),
+          isNotNull(summarySlots.lastGeneratedAt),
+          lte(summarySlots.lastGeneratedAt, cutoff),
+          ...(input.scopeKinds === "all" ? [] : [eq(summarySlots.scopeKind, input.scopeKinds)]),
+        ))
+        .orderBy(asc(summarySlots.lastGeneratedAt), asc(summarySlots.id))
+        .for("update");
+
+      const claimed: ClaimRoutineSummaryRefreshSlotsResponse["slots"] = [];
+      for (const candidate of candidates) {
+        if (claimed.length >= input.maxSlots) break;
+        if (!(await hasMeaningfulScopeChange(txDb, candidate))) continue;
+        const [nextSlot] = await txDb
+          .update(summarySlots)
+          .set({
+            status: "generating",
+            failureReason: null,
+            generatingIssueId: input.generationIssueId,
+            updatedAt: new Date(),
+          })
+          .where(eq(summarySlots.id, candidate.id))
+          .returning();
+        const document = await txDb
+          .select()
+          .from(documents)
+          .where(and(eq(documents.id, candidate.documentId!), eq(documents.companyId, input.companyId)))
+          .then((rows) => rows[0] ?? null);
+        if (nextSlot && document) claimed.push({ slot: mapSlot(nextSlot), document: mapDocument(document) });
+      }
+      return { slots: claimed };
+    });
   }
 
   async function write(
@@ -758,6 +945,7 @@ export function summarySlotService(db: Db) {
     getSlot,
     listRevisions,
     generate,
+    claimRoutineRefreshSlots,
     write,
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Scheduled routines can find work that must run again
> - Summary slots accept writes only from the active generation task
> - A summary refresh routine could not claim a stale slot before it wrote a revision
> - This pull request adds a company-scoped claim for the checked-out Summarizer routine
> - The existing revision and task guards still protect every write
> - The benefit is a safe and low-cost refresh path for stale summaries

## Linked Issues or Issue Description

No public GitHub issue exists. This section describes the feature.

**Subsystem affected**

Cross-cutting. The change affects the server API, shared types, validators, tests, and built-in Summarizer files.

**Problem or motivation**

A scheduled refresh routine can find changed stale summary slots. It cannot write a new revision when no active generation task owns the slot. The normal write guard correctly rejects that write.

**Proposed solution**

Add a company-scoped claim endpoint. Permit only the checked-out built-in Summarizer routine task to use it. Select changed stale slots and bind that task as the active generator. Keep the normal base revision and active task checks on the later write.

Enable the cheap Summarizer profile for routine dispatch. Keep an existing low-cost model override when one is present.

**Alternatives considered**

The routine could bypass the write guard. This option would weaken slot ownership and was rejected. A separate generation task for each slot would add more work objects and dispatch steps. The bounded claim keeps the current guard and uses the routine task that already exists.

**Roadmap alignment**

This change supports the completed Scheduled Routines milestone in `ROADMAP.md`. It improves a focused routine path. It does not add a new roadmap area.

**Additional context**

Related pull request #10296 changes some of the same service files for a separate run-ID foreign-key guard. It does not add this claim path or the Summarizer profile.

## What Changed

- Added a routine refresh claim API with shared request and response types.
- Added company, routine, task, slot state, and change checks before a claim can bind a slot.
- Kept the existing active task and base revision guards on summary writes.
- Enabled the cheap Summarizer profile and selected it for routine dispatch.
- Updated the built-in routine instructions, development guide, implementation specification, and skill catalog.
- Added focused service, route, routine, built-in agent, and shared type tests.

## Verification

- `pnpm exec vitest run packages/shared/src/summary-slot.test.ts server/src/__tests__/built-in-agents.test.ts server/src/__tests__/routines-service.test.ts server/src/__tests__/summary-slot-routes.test.ts server/src/__tests__/summary-slots.test.ts`
- Result: 5 test files passed. All 132 tests passed.
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/skills-catalog validate`
- Result: the catalog manifest is valid with 17 skills.
- `git diff --check origin/master...HEAD`
- Result: no whitespace errors were found.
- A three-way merge check against current `origin/master` completed without conflicts.

## Risks

- The new endpoint changes slot ownership for selected stale slots. Strict company, routine, checkout, and slot checks limit this effect.
- Concurrent refresh attempts can race. The transaction locks selected slots and keeps base revision conflict checks.
- The cheap profile changes the default model lane for the built-in refresh routine. An explicit low-cost override still has priority.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5. The model used reasoning, repository inspection, code execution, and GitHub tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
