### PR TITLE
fix(ui): label issue creator filter with company user names

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -17,7 +17,7 @@ import {
   shouldBlurPageSearchOnEscape,
 } from "../lib/keyboardShortcuts";
 import { formatAssigneeUserLabel } from "../lib/assignees";
-import { buildCompanyUserLabelMap, buildCompanyUserProfileMap } from "../lib/company-members";
+import { buildCompanyUserLabelMap, buildCompanyUserProfileMap, buildCreatorUserOption } from "../lib/company-members";
 import { createIssueDetailPath, rememberIssueDetailLocationState, withIssueDetailHeaderSeed } from "../lib/issueDetailBreadcrumb";
 import { prefetchIssueDetailForNavigation } from "../lib/issueDetailCache";
 import {
@@ -993,12 +993,7 @@ export function IssuesList({
       if (issue.createdByUserId) {
         const id = `user:${issue.createdByUserId}`;
         if (!options.has(id)) {
-          options.set(id, {
-            id,
-            label: formatAssigneeUserLabel(issue.createdByUserId, currentUserId) ?? issue.createdByUserId.slice(0, 5),
-            kind: "user",
-            searchText: `${issue.createdByUserId} board user human`,
-          });
+          options.set(id, buildCreatorUserOption(issue.createdByUserId, currentUserId, companyUserLabelMap));
         }
       }
     }
@@ -1034,7 +1029,7 @@ export function IssuesList({
       if (a.kind !== b.kind) return a.kind === "user" ? -1 : 1;
       return a.label.localeCompare(b.label);
     });
-  }, [agents, currentUserId, issues]);
+  }, [agents, companyUserLabelMap, currentUserId, issues]);
 
   const visibleIssueColumnSet = useMemo(() => new Set(visibleIssueColumns), [visibleIssueColumns]);
   const availableIssueColumns = useMemo(

--- a/ui/src/lib/company-members.test.ts
+++ b/ui/src/lib/company-members.test.ts
@@ -4,6 +4,7 @@ import {
   buildCompanyUserInlineOptions,
   buildCompanyUserLabelMap,
   buildCompanyUserProfileMap,
+  buildCreatorUserOption,
   buildIssueMentionOptions,
   buildMarkdownMentionOptions,
 } from "./company-members";
@@ -32,6 +33,33 @@ describe("company-members helpers", () => {
 
     expect(labels.get("user-1")).toBe("Taylor");
     expect(labels.get("local-board")).toBe("Board");
+  });
+
+  it("labels creator filter options with the company directory name", () => {
+    const labels = buildCompanyUserLabelMap([
+      activeMember({
+        principalId: "yvjfSqRKhr5uoyqXUl8aShbKCC4a2xCO",
+        user: { id: "yvjfSqRKhr5uoyqXUl8aShbKCC4a2xCO", name: "Taylor", email: "taylor@example.com", image: null },
+      }),
+    ]);
+
+    const option = buildCreatorUserOption("yvjfSqRKhr5uoyqXUl8aShbKCC4a2xCO", "user-9", labels);
+
+    expect(option.label).toBe("Taylor");
+    expect(option.searchText).toContain("Taylor");
+    expect(option.id).toBe("user:yvjfSqRKhr5uoyqXUl8aShbKCC4a2xCO");
+  });
+
+  it("falls back to the id prefix when the creator is outside the directory", () => {
+    const option = buildCreatorUserOption("yvjfSqRKhr5uoyqXUl8aShbKCC4a2xCO", "user-9", new Map());
+
+    expect(option.label).toBe("yvjfS");
+  });
+
+  it("keeps the current user labelled as themselves", () => {
+    const option = buildCreatorUserOption("user-9", "user-9", new Map([["user-9", "Taylor"]]));
+
+    expect(option.label).toBe("You");
   });
 
   it("builds user profiles with labels and avatars", () => {

--- a/ui/src/lib/company-members.ts
+++ b/ui/src/lib/company-members.ts
@@ -2,6 +2,7 @@ import type { CompanyMember, CompanyUserDirectoryEntry } from "@/api/access";
 import type { InlineEntityOption } from "@/components/InlineEntitySelector";
 import type { MentionOption } from "@/components/MarkdownEditor";
 import type { Agent, Issue, Project } from "@paperclipai/shared";
+import { formatAssigneeUserLabel } from "./assignees";
 
 export interface CompanyUserProfile {
   label: string;
@@ -41,6 +42,32 @@ export function buildCompanyUserLabelMap(members: CompanyUserRecord[] | null | u
     labels.set(member.principalId, baseMemberLabel(member));
   }
   return labels;
+}
+
+export interface CreatorUserOption {
+  id: string;
+  label: string;
+  kind: "user";
+  searchText: string;
+}
+
+/**
+ * Creator filter option for a human who created issues. Without the company
+ * directory the label degrades to the first characters of the user id, which
+ * reads as gibberish next to agent names.
+ */
+export function buildCreatorUserOption(
+  userId: string,
+  currentUserId: string | null | undefined,
+  userLabels?: ReadonlyMap<string, string> | null,
+): CreatorUserOption {
+  const directoryLabel = userLabels?.get(userId)?.trim() || null;
+  return {
+    id: `user:${userId}`,
+    label: formatAssigneeUserLabel(userId, currentUserId, userLabels) ?? fallbackUserLabel(userId),
+    kind: "user",
+    searchText: [directoryLabel, userId, "board user human"].filter(Boolean).join(" "),
+  };
 }
 
 export function buildCompanyUserProfileMap(

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -34,7 +34,7 @@ import {
 } from "../lib/issue-filters";
 import { collectLiveIssueIds, collectSubtreeLiveCounts } from "../lib/liveIssueIds";
 import { formatAssigneeUserLabel } from "../lib/assignees";
-import { buildCompanyUserLabelMap, buildCompanyUserProfileMap } from "../lib/company-members";
+import { buildCompanyUserLabelMap, buildCompanyUserProfileMap, buildCreatorUserOption } from "../lib/company-members";
 import {
   armIssueDetailInboxQuickArchive,
   createIssueDetailLocationState,
@@ -1043,12 +1043,7 @@ export function Inbox() {
       if (issue.createdByUserId) {
         const id = `user:${issue.createdByUserId}`;
         if (!options.has(id)) {
-          options.set(id, {
-            id,
-            label: formatAssigneeUserLabel(issue.createdByUserId, currentUserId) ?? issue.createdByUserId.slice(0, 5),
-            kind: "user",
-            searchText: `${issue.createdByUserId} board user human`,
-          });
+          options.set(id, buildCreatorUserOption(issue.createdByUserId, currentUserId, companyUserLabelMap));
         }
       }
     }
@@ -1085,7 +1080,7 @@ export function Inbox() {
       if (a.kind !== b.kind) return a.kind === "user" ? -1 : 1;
       return a.label.localeCompare(b.label);
     });
-  }, [agents, currentUserId, mineIssues, touchedIssues]);
+  }, [agents, companyUserLabelMap, currentUserId, mineIssues, touchedIssues]);
   const issuesToRender = useMemo(
     () => {
       if (tab === "mine") return visibleMineIssues;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The web UI shows issues in a list and in an inbox. Both views have a **Creator** filter. The filter lists the people and agents who created issues.
> - A user option in that filter shows five characters of a user id, not a name. The user cannot tell who the person is.
> - The label helper `formatAssigneeUserLabel` needs a company user label map. Two call sites do not give it the map. The helper then falls back to `userId.slice(0, 5)`.
> - This pull request adds one helper that builds the creator option with the directory label, and uses it in both call sites.
> - The benefit is that the filter shows real names, and creator search matches those names.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. The description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

In the issue list and in the inbox, the **Creator** filter shows a five-character fragment of a user id for other human members. Agents in the same list show their names. Example:

```
Creator
  Me
  yvjfS        <- a teammate
  Аналитик     <- an agent, named correctly
```

`creatorOptions` calls `formatAssigneeUserLabel(issue.createdByUserId, currentUserId)` and does not pass the company user label map. The helper then uses its last resort, `userId.slice(0, 5)`. Search by name in the filter also finds nothing, because the search text holds the same fragment.

**Expected behavior**

The **Creator** filter shows the display name from the company user directory, the same as issue properties, mentions and the comment thread. Search by that name finds the creator.

**Steps to reproduce**

1. Add a second human member to the company. Give the member a name in the user directory.
2. Sign in as another member. Let the second member create one issue.
3. Open the issue list, then open the filter popover and expand **Creator**.
4. The second member appears as the first five characters of the user id. Type the member name in "Search creators..." — the option does not match.
5. Repeat the steps in the inbox. The result is the same.

**Paperclip version or commit**

Reproduced on `master` at `536d5880c580f47628bc48f92c1a5750fbd7dd62`.

**Deployment mode**

Self-hosted local instance, single company.

## What Changed

- Add `buildCreatorUserOption(userId, currentUserId, userLabels)` to `ui/src/lib/company-members.ts`. It builds the creator option from the directory label. It keeps the id prefix as the fallback for a creator who is no longer in the directory. It keeps the filter value unchanged.
- Use the helper in `ui/src/components/IssuesList.tsx` and in `ui/src/pages/Inbox.tsx`. Both components already fetch the user directory and already build the label map for other parts of the render.
- Put the directory name into `searchText`, so "Search creators..." matches by name.
- Add three tests in `ui/src/lib/company-members.test.ts`: directory name, fallback to id prefix, and the current user.

## Verification

- `npx vitest run` in `ui/`: 467 files, 4225 tests, all pass. This includes the three new cases in `company-members.test.ts`.
- `npx tsc --noEmit -p ui/tsconfig.json`: clean.
- Manual check in the issue list and in the inbox: the teammate now reads as the directory name. `local-board` still reads "Board", and the signed-in user still reads "Me".

## Risks

Low risk. The change touches label text and search text only. The option value keeps the user id, so saved filters and URL state stay valid. A creator who is absent from the directory keeps the previous id-prefix label, so no call site loses an option.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, tool use through Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for similar or duplicate PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/creator-filter-user-names`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no user-facing documentation describes this filter label)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---

**Review request (2026-08-19).** Rechecked against `master` a5f3ac6b4: `buildCreatorUserOption` does not exist there, so the creator filter still labels human creators with a raw user-id prefix. All 31 checks are green and it merges cleanly.

We cannot use the reviewer field as outside contributors, so flagging the recent maintainers of the touched files instead: @cryppadotta, @devinfoley. Happy to close if this is not wanted — no need to reply otherwise.
