### PR TITLE
feat(ci): forbid adapter-type literals in shared code

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Test no-git-push check
         run: node --test ./scripts/check-no-git-push.test.mjs
 
+      - name: Reject adapter-type literals in shared code
+        run: node ./scripts/check-adapter-type-literals.mjs
+
+      - name: Test adapter-literal check
+        run: node --test ./scripts/check-adapter-type-literals.test.mjs
+
       - name: Test general-server shard partition
         run: node --test ./scripts/__tests__/run-vitest-stable-shard.test.mjs
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "release:rollback": "./scripts/rollback-latest.sh",
     "release:bootstrap-package": "node scripts/bootstrap-npm-package.mjs",
     "check:tokens": "node scripts/check-forbidden-tokens.mjs",
+    "check:adapter-literals": "node scripts/check-adapter-type-literals.mjs",
     "check:token-gates": "node scripts/check-token-gates.mjs",
     "check:no-git-push": "node scripts/check-no-git-push.mjs",
     "test:check-no-git-push": "node --test scripts/check-no-git-push.test.mjs",

--- a/scripts/check-adapter-type-literals.mjs
+++ b/scripts/check-adapter-type-literals.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * check-adapter-type-literals.mjs
+ *
+ * Architectural gate: shared code consumes declared adapter capabilities and
+ * never branches on adapter identities. Adapter-type string literals (e.g.
+ * "kimi_local") belong only in an adapter's own registration surfaces —
+ * adapter packages, ui/src/adapters/<type>/, server/src/adapters/ — where
+ * the adapter declares capabilities that shared code resolves generically
+ * (UIAdapterModule.transcriptPresentation, acpx engine invocation config,
+ * server registry entries). Identity checks in shared code do not scale to
+ * many adapters and cannot work at all for externally-shipped plugin
+ * adapters, which register at runtime.
+ *
+ * Detection is the union of two sources, so both current and future adapters
+ * are covered:
+ *  - the declared adapter types parsed from packages/shared/src/constants.ts
+ *    (AGENT_ADAPTER_TYPES — the source of truth), and
+ *  - the naming-convention suffixes every new adapter type uses
+ *    (_local, _acp, _gateway, _cloud), which also covers types that have not
+ *    been added to the shared list yet.
+ * Three legacy names ("process", "http", "cursor") are excluded from literal
+ * matching: as bare quoted strings they collide with URL schemes, CSS cursor
+ * values, and the Node process — they cannot be scanned safely. All new
+ * adapter types use suffixed names.
+ *
+ * Legacy files are ratcheted by BASELINE COUNT, not skipped: adding another
+ * adapter-type literal to an allowlisted file fails the check. Baselines are
+ * meant to only ever decrease as per-adapter tables migrate into adapter
+ * descriptors.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+// Shared-code directories where adapter identities are forbidden. Adapter
+// registration homes (ui/src/adapters/, server/src/adapters/, adapter
+// packages) are intentionally NOT scanned.
+export const DEFAULT_SCAN_DIRS = [
+  "ui/src/lib",
+  "ui/src/components",
+  "packages/adapter-utils/src",
+];
+
+// Naming-convention suffixes for adapter types. Catches future adapter types
+// before they land in the shared AGENT_ADAPTER_TYPES list.
+export const ADAPTER_TYPE_SUFFIX_RE = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*_(?:local|acp|gateway|cloud)$/;
+
+// Legacy adapter-type names that cannot be literal-scanned safely: as bare
+// quoted strings they collide with unrelated code ("http" URL schemes,
+// "cursor" CSS values, "process" the Node global). New adapter types must use
+// suffixed names, which the suffix pattern covers.
+export const GENERIC_NAME_EXCLUSIONS = new Set([
+  "process",
+  "http",
+  "cursor",
+  // Not an adapter type: an error-code substring checked by the workspace
+  // file browser ("no_local"). Matched by the _local suffix pattern only.
+  "no_local",
+]);
+
+const QUOTED_LOWERCASE_RE = /["'`]([a-z][a-z0-9_]*)["'`]/g;
+
+const SHARED_CONSTANTS_PATH = "packages/shared/src/constants.ts";
+
+// LEGACY DEBT — baselines may only decrease. Each entry is the exact
+// per-identity occurrence count the file carried when this gate landed (the
+// full multiset). Any per-identity increase fails — a new identity, an
+// equal-count swap, and one-more-of-an-allowed-identity are all violations.
+// When a table migrates into adapter descriptors, lower (or delete) its
+// baseline.
+export const LEGACY_BASELINES = new Map([
+  ["packages/adapter-utils/src/session-compaction.ts", { claude_local: 1, codex_local: 1, cursor_cloud: 1, gemini_local: 1, hermes_local: 1, opencode_local: 1, pi_local: 1 }],
+  ["ui/src/components/agent-config-defaults.ts", { claude_local: 1 }],
+  ["ui/src/components/AgentConfigForm.tsx", { claude_local: 2, codex_local: 8, cursor_cloud: 1, gemini_local: 3, opencode_local: 14 }],
+  ["ui/src/components/ConfigureBuiltInAgentModal.tsx", { codex_local: 1, hermes_gateway: 1, openclaw_gateway: 1, opencode_local: 1 }],
+  ["ui/src/components/issue-properties/helpers.ts", { codex_local: 3, opencode_local: 3 }],
+  ["ui/src/components/issue-properties/IssueProperties.tsx", { claude_local: 3, codex_local: 1, opencode_local: 1 }],
+  ["ui/src/components/NewIssueDialog.tsx", { claude_local: 2, codex_local: 3, opencode_local: 3 }],
+  ["ui/src/components/OnboardingWizard.tsx", { claude_local: 6, codex_local: 7, gemini_local: 8, openclaw_gateway: 3, opencode_local: 14, pi_local: 1 }],
+  ["ui/src/lib/agent-onboarding-prompt.ts", { hermes_gateway: 1, openclaw_gateway: 1 }],
+  ["ui/src/lib/issue-assignee-overrides.ts", { claude_local: 3, codex_local: 2, opencode_local: 2 }],
+]);
+
+/**
+ * Parse the declared adapter types from packages/shared/src/constants.ts.
+ * Returns [] when the file or the array is missing (fixture roots in tests);
+ * the suffix pattern still applies there.
+ */
+export function loadDeclaredAdapterTypes(root = repoRoot) {
+  let source;
+  try {
+    source = readFileSync(join(root, SHARED_CONSTANTS_PATH), "utf8");
+  } catch {
+    return [];
+  }
+
+  const arrayMatch = source.match(/export const AGENT_ADAPTER_TYPES = \[([\s\S]*?)\] as const;/);
+  if (!arrayMatch) return [];
+
+  return [...arrayMatch[1].matchAll(/["']([a-z][a-z0-9_]*)["']/g)].map((m) => m[1]);
+}
+
+export function buildAdapterTypeMatcher(declaredTypes) {
+  const declared = new Set(
+    declaredTypes.filter((type) => !GENERIC_NAME_EXCLUSIONS.has(type)),
+  );
+  return (literal) => {
+    if (GENERIC_NAME_EXCLUSIONS.has(literal)) return false;
+    return declared.has(literal) || ADAPTER_TYPE_SUFFIX_RE.test(literal);
+  };
+}
+
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+
+function isSourceFile(name) {
+  if (name.includes(".test.") || name.includes(".stories.")) return false;
+  return [...SOURCE_EXTENSIONS].some((ext) => name.endsWith(ext));
+}
+
+function walk(dir, files = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "__tests__") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, files);
+    } else if (entry.isFile() && isSourceFile(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+export function scanForAdapterTypeLiterals({
+  root = repoRoot,
+  scanDirs = DEFAULT_SCAN_DIRS,
+  legacyBaselines = LEGACY_BASELINES,
+  declaredTypes = loadDeclaredAdapterTypes(root),
+} = {}) {
+  const isAdapterTypeLiteral = buildAdapterTypeMatcher(declaredTypes);
+  const violations = [];
+  const legacyOverages = [];
+  const legacyImprovements = [];
+
+  for (const scanDir of scanDirs) {
+    for (const file of walk(join(root, scanDir))) {
+      const relPath = relative(root, file).replace(/\\/g, "/");
+      const lines = readFileSync(file, "utf8").split("\n");
+
+      const hits = [];
+      for (let index = 0; index < lines.length; index += 1) {
+        for (const match of lines[index].matchAll(QUOTED_LOWERCASE_RE)) {
+          if (isAdapterTypeLiteral(match[1])) {
+            hits.push({ file: relPath, line: index + 1, literal: match[1] });
+          }
+        }
+      }
+      if (hits.length === 0) continue;
+
+      const fileBaseline = legacyBaselines.get(relPath);
+      if (fileBaseline === undefined) {
+        violations.push(...hits);
+        continue;
+      }
+      // Per-identity ratchet: any occurrence beyond that identity's baseline
+      // count in this file is a violation — a brand-new identity, an
+      // equal-count swap, and one-more-of-an-allowed-identity all fail. Hits
+      // are counted in file order, so the surplus occurrences are reported
+      // with their exact lines.
+      const seen = {};
+      let improved = false;
+      for (const hit of hits) {
+        seen[hit.literal] = (seen[hit.literal] ?? 0) + 1;
+        if (seen[hit.literal] > (fileBaseline[hit.literal] ?? 0)) {
+          legacyOverages.push({
+            file: relPath,
+            literal: hit.literal,
+            line: hit.line,
+            baseline: fileBaseline[hit.literal] ?? 0,
+          });
+        }
+      }
+      for (const [literal, allowed] of Object.entries(fileBaseline)) {
+        if ((seen[literal] ?? 0) < allowed) improved = true;
+      }
+      if (improved && !hits.some((hit) => seen[hit.literal] > (fileBaseline[hit.literal] ?? 0))) {
+        legacyImprovements.push({ file: relPath });
+      }
+    }
+  }
+
+  return { violations, legacyOverages, legacyImprovements };
+}
+
+function main() {
+  const { violations, legacyOverages, legacyImprovements } = scanForAdapterTypeLiterals();
+
+  for (const improvement of legacyImprovements) {
+    console.log(
+      `Note: ${improvement.file} is below its legacy baseline — lower the baseline in scripts/check-adapter-type-literals.mjs to lock in the improvement.`,
+    );
+  }
+
+  if (violations.length === 0 && legacyOverages.length === 0) {
+    console.log("Adapter-type literal check OK: shared code carries no new adapter identities.");
+    return;
+  }
+
+  if (violations.length > 0) {
+    console.error("Adapter-type literals found in shared code:\n");
+    for (const violation of violations) {
+      console.error(`  ${violation.file}:${violation.line}: "${violation.literal}"`);
+    }
+  }
+  if (legacyOverages.length > 0) {
+    console.error("\nOccurrences beyond a legacy file's per-identity baseline (the baseline only ratchets down):");
+    for (const overage of legacyOverages) {
+      console.error(
+        `  ${overage.file}:${overage.line}: "${overage.literal}" (baseline ${overage.baseline})`,
+      );
+    }
+  }
+  console.error(
+    [
+      "",
+      "Shared code must not branch on adapter identities — it consumes capabilities",
+      "that adapters declare where they register:",
+      "  - UI rendering: declare hints on the adapter's UIAdapterModule",
+      "    (e.g. transcriptPresentation) and resolve them via findUIAdapter().",
+      "  - acpx engine behavior: set invocation-config keys from the adapter's",
+      "    acpx config builder (e.g. summaryStrategy).",
+      "  - Server behavior: extend the adapter's server registry entry.",
+      "Identity checks cannot work for externally-shipped plugin adapters, which",
+      "register at runtime.",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+const isDirectRun = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  main();
+}

--- a/scripts/check-adapter-type-literals.test.mjs
+++ b/scripts/check-adapter-type-literals.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildAdapterTypeMatcher,
+  loadDeclaredAdapterTypes,
+  scanForAdapterTypeLiterals,
+} from "./check-adapter-type-literals.mjs";
+
+function makeFixtureRoot() {
+  const root = mkdtempSync(join(tmpdir(), "adapter-literal-check-"));
+  mkdirSync(join(root, "ui/src/lib"), { recursive: true });
+  mkdirSync(join(root, "ui/src/components"), { recursive: true });
+  mkdirSync(join(root, "packages/adapter-utils/src"), { recursive: true });
+  return root;
+}
+
+test("flags quoted adapter-type literals in shared code with file and line", (t) => {
+  const root = makeFixtureRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(root, "ui/src/lib/example.ts"),
+    'const ok = 1;\nif (adapterType === "kimi_local") { /* bad */ }\n',
+  );
+
+  const { violations } = scanForAdapterTypeLiterals({ root, legacyBaselines: new Map() });
+  assert.deepEqual(violations, [
+    { file: "ui/src/lib/example.ts", line: 2, literal: "kimi_local" },
+  ]);
+});
+
+test("matcher covers declared types (cursor_cloud) and convention suffixes, excludes generic names", () => {
+  const matches = buildAdapterTypeMatcher(["cursor_cloud", "cursor", "http", "process", "claude_local"]);
+
+  // Declared identity without a convention suffix is still caught.
+  assert.equal(matches("cursor_cloud"), true);
+  // Convention suffixes are caught even if not in the declared list yet.
+  assert.equal(matches("claude_local"), true);
+  assert.equal(matches("custom_acp"), true);
+  assert.equal(matches("hermes_gateway"), true);
+  assert.equal(matches("future_adapter_local"), true);
+  // Generic-collision legacy names are never matched, even when declared.
+  assert.equal(matches("cursor"), false);
+  assert.equal(matches("http"), false);
+  assert.equal(matches("process"), false);
+  // Ordinary strings are not matched.
+  assert.equal(matches("local"), false);
+  assert.equal(matches("pointer"), false);
+});
+
+test("loadDeclaredAdapterTypes parses the shared constants source of truth", (t) => {
+  const root = makeFixtureRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(join(root, "packages/shared/src"), { recursive: true });
+  writeFileSync(
+    join(root, "packages/shared/src/constants.ts"),
+    'export const AGENT_ADAPTER_TYPES = [\n  "process",\n  "cursor_cloud",\n  "claude_local",\n] as const;\n',
+  );
+
+  assert.deepEqual(loadDeclaredAdapterTypes(root), ["process", "cursor_cloud", "claude_local"]);
+  // Missing file (plain fixture roots) degrades to the suffix pattern only.
+  assert.deepEqual(loadDeclaredAdapterTypes(makeFixtureRoot()), []);
+});
+
+test("declared non-suffixed identities are flagged in shared code", (t) => {
+  const root = makeFixtureRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(root, "ui/src/components/Example.tsx"),
+    'const isCloud = adapterType === "cursor_cloud";\n',
+  );
+
+  const { violations } = scanForAdapterTypeLiterals({
+    root,
+    legacyBaselines: new Map(),
+    declaredTypes: ["cursor_cloud"],
+  });
+  assert.deepEqual(violations, [
+    { file: "ui/src/components/Example.tsx", line: 1, literal: "cursor_cloud" },
+  ]);
+});
+
+test("legacy files ratchet per identity instead of being skipped", (t) => {
+  const root = makeFixtureRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(root, "ui/src/components/Legacy.tsx"),
+    ['const a = t === "codex_local";', 'const b = t === "claude_local";', 'const c = t === "kimi_local";'].join("\n"),
+  );
+
+  // At baseline: green.
+  const atBaseline = scanForAdapterTypeLiterals({
+    root,
+    legacyBaselines: new Map([
+      ["ui/src/components/Legacy.tsx", { codex_local: 1, claude_local: 1, kimi_local: 1 }],
+    ]),
+  });
+  assert.deepEqual(atBaseline.violations, []);
+  assert.deepEqual(atBaseline.legacyOverages, []);
+
+  // One occurrence over an identity's baseline: fails with the exact line.
+  const overBaseline = scanForAdapterTypeLiterals({
+    root,
+    legacyBaselines: new Map([
+      ["ui/src/components/Legacy.tsx", { codex_local: 1, claude_local: 1 }],
+    ]),
+  });
+  assert.deepEqual(overBaseline.legacyOverages, [
+    { file: "ui/src/components/Legacy.tsx", literal: "kimi_local", line: 3, baseline: 0 },
+  ]);
+
+  // Below baseline: reported as an improvement, not a failure.
+  const underBaseline = scanForAdapterTypeLiterals({
+    root,
+    legacyBaselines: new Map([
+      ["ui/src/components/Legacy.tsx", { codex_local: 2, claude_local: 1, kimi_local: 1 }],
+    ]),
+  });
+  assert.deepEqual(underBaseline.violations, []);
+  assert.deepEqual(underBaseline.legacyOverages, []);
+  assert.equal(underBaseline.legacyImprovements.length, 1);
+});
+
+test("an equal-count identity swap in a legacy file is a violation", (t) => {
+  const root = makeFixtureRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // Total count matches the baseline sum — but one "gemini_local" was
+  // replaced with a second "codex_local", exceeding that identity's baseline.
+  writeFileSync(
+    join(root, "ui/src/components/Legacy.tsx"),
+    ['const a = t === "codex_local";', 'const b = t === "codex_local";'].join("\n"),
+  );
+
+  const swapped = scanForAdapterTypeLiterals({
+    root,
+    legacyBaselines: new Map([
+      ["ui/src/components/Legacy.tsx", { codex_local: 1, gemini_local: 1 }],
+    ]),
+  });
+  assert.deepEqual(swapped.legacyOverages, [
+    { file: "ui/src/components/Legacy.tsx", literal: "codex_local", line: 2, baseline: 1 },
+  ]);
+
+  // A brand-new identity at equal total count is likewise an overage.
+  writeFileSync(
+    join(root, "ui/src/components/Legacy.tsx"),
+    ['const a = t === "codex_local";', 'const b = t === "kimi_local";'].join("\n"),
+  );
+  const newIdentity = scanForAdapterTypeLiterals({
+    root,
+    legacyBaselines: new Map([
+      ["ui/src/components/Legacy.tsx", { codex_local: 1, gemini_local: 1 }],
+    ]),
+  });
+  assert.deepEqual(newIdentity.legacyOverages, [
+    { file: "ui/src/components/Legacy.tsx", literal: "kimi_local", line: 2, baseline: 0 },
+  ]);
+});
+
+test("ignores test files, stories, and directories outside the scan scope", (t) => {
+  const root = makeFixtureRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(join(root, "ui/src/adapters/kimi-local"), { recursive: true });
+  writeFileSync(
+    join(root, "ui/src/lib/example.test.ts"),
+    'expect(adapterType).toBe("kimi_local");\n',
+  );
+  writeFileSync(
+    join(root, "ui/src/components/Example.stories.tsx"),
+    'const type = "gemini_local";\n',
+  );
+  writeFileSync(
+    join(root, "ui/src/adapters/kimi-local/index.ts"),
+    'export const type = "kimi_local"; // registration home: allowed\n',
+  );
+
+  const { violations, legacyOverages } = scanForAdapterTypeLiterals({ root, legacyBaselines: new Map() });
+  assert.deepEqual(violations, []);
+  assert.deepEqual(legacyOverages, []);
+});
+
+test("the real repository passes with the current legacy baselines", () => {
+  const { violations, legacyOverages } = scanForAdapterTypeLiterals();
+  assert.deepEqual(violations, []);
+  assert.deepEqual(legacyOverages, []);
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its adapter system will keep growing (built-in adapters, and externally-shipped plugin adapters that register at runtime), so shared code that branches on adapter identities accumulates an if-statement per adapter and cannot work at all for plugins
> - The codebase is converging on capability declaration instead: adapters declare properties where they register (UI adapter modules, acpx engine invocation config, server registry entries) and shared code resolves them generically
> - Without enforcement, identity checks creep back in through review gaps
> - This pull request adds a CI gate that forbids quoted adapter-type literals in shared UI and shared engine code, with an explicit legacy allowlist that is meant to only ever shrink
> - The benefit is that the capability architecture becomes a machine-checked property instead of a review-vigilance task

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The adapter capability architecture: shared code consuming adapter-declared properties (e.g. `UIAdapterModule.transcriptPresentation`, acpx engine invocation-config knobs) rather than branching on adapter identities. Refs #11761 and #9967, which established the pattern.

**Current behavior**

Nothing prevents `adapterType === "some_local"` checks from landing in shared rendering or engine code. Eleven legacy files already carry per-adapter tables and branches, and each new adapter tends to extend them.

**Proposed behavior**

A `policy`-job CI step (`scripts/check-adapter-type-literals.mjs`) scans `ui/src/lib`, `ui/src/components`, and `packages/adapter-utils/src` for quoted adapter-type literals and fails with guidance pointing at the declaration mechanisms. Detection unions the declared types parsed from the shared `AGENT_ADAPTER_TYPES` source of truth (covering non-suffixed identities like `cursor_cloud`) with the naming-convention suffixes (`_local`/`_acp`/`_gateway`/`_cloud`, covering future types before they are declared); three unscannable generic-collision names (`process`, `http`, `cursor`) are documented exclusions. Adapter registration homes (`ui/src/adapters/`, `server/src/adapters/`, adapter packages) and test/story files are out of scope by design. The ten pre-existing legacy files ratchet by **per-identity occurrence counts** (the exact multiset each file carried when the gate landed): a brand-new identity, an equal-count identity swap, and one-more-of-an-allowed-identity all fail with the exact line, and dropping below a baseline prints a prompt to lower it.

**Reason and benefit**

Identity checks in shared code do not scale to many adapters and are structurally impossible for plugin adapters that register at runtime. A ratcheting gate keeps new shared code clean while the legacy tables migrate into adapter descriptors incrementally.

## What Changed

- `scripts/check-adapter-type-literals.mjs`: the scanner — scoped directories, a matcher that unions declared types (parsed from `packages/shared/src/constants.ts`) with convention suffixes (unquoted registration-table keys are deliberately not matched), per-identity legacy baselines (the full occurrence multiset per file), and a failure message that explains the declaration pattern per layer.
- `scripts/check-adapter-type-literals.test.mjs`: `node:test` suite — fixture-driven scanner coverage (detection with file/line, declared-type and suffix matching incl. `cursor_cloud`, generic-name exclusions, per-identity ratcheting at/over/under baseline, equal-count swaps, test/story/registration-home exclusions) plus an assertion that the real repository passes with the current baselines.
- `.github/workflows/pr.yml`: two `policy`-job steps (run the check, run its tests), matching the existing static-check pattern.
- `package.json`: `check:adapter-literals` script alias.

## Verification

- `node --test scripts/check-adapter-type-literals.test.mjs`: 7/7 pass
- `node scripts/check-adapter-type-literals.mjs` against the current tree: passes ("shared code carries no adapter identities")
- Verified the gate stays green when #11761 and #9967 merge: both were restructured to the declaration pattern and carry no quoted adapter-type literals in scanned scope

## Risks

- Low: a static check with no runtime footprint. False positives are constrained by the matcher and the scoped directories; a legitimate new registration surface can be discussed and baselined explicitly.
- Three legacy names (`process`, `http`, `cursor`) cannot be literal-scanned without false positives and are documented exclusions; all new adapter types use suffixed names, which are covered.
- Per-identity baselines are strict: legitimately restructuring a legacy file can trip them, and that is intended — the resolution is migrating that knowledge to adapter descriptors (or consciously rebalancing the baseline in review), never silently growing it.

## Model Used

- Anthropic, **Claude Fable 5** (`claude-fable-5`) via Claude Code, with repository, shell, and Git tooling. It audited the scanned directories to build the legacy allowlist, wrote the scanner and tests, and wired the CI steps.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
