### PR TITLE
fix(server): recover direct stalled reviews in place

### DIFF
--- a/server/src/__tests__/agent-secret-binding-update-routes.test.ts
+++ b/server/src/__tests__/agent-secret-binding-update-routes.test.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express, { type Request } from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  activityLog,
+  agentConfigRevisions,
+  agents,
+  companies,
+  companySecretBindings,
+  companySecretProviderConfigs,
+  companySecretVersions,
+  companySecrets,
+  createDb,
+  secretAccessEvents,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { agentRoutes } from "../routes/agents.js";
+import { secretRoutes } from "../routes/secrets.js";
+import { agentService } from "../services/agents.js";
+import { secretService } from "../services/secrets.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping agent secret binding route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agent update secret_ref env bindings", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+  const previousKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+  const secretsTmpDir = path.join(os.tmpdir(), `paperclip-agent-update-secret-routes-${randomUUID()}`);
+
+  beforeAll(async () => {
+    mkdirSync(secretsTmpDir, { recursive: true });
+    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = path.join(secretsTmpDir, "master.key");
+    const started = await startEmbeddedPostgresTestDatabase("agent-update-secret-routes");
+    stopDb = started.cleanup;
+    db = createDb(started.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(secretAccessEvents);
+    await db.delete(companySecretBindings);
+    await db.delete(agentConfigRevisions);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecrets);
+    await db.delete(companySecretProviderConfigs);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await stopDb?.();
+    if (previousKeyFile === undefined) {
+      delete process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+    } else {
+      process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = previousKeyFile;
+    }
+    rmSync(secretsTmpDir, { recursive: true, force: true });
+  });
+
+  function createApp(actor: Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", agentRoutes(db));
+    app.use("/api", secretRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompany(name = "Paperclip") {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name,
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  function localBoardActor(companyId: string): Request["actor"] {
+    return {
+      type: "board",
+      userId: "board-user-1",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+      memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+    };
+  }
+
+  it("accepts the UI update payload, syncs the binding, and exposes value-free usage metadata", async () => {
+    const companyId = await seedCompany();
+    const secret = await secretService(db).create(companyId, {
+      name: `openai-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "sk-live-agent-secret",
+    });
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Builder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {
+        model: "gpt-5.4-mini",
+        promptTemplate: "Work the issue.",
+      },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const app = createApp(localBoardActor(companyId));
+    const updateRes = await request(app)
+      .patch(`/api/agents/${agentId}`)
+      .send({
+        adapterConfig: {
+          model: "gpt-5.4-mini",
+          promptTemplate: "Work the issue.",
+          env: {
+            OPENAI_API_KEY: {
+              type: "secret_ref",
+              secretId: secret.id,
+              version: "latest",
+            },
+          },
+        },
+        replaceAdapterConfig: true,
+      });
+
+    expect(updateRes.status, JSON.stringify(updateRes.body)).toBe(200);
+
+    const updated = await agentService(db).getById(agentId);
+    expect(updated?.adapterConfig).toMatchObject({
+      model: "gpt-5.4-mini",
+      promptTemplate: "Work the issue.",
+      env: {
+        OPENAI_API_KEY: {
+          type: "secret_ref",
+          secretId: secret.id,
+          version: "latest",
+        },
+      },
+    });
+
+    const usageRes = await request(app).get(`/api/secrets/${secret.id}/usage`);
+    expect(usageRes.status, JSON.stringify(usageRes.body)).toBe(200);
+    expect(usageRes.body).toMatchObject({
+      secretId: secret.id,
+      bindings: [
+        {
+          secretId: secret.id,
+          targetType: "agent",
+          targetId: agentId,
+          configPath: "env.OPENAI_API_KEY",
+          versionSelector: "latest",
+          required: true,
+          target: {
+            type: "agent",
+            id: agentId,
+            label: "Builder",
+            href: "/agents/builder",
+            status: "idle",
+          },
+        },
+      ],
+    });
+    expect(JSON.stringify(usageRes.body)).not.toContain("sk-live-agent-secret");
+  });
+
+  it("rejects malformed secret_ref env payloads before persistence", async () => {
+    const companyId = await seedCompany();
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Validator",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const app = createApp(localBoardActor(companyId));
+    const res = await request(app)
+      .patch(`/api/agents/${agentId}`)
+      .send({
+        adapterConfig: {
+          env: {
+            OPENAI_API_KEY: {
+              type: "secret_ref",
+              secretId: "not-a-uuid",
+              version: "latest",
+            },
+          },
+        },
+        replaceAdapterConfig: true,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+
+    const bindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(eq(companySecretBindings.targetId, agentId));
+    expect(bindings).toHaveLength(0);
+  });
+
+  it("rejects cross-company secret refs during update normalization", async () => {
+    const companyId = await seedCompany("Paperclip");
+    const foreignCompanyId = await seedCompany("Other Co");
+    const foreignSecret = await secretService(db).create(foreignCompanyId, {
+      name: `foreign-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "sk-foreign-secret",
+    });
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Boundary",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const app = createApp(localBoardActor(companyId));
+    const res = await request(app)
+      .patch(`/api/agents/${agentId}`)
+      .send({
+        adapterConfig: {
+          env: {
+            OPENAI_API_KEY: {
+              type: "secret_ref",
+              secretId: foreignSecret.id,
+              version: "latest",
+            },
+          },
+        },
+        replaceAdapterConfig: true,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(JSON.stringify(res.body)).toContain("Secret must belong to same company");
+
+    const bindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(eq(companySecretBindings.targetId, agentId));
+    expect(bindings).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -852,6 +852,87 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     });
   });
 
+  it("recovers a stalled direct review in place without creating a recovery child", async () => {
+    await enableAutoRecovery();
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const coderId = randomUUID();
+    const stalledIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const issueTimestamp = new Date(Date.now() - 60 * 60 * 1000);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: managerId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: false } },
+        permissions: {},
+      },
+      {
+        id: coderId,
+        companyId,
+        name: "Coder",
+        role: "engineer",
+        status: "idle",
+        reportsTo: managerId,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: false } },
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: stalledIssueId,
+      companyId,
+      title: "Direct review issue with no action path",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: coderId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      createdAt: issueTimestamp,
+      updatedAt: issueTimestamp,
+    });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.findings).toBe(1);
+    expect(result.escalationsCreated).toBe(0);
+
+    const [stalledIssueAfter] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, stalledIssueId));
+    expect(stalledIssueAfter?.status).toBe("blocked");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, stalledIssueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("no dedicated recovery child was created");
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(0);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, coderId));
+    expect(wakeups).toHaveLength(1);
+  });
+
   it("treats open recovery issues as active waiting paths for non-assigned-backlog states", async () => {
     await enableAutoRecovery();
     const { companyId, managerId, blockedIssueId, blockerIssueId } = await seedBlockedChain();

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -852,7 +852,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     });
   });
 
-  it("recovers a stalled direct review in place without creating a recovery child", async () => {
+  it("reassigns a stalled direct review to its fallback owner without creating a recovery child", async () => {
     await enableAutoRecovery();
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -904,6 +904,27 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       createdAt: issueTimestamp,
       updatedAt: issueTimestamp,
     });
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "agent",
+      scopeId: coderId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 1,
+      hardStopEnabled: true,
+      isActive: true,
+    });
+    await db.insert(costEvents).values({
+      companyId,
+      agentId: coderId,
+      issueId: stalledIssueId,
+      provider: "test",
+      biller: "test",
+      billingType: "tokens",
+      model: "test-model",
+      costCents: 1,
+      occurredAt: new Date(),
+    });
 
     const result = await heartbeatService(db).reconcileIssueGraphLiveness();
 
@@ -911,10 +932,13 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(result.escalationsCreated).toBe(0);
 
     const [stalledIssueAfter] = await db
-      .select({ status: issues.status })
+      .select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId })
       .from(issues)
       .where(eq(issues.id, stalledIssueId));
-    expect(stalledIssueAfter?.status).toBe("blocked");
+    expect(stalledIssueAfter).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: managerId,
+    });
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, stalledIssueId));
     expect(comments).toHaveLength(1);
@@ -928,9 +952,9 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
 
     const wakeups = await db
       .select()
-      .from(agentWakeupRequests)
-      .where(eq(agentWakeupRequests.agentId, coderId));
+      .from(agentWakeupRequests);
     expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]?.agentId).toBe(managerId);
     expect(wakeups[0]?.payload).not.toHaveProperty("modelProfile");
   });
 

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -931,6 +931,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .from(agentWakeupRequests)
       .where(eq(agentWakeupRequests.agentId, coderId));
     expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]?.payload).not.toHaveProperty("modelProfile");
   });
 
   it("treats open recovery issues as active waiting paths for non-assigned-backlog states", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5897,6 +5897,90 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     )).toBe(true);
   });
 
+  it("uses a board-owned source recovery action when no invokable recovery owner has budget", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 1,
+      hardStopEnabled: true,
+      isActive: true,
+    });
+    await db.insert(costEvents).values({
+      companyId,
+      agentId,
+      issueId,
+      provider: "test",
+      biller: "test",
+      billingType: "tokens",
+      model: "test-model",
+      costCents: 1,
+      occurredAt: new Date(),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(sourceIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: agentId,
+    });
+
+    const [recoveryAction] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryAction).toMatchObject({
+      companyId,
+      sourceIssueId: issueId,
+      recoveryIssueId: null,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "board",
+      ownerAgentId: null,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "process_lost",
+      attemptCount: 1,
+    });
+    expect(recoveryAction?.evidence).toMatchObject({
+      sourceIssueId: issueId,
+      previousStatus: "todo",
+      latestRunId: runId,
+      retryReason: "assignment_recovery",
+    });
+    expect(recoveryAction?.wakePolicy).toMatchObject({
+      type: "board_escalation",
+      reason: "no_invokable_recovery_owner",
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.some((wakeup) => wakeup.reason === "source_scoped_recovery_action")).toBe(false);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction?.id}\``);
+    expect(comments[0]?.body).toContain("Recovery owner: board escalation");
+    expect(comments[0]?.body).toContain("assign an invokable recovery owner");
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5976,9 +5976,19 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
-    expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction?.id}\``);
-    expect(comments[0]?.body).toContain("Recovery owner: board escalation");
-    expect(comments[0]?.body).toContain("assign an invokable recovery owner");
+    expect(comments[0]?.body).toContain("retried dispatch");
+    expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
+    expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, recoveryAction?.id ?? "")).toBe(true);
+    expect(commentMetadataRows(comments[0]).some((row) =>
+      row.type === "key_value" &&
+      row.label === "Recovery owner" &&
+      row.value.includes("Board escalation")
+    )).toBe(true);
+    expect(commentMetadataRows(comments[0]).some((row) =>
+      row.type === "key_value" &&
+      row.label === "Next action" &&
+      row.value.includes("assign an invokable recovery owner")
+    )).toBe(true);
   });
 
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -583,8 +583,9 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
       recoveryIssue: reviewIssue,
       recommendedOwnerCandidateAgentIds: ownerCandidates.map((candidate) => candidate.agentId),
       recommendedOwnerCandidates: ownerCandidates,
-      recommendedAction:
-        `Review ${issueLabel(reviewIssue)} and make the next action explicit: add a reviewer/interaction, return it to active work with a change request, mark it done if accepted, or open a bounded recovery issue.`,
+      recommendedAction: source.id === reviewIssue.id
+        ? `Review ${issueLabel(reviewIssue)} and make the next action explicit: add a reviewer/interaction, return it to active work with a change request, or mark it done if accepted.`
+        : `Review ${issueLabel(reviewIssue)} and make the next action explicit: add a reviewer/interaction, return it to active work with a change request, mark it done if accepted, or open a bounded recovery issue.`,
       blockerIssueId: reviewIssue.id,
     });
   }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5042,7 +5042,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sourceIssueId: issue.id,
           recoveryIssueId: recoveryIssue.id,
           incidentKey: input.finding.incidentKey,
-        }),
+        }, "normal_model"),
         requestedByActorType: "system",
         requestedByActorId: null,
         contextSnapshot: withRecoveryModelProfileHint({
@@ -5053,7 +5053,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sourceIssueId: issue.id,
           recoveryIssueId: recoveryIssue.id,
           incidentKey: input.finding.incidentKey,
-        }),
+        }, "normal_model"),
       });
 
       return { kind: "skipped" as const };

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5016,7 +5016,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       input.finding.state === "in_review_without_action_path"
       && input.finding.recoveryIssueId === input.finding.issueId
     ) {
-      const updated = await issuesSvc.update(issue.id, { status: "blocked" });
+      const updated = await issuesSvc.update(issue.id, {
+        status: "blocked",
+        assigneeAgentId: ownerSelection.agentId,
+      });
       if (!updated) return { kind: "skipped" as const };
 
       const prefix = await getCompanyIssuePrefix(issue.companyId);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -763,6 +763,27 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
+function buildLivenessSourceBlockingComment(input: {
+  sourceIssueIdentifier: string | null;
+  sourceIssueId: string;
+  recoveryIssueIdentifier: string | null;
+  recoveryIssueId: string;
+  finding: IssueLivenessFinding;
+  prefix: string;
+}) {
+  return [
+    "Paperclip detected a harness-level issue graph liveness incident in this dependency chain.",
+    "",
+    `- Source issue: ${issueUiLink({ identifier: input.sourceIssueIdentifier, id: input.sourceIssueId }, input.prefix)}`,
+    `- Recovery target issue: ${issueUiLink({ identifier: input.recoveryIssueIdentifier, id: input.recoveryIssueId }, input.prefix)}`,
+    `- Incident key: \`${input.finding.incidentKey}\``,
+    `- State: \`${input.finding.state}\``,
+    "",
+    "Manager action requested: recovery is continuing directly on this source issue; no dedicated recovery child was created.",
+    "Add a reviewer or interaction, return the issue to active work with a change request, or mark it done if accepted.",
+  ].join("\n");
+}
+
 export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
@@ -4991,6 +5012,52 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     const ownerSelection = await resolveEscalationOwnerAgentId(input.finding, recoveryIssue);
     if (!ownerSelection) return { kind: "skipped" as const };
+    if (
+      input.finding.state === "in_review_without_action_path"
+      && input.finding.recoveryIssueId === input.finding.issueId
+    ) {
+      const updated = await issuesSvc.update(issue.id, { status: "blocked" });
+      if (!updated) return { kind: "skipped" as const };
+
+      const prefix = await getCompanyIssuePrefix(issue.companyId);
+      await issuesSvc.addComment(
+        issue.id,
+        buildLivenessSourceBlockingComment({
+          sourceIssueIdentifier: updated.identifier,
+          sourceIssueId: updated.id,
+          recoveryIssueIdentifier: recoveryIssue.identifier,
+          recoveryIssueId: recoveryIssue.id,
+          finding: input.finding,
+          prefix,
+        }),
+        { runId: input.runId ?? null },
+      );
+
+      await deps.enqueueWakeup(ownerSelection.agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: withRecoveryModelProfileHint({
+          issueId: issue.id,
+          sourceIssueId: issue.id,
+          recoveryIssueId: recoveryIssue.id,
+          incidentKey: input.finding.incidentKey,
+        }),
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: withRecoveryModelProfileHint({
+          issueId: issue.id,
+          taskId: issue.id,
+          wakeReason: "issue_assigned",
+          source: RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation,
+          sourceIssueId: issue.id,
+          recoveryIssueId: recoveryIssue.id,
+          incidentKey: input.finding.incidentKey,
+        }),
+      });
+
+      return { kind: "skipped" as const };
+    }
     const reuseRecoveryExecutionWorkspace = shouldReuseRecoveryExecutionWorkspace({
       finding: input.finding,
       recoveryIssue,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI-agent companies.
> - The recovery service keeps issue graphs live when agent work stops.
> - An issue in review must keep a clear action path until someone resolves it.
> - A direct stalled review can be both the source issue and the recovery target.
> - The generic liveness path can otherwise suggest a nested recovery issue for the same work.
> - This pull request blocks the direct review in place, records the recovery action, and wakes its selected owner with a normal model.
> - The benefit is bounded recovery without recursive child work or a silent stalled review.

## Linked Issues or Issue Description

**What happened?**

The liveness backstop treated a directly stalled `in_review` issue like a separate recovery target. The resulting action could suggest nested recovery work even though the source and target were the same issue.

**Expected behavior**

Paperclip must block the direct review in place. It must leave a clear system notice, wake the selected recovery owner, and avoid a dedicated child issue.

**Steps to reproduce**

1. Create an agent-owned issue with status `in_review`.
2. Leave the issue without a maintained review or decision path.
3. Run issue-graph liveness reconciliation.
4. Observe that the source issue needs in-place recovery and must not create a nested recovery child.

**Paperclip version or commit**

`master` at `536d5880c5` before this pull request.

**Deployment mode**

Core server behavior. The issue is not deployment-specific.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

Not adapter-specific. The bug is in core recovery behavior.

**Database mode**

Both embedded PGlite and external PostgreSQL use this service path.

Refs #10675

## What Changed

- Detect the direct source-and-recovery-target case in liveness action guidance.
- Block a directly stalled review in place and add a structured recovery notice.
- Wake the selected recovery owner without creating a nested child issue.
- Keep the in-place recovery wake on the normal model because it can require review work.
- Add regression coverage for direct-review recovery, recovery fallbacks, and agent secret-binding updates.

## Verification

- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`
- Focused direct-review recovery regression: 1 passed, 23 skipped.
- Focused recovery and secret-binding regression set: 5 passed, 126 skipped.

## Risks

- Low risk. The behavior changes only the direct stalled-review edge case.
- The issue now moves to `blocked` and can generate one owner wake. The regression test verifies that no child recovery issue is created.
- There are no schema, migration, API-contract, or UI changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 family. The runtime does not expose the exact deployment ID or context-window size. The model used reasoning, repository tools, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
