### PR TITLE
fix(server): gate periodic heartbeat recovery to one chain in flight

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@
 // instrumentationReady before opening DB connections or constructing the
 // HTTP server, so trace coverage does not depend on incidental timing.
 import { instrumentationReady, shutdownInstrumentation } from "./instrumentation.js";
+import { createSingleFlight } from "./lib/single-flight.js";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import { resolve } from "node:path";
@@ -1009,6 +1010,9 @@ export async function startServer(): Promise<StartedServer> {
     heartbeatSchedulerInterval = setInterval(callback, config.heartbeatSchedulerIntervalMs);
     heartbeatSchedulerInterval?.unref?.();
   };
+  // At most one periodic heartbeat recovery chain runs at a time; see the
+  // tick body for why stacking these chains is a stall hazard.
+  const periodicRecoveryChain = createSingleFlight();
   const externalObjects = externalObjectService(db as any, {
     pluginWorkerManager,
     enabled: async () => (await instanceSettingsService(db).getExperimental()).enableExternalObjects === true,
@@ -1445,7 +1449,16 @@ export async function startServer(): Promise<StartedServer> {
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
           // Periodically reap orphaned runs (5-min staleness threshold) and make sure
           // persisted queued work is still being driven forward.
-          trackHeartbeatSchedulerWork(heartbeat
+          //
+          // The chain below is the expensive full-graph maintenance pass. It is
+          // gated to one invocation at a time: the interval fires every tick
+          // regardless of how long the previous pass took, and a control plane
+          // congested enough to slow this pass past the tick interval is exactly
+          // the state in which stacking more copies of it turns congestion into
+          // a full stall (2026-08-19 seven-run recovery-burst outage). A skipped
+          // tick only delays maintenance by the interval; every stage is an
+          // idempotent backstop.
+          const recoveryChainTick = periodicRecoveryChain.run(() => heartbeat
             .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
             .then(() => heartbeat.promoteDueScheduledRetries())
             .then(async (promotion) => {
@@ -1498,6 +1511,14 @@ export async function startServer(): Promise<StartedServer> {
             .catch((err) => {
               logger.error({ err }, "periodic heartbeat recovery failed");
             }));
+          if (recoveryChainTick.started) {
+            trackHeartbeatSchedulerWork(recoveryChainTick.settled);
+          } else {
+            logger.warn(
+              { inFlightForMs: recoveryChainTick.inFlightForMs },
+              "skipped periodic heartbeat recovery tick; previous chain still in flight",
+            );
+          }
         }
       })().catch((err) => {
         logger.error({ err }, "heartbeat scheduler tick failed");

--- a/server/src/lib/single-flight.test.ts
+++ b/server/src/lib/single-flight.test.ts
@@ -69,14 +69,18 @@ describe("createSingleFlight", () => {
     await (second as { settled: Promise<void> }).settled;
   });
 
-  it("releases the gate when work throws synchronously", async () => {
+  it("propagates a synchronous throw and leaves the gate free", async () => {
     const gate = createSingleFlight();
 
-    const first = gate.run(() => {
-      throw new Error("sync failure");
-    });
-    expect(first.started).toBe(true);
-    await (first as { settled: Promise<void> }).settled;
+    expect(() =>
+      gate.run(() => {
+        throw new Error("sync failure");
+      }),
+    ).toThrow("sync failure");
     expect(gate.busy).toBe(false);
+
+    const second = gate.run(async () => {});
+    expect(second.started).toBe(true);
+    await (second as { settled: Promise<void> }).settled;
   });
 });

--- a/server/src/lib/single-flight.test.ts
+++ b/server/src/lib/single-flight.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSingleFlight } from "./single-flight.js";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createSingleFlight", () => {
+  it("runs work when idle and reports busy until it settles", async () => {
+    const gate = createSingleFlight();
+    const gap = deferred();
+
+    const first = gate.run(() => gap.promise);
+    expect(first.started).toBe(true);
+    expect(gate.busy).toBe(true);
+
+    gap.resolve();
+    await (first as { settled: Promise<void> }).settled;
+    expect(gate.busy).toBe(false);
+  });
+
+  it("skips a tick while the previous invocation is still in flight", async () => {
+    const clock = { nowMs: 1_000 };
+    const gate = createSingleFlight(() => clock.nowMs);
+    const gap = deferred();
+    const work = vi.fn(() => gap.promise);
+
+    const first = gate.run(work);
+    clock.nowMs = 31_000;
+    const second = gate.run(work);
+
+    expect(second).toEqual({ started: false, inFlightForMs: 30_000 });
+    expect(work).toHaveBeenCalledTimes(1);
+
+    gap.resolve();
+    await (first as { settled: Promise<void> }).settled;
+  });
+
+  it("admits new work after the previous invocation resolves", async () => {
+    const gate = createSingleFlight();
+    const gap = deferred();
+
+    const first = gate.run(() => gap.promise);
+    gap.resolve();
+    await (first as { settled: Promise<void> }).settled;
+
+    const second = gate.run(async () => {});
+    expect(second.started).toBe(true);
+    await (second as { settled: Promise<void> }).settled;
+  });
+
+  it("releases the gate when work rejects and never rejects the settled promise", async () => {
+    const gate = createSingleFlight();
+    const gap = deferred();
+
+    const first = gate.run(() => gap.promise);
+    gap.reject(new Error("chain failed"));
+    await expect((first as { settled: Promise<void> }).settled).resolves.toBeUndefined();
+    expect(gate.busy).toBe(false);
+
+    const second = gate.run(async () => {});
+    expect(second.started).toBe(true);
+    await (second as { settled: Promise<void> }).settled;
+  });
+
+  it("releases the gate when work throws synchronously", async () => {
+    const gate = createSingleFlight();
+
+    const first = gate.run(() => {
+      throw new Error("sync failure");
+    });
+    expect(first.started).toBe(true);
+    await (first as { settled: Promise<void> }).settled;
+    expect(gate.busy).toBe(false);
+  });
+});

--- a/server/src/lib/single-flight.ts
+++ b/server/src/lib/single-flight.ts
@@ -1,0 +1,61 @@
+// A single-flight gate for periodic work scheduled on a fixed interval.
+//
+// An interval timer fires whether or not the previous invocation finished.
+// When one invocation slows past the interval (a congested control plane is
+// exactly when maintenance chains get slow), each new tick stacks another
+// full copy of the work on top of the running one, which amplifies the
+// congestion that made the first copy slow. The gate keeps at most one
+// invocation in flight and reports a skipped tick to the caller instead,
+// so periodic work degrades to "runs less often" rather than "piles up".
+export interface SingleFlightSkip {
+  started: false;
+  // How long the in-flight invocation has been running, so the caller can
+  // log a skip with enough context to spot a wedged chain.
+  inFlightForMs: number;
+}
+
+export interface SingleFlightStart {
+  started: true;
+  // Settles when the invocation settles. Never rejects: the gate exists for
+  // fire-and-forget interval work, so the caller's own error handling stays
+  // the only consumer of the failure.
+  settled: Promise<void>;
+}
+
+export type SingleFlightResult = SingleFlightSkip | SingleFlightStart;
+
+export function createSingleFlight(now: () => number = Date.now) {
+  let inFlight: Promise<void> | null = null;
+  let startedAtMs = 0;
+
+  return {
+    // True while an invocation is running.
+    get busy(): boolean {
+      return inFlight !== null;
+    },
+    run(work: () => Promise<unknown>): SingleFlightResult {
+      if (inFlight) {
+        return { started: false, inFlightForMs: now() - startedAtMs };
+      }
+      startedAtMs = now();
+      // Invoke synchronously so the work starts on this tick, not a microtask
+      // later; a synchronous throw still releases the gate.
+      let invoked: Promise<unknown>;
+      try {
+        invoked = Promise.resolve(work());
+      } catch {
+        invoked = Promise.resolve();
+      }
+      const settled = invoked
+        .then(
+          () => undefined,
+          () => undefined,
+        )
+        .finally(() => {
+          inFlight = null;
+        });
+      inFlight = settled;
+      return { started: true, settled };
+    },
+  };
+}

--- a/server/src/lib/single-flight.ts
+++ b/server/src/lib/single-flight.ts
@@ -39,14 +39,10 @@ export function createSingleFlight(now: () => number = Date.now) {
       }
       startedAtMs = now();
       // Invoke synchronously so the work starts on this tick, not a microtask
-      // later; a synchronous throw still releases the gate.
-      let invoked: Promise<unknown>;
-      try {
-        invoked = Promise.resolve(work());
-      } catch {
-        invoked = Promise.resolve();
-      }
-      const settled = invoked
+      // later. A synchronous throw means nothing was admitted: the gate stays
+      // free and the exception propagates to the caller's tick-level error
+      // handling instead of settling silently.
+      const settled = Promise.resolve(work())
         .then(
           () => undefined,
           () => undefined,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server runs a periodic heartbeat scheduler that performs recovery maintenance (orphan reaping, stranded-issue reconciliation, issue-graph liveness, watchdogs, lock sweeps)
> - The scheduler interval fires on a fixed tick and did not check if the previous maintenance pass was still running
> - When the control plane is congested, one slow pass stacks with the next tick's full copy, and the stacking amplifies the congestion into a full stall of the HTTP layer
> - This pull request adds a single-flight gate so at most one recovery chain runs at a time, and a skipped tick is logged with the age of the in-flight pass
> - The benefit is that periodic maintenance degrades to "runs less often" under load instead of wedging the API server

## Linked Issues or Issue Description

No public GitHub issue exists for this. The problem, in the bug-report template fields:

**What happened?**

On 2026-08-19 the API server became unresponsive two times (about 12:20–12:29Z and about 12:50–13:22Z) while it resumed a burst of agent runs. The process stayed alive, kept its listener open, and used about 50% CPU, but it did not answer HTTP requests. The database was healthy. The heartbeat scheduler had started overlapping copies of the full recovery chain, one per 30-second tick, because a congested pass ran longer than the tick interval.

**Expected behavior**

Periodic recovery maintenance must not stack. When a pass is still in flight, the next tick must skip and log, so a slow control plane recovers instead of stalling.

**Steps to reproduce**

Resume many agent runs at once so recovery maintenance becomes slow. Watch the scheduler start a new full recovery chain every tick while earlier chains are still running. Observe API latency grow until requests time out.

**Paperclip version or commit**

master at the parent commit of this branch.

**Additional context**

Recovery in both incidents was a sharp queue drain with no restart, which matches queued duplicate work finishing at once.

## What Changed

- Add `server/src/lib/single-flight.ts`: a small gate that admits one invocation at a time. A tick that arrives while work is in flight gets `{ started: false, inFlightForMs }` back. A synchronous throw from the supplied work propagates to the caller and leaves the gate free.
- Gate the periodic heartbeat recovery chain in `server/src/index.ts` with this gate. A skipped tick logs a warning with the age of the in-flight pass. Started work stays tracked for graceful shutdown.
- Add `server/src/lib/single-flight.test.ts` with 5 focused tests: admission, skip-while-busy with age report, re-admission after resolve, gate release on rejection, and synchronous-throw propagation.

## Verification

- `cd server && ../node_modules/.bin/vitest run src/lib/single-flight.test.ts` — 5/5 pass.
- `cd server && npx tsc --noEmit -p tsconfig.json` — clean.
- Bounded live check after the incident: with the recovery chain healthy, 3 concurrent reads plus 1 write plus a health probe all answered in well under 1 second.

## Risks

- Low risk. Every stage in the gated chain is an idempotent backstop, so a skipped tick only delays maintenance by one interval.
- Behavioral shift: under sustained congestion the recovery chain runs less often instead of stacking. This is the intended fix.
- The gate rethrows synchronous exceptions from the supplied work; the scheduler's existing tick-level catch logs them, so no new unhandled-exception path exists.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), extended thinking, agentic tool use (code edits, test runs) via the Claude Agent SDK.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
