### PR TITLE
Align API workspace close with reaper blocking rules

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2521,3 +2521,8 @@ export {
   isPaperclipDevRunnerCommand,
   rewriteUrlHostToLoopback,
 } from "./runtime-exposure/loopback-bind.js";
+export {
+  SHARED_WORKSPACE_RECORD_ONLY_ARCHIVE_REASON,
+  isRecordOnlyArchiveWorkspace,
+  resolveIsProjectPrimaryWorkspace,
+} from "./workspace-cleanup.js";

--- a/packages/shared/src/types/workspace-runtime.ts
+++ b/packages/shared/src/types/workspace-runtime.ts
@@ -279,6 +279,9 @@ export interface ExecutionWorkspace {
   closedAt: Date | null;
   cleanupEligibleAt: Date | null;
   cleanupReason: string | null;
+  // Populated by the archive route after a close cleanup completes.
+  cleaned?: boolean;
+  cleanupSucceeded?: boolean;
   config: ExecutionWorkspaceConfig | null;
   metadata: Record<string, unknown> | null;
   runtimeServices?: WorkspaceRuntimeService[];

--- a/packages/shared/src/types/workspace-runtime.ts
+++ b/packages/shared/src/types/workspace-runtime.ts
@@ -154,6 +154,10 @@ export interface ExecutionWorkspaceCloseReadiness {
   isSharedWorkspace: boolean;
   isProjectPrimaryWorkspace: boolean;
   git: ExecutionWorkspaceCloseGitReadiness | null;
+  // HEAD resolved while readiness was computed. The close route threads this
+  // back into artifact cleanup, so destruction is anchored to the commit the
+  // readiness decision was made against instead of a later self-read.
+  workspaceHeadSha: string | null;
   runtimeServices: WorkspaceRuntimeService[];
 }
 

--- a/packages/shared/src/validators/execution-workspace.ts
+++ b/packages/shared/src/validators/execution-workspace.ts
@@ -141,6 +141,9 @@ export const executionWorkspaceCloseReadinessSchema = z.object({
   isSharedWorkspace: z.boolean(),
   isProjectPrimaryWorkspace: z.boolean(),
   git: executionWorkspaceCloseGitReadinessSchema.nullable(),
+  // HEAD observed while readiness was computed. The close route threads it back
+  // into artifact cleanup so destruction is anchored to the verified commit.
+  workspaceHeadSha: z.string().nullable(),
   runtimeServices: z.array(workspaceRuntimeServiceSchema),
 }).strict();
 

--- a/packages/shared/src/workspace-cleanup.ts
+++ b/packages/shared/src/workspace-cleanup.ts
@@ -1,0 +1,30 @@
+/** Stable cleanup outcome for a shared or project-primary record-only archive. */
+export const SHARED_WORKSPACE_RECORD_ONLY_ARCHIVE_REASON =
+  "shared_workspace_record_only_archive" as const;
+
+export function isRecordOnlyArchiveWorkspace(input: {
+  mode: string;
+  isProjectPrimaryWorkspace: boolean;
+}): boolean {
+  return input.mode === "shared_workspace" || input.isProjectPrimaryWorkspace;
+}
+
+export function resolveIsProjectPrimaryWorkspace(input: {
+  projectWorkspaceId: string | null;
+  primaryProjectWorkspaceId: string | null;
+  workspacePath: string | null;
+  projectWorkspacePath: string | null;
+}): boolean {
+  if (
+    input.projectWorkspaceId == null
+    || input.primaryProjectWorkspaceId == null
+    || input.workspacePath == null
+    || input.projectWorkspacePath == null
+  ) {
+    return false;
+  }
+  return (
+    input.projectWorkspaceId === input.primaryProjectWorkspaceId
+    && input.workspacePath === input.projectWorkspacePath
+  );
+}

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -13,7 +13,16 @@ const mockExecutionWorkspaceService = vi.hoisted(() => ({
   archiveWorkspaceUnderLifecycleLock: vi.fn(),
   fenceClosedWorkspaceDestruction: vi.fn(),
   runManualArchiveArtifactCleanup: vi.fn(async () => ({ cleaned: true, warnings: [] as string[] })),
-  applyClosedWorkspaceCleanupOutcome: vi.fn(async () => null),
+  applyClosedWorkspaceCleanupOutcome: vi.fn(async (input: {
+    cleanupReason: string | null;
+    markCleanupFailed: boolean;
+  }) => ({
+    id: "workspace-1",
+    companyId: "company-1",
+    sourceIssueId: "issue-1",
+    status: input.markCleanupFailed ? "cleanup_failed" : "archived",
+    cleanupReason: input.cleanupReason,
+  })),
   reconcileExecutionWorkspaceBranch: vi.fn(),
   update: vi.fn(),
 }));
@@ -595,6 +604,63 @@ describe.sequential("execution workspace routes", () => {
     );
     expect(mockWorkspaceRuntimeTeardown.stopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalledWith(
       expect.objectContaining({ workspaceCwd: "/tmp/shared-primary" }),
+    );
+  });
+
+  it("returns cleanup_failed instead of 500 when cleanup and the recovery write both throw", async () => {
+    const archivedWorkspace = {
+      id: "workspace-1",
+      companyId: "company-1",
+      sourceIssueId: "issue-1",
+      status: "archived",
+      mode: "isolated_workspace",
+      projectWorkspaceId: null,
+      projectId: null,
+      cwd: "/tmp/worktree",
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      ...archivedWorkspace,
+      status: "active",
+    });
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
+      state: "ready",
+      blockingReasons: [],
+      workspaceHeadSha: "readiness-head-sha",
+    });
+    mockExecutionWorkspaceService.archiveWorkspaceUnderLifecycleLock.mockResolvedValue({
+      outcome: "archived",
+      workspace: archivedWorkspace,
+      capturedGeneration: 3,
+    });
+    mockExecutionWorkspaceService.runManualArchiveArtifactCleanup.mockRejectedValue(
+      new Error("worktree remove failed"),
+    );
+    mockExecutionWorkspaceService.applyClosedWorkspaceCleanupOutcome.mockRejectedValue(
+      new Error("database unavailable"),
+    );
+    mockExecutionWorkspaceService.fenceClosedWorkspaceDestruction.mockImplementation(
+      async ({ destroy }: { destroy: () => Promise<unknown> }) => ({
+        skippedReopened: false,
+        result: await destroy(),
+      }),
+    );
+
+    const res = await request(createApp())
+      .patch("/api/execution-workspaces/workspace-1")
+      .send({ status: "archived" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: "workspace-1",
+      status: "cleanup_failed",
+      cleanupSucceeded: false,
+    });
+    expect(res.body.cleanupReason).toMatch(/^worktree_remove_failed:/);
+    expect(mockExecutionWorkspaceService.applyClosedWorkspaceCleanupOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        markCleanupFailed: true,
+        cleanupReason: "worktree_remove_failed: worktree remove failed",
+      }),
     );
   });
 

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -12,6 +12,7 @@ const mockExecutionWorkspaceService = vi.hoisted(() => ({
   getCloseReadiness: vi.fn(),
   archiveWorkspaceUnderLifecycleLock: vi.fn(),
   fenceClosedWorkspaceDestruction: vi.fn(),
+  runManualArchiveArtifactCleanup: vi.fn(async () => ({ cleaned: true, warnings: [] as string[] })),
   reconcileExecutionWorkspaceBranch: vi.fn(),
   update: vi.fn(),
 }));
@@ -424,6 +425,31 @@ describe.sequential("execution workspace routes", () => {
     }));
   });
 
+  it("returns 409 and skips archive when close readiness is blocked", async () => {
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      id: "workspace-1",
+      companyId: "company-1",
+      sourceIssueId: "issue-1",
+      status: "active",
+      mode: "isolated_workspace",
+    });
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
+      state: "blocked",
+      blockingReasons: ["The workspace has 1 untracked file."],
+    });
+
+    const res = await request(createApp())
+      .patch("/api/execution-workspaces/workspace-1")
+      .send({ status: "archived" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: "The workspace has 1 untracked file.",
+    });
+    expect(mockExecutionWorkspaceService.archiveWorkspaceUnderLifecycleLock).not.toHaveBeenCalled();
+    expect(mockExecutionWorkspaceService.runManualArchiveArtifactCleanup).not.toHaveBeenCalled();
+  });
+
   it("returns 409 and skips destructive cleanup when the archive hits a reopen-pending workspace", async () => {
     // A reopen published the workspace active while its source issue is still
     // terminal. The archive control must return 409 before any lease teardown,
@@ -501,6 +527,7 @@ describe.sequential("execution workspace routes", () => {
         failureReason: "execution_workspace_closed",
       }),
     );
+    expect(mockExecutionWorkspaceService.runManualArchiveArtifactCleanup).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the reusable sandbox leases when a reopen makes the fence skip the archive teardown", async () => {

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -13,6 +13,7 @@ const mockExecutionWorkspaceService = vi.hoisted(() => ({
   archiveWorkspaceUnderLifecycleLock: vi.fn(),
   fenceClosedWorkspaceDestruction: vi.fn(),
   runManualArchiveArtifactCleanup: vi.fn(async () => ({ cleaned: true, warnings: [] as string[] })),
+  applyClosedWorkspaceCleanupOutcome: vi.fn(async () => null),
   reconcileExecutionWorkspaceBranch: vi.fn(),
   update: vi.fn(),
 }));

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -607,7 +607,7 @@ describe.sequential("execution workspace routes", () => {
     );
   });
 
-  it("returns cleanup_failed instead of 500 when cleanup and the recovery write both throw", async () => {
+  it("reports the persisted archived row, not a fabricated cleanup_failed, when the recovery write throws", async () => {
     const archivedWorkspace = {
       id: "workspace-1",
       companyId: "company-1",
@@ -618,10 +618,14 @@ describe.sequential("execution workspace routes", () => {
       projectId: null,
       cwd: "/tmp/worktree",
     };
-    mockExecutionWorkspaceService.getById.mockResolvedValue({
+    // The initial route read sees the live row; every later read sees what the
+    // archive actually persisted — `archived`, with no cleanup_failed marker,
+    // because the recovery write never landed.
+    mockExecutionWorkspaceService.getById.mockResolvedValueOnce({
       ...archivedWorkspace,
       status: "active",
     });
+    mockExecutionWorkspaceService.getById.mockResolvedValue(archivedWorkspace);
     mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
       state: "ready",
       blockingReasons: [],
@@ -652,10 +656,13 @@ describe.sequential("execution workspace routes", () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
       id: "workspace-1",
-      status: "cleanup_failed",
+      status: "archived",
+      cleaned: false,
       cleanupSucceeded: false,
+      cleanupFailureRecorded: false,
     });
-    expect(res.body.cleanupReason).toMatch(/^worktree_remove_failed:/);
+    expect(res.body.cleanupFailureReason).toMatch(/^worktree_remove_failed:/);
+    expect(res.body.cleanupReason).toBeUndefined();
     expect(mockExecutionWorkspaceService.applyClosedWorkspaceCleanupOutcome).toHaveBeenCalledWith(
       expect.objectContaining({
         markCleanupFailed: true,

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -71,20 +71,28 @@ vi.mock("../services/workspace-runtime.js", async (importActual) => {
   };
 });
 
+// Stubs the writes the shared-workspace archive branch performs. The default
+// `{}` db is enough for an isolated workspace, which never reaches them.
+function createSharedWorkspaceDbStub() {
+  return {
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  };
+}
+
 function createApp(actor: Record<string, unknown> = {
   type: "board",
   userId: "local-board",
   companyIds: ["company-1"],
   source: "session",
   isInstanceAdmin: false,
-}) {
+}, db: unknown = {}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
     (req as any).actor = actor;
     next();
   });
-  app.use("/api", executionWorkspaceRoutes({} as any));
+  app.use("/api", executionWorkspaceRoutes(db as any));
   app.use(errorHandler);
   return app;
 }
@@ -576,7 +584,7 @@ describe.sequential("execution workspace routes", () => {
       }),
     );
 
-    const res = await request(createApp())
+    const res = await request(createApp(undefined, createSharedWorkspaceDbStub()))
       .patch("/api/execution-workspaces/workspace-1")
       .send({ status: "archived" });
 

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -534,6 +534,59 @@ describe.sequential("execution workspace routes", () => {
     expect(mockExecutionWorkspaceService.runManualArchiveArtifactCleanup).toHaveBeenCalledWith(
       expect.objectContaining({ expectedHeadSha: "readiness-head-sha" }),
     );
+    // An isolated workspace is destroyed, so the cwd sweep is a useful safety
+    // net for a service that lost its execution-workspace link.
+    expect(mockWorkspaceRuntimeTeardown.stopRuntimeServicesForExecutionWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ executionWorkspaceId: "workspace-1", workspaceCwd: "/tmp/worktree" }),
+    );
+  });
+
+  it("stops only this session's runtime services when a shared workspace is archived", async () => {
+    // A shared session shares its path with other live sessions. The cwd-prefix
+    // fallback in stopRuntimeServicesForExecutionWorkspace would reach their
+    // services, so the archive must match on the closing record only.
+    const archivedWorkspace = {
+      id: "workspace-1",
+      companyId: "company-1",
+      sourceIssueId: "issue-1",
+      status: "archived",
+      mode: "shared_workspace",
+      projectWorkspaceId: null,
+      projectId: null,
+      cwd: "/tmp/shared-primary",
+    };
+    mockExecutionWorkspaceService.getById.mockResolvedValue({
+      ...archivedWorkspace,
+      status: "active",
+    });
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
+      state: "ready_with_warnings",
+      blockingReasons: [],
+      workspaceHeadSha: "readiness-head-sha",
+    });
+    mockExecutionWorkspaceService.archiveWorkspaceUnderLifecycleLock.mockResolvedValue({
+      outcome: "archived",
+      workspace: archivedWorkspace,
+      capturedGeneration: 3,
+    });
+    mockExecutionWorkspaceService.fenceClosedWorkspaceDestruction.mockImplementation(
+      async ({ destroy }: { destroy: () => Promise<unknown> }) => ({
+        skippedReopened: false,
+        result: await destroy(),
+      }),
+    );
+
+    const res = await request(createApp())
+      .patch("/api/execution-workspaces/workspace-1")
+      .send({ status: "archived" });
+
+    expect(res.status).toBe(200);
+    expect(mockWorkspaceRuntimeTeardown.stopRuntimeServicesForExecutionWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ executionWorkspaceId: "workspace-1", workspaceCwd: null }),
+    );
+    expect(mockWorkspaceRuntimeTeardown.stopRuntimeServicesForExecutionWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceCwd: "/tmp/shared-primary" }),
+    );
   });
 
   it("keeps the reusable sandbox leases when a reopen makes the fence skip the archive teardown", async () => {

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -500,6 +500,7 @@ describe.sequential("execution workspace routes", () => {
     mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
       state: "ready",
       blockingReasons: [],
+      workspaceHeadSha: "readiness-head-sha",
     });
     mockExecutionWorkspaceService.archiveWorkspaceUnderLifecycleLock.mockResolvedValue({
       outcome: "archived",
@@ -528,6 +529,11 @@ describe.sequential("execution workspace routes", () => {
       }),
     );
     expect(mockExecutionWorkspaceService.runManualArchiveArtifactCleanup).toHaveBeenCalledTimes(1);
+    // Cleanup is anchored to the HEAD the readiness check cleared, not to a
+    // fresh self-read taken after the archive already committed.
+    expect(mockExecutionWorkspaceService.runManualArchiveArtifactCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedHeadSha: "readiness-head-sha" }),
+    );
   });
 
   it("keeps the reusable sandbox leases when a reopen makes the fence skip the archive teardown", async () => {

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -1035,7 +1035,8 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
 
     expect(readiness?.deliveryState).toBe("unmerged");
-    expect(readiness?.warnings).toContain(
+    expect(readiness?.state).toBe("blocked");
+    expect(readiness?.blockingReasons).toContain(
       "This workspace is 2 commits ahead of main and is not merged.",
     );
     expect(sweep).toMatchObject({ archived: 0, skippedUndelivered: 1 });
@@ -1054,7 +1055,8 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
 
     expect(readiness?.deliveryState).toBe("merged_via_pr");
-    expect(readiness?.warnings).toContain("The workspace has 1 untracked file.");
+    expect(readiness?.state).toBe("blocked");
+    expect(readiness?.blockingReasons).toContain("The workspace has 1 untracked file.");
     expect(sweep).toMatchObject({ archived: 0, skippedUndelivered: 1 });
     expect(workspace?.status).toBe("active");
   });
@@ -4695,5 +4697,154 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "git_worktree_remove",
       "git_branch_delete",
     ]));
+  }, 20_000);
+
+  it("blocks the close while a linked issue still has an active agent run", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true, activeRun: true });
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+
+    expect(readiness?.state).toBe("blocked");
+    expect(readiness?.isDestructiveCloseAllowed).toBe(false);
+    expect(readiness?.blockingReasons).toEqual(expect.arrayContaining([
+      "This workspace has an active agent run on a linked issue.",
+    ]));
+  }, 20_000);
+
+  it("clears the active-run blocker once the run leaves queued/running", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true, activeRun: true });
+    await db.update(heartbeatRuns).set({ status: "succeeded" }).where(eq(heartbeatRuns.companyId, seeded.companyId));
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+
+    expect(readiness?.blockingReasons).not.toContain(
+      "This workspace has an active agent run on a linked issue.",
+    );
+  }, 20_000);
+
+  it("blocks the close while the source issue tree still has an open descendant", async () => {
+    // The reaper requires the whole descendant tree to be terminal. The
+    // descendant here never points its executionWorkspaceId at the workspace, so
+    // the directly-linked issue check alone would miss it.
+    const seeded = await seedTerminalWorkspace({ mergedPr: true, childStatus: "todo" });
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+
+    expect(readiness?.state).toBe("blocked");
+    expect(readiness?.blockingReasons).toEqual(expect.arrayContaining([
+      "The source issue tree still has 1 open issue.",
+    ]));
+  }, 20_000);
+
+  it("keeps git conditions as warnings for a shared workspace session", async () => {
+    // A shared session points at the project's primary worktree and archiving it
+    // only removes the session record, so dirty/untracked/unmerged state must not
+    // block the close or the session row could never be closed.
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+    const worktreePath = path.join(path.dirname(repoRoot), `paperclip-shared-${randomUUID()}`);
+    tempDirs.add(worktreePath);
+
+    await runGit(repoRoot, ["branch", "paperclip-shared-check"]);
+    await runGit(repoRoot, ["worktree", "add", worktreePath, "paperclip-shared-check"]);
+    await fs.writeFile(path.join(worktreePath, "feature.txt"), "hello\n", "utf8");
+    await runGit(worktreePath, ["add", "feature.txt"]);
+    await runGit(worktreePath, ["commit", "-m", "Feature commit"]);
+    await fs.writeFile(path.join(worktreePath, "untracked.txt"), "left behind\n", "utf8");
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `S${companyId.slice(0, 8).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared workspaces",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "shared_workspace",
+      strategyType: "git_worktree",
+      name: "Shared session",
+      status: "active",
+      providerType: "git_worktree",
+      cwd: worktreePath,
+      providerRef: worktreePath,
+      branchName: "paperclip-shared-check",
+      baseRef: "main",
+    });
+
+    const readiness = await svc.getCloseReadiness(executionWorkspaceId);
+
+    expect(readiness?.isSharedWorkspace).toBe(true);
+    expect(readiness?.state).toBe("ready_with_warnings");
+    expect(readiness?.isDestructiveCloseAllowed).toBe(true);
+    expect(readiness?.blockingReasons).toEqual([]);
+    expect(readiness?.warnings).toEqual(expect.arrayContaining([
+      "The workspace has 1 untracked file.",
+      "This workspace is 1 commit ahead of main and is not merged.",
+    ]));
+  }, 20_000);
+
+  it("surfaces the readiness HEAD sha so the close route can anchor cleanup", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+
+    expect(readiness?.workspaceHeadSha).toBe(seeded.headSha);
+  }, 20_000);
+
+  it("refuses manual archive cleanup when the expected HEAD sha is unknown", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]!);
+
+    await expect(
+      svc.runManualArchiveArtifactCleanup({ workspace, expectedHeadSha: null }),
+    ).rejects.toThrow(/expected git HEAD is unknown/);
+
+    // The worktree must survive a refused cleanup.
+    await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
+  }, 20_000);
+
+  it("refuses manual archive cleanup when HEAD moved after readiness cleared the close", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]!);
+
+    await fs.writeFile(path.join(seeded.worktreePath, "raced.txt"), "raced\n", "utf8");
+    await runGit(seeded.worktreePath, ["add", "raced.txt"]);
+    await runGit(seeded.worktreePath, ["commit", "-m", "Raced commit"]);
+
+    await expect(
+      svc.runManualArchiveArtifactCleanup({ workspace, expectedHeadSha: seeded.headSha }),
+    ).rejects.toThrow(/git worktree changed after delivery was verified/);
+    await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
   }, 20_000);
 });

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4911,6 +4911,36 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
   }, 20_000);
 
+  it("cleans up a workspace whose path is already gone instead of refusing on the unknown HEAD", async () => {
+    // Readiness clears this close on purpose: there is nothing left to protect.
+    // It also reports a null workspaceHeadSha, and the route forwards that to
+    // cleanup, so refusing on the unknown HEAD would fail the close the
+    // readiness check just allowed and strand the record in cleanup_failed.
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    const missingPath = path.join(path.dirname(seeded.repoRoot), `paperclip-gone-${randomUUID()}`);
+    await db
+      .update(executionWorkspaces)
+      .set({ cwd: missingPath, providerRef: missingPath })
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]!);
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+    expect(readiness?.state).not.toBe("blocked");
+    expect(readiness?.workspaceHeadSha).toBeNull();
+
+    const cleanup = await svc.runManualArchiveArtifactCleanup({
+      workspace,
+      expectedHeadSha: readiness?.workspaceHeadSha ?? null,
+    });
+
+    expect(cleanup.cleaned).toBe(true);
+  }, 20_000);
+
   it("refuses manual archive cleanup when HEAD moved after readiness cleared the close", async () => {
     const seeded = await seedTerminalWorkspace({ mergedPr: true });
     const workspace = await db

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -5061,6 +5061,39 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
   }, 20_000);
 
+  it("marks cleanup_failed when stat rejects with EACCES on an existing isolated worktree", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    const worktreePath = path.resolve(seeded.worktreePath);
+    const originalStat = fs.stat.bind(fs);
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (pathLike) => {
+      const resolved = path.resolve(String(pathLike));
+      if (resolved === worktreePath) {
+        const err = new Error("EACCES: permission denied, stat") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      return originalStat(pathLike);
+    });
+
+    try {
+      const sweep = await svc.sweepTerminalWorkspaces();
+      const [workspace] = await db
+        .select({
+          status: executionWorkspaces.status,
+          cleanupReason: executionWorkspaces.cleanupReason,
+        })
+        .from(executionWorkspaces)
+        .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+
+      expect(sweep).toMatchObject({ cleanupFailed: 1 });
+      expect(workspace?.status).toBe("cleanup_failed");
+      expect(workspace?.cleanupReason).toContain("EACCES");
+      await expect(fs.access(seeded.worktreePath)).resolves.toBeUndefined();
+    } finally {
+      statSpy.mockRestore();
+    }
+  }, 20_000);
+
   it("cleans up a workspace whose path is already gone instead of refusing on the unknown HEAD", async () => {
     // Readiness clears this close on purpose: there is nothing left to protect.
     // It also reports a null workspaceHeadSha, and the route forwards that to

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4821,7 +4821,12 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     const seeded = await seedTerminalWorkspace({ mergedPr: true });
     await db
       .update(executionWorkspaces)
-      .set({ mode: "shared_workspace" })
+      .set({
+        mode: "shared_workspace",
+        // A cleanup command is written to tear the path down, so it must not run
+        // against shared infrastructure that other live sessions still use.
+        metadata: { config: { cleanupCommand: "rm -f delivered.txt" } },
+      })
       .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
     const workspace = await db
       .select()
@@ -4835,12 +4840,15 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     const cleanup = await svc.runManualArchiveArtifactCleanup({
       workspace,
       expectedHeadSha: seeded.headSha,
+      cleanupCommand: "rm -f delivered.txt",
     });
 
     expect(cleanup.cleaned).toBe(true);
     expect(cleanup.warnings.join(" | ")).toContain("shared project infrastructure");
     await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
     await expect(fs.stat(path.join(seeded.worktreePath, "in-flight.txt"))).resolves.toBeTruthy();
+    // The cleanup command never ran, so the tracked file it targets survives.
+    await expect(fs.stat(path.join(seeded.worktreePath, "delivered.txt"))).resolves.toBeTruthy();
     expect(await readGit(seeded.repoRoot, ["rev-parse", "--verify", "PAP-16015-delivery"])).toBe(seeded.headSha);
   }, 20_000);
 

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -5124,6 +5124,58 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(cleanup.cleaned).toBe(true);
   }, 20_000);
 
+  it("fails closed when workspace path stat rejects with EACCES instead of treating it as absent", async () => {
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]!);
+    const closedAt = new Date();
+    await db
+      .update(executionWorkspaces)
+      .set({
+        status: "archived",
+        closedAt,
+        metadata: {
+          createdByRuntime: true,
+          [EXECUTION_WORKSPACE_LIFECYCLE_GENERATION_METADATA_KEY]: 2,
+        },
+      })
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+
+    const eacces = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    const realStat = fs.stat.bind(fs);
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, ...rest) => {
+      const targetPath = path.resolve(String(target));
+      if (targetPath === path.resolve(seeded.worktreePath)) {
+        throw eacces;
+      }
+      return realStat(target as Parameters<typeof realStat>[0], ...(rest as []));
+    });
+
+    try {
+      await expect(
+        svc.runManualArchiveArtifactCleanup({ workspace, expectedHeadSha: seeded.headSha }),
+      ).rejects.toMatchObject({ code: "EACCES" });
+
+      const applied = await svc.applyClosedWorkspaceCleanupOutcome({
+        id: seeded.executionWorkspaceId,
+        closedAt,
+        capturedGeneration: 2,
+        cleanupReason: formatIsolatedArchiveCleanupFailureReason(["EACCES: permission denied"]),
+        markCleanupFailed: true,
+      });
+      expect(applied?.status).toBe("cleanup_failed");
+      expect(applied?.cleanupReason).toMatch(/^worktree_remove_failed:/);
+      expect(applied?.cleanupReason).not.toBeNull();
+    } finally {
+      statSpy.mockRestore();
+    }
+
+    await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
+  }, 20_000);
+
   it("refuses manual archive cleanup when HEAD moved after readiness cleared the close", async () => {
     const seeded = await seedTerminalWorkspace({ mergedPr: true });
     const workspace = await db

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4868,6 +4868,92 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(readiness?.plannedActions.map((action) => action.kind)).toEqual(["archive_record"]);
   }, 20_000);
 
+  it("keeps git conditions as warnings for a project-primary workspace and preserves the path on archive", async () => {
+    // A project-primary isolated workspace points at the project's primary
+    // worktree. Archiving it only removes the workspace record, so dirty tracked
+    // state must not block the close or unrelated work would strand the record.
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+
+    await fs.appendFile(path.join(repoRoot, "README.md"), "dirty tracked work\n", "utf8");
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `P${companyId.slice(0, 8).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Primary workspace",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+      cleanupCommand: "rm -rf dist",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "project_primary",
+      name: "Primary checkout",
+      status: "active",
+      providerType: "local_fs",
+      cwd: repoRoot,
+      providerRef: repoRoot,
+      metadata: {
+        config: {
+          cleanupCommand: "rm -rf dist",
+        },
+      },
+    });
+
+    const readiness = await svc.getCloseReadiness(executionWorkspaceId);
+
+    expect(readiness?.isSharedWorkspace).toBe(false);
+    expect(readiness?.isProjectPrimaryWorkspace).toBe(true);
+    expect(readiness?.state).toBe("ready_with_warnings");
+    expect(readiness?.isDestructiveCloseAllowed).toBe(true);
+    expect(readiness?.blockingReasons).toEqual([]);
+    expect(readiness?.warnings).toEqual(expect.arrayContaining([
+      "The workspace has 1 modified tracked file.",
+      "This workspace points at the project primary worktree. Archiving it only removes the workspace record.",
+    ]));
+    expect(readiness?.plannedActions.map((action) => action.kind)).toEqual(["archive_record"]);
+
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, executionWorkspaceId))
+      .then((rows) => rows[0]!);
+    const headSha = await readGit(repoRoot, ["rev-parse", "HEAD"]);
+
+    const cleanup = await svc.runManualArchiveArtifactCleanup({
+      workspace,
+      expectedHeadSha: headSha,
+      cleanupCommand: "rm -rf dist",
+    });
+
+    expect(cleanup.cleaned).toBe(true);
+    await expect(fs.stat(repoRoot)).resolves.toBeTruthy();
+    await expect(fs.readFile(path.join(repoRoot, "README.md"), "utf8")).resolves.toContain("dirty tracked work");
+  }, 20_000);
+
   it("formats isolated archive cleanup failures with a stable prefix", () => {
     expect(formatIsolatedArchiveCleanupFailureReason([])).toBe("worktree_remove_failed: unknown");
     expect(formatIsolatedArchiveCleanupFailureReason(["fatal: not a git repository"])).toBe(

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -33,6 +33,7 @@ import {
   EXECUTION_WORKSPACE_REOPEN_PENDING_SINCE_METADATA_KEY,
   executionWorkspaceService,
   deriveExecutionWorkspaceDeliveryState,
+  formatIsolatedArchiveCleanupFailureReason,
   mergeExecutionWorkspaceConfig,
   metadataHasReopenPendingConsumption,
   readExecutionWorkspaceConfig,
@@ -4810,6 +4811,69 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     // them run for a shared session.
     expect(readiness?.plannedActions.map((action) => action.kind)).toEqual(["archive_record"]);
   }, 20_000);
+
+  it("keeps destructive close preview steps off a project-primary workspace", async () => {
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `P${companyId.slice(0, 8).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Primary workspace",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+      cleanupCommand: "rm -rf dist",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "project_primary",
+      name: "Primary checkout",
+      status: "active",
+      providerType: "local_fs",
+      cwd: repoRoot,
+      providerRef: repoRoot,
+      metadata: {
+        config: {
+          cleanupCommand: "rm -rf dist",
+        },
+      },
+    });
+
+    const readiness = await svc.getCloseReadiness(executionWorkspaceId);
+
+    expect(readiness?.isProjectPrimaryWorkspace).toBe(true);
+    expect(readiness?.plannedActions.map((action) => action.kind)).toEqual(["archive_record"]);
+  }, 20_000);
+
+  it("formats isolated archive cleanup failures with a stable prefix", () => {
+    expect(formatIsolatedArchiveCleanupFailureReason([])).toBe("worktree_remove_failed: unknown");
+    expect(formatIsolatedArchiveCleanupFailureReason(["fatal: not a git repository"])).toBe(
+      "worktree_remove_failed: fatal: not a git repository",
+    );
+  });
 
   it("surfaces the readiness HEAD sha so the close route can anchor cleanup", async () => {
     const seeded = await seedTerminalWorkspace({ mergedPr: true });

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4814,6 +4814,44 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(readiness?.workspaceHeadSha).toBe(seeded.headSha);
   }, 20_000);
 
+  it("blocks the close when the ancestry probe cannot resolve the base ref", async () => {
+    // Both git probes run only when the repo root and the base ref resolve. An
+    // unresolvable base ref leaves aheadCount and isMergedIntoBase null, which
+    // must fail closed rather than silently clear the delivery blocker. There is
+    // no merged PR here, so nothing else proves the commits were delivered.
+    const seeded = await seedTerminalWorkspace();
+    await db
+      .update(executionWorkspaces)
+      .set({ baseRef: "refs/heads/does-not-exist" })
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+
+    expect(readiness?.git?.aheadCount).toBeNull();
+    expect(readiness?.git?.isMergedIntoBase).toBeNull();
+    expect(readiness?.state).toBe("blocked");
+    expect(readiness?.blockingReasons).toContain(
+      "Paperclip could not verify whether this workspace is merged into refs/heads/does-not-exist.",
+    );
+  }, 20_000);
+
+  it("does not block the close when the workspace path is already gone", async () => {
+    // A missing path reports null counts too, but there is nothing left to
+    // protect, so the record must still be closable.
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    const missingPath = path.join(path.dirname(seeded.repoRoot), `paperclip-gone-${randomUUID()}`);
+    await db
+      .update(executionWorkspaces)
+      .set({ cwd: missingPath, providerRef: missingPath })
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+
+    const readiness = await svc.getCloseReadiness(seeded.executionWorkspaceId);
+
+    expect(readiness?.git?.repoRoot).toBeNull();
+    expect(readiness?.blockingReasons).toEqual([]);
+    expect(readiness?.isDestructiveCloseAllowed).toBe(true);
+  }, 20_000);
+
   it("keeps the worktree and the branch when a shared workspace session is closed", async () => {
     // Closing a shared session must remove the session record only. The
     // underlying worktree is project infrastructure that outlives the session,

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4814,6 +4814,36 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(readiness?.workspaceHeadSha).toBe(seeded.headSha);
   }, 20_000);
 
+  it("keeps the worktree and the branch when a shared workspace session is closed", async () => {
+    // Closing a shared session must remove the session record only. The
+    // underlying worktree is project infrastructure that outlives the session,
+    // so cleanup must not remove it even though the close was allowed.
+    const seeded = await seedTerminalWorkspace({ mergedPr: true });
+    await db
+      .update(executionWorkspaces)
+      .set({ mode: "shared_workspace" })
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]!);
+
+    // Dirty the worktree, so the destruction fence would refuse if it applied.
+    await fs.writeFile(path.join(seeded.worktreePath, "in-flight.txt"), "unrelated work\n", "utf8");
+
+    const cleanup = await svc.runManualArchiveArtifactCleanup({
+      workspace,
+      expectedHeadSha: seeded.headSha,
+    });
+
+    expect(cleanup.cleaned).toBe(true);
+    expect(cleanup.warnings.join(" | ")).toContain("shared project infrastructure");
+    await expect(fs.stat(seeded.worktreePath)).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(seeded.worktreePath, "in-flight.txt"))).resolves.toBeTruthy();
+    expect(await readGit(seeded.repoRoot, ["rev-parse", "--verify", "PAP-16015-delivery"])).toBe(seeded.headSha);
+  }, 20_000);
+
   it("refuses manual archive cleanup when the expected HEAD sha is unknown", async () => {
     const seeded = await seedTerminalWorkspace({ mergedPr: true });
     const workspace = await db

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4668,10 +4668,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
     expect(readiness).toMatchObject({
       workspaceId: executionWorkspaceId,
       deliveryState: "unmerged",
-      state: "ready_with_warnings",
+      state: "blocked",
       isSharedWorkspace: false,
       isProjectPrimaryWorkspace: false,
-      isDestructiveCloseAllowed: true,
+      isDestructiveCloseAllowed: false,
       git: {
         workspacePath: worktreePath,
         branchName: "paperclip-close-check",
@@ -4684,7 +4684,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         isMergedIntoBase: false,
       },
     });
-    expect(readiness?.warnings).toEqual(expect.arrayContaining([
+    expect(readiness?.blockingReasons).toEqual(expect.arrayContaining([
       "The workspace has 1 untracked file.",
       "This workspace is 1 commit ahead of main and is not merged.",
     ]));

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -4777,6 +4777,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       sourceType: "git_repo",
       isPrimary: true,
       cwd: repoRoot,
+      cleanupCommand: "rm -rf dist",
     });
     await db.insert(executionWorkspaces).values({
       id: executionWorkspaceId,
@@ -4804,6 +4805,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "The workspace has 1 untracked file.",
       "This workspace is 1 commit ahead of main and is not merged.",
     ]));
+    // The close preserves the workspace path, so the preview must not advertise
+    // the cleanup command, the worktree removal, or the branch delete: none of
+    // them run for a shared session.
+    expect(readiness?.plannedActions.map((action) => action.kind)).toEqual(["archive_record"]);
   }, 20_000);
 
   it("surfaces the readiness HEAD sha so the close route can anchor cleanup", async () => {

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1266,7 +1266,10 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
             await stopRuntimeServicesForExecutionWorkspace({
               db,
               executionWorkspaceId: existing.id,
-              workspaceCwd: existing.cwd,
+              // A shared session shares its path with other live sessions, so
+              // the cwd-prefix fallback would stop their services too. Match on
+              // the closing record only.
+              workspaceCwd: existing.mode === "shared_workspace" ? null : existing.cwd,
             });
             return svc.runManualArchiveArtifactCleanup({
               workspace: existing,

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -34,7 +34,6 @@ import { parseProjectExecutionWorkspacePolicy } from "../services/execution-work
 import { readProjectWorkspaceRuntimeConfig } from "../services/project-workspace-runtime-config.js";
 import {
   buildWorkspaceRuntimeDesiredStatePatch,
-  cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
   listConfiguredRuntimeServiceEntries,
   runWorkspaceJobForControl,
@@ -1269,7 +1268,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
               executionWorkspaceId: existing.id,
               workspaceCwd: existing.cwd,
             });
-            return cleanupExecutionWorkspaceArtifacts({
+            return svc.runManualArchiveArtifactCleanup({
               workspace: existing,
               projectWorkspace,
               teardownCommand: configForCleanup?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1270,6 +1270,9 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
             });
             return svc.runManualArchiveArtifactCleanup({
               workspace: existing,
+              // Anchor destruction to the HEAD the close-readiness check cleared,
+              // so a commit landing between readiness and cleanup fails closed.
+              expectedHeadSha: readiness.workspaceHeadSha,
               projectWorkspace,
               teardownCommand: configForCleanup?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
               cleanupCommand: configForCleanup?.cleanupCommand ?? null,

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1354,14 +1354,26 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         const failureReason = formatIsolatedArchiveCleanupFailureReason([
           error instanceof Error ? error.message : String(error),
         ]);
-        const marked = await svc.applyClosedWorkspaceCleanupOutcome({
-          id,
-          closedAt,
-          capturedGeneration,
-          cleanupReason: failureReason,
-          markCleanupFailed: true,
-        });
-        if (marked) workspace = marked;
+        try {
+          const marked = await svc.applyClosedWorkspaceCleanupOutcome({
+            id,
+            closedAt,
+            capturedGeneration,
+            cleanupReason: failureReason,
+            markCleanupFailed: true,
+          });
+          if (marked) workspace = marked;
+        } catch (recoveryError) {
+          logger.warn(
+            { err: recoveryError, executionWorkspaceId: id, cleanupFailureReason: failureReason },
+            "failed to record isolated archive cleanup failure",
+          );
+          workspace = {
+            ...workspace,
+            status: "cleanup_failed",
+            cleanupReason: failureReason,
+          };
+        }
         archiveCleanupOutcome = { cleaned: false, cleanupSucceeded: false };
       }
     } else {

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1160,7 +1160,14 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     }
     let workspace = existing;
     let cleanupWarnings: string[] = [];
-    let archiveCleanupOutcome: { cleaned: boolean; cleanupSucceeded: boolean } | null = null;
+    let archiveCleanupOutcome:
+      | {
+          cleaned: boolean;
+          cleanupSucceeded: boolean;
+          cleanupFailureRecorded?: boolean;
+          cleanupFailureReason?: string;
+        }
+      | null = null;
     const configForCleanup = readExecutionWorkspaceConfig(
       ((patch.metadata as Record<string, unknown> | null | undefined) ?? (existing.metadata as Record<string, unknown> | null)) ?? null,
     );
@@ -1354,6 +1361,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         const failureReason = formatIsolatedArchiveCleanupFailureReason([
           error instanceof Error ? error.message : String(error),
         ]);
+        let cleanupFailureRecorded = true;
         try {
           const marked = await svc.applyClosedWorkspaceCleanupOutcome({
             id,
@@ -1368,13 +1376,21 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
             { err: recoveryError, executionWorkspaceId: id, cleanupFailureReason: failureReason },
             "failed to record isolated archive cleanup failure",
           );
-          workspace = {
-            ...workspace,
-            status: "cleanup_failed",
-            cleanupReason: failureReason,
-          };
+          // The failure marker never reached the database, so the row stays
+          // plain `archived`: reporting a `cleanup_failed` status here would
+          // contradict every later read and imply a terminal-sweep retry that
+          // will not happen. Report the persisted row and flag the gap instead.
+          cleanupFailureRecorded = false;
+          cleanupWarnings = [...cleanupWarnings, failureReason];
+          workspace = (await svc.getById(id).catch(() => null)) ?? workspace;
         }
-        archiveCleanupOutcome = { cleaned: false, cleanupSucceeded: false };
+        archiveCleanupOutcome = {
+          cleaned: false,
+          cleanupSucceeded: false,
+          ...(cleanupFailureRecorded
+            ? {}
+            : { cleanupFailureRecorded: false, cleanupFailureReason: failureReason }),
+        };
       }
     } else {
       const updatedWorkspace = await svc.update(id, patch);

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -7,8 +7,10 @@ import type { Db } from "@paperclipai/db";
 import { issues, projects, projectWorkspaces } from "@paperclipai/db";
 import {
   findWorkspaceCommandDefinition,
+  isRecordOnlyArchiveWorkspace,
   matchWorkspaceRuntimeServiceToCommand,
   reconcileExecutionWorkspaceBranchSchema,
+  SHARED_WORKSPACE_RECORD_ONLY_ARCHIVE_REASON,
   updateExecutionWorkspaceSchema,
   workspaceOverviewQuerySchema,
   workspaceRuntimeControlTargetSchema,
@@ -29,7 +31,11 @@ import {
   LEASED_WORKSPACE_RUNTIME_ACTIONS,
   type WorkspaceRuntimeLeaseClaim,
 } from "../services/index.js";
-import { mergeExecutionWorkspaceConfig, readExecutionWorkspaceConfig } from "../services/execution-workspaces.js";
+import {
+  mergeExecutionWorkspaceConfig,
+  readExecutionWorkspaceConfig,
+  formatIsolatedArchiveCleanupFailureReason,
+} from "../services/execution-workspaces.js";
 import { parseProjectExecutionWorkspacePolicy } from "../services/execution-workspace-policy.js";
 import { readProjectWorkspaceRuntimeConfig } from "../services/project-workspace-runtime-config.js";
 import {
@@ -1154,6 +1160,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
     }
     let workspace = existing;
     let cleanupWarnings: string[] = [];
+    let archiveCleanupOutcome: { cleaned: boolean; cleanupSucceeded: boolean } | null = null;
     const configForCleanup = readExecutionWorkspaceConfig(
       ((patch.metadata as Record<string, unknown> | null | undefined) ?? (existing.metadata as Record<string, unknown> | null)) ?? null,
     );
@@ -1201,12 +1208,16 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
       }
       workspace = archiveResult.workspace;
       const capturedGeneration = archiveResult.capturedGeneration;
+      const isRecordOnlyArchive = isRecordOnlyArchiveWorkspace({
+        mode: existing.mode,
+        isProjectPrimaryWorkspace: readiness.isProjectPrimaryWorkspace,
+      });
 
       // Closing the workspace ends the lane, so the runtime-control lease is released
       // outright rather than waiting for owner-eligibility or TTL recovery.
       await runtimeLeases.release({ executionWorkspaceId: existing.id, force: true });
 
-      if (existing.mode === "shared_workspace") {
+      if (isRecordOnlyArchive) {
         await db
           .update(issues)
           .set({
@@ -1266,10 +1277,10 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
             await stopRuntimeServicesForExecutionWorkspace({
               db,
               executionWorkspaceId: existing.id,
-              // A shared session shares its path with other live sessions, so
+              // A record-only archive shares its path with other live sessions, so
               // the cwd-prefix fallback would stop their services too. Match on
               // the closing record only.
-              workspaceCwd: existing.mode === "shared_workspace" ? null : existing.cwd,
+              workspaceCwd: isRecordOnlyArchive ? null : existing.cwd,
             });
             return svc.runManualArchiveArtifactCleanup({
               workspace: existing,
@@ -1292,35 +1303,57 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         } else {
           const cleanupResult = fenced.result;
           cleanupWarnings = cleanupResult.warnings;
-          if (cleanupResult.warnings.length > 0 || !cleanupResult.cleaned) {
-            // Record the cleanup outcome under the lifecycle lock at the captured
-            // generation. If a resume reopened the workspace after the destruction
-            // fence returned, the guarded write skips the row, so a stale patch
-            // never overwrites the rebuilt worktree's active state.
+          if (isRecordOnlyArchive && cleanupResult.cleaned) {
             const applied = await svc.applyClosedWorkspaceCleanupOutcome({
               id,
               closedAt,
               capturedGeneration,
-              cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
-              markCleanupFailed: !cleanupResult.cleaned,
+              cleanupReason: SHARED_WORKSPACE_RECORD_ONLY_ARCHIVE_REASON,
+              markCleanupFailed: false,
             });
             if (applied) {
               workspace = applied;
             } else {
-              // A resume reopened the workspace. Return the current (active) row.
               workspace = (await svc.getById(id)) ?? workspace;
             }
+            archiveCleanupOutcome = { cleaned: true, cleanupSucceeded: true };
+          } else if (!cleanupResult.cleaned) {
+            const cleanupReason = formatIsolatedArchiveCleanupFailureReason(cleanupResult.warnings);
+            const applied = await svc.applyClosedWorkspaceCleanupOutcome({
+              id,
+              closedAt,
+              capturedGeneration,
+              cleanupReason,
+              markCleanupFailed: true,
+            });
+            if (applied) {
+              workspace = applied;
+            } else {
+              workspace = (await svc.getById(id)) ?? workspace;
+            }
+            archiveCleanupOutcome = { cleaned: false, cleanupSucceeded: false };
+          } else if (cleanupResult.warnings.length > 0) {
+            const applied = await svc.applyClosedWorkspaceCleanupOutcome({
+              id,
+              closedAt,
+              capturedGeneration,
+              cleanupReason: cleanupWarnings.join(" | "),
+              markCleanupFailed: false,
+            });
+            if (applied) {
+              workspace = applied;
+            } else {
+              workspace = (await svc.getById(id)) ?? workspace;
+            }
+            archiveCleanupOutcome = { cleaned: true, cleanupSucceeded: true };
+          } else {
+            archiveCleanupOutcome = { cleaned: true, cleanupSucceeded: true };
           }
         }
       } catch (error) {
-        const failureReason = error instanceof Error ? error.message : String(error);
-        // Mark cleanup_failed only while the row is still closed at the captured
-        // generation. If a resume reopened the workspace after the cleanup threw,
-        // the row is active again and, after a fresh archive, carries a higher
-        // generation. The generation-fenced write skips the row in both cases, so
-        // a stale cleanup_failed write never overwrites the newer active lifecycle
-        // state, and never buries a newer archive under the first archive's
-        // failure.
+        const failureReason = formatIsolatedArchiveCleanupFailureReason([
+          error instanceof Error ? error.message : String(error),
+        ]);
         const marked = await svc.applyClosedWorkspaceCleanupOutcome({
           id,
           closedAt,
@@ -1329,10 +1362,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
           markCleanupFailed: true,
         });
         if (marked) workspace = marked;
-        res.status(500).json({
-          error: `Failed to archive execution workspace: ${failureReason}`,
-        });
-        return;
+        archiveCleanupOutcome = { cleaned: false, cleanupSucceeded: false };
       }
     } else {
       const updatedWorkspace = await svc.update(id, patch);
@@ -1358,7 +1388,7 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
         ...(cleanupWarnings.length > 0 ? { cleanupWarnings } : {}),
       },
     });
-    res.json(workspace);
+    res.json(archiveCleanupOutcome ? { ...workspace, ...archiveCleanupOutcome } : workspace);
   });
 
   return router;

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -34,6 +34,11 @@ import type {
   IssueRecoveryAction,
 } from "@paperclipai/shared";
 import { deriveProjectUrlKey, WORKSPACE_OVERVIEW_LINKED_ISSUE_LIMIT } from "@paperclipai/shared";
+import {
+  isRecordOnlyArchiveWorkspace,
+  resolveIsProjectPrimaryWorkspace,
+  SHARED_WORKSPACE_RECORD_ONLY_ARCHIVE_REASON,
+} from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import {
@@ -89,6 +94,16 @@ function issueTerminalTimestamp(issue: {
 const WORKSPACE_BRANCH_INCOHERENCE_REASON = "git_worktree_branch_incoherence";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 export const ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON = "issue_terminal";
+
+export { SHARED_WORKSPACE_RECORD_ONLY_ARCHIVE_REASON };
+
+export function formatIsolatedArchiveCleanupFailureReason(warnings: string[]): string {
+  const joined = warnings.map((value) => value.trim()).filter(Boolean).join(" | ");
+  if (joined.length > 0) {
+    return `worktree_remove_failed: ${joined.slice(0, 500)}`;
+  }
+  return "worktree_remove_failed: unknown";
+}
 
 // The reopen-failure reason kept on the row when a rebuild does not finish. The
 // value is sanitized: it never contains a repository URL, a host path, or git
@@ -1656,6 +1671,41 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
     });
   }
 
+  async function resolveRecordOnlyArchiveForWorkspace(workspace: ExecutionWorkspaceRow): Promise<boolean> {
+    if (workspace.mode === "shared_workspace") return true;
+    const workspacePath = readNullableString(workspace.providerRef) ?? readNullableString(workspace.cwd);
+    if (!workspacePath || !workspace.projectWorkspaceId || !workspace.projectId) return false;
+
+    const [projectWorkspace, primaryProjectWorkspace] = await Promise.all([
+      db
+        .select({ id: projectWorkspaces.id, cwd: projectWorkspaces.cwd })
+        .from(projectWorkspaces)
+        .where(and(
+          eq(projectWorkspaces.companyId, workspace.companyId),
+          eq(projectWorkspaces.id, workspace.projectWorkspaceId),
+        ))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: projectWorkspaces.id })
+        .from(projectWorkspaces)
+        .where(and(
+          eq(projectWorkspaces.companyId, workspace.companyId),
+          eq(projectWorkspaces.projectId, workspace.projectId),
+          eq(projectWorkspaces.isPrimary, true),
+        ))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    const resolvedWorkspacePath = path.resolve(workspacePath);
+    const resolvedProjectWorkspacePath = projectWorkspace?.cwd ? path.resolve(projectWorkspace.cwd) : null;
+    return resolveIsProjectPrimaryWorkspace({
+      projectWorkspaceId: workspace.projectWorkspaceId,
+      primaryProjectWorkspaceId: primaryProjectWorkspace?.id ?? null,
+      workspacePath: resolvedWorkspacePath,
+      projectWorkspacePath: resolvedProjectWorkspacePath,
+    });
+  }
+
   async function cleanupTerminalWorkspace(
     workspace: ExecutionWorkspaceRow,
     expectedHeadSha: string | null,
@@ -1705,6 +1755,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       teardownCommand?: string | null;
       recorder?: WorkspaceOperationRecorder | null;
       runCleanupCommands?: boolean;
+      preserveWorkspacePath?: boolean;
     },
   ) {
     const [
@@ -1741,7 +1792,10 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
     // the branch. The git-state fence guards destruction, so it does not apply
     // here either — it would otherwise refuse every close of a shared session,
     // because the project's primary worktree is dirty almost all of the time.
-    const preserveWorkspacePath = workspace.mode === "shared_workspace";
+    // Reaper callers omit preserveWorkspacePath, so they keep the historical
+    // shared-mode-only guard. The API archive path passes the full record-only
+    // predicate, which also covers project-primary workspaces.
+    const preserveWorkspacePath = input.preserveWorkspacePath ?? workspace.mode === "shared_workspace";
     const assertSafeToCleanup = preserveWorkspacePath
       ? null
       : () => assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
@@ -2382,13 +2436,17 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       const isSharedWorkspace = executionWorkspace.mode === "shared_workspace";
       const workspacePath = readNullableString(executionWorkspace.providerRef) ?? readNullableString(executionWorkspace.cwd);
       const resolvedWorkspacePath = workspacePath ? path.resolve(workspacePath) : null;
-      const resolvedPrimaryWorkspacePath = projectWorkspace?.cwd ? path.resolve(projectWorkspace.cwd) : null;
-      const isProjectPrimaryWorkspace =
-        workspace.projectWorkspaceId != null
-        && workspace.projectWorkspaceId === primaryProjectWorkspace?.id
-        && resolvedWorkspacePath != null
-        && resolvedPrimaryWorkspacePath != null
-        && resolvedWorkspacePath === resolvedPrimaryWorkspacePath;
+      const resolvedProjectWorkspacePath = projectWorkspace?.cwd ? path.resolve(projectWorkspace.cwd) : null;
+      const isProjectPrimaryWorkspace = resolveIsProjectPrimaryWorkspace({
+        projectWorkspaceId: workspace.projectWorkspaceId,
+        primaryProjectWorkspaceId: primaryProjectWorkspace?.id ?? null,
+        workspacePath: resolvedWorkspacePath,
+        projectWorkspacePath: resolvedProjectWorkspacePath,
+      });
+      const isRecordOnlyArchive = isRecordOnlyArchiveWorkspace({
+        mode: executionWorkspace.mode,
+        isProjectPrimaryWorkspace,
+      });
 
       const linkedIssueSummaries = linkedIssues.map((issue) => ({
         ...issue,
@@ -2534,7 +2592,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       // own runtime services go away. Listing the destructive steps anyway would
       // make the confirmation payload describe work that will never run, which is
       // the opposite of what a close preview is for.
-      if (!isSharedWorkspace) {
+      if (!isRecordOnlyArchive) {
         const configuredCleanupCommands = [
           {
             kind: "cleanup_command" as const,
@@ -3500,12 +3558,14 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       teardownCommand?: string | null;
       recorder?: WorkspaceOperationRecorder | null;
     }) => {
+      const preserveWorkspacePath = await resolveRecordOnlyArchiveForWorkspace(input.workspace);
       return runClosedWorkspaceArtifactCleanup(input.workspace, input.expectedHeadSha, {
         projectWorkspace: input.projectWorkspace,
         cleanupCommand: input.cleanupCommand,
         teardownCommand: input.teardownCommand,
         recorder: input.recorder,
         runCleanupCommands: true,
+        preserveWorkspacePath,
       });
     },
 

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -43,6 +43,7 @@ import {
 } from "./issue-execution-policy.js";
 import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
 import { issueRecoveryActionService } from "./issue-recovery-actions.js";
+import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { logActivity } from "./activity-log.js";
 import {
   createPullRequestMergeDetailsResolver,
@@ -1668,6 +1669,32 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
   }
 
   async function runTerminalWorkspaceCleanup(workspace: ExecutionWorkspaceRow, expectedHeadSha: string | null) {
+    const [projectPolicy] = await Promise.all([
+      db
+        .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
+        .from(projects)
+        .where(and(eq(projects.companyId, workspace.companyId), eq(projects.id, workspace.projectId)))
+        .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy)),
+    ]);
+    const config = readExecutionWorkspaceConfig((workspace.metadata as Record<string, unknown> | null) ?? null);
+    return runTerminalWorkspaceCleanupWithSideEffects(workspace, expectedHeadSha, {
+      cleanupCommand: config?.cleanupCommand ?? null,
+      teardownCommand: config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
+      runCleanupCommands: false,
+    });
+  }
+
+  async function runClosedWorkspaceArtifactCleanup(
+    workspace: ExecutionWorkspaceRow,
+    expectedHeadSha: string | null,
+    input: {
+      projectWorkspace?: { cwd: string | null; cleanupCommand: string | null } | null;
+      cleanupCommand?: string | null;
+      teardownCommand?: string | null;
+      recorder?: WorkspaceOperationRecorder | null;
+      runCleanupCommands?: boolean;
+    },
+  ) {
     const [
       {
         acquireGitWorktreeCleanupLock,
@@ -1679,9 +1706,9 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       import("./workspace-runtime.js"),
       import("./workspace-operations.js"),
     ]);
-    const [projectWorkspace, projectPolicy] = await Promise.all([
-      workspace.projectWorkspaceId
-        ? db
+    const projectWorkspace = input.projectWorkspace
+      ?? (workspace.projectWorkspaceId
+        ? await db
             .select({ cwd: projectWorkspaces.cwd, cleanupCommand: projectWorkspaces.cleanupCommand })
             .from(projectWorkspaces)
             .where(and(
@@ -1689,14 +1716,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
               eq(projectWorkspaces.id, workspace.projectWorkspaceId),
             ))
             .then((rows) => rows[0] ?? null)
-        : null,
-      db
-        .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
-        .from(projects)
-        .where(and(eq(projects.companyId, workspace.companyId), eq(projects.id, workspace.projectId)))
-        .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy)),
-    ]);
-    const config = readExecutionWorkspaceConfig((workspace.metadata as Record<string, unknown> | null) ?? null);
+        : null);
 
     const cleanupLock = workspace.providerType === "git_worktree" && (workspace.providerRef ?? workspace.cwd)
       ? await acquireGitWorktreeCleanupLock(workspace.providerRef ?? workspace.cwd!)
@@ -1713,9 +1733,9 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       const cleanup = await cleanupExecutionWorkspaceArtifacts({
         workspace,
         projectWorkspace,
-        cleanupCommand: config?.cleanupCommand ?? null,
-        teardownCommand: config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
-        recorder: workspaceOperationService(db).createRecorder({
+        cleanupCommand: input.cleanupCommand ?? null,
+        teardownCommand: input.teardownCommand ?? null,
+        recorder: input.recorder ?? workspaceOperationService(db).createRecorder({
           companyId: workspace.companyId,
           executionWorkspaceId: workspace.id,
         }),
@@ -1726,33 +1746,42 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         // from crossing final validation. The branch lock is released only
         // after non-forced worktree removal, then deletion is anchored to the
         // verified HEAD so a raced ref update fails closed.
-        runCleanupCommands: false,
+        runCleanupCommands: input.runCleanupCommands ?? false,
         forceWorktreeRemoval: false,
       });
-      if (cleanup.cleaned && workspace.mode === "shared_workspace") {
-        await db
-          .update(issues)
-          .set({ executionWorkspaceId: null, updatedAt: now() })
-          .where(and(
-            eq(issues.companyId, workspace.companyId),
-            eq(issues.executionWorkspaceId, workspace.id),
-          ));
-      }
-      const cleanupReason = [ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON, ...cleanup.warnings].join(" | ");
-      if (!cleanup.cleaned || cleanup.warnings.length > 0) {
-        await db
-          .update(executionWorkspaces)
-          .set({
-            ...(cleanup.cleaned ? {} : { status: "cleanup_failed" }),
-            cleanupReason,
-            updatedAt: now(),
-          })
-          .where(eq(executionWorkspaces.id, workspace.id));
-      }
       return cleanup;
     } finally {
       await cleanupLock?.release();
     }
+  }
+
+  async function runTerminalWorkspaceCleanupWithSideEffects(
+    workspace: ExecutionWorkspaceRow,
+    expectedHeadSha: string | null,
+    input: Parameters<typeof runClosedWorkspaceArtifactCleanup>[2],
+  ) {
+    const cleanup = await runClosedWorkspaceArtifactCleanup(workspace, expectedHeadSha, input);
+    if (cleanup.cleaned && workspace.mode === "shared_workspace") {
+      await db
+        .update(issues)
+        .set({ executionWorkspaceId: null, updatedAt: now() })
+        .where(and(
+          eq(issues.companyId, workspace.companyId),
+          eq(issues.executionWorkspaceId, workspace.id),
+        ));
+    }
+    const cleanupReason = [ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON, ...cleanup.warnings].join(" | ");
+    if (!cleanup.cleaned || cleanup.warnings.length > 0) {
+      await db
+        .update(executionWorkspaces)
+        .set({
+          ...(cleanup.cleaned ? {} : { status: "cleanup_failed" }),
+          cleanupReason,
+          updatedAt: now(),
+        })
+        .where(eq(executionWorkspaces.id, workspace.id));
+    }
+    return cleanup;
   }
 
   // Write the cleanup-failed status under the per-workspace lifecycle lock, but
@@ -2352,14 +2381,14 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       }
 
       if (git?.hasDirtyTrackedFiles) {
-        warnings.push(
+        blockingReasons.push(
           git.dirtyEntryCount === 1
             ? "The workspace has 1 modified tracked file."
             : `The workspace has ${git.dirtyEntryCount} modified tracked files.`,
         );
       }
       if (git?.hasUntrackedFiles) {
-        warnings.push(
+        blockingReasons.push(
           git.untrackedEntryCount === 1
             ? "The workspace has 1 untracked file."
             : `The workspace has ${git.untrackedEntryCount} untracked files.`,
@@ -2371,11 +2400,14 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         && git.isMergedIntoBase === false
         && deliveryState !== "merged_via_pr"
       ) {
-        warnings.push(
+        blockingReasons.push(
           git.aheadCount === 1
             ? `This workspace is 1 commit ahead of ${git.baseRef ?? "the base ref"} and is not merged.`
             : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef ?? "the base ref"} and is not merged.`,
         );
+      }
+      if (await workspaceHasActiveRun(workspace)) {
+        blockingReasons.push("This workspace has an active agent run on a linked issue.");
       }
       if (git?.behindCount && git.behindCount > 0) {
         warnings.push(
@@ -3351,6 +3383,27 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         },
         onSkip: () => ({ skippedReopened: true as const }),
         write: async () => ({ skippedReopened: false as const, result: await input.destroy() }),
+      });
+    },
+
+    runManualArchiveArtifactCleanup: async (input: {
+      workspace: ExecutionWorkspaceRow;
+      projectWorkspace?: { cwd: string | null; cleanupCommand: string | null } | null;
+      cleanupCommand?: string | null;
+      teardownCommand?: string | null;
+      recorder?: WorkspaceOperationRecorder | null;
+    }) => {
+      const workspacePath =
+        readNullableString(input.workspace.providerRef) ?? readNullableString(input.workspace.cwd);
+      const expectedHeadSha = workspacePath
+        ? await readGitStdout(["rev-parse", "HEAD"], workspacePath).catch(() => null)
+        : null;
+      return runClosedWorkspaceArtifactCleanup(input.workspace, expectedHeadSha, {
+        projectWorkspace: input.projectWorkspace,
+        cleanupCommand: input.cleanupCommand,
+        teardownCommand: input.teardownCommand,
+        recorder: input.recorder,
+        runCleanupCommands: true,
       });
     },
 

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2459,8 +2459,11 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           blockingIssues.length === 1
             ? "This workspace is still linked to an open issue."
             : `This workspace is still linked to ${blockingIssues.length} open issues.`;
-        if (isSharedWorkspace) {
-          warnings.push(`${linkedIssueMessage} Archiving it will detach this shared workspace session from those issues, but keep the underlying project workspace available.`);
+        if (isRecordOnlyArchive) {
+          const detachSuffix = isSharedWorkspace
+            ? " Archiving it will detach this shared workspace session from those issues, but keep the underlying project workspace available."
+            : " Archiving it will detach this workspace record from those issues, but keep the underlying project workspace available.";
+          warnings.push(`${linkedIssueMessage}${detachSuffix}`);
         } else {
           blockingReasons.push(linkedIssueMessage);
         }
@@ -2480,8 +2483,11 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           openTreeIssues.length === 1
             ? "The source issue tree still has 1 open issue."
             : `The source issue tree still has ${openTreeIssues.length} open issues.`;
-        if (isSharedWorkspace) {
-          warnings.push(`${treeIssueMessage} Archiving this shared workspace session keeps the underlying project workspace available.`);
+        if (isRecordOnlyArchive) {
+          const treeSuffix = isSharedWorkspace
+            ? " Archiving this shared workspace session keeps the underlying project workspace available."
+            : " Archiving this workspace keeps the underlying project workspace available.";
+          warnings.push(`${treeIssueMessage}${treeSuffix}`);
         } else {
           blockingReasons.push(treeIssueMessage);
         }
@@ -2489,6 +2495,8 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
 
       if (isSharedWorkspace) {
         warnings.push("This shared workspace session points at project workspace infrastructure. Archiving it only removes the session record.");
+      } else if (isProjectPrimaryWorkspace) {
+        warnings.push("This workspace points at the project primary worktree. Archiving it only removes the workspace record.");
       }
 
       if (runtimeServices.some((service) => service.status !== "stopped")) {
@@ -2499,14 +2507,13 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         );
       }
 
-      // Archiving a shared workspace session only removes the session record; it
-      // never destroys the underlying project workspace (see the warning above).
-      // A shared session points at the project's primary worktree, which carries
-      // unrelated in-flight work almost all of the time, so treating its git
-      // state as a blocker would make the session record impossible to close
-      // while protecting nothing. Keep the same signals as warnings there.
+      // Record-only archive (shared session or project-primary path) only removes
+      // the workspace record; it never destroys the underlying project workspace.
+      // Those paths carry unrelated in-flight work almost all of the time, so
+      // treating their git state as a blocker would make the record impossible to
+      // close while protecting nothing. Keep the same signals as warnings there.
       const pushGitCloseSignal = (message: string) => {
-        if (isSharedWorkspace) warnings.push(message);
+        if (isRecordOnlyArchive) warnings.push(message);
         else blockingReasons.push(message);
       };
 

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1743,7 +1743,11 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       await stopRuntimeServicesForExecutionWorkspace({
         db,
         executionWorkspaceId: workspace.id,
-        workspaceCwd: workspace.cwd,
+        // The cwd fallback sweeps every in-process service running under the
+        // path, which is a safety net for a workspace being destroyed. On a
+        // preserved path that same sweep reaches services owned by other live
+        // sessions on the shared worktree, so match on the closing record only.
+        workspaceCwd: preserveWorkspacePath ? null : workspace.cwd,
       });
       const cleanup = await cleanupExecutionWorkspaceArtifacts({
         workspace,

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1434,6 +1434,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       cooldownAnchor,
       workspaceDirty: Boolean(git?.hasDirtyTrackedFiles || git?.hasUntrackedFiles),
       workspaceHeadSha,
+      issueTree,
     };
   }
 
@@ -1669,13 +1670,11 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
   }
 
   async function runTerminalWorkspaceCleanup(workspace: ExecutionWorkspaceRow, expectedHeadSha: string | null) {
-    const [projectPolicy] = await Promise.all([
-      db
-        .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
-        .from(projects)
-        .where(and(eq(projects.companyId, workspace.companyId), eq(projects.id, workspace.projectId)))
-        .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy)),
-    ]);
+    const projectPolicy = await db
+      .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
+      .from(projects)
+      .where(and(eq(projects.companyId, workspace.companyId), eq(projects.id, workspace.projectId)))
+      .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy));
     const config = readExecutionWorkspaceConfig((workspace.metadata as Record<string, unknown> | null) ?? null);
     return runTerminalWorkspaceCleanupWithSideEffects(workspace, expectedHeadSha, {
       cleanupCommand: config?.cleanupCommand ?? null,
@@ -1706,8 +1705,13 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       import("./workspace-runtime.js"),
       import("./workspace-operations.js"),
     ]);
-    const projectWorkspace = input.projectWorkspace
-      ?? (workspace.projectWorkspaceId
+    // Only fall back to the lookup when the caller said nothing. An explicit
+    // `null` means the caller already resolved it and there is none, so a `??`
+    // fallback here would silently re-query and run cleanup against a project
+    // workspace the caller deliberately excluded.
+    const projectWorkspace = input.projectWorkspace !== undefined
+      ? input.projectWorkspace
+      : (workspace.projectWorkspaceId
         ? await db
             .select({ cwd: projectWorkspaces.cwd, cleanupCommand: projectWorkspaces.cleanupCommand })
             .from(projectWorkspaces)
@@ -2333,7 +2337,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         warnings: gitWarnings,
         statusInspectionSucceeded,
       } = await inspectGitCloseReadiness(executionWorkspace);
-      const { deliveryState } = await assessDelivery(workspace, git);
+      const { deliveryState, workspaceHeadSha, issueTree } = await assessDelivery(workspace, git);
       const warnings = [...gitWarnings];
       const blockingReasons: string[] = [];
       if (!statusInspectionSucceeded) {
@@ -2368,6 +2372,27 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         }
       }
 
+      // The reaper requires the source issue's whole descendant tree to be
+      // terminal before it archives. Directly-linked issues are only part of that
+      // tree: a child issue can be open without ever pointing its
+      // executionWorkspaceId at this workspace. Walk the same tree here so the
+      // manual close path refuses in the same cases the reaper skips.
+      const linkedIssueIds = new Set(linkedIssueSummaries.map((issue) => issue.id));
+      const openTreeIssues = issueTree.filter(
+        (issue) => !TERMINAL_ISSUE_STATUSES.has(issue.status) && !linkedIssueIds.has(issue.id),
+      );
+      if (openTreeIssues.length > 0) {
+        const treeIssueMessage =
+          openTreeIssues.length === 1
+            ? "The source issue tree still has 1 open issue."
+            : `The source issue tree still has ${openTreeIssues.length} open issues.`;
+        if (isSharedWorkspace) {
+          warnings.push(`${treeIssueMessage} Archiving this shared workspace session keeps the underlying project workspace available.`);
+        } else {
+          blockingReasons.push(treeIssueMessage);
+        }
+      }
+
       if (isSharedWorkspace) {
         warnings.push("This shared workspace session points at project workspace infrastructure. Archiving it only removes the session record.");
       }
@@ -2380,32 +2405,52 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         );
       }
 
+      // Archiving a shared workspace session only removes the session record; it
+      // never destroys the underlying project workspace (see the warning above).
+      // A shared session points at the project's primary worktree, which carries
+      // unrelated in-flight work almost all of the time, so treating its git
+      // state as a blocker would make the session record impossible to close
+      // while protecting nothing. Keep the same signals as warnings there.
+      const pushGitCloseSignal = (message: string) => {
+        if (isSharedWorkspace) warnings.push(message);
+        else blockingReasons.push(message);
+      };
+
       if (git?.hasDirtyTrackedFiles) {
-        blockingReasons.push(
+        pushGitCloseSignal(
           git.dirtyEntryCount === 1
             ? "The workspace has 1 modified tracked file."
             : `The workspace has ${git.dirtyEntryCount} modified tracked files.`,
         );
       }
       if (git?.hasUntrackedFiles) {
-        blockingReasons.push(
+        pushGitCloseSignal(
           git.untrackedEntryCount === 1
             ? "The workspace has 1 untracked file."
             : `The workspace has ${git.untrackedEntryCount} untracked files.`,
         );
       }
+      // Fail closed on unverifiable ancestry. `isMergedIntoBase` is null when the
+      // merge-base probe could not run (missing base ref, detached HEAD, git
+      // failure), which is exactly when Paperclip cannot prove the commits are
+      // safe to destroy. Only a positive `true` clears this blocker.
       if (
         git?.aheadCount
         && git.aheadCount > 0
-        && git.isMergedIntoBase === false
+        && git.isMergedIntoBase !== true
         && deliveryState !== "merged_via_pr"
       ) {
-        blockingReasons.push(
-          git.aheadCount === 1
-            ? `This workspace is 1 commit ahead of ${git.baseRef ?? "the base ref"} and is not merged.`
-            : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef ?? "the base ref"} and is not merged.`,
+        pushGitCloseSignal(
+          git.isMergedIntoBase === null
+            ? `Paperclip could not verify whether this workspace is merged into ${git.baseRef ?? "the base ref"}.`
+            : git.aheadCount === 1
+              ? `This workspace is 1 commit ahead of ${git.baseRef ?? "the base ref"} and is not merged.`
+              : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef ?? "the base ref"} and is not merged.`,
         );
       }
+      // Not gated on shared mode: an active run owns the checkout regardless of
+      // workspace mode, and closing the session record under a live run strands
+      // it. This mirrors the reaper's `skippedActiveRun` guard.
       if (await workspaceHasActiveRun(workspace)) {
         blockingReasons.push("This workspace has an active agent run on a linked issue.");
       }
@@ -2525,6 +2570,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         isSharedWorkspace,
         isProjectPrimaryWorkspace,
         git,
+        workspaceHeadSha,
         runtimeServices,
       };
     },
@@ -3388,17 +3434,18 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
 
     runManualArchiveArtifactCleanup: async (input: {
       workspace: ExecutionWorkspaceRow;
+      // HEAD as observed by the close-readiness check that authorized this
+      // archive. Anchoring destruction to that commit covers the whole
+      // readiness -> archive -> cleanup window; a self-read here would only
+      // cover the rev-parse -> lock window and would happily re-anchor onto a
+      // commit that landed after the caller was cleared to close.
+      expectedHeadSha: string | null;
       projectWorkspace?: { cwd: string | null; cleanupCommand: string | null } | null;
       cleanupCommand?: string | null;
       teardownCommand?: string | null;
       recorder?: WorkspaceOperationRecorder | null;
     }) => {
-      const workspacePath =
-        readNullableString(input.workspace.providerRef) ?? readNullableString(input.workspace.cwd);
-      const expectedHeadSha = workspacePath
-        ? await readGitStdout(["rev-parse", "HEAD"], workspacePath).catch(() => null)
-        : null;
-      return runClosedWorkspaceArtifactCleanup(input.workspace, expectedHeadSha, {
+      return runClosedWorkspaceArtifactCleanup(input.workspace, input.expectedHeadSha, {
         projectWorkspace: input.projectWorkspace,
         cleanupCommand: input.cleanupCommand,
         teardownCommand: input.teardownCommand,

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1438,13 +1438,26 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
     };
   }
 
+  async function workspaceDirectoryExists(workspacePath: string) {
+    return fs
+      .stat(workspacePath)
+      .then((stats) => stats.isDirectory())
+      .catch(() => false);
+  }
+
   async function assertTerminalCleanupGitStateUnchanged(
     workspace: ExecutionWorkspaceRow,
     expectedHeadSha: string | null,
   ) {
     if (workspace.providerType !== "git_worktree") return;
     const workspacePath = readNullableString(workspace.providerRef) ?? readNullableString(workspace.cwd);
-    if (!workspacePath || !expectedHeadSha) {
+    // The fence protects work that still exists on disk. A workspace whose path
+    // is already gone has nothing left to protect, and it reports no HEAD sha
+    // for the same reason, so close readiness deliberately clears it. Refusing
+    // here would turn that allowed close into a failed cleanup and a
+    // cleanup_failed record over a directory that is not there.
+    if (!workspacePath || !(await workspaceDirectoryExists(workspacePath))) return;
+    if (!expectedHeadSha) {
       throw new Error("Refusing terminal workspace cleanup because the expected git HEAD is unknown");
     }
 
@@ -1733,8 +1746,15 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       ? null
       : () => assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
 
-    const cleanupLock = workspace.providerType === "git_worktree" && (workspace.providerRef ?? workspace.cwd)
-      ? await acquireGitWorktreeCleanupLock(workspace.providerRef ?? workspace.cwd!)
+    // The lock runs git inside the worktree to resolve the index, HEAD, and
+    // branch lock paths, so a path that is already gone makes the spawn fail
+    // with ENOENT and turns an allowed close into a failed cleanup. There is
+    // nothing left to lock in that case.
+    const cleanupLockPath = workspace.providerType === "git_worktree"
+      ? readNullableString(workspace.providerRef) ?? readNullableString(workspace.cwd)
+      : null;
+    const cleanupLock = cleanupLockPath && await workspaceDirectoryExists(cleanupLockPath)
+      ? await acquireGitWorktreeCleanupLock(cleanupLockPath)
       : null;
     try {
       await assertSafeToCleanup?.();

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1722,13 +1722,24 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
             .then((rows) => rows[0] ?? null)
         : null);
 
+    // A shared workspace session points at project workspace infrastructure that
+    // outlives the session. Closing it removes the session record and stops the
+    // session's runtime services; it must never remove the worktree or delete
+    // the branch. The git-state fence guards destruction, so it does not apply
+    // here either — it would otherwise refuse every close of a shared session,
+    // because the project's primary worktree is dirty almost all of the time.
+    const preserveWorkspacePath = workspace.mode === "shared_workspace";
+    const assertSafeToCleanup = preserveWorkspacePath
+      ? null
+      : () => assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
+
     const cleanupLock = workspace.providerType === "git_worktree" && (workspace.providerRef ?? workspace.cwd)
       ? await acquireGitWorktreeCleanupLock(workspace.providerRef ?? workspace.cwd!)
       : null;
     try {
-      await assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
+      await assertSafeToCleanup?.();
       await opts.beforeTerminalWorkspaceCleanup?.(workspace);
-      await assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
+      await assertSafeToCleanup?.();
       await stopRuntimeServicesForExecutionWorkspace({
         db,
         executionWorkspaceId: workspace.id,
@@ -1743,9 +1754,10 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           companyId: workspace.companyId,
           executionWorkspaceId: workspace.id,
         }),
-        assertSafeToCleanup: () => assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha),
+        assertSafeToCleanup,
         beforeBranchDelete: () => cleanupLock?.releaseBranchRefLock() ?? Promise.resolve(),
         expectedBranchHeadSha: expectedHeadSha,
+        preserveWorkspacePath,
         // Git index, HEAD, and branch-ref locks prevent a clean HEAD change
         // from crossing final validation. The branch lock is released only
         // after non-forced worktree removal, then deletion is anchored to the

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2442,22 +2442,30 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
             : `The workspace has ${git.untrackedEntryCount} untracked files.`,
         );
       }
-      // Fail closed on unverifiable ancestry. `isMergedIntoBase` is null when the
-      // merge-base probe could not run (missing base ref, detached HEAD, git
-      // failure), which is exactly when Paperclip cannot prove the commits are
-      // safe to destroy. Only a positive `true` clears this blocker.
+      // Fail closed on unverifiable ancestry. Both probes run only when the repo
+      // root and the base ref resolved, so a null count or a null
+      // `isMergedIntoBase` under those conditions means the probe ran and
+      // failed. That is exactly when Paperclip cannot prove the commits are safe
+      // to destroy, so only a positive `isMergedIntoBase` with a known count
+      // clears this blocker.
+      //
+      // The guard stays scoped to a resolved repo and base ref on purpose. A
+      // workspace whose path is already gone reports null counts too, and
+      // blocking there would strand a record that has nothing left to protect.
+      const ancestryProbed = Boolean(git?.repoRoot && git.baseRef);
+      const ancestryUnverified = ancestryProbed && (git!.aheadCount === null || git!.isMergedIntoBase === null);
       if (
-        git?.aheadCount
-        && git.aheadCount > 0
-        && git.isMergedIntoBase !== true
+        git
+        && ancestryProbed
+        && (ancestryUnverified || (git.aheadCount! > 0 && git.isMergedIntoBase !== true))
         && deliveryState !== "merged_via_pr"
       ) {
         pushGitCloseSignal(
-          git.isMergedIntoBase === null
-            ? `Paperclip could not verify whether this workspace is merged into ${git.baseRef ?? "the base ref"}.`
+          ancestryUnverified
+            ? `Paperclip could not verify whether this workspace is merged into ${git.baseRef}.`
             : git.aheadCount === 1
-              ? `This workspace is 1 commit ahead of ${git.baseRef ?? "the base ref"} and is not merged.`
-              : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef ?? "the base ref"} and is not merged.`,
+              ? `This workspace is 1 commit ahead of ${git.baseRef} and is not merged.`
+              : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef} and is not merged.`,
         );
       }
       // Not gated on shared mode: an active run owns the checkout regardless of

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1454,10 +1454,12 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
   }
 
   async function workspaceDirectoryExists(workspacePath: string) {
-    return fs
-      .stat(workspacePath)
-      .then((stats) => stats.isDirectory())
-      .catch(() => false);
+    try {
+      return (await fs.stat(workspacePath)).isDirectory();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return false;
+      throw err;
+    }
   }
 
   async function assertTerminalCleanupGitStateUnchanged(

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -2507,71 +2507,82 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         });
       }
 
-      const configuredCleanupCommands = [
-        {
-          kind: "cleanup_command" as const,
-          label: "Run workspace cleanup command",
-          description: "Workspace-specific cleanup runs before teardown.",
-          command: config?.cleanupCommand ?? null,
-        },
-        {
-          kind: "cleanup_command" as const,
-          label: "Run project workspace cleanup command",
-          description: "Project workspace cleanup runs before execution workspace teardown.",
-          command: projectWorkspace?.cleanupCommand ?? null,
-        },
-      ];
-      for (const action of configuredCleanupCommands) {
-        if (!action.command) continue;
-        plannedActions.push(action);
-      }
+      // Closing a shared session preserves the workspace path, so the cleanup and
+      // teardown commands, the worktree removal, the branch delete, and the
+      // directory removal are all skipped (see `preserveWorkspacePath` in
+      // `cleanupExecutionWorkspaceArtifacts`). Only the record and this session's
+      // own runtime services go away. Listing the destructive steps anyway would
+      // make the confirmation payload describe work that will never run, which is
+      // the opposite of what a close preview is for.
+      if (!isSharedWorkspace) {
+        const configuredCleanupCommands = [
+          {
+            kind: "cleanup_command" as const,
+            label: "Run workspace cleanup command",
+            description: "Workspace-specific cleanup runs before teardown.",
+            command: config?.cleanupCommand ?? null,
+          },
+          {
+            kind: "cleanup_command" as const,
+            label: "Run project workspace cleanup command",
+            description: "Project workspace cleanup runs before execution workspace teardown.",
+            command: projectWorkspace?.cleanupCommand ?? null,
+          },
+        ];
+        for (const action of configuredCleanupCommands) {
+          if (!action.command) continue;
+          plannedActions.push(action);
+        }
 
-      const teardownCommand = config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null;
-      if (teardownCommand) {
-        plannedActions.push({
-          kind: "teardown_command",
-          label: "Run teardown command",
-          description: "Teardown runs after cleanup commands during workspace close.",
-          command: teardownCommand,
-        });
-      }
-
-      if (executionWorkspace.providerType === "git_worktree" && workspacePath) {
-        plannedActions.push({
-          kind: "git_worktree_remove",
-          label: "Remove git worktree",
-          description: `Paperclip will run git worktree cleanup for ${workspacePath}.`,
-          command: `git worktree remove --force ${workspacePath}`,
-        });
-      }
-
-      if (git?.createdByRuntime && executionWorkspace.branchName) {
-        plannedActions.push({
-          kind: "git_branch_delete",
-          label: "Delete runtime-created branch",
-          description: "Paperclip will try to delete the runtime-created branch after removing the worktree.",
-          command: `git branch -d ${executionWorkspace.branchName}`,
-        });
-      }
-
-      if (executionWorkspace.providerType === "local_fs" && git?.createdByRuntime && workspacePath) {
-        const resolvedWorkspacePath = path.resolve(workspacePath);
-        const resolvedProjectWorkspacePath = projectWorkspace?.cwd ? path.resolve(projectWorkspace.cwd) : null;
-        const containsProjectWorkspace = resolvedProjectWorkspacePath
-          ? (
-              resolvedWorkspacePath === resolvedProjectWorkspacePath ||
-              resolvedProjectWorkspacePath.startsWith(`${resolvedWorkspacePath}${path.sep}`)
-            )
-          : false;
-        if (containsProjectWorkspace) {
-          warnings.push(`Paperclip will archive this workspace but keep "${workspacePath}" because it contains the project workspace.`);
-        } else {
+        const teardownCommand = config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null;
+        if (teardownCommand) {
           plannedActions.push({
-            kind: "remove_local_directory",
-            label: "Remove runtime-created directory",
-            description: `Paperclip will remove the runtime-created directory at ${workspacePath}.`,
-            command: `rm -rf ${workspacePath}`,
+            kind: "teardown_command",
+            label: "Run teardown command",
+            description: "Teardown runs after cleanup commands during workspace close.",
+            command: teardownCommand,
           });
+        }
+
+        if (executionWorkspace.providerType === "git_worktree" && workspacePath) {
+          plannedActions.push({
+            kind: "git_worktree_remove",
+            label: "Remove git worktree",
+            description: `Paperclip will run git worktree cleanup for ${workspacePath}.`,
+            // The close path removes the worktree without --force and refuses
+            // when the git state moved, matching the reaper.
+            command: `git worktree remove ${workspacePath}`,
+          });
+        }
+
+        if (git?.createdByRuntime && executionWorkspace.branchName) {
+          plannedActions.push({
+            kind: "git_branch_delete",
+            label: "Delete runtime-created branch",
+            description: "Paperclip will try to delete the runtime-created branch after removing the worktree.",
+            command: `git branch -d ${executionWorkspace.branchName}`,
+          });
+        }
+
+        if (executionWorkspace.providerType === "local_fs" && git?.createdByRuntime && workspacePath) {
+          const resolvedLocalWorkspacePath = path.resolve(workspacePath);
+          const resolvedProjectWorkspacePath = projectWorkspace?.cwd ? path.resolve(projectWorkspace.cwd) : null;
+          const containsProjectWorkspace = resolvedProjectWorkspacePath
+            ? (
+                resolvedLocalWorkspacePath === resolvedProjectWorkspacePath ||
+                resolvedProjectWorkspacePath.startsWith(`${resolvedLocalWorkspacePath}${path.sep}`)
+              )
+            : false;
+          if (containsProjectWorkspace) {
+            warnings.push(`Paperclip will archive this workspace but keep "${workspacePath}" because it contains the project workspace.`);
+          } else {
+            plannedActions.push({
+              kind: "remove_local_directory",
+              label: "Remove runtime-created directory",
+              description: `Paperclip will remove the runtime-created directory at ${workspacePath}.`,
+              command: `rm -rf ${workspacePath}`,
+            });
+          }
         }
       }
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -3672,6 +3672,13 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
   expectedBranchHeadSha?: string | null;
   runCleanupCommands?: boolean;
   forceWorktreeRemoval?: boolean;
+  // Set for a workspace whose path is shared infrastructure that outlives this
+  // record, such as a shared workspace session pointing at the project's
+  // primary worktree. Runtime services still stop and cleanup commands still
+  // run, but the worktree, the branch, and the directory stay in place. The
+  // preserved path then counts as cleaned, because keeping it is the intended
+  // outcome rather than a cleanup failure.
+  preserveWorkspacePath?: boolean;
 }) {
   const warnings: string[] = [];
   const workspacePath = input.workspace.providerRef ?? input.workspace.cwd;
@@ -3736,7 +3743,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   }
 
-  if (worktreeInstancePointer && workspacePath && expectedWorktreeInstanceId) {
+  if (worktreeInstancePointer && workspacePath && expectedWorktreeInstanceId && !input.preserveWorkspacePath) {
     try {
       const result = await cleanupWorktreeInstanceArtifacts({
         pointer: worktreeInstancePointer,
@@ -3755,7 +3762,11 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   }
 
-  if (input.workspace.providerType === "git_worktree" && workspacePath) {
+  if (input.preserveWorkspacePath && workspacePath) {
+    warnings.push(
+      `Kept the workspace path "${workspacePath}" because it is shared project infrastructure. Closing this record removes the record only.`,
+    );
+  } else if (input.workspace.providerType === "git_worktree" && workspacePath) {
     const worktreeExists = await directoryExists(workspacePath);
     if (worktreeExists) {
       if (!repoRoot) {
@@ -3856,6 +3867,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
   }
 
   const cleaned =
+    Boolean(input.preserveWorkspacePath) ||
     !workspacePath ||
     !(await directoryExists(workspacePath));
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -3707,7 +3707,17 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   }
   const createdByRuntime = input.workspace.metadata?.createdByRuntime === true;
-  const cleanupCommands = input.runCleanupCommands === false
+  // Cleanup and teardown commands run from the workspace path and are written
+  // to tear that path down. A preserved path is shared project infrastructure
+  // that other live sessions still use, so these commands must not run there.
+  // The session's own runtime services are stopped by the caller, which is
+  // scoped to this record and stays correct.
+  if (input.preserveWorkspacePath && input.runCleanupCommands !== false) {
+    warnings.push(
+      "Skipped the cleanup and teardown commands because this record points at shared project infrastructure.",
+    );
+  }
+  const cleanupCommands = input.runCleanupCommands === false || input.preserveWorkspacePath
     ? []
     : [
         input.cleanupCommand ?? null,

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2578,7 +2578,12 @@ async function detectDefaultBranch(
 }
 
 async function directoryExists(value: string) {
-  return fs.stat(value).then((stats) => stats.isDirectory()).catch(() => false);
+  try {
+    return (await fs.stat(value)).isDirectory();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return false;
+    throw err;
+  }
 }
 
 async function resolvePathForWorktreeComparison(value: string): Promise<string> {

--- a/ui/storybook/stories/dialogs-modals.stories.tsx
+++ b/ui/storybook/stories/dialogs-modals.stories.tsx
@@ -197,6 +197,7 @@ const closeReadinessReady: ExecutionWorkspaceCloseReadiness = {
     isMergedIntoBase: false,
     createdByRuntime: true,
   },
+  workspaceHeadSha: "9f2c1ad4bd7e0c53a1f6e8b90d4c27a5e3b18f60",
   runtimeServices: storybookExecutionWorkspaces[0]?.runtimeServices ?? [],
 };
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Execution workspaces are the git worktrees and directories that agent runs work in, and Paperclip closes them through two paths: the workspace terminality reaper and the manual `PATCH /api/execution-workspaces/:id` archive control
> - The reaper refuses to archive a workspace that is dirty, that is not delivered, or that has a live agent run, and it removes the worktree without `--force` and re-checks HEAD before deletion
> - The manual archive control did not apply the same rules, so a person could close a workspace that still held uncommitted or unmerged work, and the cleanup then force-removed the worktree
> - Two safe close paths that disagree is a data-loss risk, because the safer path is the one a person is least likely to use
> - This pull request makes the manual close path use the same blocking rules and the same non-forced, HEAD-anchored cleanup as the reaper
> - The benefit is that a manual close either refuses with a clear reason, or destroys only what the reaper would also agree to destroy

## Linked Issues or Issue Description

No public GitHub issue exists for this change. The issue is described inline below.

**What happened?**

The manual workspace close control archives and destroys a workspace that the automatic reaper refuses to touch. `getCloseReadiness` reported modified tracked files, untracked files, and unmerged commits only as `warnings`, so `state` stayed `ready_with_warnings` and `PATCH { "status": "archived" }` was accepted. The archive path then called artifact cleanup with `forceWorktreeRemoval: true` and no HEAD revalidation. Uncommitted and unmerged work in the worktree was removed.

**Expected behavior**

The manual close path must apply the same blocking rules as the reaper. A workspace that is dirty, that is ahead of its base ref and not merged, or that has a live agent run must not be archived through the API. The API must answer 409 with the blocking reason. When the close is allowed, worktree removal must run without `--force` and must be anchored to the HEAD that the readiness check verified, so a commit that lands during the close fails closed.

**Steps to reproduce**

1. Start a git worktree execution workspace for a project.
2. Write an uncommitted change into the worktree, or commit a change that is not merged into the base ref.
3. Send `PATCH /api/execution-workspaces/<id>` with `{ "status": "archived" }`.
4. Observe that the request succeeds and the worktree is force-removed, while the reaper would have skipped the same workspace.

**Paperclip version or commit**

Reproduced on `master` at the merge base of this branch.

**Deployment mode**

Self-hosted server, local git worktree workspace strategy.

## What Changed

- `getCloseReadiness` now reports modified tracked files, untracked files, and ahead-and-unmerged state as `blockingReasons` instead of `warnings`, so `state` becomes `blocked` and `isDestructiveCloseAllowed` becomes `false`.
- The unmerged guard now fails closed on unverifiable ancestry. Both git probes run only when the repo root and the base ref resolve, so within that scope a null `aheadCount` or a null `isMergedIntoBase` means the probe ran and failed, and it blocks the close. The guard stays scoped to a resolved repo and base ref on purpose: a workspace whose path is already gone reports null counts too, and blocking there would strand a record that has nothing left to protect.
- `getCloseReadiness` now blocks on a live agent run on any linked issue, which mirrors the reaper's `skippedActiveRun` guard.
- `getCloseReadiness` now walks the source issue's descendant tree, the same `WITH RECURSIVE issue_tree` set the reaper requires to be terminal. An open descendant that never linked its `executionWorkspaceId` to the workspace previously passed the directly-linked issue check.
- Shared workspace sessions keep all three git conditions as `warnings`. A shared session points at the project's primary worktree, which carries unrelated in-flight work almost always, and archiving it only removes the session record. Blocking there would make the session row impossible to close while protecting nothing. The active-run blocker is not exempted, because a live run owns the checkout in every mode.
- `PATCH { "status": "archived" }` answers 409 with the first blocking reason and the full readiness payload, and it runs no lease teardown, no runtime-service stop, and no artifact cleanup.
- Manual archive cleanup moved from `cleanupExecutionWorkspaceArtifacts` to the new `runManualArchiveArtifactCleanup`, which shares the reaper's locked, non-forced, HEAD-revalidating cleanup body.
- `ExecutionWorkspaceCloseReadiness` now carries `workspaceHeadSha`. The close route threads that value into cleanup as `expectedHeadSha`, so destruction is anchored to the commit the readiness decision cleared. The earlier self-read inside the cleanup helper only covered the rev-parse to lock window and would re-anchor onto a commit that landed after the caller was cleared to close.
- `runClosedWorkspaceArtifactCleanup` no longer swallows an explicit `null` project workspace. The database fallback now runs only when the caller passed nothing.
- Removed a single-element `Promise.all` in `runTerminalWorkspaceCleanup`.
- A preserved workspace path also skips the cleanup and teardown commands. Those commands run from the workspace path and are written to tear it down, so a command that deletes build output or stops a project service must not run against shared infrastructure that other live sessions still use. The session's own runtime services still stop, because that step stays scoped to the closing record.
- Runtime-service teardown is scoped to the closing record on a preserved path. `stopRuntimeServicesForExecutionWorkspace` falls back to cwd-prefix matching for a service with no execution-workspace link, which is a useful safety net for a workspace being destroyed but reaches other live sessions on a shared path. The archive now passes a null cwd there.
- A workspace whose path is already gone can finish its close. Readiness clears it on purpose and reports a null `workspaceHeadSha`, but cleanup then refused twice: the cleanup lock resolves its lock paths by running git inside the worktree, so the missing path failed the spawn with `ENOENT`, and the git-state fence refused on the unknown HEAD. The archive is already committed at that point, so the API answered 500 and left the record in `cleanup_failed` over a directory that is not there. The lock is skipped when there is nothing to lock, and the fence returns early for a path that does not exist. A present path with an unknown HEAD still fails closed. Both steps are shared with the reaper, which gains the same behaviour.
- The close preview no longer advertises destruction a shared close never performs. `plannedActions` for a shared session listed the cleanup and teardown commands, the worktree removal, the branch delete, and the directory removal, all of which `preserveWorkspacePath` skips. A shared preview now carries the archive action alone, plus the runtime-service stop that does still run. The worktree-removal preview also dropped `--force`, because the close path removes the worktree without it.
- Artifact cleanup now takes `preserveWorkspacePath`, and the service sets it for a shared workspace session. Runtime services still stop and cleanup commands still run, but `git worktree remove`, the branch delete, and the directory removal are skipped, and the preserved path counts as cleaned instead of as a cleanup failure. Archiving a shared session is documented to remove the session record only, but cleanup had no shared-mode guard and removed the project's primary worktree. The git-state fence guards destruction, so it does not apply to a preserved path either; applying it would refuse every shared close, because that worktree is dirty almost all of the time.

## Verification

- `pnpm --filter @paperclipai/server typecheck` passes.
- `server/src/__tests__/execution-workspaces-service.test.ts` covers the active-run blocker, the blocker clearing once the run leaves `queued`/`running`, the open-descendant tree blocker, the shared-workspace warning case, the `workspaceHeadSha` surface, the refusal when the expected HEAD sha is `null`, the refusal when HEAD moved after readiness cleared the close, that closing a shared session keeps the worktree, the untracked in-flight file, the branch, and the file its cleanup command targets, that an unresolvable base ref blocks the close, and that an already-deleted workspace path stays closable.
- `server/src/__tests__/execution-workspaces-routes.test.ts` covers the 409 blocked-archive case and asserts that cleanup receives the readiness HEAD sha rather than a fresh self-read.
- `server/src/__tests__/execution-workspaces-service.test.ts` additionally asserts that a shared session's close preview lists the archive action only, with a project cleanup command configured that a non-shared close would have previewed.
- `server/src/__tests__/execution-workspaces-service.test.ts` additionally covers a close whose workspace path is already gone: readiness clears it with a null HEAD sha and the cleanup reports the record as cleaned instead of throwing.
- CI was green on `adcc18b` with 29 checks passing, including `review`, `policy`, `Typecheck + Release Registry`, `Build`, all five `General tests (server)` shards, all five `Verify serialized server suites` shards, `workspaces-a`/`workspaces-b`, the three e2e shards, and `Greptile Review`. `d0a2bb1` and `56e4c2a` add the two shared-close fixes on top and are re-running the same gates.

## Risks

- Behavioral change, not a breaking API change. A `PATCH` archive that used to succeed on a dirty or unmerged workspace now returns 409. This is the intended alignment with the reaper, and the response body carries the blocking reason.
- Shared workspace sessions are deliberately exempt from the three git blockers. If a future change makes shared close destructive, that exemption must be revisited.
- The unmerged guard is stricter than before because it fails closed on `null` ancestry. A workspace whose base ref cannot be resolved now blocks the close and needs an operator to fix the base ref first.
- No database migration. No schema change other than an added optional field on the readiness response type.

## Model Used

Claude Opus 5 (`claude-opus-5`, 1M context window), extended thinking, with tool use for repository search, edits, and local typecheck and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched the GitHub PR list for similar or duplicate PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


