### PR TITLE
fix: accept ambient host credentials for local push runs

### DIFF
--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -1026,6 +1026,55 @@ describe("resolveExecutionRunAdapterConfig", () => {
     expect(resolveInjectedEnvBindingForRuntime).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["agent", "empty string", { executionRunConfig: { env: { GH_TOKEN: "" } } }],
+    ["agent", "empty plain binding", { executionRunConfig: { env: { GITHUB_TOKEN: { type: "plain", value: "" } } } }],
+    ["project", "empty string", { projectEnv: { GH_TOKEN: "" } }],
+    ["project", "empty plain binding", { projectEnv: { GITHUB_TOKEN: { type: "plain", value: "" } } }],
+    ["environment", "empty string", { environmentEnv: { GH_TOKEN: "" } }],
+    ["environment", "empty plain binding", { environmentEnv: { GITHUB_TOKEN: { type: "plain", value: "" } } }],
+    ["routine", "empty string", { routineEnv: { GH_TOKEN: "" } }],
+    ["routine", "empty plain binding", { routineEnv: { GITHUB_TOKEN: { type: "plain", value: "" } } }],
+  ])("fails closed for an explicit %s-scoped %s instead of injecting a company secret", async (_scope, _binding, scopeConfig) => {
+    const getByNameInsensitive = vi.fn().mockResolvedValue({ id: "secret-1", name: "GH_TOKEN" });
+    const resolveInjectedEnvBindingForRuntime = vi.fn();
+
+    await expect(resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      projectId: "project-1",
+      environmentId: "environment-1",
+      routineId: "routine-1",
+      executionRunConfig: { env: {} },
+      projectEnv: null,
+      ...scopeConfig,
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation: "No GitHub credential found.",
+        fallbackSecretNames: ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"],
+        fallbackInjectionEnvKey: "GH_TOKEN",
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime: vi.fn(),
+        resolveEnvBindings: vi.fn(),
+        resolveInjectedEnvBindingForRuntime,
+        getByNameInsensitive,
+      } as any,
+    })).rejects.toMatchObject({
+      code: "configuration_incomplete",
+      resultJson: {
+        configurationIncomplete: {
+          reason: "push_write_credential_missing",
+        },
+      },
+    });
+    expect(getByNameInsensitive).not.toHaveBeenCalled();
+    expect(resolveInjectedEnvBindingForRuntime).not.toHaveBeenCalled();
+  });
+
   it("skips well-known-secret injection when a supported-scope binding exists", async () => {
     const getByNameInsensitive = vi.fn();
     const resolveInjectedEnvBindingForRuntime = vi.fn();

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -479,7 +479,7 @@ describe("resolveExecutionRunAdapterConfig", () => {
       } as any,
     });
 
-    expect(probe).toHaveBeenCalledWith("/checkout");
+    expect(probe).toHaveBeenCalledWith("/checkout", { configuredPushUrls: undefined });
     expect(result.resolvedConfig.env).toEqual({ AGENT_ONLY: "agent-only" });
     expect(result.secretKeys).toEqual(new Set());
     expect(getByNameInsensitive).not.toHaveBeenCalled();

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -442,6 +442,168 @@ describe("resolveExecutionRunAdapterConfig", () => {
     ]);
   });
 
+  it("passes with an ambient gh credential without injecting a token into the run env", async () => {
+    const probe = vi.fn().mockResolvedValue("gh_cli");
+    const getByNameInsensitive = vi.fn();
+    const resolveInjectedEnvBindingForRuntime = vi.fn();
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      executionRunConfig: { env: { AGENT_ONLY: "agent-only" } },
+      projectEnv: null,
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation: "No GitHub credential found.",
+        fallbackSecretNames: ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"],
+        fallbackInjectionEnvKey: "GH_TOKEN",
+        ambientHostCredential: {
+          enabled: true,
+          checkoutCwd: "/checkout",
+          probe,
+        },
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime: vi.fn().mockResolvedValue({
+          config: { env: { AGENT_ONLY: "agent-only" } },
+          secretKeys: new Set<string>(),
+          manifest: [],
+        }),
+        resolveEnvBindings: vi.fn(),
+        resolveInjectedEnvBindingForRuntime,
+        getByNameInsensitive,
+        collectMissingRuntimeBindings: vi.fn().mockResolvedValue([]),
+      } as any,
+    });
+
+    expect(probe).toHaveBeenCalledWith("/checkout");
+    expect(result.resolvedConfig.env).toEqual({ AGENT_ONLY: "agent-only" });
+    expect(result.secretKeys).toEqual(new Set());
+    expect(getByNameInsensitive).not.toHaveBeenCalled();
+    expect(resolveInjectedEnvBindingForRuntime).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["timeout", Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })],
+    ["non-zero exit", Object.assign(new Error("exited 1"), { code: 1 })],
+  ])("falls through to the company-secret tier after an ambient gh probe %s", async (_case, probeError) => {
+    const probe = vi.fn().mockRejectedValue(probeError);
+    const resolveInjectedEnvBindingForRuntime = vi.fn().mockResolvedValue({
+      env: { GH_TOKEN: "resolved-token" },
+      secretKeys: new Set(["GH_TOKEN"]),
+      manifest: [],
+    });
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      executionRunConfig: { env: {} },
+      projectEnv: null,
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation: "No GitHub credential found.",
+        fallbackSecretNames: ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"],
+        fallbackInjectionEnvKey: "GH_TOKEN",
+        ambientHostCredential: { enabled: true, checkoutCwd: "/checkout", probe },
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime: vi.fn().mockResolvedValue({
+          config: { env: {} },
+          secretKeys: new Set<string>(),
+          manifest: [],
+        }),
+        resolveEnvBindings: vi.fn(),
+        resolveInjectedEnvBindingForRuntime,
+        getByNameInsensitive: vi.fn().mockResolvedValue({ id: "secret-1", name: "GH_TOKEN" }),
+        collectMissingRuntimeBindings: vi.fn().mockResolvedValue([]),
+      } as any,
+    });
+
+    expect(probe).toHaveBeenCalledOnce();
+    expect(result.resolvedConfig.env).toEqual({ GH_TOKEN: "resolved-token" });
+    expect(resolveInjectedEnvBindingForRuntime).toHaveBeenCalledOnce();
+  });
+
+  it("passes with an SSH-style push remote and no injected token", async () => {
+    const probe = vi.fn().mockResolvedValue("ssh_push_remote");
+    const resolveInjectedEnvBindingForRuntime = vi.fn();
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      executionRunConfig: { env: {} },
+      projectEnv: null,
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation: "No GitHub credential found.",
+        fallbackSecretNames: ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"],
+        fallbackInjectionEnvKey: "GH_TOKEN",
+        ambientHostCredential: { enabled: true, checkoutCwd: "/checkout", probe },
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime: vi.fn().mockResolvedValue({
+          config: { env: {} },
+          secretKeys: new Set<string>(),
+          manifest: [],
+        }),
+        resolveEnvBindings: vi.fn(),
+        resolveInjectedEnvBindingForRuntime,
+        getByNameInsensitive: vi.fn(),
+        collectMissingRuntimeBindings: vi.fn().mockResolvedValue([]),
+      } as any,
+    });
+
+    expect(result.resolvedConfig.env).toEqual({});
+    expect(resolveInjectedEnvBindingForRuntime).not.toHaveBeenCalled();
+  });
+
+  it("skips the ambient tier for a remote execution target", async () => {
+    const probe = vi.fn();
+    const resolveInjectedEnvBindingForRuntime = vi.fn().mockResolvedValue({
+      env: { GH_TOKEN: "resolved-token" },
+      secretKeys: new Set(["GH_TOKEN"]),
+      manifest: [],
+    });
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      executionRunConfig: { env: {} },
+      projectEnv: null,
+      requiredScopedEnvBinding: {
+        keys: ["GH_TOKEN", "GITHUB_TOKEN"],
+        consumerScopes: ["agent", "project", "environment", "routine"],
+        reason: "push_write_credential_missing",
+        remediation: "No GitHub credential found.",
+        fallbackSecretNames: ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"],
+        fallbackInjectionEnvKey: "GH_TOKEN",
+        ambientHostCredential: { enabled: false, checkoutCwd: "/checkout", probe },
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime: vi.fn().mockResolvedValue({
+          config: { env: {} },
+          secretKeys: new Set<string>(),
+          manifest: [],
+        }),
+        resolveEnvBindings: vi.fn(),
+        resolveInjectedEnvBindingForRuntime,
+        getByNameInsensitive: vi.fn().mockResolvedValue({ id: "secret-1", name: "GH_TOKEN" }),
+        collectMissingRuntimeBindings: vi.fn().mockResolvedValue([]),
+      } as any,
+    });
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(result.resolvedConfig.env).toEqual({ GH_TOKEN: "resolved-token" });
+  });
+
   it("does not accept a lowercase GitHub credential binding key", async () => {
     await expect(resolveExecutionRunAdapterConfig({
       companyId: "company-1",

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -22,6 +22,7 @@ import {
   mergeExecutionWorkspaceMetadataForPersistence,
   mergeCoalescedContextSnapshot,
   preflightLowTrustWorkspaceIsolation,
+  probeAmbientHostPushCredential,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
   provisionExecutionWorkspaceForFreshnessDecision,
@@ -36,6 +37,7 @@ import {
   resolveWorkspaceAfterLowTrustPreflight,
   resolveRuntimeSessionParamsForWorkspace,
   shouldDeferFollowupWakeForSameIssue,
+  shouldProbeAmbientHostPushCredential,
   stripHostWorkspaceProvisionForLowTrustSandbox,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForModelChange,
@@ -969,6 +971,84 @@ describe("assertPushCapabilityCheckoutValid", () => {
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+describe("probeAmbientHostPushCredential", () => {
+  it("uses the host gh auth store without passing an injected environment", async () => {
+    const execFileMock = vi.fn().mockResolvedValue({ stdout: "gho_ambient\n", stderr: "" });
+
+    await expect(probeAmbientHostPushCredential("/checkout", {
+      execFile: execFileMock as unknown as typeof execFile,
+    })).resolves.toBe("gh_cli");
+
+    expect(execFileMock).toHaveBeenCalledOnce();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "gh",
+      ["auth", "token", "--hostname", "github.com"],
+      expect.objectContaining({ timeout: 2_000 }),
+    );
+    expect(execFileMock.mock.calls[0]?.[2]).not.toHaveProperty("env");
+  });
+
+  it.each([
+    "ssh://git@github.com/example/repo.git",
+    "git@github.com:example/repo.git",
+  ])("accepts SSH push remote %s after the gh probe misses", async (pushUrl) => {
+    const execFileMock = vi.fn(async (command: string, args: string[]) => {
+      if (command === "gh") throw Object.assign(new Error("not logged in"), { code: 1 });
+      if (args[0] === "remote" && args.length === 1) return { stdout: "origin\n", stderr: "" };
+      return { stdout: `${pushUrl}\n`, stderr: "" };
+    });
+
+    await expect(probeAmbientHostPushCredential("/checkout", {
+      execFile: execFileMock as unknown as typeof execFile,
+    })).resolves.toBe("ssh_push_remote");
+    expect(execFileMock.mock.calls[0]?.[0]).toBe("gh");
+    expect(execFileMock.mock.calls[2]?.[1]).toEqual(["remote", "get-url", "--push", "origin"]);
+  });
+
+  it("treats gh and git probe failures as a tier miss", async () => {
+    const execFileMock = vi.fn().mockRejectedValue(Object.assign(new Error("timed out"), {
+      code: "ETIMEDOUT",
+    }));
+
+    await expect(probeAmbientHostPushCredential("/checkout", {
+      execFile: execFileMock as unknown as typeof execFile,
+    })).resolves.toBeNull();
+  });
+});
+
+describe("shouldProbeAmbientHostPushCredential", () => {
+  it.each(["ssh", "sandbox", "plugin"])("skips the ambient host tier for %s execution", (driver) => {
+    expect(shouldProbeAmbientHostPushCredential({
+      pushCapabilityPreflightRequired: true,
+      environmentDriver: driver,
+    })).toBe(false);
+  });
+
+  it("enables the ambient host tier for a standard local execution target", () => {
+    expect(shouldProbeAmbientHostPushCredential({
+      pushCapabilityPreflightRequired: true,
+      environmentDriver: "local",
+    })).toBe(true);
+  });
+
+  it("skips the host tier when low-trust preflight will redirect local selection to a sandbox", () => {
+    expect(shouldProbeAmbientHostPushCredential({
+      pushCapabilityPreflightRequired: true,
+      environmentDriver: "local",
+      trustPreset: {
+        kind: "low_trust_review",
+        preset: "low_trust_review",
+        boundary: {
+          mode: "low_trust_review",
+          companyId: "company-1",
+          issueIds: ["issue-1"],
+        },
+        sourcePresets: {},
+      },
+    })).toBe(false);
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -24,6 +24,7 @@ import {
   preflightLowTrustWorkspaceIsolation,
   probeAmbientHostPushCredential,
   prioritizeProjectWorkspaceCandidatesForRun,
+  resolveAmbientHostCredentialCheckout,
   parseSessionCompactionPolicy,
   provisionExecutionWorkspaceForFreshnessDecision,
   reconcileReusedExecutionWorkspaceProjectWorkspaceId,
@@ -1016,6 +1017,52 @@ describe("probeAmbientHostPushCredential", () => {
     await expect(probeAmbientHostPushCredential("/checkout", {
       execFile: execFileMock as unknown as typeof execFile,
     })).resolves.toBeNull();
+  });
+
+  it("accepts the selected fresh workspace SSH URL before its checkout exists", async () => {
+    const execFileMock = vi.fn(async (command: string) => {
+      if (command === "gh") throw Object.assign(new Error("not logged in"), { code: 1 });
+      throw Object.assign(new Error("checkout not realized"), { code: "ENOENT" });
+    });
+
+    await expect(probeAmbientHostPushCredential("/future/checkout", {
+      execFile: execFileMock as unknown as typeof execFile,
+      configuredPushUrls: ["git@github.com:example/repo.git"],
+    })).resolves.toBe("ssh_push_remote");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("resolveAmbientHostCredentialCheckout", () => {
+  it("uses the preferred fresh project workspace instead of the static adapter cwd", () => {
+    expect(resolveAmbientHostCredentialCheckout({
+      adapterCwd: "/static/adapter",
+      preferredProjectWorkspaceId: "workspace-2",
+      projectWorkspaces: [
+        { id: "workspace-1", cwd: "/checkout/one", repoUrl: "https://github.com/example/one.git" },
+        { id: "workspace-2", cwd: "/__paperclip_repo_only__", repoUrl: "git@github.com:example/two.git" },
+      ],
+    })).toEqual({
+      checkoutCwd: "/static/adapter",
+      configuredPushUrls: ["git@github.com:example/two.git"],
+    });
+  });
+
+  it("prefers a reusable realized checkout over project and adapter paths", () => {
+    expect(resolveAmbientHostCredentialCheckout({
+      adapterCwd: "/static/adapter",
+      preferredProjectWorkspaceId: "workspace-1",
+      projectWorkspaces: [
+        { id: "workspace-1", cwd: "/project/checkout", repoUrl: "git@github.com:example/project.git" },
+      ],
+      reusableExecutionWorkspace: {
+        cwd: "/reused/checkout",
+        repoUrl: "ssh://git@github.com/example/reused.git",
+      },
+    })).toEqual({
+      checkoutCwd: "/reused/checkout",
+      configuredPushUrls: ["ssh://git@github.com/example/reused.git"],
+    });
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -855,10 +855,14 @@ export type AmbientHostPushCredential = "gh_cli" | "ssh_push_remote";
  */
 export async function probeAmbientHostPushCredential(
   cwd: string | null | undefined,
-  deps: { execFile: typeof execFile } = { execFile },
+  deps: {
+    execFile?: typeof execFile;
+    configuredPushUrls?: readonly string[];
+  } = {},
 ): Promise<AmbientHostPushCredential | null> {
+  const execFileImpl = deps.execFile ?? execFile;
   try {
-    const result = await deps.execFile(
+    const result = await execFileImpl(
       "gh",
       ["auth", "token", "--hostname", "github.com"],
       { timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS, windowsHide: true },
@@ -868,38 +872,73 @@ export async function probeAmbientHostPushCredential(
     // A missing CLI, timeout, non-zero exit, or unreadable auth state is a tier miss.
   }
 
+  const pushUrls: string[] = [];
   const normalizedCwd = readNonEmptyString(cwd);
-  if (!normalizedCwd) return null;
-  const remoteNames = await deps.execFile(
-    "git",
-    ["remote"],
-    {
-      cwd: normalizedCwd,
-      timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS,
-      windowsHide: true,
-    },
-  ).then((result) =>
-    result.stdout
-      .split(/\r?\n/)
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0),
-  ).catch(() => []);
-
-  for (const remoteName of remoteNames) {
-    const pushUrl = await deps.execFile(
+  if (normalizedCwd) {
+    const remoteNames = await execFileImpl(
       "git",
-      ["remote", "get-url", "--push", remoteName],
+      ["remote"],
       {
         cwd: normalizedCwd,
         timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS,
         windowsHide: true,
       },
-    ).then((result) => readNonEmptyString(result.stdout)).catch(() => null);
-    if (pushUrl && (/^ssh:\/\//i.test(pushUrl) || /^[^\s/@:]+@[^\s/:]+:.+/.test(pushUrl))) {
-      return "ssh_push_remote";
+    ).then((result) =>
+      result.stdout
+        .split(/\r?\n/)
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0),
+    ).catch(() => []);
+
+    for (const remoteName of remoteNames) {
+      const pushUrl = await execFileImpl(
+        "git",
+        ["remote", "get-url", "--push", remoteName],
+        {
+          cwd: normalizedCwd,
+          timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS,
+          windowsHide: true,
+        },
+      ).then((result) => readNonEmptyString(result.stdout)).catch(() => null);
+      if (pushUrl) pushUrls.push(pushUrl);
     }
   }
+
+  // A fresh workspace has no checkout to inspect yet. Its selected project-workspace URL becomes
+  // the clone's origin, so treat that URL as the future push remote. This remains deliberately
+  // network-free: the tier identifies SSH transport, while the eventual push remains the authority
+  // for key, agent, host, and repository authorization.
+  pushUrls.push(...(deps.configuredPushUrls ?? []));
+  if (pushUrls.some((pushUrl) => (
+    /^ssh:\/\//i.test(pushUrl) || /^[^\s/@:]+@[^\s/:]+:.+/.test(pushUrl)
+  ))) {
+    return "ssh_push_remote";
+  }
   return null;
+}
+
+export function resolveAmbientHostCredentialCheckout(input: {
+  adapterCwd: string | null | undefined;
+  preferredProjectWorkspaceId: string | null | undefined;
+  projectWorkspaces: Array<{ id: string; cwd: string | null; repoUrl: string | null }>;
+  reusableExecutionWorkspace?: { cwd: string | null; repoUrl: string | null } | null;
+}) {
+  const selectedProjectWorkspace = prioritizeProjectWorkspaceCandidatesForRun(
+    input.projectWorkspaces,
+    input.preferredProjectWorkspaceId,
+  )[0] ?? null;
+  const reusableCwd = readNonEmptyString(input.reusableExecutionWorkspace?.cwd);
+  const projectCwd = readNonEmptyString(selectedProjectWorkspace?.cwd);
+  const checkoutCwd = reusableCwd
+    ?? (projectCwd === REPO_ONLY_CWD_SENTINEL ? null : projectCwd)
+    ?? readNonEmptyString(input.adapterCwd);
+  const configuredPushUrl = readNonEmptyString(
+    input.reusableExecutionWorkspace?.repoUrl ?? selectedProjectWorkspace?.repoUrl,
+  );
+  return {
+    checkoutCwd,
+    configuredPushUrls: configuredPushUrl ? [configuredPushUrl] : [],
+  };
 }
 
 export function shouldProbeAmbientHostPushCredential(input: {
@@ -996,6 +1035,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
     ambientHostCredential?: {
       enabled: boolean;
       checkoutCwd?: string | null;
+      configuredPushUrls?: readonly string[];
       probe?: typeof probeAmbientHostPushCredential;
     };
   };
@@ -1050,7 +1090,10 @@ export async function resolveExecutionRunAdapterConfig(input: {
     && requiredScopedEnvBinding.ambientHostCredential?.enabled
     ? await (
         requiredScopedEnvBinding.ambientHostCredential.probe ?? probeAmbientHostPushCredential
-      )(requiredScopedEnvBinding.ambientHostCredential.checkoutCwd).catch(() => null)
+      )(
+        requiredScopedEnvBinding.ambientHostCredential.checkoutCwd,
+        { configuredPushUrls: requiredScopedEnvBinding.ambientHostCredential.configuredPushUrls },
+      ).catch(() => null)
     : null;
   let fallbackSecret: Awaited<ReturnType<RuntimeConfigSecretResolver["getByNameInsensitive"]>> | null = null;
   let fallbackAuthorization: {
@@ -14794,6 +14837,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       environmentDriver: selectedEnvironmentForConfig?.driver ?? null,
       trustPreset,
     });
+    const ambientProjectWorkspaceRows = ambientHostPushCredentialEnabled
+      && requestedExecutionWorkspaceMode !== "agent_default"
+      && projectContext?.id
+      ? await db
+          .select({
+            id: projectWorkspaces.id,
+            cwd: projectWorkspaces.cwd,
+            repoUrl: projectWorkspaces.repoUrl,
+          })
+          .from(projectWorkspaces)
+          .where(and(
+            eq(projectWorkspaces.companyId, agent.companyId),
+            eq(projectWorkspaces.projectId, projectContext.id),
+          ))
+          .orderBy(asc(projectWorkspaces.createdAt), asc(projectWorkspaces.id))
+      : [];
+    const ambientHostCredentialCheckout = resolveAmbientHostCredentialCheckout({
+      adapterCwd: executionRunConfig.cwd as string | null | undefined,
+      preferredProjectWorkspaceId: issueRef?.projectWorkspaceId,
+      projectWorkspaces: ambientProjectWorkspaceRows,
+      reusableExecutionWorkspace: reusableExistingExecutionWorkspace
+        ? {
+            cwd: reusableExistingExecutionWorkspace.cwd,
+            repoUrl: reusableExistingExecutionWorkspace.repoUrl,
+          }
+        : null,
+    });
     const { resolvedConfig, secretKeys, secretManifest } = await resolveExecutionRunAdapterConfig({
       companyId: agent.companyId,
       agentId: agent.id,
@@ -14823,9 +14893,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             fallbackInjectionEnvKey: "GH_TOKEN",
             ambientHostCredential: {
               enabled: ambientHostPushCredentialEnabled,
-              checkoutCwd:
-                reusableExistingExecutionWorkspace?.cwd
-                ?? executionRunConfig.cwd as string | null | undefined,
+              checkoutCwd: ambientHostCredentialCheckout.checkoutCwd,
+              configuredPushUrls: ambientHostCredentialCheckout.configuredPushUrls,
             },
           }
         : undefined,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -824,7 +824,11 @@ function formatMissingBindingForOperator(missing: MissingRuntimeBinding): string
   return `secret ${secretLabel} not bound at ${missing.consumerType} ${missing.configPath}`;
 }
 
-function isConfiguredEnvBindingValue(binding: unknown) {
+function hasOwnEnvBinding(env: Record<string, unknown> | null, key: string) {
+  return env !== null && Object.prototype.hasOwnProperty.call(env, key);
+}
+
+function isUsableEnvBindingValue(binding: unknown) {
   const parsed = envBindingSchema.safeParse(binding);
   if (!parsed.success) return false;
   const value = parsed.data;
@@ -1011,23 +1015,38 @@ export async function resolveExecutionRunAdapterConfig(input: {
     assertLowTrustEnvConfigAllowed(routineEnv, "routine.env");
   }
   const requiredScopedEnvBinding = input.requiredScopedEnvBinding ?? null;
+  const requiredScopedBindingPresent = requiredScopedEnvBinding
+    ? requiredScopedEnvBinding.keys.some((key) => (
+      requiredScopedEnvBinding.consumerScopes.includes("agent")
+      && hasOwnEnvBinding(agentEnv, key)
+    ) || (
+      requiredScopedEnvBinding.consumerScopes.includes("project")
+      && hasOwnEnvBinding(projectEnv, key)
+    ) || (
+      requiredScopedEnvBinding.consumerScopes.includes("environment")
+      && hasOwnEnvBinding(environmentEnv, key)
+    ) || (
+      requiredScopedEnvBinding.consumerScopes.includes("routine")
+      && hasOwnEnvBinding(routineEnv, key)
+    ))
+    : false;
   const requiredScopedBindingsConfigured = requiredScopedEnvBinding
     ? requiredScopedEnvBinding.keys.some((key) => (
       requiredScopedEnvBinding.consumerScopes.includes("agent")
-      && isConfiguredEnvBindingValue(agentEnv[key])
+      && isUsableEnvBindingValue(agentEnv[key])
     ) || (
       requiredScopedEnvBinding.consumerScopes.includes("project")
-      && isConfiguredEnvBindingValue(projectEnv?.[key])
+      && isUsableEnvBindingValue(projectEnv?.[key])
     ) || (
       requiredScopedEnvBinding.consumerScopes.includes("environment")
-      && isConfiguredEnvBindingValue(environmentEnv?.[key])
+      && isUsableEnvBindingValue(environmentEnv?.[key])
     ) || (
       requiredScopedEnvBinding.consumerScopes.includes("routine")
-      && isConfiguredEnvBindingValue(routineEnv?.[key])
+      && isUsableEnvBindingValue(routineEnv?.[key])
     ))
     : false;
   const ambientHostCredential = requiredScopedEnvBinding
-    && !requiredScopedBindingsConfigured
+    && !requiredScopedBindingPresent
     && requiredScopedEnvBinding.ambientHostCredential?.enabled
     ? await (
         requiredScopedEnvBinding.ambientHostCredential.probe ?? probeAmbientHostPushCredential
@@ -1042,7 +1061,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
   } | null = null;
   if (
     requiredScopedEnvBinding
-    && !requiredScopedBindingsConfigured
+    && !requiredScopedBindingPresent
     && !ambientHostCredential
     && requiredScopedEnvBinding.fallbackSecretNames?.length
     && typeof input.secretsSvc.getByNameInsensitive === "function"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -463,6 +463,7 @@ const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE = "execution_review_participan
 const GITHUB_PR_WORKFLOW_SKILL_KEY = "paperclipai/bundled/software-development/github-pr-workflow";
 const GITHUB_PR_WORKFLOW_SKILL_SLUG = "github-pr-workflow";
 const PUSH_CAPABILITY_ENV_KEYS = ["GH_TOKEN", "GITHUB_TOKEN"] as const;
+const AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS = 2_000;
 // Keep this in sync with local adapters that require a git workspace before launch.
 const GIT_SENSITIVE_LOCAL_ADAPTER_TYPES = new Set([
   "claude_local",
@@ -841,6 +842,72 @@ function hasGithubPrWorkflowSkill(desiredSkills: string[]) {
   });
 }
 
+export type AmbientHostPushCredential = "gh_cli" | "ssh_push_remote";
+
+/**
+ * Probe credentials that are already available to a local execution host without
+ * copying them into the dispatched run. In particular, do not pass the resolved
+ * run env to `gh`: an injected GH_TOKEN would override a working hosts.yml login.
+ */
+export async function probeAmbientHostPushCredential(
+  cwd: string | null | undefined,
+  deps: { execFile: typeof execFile } = { execFile },
+): Promise<AmbientHostPushCredential | null> {
+  try {
+    const result = await deps.execFile(
+      "gh",
+      ["auth", "token", "--hostname", "github.com"],
+      { timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS, windowsHide: true },
+    );
+    if (readNonEmptyString(result.stdout)) return "gh_cli";
+  } catch {
+    // A missing CLI, timeout, non-zero exit, or unreadable auth state is a tier miss.
+  }
+
+  const normalizedCwd = readNonEmptyString(cwd);
+  if (!normalizedCwd) return null;
+  const remoteNames = await deps.execFile(
+    "git",
+    ["remote"],
+    {
+      cwd: normalizedCwd,
+      timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS,
+      windowsHide: true,
+    },
+  ).then((result) =>
+    result.stdout
+      .split(/\r?\n/)
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+  ).catch(() => []);
+
+  for (const remoteName of remoteNames) {
+    const pushUrl = await deps.execFile(
+      "git",
+      ["remote", "get-url", "--push", remoteName],
+      {
+        cwd: normalizedCwd,
+        timeout: AMBIENT_GITHUB_CREDENTIAL_PROBE_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    ).then((result) => readNonEmptyString(result.stdout)).catch(() => null);
+    if (pushUrl && (/^ssh:\/\//i.test(pushUrl) || /^[^\s/@:]+@[^\s/:]+:.+/.test(pushUrl))) {
+      return "ssh_push_remote";
+    }
+  }
+  return null;
+}
+
+export function shouldProbeAmbientHostPushCredential(input: {
+  pushCapabilityPreflightRequired: boolean;
+  environmentDriver: string | null | undefined;
+  trustPreset?: TrustPresetResolution;
+}) {
+  return input.pushCapabilityPreflightRequired
+    && input.trustPreset?.kind !== "low_trust_review"
+    && !isRemoteExecutionEnvironmentDriver(input.environmentDriver);
+}
+
 export function requiresPushCapabilityPreflight(input: {
   adapterType: string;
   issueId: string | null | undefined;
@@ -922,6 +989,11 @@ export async function resolveExecutionRunAdapterConfig(input: {
     remediation: string;
     fallbackSecretNames?: readonly string[];
     fallbackInjectionEnvKey?: string;
+    ambientHostCredential?: {
+      enabled: boolean;
+      checkoutCwd?: string | null;
+      probe?: typeof probeAmbientHostPushCredential;
+    };
   };
 }) {
   const executionRunConfig = stripForbiddenEnvFromAdapterConfig(input.executionRunConfig);
@@ -954,6 +1026,13 @@ export async function resolveExecutionRunAdapterConfig(input: {
       && isConfiguredEnvBindingValue(routineEnv?.[key])
     ))
     : false;
+  const ambientHostCredential = requiredScopedEnvBinding
+    && !requiredScopedBindingsConfigured
+    && requiredScopedEnvBinding.ambientHostCredential?.enabled
+    ? await (
+        requiredScopedEnvBinding.ambientHostCredential.probe ?? probeAmbientHostPushCredential
+      )(requiredScopedEnvBinding.ambientHostCredential.checkoutCwd).catch(() => null)
+    : null;
   let fallbackSecret: Awaited<ReturnType<RuntimeConfigSecretResolver["getByNameInsensitive"]>> | null = null;
   let fallbackAuthorization: {
     bindingId: string;
@@ -964,6 +1043,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
   if (
     requiredScopedEnvBinding
     && !requiredScopedBindingsConfigured
+    && !ambientHostCredential
     && requiredScopedEnvBinding.fallbackSecretNames?.length
     && typeof input.secretsSvc.getByNameInsensitive === "function"
   ) {
@@ -1001,7 +1081,12 @@ export async function resolveExecutionRunAdapterConfig(input: {
       break;
     }
   }
-  if (requiredScopedEnvBinding && !requiredScopedBindingsConfigured && !fallbackSecret) {
+  if (
+    requiredScopedEnvBinding
+    && !requiredScopedBindingsConfigured
+    && !ambientHostCredential
+    && !fallbackSecret
+  ) {
     throw new ConfigurationIncompleteFailure(`configuration incomplete: ${requiredScopedEnvBinding.remediation}`, {
       configurationIncomplete: {
         reason: requiredScopedEnvBinding.reason,
@@ -1304,13 +1389,19 @@ export async function resolveExecutionRunAdapterConfig(input: {
     }
   }
   if (requiredScopedEnvBinding) {
+    const tier = requiredScopedBindingsConfigured
+      ? "T1_env_binding"
+      : ambientHostCredential
+        ? "T2_ambient_host_credential"
+        : "T3_well_known_company_secret";
     logger.info(
       {
         companyId: input.companyId,
         agentId: input.agentId ?? null,
         issueId: input.issueId ?? null,
         heartbeatRunId: input.heartbeatRunId ?? null,
-        tier: fallbackSecret ? "T3_well_known_company_secret" : "T1_env_binding",
+        tier,
+        ambientCredentialKind: ambientHostCredential,
         selectedSecretName: fallbackSecret?.name ?? null,
       },
       "Push-capability preflight satisfied",
@@ -14679,6 +14770,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueId,
       explicitRunScopedSkillKeys: runScopedMentionedSkillKeys,
     });
+    const ambientHostPushCredentialEnabled = shouldProbeAmbientHostPushCredential({
+      pushCapabilityPreflightRequired,
+      environmentDriver: selectedEnvironmentForConfig?.driver ?? null,
+      trustPreset,
+    });
     const { resolvedConfig, secretKeys, secretManifest } = await resolveExecutionRunAdapterConfig({
       companyId: agent.companyId,
       agentId: agent.id,
@@ -14701,10 +14797,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             keys: [...PUSH_CAPABILITY_ENV_KEYS],
             consumerScopes: ["agent", "project", "environment", "routine"],
             reason: "push_write_credential_missing",
-            remediation:
-              "GitHub PR workflow found no GH_TOKEN/GITHUB_TOKEN binding at agent, project, environment, or routine scope and no company secret named GITHUB_TOKEN, GH_TOKEN, or PAPERCLIP_GITHUB_TOKEN. Bind GH_TOKEN or GITHUB_TOKEN at one of those scopes, or configure one of the well-known company secrets.",
+            remediation: ambientHostPushCredentialEnabled
+              ? "GitHub PR workflow found no GH_TOKEN/GITHUB_TOKEN binding at agent, project, environment, or routine scope, no ambient gh/ssh credential on host, and no company secret named GITHUB_TOKEN, GH_TOKEN, or PAPERCLIP_GITHUB_TOKEN. Bind GH_TOKEN or GITHUB_TOKEN at one of those scopes, authenticate gh or configure an SSH push remote on the local host, or configure one of the well-known company secrets."
+              : "GitHub PR workflow found no GH_TOKEN/GITHUB_TOKEN binding at agent, project, environment, or routine scope and no company secret named GITHUB_TOKEN, GH_TOKEN, or PAPERCLIP_GITHUB_TOKEN. Bind GH_TOKEN or GITHUB_TOKEN at one of those scopes, or configure one of the well-known company secrets.",
             fallbackSecretNames: DEFAULT_GITHUB_TOKEN_SECRET_NAMES,
             fallbackInjectionEnvKey: "GH_TOKEN",
+            ambientHostCredential: {
+              enabled: ambientHostPushCredentialEnabled,
+              checkoutCwd:
+                reusableExistingExecutionWorkspace?.cwd
+                ?? executionRunConfig.cwd as string | null | undefined,
+            },
           }
         : undefined,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and starts their work through adapters.
> - Local coding adapters can use Git credentials that already exist on the execution host.
> - The push preflight only accepted configured environment bindings or stored company secrets.
> - A local run could therefore stop even when the host `gh` login or SSH push remote already worked.
> - This pull request adds a host credential tier before the company-secret fallback.
> - The benefit is that local runs use working host authentication without replacing it with a possibly stale stored token.

## Linked Issues or Issue Description

Depends on #11704. Related scope plumbing is in #11702.

**What happened?**

The GitHub PR workflow preflight blocked local coding adapters when no `GH_TOKEN` or `GITHUB_TOKEN` binding existed. It did not accept a working host `gh` login or an SSH push remote.

**Expected behavior**

A local execution target should pass the preflight when the host `gh` credential store returns a token or the checkout uses an SSH push URL. Remote execution targets should not inspect host credentials.

The SSH check is intentionally network-free. It selects the Git transport, not repository authorization: an HTTPS token cannot authenticate or affect an SSH push, so Paperclip must not inject the company-token fallback for an SSH remote. The eventual `git push` remains responsible for validating the host key, SSH agent or key, and repository authorization.

**Steps to reproduce**

1. Configure a local coding adapter with the GitHub PR workflow skill.
2. Leave token bindings unset and authenticate the host with `gh auth login`, or configure an SSH push remote.
3. Start a run and observe that the old preflight reports a missing credential.

**Paperclip version or commit**

`51a843e135`

**Deployment mode**

Local dev or a self-hosted server with local coding adapters.

## What Changed

- Probe `gh auth token --hostname github.com` with a two-second timeout on local execution hosts.
- Accept SSH and scp-style checkout push URLs after the `gh` probe misses.
- Use the selected project workspace path and configured origin for a fresh checkout that is not realized yet.
- Do not inject a token when ambient host authentication or SSH transport satisfies the preflight.
- Skip the host tier for remote and low-trust execution targets.
- Log the selected preflight tier and add local remediation text.
- Add regression tests for success, timeout, non-zero exit, SSH remotes, fresh workspace selection, and remote-target skipping.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-project-env.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`

## Risks

- Low risk. The new probe runs only for local push-capable runs with no configured token binding.
- Probe failures are tier misses and fall through to the existing company-secret behavior.
- Each subprocess has a two-second timeout.
- SSH URL detection does not prove repository authorization. This is intentional because the preflight must remain network-free and an HTTPS token is not a valid fallback for an SSH push. The later push reports SSH authorization failures normally.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5`. The runtime did not expose its context-window size. The model used reasoning, tool calls, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
