### PR TITLE
fix(heartbeat): gate review parents on owner child

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -995,14 +995,28 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.companyId, companyId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        return runs.length === 1 && runs[0]?.status === "succeeded";
       }, 90_000);
+      await waitFor(async () => {
+        const deferred = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, mentionedAgentId),
+              eq(agentWakeupRequests.status, "skipped"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return deferred?.status === "skipped";
+      }, 90_000);
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
 
       const issueAfterPromotion = await db
         .select({
@@ -1018,22 +1032,6 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       });
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
-      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toBeUndefined();
-      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
-      expect(secondWake).toMatchObject({
-        reason: "issue_comment_mentioned",
-        commentIds: [comment.id],
-        latestCommentId: comment.id,
-        issue: {
-          id: issueId,
-          identifier: `${issuePrefix}-1`,
-          title: "Do not reopen from agent mention",
-          status: "done",
-          priority: "medium",
-        },
-      });
-      expect(String(secondPayload.message ?? "")).toContain("please review after I finish");
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -1177,17 +1175,28 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      // The deferred wake still promotes (so the agent gets the message), but
-      // the issue must remain `done` because the only referenced comment is
-      // self-authored by the run that is now ending.
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
         const runs = await db
           .select()
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.agentId, agentId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        return runs.length === 1 && runs[0]?.status === "succeeded";
       }, 90_000);
+      await waitFor(async () => {
+        const deferred = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "skipped"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return deferred?.status === "skipped";
+      }, 90_000);
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
 
       const issueAfterPromotion = await db
         .select({

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -430,8 +430,18 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     const promotedBlockedRunCount = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(heartbeatRuns)
-      .where(sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${blockedIssueId}`)
+      .where(and(
+        sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${blockedIssueId}`,
+        sql`${heartbeatRuns.contextSnapshot} ->> 'wakeReason' = 'issue_blockers_resolved'`,
+      ))
       .then((rows) => rows[0]?.count ?? 0);
+    const dependencyWakeRequests = await db
+      .select({ idempotencyKey: agentWakeupRequests.idempotencyKey })
+      .from(agentWakeupRequests)
+      .where(eq(
+        agentWakeupRequests.idempotencyKey,
+        `issue_blockers_resolved:${blockedIssueId}:${blockerId}`,
+      ));
     const blockedWakeRequestCount = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(agentWakeupRequests)
@@ -442,9 +452,9 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         ),
       )
       .then((rows) => rows[0]?.count ?? 0);
-
     expect(promotedBlockedRun?.status).toBe("succeeded");
     expect(promotedBlockedRunCount).toBe(1);
+    expect(dependencyWakeRequests).toHaveLength(1);
     expect(descendantRuns).toBe(0);
     expect(blockedWakeRequestCount).toBeGreaterThanOrEqual(2);
 

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -170,6 +170,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     const agentId = randomUUID();
     const blockerId = randomUUID();
     const blockedIssueId = randomUUID();
+    const descendantIssueId = randomUUID();
     const readyIssueId = randomUUID();
 
     await db.insert(companies).values({
@@ -214,6 +215,15 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         responsibleUserId: "responsible-user",
       },
       {
+        id: descendantIssueId,
+        companyId,
+        title: "Mission 3",
+        status: "todo",
+        priority: "low",
+        assigneeAgentId: agentId,
+        responsibleUserId: "responsible-user",
+      },
+      {
         id: readyIssueId,
         companyId,
         title: "Mission 1",
@@ -223,12 +233,20 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         responsibleUserId: "responsible-user",
       },
     ]);
-    await db.insert(issueRelations).values({
-      companyId,
-      issueId: blockerId,
-      relatedIssueId: blockedIssueId,
-      type: "blocks",
-    });
+    await db.insert(issueRelations).values([
+      {
+        companyId,
+        issueId: blockerId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      },
+      {
+        companyId,
+        issueId: blockedIssueId,
+        relatedIssueId: descendantIssueId,
+        type: "blocks",
+      },
+    ]);
 
     const blockedWake = await heartbeat.wakeup(agentId, {
       source: "assignment",
@@ -269,41 +287,30 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       .then((rows) => rows[0]?.count ?? 0);
     expect(blockedRunsBeforeResolution).toBe(0);
 
-    const interactionWake = await heartbeat.wakeup(agentId, {
-      source: "automation",
-      triggerDetail: "system",
-      reason: "issue_commented",
-      payload: { issueId: blockedIssueId, commentId: randomUUID() },
-      contextSnapshot: {
-        issueId: blockedIssueId,
-        wakeReason: "issue_commented",
-      },
-    });
-    expect(interactionWake).not.toBeNull();
+    const interactionWakeResults = await Promise.all(
+      ["issue_commented", "issue_comment_mentioned"].map((reason) =>
+        heartbeat.wakeup(agentId, {
+          source: "automation",
+          triggerDetail: "system",
+          reason,
+          payload: { issueId: blockedIssueId, commentId: randomUUID() },
+          contextSnapshot: {
+            issueId: blockedIssueId,
+            wakeReason: reason,
+          },
+        }),
+      ),
+    );
+    expect(interactionWakeResults).toEqual([null, null]);
 
-    await waitForCondition(async () => {
-      const run = await db
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, interactionWake!.id))
-        .then((rows) => rows[0] ?? null);
-      return run?.status === "succeeded";
-    });
-
-    const interactionRun = await db
-      .select({
-        status: heartbeatRuns.status,
-        contextSnapshot: heartbeatRuns.contextSnapshot,
-      })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, interactionWake!.id))
-      .then((rows) => rows[0] ?? null);
-
-    expect(interactionRun?.status).toBe("succeeded");
-    expect(interactionRun?.contextSnapshot).toMatchObject({
-      dependencyBlockedInteraction: true,
-      unresolvedBlockerIssueIds: [blockerId],
-    });
+    const blockedInteractionWakeRequests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(sql`${agentWakeupRequests.payload} ->> 'issueId' = ${blockedIssueId}`);
+    expect(blockedInteractionWakeRequests).toHaveLength(3);
+    expect(blockedInteractionWakeRequests.every(
+      (wakeup) => wakeup.status === "skipped" && wakeup.reason === "issue_dependencies_blocked",
+    )).toBe(true);
 
     let finishReadyRun!: () => void;
     const readyRunCanFinish = new Promise<void>((resolve) => {
@@ -392,6 +399,27 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, promotedWake!.id))
       .then((rows) => rows[0] ?? null);
+    const descendantCommentWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: descendantIssueId, commentId: randomUUID() },
+      contextSnapshot: {
+        issueId: descendantIssueId,
+        wakeReason: "issue_commented",
+      },
+    });
+    expect(descendantCommentWake).toBeNull();
+    const descendantRuns = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${descendantIssueId}`)
+      .then((rows) => rows[0]?.count ?? 0);
+    const promotedBlockedRunCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${blockedIssueId}`)
+      .then((rows) => rows[0]?.count ?? 0);
     const blockedWakeRequestCount = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(agentWakeupRequests)
@@ -404,6 +432,8 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       .then((rows) => rows[0]?.count ?? 0);
 
     expect(promotedBlockedRun?.status).toBe("succeeded");
+    expect(promotedBlockedRunCount).toBe(1);
+    expect(descendantRuns).toBe(0);
     expect(blockedWakeRequestCount).toBeGreaterThanOrEqual(2);
 
     const noActiveRuns = await waitForCondition(async () => {
@@ -680,7 +710,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     }
   }, 40_000);
 
-  it("cancels stale queued runs when issue blockers are still unresolved", async () => {
+  it("cancels queued comment wakes when issue blockers are still unresolved", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const blockerId = randomUUID();
@@ -755,8 +785,8 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         agentId,
         source: "automation",
         triggerDetail: "system",
-        reason: "transient_failure_retry",
-        payload: { issueId: blockedIssueId },
+        reason: "issue_commented",
+        payload: { issueId: blockedIssueId, commentId: randomUUID() },
         status: "queued",
       },
       {
@@ -781,7 +811,8 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         wakeupRequestId: blockedWakeupRequestId,
         contextSnapshot: {
           issueId: blockedIssueId,
-          wakeReason: "transient_failure_retry",
+          wakeReason: "issue_commented",
+          commentId: randomUUID(),
         },
       },
       {

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -467,6 +467,105 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     expect(noActiveRuns).toBe(true);
   });
 
+  it("atomically claims one dependency-resolution wake across concurrent producers", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerId = randomUUID();
+    const dependentIssueId = randomUUID();
+    const idempotencyKey = `issue_blockers_resolved:${dependentIssueId}:${blockerId}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "DependencyWakeOwner",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Resolved prerequisite",
+        status: "done",
+        priority: "high",
+        responsibleUserId: "responsible-user",
+      },
+      {
+        id: dependentIssueId,
+        companyId,
+        title: "Ready dependent",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        responsibleUserId: "responsible-user",
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: dependentIssueId,
+      type: "blocks",
+    });
+
+    const wake = (source: "route" | "recovery") => heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: dependentIssueId, resolvedBlockerIssueId: blockerId, source },
+      idempotencyKey,
+      contextSnapshot: {
+        issueId: dependentIssueId,
+        wakeReason: "issue_blockers_resolved",
+        resolvedBlockerIssueId: blockerId,
+        source,
+      },
+    });
+
+    const [routeTimeWake, recoveryWake] = await Promise.all([wake("route"), wake("recovery")]);
+    expect([routeTimeWake, recoveryWake].filter(Boolean)).toHaveLength(1);
+
+    const completed = await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${dependentIssueId}`)
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+    expect(completed).toBe(true);
+
+    const dependencyWakeRequests = await db
+      .select({ id: agentWakeupRequests.id, runId: agentWakeupRequests.runId })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.idempotencyKey, idempotencyKey),
+      ));
+    const dependencyRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.companyId, companyId),
+        sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${dependentIssueId}`,
+        sql`${heartbeatRuns.contextSnapshot} ->> 'wakeReason' = 'issue_blockers_resolved'`,
+      ));
+
+    expect(dependencyWakeRequests).toHaveLength(1);
+    expect(dependencyWakeRequests[0]?.runId).toBe(dependencyRuns[0]?.id);
+    expect(dependencyRuns).toHaveLength(1);
+  });
+
   it("defers issue_blockers_resolved as a follow-up when the same issue is already running", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -363,6 +363,18 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       .then((rows) => rows[0] ?? null);
 
     expect(readyRun?.status).toBe("succeeded");
+    // Run status is persisted before finalization clears the issue lock. Wait for
+    // finalization so the explicit post-resolution wake below is the only owner
+    // wake introduced after the blocker becomes done.
+    const readyRunReleased = await waitForCondition(async () => {
+      const issue = await db
+        .select({ executionRunId: issues.executionRunId })
+        .from(issues)
+        .where(eq(issues.id, readyIssueId))
+        .then((rows) => rows[0] ?? null);
+      return issue?.executionRunId === null;
+    });
+    expect(readyRunReleased).toBe(true);
 
     await db
       .update(issues)

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1078,7 +1078,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
-  it("cancels queued runs when the issue reaches a terminal status before the run starts", async () => {
+  it("cancels queued comment wakes when the issue reaches a terminal status before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();
     await db.insert(issues).values({
@@ -1094,7 +1094,11 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       companyId,
       agentId,
       issueId,
-      wakeReason: "issue_assigned",
+      wakeReason: "issue_commented",
+      contextExtras: {
+        wakeCommentId: "comment-1",
+        wakeReason: "issue_commented",
+      },
     });
 
     await heartbeat.resumeQueuedRuns();

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -398,16 +398,17 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
-    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+  it("explicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+    const issue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
-      ...makeIssue("done"),
+      ...issue,
       ...patch,
     }));
 
     const res = await request(await installActor(createApp()))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
-      .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
+      .send({ comment: "hello", reopen: true, assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -510,31 +511,30 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("keeps done issues terminal for ordinary POST comments when an agent is assigned", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
       ...patch,
     }));
 
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-ordinary-done",
+      issueId: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      body: "hello",
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([
+      "44444444-4444-4444-8444-444444444444",
+    ]);
+
     const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {
@@ -1156,7 +1156,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("still implicitly reopens done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
+  it("keeps done issues terminal when a POST comment runId differs from the issue's owning run", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),
       checkoutRunId: "run-owning",
@@ -1179,9 +1179,9 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "Real human follow-up — please reopen" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({ status: "todo" }),
     );
   });
 

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -41,8 +41,10 @@ const mockTx = vi.hoisted(() => ({
   insert: mockTxInsert,
 }));
 const mockDbSelectOrderBy = vi.hoisted(() => vi.fn(async () => []));
+const mockDbSelectLimit = vi.hoisted(() => vi.fn(async () => []));
 const mockDbSelectWhere = vi.hoisted(() => vi.fn(() => ({
   orderBy: mockDbSelectOrderBy,
+  limit: mockDbSelectLimit,
   then: (onFulfilled: (rows: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
     Promise.resolve([]).then(onFulfilled, onRejected),
 })));
@@ -272,12 +274,15 @@ describe.sequential("issue comment reopen routes", () => {
     mockDbSelectFrom.mockReset();
     mockDbSelectWhere.mockReset();
     mockDbSelectOrderBy.mockReset();
+    mockDbSelectLimit.mockReset();
     mockDb.transaction.mockReset();
     mockTxInsertValues.mockResolvedValue(undefined);
     mockTxInsert.mockImplementation(() => ({ values: mockTxInsertValues }));
     mockDbSelectOrderBy.mockResolvedValue([]);
+    mockDbSelectLimit.mockResolvedValue([]);
     mockDbSelectWhere.mockImplementation(() => ({
       orderBy: mockDbSelectOrderBy,
+      limit: mockDbSelectLimit,
       then: (onFulfilled: (rows: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
         Promise.resolve([]).then(onFulfilled, onRejected),
     }));

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1727,7 +1727,7 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   // Only human comments should implicitly reopen finished work.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -8445,24 +8445,26 @@ export function issueRoutes(
           logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
         }
 
-        for (const mentionedId of mentionedIds) {
-          if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
-          addWakeup(mentionedId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "issue_comment_mentioned",
-            payload: { issueId: id, commentId: comment.id },
-            requestedByActorType: actor.actorType,
-            requestedByActorId: actor.actorId,
-            contextSnapshot: {
-              issueId: id,
-              taskId: id,
-              commentId: comment.id,
-              wakeCommentId: comment.id,
-              wakeReason: "issue_comment_mentioned",
-              source: "comment.mention",
-            },
-          });
+        if (reopened || !isClosed) {
+          for (const mentionedId of mentionedIds) {
+            if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
+            addWakeup(mentionedId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "issue_comment_mentioned",
+              payload: { issueId: id, commentId: comment.id },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: id,
+                taskId: id,
+                commentId: comment.id,
+                wakeCommentId: comment.id,
+                wakeReason: "issue_comment_mentioned",
+                source: "comment.mention",
+              },
+            });
+          }
         }
       }
 
@@ -9975,24 +9977,26 @@ export function issueRoutes(
         logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
       }
 
-      for (const mentionedId of mentionedIds) {
-        if (actorIsAgent && actor.actorId === mentionedId) continue;
-        addWakeup(mentionedId, {
-          source: "automation",
-          triggerDetail: "system",
-          reason: "issue_comment_mentioned",
-          payload: { issueId: id, commentId: comment.id },
-          requestedByActorType: actor.actorType,
-          requestedByActorId: actor.actorId,
-          contextSnapshot: {
-            issueId: id,
-            taskId: id,
-            commentId: comment.id,
-            wakeCommentId: comment.id,
-            wakeReason: "issue_comment_mentioned",
-            source: "comment.mention",
-          },
-        });
+      if (reopened || !isClosed) {
+        for (const mentionedId of mentionedIds) {
+          if (actorIsAgent && actor.actorId === mentionedId) continue;
+          addWakeup(mentionedId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_comment_mentioned",
+            payload: { issueId: id, commentId: comment.id },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: id,
+              taskId: id,
+              commentId: comment.id,
+              wakeCommentId: comment.id,
+              wakeReason: "issue_comment_mentioned",
+              source: "comment.mention",
+            },
+          });
+        }
       }
 
       const becameDone = issueBeforeCommentDecision.status !== "done" && currentIssue.status === "done";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3003,37 +3003,6 @@ function allowsIssueInteractionWake(
   return Boolean(deriveCommentId(contextSnapshot, null));
 }
 
-async function listUnresolvedBlockerSummaries(
-  dbOrTx: Pick<Db, "select">,
-  companyId: string,
-  issueId: string,
-  unresolvedBlockerIssueIds: string[],
-) {
-  const ids = [...new Set(unresolvedBlockerIssueIds.filter(Boolean))];
-  if (ids.length === 0) return [];
-  return dbOrTx
-    .select({
-      id: issues.id,
-      identifier: issues.identifier,
-      title: issues.title,
-      status: issues.status,
-      priority: issues.priority,
-      assigneeAgentId: issues.assigneeAgentId,
-      assigneeUserId: issues.assigneeUserId,
-    })
-    .from(issueRelations)
-    .innerJoin(issues, eq(issueRelations.issueId, issues.id))
-    .where(
-      and(
-        eq(issueRelations.companyId, companyId),
-        eq(issueRelations.type, "blocks"),
-        eq(issueRelations.relatedIssueId, issueId),
-        inArray(issues.id, ids),
-      ),
-    )
-    .orderBy(asc(issues.title));
-}
-
 export function formatRuntimeWorkspaceWarningLog(warning: string) {
   return {
     stream: "stdout" as const,
@@ -10274,7 +10243,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
       const readiness = dependencyReadiness.get(issueId);
       const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
-      if (unresolvedBlockerCount > 0 && !allowsIssueInteractionWake(context)) {
+      if (unresolvedBlockerCount > 0) {
         await cancelQueuedRunForBlockedDependencies(run, issueId, readiness?.unresolvedBlockerIssueIds ?? []);
         logger.info({ runId: run.id, issueId, unresolvedBlockerCount }, "claimQueuedRun: cancelled blocked queued run");
         return null;
@@ -15193,27 +15162,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           tx,
         ).then((rows) => rows.get(issue.id) ?? null);
 
-        // Blocked descendants should stay idle until the final blocker resolves.
-        // Human comment/mention wakes are the exception: they may run in a
-        // bounded interaction mode so the assignee can answer or triage.
-        const blockedInteractionWake =
-          dependencyReadiness &&
-          !dependencyReadiness.isDependencyReady &&
-          allowsIssueInteractionWake(enrichedContextSnapshot);
-
-        if (blockedInteractionWake) {
-          enrichedContextSnapshot.dependencyBlockedInteraction = true;
-          enrichedContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
-          enrichedContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
-          enrichedContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
-            tx,
-            issue.companyId,
-            issue.id,
-            dependencyReadiness.unresolvedBlockerIssueIds,
-          );
-        }
-
-        if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {
+        if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady) {
           await tx.insert(agentWakeupRequests).values({
             companyId: agent.companyId,
             agentId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14129,6 +14129,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
 
+        const deferredResumeIntent =
+          promotedContextSeed.resumeIntent === true || promotedContextSeed.followUpRequested === true;
+        if (
+          (issue.status === "done" || issue.status === "cancelled") &&
+          deferredCommentIds.length > 0 &&
+          !shouldReopenDeferredCommentWake &&
+          !deferredResumeIntent
+        ) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "skipped",
+              finishedAt: new Date(),
+              error: "Deferred comment wake suppressed because the issue reached terminal status without a valid reopen trigger",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
+
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
           (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10479,7 +10479,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
-      if (!resumeIntent && !wakeCommentId) {
+      // A comment is evidence, not an implicit resume command. A queued ordinary
+      // comment/mention wake must remain inert after the issue becomes terminal;
+      // only an explicit resume intent can revive it.
+      if (!resumeIntent) {
         return {
           stale: true,
           errorCode: "issue_terminal_status",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -134,7 +134,10 @@ import { issueService } from "./issues.js";
 import { createToolGatewayService } from "./tool-gateway.js";
 import { toolAccessService } from "./tool-access.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
-import { ISSUE_BLOCKERS_RESOLVED_WAKE_REASON } from "./issue-dependency-wakeups.js";
+import {
+  buildIssueBlockersResolvedWakeIdempotencyKey,
+  ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
+} from "./issue-dependency-wakeups.js";
 import {
   buildIssueMonitorClearedPatch,
   buildIssueMonitorTriggeredPatch,
@@ -14627,6 +14630,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       payload,
     });
     let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+    const resolvedBlockerIssueId =
+      readNonEmptyString(parseObject(payload).resolvedBlockerIssueId) ??
+      readNonEmptyString(enrichedContextSnapshot.resolvedBlockerIssueId);
+    let idempotencyKey = opts.idempotencyKey ?? null;
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
@@ -14759,6 +14766,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
       }
+    }
+    if (!idempotencyKey && reason === ISSUE_BLOCKERS_RESOLVED_WAKE_REASON && issueId && resolvedBlockerIssueId) {
+      idempotencyKey = buildIssueBlockersResolvedWakeIdempotencyKey({
+        dependentIssueId: issueId,
+        resolvedBlockerIssueId,
+      });
     }
     // Propagate projectId into context so resolveWorkspaceForRun can bind the
     // project workspace even when context.projectId wasn't set by the caller.
@@ -15608,7 +15621,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             status: "queued",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
+            idempotencyKey,
           })
           .returning()
           .then((rows) => rows[0]);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -136,6 +136,7 @@ import { toolAccessService } from "./tool-access.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import {
   buildIssueBlockersResolvedWakeIdempotencyKey,
+  findExistingIssueBlockersResolvedWake,
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
 } from "./issue-dependency-wakeups.js";
 import {
@@ -15151,6 +15152,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(eq(issues.id, issue.id));
         }
 
+        // Every dependency-resolution producer enters this issue-row transaction.
+        // Claim the canonical key here, after the row lock, rather than relying on
+        // each producer's pre-enqueue lookup. This serializes route and recovery
+        // producers and preserves retries when a prior attempt was only skipped.
+        if (reason === ISSUE_BLOCKERS_RESOLVED_WAKE_REASON && idempotencyKey) {
+          const existingWake = await findExistingIssueBlockersResolvedWake(tx, {
+            companyId: agent.companyId,
+            idempotencyKey,
+          });
+          if (existingWake) return { kind: "deduplicated" as const };
+        }
+
         if (!activeExecutionRun) {
           const legacyRun = await tx
             .select()
@@ -15658,7 +15671,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "queued" as const, run: newRun };
       });
 
-      if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
+      if (outcome.kind === "deferred" || outcome.kind === "skipped" || outcome.kind === "deduplicated") return null;
       if (outcome.kind === "coalesced") {
         await startNextQueuedRunForAgent(agent.id);
         return outcome.run;

--- a/server/src/services/issue-dependency-wakeups.ts
+++ b/server/src/services/issue-dependency-wakeups.ts
@@ -2,6 +2,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentWakeupRequests } from "@paperclipai/db";
 
+type WakeupRequestReader = Pick<Db, "select">;
+
 export const ISSUE_BLOCKERS_RESOLVED_WAKE_REASON = "issue_blockers_resolved";
 
 const IDEMPOTENT_DEPENDENCY_WAKE_STATUSES = [
@@ -23,7 +25,7 @@ export function buildIssueBlockersResolvedWakeIdempotencyKey(input: {
 }
 
 export async function findExistingIssueBlockersResolvedWake(
-  db: Db,
+  db: WakeupRequestReader,
   input: {
     companyId: string;
     idempotencyKey: string;
@@ -44,7 +46,7 @@ export async function findExistingIssueBlockersResolvedWake(
 }
 
 export async function findExistingIssueBlockersResolvedWakeForAnyKey(
-  db: Db,
+  db: WakeupRequestReader,
   input: {
     companyId: string;
     idempotencyKeys: string[];


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent work and creates heartbeat runs from issue events.
> - The heartbeat service must block work that depends on unfinished issues.
> - A comment on a dependency-blocked WPR2 gate created an executable run.
> - A comment on a terminal issue could also reopen the issue without explicit intent.
> - This pull request makes dependency and terminal state authoritative before a run is created or claimed.
> - The benefit is a safe control plane with one intended wake after the real prerequisite resolves.

## Linked Issues or Issue Description

**Describe the bug**
A comment or mention on an issue with unresolved dependencies could create a live or queued agent run. A normal comment on a done or cancelled issue could also reopen work or send a mention wake without an explicit reopen action.

**To Reproduce**
Create an assigned issue with an unresolved blocker or a terminal status. Post a normal comment or a comment with an agent mention. Observe that the old control path could enqueue work that was not ready.

**Expected behavior**
Paperclip records a skipped wake while dependencies remain unresolved. A normal terminal comment stays inert. A supported explicit reopen action can create the intended next wake after the prerequisite is terminal.

**Actual behavior**
The previous bounded interaction exception allowed dependency-blocked comment and mention wakes to create runnable work. Terminal comments could re-enter the normal wake path without explicit reopen intent.

## What Changed

- Remove the runnable dependency-blocked interaction exception and revalidate dependencies when a queued run is claimed.
- Gate an in-review parent while an externally owned child is non-terminal.
- Allow the parent wake only after that child is done or cancelled.
- Require explicit reopen intent for terminal issue comment wakes.
- Suppress terminal issue mention wakes unless the comment explicitly reopens the issue.
- Add route and scheduler regression coverage.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issue-update-comment-wakeup-routes.test.ts` passed: 105 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `git diff --check origin/master...HEAD` passed.
- The embedded PostgreSQL scheduler suites were skipped on this host because the fixture did not start after five attempts. CI must run those suites.

## Risks

The behavior change intentionally suppresses agent execution for comments and mentions on dependency-blocked work. This prevents the WPR2 execution defect. Users can still use the issue thread for coordination, and the owner receives the next execution wake only after the actual gate resolves. The main residual risk is an unintended suppression of a valid wake, covered by the resolved-owner-child regression and pending CI.

## Model Used

OpenAI Codex gpt-5.6-terra. Tool-assisted code navigation, source review, rebasing, focused tests, TypeScript typecheck, and GitHub CLI verification were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked the existing PR lineage
- [x] I have described the issue in this PR following the bug issue template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change
- [x] I have run focused tests locally
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open recommendations
- [x] I will address all reviewer comments before requesting merge