### PR TITLE
fix: accept environment and routine push credentials

### DIFF
--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -401,7 +401,7 @@ describe("resolveExecutionRunAdapterConfig", () => {
     });
   });
 
-  it("fails push-capability preflight when no GitHub write credential is bound at agent or project scope", async () => {
+  it("fails push-capability preflight when no GitHub write credential is bound at any supported scope", async () => {
     await expect(resolveExecutionRunAdapterConfig({
       companyId: "company-1",
       agentId: "agent-1",
@@ -410,9 +410,10 @@ describe("resolveExecutionRunAdapterConfig", () => {
       projectEnv: { PROJECT_ONLY: "project-only" },
       requiredScopedEnvBinding: {
         keys: ["GH_TOKEN", "GITHUB_TOKEN"],
-        consumerScopes: ["agent", "project"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
         reason: "push_write_credential_missing",
-        remediation: "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at project or agent scope.",
+        remediation:
+          "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at agent, project, environment, or routine scope.",
       },
       secretsSvc: {
         resolveAdapterConfigForRuntime: vi.fn(),
@@ -420,13 +421,45 @@ describe("resolveExecutionRunAdapterConfig", () => {
       } as any,
     })).rejects.toMatchObject({
       code: "configuration_incomplete",
-      message: expect.stringContaining("GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN"),
+      message: expect.stringContaining("agent, project, environment, or routine scope"),
       resultJson: {
         configurationIncomplete: {
           reason: "push_write_credential_missing",
           requiredEnvKeys: ["GH_TOKEN", "GITHUB_TOKEN"],
-          requiredScopes: ["agent", "project"],
+          requiredScopes: ["agent", "project", "environment", "routine"],
           missingBindings: [],
+        },
+      },
+    });
+  });
+
+  it("does not accept a lowercase GitHub credential binding key", async () => {
+    await expect(resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      environmentId: "environment-1",
+      routineId: "routine-1",
+      executionRunConfig: { env: { gh_token: "agent-token" } },
+      environmentEnv: { gh_token: "environment-token" },
+      projectEnv: { gh_token: "project-token" },
+      routineEnv: { gh_token: "routine-token" },
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation:
+          "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at agent, project, environment, or routine scope.",
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime: vi.fn(),
+        resolveEnvBindings: vi.fn(),
+      } as any,
+    })).rejects.toMatchObject({
+      code: "configuration_incomplete",
+      resultJson: {
+        configurationIncomplete: {
+          reason: "push_write_credential_missing",
         },
       },
     });
@@ -454,9 +487,10 @@ describe("resolveExecutionRunAdapterConfig", () => {
       projectEnv: { GH_TOKEN: { type: "plain", value: "github-token" } },
       requiredScopedEnvBinding: {
         keys: ["GH_TOKEN", "GITHUB_TOKEN"],
-        consumerScopes: ["agent", "project"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
         reason: "push_write_credential_missing",
-        remediation: "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at project or agent scope.",
+        remediation:
+          "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at agent, project, environment, or routine scope.",
       },
       secretsSvc: {
         resolveAdapterConfigForRuntime,
@@ -474,6 +508,98 @@ describe("resolveExecutionRunAdapterConfig", () => {
     expect(collectMissingRuntimeBindings.mock.calls[1]?.[2]).toMatchObject({
       consumerType: "project",
       consumerId: "project-1",
+    });
+  });
+
+  it("passes push-capability preflight for an environment-scoped GitHub credential", async () => {
+    const resolveAdapterConfigForRuntime = vi.fn().mockResolvedValue({
+      config: { env: { AGENT_ONLY: "agent-only" } },
+      secretKeys: new Set<string>(),
+      manifest: [],
+    });
+    const resolveEnvBindings = vi.fn().mockResolvedValue({
+      env: { GH_TOKEN: "environment-token" },
+      secretKeys: new Set(["GH_TOKEN"]),
+      manifest: [],
+    });
+    const collectMissingRuntimeBindings = vi.fn().mockResolvedValue([]);
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      environmentId: "environment-1",
+      environmentEnv: { GH_TOKEN: { type: "plain", value: "environment-token" } },
+      executionRunConfig: { env: { AGENT_ONLY: "agent-only" } },
+      projectEnv: null,
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation:
+          "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at agent, project, environment, or routine scope.",
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime,
+        resolveEnvBindings,
+        collectMissingRuntimeBindings,
+      } as any,
+    });
+
+    expect(result.resolvedConfig.env).toEqual({
+      GH_TOKEN: "environment-token",
+      AGENT_ONLY: "agent-only",
+    });
+    expect(resolveEnvBindings).toHaveBeenCalledOnce();
+    expect(collectMissingRuntimeBindings.mock.calls[0]?.[2]).toMatchObject({
+      consumerType: "environment",
+      consumerId: "environment-1",
+    });
+  });
+
+  it("passes push-capability preflight for a routine-scoped GitHub credential", async () => {
+    const resolveAdapterConfigForRuntime = vi.fn().mockResolvedValue({
+      config: { env: { AGENT_ONLY: "agent-only" } },
+      secretKeys: new Set<string>(),
+      manifest: [],
+    });
+    const resolveEnvBindings = vi.fn().mockResolvedValue({
+      env: { GITHUB_TOKEN: "routine-token" },
+      secretKeys: new Set(["GITHUB_TOKEN"]),
+      manifest: [],
+    });
+    const collectMissingRuntimeBindings = vi.fn().mockResolvedValue([]);
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      routineId: "routine-1",
+      executionRunConfig: { env: { AGENT_ONLY: "agent-only" } },
+      projectEnv: null,
+      routineEnv: { GITHUB_TOKEN: { type: "plain", value: "routine-token" } },
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation:
+          "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at agent, project, environment, or routine scope.",
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime,
+        resolveEnvBindings,
+        collectMissingRuntimeBindings,
+      } as any,
+    });
+
+    expect(result.resolvedConfig.env).toEqual({
+      AGENT_ONLY: "agent-only",
+      GITHUB_TOKEN: "routine-token",
+    });
+    expect(resolveEnvBindings).toHaveBeenCalledOnce();
+    expect(collectMissingRuntimeBindings.mock.calls[1]?.[2]).toMatchObject({
+      consumerType: "routine",
+      consumerId: "routine-1",
     });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -913,7 +913,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
   trustPreset?: TrustPresetResolution;
   requiredScopedEnvBinding?: {
     keys: string[];
-    consumerScopes: Array<"agent" | "project">;
+    consumerScopes: Array<"agent" | "project" | "environment" | "routine">;
     reason: string;
     remediation: string;
   };
@@ -940,6 +940,12 @@ export async function resolveExecutionRunAdapterConfig(input: {
     ) || (
       requiredScopedEnvBinding.consumerScopes.includes("project")
       && isConfiguredEnvBindingValue(projectEnv?.[key])
+    ) || (
+      requiredScopedEnvBinding.consumerScopes.includes("environment")
+      && isConfiguredEnvBindingValue(environmentEnv?.[key])
+    ) || (
+      requiredScopedEnvBinding.consumerScopes.includes("routine")
+      && isConfiguredEnvBindingValue(routineEnv?.[key])
     ))
     : false;
   if (requiredScopedEnvBinding && !requiredScopedBindingsConfigured) {
@@ -1033,7 +1039,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
       const requiredEnvKeys = new Set(requiredScopedEnvBinding.keys);
       const requiredScopes = new Set(requiredScopedEnvBinding.consumerScopes);
       const requiredMissingBindings = missingBindings.filter((binding) =>
-        requiredScopes.has(binding.consumerType as "agent" | "project")
+        requiredScopes.has(binding.consumerType as "agent" | "project" | "environment" | "routine")
         && requiredEnvKeys.has(binding.envKey),
       );
       if (requiredMissingBindings.length > 0) {
@@ -14596,10 +14602,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       requiredScopedEnvBinding: pushCapabilityPreflightRequired
         ? {
             keys: [...PUSH_CAPABILITY_ENV_KEYS],
-            consumerScopes: ["agent", "project"],
+            consumerScopes: ["agent", "project", "environment", "routine"],
             reason: "push_write_credential_missing",
             remediation:
-              "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at project or agent scope.",
+              "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at agent, project, environment, or routine scope.",
           }
         : undefined,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent runs through heartbeat dispatch.
> - Some agent runs must push Git changes before they can complete their work.
> - The push preflight checks for a GitHub token before dispatch.
> - The runtime already supports environment and routine environment overlays.
> - The preflight checked only agent and project overlays, so it rejected valid configurations.
> - This pull request checks all four runtime environment scopes.
> - The benefit is that valid environment-scoped and routine-scoped credentials can dispatch without weakening the exact-case token check.

## Linked Issues or Issue Description

**What happened?**

The push-capability preflight rejected runs when `GH_TOKEN` or `GITHUB_TOKEN` was configured in an environment or routine overlay. The runtime parsed and resolved both overlays, but the preflight inspected only agent and project environment bindings.

**Expected behavior**

The preflight should accept an exact-case `GH_TOKEN` or `GITHUB_TOKEN` binding from the agent, project, environment, or routine scope. A lowercase binding must not pass because environment variable names are case-sensitive.

**Steps to reproduce**

1. Configure a local Git-sensitive agent that uses the GitHub PR workflow.
2. Bind `GH_TOKEN` only in the selected environment or routine environment.
3. Start the run.
4. Observe that dispatch stops with `push_write_credential_missing` before this change.

**Paperclip version or commit**

Current `master` before this pull request.

**Deployment mode**

Local or self-hosted execution with a Git-sensitive local adapter.

## What Changed

- Accept exact-case GitHub token bindings from environment and routine scopes in the push preflight.
- Pass all four scopes at dispatch and list all probed scopes in the remediation message.
- Add regression tests for environment, routine, lowercase, and missing bindings.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-project-env.test.ts` — 38 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed on the isolated change before parallel work entered the shared execution worktree.
- GitHub CI — the full clean-checkout matrix passed on commit `6d4664801c`.

## Risks

- Low risk. The change only widens the accepted source scopes for two exact-case environment keys.
- Existing agent and project behavior stays unchanged.
- No schema, migration, public API, telemetry, or UI behavior changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex based on GPT-5. The runtime does not expose a more specific model deployment ID or context-window size. The agent used reasoning, repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
