### PR TITLE
fix(cli): stop the doctor managed-install check from firing on a global npm install

### DIFF
--- a/cli/src/__tests__/managed-install-check.test.ts
+++ b/cli/src/__tests__/managed-install-check.test.ts
@@ -73,6 +73,36 @@ describe("managed install doctor checks", () => {
     ]);
   });
 
+  it("ignores a foreign binary that a global npm install left at the shim path", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
+    const paths = resolveInstallStorePaths({
+      paperclipHome: path.join(root, ".paperclip"),
+      homeDir: root,
+    });
+    // `npm config set prefix ~/.local` puts the global binary on exactly the
+    // path the managed installer uses for its shim.
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    const npmGlobalBinary = "#!/bin/sh exec node $HOME/.local/lib/node_modules/paperclipai/dist/index.js";
+    fs.writeFileSync(paths.shimPath, npmGlobalBinary);
+
+    expect(managedInstallChecks(paths)).toEqual([
+      expect.objectContaining({ name: "Managed install", status: "pass" }),
+    ]);
+  });
+
+  it("still detects a managed install from the shim marker alone", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
+    const paths = resolveInstallStorePaths({
+      paperclipHome: path.join(root, ".paperclip"),
+      homeDir: root,
+    });
+    writeManagedShim(paths);
+
+    expect(managedInstallChecks(paths)).toEqual([
+      expect.objectContaining({ name: "Managed install manifest", status: "fail" }),
+    ]);
+  });
+
   it("ignores an empty installs directory left by a harmless lock lifecycle", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
     const paths = resolveInstallStorePaths({

--- a/cli/src/checks/managed-install-check.ts
+++ b/cli/src/checks/managed-install-check.ts
@@ -16,14 +16,27 @@ function pathContains(directory: string): boolean {
     .some((entry) => path.resolve(entry) === normalized);
 }
 
+function isManagedShim(shimPath: string): boolean {
+  try {
+    return fs.readFileSync(shimPath, "utf8").includes(MANAGED_SHIM_MARKER);
+  } catch {
+    return false;
+  }
+}
+
 function hasManagedArtifacts(paths: InstallStorePaths): boolean {
   const persistentArtifacts = [
     paths.manifestPath,
     paths.markerPath,
     paths.currentPath,
-    paths.shimPath,
   ].some((entry) => fs.existsSync(entry));
   if (persistentArtifacts) return true;
+  // `shimPath` is `~/.local/bin/paperclipai`. A global npm install with
+  // `npm config set prefix ~/.local` writes its own binary to that exact path,
+  // so the file existing is not evidence of a managed install. Read the marker
+  // the managed installer puts in the shim instead. The paths above live under
+  // `~/.paperclip/cli/`, which only the managed installer creates.
+  if (isManagedShim(paths.shimPath)) return true;
   try {
     return fs.readdirSync(paths.installsRoot).length > 0;
   } catch (error) {
@@ -112,12 +125,7 @@ export function managedInstallChecks(
         },
   );
 
-  let shimValid = false;
-  try {
-    shimValid = fs.readFileSync(paths.shimPath, "utf8").includes(MANAGED_SHIM_MARKER);
-  } catch {
-    shimValid = false;
-  }
+  const shimValid = isManagedShim(paths.shimPath);
   results.push(
     shimValid
       ? { name: "Managed install shim", status: "pass", message: paths.shimPath }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Self-hosters install the `paperclipai` CLI in several supported ways, and `paperclipai run` calls `doctor` before it starts the server
> - `doctor` includes optional managed-install checks, which the docs say must report "not present" for npx, global npm, and source-checkout usage
> - The check decides an install is managed when any artifact path exists, and one of those paths is the shim at `~/.local/bin/paperclipai`
> - A global npm install with `npm config set prefix ~/.local` — the no-sudo setup the CLI docs recommend — writes its own binary to that exact path, so the check sees a managed install that does not exist, looks for a manifest, and fails
> - Because `run` calls `doctor` first, the server refuses to start, and the operator has no flag to skip it
> - This pull request counts the shim only when it carries the marker the managed installer writes
> - The benefit is that a documented install method stops being blocked, and the check keeps working for real managed installs

## Linked Issues or Issue Description

Refs #11755 — a global npm install upgraded to 2026.817.0 could not start: `doctor` failed with "Managed install artifacts exist but /home/.../.paperclip/cli/install.json is missing", and the reporter had to downgrade to recover.

This pull request fixes the false positive, which is the part that blocks the server. The issue lists two more suggestions that stay out of scope:

- Degrading the check to a warning for non-managed installs. With the false positive fixed, a non-managed install no longer reaches that branch, and a real managed install with a missing manifest should still fail.
- Shipping `install`, `update`, and `service` in the same npm publish as the checks that reference them. That is a release-packaging question, not a change to this check.

**What happened?**
`doctor` reported a failing "Managed install manifest" check on an instance that has only ever been a global npm install. `paperclipai run` calls `doctor` before it starts the server, so the server did not start.

**Expected behavior**
Per the setup-commands documentation, the managed-install checks are optional: "Running Paperclip through npx, a global npm install, or a source checkout, with no background service, passes cleanly — the checks report 'not present' rather than complaining."

**Steps to reproduce**
1. `npm config set prefix ~/.local` and install the CLI with `npm install -g paperclipai`.
2. Do not use the managed installer, so `~/.paperclip/cli/` does not exist.
3. Run `paperclipai doctor`. The "Managed install manifest" check fails.

**Paperclip version or commit**
Reproduced on `master`. The reporter saw it on 2026.817.0, upgraded from 2026.722.0.

**Deployment mode**
Self-hosted server, external PostgreSQL, hand-written systemd unit.

I searched the open pull requests for `11755`, `managed install manifest`, and `hasManagedArtifacts`. No open pull request changes this check.

## What Changed

- `cli/src/checks/managed-install-check.ts`: `hasManagedArtifacts` no longer counts a file at `shimPath`. It counts the shim only when the file contains `MANAGED_SHIM_MARKER`, through a new `isManagedShim` helper. The remaining artifact paths — `install.json`, `.managed-install`, `current`, and the `installs` directory — live under `~/.paperclip/cli/`, which only the managed installer creates, so they are unchanged.
- `cli/src/checks/managed-install-check.ts`: the later shim validity check reuses `isManagedShim` instead of repeating the read.
- `cli/src/__tests__/managed-install-check.test.ts`: two tests — a foreign binary at the shim path reports "Not present", and a managed shim alone is still detected.

The marker is the right discriminator because the check already used it to validate the shim further down. npm writes no such marker, so the two cases were already distinguishable; the detection step simply did not ask.

## Verification

- `npx vitest run --root cli src/__tests__/managed-install-check.test.ts` — 6/6 pass.
- The false-positive test fails without the change, which is the reported symptom. The managed-shim test passes before and after, so detection of a real managed install is unchanged.
- `npx vitest run --root cli` — 370 pass. 28 tests fail on my Windows workstation, and the same 28 fail on an unmodified checkout, so they are unrelated to this change.
- `pnpm typecheck` — clean across the workspace.

## Risks

Low. The change narrows one detection condition.

- A managed install is still detected by `install.json`, `.managed-install`, `current`, a non-empty `installs` directory, or a shim that carries the marker. The managed installer writes the marker whenever it writes the shim.
- A managed install whose shim was replaced by a foreign binary, and whose `~/.paperclip/cli/` was also removed, now reports "Not present" instead of failing. Nothing in that state is repairable by the check, and `paperclipai install` remains the documented recovery.
- No behavior changes for npx or source-checkout usage, which never matched the shim path.

## Model Used

Claude Opus 5 (`claude-opus-5`, Anthropic) through Claude Code, with extended thinking and tool use. The model located the path collision, wrote the guard and the tests, and ran the test and typecheck commands. @Drizzy07x reviewed the change and submits it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable — the documented behavior is what this change restores)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (the first CI run is pending)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending)
- [x] I will address all Greptile and reviewer comments before requesting merge
