### PR TITLE
fix(authz): allow prior-owner terminal close after recovery steal

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -2197,6 +2197,19 @@ describeEmbeddedPostgres("authorization service", () => {
 
     await expect(authz.decide({
       actor,
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: unrelatedIssue.id,
+      },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_scope",
+    });
+
+    await expect(authz.decide({
+      actor,
       action: "agent_config:read",
       resource: {
         type: "agent",
@@ -2243,6 +2256,19 @@ describeEmbeddedPostgres("authorization service", () => {
     await expect(authz.decide({
       actor,
       action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: otherIssue.id,
+      },
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: "deny_scope",
+    });
+
+    await expect(authz.decide({
+      actor,
+      action: "issue:comment",
       resource: {
         type: "issue",
         companyId: company.id,

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -363,6 +363,39 @@ async function createApp(actor: Record<string, unknown>, db?: unknown) {
   return app;
 }
 
+
+function makeActiveRecovery(overrides: Record<string, unknown> = {}) {
+  return {
+    id: recoveryActionId,
+    companyId,
+    sourceIssueId: issueId,
+    recoveryIssueId: null,
+    kind: "issue_graph_liveness",
+    status: "active",
+    ownerType: "agent",
+    ownerAgentId,
+    ownerUserId: null,
+    previousOwnerAgentId: peerAgentId,
+    returnOwnerAgentId: peerAgentId,
+    cause: "stranded_assigned_issue",
+    fingerprint: "stranded:test",
+    evidence: {},
+    nextAction: "Restore a live execution path.",
+    wakePolicy: null,
+    monitorPolicy: null,
+    attemptCount: 1,
+    maxAttempts: null,
+    timeoutAt: null,
+    lastAttemptAt: new Date("2026-08-19T12:00:00.000Z"),
+    outcome: null,
+    resolutionNote: null,
+    resolvedAt: null,
+    createdAt: new Date("2026-08-19T12:00:00.000Z"),
+    updatedAt: new Date("2026-08-19T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 function peerActor(overrides: Record<string, unknown> = {}) {
   return {
     type: "agent",
@@ -894,6 +927,178 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(201);
     expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+
+  it("allows standard-trust peer comments on a peer-owned in-progress issue without mutating status", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_visible_issue_write" : "allow_explicit_grant",
+      explanation: "Allowed by the shared visible-issue write rule.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Cross-lane append-only note." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["low-trust", "deny_low_trust_boundary", "Issue is outside this low-trust boundary.", {}],
+    ["skill-test", "deny_scope", "Skill-test keys cannot comment on another issue.", { keyScope: { kind: "skill_test", issueId: "99999999-9999-4999-8999-999999999999" } }],
+    ["task-bridge", "deny_scope", "Task-bridge keys cannot comment on an unrelated issue.", { keyId: "99999999-9999-4999-8999-999999999999", keyScope: { kind: "task_bridge", parentIssueId: "99999999-9999-4999-8999-999999999999" } }],
+  ])("denies %s peer comments on a peer-owned issue", async (_label, reason, explanation, actorOverrides) => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason,
+      explanation,
+    }));
+
+    const res = await request(await createApp(peerActor(actorOverrides)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Should stay denied." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows the previous owner to close a recovery-stolen in-progress issue", async () => {
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+    mockIssueService.listComments.mockResolvedValue([]);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "done" }),
+      expect.anything(),
+    );
+  });
+
+  it("allows the previous owner to cancel a recovery-stolen issue", async () => {
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+    mockIssueService.listComments.mockResolvedValue([]);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "cancelled" }),
+      expect.anything(),
+    );
+  });
+
+  it("allows the previous owner to close a recovery-stolen blocked issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+    mockIssueService.listComments.mockResolvedValue([]);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "done" }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects previous-owner description rewrites after recovery steal", async () => {
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ description: "Should stay denied." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects previous-owner reassignment after recovery steal", async () => {
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("revokes prior-owner close after the new owner successfully checkouts", async () => {
+    const checkoutRunId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      assigneeAgentId: ownerAgentId,
+      checkoutRunId,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+    mockHeartbeatService.getRun.mockResolvedValue({ id: checkoutRunId, agentId: ownerAgentId });
+    mockIssueService.listComments.mockResolvedValue([]);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("revokes prior-owner close after the new owner posts a non-recovery comment", async () => {
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+    mockIssueService.listComments.mockResolvedValue([{
+      id: "comment-new-owner",
+      authorAgentId: ownerAgentId,
+      createdAt: new Date("2026-08-19T12:10:00.000Z"),
+      presentation: null,
+      deletedAt: null,
+    }]);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("does not revoke prior-owner close on a recovery system_notice from the new owner", async () => {
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecovery());
+    mockIssueService.listComments.mockResolvedValue([{
+      id: "comment-recovery",
+      authorAgentId: ownerAgentId,
+      createdAt: new Date("2026-08-19T12:01:00.000Z"),
+      presentation: { kind: "system_notice" },
+      deletedAt: null,
+    }]);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "done" }),
+      expect.anything(),
+    );
   });
 
   it("rejects peer agents from listing comments when issue read is outside their boundary", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4036,15 +4036,19 @@ export function issueRoutes(
   ) {
     if (req.actor.type !== "agent" || !req.actor.agentId) return false;
     if (!isPriorOwnerTerminalClosePatch(body)) return false;
+    if (issue.assigneeAgentId === req.actor.agentId) return false;
     const recovery = await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id);
+    if (!recovery?.previousOwnerAgentId || recovery.previousOwnerAgentId !== req.actor.agentId) {
+      return false;
+    }
     const checkoutRunId = issue.checkoutRunId ?? null;
     const checkoutRun = checkoutRunId ? await heartbeat.getRun(checkoutRunId) : null;
     const comments = await svc.listComments(issue.id, { order: "desc", limit: 100 });
     return evaluatePriorOwnerTerminalCloseGrant({
       actorAgentId: req.actor.agentId,
       currentAssigneeAgentId: issue.assigneeAgentId,
-      previousOwnerAgentId: recovery?.previousOwnerAgentId ?? null,
-      recoveryCreatedAt: recovery?.createdAt ?? null,
+      previousOwnerAgentId: recovery.previousOwnerAgentId,
+      recoveryCreatedAt: recovery.createdAt ?? null,
       checkoutRunAgentId: checkoutRun?.agentId ?? null,
       comments,
     }).allowed;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -142,6 +142,10 @@ import {
 } from "../services/index.js";
 import { artifactReviewDocumentService } from "../services/artifact-review-documents.js";
 import { assertCanResolveProposal } from "../services/secret-proposal-authorization.js";
+import {
+  evaluatePriorOwnerTerminalCloseGrant,
+  isPriorOwnerTerminalClosePatch,
+} from "../services/prior-owner-close.js";
 import { buildDocumentReviewContext, buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
   decideIssueReviewPathRecovery,
@@ -4019,6 +4023,33 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+
+  async function priorOwnerTerminalCloseGranted(
+    req: Request,
+    issue: {
+      id: string;
+      companyId: string;
+      assigneeAgentId: string | null;
+      checkoutRunId?: string | null;
+    },
+    body: Record<string, unknown>,
+  ) {
+    if (req.actor.type !== "agent" || !req.actor.agentId) return false;
+    if (!isPriorOwnerTerminalClosePatch(body)) return false;
+    const recovery = await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id);
+    const checkoutRunId = issue.checkoutRunId ?? null;
+    const checkoutRun = checkoutRunId ? await heartbeat.getRun(checkoutRunId) : null;
+    const comments = await svc.listComments(issue.id, { order: "desc", limit: 100 });
+    return evaluatePriorOwnerTerminalCloseGrant({
+      actorAgentId: req.actor.agentId,
+      currentAssigneeAgentId: issue.assigneeAgentId,
+      previousOwnerAgentId: recovery?.previousOwnerAgentId ?? null,
+      recoveryCreatedAt: recovery?.createdAt ?? null,
+      checkoutRunAgentId: checkoutRun?.agentId ?? null,
+      comments,
+    }).allowed;
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -4034,7 +4065,7 @@ export function issueRoutes(
       /** Used only to name the task in denial copy (plan §6). */
       identifier?: string | null;
     },
-    options: { allowVisibleIssueWrite?: boolean } = {},
+    options: { allowVisibleIssueWrite?: boolean; priorOwnerTerminalClose?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -4077,6 +4108,7 @@ export function issueRoutes(
         return true;
       }
       if (issue.status === "in_progress") {
+        if (options.priorOwnerTerminalClose) return true;
         // Run/checkout ownership stays assignee-scoped even though writes are
         // open, so this lock clears on its own — the copy routes to comments.
         return denyIssueWrite(req, res, issue, "issue_write_assignee_run_lock", {
@@ -5132,8 +5164,9 @@ export function issueRoutes(
     req: Request,
     issue: { id: string; companyId: string; assigneeAgentId: string | null },
     activeRecoveryAction: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>>,
-    input: { source: "issue_update" | "recovery_action_resolution" },
+    input: { source: "issue_update" | "recovery_action_resolution"; priorOwnerTerminalClose?: boolean },
   ) {
+    if (input.priorOwnerTerminalClose) return true;
     if (req.actor.type !== "agent") return true;
     if (!activeRecoveryAction) return true;
 
@@ -9373,11 +9406,16 @@ export function issueRoutes(
       await denyIssueWrite(req, res, existing, "issue_write_attribution_spoof_rejected");
       return;
     }
+    const priorOwnerTerminalClose = await priorOwnerTerminalCloseGranted(
+      req,
+      existing,
+      req.body as Record<string, unknown>,
+    );
     const issueMutationAccess = await assertAgentIssueMutationAllowed(
       req,
       res,
       existing,
-      { allowVisibleIssueWrite: true },
+      { allowVisibleIssueWrite: true, priorOwnerTerminalClose },
     );
     if (!issueMutationAccess) return;
     const issueMutationAuthorizationReason = req.actor.type === "agent"
@@ -9475,7 +9513,7 @@ export function issueRoutes(
         req,
         existing,
         activeRecoveryActionBeforeUpdate,
-        { source: "issue_update" },
+        { source: "issue_update", priorOwnerTerminalClose },
       );
       const recoveryRestrictedSourceMutationRequested =
         activeRecoveryActionBeforeUpdate != null &&
@@ -9490,13 +9528,14 @@ export function issueRoutes(
             updateFields.status !== existing.status
           )
         );
-      if (recoveryRestrictedSourceMutationRequested) {
+      if (recoveryRestrictedSourceMutationRequested && !priorOwnerTerminalClose) {
         await requireRecoverySourceMutationAuthority(req, existing);
       }
     }
     if (
       resumeRequested !== true &&
       agentStatusTransitionRequiresResumeAuthority &&
+      !priorOwnerTerminalClose &&
       !(await assertExplicitResumeIntentAllowed(req, res, existing))
     ) {
       return;

--- a/server/src/services/prior-owner-close.test.ts
+++ b/server/src/services/prior-owner-close.test.ts
@@ -67,6 +67,17 @@ describe("evaluatePriorOwnerTerminalCloseGrant", () => {
     }).allowed).toBe(false);
   });
 
+  it("never grants prior-owner close to the current assignee", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant({
+      ...base,
+      actorAgentId: currentAssigneeAgentId,
+      previousOwnerAgentId: currentAssigneeAgentId,
+    })).toEqual({
+      allowed: false,
+      reason: "not_prior_owner",
+    });
+  });
+
   it("revokes after the new owner successfully checkouts", () => {
     expect(evaluatePriorOwnerTerminalCloseGrant({
       ...base,

--- a/server/src/services/prior-owner-close.test.ts
+++ b/server/src/services/prior-owner-close.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluatePriorOwnerTerminalCloseGrant,
+  isPriorOwnerTerminalClosePatch,
+  isRecoverySystemNoticePresentation,
+} from "./prior-owner-close.js";
+
+const previousOwnerAgentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const currentAssigneeAgentId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const recoveryCreatedAt = new Date("2026-08-19T12:00:00.000Z");
+
+describe("isPriorOwnerTerminalClosePatch", () => {
+  it("allows status-only done and cancelled patches", () => {
+    expect(isPriorOwnerTerminalClosePatch({ status: "done" })).toBe(true);
+    expect(isPriorOwnerTerminalClosePatch({ status: "cancelled" })).toBe(true);
+  });
+
+  it("allows an append-only comment alongside terminal status", () => {
+    expect(isPriorOwnerTerminalClosePatch({ status: "done", comment: "Finished." })).toBe(true);
+  });
+
+  it("rejects non-terminal status and extra mutate fields", () => {
+    expect(isPriorOwnerTerminalClosePatch({ status: "todo" })).toBe(false);
+    expect(isPriorOwnerTerminalClosePatch({ status: "done", description: "rewrite" })).toBe(false);
+    expect(isPriorOwnerTerminalClosePatch({ status: "done", assigneeAgentId: currentAssigneeAgentId })).toBe(false);
+    expect(isPriorOwnerTerminalClosePatch({ status: "done", title: "retitle" })).toBe(false);
+    expect(isPriorOwnerTerminalClosePatch({ status: "done", resume: true })).toBe(false);
+    expect(isPriorOwnerTerminalClosePatch({ status: "done", reopen: true })).toBe(false);
+    expect(isPriorOwnerTerminalClosePatch({ status: "cancelled", interrupt: true })).toBe(false);
+  });
+});
+
+describe("isRecoverySystemNoticePresentation", () => {
+  it("treats compact recovery notices as recovery comments", () => {
+    expect(isRecoverySystemNoticePresentation({ kind: "system_notice" })).toBe(true);
+    expect(isRecoverySystemNoticePresentation({ kind: "callout" })).toBe(false);
+    expect(isRecoverySystemNoticePresentation(null)).toBe(false);
+  });
+});
+
+describe("evaluatePriorOwnerTerminalCloseGrant", () => {
+  const base = {
+    actorAgentId: previousOwnerAgentId,
+    currentAssigneeAgentId,
+    previousOwnerAgentId,
+    recoveryCreatedAt,
+    checkoutRunAgentId: null as string | null,
+    comments: [] as Array<{
+      authorAgentId?: string | null;
+      deletedAt?: Date | null;
+      createdAt?: Date;
+      presentation?: { kind?: string } | null;
+    }>,
+  };
+
+  it("allows the previous owner after recovery steal", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant(base)).toEqual({
+      allowed: true,
+      reason: "allow",
+    });
+  });
+
+  it("denies a peer who is not the recorded previous owner", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant({
+      ...base,
+      actorAgentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    }).allowed).toBe(false);
+  });
+
+  it("revokes after the new owner successfully checkouts", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant({
+      ...base,
+      checkoutRunAgentId: currentAssigneeAgentId,
+    })).toEqual({
+      allowed: false,
+      reason: "revoked_checkout",
+    });
+  });
+
+  it("does not revoke on a stale previous-owner checkout lock", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant({
+      ...base,
+      checkoutRunAgentId: previousOwnerAgentId,
+    }).allowed).toBe(true);
+  });
+
+  it("revokes after the new owner posts a non-recovery comment", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant({
+      ...base,
+      comments: [{
+        authorAgentId: currentAssigneeAgentId,
+        createdAt: new Date("2026-08-19T12:05:00.000Z"),
+        presentation: null,
+      }],
+    })).toEqual({
+      allowed: false,
+      reason: "revoked_comment",
+    });
+  });
+
+  it("does not revoke on a recovery system_notice from the new owner", () => {
+    expect(evaluatePriorOwnerTerminalCloseGrant({
+      ...base,
+      comments: [{
+        authorAgentId: currentAssigneeAgentId,
+        createdAt: new Date("2026-08-19T12:01:00.000Z"),
+        presentation: { kind: "system_notice" },
+      }],
+    }).allowed).toBe(true);
+  });
+});

--- a/server/src/services/prior-owner-close.ts
+++ b/server/src/services/prior-owner-close.ts
@@ -1,0 +1,79 @@
+const TERMINAL_CLOSE_STATUSES = new Set(["done", "cancelled"]);
+const TERMINAL_CLOSE_PASSTHROUGH_KEYS = new Set(["status", "comment"]);
+
+export type PriorOwnerCloseReason =
+  | "allow"
+  | "not_prior_owner"
+  | "revoked_checkout"
+  | "revoked_comment";
+
+export type PriorOwnerCloseComment = {
+  authorAgentId?: string | null;
+  deletedAt?: Date | string | null;
+  createdAt?: Date | string | null;
+  presentation?: { kind?: string } | null;
+};
+
+export type PriorOwnerCloseDecision = {
+  allowed: boolean;
+  reason: PriorOwnerCloseReason;
+};
+
+export function isPriorOwnerTerminalClosePatch(body: Record<string, unknown> | null | undefined): boolean {
+  if (!body || !TERMINAL_CLOSE_STATUSES.has(String(body.status ?? ""))) return false;
+  if (body.resume === true || body.reopen === true || body.interrupt === true) return false;
+  for (const [key, value] of Object.entries(body)) {
+    if (value === undefined) continue;
+    if (TERMINAL_CLOSE_PASSTHROUGH_KEYS.has(key)) continue;
+    return false;
+  }
+  return true;
+}
+
+export function isRecoverySystemNoticePresentation(
+  presentation: { kind?: string } | null | undefined,
+): boolean {
+  return presentation?.kind === "system_notice";
+}
+
+function asDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function evaluatePriorOwnerTerminalCloseGrant(input: {
+  actorAgentId: string;
+  currentAssigneeAgentId: string | null;
+  previousOwnerAgentId: string | null | undefined;
+  recoveryCreatedAt: Date | string | null | undefined;
+  checkoutRunAgentId: string | null;
+  comments: PriorOwnerCloseComment[];
+}): PriorOwnerCloseDecision {
+  if (!input.previousOwnerAgentId || input.actorAgentId !== input.previousOwnerAgentId) {
+    return { allowed: false, reason: "not_prior_owner" };
+  }
+  if (
+    input.currentAssigneeAgentId &&
+    input.checkoutRunAgentId &&
+    input.checkoutRunAgentId === input.currentAssigneeAgentId
+  ) {
+    return { allowed: false, reason: "revoked_checkout" };
+  }
+
+  const stolenAt = asDate(input.recoveryCreatedAt);
+  const currentAssigneeAgentId = input.currentAssigneeAgentId;
+  if (currentAssigneeAgentId && stolenAt) {
+    const revokedByComment = input.comments.some((comment) => {
+      if (comment.deletedAt) return false;
+      if (comment.authorAgentId !== currentAssigneeAgentId) return false;
+      const createdAt = asDate(comment.createdAt);
+      if (!createdAt || createdAt < stolenAt) return false;
+      return !isRecoverySystemNoticePresentation(comment.presentation);
+    });
+    if (revokedByComment) return { allowed: false, reason: "revoked_comment" };
+  }
+
+  return { allowed: true, reason: "allow" };
+}

--- a/server/src/services/prior-owner-close.ts
+++ b/server/src/services/prior-owner-close.ts
@@ -51,7 +51,11 @@ export function evaluatePriorOwnerTerminalCloseGrant(input: {
   checkoutRunAgentId: string | null;
   comments: PriorOwnerCloseComment[];
 }): PriorOwnerCloseDecision {
-  if (!input.previousOwnerAgentId || input.actorAgentId !== input.previousOwnerAgentId) {
+  if (
+    !input.previousOwnerAgentId
+    || input.actorAgentId !== input.previousOwnerAgentId
+    || input.actorAgentId === input.currentAssigneeAgentId
+  ) {
     return { allowed: false, reason: "not_prior_owner" };
   }
   if (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Same-company standard-trust agents already have default-open comments on visible peer-owned issues.
> - Recovery can reassign an in-progress issue before the previous owner PATCHes `done`.
> - That PATCH currently dies on the assignee run lock, or on recovery-action authority when the issue is blocked.
> - The previous owner should be able to close with status `done` or `cancelled` only.
> - The grant revokes when the new owner checkouts or posts a non-recovery comment.
> - This pull request adds that narrow close path and leaves peer mutate otherwise unchanged.
> - The benefit is that an agent that finished the work can still close the issue after recovery steal.

## Linked Issues or Issue Description

**What happened?**

Live Paperclip `2026.817.0` already allows standard-trust peer `POST /comments` (`allow_visible_issue_write`). After recovery steals an issue, the previous assignee still cannot `PATCH` status to `done`/`cancelled`.

Reproduced against the live instance:

- Peer comment on a different agent's assigned issue → `201` / `allow_visible_issue_write`
- Peer comment on an in-progress peer-owned issue → `201` / `allow_visible_issue_write`
- Peer `PATCH { status: "done" }` on an in-progress peer-owned issue → `409` `issue_write_assignee_run_lock`
- Blocked stolen issues with an active recovery action also hit `Agent cannot resolve another owner's recovery action`

**Expected behavior**

- Standard-trust same-company peers who can `issue:read` may comment without mutating status.
- Low-trust, skill-test, and task-bridge peer comments stay denied.
- After recovery steal, the previous assignee may PATCH status `done`/`cancelled` only.
- That grant revokes after the new owner checkouts or posts a non-recovery comment.
- No blanket CTO/manager mutate exemption.

**Steps to reproduce**

1. Assign issue A to agent X, status `in_progress`.
2. Open an active recovery action that reassigns A to agent Y and sets `previousOwnerAgentId=X`.
3. As X, `PATCH /api/issues/:id` with `{ "status": "done" }`.
4. Observe that current master/live denies with `issue_write_assignee_run_lock` or recovery-action authority.

**Paperclip version or commit**

Live: `2026.817.0`. Workspace master at implementation: `536d5880c`.

Related (not duplicates): Refs #10884, Refs #10282, Refs #11502, Refs #11385. Those cover recovery-owner writes or keeping source ownership. This PR grants the *previous* assignee status-only terminal close.

## What Changed

- Add `evaluatePriorOwnerTerminalCloseGrant` keyed off the active recovery action's `previousOwnerAgentId`.
- Bypass the in-progress run lock, recovery-action authority, and resume-follow-up gate only for status-only `done`/`cancelled` (optional comment allowed).
- Revoke after a checkout run owned by the current assignee, or a non-`system_notice` comment from that assignee after steal.
- Recovery `system_notice` comments do not revoke.
- Description rewrite and reassignment stay on the existing run lock.
- Tests cover peer comments, scoped denials, prior-owner close, and the revoke rule.

Automatic reassignment that does not write `issue_recovery_actions.previousOwnerAgentId` does not mint this grant. That is the recorded steal signal for recovery.

## Verification

- `../node_modules/.bin/vitest run src/services/prior-owner-close.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 98 passed
- `../node_modules/.bin/vitest run src/__tests__/authorization-service.test.ts` — 61 passed
- `bin/ci` is absent in this repo. These are the targeted server tests for the changed paths.

```test-evidence:
sha: 096a8d70bacfb03dc9a6752e605d170e8c2bf244
command: ../node_modules/.bin/vitest run src/services/prior-owner-close.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/authorization-service.test.ts
exit: 0
totals: 159 passed (98 ownership+helper, 61 authorization); 3 test files passed
worktree: clean before and after; local == remote == PR head
finished_at: 2026-08-19T13:20:38Z
```

## Risks

- Narrow: only previous owners on an active recovery action, and only terminal status. Peer comments were already default-open on this build.
- Live deploy gap remains: this is not in `2026.817.0`. Do not restart or replace the live instance from this PR.

## Model Used

- Provider: Cursor / SpaceXAI
- Model: Cursor Grok 4.6
- Mode: agentic coding with tool use and local test execution
- Context: long-context repository worktree session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge