### PR TITLE
fix(server): let a timer run write to an issue it checked out

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -10,6 +10,8 @@ import {
 function counterDb(
   initialCount = 0,
   runOverrides: Record<string, unknown> | null = {},
+  /** Set to true to simulate that the target issue is checked out by this run. */
+  targetIssueCheckedOutByRun = false,
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
@@ -18,10 +20,19 @@ function counterDb(
       from: () => ({
         where: () => {
           if (Object.keys(selection).includes("count")) {
+            // Activity-log count query.
             return {
               then: (resolve: (rows: unknown[]) => unknown) => resolve([{ count: observedCount }]),
             };
           }
+          if (Object.keys(selection).length === 1 && "id" in selection) {
+            // Issues checkout query (select {id} from issues where ...).
+            return {
+              then: (resolve: (rows: unknown[]) => unknown) =>
+                resolve(targetIssueCheckedOutByRun ? [{ id: "55555555-5555-4555-8555-555555555555" }] : []),
+            };
+          }
+          // Heartbeat-runs row query (uses .for("update")).
           return {
             for: () => ({
               then: (resolve: (rows: unknown[]) => unknown) => resolve(runOverrides === null ? [] : [{
@@ -198,8 +209,9 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
-    const fake = counterDb(0, { contextSnapshot: {} });
+  it("fails closed when the persisted run has no source issue and no checkout on the target", async () => {
+    // Timer run: empty contextSnapshot, no checkout on the target issue.
+    const fake = counterDb(0, { contextSnapshot: {} }, false);
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
       companyId: "22222222-2222-4222-8222-222222222222",
@@ -211,6 +223,21 @@ describe("cross-issue influence limit rollout", () => {
       status: 403,
       details: { code: "cross_issue_influence_run_context_required" },
     });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("allows writes for a timer run that has checked out the target issue", async () => {
+    // Timer run: empty contextSnapshot (no issueId), but has a checkout on the target.
+    const fake = counterDb(0, { contextSnapshot: {} }, true);
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+    })).resolves.toBeNull();
+    // No cross-issue-influence activity should be recorded.
     expect(fake.inserted).toEqual([]);
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -7,18 +7,49 @@ import {
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.ts";
 
+/** One row of the fake `issues` table, holding only the checkout columns the guard reads. */
+type IssueCheckoutRow = { companyId: string; id: string; executionRunId: string };
+
+/**
+ * Collects the bound parameter values out of a drizzle condition.
+ *
+ * `and(eq(a, x), eq(b, y))` flattens to a chunk list holding literal SQL
+ * fragments (whose value is a `string[]`) alongside bound parameters (whose
+ * value is the scalar). Dropping the arrays leaves the values the guard
+ * actually filtered on.
+ */
+function boundParams(condition: unknown): unknown[] {
+  const out: unknown[] = [];
+  const walk = (node: unknown) => {
+    if (!node || typeof node !== "object" || Array.isArray(node)) return;
+    const record = node as Record<string, unknown>;
+    if (Array.isArray(record.queryChunks)) {
+      for (const chunk of record.queryChunks) walk(chunk);
+      return;
+    }
+    if ("value" in record && !Array.isArray(record.value)) out.push(record.value);
+  };
+  walk(condition);
+  return out;
+}
+
 function counterDb(
   initialCount = 0,
   runOverrides: Record<string, unknown> | null = {},
-  /** Set to true to simulate that the target issue is checked out by this run. */
-  targetIssueCheckedOutByRun = false,
+  /**
+   * Rows the fake `issues` table holds. The checkout lookup matches these on
+   * company id, issue id, and execution run id, so a grant is only reachable
+   * when the guard constrains its query to the target issue and to this run.
+   * A lookup that dropped either predicate finds no row here.
+   */
+  issueRows: IssueCheckoutRow[] = [],
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
   const tx = {
     select: (selection: Record<string, unknown>) => ({
       from: () => ({
-        where: () => {
+        where: (condition: unknown) => {
           if (Object.keys(selection).includes("count")) {
             // Activity-log count query.
             return {
@@ -27,9 +58,18 @@ function counterDb(
           }
           if (Object.keys(selection).length === 1 && "id" in selection) {
             // Issues checkout query (select {id} from issues where ...).
+            const params = boundParams(condition);
+            const matched = issueRows.filter((row) => {
+              const values = new Set<unknown>([row.companyId, row.id, row.executionRunId]);
+              // Model the equality filter itself: a row survives when every
+              // bound value matches one of its columns. A predicate the guard
+              // never sent is therefore never applied, so dropping one widens
+              // the result set here exactly as it would in PostgreSQL.
+              return params.length > 0 && params.every((param) => values.has(param));
+            });
             return {
               then: (resolve: (rows: unknown[]) => unknown) =>
-                resolve(targetIssueCheckedOutByRun ? [{ id: "55555555-5555-4555-8555-555555555555" }] : []),
+                resolve(matched.map((row) => ({ id: row.id }))),
             };
           }
           // Heartbeat-runs row query (uses .for("update")).
@@ -210,8 +250,8 @@ describe("cross-issue influence limit rollout", () => {
   });
 
   it("fails closed when the persisted run has no source issue and no checkout on the target", async () => {
-    // Timer run: empty contextSnapshot, no checkout on the target issue.
-    const fake = counterDb(0, { contextSnapshot: {} }, false);
+    // Timer run: empty contextSnapshot, no checkout on any issue.
+    const fake = counterDb(0, { contextSnapshot: {} }, []);
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
       companyId: "22222222-2222-4222-8222-222222222222",
@@ -227,8 +267,12 @@ describe("cross-issue influence limit rollout", () => {
   });
 
   it("allows writes for a timer run that has checked out the target issue", async () => {
-    // Timer run: empty contextSnapshot (no issueId), but has a checkout on the target.
-    const fake = counterDb(0, { contextSnapshot: {} }, true);
+    // Timer run: empty contextSnapshot (no issueId), but holds the checkout on the target.
+    const fake = counterDb(0, { contextSnapshot: {} }, [{
+      companyId: "22222222-2222-4222-8222-222222222222",
+      id: "55555555-5555-4555-8555-555555555555",
+      executionRunId: "11111111-1111-4111-8111-111111111111",
+    }]);
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
       companyId: "22222222-2222-4222-8222-222222222222",
@@ -238,6 +282,52 @@ describe("cross-issue influence limit rollout", () => {
       kind: "comment",
     })).resolves.toBeNull();
     // No cross-issue-influence activity should be recorded.
+    expect(fake.inserted).toEqual([]);
+  });
+
+  // A checkout is a claim on one issue, not a company-wide write pass. Without
+  // this case the grant above would still pass if the lookup forgot to filter
+  // on the target issue, which is exactly the containment boundary the guard exists for.
+  it("fails closed when the timer run's only checkout is on a different issue", async () => {
+    const fake = counterDb(0, { contextSnapshot: {} }, [{
+      companyId: "22222222-2222-4222-8222-222222222222",
+      id: "66666666-6666-4666-8666-666666666666",
+      executionRunId: "11111111-1111-4111-8111-111111111111",
+    }]);
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "update",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  // A board force-release or a tree cancel hands the execution lock to someone
+  // else. The grant follows the lock, so the next request from the old holder
+  // is refused again — the guard reads the row, it does not cache the checkout.
+  it("fails closed once the target issue's checkout has moved to another run", async () => {
+    const fake = counterDb(0, { contextSnapshot: {} }, [{
+      companyId: "22222222-2222-4222-8222-222222222222",
+      id: "55555555-5555-4555-8555-555555555555",
+      executionRunId: "77777777-7777-4777-8777-777777777777",
+    }]);
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
     expect(fake.inserted).toEqual([]);
   });
 });

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -115,6 +115,18 @@ export async function observeCrossIssueInfluence(
       // They are still allowed to write to issues they have checked out in
       // this run — that is not cross-issue influence; it is in-scope work.
       // Check whether this run holds an executionRunId checkout on the target.
+      //
+      // Read without `for update` on purpose. The lock above is on
+      // `heartbeat_runs`, and the checkout-clearing paths in the issues service
+      // take `issues` first and `heartbeat_runs` second, so locking the issue
+      // row here would order the two sides against each other and deadlock.
+      // The read is also not the last word: the decision is re-derived from the
+      // row on every request, so a released checkout refuses the next write.
+      // What it does not do is span the route mutation that follows — the same
+      // property every gate on that route has, since they all decide from the
+      // issue snapshot the handler loaded once. Containment does not rest on
+      // this window: `issue:mutate` is authorized separately and earlier, and
+      // this branch can only ever return the issue the run itself checked out.
       const ownCheckout = await tx
         .select({ id: issues.id })
         .from(issues)

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,6 +1,6 @@
 import { and, count, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns } from "@paperclipai/db";
+import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -110,7 +110,23 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
+    if (!sourceIssueId) {
+      // Timer-triggered runs have no issueId/taskId in their contextSnapshot.
+      // They are still allowed to write to issues they have checked out in
+      // this run — that is not cross-issue influence; it is in-scope work.
+      // Check whether this run holds an executionRunId checkout on the target.
+      const ownCheckout = await tx
+        .select({ id: issues.id })
+        .from(issues)
+        .where(and(
+          eq(issues.companyId, input.companyId),
+          eq(issues.id, input.targetIssueId),
+          eq(issues.executionRunId, input.runId),
+        ))
+        .then((rows) => rows.length > 0);
+      if (ownCheckout) return null;
+      throw crossIssueInfluenceRunContextError();
+    }
     if (
       sourceIssueId === input.targetIssueId ||
       (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents report their work through `PATCH /api/issues/:id` and `POST /api/issues/:id/comments`
> - Cross-issue influence containment stops a run from writing to issues outside its scope
> - The guard reads the run's source issue from `heartbeat_runs.contextSnapshot`
> - A scheduler wake (`invocationSource: timer`) starts before the agent picks an issue, so that snapshot holds no `issueId` and no `taskId`
> - The guard then refuses every issue write for the full life of the run, including a write to an issue that the same run checked out
> - This pull request lets the guard confirm the checkout before it refuses, and it keeps the refusal for all other cases
> - The benefit is that a timer heartbeat can report its own work instead of leaving that work unrecorded

## Linked Issues or Issue Description

No public issue exists. The problem is described below.

Related pull requests, found in a search before this one was opened. They treat the same containment guard:

- Refs #11500 — same diagnosis (a timer wake records no source issue). It counts the write against the per-run cap instead of refusing it.
- Refs #11232 — fixes the same symptom earlier, by recording the issue on the run during a self-checkout.
- Refs #11701 — allows a comment-only self-report path for an unbound run.
- Refs #11362 — closed. It exempted the run's assigned issue, but it also contained a large amount of unrelated work.

This pull request differs from all four. It keeps the refusal as the default, and it permits a write only after it reads the database and confirms that the target issue is checked out by this run.

**What happened?**

An agent run that the scheduler starts receives `403 cross_issue_influence_run_context_required` on every `PATCH /api/issues/:id` call and every `POST /api/issues/:id/comments` call. The refusal also applies to an issue that the same run checked out one moment earlier, and to an issue that the same run created.

The `X-Paperclip-Run-Id` header is present and correct in these requests. It matches the `run_id` claim in the API key. It matches `activeRun.id` from `GET /api/agents/me/inbox-lite`. The error text asks the caller to send that header, so the error gives no usable next step.

The cause is in `server/src/services/cross-issue-influence-limit.ts`. `readRunSourceIssueId()` returns `null` for a timer run, because the scheduler queues the run before the agent reads its inbox and picks an issue. `observeCrossIssueInfluence()` then throws before it reaches the same-issue short circuit:

```ts
const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
```

Not all write paths fail. `PUT /api/issues/:id/documents/:key`, `POST /api/issues/:id/interactions`, `POST /api/companies/:id/issues`, `POST /api/issues/:id/checkout`, and `DELETE /api/issues/:id` all succeed in the same run with the same headers. Only the two paths that the heartbeat instructions name as the standard way to change status and to post a close-out comment are refused.

The practical result is a data quality problem that users see. An agent that cannot write to its own issue does not stop. It creates a new issue instead, or it writes its findings into an issue document. The board then shows stale status and stale assignees on the real issues, next to a growing set of near-duplicate issues that hold the actual result. Work that finished looks unfinished.

**Expected behavior**

A run must be able to write to an issue that it holds a checkout on. That write is in scope by definition, so it is not cross-issue influence. A run that holds no checkout on the target issue must still be refused.

**Steps to reproduce**

Identifiers below are anonymized.

1. Let the scheduler start a heartbeat run. Confirm that `invocationSource` is `timer` and that `contextSnapshot` contains no `issueId` and no `taskId`.
2. Call `POST /api/issues/{issue-a}/checkout`. The call returns 200. `executionRunId` is now the current run id.
3. Call `PATCH /api/issues/{issue-a}` with the body `{"priority":"high"}` and the header `X-Paperclip-Run-Id: {current-run-id}`.
4. The call returns `403 cross_issue_influence_run_context_required`.
5. Call `POST /api/issues/{issue-a}/comments` on the same issue. It returns the same 403.

Step 3 is the smallest reproduction. The run writes to the issue that it checked out one step earlier, and the guard classifies that write as cross-issue.

**Paperclip version or commit**

`51a843e` on `master`, 2026-08-19.

**Node.js version**

v22.23.2

**Operating system**

macOS 26.5.1

## What Changed

- `server/src/services/cross-issue-influence-limit.ts`: when `readRunSourceIssueId()` returns `null`, the guard now queries the `issues` table before it throws. The query matches on company id, target issue id, and `executionRunId` equal to the current run id. The guard returns `null` (no cross-issue influence) when that row exists. It throws the same error as before when the row does not exist.
- `server/src/__tests__/cross-issue-influence-limit.test.ts`: added a test that a timer run with an empty `contextSnapshot` can write to an issue it checked out, and that the guard records no cross-issue activity for that write.
- `server/src/__tests__/cross-issue-influence-limit.test.ts`: renamed the existing fail-closed test to state that it covers the case with no checkout on the target. Its behavior is unchanged.

The query runs inside the transaction that the guard already opens. It runs only on the `null` source path, so a run that carries a source issue does one query less than this path, exactly as before.

## Verification

Run the unit tests for the guard:

```
pnpm vitest run server/src/__tests__/cross-issue-influence-limit.test.ts
```

Result: 11 tests pass, 11 total. The suite includes the two tests that hold the new behavior in place:

- `allows writes for a timer run that has checked out the target issue` — passes only with this change.
- `fails closed when the persisted run has no source issue and no checkout on the target` — passes before and after, and proves that the refusal still applies without a checkout.

To confirm by hand, follow the five reproduction steps above. Step 3 returns 200 with this change. Repeat step 3 against an issue that the run did not check out, and confirm that it still returns 403.

## Risks

Low risk, with one deliberate widening.

- The guard now accepts one class of write that it refused before: a run with no source issue that writes to an issue it holds `executionRunId` on. A checkout is an explicit claim on an issue, so this is the run's own scope.
- Containment is unchanged everywhere else. A run with no source issue and no checkout on the target is still refused with the same error and the same code. The per-run cross-issue cap is untouched. The source-issue path is untouched.
- The change adds one indexed lookup by primary key on the `null` source path only. It does not run for a normal scoped run.
- No migration. No schema change. No API contract change. A client that receives 403 today receives 200 only in the case described above.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) wrote the fix and the tests, with extended thinking and tool use.
Claude Opus 5, 1M context (`claude-opus-5[1m]`) reviewed the change, searched for related pull requests, and wrote this description.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation states the refused behavior, so there is nothing to correct.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — CI has not run yet on this branch.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — Greptile has not run yet.
- [x] I will address all Greptile and reviewer comments before requesting merge
