### PR TITLE
fix(pi-local): keep prompts off the Windows cmd.exe command line

### DIFF
--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -27,7 +27,7 @@ Don't use when:
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file appended to system prompt via --append-system-prompt
-- promptTemplate (string, optional): user prompt template passed via -p flag
+- promptTemplate (string, optional): user prompt template sent to Pi on stdin in print mode (-p)
 - model (string, required): Pi model id in provider/model format (for example xai/grok-4)
 - thinking (string, optional): thinking level (off, minimal, low, medium, high, xhigh)
 - command (string, optional): defaults to "pi"
@@ -42,5 +42,5 @@ Notes:
 - Paperclip requires an explicit \`model\` value for \`pi_local\` agents.
 - Sessions are stored in ~/.pi/paperclips/ and resumed with --session.
 - All tools (read, bash, edit, write, grep, find, ls) are enabled by default.
-- Agent instructions are appended to Pi's system prompt via --append-system-prompt, while the user task is sent via -p.
+- Agent instructions are appended to Pi's system prompt via --append-system-prompt. On local targets the adapter writes that text to a temp file and passes the file path so the command line stays under the Windows cmd.exe 8191-character limit. The user task is sent on stdin with -p.
 `;

--- a/packages/adapters/pi-local/src/server/execute.prompt.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.prompt.test.ts
@@ -1,0 +1,162 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const WINDOWS_CMD_LINE_LIMIT = 8191;
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+  ensurePiModelConfiguredAndAvailable,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: JSON.stringify({
+      type: "turn_end",
+      message: {
+        role: "assistant",
+        content: "done",
+        usage: {
+          input: 10,
+          output: 20,
+          cacheRead: 0,
+          cost: { total: 0.01 },
+        },
+      },
+      toolResults: [],
+    }),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "pi"),
+  ensurePiModelConfiguredAndAvailable: vi.fn(async () => [
+    { id: "openai/gpt-5.4-mini", label: "openai/gpt-5.4-mini" },
+  ]),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+vi.mock("./models.js", async () => {
+  const actual = await vi.importActual<typeof import("./models.js")>("./models.js");
+  return {
+    ...actual,
+    ensurePiModelConfiguredAndAvailable,
+  };
+});
+
+import { execute } from "./execute.js";
+
+type SpawnCall = [
+  string,
+  string,
+  string[],
+  { env: Record<string, string>; stdin?: string },
+];
+
+describe("pi local prompt delivery", () => {
+  const cleanupDirs: string[] = [];
+  const cleanupFiles: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupFiles.length > 0) {
+      const file = cleanupFiles.pop();
+      if (!file) continue;
+      await rm(file, { force: true }).catch(() => undefined);
+    }
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("keeps a 12k+ prompt off argv and under the Windows cmd.exe limit", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-pi-prompt-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    const hugeInstructions = `Use the isolated workspace.\n${"A".repeat(12_000)}`;
+    const instructionsPath = path.join(workspaceDir, "AGENTS.md");
+    await writeFile(instructionsPath, hugeInstructions, "utf8");
+
+    let capturedArgs: string[] = [];
+    let stagedPrompt = "";
+    const result = await execute({
+      runId: "run-prompt-limit",
+      agent: {
+        id: "agent-prompt-limit",
+        companyId: "company-1",
+        name: "Pi Builder",
+        adapterType: "pi_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "pi",
+        model: "openai/gpt-5.4-mini",
+        instructionsFilePath: instructionsPath,
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async (meta) => {
+        capturedArgs = Array.isArray(meta.commandArgs) ? meta.commandArgs.map(String) : [];
+        const promptFlag = capturedArgs.indexOf("--append-system-prompt");
+        const promptArg = promptFlag >= 0 ? capturedArgs[promptFlag + 1] : "";
+        if (promptArg) stagedPrompt = await readFile(promptArg, "utf8");
+      },
+    });
+
+    if (typeof result.sessionId === "string" && result.sessionId.length > 0) {
+      cleanupFiles.push(result.sessionId);
+    }
+
+    const call = runChildProcess.mock.calls[0] as unknown as SpawnCall | undefined;
+    expect(call).toBeDefined();
+    const args = call?.[2] ?? [];
+    const stdin = call?.[3].stdin ?? "";
+
+    expect(args).toContain("-p");
+    expect(args).toContain("--append-system-prompt");
+    expect(args.join(" ").length).toBeLessThan(WINDOWS_CMD_LINE_LIMIT);
+    expect(capturedArgs.join(" ").length).toBeLessThan(WINDOWS_CMD_LINE_LIMIT);
+    expect(args.join("\0")).not.toContain(hugeInstructions);
+    expect(capturedArgs.join("\0")).not.toContain(hugeInstructions);
+    expect(args).not.toContain(stdin);
+    expect(stdin.length).toBeGreaterThan(0);
+
+    const promptFlag = args.indexOf("--append-system-prompt");
+    const promptArg = promptFlag >= 0 ? args[promptFlag + 1] : "";
+    expect(promptArg).toBeTruthy();
+    expect(promptArg.length).toBeLessThan(400);
+    expect(stagedPrompt).toContain(hugeInstructions);
+    expect(stagedPrompt).toContain("The above agent instructions were loaded from");
+  });
+});

--- a/packages/adapters/pi-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.remote.test.ts
@@ -190,11 +190,20 @@ describe("pi remote execution", () => {
       expect.anything(),
     );
     const call = runChildProcess.mock.calls[0] as unknown as
-      | [string, string, string[], { env: Record<string, string>; remoteExecution?: { remoteCwd: string } | null }]
+      | [string, string, string[], { env: Record<string, string>; stdin?: string; remoteExecution?: { remoteCwd: string } | null }]
       | undefined;
     expect(call?.[2]).toContain("--session");
     expect(call?.[2]).toContain("--skill");
+    expect(call?.[2]).toContain("-p");
     expect(call?.[2]).toContain(`${managedRemoteWorkspace}/.paperclip-runtime/pi/skills`);
+    expect(typeof call?.[3].stdin).toBe("string");
+    expect((call?.[3].stdin ?? "").length).toBeGreaterThan(0);
+    expect(call?.[2]?.at(-1)).not.toBe(call?.[3].stdin);
+    const systemPromptFlag = call?.[2].indexOf("--append-system-prompt") ?? -1;
+    expect(systemPromptFlag).toBeGreaterThanOrEqual(0);
+    const systemPromptArg = systemPromptFlag >= 0 ? call?.[2][systemPromptFlag + 1] : "";
+    expect(systemPromptArg).toContain("You are agent");
+    expect(systemPromptArg).not.toContain("paperclip-pi-prompt-");
     expect(call?.[3].env.PAPERCLIP_WORKSPACE_CWD).toBe(managedRemoteWorkspace);
     expect(JSON.parse(call?.[3].env.PAPERCLIP_WORKSPACES_JSON ?? "[]")).toEqual([
       {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -44,7 +44,6 @@ import {
   isPaperclipRecoveryWakePayload,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
-  runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import { shellQuote } from "@paperclipai/adapter-utils/ssh";
 import { isPiUnknownSessionError, parsePiJsonl } from "./parse.js";
@@ -325,6 +324,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (localAgentConfigDir) {
     env.PI_CODING_AGENT_DIR = localAgentConfigDir;
   }
+  let localSystemPromptDir: string | null = null;
   try {
     // Prepend installed skill `bin/` dirs to PATH so an agent's bash tool can
     // invoke skill binaries (e.g. `paperclip-get-issue`) by name. Without this,
@@ -624,19 +624,41 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       heartbeatPromptChars: renderedHeartbeatPrompt.length,
     };
 
+    // Windows `pi.cmd` is launched through cmd.exe, which hard-caps the command
+    // line at 8191 characters. Inline system + user prompts routinely exceed
+    // that. Keep the rendered system prompt in a file (Pi accepts a path for
+    // --append-system-prompt) and send the user prompt on stdin (`pi -p`
+    // merges piped stdin into the initial prompt). Remote targets keep the
+    // system prompt inline because the file would have to be uploaded first;
+    // Linux ARG_MAX is large enough, and stdin still carries the user prompt.
+    let systemPromptArg = renderedSystemPromptExtension;
+    if (!executionTargetIsRemote && renderedSystemPromptExtension.length > 0) {
+      localSystemPromptDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-prompt-"));
+      const localSystemPromptFile = path.join(localSystemPromptDir, "append-system-prompt.md");
+      await fs.writeFile(localSystemPromptFile, renderedSystemPromptExtension, "utf8");
+      systemPromptArg = localSystemPromptFile;
+    }
+
     const commandNotes = (() => {
       const notes = [...preparedRuntimeConfig.notes];
-      if (!resolvedInstructionsFilePath) return notes;
-      if (instructionsReadFailed) {
-        notes.push(
-          `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
-        );
-        return notes;
+      if (resolvedInstructionsFilePath) {
+        if (instructionsReadFailed) {
+          notes.push(
+            `Configured instructionsFilePath ${resolvedInstructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+          );
+        } else {
+          notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
+          notes.push(
+            `Appended instructions + path directive to system prompt (relative references from ${instructionsFileDir}).`,
+          );
+        }
       }
-      notes.push(`Loaded agent instructions from ${resolvedInstructionsFilePath}`);
-      notes.push(
-        `Appended instructions + path directive to system prompt (relative references from ${instructionsFileDir}).`,
-      );
+      if (localSystemPromptDir) {
+        notes.push(
+          `Wrote system prompt to ${path.join(localSystemPromptDir, "append-system-prompt.md")} for --append-system-prompt.`,
+        );
+      }
+      notes.push("Passed the user prompt to Pi via stdin.");
       return notes;
     })();
 
@@ -645,10 +667,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
       // Use JSON mode for structured output with print mode (non-interactive)
       args.push("--mode", "json");
-      args.push("-p"); // Non-interactive mode: process prompt and exit
+      // -p with no following message: Pi reads the user prompt from stdin.
+      args.push("-p");
 
-      // Use --append-system-prompt to extend Pi's default system prompt
-      args.push("--append-system-prompt", renderedSystemPromptExtension);
+      if (systemPromptArg.length > 0) {
+        args.push("--append-system-prompt", systemPromptArg);
+      }
 
       if (provider) args.push("--provider", provider);
       if (modelId) args.push("--model", modelId);
@@ -659,9 +683,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--skill", remoteSkillsDir ?? PI_AGENT_SKILLS_DIR);
 
       if (extraArgs.length > 0) args.push(...extraArgs);
-
-      // Add the user prompt as the last argument
-      args.push(userPrompt);
 
       return args;
     };
@@ -708,6 +729,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
         cwd,
         env: executionTargetIsRemote ? env : runtimeEnv,
+        stdin: userPrompt,
         timeoutSec,
         graceSec,
         onSpawn,
@@ -842,6 +864,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ]);
     }
   } finally {
-    await preparedRuntimeConfig.cleanup();
+    await Promise.all([
+      preparedRuntimeConfig.cleanup(),
+      localSystemPromptDir
+        ? fs.rm(localSystemPromptDir, { recursive: true, force: true }).catch(() => undefined)
+        : Promise.resolve(),
+    ]);
   }
 }

--- a/packages/adapters/pi-local/src/server/execute.windows-cmdline.bench.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.windows-cmdline.bench.test.ts
@@ -1,0 +1,236 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Goal: prove #11602 with the same Windows spawn math Paperclip uses.
+ *
+ * Pass marks (all must be true):
+ * 1. Legacy argv (system prompt + user prompt inline) exceeds cmd.exe 8191 after quoting.
+ * 2. Fixed argv (file path + stdin) stays under 8191 after quoting.
+ * 3. The 12k instructions body never appears on the fixed argv.
+ * 4. stdin carries the user prompt.
+ * 5. On Windows, cmd.exe rejects the legacy line and accepts a short fixed line.
+ */
+
+const WINDOWS_CMD_LINE_LIMIT = 8191;
+const REALISTIC_PI_CMD = path.join(
+  process.env.APPDATA ?? "C:\\Users\\fixture\\AppData\\Roaming",
+  "npm",
+  "pi.cmd",
+);
+
+// Must match `quoteForCmd` in packages/adapter-utils/src/server-utils.ts.
+function quoteForCmd(arg: string) {
+  if (!arg.length) return '""';
+  const escaped = arg.replace(/"/g, '""');
+  return /[\s"&<>|^()]/.test(escaped) ? `"${escaped}"` : escaped;
+}
+
+function buildWindowsCmdLine(executable: string, args: string[]): string {
+  return [quoteForCmd(executable), ...args.map(quoteForCmd)].join(" ");
+}
+
+function replaceAppendSystemPrompt(args: string[], replacement: string): string[] {
+  const next = [...args];
+  const index = next.indexOf("--append-system-prompt");
+  if (index >= 0 && index + 1 < next.length) next[index + 1] = replacement;
+  return next;
+}
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+  ensurePiModelConfiguredAndAvailable,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: JSON.stringify({
+      type: "turn_end",
+      message: {
+        role: "assistant",
+        content: "done",
+        usage: {
+          input: 10,
+          output: 20,
+          cacheRead: 0,
+          cost: { total: 0.01 },
+        },
+      },
+      toolResults: [],
+    }),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "pi"),
+  ensurePiModelConfiguredAndAvailable: vi.fn(async () => [
+    { id: "openai/gpt-5.4-mini", label: "openai/gpt-5.4-mini" },
+  ]),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+vi.mock("./models.js", async () => {
+  const actual = await vi.importActual<typeof import("./models.js")>("./models.js");
+  return {
+    ...actual,
+    ensurePiModelConfiguredAndAvailable,
+  };
+});
+
+import { execute } from "./execute.js";
+
+type SpawnCall = [
+  string,
+  string,
+  string[],
+  { env: Record<string, string>; stdin?: string },
+];
+
+describe("pi_local Windows cmdline marking bench", () => {
+  const cleanupDirs: string[] = [];
+  const cleanupFiles: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupFiles.length > 0) {
+      const file = cleanupFiles.pop();
+      if (!file) continue;
+      await rm(file, { force: true }).catch(() => undefined);
+    }
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("scores legacy overflow vs fixed stdin/file transport against the cmd.exe limit", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-pi-cmdline-bench-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    const hugeInstructions = `Use the isolated workspace.\n${"A".repeat(12_000)}`;
+    const instructionsPath = path.join(workspaceDir, "AGENTS.md");
+    await writeFile(instructionsPath, hugeInstructions, "utf8");
+
+    let stagedPrompt = "";
+    const result = await execute({
+      runId: "run-cmdline-bench",
+      agent: {
+        id: "agent-cmdline-bench",
+        companyId: "company-1",
+        name: "Pi Builder",
+        adapterType: "pi_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "pi",
+        model: "openai/gpt-5.4-mini",
+        instructionsFilePath: instructionsPath,
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+      onMeta: async (meta) => {
+        const args = Array.isArray(meta.commandArgs) ? meta.commandArgs.map(String) : [];
+        const promptFlag = args.indexOf("--append-system-prompt");
+        const promptArg = promptFlag >= 0 ? args[promptFlag + 1] : "";
+        if (promptArg) stagedPrompt = await readFile(promptArg, "utf8");
+      },
+    });
+
+    if (typeof result.sessionId === "string" && result.sessionId.length > 0) {
+      cleanupFiles.push(result.sessionId);
+    }
+
+    const call = runChildProcess.mock.calls[0] as unknown as SpawnCall | undefined;
+    expect(call).toBeDefined();
+    const fixedArgs = call?.[2] ?? [];
+    const stdin = call?.[3].stdin ?? "";
+
+    const legacyArgs = [...replaceAppendSystemPrompt(fixedArgs, stagedPrompt), stdin];
+    const legacyCmdLine = buildWindowsCmdLine(REALISTIC_PI_CMD, legacyArgs);
+    const fixedCmdLine = buildWindowsCmdLine(REALISTIC_PI_CMD, fixedArgs);
+
+    const marks = {
+      legacyExceedsLimit: legacyCmdLine.length > WINDOWS_CMD_LINE_LIMIT,
+      fixedUnderLimit: fixedCmdLine.length < WINDOWS_CMD_LINE_LIMIT,
+      payloadOffArgv: !fixedArgs.join("\0").includes(hugeInstructions),
+      stdinCarriesUserPrompt: stdin.length > 0 && !fixedArgs.includes(stdin),
+      systemPromptStagedToFile: stagedPrompt.includes(hugeInstructions),
+    };
+
+    // Visible in CI logs so reviewers can see the proof, not just a boolean.
+    console.log(
+      JSON.stringify(
+        {
+          goal: "Prove #11602: legacy inline argv overflows cmd.exe; file+stdin does not.",
+          limit: WINDOWS_CMD_LINE_LIMIT,
+          legacyCmdLineChars: legacyCmdLine.length,
+          fixedCmdLineChars: fixedCmdLine.length,
+          marginUnderLimit: WINDOWS_CMD_LINE_LIMIT - fixedCmdLine.length,
+          stdinChars: stdin.length,
+          stagedSystemPromptChars: stagedPrompt.length,
+          marks,
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(stagedPrompt.length).toBeGreaterThan(12_000);
+    expect(marks.legacyExceedsLimit).toBe(true);
+    expect(marks.fixedUnderLimit).toBe(true);
+    expect(marks.payloadOffArgv).toBe(true);
+    expect(marks.stdinCarriesUserPrompt).toBe(true);
+    expect(marks.systemPromptStagedToFile).toBe(true);
+    expect(Object.values(marks).every(Boolean)).toBe(true);
+
+    if (process.platform === "win32") {
+      const cmdExe = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "cmd.exe");
+      const legacyOs = spawnSync(cmdExe, ["/d", "/s", "/c", legacyCmdLine], {
+        encoding: "utf8",
+        windowsHide: true,
+      });
+      const fixedProbeLine = buildWindowsCmdLine(cmdExe, ["/c", "echo paperclip-cmdline-ok"]);
+      const fixedOs = spawnSync(cmdExe, ["/d", "/s", "/c", "echo paperclip-cmdline-ok"], {
+        encoding: "utf8",
+        windowsHide: true,
+      });
+      const legacyText = `${legacyOs.stderr ?? ""}${legacyOs.stdout ?? ""}${legacyOs.error?.message ?? ""}`;
+      expect(legacyText.toLowerCase()).toContain("too long");
+      expect(fixedOs.status).toBe(0);
+      expect((fixedOs.stdout ?? "").toLowerCase()).toContain("paperclip-cmdline-ok");
+      expect(fixedProbeLine.length).toBeLessThan(WINDOWS_CMD_LINE_LIMIT);
+    }
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - One adapter is `pi_local`. It starts the Pi CLI on the host or on a remote target.
> - The adapter put both the system prompt and the user prompt on the process argv.
> - On Windows the spawn path launches `pi.cmd` through `cmd.exe`. `cmd.exe` rejects a command line over 8191 characters.
> - A default `AGENTS.md` plus a normal wake prompt already lands near 12,000 characters. Pi never starts. The run fails with `The command line is too long.`
> - This pull request writes the system prompt to a temp file on local targets and sends the user prompt on stdin.
> - The benefit is that local Windows `pi_local` agents can start. The command line stays short.

## Linked Issues or Issue Description

- Fixes: #11602
- Refs #5068 — same Windows argv class for `gemini-local` (stdin). Still open. Missing PR template. Greptile 4/5. This PR does not change gemini-local.
- Refs #6395 — same gemini-local stdin idea. Still open. No tests. This PR does not replace it.
- Refs #6397 — gemini stdin plus a recovery-storm cap. Closed unmerged. This PR stays one adapter and one bug.
- Refs #8522 — broader Windows OS-limit issue. Same 8k class. Not pi-specific.
- Refs #8520 — kitchen-sink Windows PR. Wraps long argv in PowerShell. That raises the ceiling. It does not remove prompts from argv. Complementary, not a substitute.

I searched GitHub for open `pi-local` / `pi_local` stdin and argv PRs. I did not find a duplicate of this change.

## What Changed

- On local targets, write the rendered system prompt to a temp file and pass that path to `--append-system-prompt`. Pi accepts a file path for that flag.
- Send the user prompt to `runAdapterExecutionTargetProcess` on stdin. Keep `-p`. Do not put the user prompt on argv.
- On remote targets, keep the system prompt inline. Linux ARG_MAX is large enough. Still send the user prompt on stdin.
- Delete the temp prompt directory after the run.
- Add `execute.prompt.test.ts`. A 12k+ instructions file must stay off argv and under the 8191-character limit.
- Assert remote runs set stdin and do not append the user prompt as the last argv token.
- Update the `pi_local` adapter docs.

## Verification

- Ran `pnpm exec vitest run packages/adapters/pi-local/src/server`.
- Result: 5 files, 36 tests passed. This includes `execute.prompt.test.ts` and the remote stdin assertions.
- Ran `pnpm --filter @paperclipai/adapter-pi-local typecheck`. Result: pass.
- I did not run a live Windows `pi_local` agent after this change. The issue repro is a full agent run with a real Pi CLI. The new unit test covers the argv budget and the file/stdin transport.

## Risks

- Pi print mode (`-p` plus `--mode json`) merges piped stdin into the initial prompt. Text-mode stdin behavior is a different contract and is not used here.
- Remote targets still put the system prompt on argv. A huge system prompt on a Windows remote host could still hit 8191 characters. This PR does not upload a prompt file to remote hosts.
- The temp file lives under the OS temp directory for the length of the run. The adapter deletes it in `finally`.
- Older Pi builds that treat `--append-system-prompt` as literal text only would receive a file path instead of the prompt body. Current Pi documents a file path for that flag. The adapter pin is `@earendil-works/pi-coding-agent@0.74.0`.

> This is a bug fix in one adapter. It is not a core roadmap feature. I checked `ROADMAP.md`.

## Model Used

- Provider: xAI via Cursor
- Model: Cursor Grok 4.6
- Capabilities: tool use, repository search, test execution
- Human review of the change and the PR text: Zwin-ux

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)