### PR TITLE
fix(ui): refine decision card navigation and disclosure

### DIFF
--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -335,6 +335,49 @@ describe("AttentionQueueRow", () => {
     expect(onToggleExpand).toHaveBeenCalledTimes(2);
   });
 
+  it("toggles expand from the keyboard-focused decision body", () => {
+    const onToggleExpand = vi.fn();
+    render(
+      <AttentionQueueRow
+        item={buildItem()}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={onToggleExpand}
+        onDismiss={noop}
+      />,
+    );
+    const body = container?.querySelector<HTMLElement>("[data-attention-card-body]");
+    const keyboardTarget = container?.querySelector<HTMLElement>("[data-attention-keyboard-target]");
+    expect(body?.getAttribute("role")).toBeNull();
+    expect(keyboardTarget?.getAttribute("role")).toBe("button");
+    expect(keyboardTarget?.tabIndex).toBe(0);
+    expect(keyboardTarget?.getAttribute("aria-expanded")).toBe("false");
+    act(() => {
+      keyboardTarget?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      keyboardTarget?.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+    expect(onToggleExpand).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not toggle when an ARIA button inside the decision body is clicked", () => {
+    const onToggleExpand = vi.fn();
+    render(
+      <AttentionQueueRow
+        item={buildItem()}
+        companyId="c1"
+        expanded={false}
+        onToggleExpand={onToggleExpand}
+        onDismiss={noop}
+      />,
+    );
+    const body = container?.querySelector("[data-attention-card-body]");
+    const ariaButton = document.createElement("span");
+    ariaButton.setAttribute("role", "button");
+    body?.appendChild(ariaButton);
+    act(() => ariaButton.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onToggleExpand).not.toHaveBeenCalled();
+  });
+
   it("exposes the visible expand chevron as an accessible button", () => {
     const onToggleExpand = vi.fn();
     render(

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -311,7 +311,7 @@ describe("AttentionQueueRow", () => {
     expect(trigger).toBeTruthy();
   });
 
-  it("toggles expand when the collapsed header of an inline row is clicked", () => {
+  it("toggles expand when the decision body or empty summary space is clicked", () => {
     const onToggleExpand = vi.fn();
     render(
       <AttentionQueueRow
@@ -322,13 +322,17 @@ describe("AttentionQueueRow", () => {
         onDismiss={noop}
       />,
     );
-    const header = container?.querySelector('[role="button"][aria-expanded]');
-    expect(header).toBeTruthy();
-    expect(header?.getAttribute("aria-expanded")).toBe("false");
+    const body = container?.querySelector("[data-attention-card-body]");
+    const detail = Array.from(container?.querySelectorAll("p") ?? []).find((element) =>
+      element.textContent?.includes("Approval is pending"),
+    );
+    expect(body).toBeTruthy();
+    expect(detail).toBeTruthy();
     act(() => {
-      header?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      detail?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      body?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    expect(onToggleExpand).toHaveBeenCalledTimes(1);
+    expect(onToggleExpand).toHaveBeenCalledTimes(2);
   });
 
   it("exposes the visible expand chevron as an accessible button", () => {
@@ -350,19 +354,41 @@ describe("AttentionQueueRow", () => {
     expect(onToggleExpand).toHaveBeenCalledWith(expect.objectContaining({ id: "a1" }));
   });
 
-  it("does not navigate on title click — the title is plain text, not a link", () => {
+  it("opens the title, task key, and timestamp in a new tab without toggling", () => {
+    const onToggleExpand = vi.fn();
     render(
       <AttentionQueueRow
-        item={buildItem()}
+        item={buildItem({
+          relatedIssue: {
+            kind: "issue",
+            id: "issue-1",
+            companyId: "c1",
+            title: "Implement linked decision",
+            identifier: "PAP-42",
+            status: "in_progress",
+            href: "/PAP/issues/PAP-42",
+            metadata: {},
+          },
+        })}
         companyId="c1"
         expanded={false}
-        onToggleExpand={noop}
+        onToggleExpand={onToggleExpand}
         onDismiss={noop}
       />,
     );
-    const links = Array.from(container?.querySelectorAll("a") ?? []);
-    // No anchor should carry the subject title (only the identifier link, absent here).
-    expect(links.some((a) => a.textContent?.includes("Hire agent: Research Analyst"))).toBe(false);
+    const links = Array.from(container?.querySelectorAll('a[href="/PAP/issues/PAP-42"]') ?? []);
+    expect(links.map((link) => link.textContent?.trim())).toEqual([
+      "PAP-42",
+      expect.any(String),
+      "Hire agent: Research Analyst",
+    ]);
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+      link.addEventListener("click", (event) => event.preventDefault());
+      act(() => link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true })));
+    }
+    expect(onToggleExpand).not.toHaveBeenCalled();
   });
 
   // The eyebrow carries the decision kind and the task key only. Project
@@ -511,9 +537,9 @@ describe("AttentionQueueRow", () => {
       />,
     );
 
-    const header = container?.querySelector('[role="button"][aria-expanded]');
-    expect(header?.textContent).not.toContain("Approve");
-    expect(header?.textContent).not.toContain("Reject");
+    const body = container?.querySelector("[data-attention-card-body]");
+    expect(body?.textContent).not.toContain("Approve");
+    expect(body?.textContent).not.toContain("Reject");
 
     const decisionActions = container?.querySelector('[aria-label="Decision actions"]');
     expect(decisionActions?.textContent).toContain("Approve");
@@ -711,7 +737,7 @@ describe("AttentionQueueRow", () => {
         onDismiss={noop}
       />,
     );
-    expect(container?.querySelector('[role="button"][aria-expanded]')).toBeNull();
+    expect(container?.querySelector('button[aria-label="Expand decision"]')).toBeNull();
   });
 
   it("makes a non-inline row with images expandable", () => {
@@ -736,9 +762,9 @@ describe("AttentionQueueRow", () => {
         onDismiss={noop}
       />,
     );
-    const header = container?.querySelector('[role="button"][aria-expanded]');
-    expect(header).not.toBeNull();
-    act(() => (header as HTMLElement).click());
+    const body = container?.querySelector("[data-attention-card-body]");
+    expect(body).not.toBeNull();
+    act(() => (body as HTMLElement).click());
     expect(onToggleExpand).toHaveBeenCalledTimes(1);
   });
 

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type MouseEvent, type ReactNode } from "react";
+import { memo, useState, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlarmClock,
@@ -135,9 +135,10 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const detailLine = attentionDetailLine(item) ?? item.whyNow;
   const images = attentionDetailImages(item);
   const hasImages = images.length > 0;
-  // The issue (or source) this row points at — used as the target for the
-  // "n more" affordance in the expanded gallery.
+  // Only task-backed rows get the new-tab navigation treatment. Keep the
+  // broader source fallback for the expanded gallery's "n more" affordance.
   const issueHref = taskRef?.href ?? null;
+  const detailHref = item.relatedIssue?.href ?? href;
   // Inline-resolvable active rows expand to reveal their resolver; rows with
   // images expand to reveal a larger gallery (PAP-13544); triage-enabled rows
   // expand to reveal the per-card triage strip (PAP-16032 §4.5). Any of these
@@ -155,6 +156,11 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
       );
       if (interactive && interactive !== event.currentTarget) return;
     }
+    activate();
+  };
+  const activateFromCardKeyboard = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
     activate();
   };
   // Which rows contribute an action bar. Inline rows carry compact decision
@@ -261,93 +267,99 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
         {/* Meta band: one breadcrumb of identity on the left (kind → task →
             project), recency + overflow on the right. */}
         <div className="flex items-start justify-between gap-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-1">
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
-            <StatusGlyph status={status} size="md" />
-            {meta.label}
-          </span>
-          {taskRef && (
-            <>
-              <EyebrowSeparator />
+          <div className="flex min-w-0 flex-wrap items-center gap-1">
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
+              <StatusGlyph status={status} size="md" />
+              {meta.label}
+            </span>
+            {taskRef && (
+              <>
+                <EyebrowSeparator />
+                {taskRef.href ? (
+                  <Link
+                    to={taskRef.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-(length:--text-nano) text-muted-foreground hover:text-foreground"
+                  >
+                    {taskRef.identifier}
+                  </Link>
+                ) : (
+                  <span className="font-mono text-(length:--text-nano) text-muted-foreground">
+                    {taskRef.identifier}
+                  </span>
+                )}
+              </>
+            )}
+            {item.decideBy && (
+              <>
+                <EyebrowSeparator />
+                <span
+                  className="inline-flex items-center gap-1 text-(length:--text-nano) text-muted-foreground"
+                  data-attention-decide-by={item.decideBy}
+                  title={decideByProvenance(item) ? `Set by ${decideByProvenance(item)}` : undefined}
+                >
+                  <CalendarClock className="h-3 w-3" />
+                  {decideByLabel(item.decideBy)}
+                  {decideByProvenance(item) && (
+                    <span className="text-muted-foreground/80">· set by {decideByProvenance(item)}</span>
+                  )}
+                </span>
+              </>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1" data-attention-menu="true">
+            {isHidden && snoozedUntil ? (
+              <span
+                className="text-(length:--text-nano) text-muted-foreground"
+                title={`Reappears ${new Date(snoozedUntil).toLocaleString()}`}
+              >
+                Reappears {reappearLabel(snoozedUntil)}
+              </span>
+            ) : issueHref ? (
               <Link
-                to={taskRef.href ?? "#"}
+                to={issueHref}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-mono text-(length:--text-nano) text-muted-foreground hover:text-foreground"
+                className="text-(length:--text-nano) text-muted-foreground hover:text-foreground"
+                aria-label="Open task in a new tab"
               >
-                {taskRef.identifier}
+                {relativeTime(item.activityAt)}
               </Link>
-            </>
-          )}
-          {item.decideBy && (
-            <>
-              <EyebrowSeparator />
-              <span
-                className="inline-flex items-center gap-1 text-(length:--text-nano) text-muted-foreground"
-                data-attention-decide-by={item.decideBy}
-                title={decideByProvenance(item) ? `Set by ${decideByProvenance(item)}` : undefined}
-              >
-                <CalendarClock className="h-3 w-3" />
-                {decideByLabel(item.decideBy)}
-                {decideByProvenance(item) && (
-                  <span className="text-muted-foreground/80">· set by {decideByProvenance(item)}</span>
-                )}
-              </span>
-            </>
-          )}
-        </div>
-
-        <div className="flex shrink-0 items-center gap-1" data-attention-menu="true">
-          {isHidden && snoozedUntil ? (
-            <span
-              className="text-(length:--text-nano) text-muted-foreground"
-              title={`Reappears ${new Date(snoozedUntil).toLocaleString()}`}
-            >
-              Reappears {reappearLabel(snoozedUntil)}
-            </span>
-          ) : issueHref ? (
-            <Link
-              to={issueHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-(length:--text-nano) text-muted-foreground hover:text-foreground"
-              aria-label="Open task in a new tab"
-            >
-              {relativeTime(item.activityAt)}
-            </Link>
-          ) : (
-            <span className="text-(length:--text-nano) text-muted-foreground">{relativeTime(item.activityAt)}</span>
-          )}
-          {!isHidden && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-muted-foreground"
-                  aria-label="Row actions"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {onSnooze && <SnoozeSubmenu onSnooze={(iso) => onSnooze(item, iso)} />}
-                <DropdownMenuItem onClick={() => onDismiss(item)}>
-                  <X className="h-4 w-4" />
-                  Dismiss
-                </DropdownMenuItem>
-                {href && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                      <Link to={href}>Open source</Link>
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
+            ) : (
+              <span className="text-(length:--text-nano) text-muted-foreground">{relativeTime(item.activityAt)}</span>
+            )}
+            {!isHidden && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground"
+                    aria-label="Row actions"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {onSnooze && <SnoozeSubmenu onSnooze={(iso) => onSnooze(item, iso)} />}
+                  <DropdownMenuItem onClick={() => onDismiss(item)}>
+                    <X className="h-4 w-4" />
+                    Dismiss
+                  </DropdownMenuItem>
+                  {href && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem asChild>
+                        <Link to={href}>Open source</Link>
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
         </div>
 
         {/* The title navigates to its task; detail text and surrounding empty
@@ -368,7 +380,29 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
               {item.subject.title ?? meta.label}
             </span>
           )}
-          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{detailLine}</p>
+          <div
+            className={cn(
+              "mt-0.5 rounded-md",
+              expandable &&
+                "focus-visible:ring-ring focus-visible:ring-(length:--rad-3) focus-visible:outline-none",
+            )}
+            {...(expandable
+              ? {
+                  role: "button",
+                  tabIndex: 0,
+                  "aria-expanded": expanded,
+                  "aria-label": expanded ? "Collapse decision" : "Expand decision",
+                  onClick: (event: MouseEvent<HTMLDivElement>) => {
+                    event.stopPropagation();
+                    activate();
+                  },
+                  onKeyDown: activateFromCardKeyboard,
+                }
+              : {})}
+            data-attention-keyboard-target
+          >
+            <p className="line-clamp-2 text-xs text-muted-foreground">{detailLine}</p>
+          </div>
         </div>
       </div>
 
@@ -401,7 +435,7 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
       <Collapsible open={expanded} onOpenChange={() => onToggleExpand(item)} className="contents">
         <CollapsibleContent data-decision-disclosure className="-mt-4">
           <div className="flex flex-col gap-4 pt-4">
-            {hasImages && <ExpandedImages images={images} issueHref={issueHref} />}
+            {hasImages && <ExpandedImages images={images} issueHref={detailHref} />}
             {triageEnabled && <DecisionTriageStrip item={item} companyId={companyId} agents={agents} />}
             {inline && (
               <InlineResolver

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type KeyboardEvent, type ReactNode } from "react";
+import { memo, useState, type MouseEvent, type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlarmClock,
@@ -137,7 +137,7 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const hasImages = images.length > 0;
   // The issue (or source) this row points at — used as the target for the
   // "n more" affordance in the expanded gallery.
-  const issueHref = item.relatedIssue?.href ?? href;
+  const issueHref = taskRef?.href ?? null;
   // Inline-resolvable active rows expand to reveal their resolver; rows with
   // images expand to reveal a larger gallery (PAP-13544); triage-enabled rows
   // expand to reveal the per-card triage strip (PAP-16032 §4.5). Any of these
@@ -148,14 +148,15 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
   const activate = () => {
     if (expandable) onToggleExpand(item);
   };
-  const onHeaderKeyDown = (e: KeyboardEvent) => {
-    if (!expandable) return;
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onToggleExpand(item);
+  const activateFromCard = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target instanceof Element) {
+      const interactive = event.target.closest(
+        "a,button,input,textarea,select,[role='button'],[role='menuitem']",
+      );
+      if (interactive && interactive !== event.currentTarget) return;
     }
+    activate();
   };
-
   // Which rows contribute an action bar. Inline rows carry compact decision
   // verbs; deep-link rows carry an Open button; curtain rows carry Restore.
   const compactActions = !isHidden ? collectCompactActions(item) : [];
@@ -250,10 +251,16 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
       data-attention-source={item.sourceKind}
       data-attention-severity={item.severity}
     >
-      {/* Meta band: one breadcrumb of identity on the left (kind → task →
-          project), recency + overflow on the right. Not part of the clickable
-          headline, so the menu never toggles it. */}
-      <div className="flex items-start justify-between gap-2">
+      {/* The summary body is the larger disclosure target. Nested links and
+          controls keep their own behavior through activateFromCard's guard. */}
+      <div
+        className={cn("flex flex-col gap-4", expandable && "cursor-pointer")}
+        onClick={activateFromCard}
+        data-attention-card-body
+      >
+        {/* Meta band: one breadcrumb of identity on the left (kind → task →
+            project), recency + overflow on the right. */}
+        <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 flex-wrap items-center gap-1">
           <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
             <StatusGlyph status={status} size="md" />
@@ -264,8 +271,9 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
               <EyebrowSeparator />
               <Link
                 to={taskRef.href ?? "#"}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="font-mono text-(length:--text-nano) text-muted-foreground hover:text-foreground"
-                onClick={(e) => e.stopPropagation()}
               >
                 {taskRef.identifier}
               </Link>
@@ -297,6 +305,16 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
             >
               Reappears {reappearLabel(snoozedUntil)}
             </span>
+          ) : issueHref ? (
+            <Link
+              to={issueHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-(length:--text-nano) text-muted-foreground hover:text-foreground"
+              aria-label="Open task in a new tab"
+            >
+              {relativeTime(item.activityAt)}
+            </Link>
           ) : (
             <span className="text-(length:--text-nano) text-muted-foreground">{relativeTime(item.activityAt)}</span>
           )}
@@ -330,30 +348,28 @@ export const AttentionQueueRow = memo(function AttentionQueueRow({
             </DropdownMenu>
           )}
         </div>
-      </div>
+        </div>
 
-      {/* Headline — the primary expand target for inline rows. Title wraps to
-          two lines instead of truncating to a sliver on narrow screens. */}
-      <div
-        className={cn(
-          "min-w-0 rounded-md",
-          expandable && "cursor-pointer focus-visible:ring-ring focus-visible:ring-(length:--rad-3) focus-visible:outline-none",
-        )}
-        {...(expandable
-          ? {
-              role: "button",
-              tabIndex: 0,
-              "aria-expanded": expanded,
-              "aria-label": expanded ? "Collapse decision" : "Expand decision",
-              onClick: activate,
-              onKeyDown: onHeaderKeyDown,
-            }
-          : {})}
-      >
-        <span className="line-clamp-2 text-sm font-medium text-foreground" title={item.subject.title ?? undefined}>
-          {item.subject.title ?? meta.label}
-        </span>
-        <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{detailLine}</p>
+        {/* The title navigates to its task; detail text and surrounding empty
+            summary space remain disclosure targets. */}
+        <div className="min-w-0 rounded-md">
+          {issueHref ? (
+            <Link
+              to={issueHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="line-clamp-2 text-sm font-medium text-foreground hover:underline"
+              title={item.subject.title ?? undefined}
+            >
+              {item.subject.title ?? meta.label}
+            </Link>
+          ) : (
+            <span className="line-clamp-2 text-sm font-medium text-foreground" title={item.subject.title ?? undefined}>
+              {item.subject.title ?? meta.label}
+            </span>
+          )}
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{detailLine}</p>
+        </div>
       </div>
 
       {/* Collapsed-only content. It has no counterpart to morph into — the


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Decisions view helps operators review items that need attention.
> - A decision card must separate navigation from disclosure.
> - The task links must open the source task without changing the current view.
> - The card body must show or hide the decision detail without opening the task.
> - This pull request adds these two actions to the current attention card design.
> - The benefit is a clear mouse and keyboard flow that keeps the Decisions view open.

## Linked Issues or Issue Description

**What happened?**

In the Decisions view, the task key, title, and time did not open the source task in a new tab. A click on the card body also did not show or hide the decision detail.

**Expected behavior**

The task key, title, and time open the source task in a new tab. A click on the card body or empty card space shows or hides the decision detail. Keyboard users can operate both actions.

**Steps to reproduce**

1. Open the Decisions view.
2. Select a decision card that has a source task.
3. Select the task key, title, or time.
4. Select the card body.

Related prior work: Refs #9575 and #10474.

## What Changed

- Add new-tab task links to the task key, title, and time.
- Make the decision card body toggle the detail section.
- Keep nested controls separate from the body toggle.
- Add keyboard access and clear disclosure attributes.
- Add tests for navigation, mouse actions, keyboard actions, and nested controls.

## Verification

- `NODE_ENV=development pnpm exec vitest run ui/src/components/AttentionQueueRow.test.tsx ui/src/lib/attention.test.ts` (87 tests passed)
- `NODE_ENV=development pnpm --filter @paperclipai/ui typecheck`
- `pnpm check:token-gates`
- `git diff --check`
- All 29 latest-head GitHub checks passed or were intentionally skipped.
- Greptile reviewed the latest head at 5/5 with no open threads.

## Risks

- Low risk. The change only affects decision-card interactions.
- The click filter protects links, buttons, form controls, and menu controls from an extra disclosure action.
- No API, database, or migration changes are included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The exact serving revision and context window are not exposed to this session. The agent used repository tools, code execution, and reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

