### PR TITLE
fix(heartbeat): truncate an over-long run summary, do not discard it

### DIFF
--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -3,6 +3,7 @@ import {
   summarizeHeartbeatRunResultJson,
   buildHeartbeatRunIssueComment,
   mergeHeartbeatRunResultJson,
+  MAX_FALLBACK_COMMENT_CHARS,
 } from "../services/heartbeat-run-summary.js";
 
 describe("summarizeHeartbeatRunResultJson", () => {
@@ -100,10 +101,50 @@ describe("buildHeartbeatRunIssueComment", () => {
     }
   });
 
-  it("suppresses over-long fallback summaries even without a narration opener", () => {
-    const comment = buildHeartbeatRunIssueComment({ summary: "x".repeat(1201) });
+  // BRO-2310. Length and narration were one branch, and they are different problems.
+  //
+  // Narration is unusable at any length — BRO-1507/1516 withheld it for content, correctly.
+  // Length is not a content judgement. A long, declarative status report is exactly what a
+  // productive run produces, and discarding it told the board the agent had reported nothing.
+  //
+  // Real case: BRO-2300 ended four runs with a 2214-character status beginning "Status:
+  // assets ready for CEO QC; branch committed locally, pending push to open PR", followed by
+  // a file manifest. It was declarative, correct, and the only record of finished work. Each
+  // run replaced it with "did not post a summary comment", so the disposition check saw
+  // nothing, moved the issue to `missing_disposition`, and blocked it on a recovery owner
+  // that was the same stalled agent. The work stayed invisible for five hours.
+  //
+  // Truncation keeps the front of the message, which is where a status report puts its
+  // conclusion, and points at the run log for the rest.
+  it("truncates an over-long summary instead of discarding it", () => {
+    const summary = "Status: done. " + "x".repeat(2000);
+    const comment = buildHeartbeatRunIssueComment({ summary });
+
+    expect(comment).not.toBeNull();
+    expect(comment).toContain("Status: done.");
+    expect(comment).not.toContain("did not post a summary comment");
+  });
+
+  it("marks a truncated summary as truncated and points at the run log", () => {
+    const comment = buildHeartbeatRunIssueComment({ summary: "Status: done. " + "x".repeat(2000) });
+
+    expect(comment).toContain("truncated");
+    expect(comment).toContain("run log");
+  });
+
+  it("keeps a truncated summary within the character budget", () => {
+    const comment = buildHeartbeatRunIssueComment({ summary: "Status: done. " + "x".repeat(9000) });
+
+    // The marker is allowed on top of the cap; the body it carries is not.
+    expect(comment!.length).toBeLessThanOrEqual(MAX_FALLBACK_COMMENT_CHARS + 200);
+  });
+
+  it("still withholds narration outright, however long it is", () => {
+    // The narration branch is unchanged: content, not length, decides it.
+    const comment = buildHeartbeatRunIssueComment({ summary: "Let me check the thread. " + "y".repeat(2000) });
+
     expect(comment).toContain("did not post a summary comment");
-    expect(comment).not.toContain("xxxx");
+    expect(comment).not.toContain("yyyy");
   });
 
   it("posts a clean, in-length summary with no narration opener normally", () => {

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -104,6 +104,22 @@ const NARRATION_OPENERS =
   /^(let me\b|i['’]ll\b|i['’]m going\b|i need to\b|i can see\b|now i['’]ll\b|next,? i['’]ll\b|looking at\b|fetching\b|checking\b|first,)/i;
 const FALLBACK_WITHHELD_COMMENT =
   "Run completed. Agent did not post a summary comment this run (transcript withheld — see run log).";
+// Appended to a summary the agent really did write, when only its length was the problem.
+// It must read as an elision, never as an error — the run succeeded and the text is genuine.
+const TRUNCATION_MARKER =
+  "_(summary truncated at the comment length limit — see the run log for the full text.)_";
+
+/**
+ * Cut to at most `limit` characters, preferring the last line or word break in the final
+ * fifth of the budget. A cut through the middle of a word reads as corruption rather than
+ * as an elision, which invites the reader to distrust the part that did survive.
+ */
+function truncateToBoundary(text: string, limit: number): string {
+  const head = text.slice(0, limit);
+  const earliestBreak = Math.floor(limit * 0.8);
+  const boundary = Math.max(head.lastIndexOf("\n"), head.lastIndexOf(" "));
+  return (boundary >= earliestBreak ? head.slice(0, boundary) : head).trimEnd();
+}
 
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
@@ -120,8 +136,22 @@ export function buildHeartbeatRunIssueComment(
     return null;
   }
 
-  if (text.length > MAX_FALLBACK_COMMENT_CHARS || NARRATION_OPENERS.test(text)) {
+  // Narration is withheld on content, at any length (BRO-1507 / BRO-1516). Nothing in a
+  // stream of inter-tool narration becomes publishable by being shorter.
+  if (NARRATION_OPENERS.test(text)) {
     return FALLBACK_WITHHELD_COMMENT;
+  }
+
+  // Length is not a content judgement, and BRO-2310 is what it cost to treat it as one.
+  // A long declarative status report is what a productive run produces. Discarding it told
+  // the board the agent had reported nothing, so the disposition check found nothing, moved
+  // the issue to `missing_disposition`, and blocked it on a recovery owner that was the same
+  // stalled agent. On BRO-2300 that hid finished work across four runs and five hours.
+  //
+  // Truncate instead. A status report states its conclusion first, so the head of the message
+  // is the part worth keeping; the marker sends the reader to the run log for the remainder.
+  if (text.length > MAX_FALLBACK_COMMENT_CHARS) {
+    return `${truncateToBoundary(text, MAX_FALLBACK_COMMENT_CHARS)}\n\n${TRUNCATION_MARKER}`;
   }
 
   return text;


### PR DESCRIPTION
## The bug

`buildHeartbeatRunIssueComment` withheld a run summary when it was **either** narration **or** longer than `MAX_FALLBACK_COMMENT_CHARS` (1200):

```ts
if (text.length > MAX_FALLBACK_COMMENT_CHARS || NARRATION_OPENERS.test(text)) {
  return FALLBACK_WITHHELD_COMMENT;
}
```

Those are different problems, and only one of them is about content.

Narration is unusable at any length — that guard is correct and unchanged. **Length is not a content judgement.** A long, declarative status report is exactly what a productive run produces. Discarding it posts:

> Run completed. Agent did not post a summary comment this run (transcript withheld — see run log).

That statement is false. The agent did post one. Downstream, the disposition check finds no comment, moves the issue to `missing_disposition`, and blocks it on a recovery owner — which, when the agent is the assignee, is the same agent that just stalled.

## Measured, not inferred

Reproduced against a real run log. An issue ended four consecutive runs with a **2214-character** summary starting:

> Status: assets ready for CEO QC; branch committed locally, pending push to open PR

followed by a file manifest. It matched **no** narration opener. It was discarded every time. Finished work stayed invisible to the board for five hours, and a second agent re-implemented part of it before anyone noticed the first was done.

Three issues in that fleet are currently parked in `missing_disposition`.

## The change

Split the branch:

- **Narration → withheld**, at any length. Unchanged.
- **Over-long, non-narration → truncated** on a line or word boundary, with a marker pointing at the run log.

The marker reads as an elision rather than an error, because the run succeeded and the text is genuine:

> _(summary truncated at the comment length limit — see the run log for the full text.)_

Truncation keeps the **head** of the message deliberately: a status report states its conclusion first. Cutting at a boundary rather than mid-word matters — a cut through a word reads as corruption and invites a reader to distrust the part that did survive.

## Verification

| Suite | Result |
|---|---|
| `heartbeat-run-summary` | 17/17 pass |
| `heartbeat-process-recovery` | 103/103 pass |
| all `heartbeat*` suites | 621/623 pass |

The 2 failures are in `heartbeat-workspace-branch-containment` and **fail identically with this change stashed** — verified by running the suite both ways. The 19 `@paperclipai/plugin-sdk` typecheck errors are likewise present at baseline and come from an unbuilt SDK `dist` in the worktree.

Two mutations caught:

| Mutation | Tests failed |
|---|---|
| Recombine length into the withhold branch (the original bug) | 2 |
| Let narration fall through to truncation | 3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198HFSvnatHmEd1tZh2paC8
