### PR TITLE
feat(issues): add staleHours filter to issue list route

### DIFF
--- a/cli/src/__tests__/issue-subresources.test.ts
+++ b/cli/src/__tests__/issue-subresources.test.ts
@@ -255,6 +255,25 @@ describe("issue subresource commands", () => {
     const file = (init.body as FormData).get("file") as File;
     expect(file.type).toBe("text/html");
   });
+
+  it("forwards --stale-hours as a saved-query staleHours filter on issue list", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse([])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await run([
+      "issue", "list",
+      "--company-id", COMPANY_ID,
+      "--status", "todo,in_progress,in_review,blocked",
+      "--stale-hours", "100",
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe(`/api/companies/${COMPANY_ID}/issues`);
+    expect(parsed.searchParams.get("staleHours")).toBe("100");
+    expect(parsed.searchParams.get("status")).toBe("todo,in_progress,in_review,blocked");
+  });
 });
 
 function jsonResponse(body: unknown = { ok: true }, init: ResponseInit = { status: 200 }): Response {

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -48,6 +48,7 @@ interface IssueBaseOptions extends BaseClientOptions {
   assigneeAgentId?: string;
   projectId?: string;
   match?: string;
+  staleHours?: string;
 }
 
 interface IssueCreateOptions extends BaseClientOptions {
@@ -179,6 +180,10 @@ export function registerIssueCommands(program: Command): void {
       .option("--assignee-agent-id <id>", "Filter by assignee agent ID")
       .option("--project-id <id>", "Filter by project ID")
       .option("--match <text>", "Local text match on identifier/title/description")
+      .option(
+        "--stale-hours <hours>",
+        "Only issues with no activity in the last N hours (saved-query example for stale-issue visibility: --status todo,in_progress,in_review,blocked --stale-hours 100)",
+      )
       .action(async (opts: IssueBaseOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
@@ -186,6 +191,7 @@ export function registerIssueCommands(program: Command): void {
           if (opts.status) params.set("status", opts.status);
           if (opts.assigneeAgentId) params.set("assigneeAgentId", opts.assigneeAgentId);
           if (opts.projectId) params.set("projectId", opts.projectId);
+          if (opts.staleHours) params.set("staleHours", opts.staleHours);
 
           const query = params.toString();
           const path = `${apiPath`/api/companies/${ctx.companyId}/issues`}${query ? `?${query}` : ""}`;

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -338,7 +338,7 @@ Notes:
 ## Issue Commands
 
 ```sh
-npx paperclipai issue list --company-id <company-id> [--status todo,in_progress] [--assignee-agent-id <agent-id>] [--match text]
+npx paperclipai issue list --company-id <company-id> [--status todo,in_progress] [--assignee-agent-id <agent-id>] [--match text] [--stale-hours <hours>]
 npx paperclipai issue get <issue-id-or-identifier>
 npx paperclipai issue create --company-id <company-id> --title "..." [--description "..."] [--status todo] [--priority high]
 npx paperclipai issue update <issue-id> [--status in_progress] [--comment "..."]
@@ -412,6 +412,23 @@ npx paperclipai issue label:delete <label-id>
 npx paperclipai issue feedback:votes <issue-id>
 npx paperclipai issue feedback:vote <issue-id> --payload-json '{"targetType":"issue_comment","targetId":"...","vote":"up"}'
 ```
+
+### Stale-issue visibility (saved query)
+
+Open issues can sit untouched with no signal on the board. `GET /companies/:companyId/issues` supports a `staleHours` filter built on `lastActivityAt` (comments, activity-log entries, and field updates all count as activity). Use it as a saved query — bookmark the command or script it into a periodic audit instead of scanning the board by hand:
+
+```sh
+# Open issues with no activity in the last 100 hours
+npx paperclipai issue list --company-id <company-id> --status todo,in_progress,in_review,blocked --stale-hours 100
+```
+
+Equivalent raw API call:
+
+```
+GET /companies/{id}/issues?staleHours=100&status=todo,in_progress,in_review,blocked
+```
+
+`staleHours` must be a positive number; the server returns `400` otherwise.
 
 ## Project Commands
 

--- a/server/src/__tests__/issue-list-stalehours-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-stalehours-filter-routes.test.ts
@@ -1,0 +1,237 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  companyMemberships,
+  createDb,
+  issueComments,
+  issues,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue list route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue list routes staleHours filter", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-list-stalehours-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function uniqueIssuePrefix() {
+    return `P${randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+  }
+
+  async function seedCloudTenantMember(companyId: string) {
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+  }
+
+  async function seedCompany(companyId: string) {
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+  }
+
+  it("excludes an issue updated below the staleHours threshold", async () => {
+    const companyId = randomUUID();
+    const freshIssueId = randomUUID();
+    await seedCompany(companyId);
+    // Updated 10 hours ago -- below a 100h threshold, must be excluded.
+    const recentUpdatedAt = new Date(Date.now() - 10 * 60 * 60 * 1000);
+    await db.insert(issues).values({
+      id: freshIssueId,
+      companyId,
+      title: "Recently touched issue",
+      status: "todo",
+      priority: "medium",
+      updatedAt: recentUpdatedAt,
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "100", status: "todo,in_progress,in_review,blocked", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([]);
+  });
+
+  it("includes an issue with no activity beyond the staleHours threshold", async () => {
+    const companyId = randomUUID();
+    const staleIssueId = randomUUID();
+    await seedCompany(companyId);
+    // Updated 200 hours ago -- above a 100h threshold, must be included.
+    const oldUpdatedAt = new Date(Date.now() - 200 * 60 * 60 * 1000);
+    await db.insert(issues).values({
+      id: staleIssueId,
+      companyId,
+      title: "Untouched issue",
+      status: "in_progress",
+      priority: "medium",
+      updatedAt: oldUpdatedAt,
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "100", status: "todo,in_progress,in_review,blocked", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([staleIssueId]);
+  });
+
+  it("treats a recent comment as activity, excluding the issue even though updatedAt is old", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await seedCompany(companyId);
+    const oldUpdatedAt = new Date(Date.now() - 200 * 60 * 60 * 1000);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Old row, recently commented",
+      status: "in_progress",
+      priority: "medium",
+      updatedAt: oldUpdatedAt,
+    });
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      authorType: "user",
+      authorUserId: "cloud-user-1",
+      body: "still working on this",
+      createdAt: new Date(Date.now() - 5 * 60 * 60 * 1000),
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "100", status: "todo,in_progress,in_review,blocked", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([]);
+  });
+
+  it("treats a recent non-inbox activity log entry as activity, excluding the issue", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await seedCompany(companyId);
+    const oldUpdatedAt = new Date(Date.now() - 200 * 60 * 60 * 1000);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Old row, recently logged",
+      status: "in_progress",
+      priority: "medium",
+      updatedAt: oldUpdatedAt,
+    });
+    await db.insert(activityLog).values({
+      id: randomUUID(),
+      companyId,
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "issue.status_changed",
+      entityType: "issue",
+      entityId: issueId,
+      createdAt: new Date(Date.now() - 5 * 60 * 60 * 1000),
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "100", status: "todo,in_progress,in_review,blocked", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([]);
+  });
+
+  it("rejects a non-positive staleHours with 400", async () => {
+    const companyId = randomUUID();
+    await seedCompany(companyId);
+
+    const app = createApp(companyId);
+    const resZero = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "0", limit: "20" });
+    expect(resZero.status).toBe(400);
+    expect(resZero.body).toMatchObject({ error: "staleHours must be a positive number when provided" });
+
+    const resNegative = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "-5", limit: "20" });
+    expect(resNegative.status).toBe(400);
+
+    const resNonNumeric = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "not-a-number", limit: "20" });
+    expect(resNonNumeric.status).toBe(400);
+  });
+});

--- a/server/src/__tests__/issue-list-stalehours-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-stalehours-filter-routes.test.ts
@@ -233,5 +233,11 @@ describeEmbeddedPostgres("issue list routes staleHours filter", () => {
       .get(`/api/companies/${companyId}/issues`)
       .query({ staleHours: "not-a-number", limit: "20" });
     expect(resNonNumeric.status).toBe(400);
+
+    const resOversized = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ staleHours: "1e308", limit: "20" });
+    expect(resOversized.status, JSON.stringify(resOversized.body)).toBe(400);
+    expect(resOversized.body).toMatchObject({ error: "staleHours must be a positive number when provided" });
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5819,6 +5819,7 @@ export function issueRoutes(
     const assigneeAgentFilterRaw = req.query.assigneeAgentId;
     let assigneeAgentId: string | null | undefined;
     const rawUpdatedSince = req.query.updatedSince as string | undefined;
+    const rawStaleHours = req.query.staleHours as string | undefined;
 
     if (assigneeUserFilterRaw === "me" && (!assigneeUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "assigneeUserId=me requires board authentication" });
@@ -5889,6 +5890,15 @@ export function issueRoutes(
       res.status(400).json({ error: "updatedSince must be a valid ISO 8601 timestamp when provided" });
       return;
     }
+    let staleHours: number | undefined;
+    if (rawStaleHours !== undefined) {
+      const parsedStaleHours = Number(rawStaleHours);
+      if (!Number.isFinite(parsedStaleHours) || parsedStaleHours <= 0) {
+        res.status(400).json({ error: "staleHours must be a positive number when provided" });
+        return;
+      }
+      staleHours = parsedStaleHours;
+    }
     const offset = parsedOffset ?? 0;
 
     const listFilters: IssueFilters = {
@@ -5926,6 +5936,7 @@ export function issueRoutes(
       sortField: sortField === "updated" ? "updated" : undefined,
       sortDir: sortDir === "asc" || sortDir === "desc" ? sortDir : undefined,
       updatedSince: rawUpdatedSince,
+      staleHours,
     };
     const requestKey = issueListRequestKey({
       req,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5893,7 +5893,13 @@ export function issueRoutes(
     let staleHours: number | undefined;
     if (rawStaleHours !== undefined) {
       const parsedStaleHours = Number(rawStaleHours);
-      if (!Number.isFinite(parsedStaleHours) || parsedStaleHours <= 0) {
+      const staleCutoffMs = Date.now() - parsedStaleHours * 60 * 60 * 1000;
+      if (
+        !Number.isFinite(parsedStaleHours) ||
+        parsedStaleHours <= 0 ||
+        !Number.isFinite(staleCutoffMs) ||
+        !Number.isFinite(new Date(staleCutoffMs).getTime())
+      ) {
         res.status(400).json({ error: "staleHours must be a positive number when provided" });
         return;
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -576,6 +576,8 @@ export interface IssueFilters {
   sortDir?: "asc" | "desc";
   /** ISO 8601 timestamp — only return issues with updatedAt strictly after this value. */
   updatedSince?: string;
+  /** Only return issues whose canonical last-activity timestamp (max of updatedAt, latest comment, latest non-inbox activity log) is at or before now - staleHours hours. */
+  staleHours?: number;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -1563,6 +1565,12 @@ function issueCanonicalLastActivityAtExpr(companyId: string) {
       COALESCE(${latestLogAt}, to_timestamp(0))
     )
   `;
+}
+
+function staleHoursCondition(companyId: string, staleHours: number) {
+  const canonicalLastActivityAt = issueCanonicalLastActivityAtExpr(companyId);
+  const staleBefore = new Date(Date.now() - staleHours * 60 * 60 * 1000);
+  return sql<boolean>`${canonicalLastActivityAt} <= ${staleBefore.toISOString()}::timestamptz`;
 }
 
 function unreadForUserCondition(companyId: string, userId: string) {
@@ -5589,6 +5597,9 @@ export function issueService(db: Db) {
         if (Number.isFinite(since.getTime())) {
           conditions.push(gt(issues.updatedAt, since));
         }
+      }
+      if (filters?.staleHours !== undefined && Number.isFinite(filters.staleHours) && filters.staleHours > 0) {
+        conditions.push(staleHoursCondition(companyId, filters.staleHours));
       }
       if (filters?.excludeRoutineExecutions && !filters?.originKind && !filters?.originId) {
         conditions.push(ne(issues.originKind, "routine_execution"));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue list API (`GET /companies/:companyId/issues`) is how supervisors and agents find what needs attention
> - A recurring failure mode is issues sitting untouched for a long time with nothing on the board flagging it — this was only caught via a one-off manual scan comparing `updatedAt` timestamps by hand
> - `lastActivityAt` (max of `updatedAt`, latest comment, latest non-inbox activity log) already exists on the issue payload and already powers `?sortField=updated`, but there is no way to filter by *age* of that activity, only to sort by it or filter by an absolute `updatedSince` cutoff
> - Without an age-threshold filter, surfacing "stale" issues requires fetching everything and computing the threshold client-side
> - This pull request adds a `staleHours` query param that filters issues whose canonical last-activity timestamp is at or before `now - staleHours` hours, reusing the exact same last-activity SQL expression that already backs sorting
> - The benefit is a single API call (`?staleHours=100&status=todo,in_progress,in_review,blocked`) surfaces exactly the stale-issue set, with no client-side computation and no manual audit

## Linked Issues or Issue Description

No existing public GitHub issue covers this; describing in-PR per the **Enhancement proposal** template.

**What existing behavior does this improve?**

`GET /companies/:companyId/issues` — the list route already supports `sortField=updated` (sort by last activity) and `updatedSince` (absolute-timestamp cutoff on `updatedAt` only), but has no way to filter by *age* of activity, and no way to account for comments/activity-log entries when filtering (only `updatedSince` looks at the raw `updatedAt` column).

**Subsystem affected**

server/ — REST API & orchestration services

**Current behavior**

To find issues with no activity in the last N hours, a caller must fetch the full open-issue list and filter client-side, and must additionally reconcile `updatedAt` against comments/activity-log entries by hand, because `updatedSince` only compares the raw `updatedAt` column, not the same canonical last-activity computation the API already uses elsewhere (`lastActivityAt`, `sortField=updated`).

**Proposed behavior**

`GET /companies/:companyId/issues?staleHours=100` returns only issues whose canonical last-activity timestamp (`GREATEST(updatedAt, latest comment createdAt, latest non-inbox activity-log createdAt)`) is at or before `now - 100h`. Combines with `status` and all other existing filters via AND. `staleHours` must be a positive number; non-positive or non-numeric values return `400`, mirroring the existing `updatedSince` validation.

## What Changed

- `server/src/routes/issues.ts`: parse and validate the new `staleHours` query param (positive number, else `400`); wire it into the existing `listFilters` object passed to the issue service.
- `server/src/services/issues.ts`: add `staleHoursCondition()`, a SQL condition built on the pre-existing `issueCanonicalLastActivityAtExpr()` helper (the same expression already used for `sortField=updated` sorting), applied in the main `WHERE` clause so pagination stays correct — no post-fetch filtering that could shrink a page below `limit`.
- `server/src/__tests__/issue-list-stalehours-filter-routes.test.ts`: new test file covering below-threshold exclusion, above-threshold inclusion, a recent comment keeping an otherwise-stale issue "fresh", a recent non-inbox activity-log entry doing the same, and invalid `staleHours` rejection (zero, negative, non-numeric).

**Surfacing choice:** ships as a query param only (engineer's call, per the enhancement's scope). No new UI column/badge was added in this change; a saved query (`?staleHours=100&status=todo,in_progress,in_review,blocked`) is the documented way to surface stale issues today. A UI affordance (column/badge) is a reasonable, separate follow-up if the board wants persistent visibility instead of an on-demand API/saved-query call.

## Verification

Ran the new test file directly:

```
$ pnpm -F @paperclipai/server exec vitest run src/__tests__/issue-list-stalehours-filter-routes.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Confirmed no regression in the sibling `updatedSince` filter test:

```
$ pnpm -F @paperclipai/server exec vitest run src/__tests__/issue-list-updatedsince-filter-routes.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Also manually verified the acceptance scenario end to end against an embedded Postgres instance: seeded issues at 37h/99h/100h/101h/250h/500h since `updatedAt` (the 500h one with `status=done`), called `GET .../issues?staleHours=100&status=todo,in_progress,in_review,blocked`, and independently recomputed the expected set by hand from the raw `updatedAt` values plus the status filter (without touching the `staleHours` code path). Both matched exactly: the 100h/101h/250h issues were returned; the 37h/99h issues were correctly excluded (below threshold); the 500h `done` issue was correctly excluded by the status filter; the 100h-exactly issue was correctly included (`<=` boundary, not `<`).

## Risks

- Low risk. Purely additive: a new optional query param with its own validation branch; no existing filter behavior changes when `staleHours` is omitted.
- The underlying `issueCanonicalLastActivityAtExpr()` SQL helper is pre-existing and already used in production for `sortField=updated` sorting and for the `lastActivityAt` field in list responses, so this reuses a well-exercised expression rather than introducing new activity-computation logic.
- No schema or migration changes.

## Model Used

Claude (Anthropic), accessed via the Pi coding agent harness — extended reasoning mode, tool use (file edit/read, bash, grep), no code execution outside the local dev/test environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
