### PR TITLE
fix(claude-local): support multiple subscription profiles

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
@@ -53,7 +53,7 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
   };
 });
 
-import { execute } from "./execute.js";
+import { execute, runClaudeLogin } from "./execute.js";
 
 function buildContext(input: {
   config?: Record<string, unknown>;
@@ -144,6 +144,25 @@ describe("claude_local subscription profile isolation", () => {
     expect(result.sessionParams).toEqual(
       expect.objectContaining({ claudeConfigDir: expectedDir }),
     );
+  });
+
+  it("uses the same normalized relative profile for Claude login", async () => {
+    const workspaceDir = "/var/tmp/paperclip-agent-workspace";
+    const relativeDir = "../claude-profiles/account-b/.claude";
+    const expectedDir = path.resolve(relativeDir);
+
+    await runClaudeLogin({
+      runId: "login-1",
+      agent: buildContext().agent,
+      config: {
+        cwd: workspaceDir,
+        env: { CLAUDE_CONFIG_DIR: relativeDir },
+      },
+    } as never);
+    const { args, options } = invocation();
+
+    expect(args).toEqual(["login"]);
+    expect(options.env.CLAUDE_CONFIG_DIR).toBe(expectedDir);
   });
 
   it("starts a fresh session when an agent is moved to another subscription profile", async () => {

--- a/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+} = vi.hoisted(() => ({
+  ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+  ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+  resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "claude"),
+  runAdapterExecutionTargetProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "11111111-1111-4111-8111-111111111111",
+        model: "claude-sonnet",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: "11111111-1111-4111-8111-111111111111",
+        message: { content: [{ type: "text", text: "hello" }] },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "11111111-1111-4111-8111-111111111111",
+        result: "hello",
+        usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildContext(input: {
+  config?: Record<string, unknown>;
+  sessionParams?: Record<string, unknown> | null;
+} = {}) {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: input.sessionParams ?? null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: { engine: "cli", ...(input.config ?? {}) },
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+function invocation() {
+  expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+  const call = (runAdapterExecutionTargetProcess as unknown as { mock: { calls: unknown[][] } })
+    .mock.calls[0]!;
+  return {
+    args: call[3] as string[],
+    options: call[4] as {
+      env: Record<string, string | undefined>;
+      localProcessSandbox: { managedPaths: Array<{ path: string; access: string }> } | null;
+    },
+  };
+}
+
+describe("claude_local subscription profile isolation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the explicit profile for both the sandbox mount and Claude environment", async () => {
+    const sharedDir = "/var/tmp/paperclip-claude-shared/.claude";
+    const explicitDir = "/var/tmp/paperclip-claude-account-b/.claude";
+    vi.stubEnv("CLAUDE_CONFIG_DIR", sharedDir);
+
+    const result = await execute(buildContext({
+      config: {
+        filesystemScope: "workspace",
+        env: { CLAUDE_CONFIG_DIR: explicitDir },
+      },
+    }) as never);
+    const { options } = invocation();
+
+    expect(options.env.CLAUDE_CONFIG_DIR).toBe(explicitDir);
+    expect(options.localProcessSandbox?.managedPaths).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: explicitDir, access: "rw" }),
+      ]),
+    );
+    expect(options.localProcessSandbox?.managedPaths.some((entry) => entry.path === sharedDir)).toBe(false);
+    expect(result.sessionParams).toEqual(
+      expect.objectContaining({ claudeConfigDir: explicitDir }),
+    );
+  });
+
+  it("starts a fresh session when an agent is moved to another subscription profile", async () => {
+    const previousDir = "/var/tmp/paperclip-claude-account-a/.claude";
+    const selectedDir = "/var/tmp/paperclip-claude-account-b/.claude";
+    const previousSessionId = "22222222-2222-4222-8222-222222222222";
+    const ctx = buildContext({
+      config: { env: { CLAUDE_CONFIG_DIR: selectedDir } },
+      sessionParams: {
+        sessionId: previousSessionId,
+        cwd: process.cwd(),
+        claudeConfigDir: previousDir,
+      },
+    });
+
+    const result = await execute(ctx as never);
+    const { args } = invocation();
+
+    expect(args).not.toContain("--resume");
+    expect(ctx.onLog).toHaveBeenCalledWith(
+      "stdout",
+      expect.stringContaining("belongs to a different Claude profile"),
+    );
+    expect(result.sessionParams).toEqual(
+      expect.objectContaining({ claudeConfigDir: selectedDir }),
+    );
+  });
+
+  it("starts fresh once when a legacy session first selects an explicit profile", async () => {
+    const selectedDir = "/var/tmp/paperclip-claude-account-b/.claude";
+    const previousSessionId = "33333333-3333-4333-8333-333333333333";
+    const ctx = buildContext({
+      config: { env: { CLAUDE_CONFIG_DIR: selectedDir } },
+      sessionParams: {
+        sessionId: previousSessionId,
+        cwd: process.cwd(),
+      },
+    });
+
+    await execute(ctx as never);
+    const { args } = invocation();
+
+    expect(args).not.toContain("--resume");
+    expect(ctx.onLog).toHaveBeenCalledWith(
+      "stdout",
+      expect.stringContaining("belongs to a different Claude profile"),
+    );
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -126,10 +127,10 @@ describe("claude_local subscription profile isolation", () => {
     );
   });
 
-  it("resolves a relative local profile from the Claude process working directory", async () => {
+  it("normalizes a relative local profile independently of the agent workspace", async () => {
     const workspaceDir = "/var/tmp/paperclip-agent-workspace";
     const relativeDir = "../claude-profiles/account-b/.claude";
-    const expectedDir = "/var/tmp/claude-profiles/account-b/.claude";
+    const expectedDir = path.resolve(relativeDir);
 
     const result = await execute(buildContext({
       config: {

--- a/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
@@ -126,6 +126,25 @@ describe("claude_local subscription profile isolation", () => {
     );
   });
 
+  it("resolves a relative local profile from the Claude process working directory", async () => {
+    const workspaceDir = "/var/tmp/paperclip-agent-workspace";
+    const relativeDir = "../claude-profiles/account-b/.claude";
+    const expectedDir = "/var/tmp/claude-profiles/account-b/.claude";
+
+    const result = await execute(buildContext({
+      config: {
+        cwd: workspaceDir,
+        env: { CLAUDE_CONFIG_DIR: relativeDir },
+      },
+    }) as never);
+    const { options } = invocation();
+
+    expect(options.env.CLAUDE_CONFIG_DIR).toBe(expectedDir);
+    expect(result.sessionParams).toEqual(
+      expect.objectContaining({ claudeConfigDir: expectedDir }),
+    );
+  });
+
   it("starts a fresh session when an agent is moved to another subscription profile", async () => {
     const previousDir = "/var/tmp/paperclip-claude-account-a/.claude";
     const selectedDir = "/var/tmp/paperclip-claude-account-b/.claude";

--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -338,4 +338,70 @@ describe("claude remote execution", () => {
     expect(call?.[2]).toContain("12345678-1234-4abc-9def-123456789012");
   });
 
+  it("starts fresh when a remote SSH agent selects a different Claude profile", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-remote-profile-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const managedRemoteWorkspace = "/remote/workspace/.paperclip-runtime/runs/run-ssh-profile/workspace";
+    await mkdir(workspaceDir, { recursive: true });
+
+    const result = await execute({
+      runId: "run-ssh-profile",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "12345678-1234-4abc-9def-123456789012",
+        sessionParams: {
+          sessionId: "12345678-1234-4abc-9def-123456789012",
+          cwd: managedRemoteWorkspace,
+          claudeConfigDir: "/profiles/account-a/.claude",
+          remoteExecution: {
+            transport: "ssh",
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteCwd: managedRemoteWorkspace,
+          },
+        },
+        sessionDisplayId: "12345678-1234-4abc-9def-123456789012",
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+        env: { CLAUDE_CONFIG_DIR: "/profiles/account-b/.claude" },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).not.toContain("--resume");
+    expect(result.sessionParams).toEqual(expect.objectContaining({
+      claudeConfigDir: "/profiles/account-b/.claude",
+    }));
+  });
+
 });

--- a/packages/adapters/claude-local/src/server/index.test.ts
+++ b/packages/adapters/claude-local/src/server/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { sessionCodec } from "./index.js";
+
+describe("claude_local sessionCodec", () => {
+  it("round-trips CLI resume discriminators", () => {
+    const params = {
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      cwd: "/workspace",
+      promptBundleKey: "prompt-v1",
+      mcpServerIdentity: '[{"name":"paperclip"}]',
+      claudeConfigDir: "/profiles/account-b/.claude",
+      remoteExecution: { kind: "ssh", host: "runner.example" },
+      workspaceId: "workspace-1",
+      repoUrl: "https://example.com/repo.git",
+      repoRef: "main",
+    };
+
+    expect(sessionCodec.deserialize(params)).toEqual(params);
+    expect(sessionCodec.serialize(params)).toEqual(params);
+  });
+
+  it("normalizes legacy snake-case profile fields", () => {
+    expect(sessionCodec.deserialize({
+      session_id: "22222222-2222-4222-8222-222222222222",
+      claude_config_dir: "/profiles/account-a/.claude",
+      mcp_server_identity: "[]",
+      remote_execution: { kind: "ssh" },
+    })).toEqual({
+      sessionId: "22222222-2222-4222-8222-222222222222",
+      claudeConfigDir: "/profiles/account-a/.claude",
+      mcpServerIdentity: "[]",
+      remoteExecution: { kind: "ssh" },
+    });
+  });
+});

--- a/packages/db/scripts/clean-poisoned-claude-sessions.test.ts
+++ b/packages/db/scripts/clean-poisoned-claude-sessions.test.ts
@@ -110,31 +110,25 @@ describe("resolveClaudeConfigDir", () => {
 
 describe("resolveSessionClaudeConfigDir", () => {
   it("uses the profile persisted with the session", () => {
-    expect(
-      resolveSessionClaudeConfigDir(
-        { claudeConfigDir: "/profiles/account-b/.claude" },
-        "/profiles/default/.claude",
-      ),
-    ).toBe(path.resolve("/profiles/account-b/.claude"));
+    expect(resolveSessionClaudeConfigDir(
+      { claudeConfigDir: "/profiles/account-b/.claude" },
+      "/profiles/default/.claude",
+    )).toBe(path.resolve("/profiles/account-b/.claude"));
   });
 
   it("keeps old session rows on the default profile", () => {
-    expect(
-      resolveSessionClaudeConfigDir(
-        { claudeConfigDir: null },
-        "/profiles/default/.claude",
-      ),
-    ).toBe("/profiles/default/.claude");
+    expect(resolveSessionClaudeConfigDir(
+      { claudeConfigDir: null },
+      "/profiles/default/.claude",
+    )).toBe("/profiles/default/.claude");
   });
 
   it("lets an explicit maintenance override win", () => {
-    expect(
-      resolveSessionClaudeConfigDir(
-        { claudeConfigDir: "/profiles/account-b/.claude" },
-        "/profiles/default/.claude",
-        "/profiles/recovery/.claude",
-      ),
-    ).toBe(path.resolve("/profiles/recovery/.claude"));
+    expect(resolveSessionClaudeConfigDir(
+      { claudeConfigDir: "/profiles/account-b/.claude" },
+      "/profiles/default/.claude",
+      "/profiles/recovery/.claude",
+    )).toBe(path.resolve("/profiles/recovery/.claude"));
   });
 });
 

--- a/packages/db/scripts/clean-poisoned-claude-sessions.test.ts
+++ b/packages/db/scripts/clean-poisoned-claude-sessions.test.ts
@@ -4,8 +4,11 @@ import {
   classifyJsonlText,
   classifyRow,
   encodeClaudeCwd,
+  extractSessionParams,
+  hasKnownSessionClaudeConfigDir,
   jsonlPathFor,
   resolveClaudeConfigDir,
+  resolveSessionClaudeConfigDir,
 } from "./clean-poisoned-claude-sessions.js";
 
 describe("classifyJsonlText", () => {
@@ -105,6 +108,63 @@ describe("resolveClaudeConfigDir", () => {
   });
 });
 
+describe("resolveSessionClaudeConfigDir", () => {
+  it("uses the profile persisted with the session", () => {
+    expect(
+      resolveSessionClaudeConfigDir(
+        { claudeConfigDir: "/profiles/account-b/.claude" },
+        "/profiles/default/.claude",
+      ),
+    ).toBe(path.resolve("/profiles/account-b/.claude"));
+  });
+
+  it("keeps old session rows on the default profile", () => {
+    expect(
+      resolveSessionClaudeConfigDir(
+        { claudeConfigDir: null },
+        "/profiles/default/.claude",
+      ),
+    ).toBe("/profiles/default/.claude");
+  });
+
+  it("lets an explicit maintenance override win", () => {
+    expect(
+      resolveSessionClaudeConfigDir(
+        { claudeConfigDir: "/profiles/account-b/.claude" },
+        "/profiles/default/.claude",
+        "/profiles/recovery/.claude",
+      ),
+    ).toBe(path.resolve("/profiles/recovery/.claude"));
+  });
+});
+
+describe("hasKnownSessionClaudeConfigDir", () => {
+  it("does not treat the fallback directory as proof for a legacy row", () => {
+    expect(hasKnownSessionClaudeConfigDir({ claudeConfigDir: null })).toBe(false);
+  });
+
+  it("accepts a persisted profile or an explicit maintenance override", () => {
+    expect(hasKnownSessionClaudeConfigDir({ claudeConfigDir: "/profiles/account-b/.claude" })).toBe(true);
+    expect(hasKnownSessionClaudeConfigDir({ claudeConfigDir: null }, "/profiles/default/.claude")).toBe(true);
+  });
+});
+
+describe("extractSessionParams", () => {
+  it("normalizes legacy aliases before cleanup classification", () => {
+    expect(extractSessionParams({
+      session_id: "11111111-1111-4111-8111-111111111111",
+      workdir: "/workspace",
+      remote_execution: { transport: "ssh" },
+      claude_config_dir: "/profiles/account-a/.claude",
+    })).toEqual({
+      sessionId: "11111111-1111-4111-8111-111111111111",
+      cwd: "/workspace",
+      isRemote: true,
+      claudeConfigDir: "/profiles/account-a/.claude",
+    });
+  });
+});
+
 describe("classifyRow", () => {
   const claudeConfigDir = "/tmp/.claude";
   const cwd = "/Users/dj/work";
@@ -113,7 +173,7 @@ describe("classifyRow", () => {
 
   it("returns skipped_no_session_id when sessionId is null", () => {
     const result = classifyRow(
-      { sessionId: null, cwd, isRemote: false },
+      { sessionId: null, cwd, isRemote: false, claudeConfigDir: null },
       { claudeConfigDir, readJsonl: () => null },
     );
     expect(result.kind).toBe("skipped_no_session_id");
@@ -121,7 +181,7 @@ describe("classifyRow", () => {
 
   it("returns skipped_remote when the row has remoteExecution params", () => {
     const result = classifyRow(
-      { sessionId, cwd, isRemote: true },
+      { sessionId, cwd, isRemote: true, claudeConfigDir: null },
       { claudeConfigDir, readJsonl: () => null },
     );
     expect(result.kind).toBe("skipped_remote");
@@ -129,7 +189,7 @@ describe("classifyRow", () => {
 
   it("returns missing_jsonl with the expected path when the file does not exist", () => {
     const result = classifyRow(
-      { sessionId, cwd, isRemote: false },
+      { sessionId, cwd, isRemote: false, claudeConfigDir: null },
       { claudeConfigDir, readJsonl: () => null },
     );
     expect(result.kind).toBe("missing_jsonl");
@@ -144,7 +204,7 @@ describe("classifyRow", () => {
       JSON.stringify({ type: "assistant", message: { id: "synthetic-uuid" } }),
     ].join("\n");
     const result = classifyRow(
-      { sessionId, cwd, isRemote: false },
+      { sessionId, cwd, isRemote: false, claudeConfigDir: null },
       { claudeConfigDir, readJsonl: () => jsonl },
     );
     expect(result.kind).toBe("poisoned");
@@ -158,7 +218,7 @@ describe("classifyRow", () => {
       JSON.stringify({ type: "assistant", message: { id: "msg_only" } }),
     ].join("\n");
     const result = classifyRow(
-      { sessionId, cwd, isRemote: false },
+      { sessionId, cwd, isRemote: false, claudeConfigDir: null },
       { claudeConfigDir, readJsonl: () => jsonl },
     );
     expect(result.kind).toBe("healthy");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Claude local adapter runs Claude Code with subscription or API authentication
> - One Paperclip process can manage agents that belong to different operators or capacity pools
> - The local sandbox currently replaces an explicit `CLAUDE_CONFIG_DIR` with the shared profile
> - Session cleanup also assumes that every Claude session uses one shared profile directory
> - This pull request makes the selected Claude profile part of the session identity
> - The benefit is that operators can assign agents to separate Claude subscription accounts without storing credentials in Paperclip or mixing sessions between accounts

## Linked Issues or Issue Description

Fixes: #10754

Refs: #10808

## What Changed

- Honor an explicit `CLAUDE_CONFIG_DIR` in local sandboxed Claude CLI runs.
- Persist the selected profile with CLI session parameters and preserve all resume discriminators through the adapter session codec.
- Start a fresh Claude session when a local or remote agent changes its explicit profile.
- Resolve poisoned-session JSONL files from each persisted profile. Require an explicit directory before deleting a missing legacy session whose profile is unknown.
- Use the same stable normalized local profile for agent execution and `claude login`, independent of agent workspace changes.
- Document named Paperclip environments as the configuration surface for multiple subscription accounts.

## Verification

- Claude adapter profile, remote-resume, and session-codec tests: 11 passed.
- Database cleanup tests: 21 passed.
- `tsc --noEmit` passed for `@paperclipai/adapter-claude-local` and `@paperclipai/db`.
- Multiple review/fix loops plus a final fresh review found no remaining material issue.
- The complete GitHub Actions matrix and Greptile review pass on `b100ac1`.

## Risks

- Existing CLI sessions that predate profile persistence start fresh once when an explicit profile is first selected.
- Legacy rows without a known profile are no longer deleted by `--delete-missing-jsonl` unless the operator supplies `--claude-config-dir`.
- Automatic quota failover is not included. Operators select profiles deliberately.
- Managed remote-home behavior is unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex `gpt-5.6-sol` with high reasoning and repository tool access implemented the change.
- OpenAI `gpt-5.5` and `gpt-5.4` with high reasoning performed fresh review passes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
