### PR TITLE
fix(server): make silent detect-port fallback loud, and optionally fatal

### DIFF
--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -158,6 +158,7 @@ function buildTestConfig(overrides: Record<string, unknown> = {}) {
     customBindHost: undefined,
     host: "127.0.0.1",
     port: 3210,
+    portStrictMode: false,
     allowedHostnames: [],
     authBaseUrlMode: "auto",
     authPublicBaseUrl: undefined,
@@ -729,5 +730,29 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+});
+
+describe("startServer PAPERCLIP_PORT_STRICT_MODE", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PAPERCLIP_DECISION_SIGNING_SECRET = "fedcba9876543210fedcba9876543210";
+    process.env.BETTER_AUTH_SECRET = "test-secret";
+  });
+
+  it("refuses to fall back to a different port when strict mode is enabled", async () => {
+    loadConfigMock.mockReturnValue(buildTestConfig({ port: 3100, portStrictMode: true }));
+    detectPortMock.mockResolvedValueOnce(3110);
+
+    await expect(startServer()).rejects.toThrow(/PORT_FALLBACK_REFUSED/);
+  });
+
+  it("still falls back by default when strict mode is not set", async () => {
+    loadConfigMock.mockReturnValue(buildTestConfig({ port: 3100, portStrictMode: false }));
+    detectPortMock.mockResolvedValueOnce(3110);
+
+    const started = await startServer();
+
+    expect(started.listenPort).toBe(3110);
   });
 });

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -56,6 +56,7 @@ export interface Config {
   customBindHost: string | undefined;
   host: string;
   port: number;
+  portStrictMode: boolean;
   allowedHostnames: string[];
   authBaseUrlMode: AuthBaseUrlMode;
   authPublicBaseUrl: string | undefined;
@@ -308,6 +309,7 @@ export function loadConfig(): Config {
     customBindHost: resolvedBind.customBindHost,
     host: resolvedBind.host,
     port: Number(process.env.PORT) || fileConfig?.server.port || 3100,
+    portStrictMode: process.env.PAPERCLIP_PORT_STRICT_MODE === "true",
     allowedHostnames,
     authBaseUrlMode,
     authPublicBaseUrl,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -141,6 +141,33 @@ export interface StartedServer {
   databaseUrl: string;
 }
 
+// `detect-port` silently returns the next free port when the requested one is
+// busy. Left unguarded, a slow-to-release socket during a crash/restart race
+// makes the process bind to an unrouted port with only a log line to show for
+// it (see PAPERCLIP_PORT_STRICT_MODE below). We always log the mismatch at
+// `error` with a greppable prefix; PAPERCLIP_PORT_STRICT_MODE additionally
+// makes it fatal so supervisors (launchd/systemd KeepAlive) keep restarting
+// until the requested port is actually free, instead of the process quietly
+// serving traffic a reverse proxy never sends it.
+async function resolveListenPort(
+  requestedPort: number,
+  opts: { label: string; strict: boolean },
+): Promise<number> {
+  const selectedPort = await detectPort(requestedPort);
+  if (selectedPort === requestedPort) return selectedPort;
+
+  const detail = `requestedPort=${requestedPort}, selectedPort=${selectedPort}, label=${opts.label}`;
+  if (opts.strict) {
+    throw new Error(
+      `PORT_FALLBACK_REFUSED: ${opts.label} port ${requestedPort} is already in use and ` +
+        `PAPERCLIP_PORT_STRICT_MODE is enabled, so refusing to fall back to port ${selectedPort}. ` +
+        "Free the requested port (check for a lingering process from a fast crash/restart) and retry.",
+    );
+  }
+  logger.error(`PORT_FALLBACK: ${opts.label} port is busy; using next free port (${detail})`);
+  return selectedPort;
+}
+
 export async function startServer(): Promise<StartedServer> {
   // Tracing must be active (or have failed and logged) before the first DB
   // connection or the HTTP server exists — see instrumentation.ts.
@@ -448,11 +475,10 @@ export async function startServer(): Promise<StartedServer> {
           `Embedded PostgreSQL appears to already be reachable without a pid file; reusing existing server on configured port ${configuredPort}`,
         );
       } catch {
-        const detectedPort = await detectPort(configuredPort);
-        if (detectedPort !== configuredPort) {
-          logger.warn(`Embedded PostgreSQL port is in use; using next free port (requestedPort=${configuredPort}, selectedPort=${detectedPort})`);
-        }
-        port = detectedPort;
+        port = await resolveListenPort(configuredPort, {
+          label: "Embedded PostgreSQL",
+          strict: config.portStrictMode,
+        });
         logger.info(`Using embedded PostgreSQL because no DATABASE_URL set (dataDir=${dataDir}, port=${port})`);
         const createEmbeddedPostgres = () => new EmbeddedPostgres({
           databaseDir: dataDir,
@@ -576,7 +602,10 @@ export async function startServer(): Promise<StartedServer> {
   }
 
   const requestedListenPort = config.port;
-  const listenPort = await detectPort(requestedListenPort);
+  const listenPort = await resolveListenPort(requestedListenPort, {
+    label: "server",
+    strict: config.portStrictMode,
+  });
   if (config.authBaseUrlMode === "explicit" && config.authPublicBaseUrl) {
     config.authPublicBaseUrl = rewriteLoopbackUrlPort(config.authPublicBaseUrl, listenPort);
   }
@@ -805,11 +834,7 @@ export async function startServer(): Promise<StartedServer> {
   // This prevents intermittent 502/ECONNRESET errors caused by Node's 5s default.
   server.keepAliveTimeout = 185000;
   server.headersTimeout = 186000;
-  
-  if (listenPort !== requestedListenPort) {
-    logger.warn(`Requested port is busy; using next free port (requestedPort=${requestedListenPort}, selectedPort=${listenPort})`);
-  }
-  
+
   const runtimeListenHost = config.host;
   const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,


### PR DESCRIPTION
## Summary

`server/src/index.ts` silently rebinds to a fallback port via `detect-port` when the configured port is busy — both for the app's listen port and the embedded-Postgres port — logging only a `warn` after the fact. During a fast crash/restart race under a supervisor with `KeepAlive` (e.g. launchd/systemd), a not-yet-released socket on the intended port causes the process to silently start on an unrouted port, with reverse proxies still pointed at the dead one, and no alert. See the incident writeup in the linked issue.

- Adds a shared `resolveListenPort()` helper used by both the app listen port and the embedded-Postgres port call sites.
- Always logs the port mismatch at `error` (previously `warn`) with a greppable `PORT_FALLBACK` prefix.
- Adds an opt-in `PAPERCLIP_PORT_STRICT_MODE` env var: when set to `true`, a port conflict throws instead of silently falling back, so a process supervisor's restart loop keeps retrying until the real port is free rather than serving traffic no one is routing to.
- Default behavior is unchanged (fallback still allowed) — this is additive so existing single-host dev/test setups that rely on the fallback (see `BRO-1558` test coverage) keep working. Production-style single-instance deployments (e.g. FinalFinal's launchd-supervised install) can opt in via the new env var.

## Why not make it fatal by default?

This is shared application code used across every deployment shape, including local dev and parallel test runs that intentionally rely on the fallback. Flipping the default to fatal would be a breaking change with a much larger blast radius than this incident warrants. The opt-in flag gets single-instance production deployments the fail-fast behavior they need without affecting anyone else.

## Test plan

- [x] `vitest run server/src/__tests__/server-startup-feedback-export.test.ts` — 18/18 passing, including 2 new cases covering `PAPERCLIP_PORT_STRICT_MODE` (refuses fallback when enabled, still falls back by default).
- [x] `tsc --noEmit` on `server/` shows no new errors introduced by this change (pre-existing unrelated errors come from a skipped plugin-sdk build step).

Fixes FIN-423 (child of FIN-422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)