### PR TITLE
fix(ui): stop an Invalid Date on a live run from taking down the issue page

### DIFF
--- a/ui/src/components/IssueRunLedger.test.tsx
+++ b/ui/src/components/IssueRunLedger.test.tsx
@@ -608,4 +608,24 @@ describe("IssueRunLedger", () => {
 
     expect(container.querySelector('[data-testid="responsible-user-denial-notice"]')).toBeNull();
   });
+
+  it("renders instead of throwing when a live run carries an Invalid Date", () => {
+    // Regression: toIsoString guarded on `instanceof Date`, which is true for an
+    // Invalid Date, so toISOString() threw RangeError: Invalid time value. That
+    // happened inside the ledger useMemo, so it took the entire issue page down
+    // rather than degrading the ledger. Live runs are typed `string | Date | null`
+    // (api/heartbeats.ts), so a Date is a legitimate input shape here.
+    expect(() =>
+      renderLedger({
+        runs: [createRun({ runId: "run-live-1", status: "running", finishedAt: null })],
+        activeRun: createActiveRun({
+          startedAt: new Date("not-a-date"),
+          finishedAt: new Date("not-a-date"),
+        }),
+      }),
+    ).not.toThrow();
+
+    expect(container.textContent).toContain("CodexCoder");
+  });
+
 });

--- a/ui/src/components/IssueRunLedger.tsx
+++ b/ui/src/components/IssueRunLedger.tsx
@@ -225,7 +225,16 @@ function formatDuration(start: string | Date | null | undefined, end: string | D
 
 function toIsoString(value: string | Date | null | undefined) {
   if (!value) return null;
-  return value instanceof Date ? value.toISOString() : value;
+  if (value instanceof Date) {
+    // An Invalid Date passes both guards above — it is truthy and it is a Date —
+    // and toISOString() then throws RangeError: Invalid time value. Because this
+    // runs inside the useMemo that builds the ledger, that exception takes the
+    // whole issue page down, not just the ledger. Live runs reach here with
+    // `string | Date | null` (api/heartbeats.ts), so a malformed date from that
+    // path must degrade to null rather than throw.
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  return value;
 }
 
 function liveRunToLedgerRun(run: LiveRunForIssue | ActiveRunForIssue): LedgerRun {


### PR DESCRIPTION
## The bug

Opening an issue whose live run carries an unparseable date replaces the entire page with the error boundary:

```
This page hit an error
Invalid time value
```

`toIsoString` in `ui/src/components/IssueRunLedger.tsx` guards on `instanceof Date`, which is also true for an Invalid Date. That value is truthy, so it clears the `!value` check too, and `toISOString()` then throws `RangeError: Invalid time value`.

```ts
function toIsoString(value: string | Date | null | undefined) {
  if (!value) return null;
  return value instanceof Date ? value.toISOString() : value;   // throws on Invalid Date
}
```

The call site is `liveRunToLedgerRun`, which runs inside the `useMemo` that builds the ledger. The exception therefore escapes during render, so the whole issue page dies rather than the ledger degrading.

## How it was found

Captured on a real issue by wrapping `Date.prototype.toISOString`:

```
toISOString on Invalid Date
  at PRn   (index-*.js)   → toIsoString
  at qRn   (index-*.js)   → liveRunToLedgerRun
  at Object.useMemo
```

That issue's 11 stored runs all carry valid dates, so the bad value does not come from `/api/issues/{id}/runs`. It arrives through the live path, where `ActiveRunForIssue` types these fields `string | Date | null` (`ui/src/api/heartbeats.ts:24-26`) — a `Date` is a legitimate input shape here, which is why the guard was written that way in the first place.

I did not track down which producer emits the Invalid Date. The fix stands regardless: this helper declares that it accepts a `Date`, so it must not throw on one.

## The fix

Return `null` for an unparseable `Date`. Safe at every call site — `createdAt` already falls back to `new Date().toISOString()`, and `startedAt`/`finishedAt` are nullable on `LedgerRun`.

Verified that the only behavioural change is the Invalid Date case:

| input | before | after |
|---|---|---|
| Invalid Date | **throws RangeError** | `null` |
| valid Date | `"2026-04-18T19:58:00.000Z"` | unchanged |
| ISO string | `"2026-04-18T19:58:00.000Z"` | unchanged |
| `null` / `undefined` / `""` | `null` | unchanged |

## Testing

A regression test is included, asserting the ledger renders instead of throwing when an active run carries an Invalid Date.

**I was not able to run it.** `npm test` for `ui/` needs a toolchain I could not stand up here: no `node_modules` on this machine, host Node is 20.9 (vitest needs `node:util`'s `styleText`, added in 20.12), and in a container built from this repo's image every test in that file fails on `__vi_import_1__.act is not a function` — the image's React predates the `act` export the test file imports. All 19 pre-existing tests fail there for that same unrelated reason.

So the test is written but unverified, and someone with a working `ui/` test environment should confirm it fails without the one-line change and passes with it. The behavioural table above was produced by running both implementations directly under Node, which is the part I could verify.
