### PR TITLE
fix(server): bound all workspace Git probes

### DIFF
--- a/packages/adapter-utils/src/git-workspace-sync.test.ts
+++ b/packages/adapter-utils/src/git-workspace-sync.test.ts
@@ -38,7 +38,7 @@ describe("git workspace sync", () => {
     }
   });
 
-  it("delegates every host-side full-tree enumeration to the registered scheduler", async () => {
+  it("delegates metadata probes and full-tree enumeration to the registered scheduler", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-git-scheduler-hook-"));
     cleanupDirs.push(rootDir);
     const repo = await createRepo(rootDir);
@@ -46,10 +46,11 @@ describe("git workspace sync", () => {
     const operations: string[] = [];
     setExpensiveWorkspaceGitExecutor(async (input) => {
       operations.push(input.operation);
-      return await runLocalGit(input.localDir, [...input.args], {
+      const result = await execFile("git", ["-C", input.localDir, ...input.args], {
         timeout: input.timeout,
         maxBuffer: input.maxBuffer,
       });
+      return { stdout: result.stdout, stderr: result.stderr };
     });
 
     const snapshot = await readGitWorkspaceSnapshot(repo);
@@ -57,6 +58,9 @@ describe("git workspace sync", () => {
     expect(snapshot?.overlayPaths).toContain("untracked.txt");
     expect(operations.sort()).toEqual([
       "adapter_sync.deleted_files",
+      "adapter_sync.git",
+      "adapter_sync.git",
+      "adapter_sync.git",
       "adapter_sync.ignored_files",
       "adapter_sync.overlay_diff",
       "adapter_sync.untracked_files",

--- a/packages/adapter-utils/src/git-workspace-sync.ts
+++ b/packages/adapter-utils/src/git-workspace-sync.ts
@@ -69,15 +69,27 @@ export async function runLocalGit(
   options: {
     timeout?: number;
     maxBuffer?: number;
+    operation?: string;
   } = {},
 ): Promise<GitCommandResult> {
+  const timeout = options.timeout ?? 15_000;
+  const maxBuffer = options.maxBuffer ?? 1024 * 128;
+  if (expensiveWorkspaceGitExecutor) {
+    return await expensiveWorkspaceGitExecutor({
+      localDir,
+      args,
+      operation: options.operation ?? "adapter_sync.git",
+      timeout,
+      maxBuffer,
+    });
+  }
   return await new Promise<GitCommandResult>((resolve, reject) => {
     execFile(
       "git",
       ["-C", localDir, ...args],
       {
-        timeout: options.timeout ?? 15_000,
-        maxBuffer: options.maxBuffer ?? 1024 * 128,
+        timeout,
+        maxBuffer,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -99,16 +111,7 @@ async function runExpensiveWorkspaceGit(
   operation: string,
   options: { timeout: number; maxBuffer: number },
 ): Promise<GitCommandResult> {
-  if (expensiveWorkspaceGitExecutor) {
-    return await expensiveWorkspaceGitExecutor({
-      localDir,
-      args,
-      operation,
-      timeout: options.timeout,
-      maxBuffer: options.maxBuffer,
-    });
-  }
-  return await runLocalGit(localDir, args, options);
+  return await runLocalGit(localDir, args, { ...options, operation });
 }
 
 export async function readGitWorkspaceSnapshot(localDir: string): Promise<GitWorkspaceSnapshot | null> {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -97,6 +97,7 @@ import type {
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { parseObject, asBoolean, asNumber, appendWithByteCap, MAX_EXCERPT_BYTES } from "../adapters/utils.js";
 import { costService } from "./costs.js";
+import { workspaceGitOperationScheduler } from "./workspace-git-operation-scheduler.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
@@ -1910,7 +1911,12 @@ async function hasGitMetadata(cwd: string | null | undefined) {
 async function isGitCheckout(cwd: string | null | undefined) {
   const normalized = readNonEmptyString(cwd);
   if (!normalized) return false;
-  return execFile("git", ["rev-parse", "--show-toplevel"], { cwd: normalized })
+  return workspaceGitOperationScheduler.run({
+    workspacePath: normalized,
+    args: ["rev-parse", "--show-toplevel"],
+    operation: "heartbeat.workspace_preflight.checkout",
+    cacheTtlMs: 10_000,
+  })
     .then((result) => Boolean(readNonEmptyString(result.stdout)))
     .catch(() => false);
 }
@@ -1925,7 +1931,12 @@ function sameResolvedPath(left: string | null | undefined, right: string | null 
 async function hasGitPushRemote(cwd: string | null | undefined) {
   const normalized = readNonEmptyString(cwd);
   if (!normalized) return false;
-  const remoteNames = await execFile("git", ["remote"], { cwd: normalized })
+  const remoteNames = await workspaceGitOperationScheduler.run({
+    workspacePath: normalized,
+    args: ["remote"],
+    operation: "heartbeat.workspace_preflight.remotes",
+    cacheTtlMs: 10_000,
+  })
     .then((result) =>
       result.stdout
         .split(/\r?\n/)
@@ -1935,7 +1946,12 @@ async function hasGitPushRemote(cwd: string | null | undefined) {
     .catch(() => []);
 
   for (const remoteName of remoteNames) {
-    const pushUrl = await execFile("git", ["remote", "get-url", "--push", remoteName], { cwd: normalized })
+    const pushUrl = await workspaceGitOperationScheduler.run({
+      workspacePath: normalized,
+      args: ["remote", "get-url", "--push", remoteName],
+      operation: "heartbeat.workspace_preflight.push_remote",
+      cacheTtlMs: 10_000,
+    })
       .then((result) => readNonEmptyString(result.stdout))
       .catch(() => null);
     if (pushUrl) return true;


### PR DESCRIPTION
## Summary

- route adapter workspace metadata probes through the existing bounded Git scheduler, not only full-tree enumeration
- route heartbeat checkout and push-remote preflight through the same scheduler
- retain per-command timeouts/output limits while adding concurrency bounds, admission control, single-flight deduplication, and short-lived preflight caching

## Why

On a busy single-box deployment, concurrent agent preparation could bypass the scheduler through `runLocalGit()` and heartbeat `execFile("git", ...)` calls. The server accumulated thousands of exited Git children faster than Node could service child-exit callbacks, exhausting the service cgroup and making health requests time out.

The previous scheduler fix covered file-resource scans and selected expensive adapter sync commands, but left metadata probes and heartbeat validation unbounded.

## Verification

- `pnpm exec vitest run --project @paperclipai/adapter-utils packages/adapter-utils/src/git-workspace-sync.test.ts` (19 passed)
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-project-env.test.ts src/__tests__/heartbeat-workspace-session.test.ts --no-file-parallelism --maxWorkers=1` (174 passed)
- adapter-utils typecheck passed
- server typecheck could not complete in the shared-node_modules worktree because package-local dependencies for `packages/shared` were not linked; focused server tests compile and pass
