### PR TITLE
fix(server): gate done transition on open/unmerged/red-CI PRs (AGE-569)

### DIFF
--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -338,3 +338,4 @@ backlog -> todo -> in_progress -> in_review -> done
 - `started_at` auto-set on `in_progress`
 - `completed_at` auto-set on `done`
 - Terminal states: `done`, `cancelled`
+- `done` is refused with `422` (`details.code: "done_transition_pr_gate"`) when the issue references a GitHub pull request that is not merged, or is merged with a non-`success` check-run/status state. The error names the pull request and the reason (`open`, `unmerged`, `checks red`, `checks pending`). There is no bypass; unlink the pull-request reference to force the transition.

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -372,6 +372,56 @@ describe("GitHub external object provider", () => {
     });
   });
 
+  it("gates a merged PR's checksState on the merge commit, not the (green) pre-merge head SHA", async () => {
+    // Regression coverage for AGE-569 follow-up: a PR's head SHA only ever
+    // carries pre-merge CI. A merge-queue/canary gate that only runs against
+    // the merge commit on the base branch (e.g. canary-pr-control-plane) can
+    // fail on that landed commit even though the PR's own head SHA was green.
+    // The done-transition gate must not read this PR as "merged and green"
+    // in that case.
+    const fetch = vi.fn(async (url: string) => {
+      if (url.includes("/commits/mergecommitsha/check-runs")) {
+        return checkRunsResponse([{ status: "completed", conclusion: "failure" }]);
+      }
+      if (url.includes("/commits/mergecommitsha/status")) return response({ state: "success" });
+      if (url.includes("/commits/deadbeef/check-runs")) {
+        return checkRunsResponse([{ status: "completed", conclusion: "success" }]);
+      }
+      if (url.includes("/commits/deadbeef/status")) return response({ state: "success" });
+      return response({
+        state: "closed",
+        draft: false,
+        merged: true,
+        merged_at: "2026-08-20T12:00:00Z",
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+        merge_commit_sha: "mergecommitsha",
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/commits/mergecommitsha/check-runs?per_page=100",
+      expect.any(Object),
+    );
+    expect(fetch).not.toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/commits/deadbeef/check-runs?per_page=100",
+      expect.any(Object),
+    );
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ merged: true, checksState: "failure" }),
+      }),
+    });
+  });
+
   it("falls back to the combined commit status endpoint when there are no check-runs", async () => {
     const fetch = vi.fn(async (url: string) => {
       if (url.includes("/check-runs")) return checkRunsResponse([]);

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -507,6 +507,101 @@ describe("GitHub external object provider", () => {
     });
   });
 
+  it("does not report checksState success when the check-runs lookup fails but the legacy status succeeds", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) return new Response("", { status: 502 });
+      if (url.endsWith("/status")) {
+        return response({
+          state: "success",
+          statuses: [{ state: "success", context: "ci/legacy-jenkins" }],
+        });
+      }
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    // The legacy status endpoint reports green, but the check-runs lookup
+    // itself failed (502) -- we have no idea whether there is a failing
+    // required check-run we simply could not see. Reporting "success" here
+    // would let an unverified merged PR pass the done gate.
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.not.objectContaining({ checksState: expect.anything() }),
+      }),
+    });
+  });
+
+  it("treats an unreadable 2xx check-runs body the same as a failed lookup, not an empty list", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) return new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
+      if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.not.objectContaining({ checksState: expect.anything() }),
+      }),
+    });
+  });
+
+  it("treats an unrecognized completed check-run conclusion as failure, not success", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) {
+        return checkRunsResponse([{ status: "completed", conclusion: "stale" }]);
+      }
+      if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ checksState: "failure" }),
+      }),
+    });
+  });
+
   it.each([
     [
       "auth-required",

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -375,7 +375,12 @@ describe("GitHub external object provider", () => {
   it("falls back to the combined commit status endpoint when there are no check-runs", async () => {
     const fetch = vi.fn(async (url: string) => {
       if (url.endsWith("/check-runs")) return checkRunsResponse([]);
-      if (url.endsWith("/status")) return response({ state: "failure" });
+      if (url.endsWith("/status")) {
+        return response({
+          state: "failure",
+          statuses: [{ state: "failure", context: "ci/legacy-jenkins" }],
+        });
+      }
       return response({
         state: "open",
         draft: false,
@@ -428,6 +433,76 @@ describe("GitHub external object provider", () => {
       ok: true,
       snapshot: expect.objectContaining({
         data: expect.objectContaining({ checksState: "success" }),
+      }),
+    });
+  });
+
+  it("does not report checksState success when both the check-runs and status lookups fail", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) return new Response("", { status: 500 });
+      if (url.endsWith("/status")) return new Response("", { status: 502 });
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    // Both CI lookups genuinely failed (non-2xx). This must NOT be coerced to
+    // "success" -- a failed lookup is not a confirmed-green signal, and the
+    // done-transition gate in routes/issues.ts treats a missing checksState on
+    // a merged PR as blocking ("checks pending"), never as a pass.
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.not.objectContaining({ checksState: expect.anything() }),
+      }),
+    });
+  });
+
+  it("reports the worse of check-runs and a failing legacy combined status", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) {
+        return checkRunsResponse([{ status: "completed", conclusion: "success" }]);
+      }
+      if (url.endsWith("/status")) {
+        return response({
+          state: "failure",
+          statuses: [{ state: "failure", context: "ci/legacy-jenkins" }],
+        });
+      }
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    // All GitHub Checks are green, but a separate legacy commit-status
+    // integration reports failure on the same commit. The overall checksState
+    // must reflect the worse signal so this does not silently pass the gate.
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ checksState: "failure" }),
       }),
     });
   });

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -314,6 +314,124 @@ describe("GitHub external object provider", () => {
     expect(JSON.stringify(result)).not.toContain("ghp_secret");
   });
 
+  function checkRunsResponse(checkRuns: Array<Record<string, unknown>>) {
+    return response({ check_runs: checkRuns });
+  }
+
+  it.each([
+    [
+      "pending",
+      [{ status: "in_progress", conclusion: null }],
+      "pending",
+    ],
+    [
+      "failure",
+      [
+        { status: "completed", conclusion: "success" },
+        { status: "completed", conclusion: "failure" },
+      ],
+      "failure",
+    ],
+    [
+      "success",
+      [
+        { status: "completed", conclusion: "success" },
+        { status: "completed", conclusion: "skipped" },
+      ],
+      "success",
+    ],
+  ])("resolves an open pull request with %s checksState from check-runs", async (_name, checkRuns, expectedChecksState) => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) return checkRunsResponse(checkRuns);
+      if (url.endsWith("/status")) return response({ state: "success" });
+      return response({
+        state: "open",
+        draft: false,
+        merged: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/commits/deadbeef/check-runs",
+      expect.any(Object),
+    );
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ checksState: expectedChecksState }),
+      }),
+    });
+  });
+
+  it("falls back to the combined commit status endpoint when there are no check-runs", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) return checkRunsResponse([]);
+      if (url.endsWith("/status")) return response({ state: "failure" });
+      return response({
+        state: "open",
+        draft: false,
+        merged: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/commits/deadbeef/status",
+      expect.any(Object),
+    );
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ checksState: "failure" }),
+      }),
+    });
+  });
+
+  it("defaults checksState to success when neither check-runs nor commit status report anything", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.endsWith("/check-runs")) return checkRunsResponse([]);
+      if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
+      return response({
+        state: "open",
+        draft: false,
+        merged: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ checksState: "success" }),
+      }),
+    });
+  });
+
   it.each([
     [
       "auth-required",

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -342,7 +342,7 @@ describe("GitHub external object provider", () => {
     ],
   ])("resolves an open pull request with %s checksState from check-runs", async (_name, checkRuns, expectedChecksState) => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) return checkRunsResponse(checkRuns);
+      if (url.includes("/check-runs")) return checkRunsResponse(checkRuns);
       if (url.endsWith("/status")) return response({ state: "success" });
       return response({
         state: "open",
@@ -361,7 +361,7 @@ describe("GitHub external object provider", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.github.com/repos/acme/app/commits/deadbeef/check-runs",
+      "https://api.github.com/repos/acme/app/commits/deadbeef/check-runs?per_page=100",
       expect.any(Object),
     );
     expect(result).toEqual({
@@ -374,7 +374,7 @@ describe("GitHub external object provider", () => {
 
   it("falls back to the combined commit status endpoint when there are no check-runs", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) return checkRunsResponse([]);
+      if (url.includes("/check-runs")) return checkRunsResponse([]);
       if (url.endsWith("/status")) {
         return response({
           state: "failure",
@@ -411,7 +411,7 @@ describe("GitHub external object provider", () => {
 
   it("defaults checksState to success when neither check-runs nor commit status report anything", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) return checkRunsResponse([]);
+      if (url.includes("/check-runs")) return checkRunsResponse([]);
       if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
       return response({
         state: "open",
@@ -439,7 +439,7 @@ describe("GitHub external object provider", () => {
 
   it("does not report checksState success when both the check-runs and status lookups fail", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) return new Response("", { status: 500 });
+      if (url.includes("/check-runs")) return new Response("", { status: 500 });
       if (url.endsWith("/status")) return new Response("", { status: 502 });
       return response({
         state: "closed",
@@ -471,7 +471,7 @@ describe("GitHub external object provider", () => {
 
   it("reports the worse of check-runs and a failing legacy combined status", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) {
+      if (url.includes("/check-runs")) {
         return checkRunsResponse([{ status: "completed", conclusion: "success" }]);
       }
       if (url.endsWith("/status")) {
@@ -509,7 +509,7 @@ describe("GitHub external object provider", () => {
 
   it("does not report checksState success when the check-runs lookup fails but the legacy status succeeds", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) return new Response("", { status: 502 });
+      if (url.includes("/check-runs")) return new Response("", { status: 502 });
       if (url.endsWith("/status")) {
         return response({
           state: "success",
@@ -546,7 +546,7 @@ describe("GitHub external object provider", () => {
 
   it("treats an unreadable 2xx check-runs body the same as a failed lookup, not an empty list", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) return new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
+      if (url.includes("/check-runs")) return new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
       if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
       return response({
         state: "closed",
@@ -574,8 +574,82 @@ describe("GitHub external object provider", () => {
 
   it("treats an unrecognized completed check-run conclusion as failure, not success", async () => {
     const fetch = vi.fn(async (url: string) => {
-      if (url.endsWith("/check-runs")) {
+      if (url.includes("/check-runs")) {
         return checkRunsResponse([{ status: "completed", conclusion: "stale" }]);
+      }
+      if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ checksState: "failure" }),
+      }),
+    });
+  });
+
+  it("does not report success from a paginated check-runs list when later pages are not fetched", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.includes("/check-runs")) {
+        // GitHub reports total_count for the full set of check-runs on this
+        // commit, but this response only contains the first page (30 by
+        // default; here trimmed to one for the test). A failing run could
+        // be sitting on a page we never fetched.
+        return response({
+          total_count: 45,
+          check_runs: [{ status: "completed", conclusion: "success" }],
+        });
+      }
+      if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
+      return response({
+        state: "closed",
+        merged: true,
+        draft: false,
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("per_page=100"),
+      expect.any(Object),
+    );
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.not.objectContaining({ checksState: expect.anything() }),
+      }),
+    });
+  });
+
+  it("still reports failure from a paginated check-runs list when the visible page already has a failing run", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url.includes("/check-runs")) {
+        return response({
+          total_count: 45,
+          check_runs: [{ status: "completed", conclusion: "failure" }],
+        });
       }
       if (url.endsWith("/status")) return response({ total_count: 0, statuses: [] });
       return response({

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -410,10 +410,53 @@ describe("GitHub external object provider", () => {
       "https://api.github.com/repos/acme/app/commits/mergecommitsha/check-runs?per_page=100",
       expect.any(Object),
     );
-    expect(fetch).not.toHaveBeenCalledWith(
+    // The resolver also checks the pre-merge head SHA alongside the merge
+    // commit (AGE-569 fix: some CI setups never run checks against the
+    // merge commit at all, so it alone can't be trusted as "no CI signal" ==
+    // "success"). Both are consulted and the worse of the two wins -- here
+    // the merge commit's failure wins regardless.
+    expect(fetch).toHaveBeenCalledWith(
       "https://api.github.com/repos/acme/app/commits/deadbeef/check-runs?per_page=100",
       expect.any(Object),
     );
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ merged: true, checksState: "failure" }),
+      }),
+    });
+  });
+
+  it("gates a merged PR on the head SHA's CI when the merge commit has no CI configured at all", async () => {
+    // Regression coverage for the Greptile-flagged gap: a merge commit with
+    // zero check-runs and zero commit statuses used to be read as "nothing
+    // configured, therefore success" in isolation, hiding a failing/pending
+    // head-SHA CI run that never ran against the merge commit.
+    const fetch = vi.fn(async (url: string) => {
+      if (url.includes("/commits/mergecommitsha/check-runs")) return checkRunsResponse([]);
+      if (url.includes("/commits/mergecommitsha/status")) return response({ state: "pending", statuses: [] });
+      if (url.includes("/commits/deadbeef/check-runs")) {
+        return checkRunsResponse([{ status: "completed", conclusion: "failure" }]);
+      }
+      if (url.includes("/commits/deadbeef/status")) return response({ state: "success" });
+      return response({
+        state: "closed",
+        draft: false,
+        merged: true,
+        merged_at: "2026-08-20T12:00:00Z",
+        title: "Ship it",
+        head: { sha: "deadbeef" },
+        merge_commit_sha: "mergecommitsha",
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
     expect(result).toEqual({
       ok: true,
       snapshot: expect.objectContaining({

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -310,6 +310,50 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
     });
   });
 
+  it("gates done when the pull request is referenced only from a comment, not the description", async () => {
+    stubGitHubFetch();
+    prFixtures.set("108", {
+      state: "open",
+      merged: false,
+      headSha: "sha-comment-only-108",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Ship PR 108",
+        // Deliberately no PR URL in the description -- it is only ever
+        // mentioned in a follow-up comment below.
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "cloud-user-1",
+      });
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(201);
+    const issueId = createRes.body.id as string;
+
+    const commentRes = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Implements https://github.com/acme/app/pull/108" });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    const objectsRes = await request(app).get(`/api/issues/${issueId}/external-objects`);
+    expect(objectsRes.status, JSON.stringify(objectsRes.body)).toBe(200);
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    // The gate's main loop iterates every linked external object regardless
+    // of which source (title, description, comment, document) produced the
+    // mention -- a PR referenced only in a comment must be gated exactly
+    // like one referenced in the description.
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#108");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "open",
+      pullRequest: expect.objectContaining({ number: 108 }),
+    });
+  });
+
   it("does not gate issues with no linked pull request", async () => {
     stubGitHubFetch();
     const createRes = await request(app)

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -394,6 +394,57 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
     expect(getRes.body.status).toBe("in_progress");
   });
 
+  it("allows done when the same PATCH removes the issue's only (bad) pull-request reference", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(110, {
+      state: "open",
+      merged: false,
+      headSha: "sha-open-110",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+
+    // Sanity check: with the description untouched, the open PR still gates.
+    const stillGatedRes = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+    expect(stillGatedRes.status, JSON.stringify(stillGatedRes.body)).toBe(422);
+
+    // The same request that requests `done` also rewrites the description to
+    // drop the PR #110 reference entirely (e.g. the user decided this issue
+    // no longer depends on that PR). listForIssue still reflects the *old*
+    // persisted description mentioning #110, but the PR is being removed by
+    // this very request, so it must not block the transition.
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", description: "No longer needs a PR." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  });
+
+  it("still gates done when a removed pull-request reference is also linked from a comment", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(111, {
+      state: "open",
+      merged: false,
+      headSha: "sha-open-111",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    const commentRes = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Also see https://github.com/acme/app/pull/111" });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    // The description no longer mentions PR #111, but it is still linked via
+    // the comment above -- removing it from the description alone must not
+    // bypass the gate.
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", description: "No longer in the description, but still commented." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#111");
+  });
+
   it("does not gate issues with no linked pull request", async () => {
     stubGitHubFetch();
     const createRes = await request(app)

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { companies, companyMemberships, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { instanceSettingsService } from "../services/instance-settings.js";
+import type { StorageService } from "../storage/types.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres done-transition PR gate route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+type PrFixture = {
+  state: "open" | "closed";
+  merged: boolean;
+  draft?: boolean;
+  headSha: string;
+  checkRuns: Array<{ status: string; conclusion: string | null }>;
+};
+
+describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let app!: ReturnType<typeof createApp>;
+  let companyId!: string;
+  let prFixtures: Map<string, PrFixture>;
+
+  function createStorage(): StorageService {
+    return {
+      provider: "local_disk",
+      putFile: vi.fn(async () => {
+        throw new Error("Unexpected storage.putFile call in done-transition PR gate route test");
+      }),
+      getObject: vi.fn(async () => {
+        throw new Error("Unexpected storage.getObject call in done-transition PR gate route test");
+      }),
+      headObject: vi.fn(async () => ({ exists: false })),
+      deleteObject: vi.fn(async () => undefined),
+    };
+  }
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, createStorage()));
+    app.use(errorHandler);
+    return app;
+  }
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-done-pr-gate-");
+    db = createDb(tempDb.connectionString);
+    companyId = randomUUID();
+    app = createApp(companyId);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "PR gate tenant",
+      issuePrefix: "PRG",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await instanceSettingsService(db).updateExperimental({ enableExternalObjects: true });
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubGitHubFetch() {
+    prFixtures = new Map();
+    const fetchStub = vi.fn(async (input: string | URL, _init?: RequestInit) => {
+      const url = String(input);
+      const prMatch = /\/repos\/acme\/app\/pulls\/(\d+)$/.exec(url);
+      if (prMatch) {
+        const fixture = prFixtures.get(prMatch[1]!);
+        if (!fixture) return new Response("", { status: 404 });
+        return new Response(
+          JSON.stringify({
+            state: fixture.state,
+            merged: fixture.merged,
+            draft: fixture.draft ?? false,
+            title: `PR ${prMatch[1]}`,
+            updated_at: "2026-04-24T01:02:03Z",
+            head: { sha: fixture.headSha, ref: "feature" },
+            base: { ref: "main" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      const checkRunsMatch = /\/repos\/acme\/app\/commits\/([^/]+)\/check-runs$/.exec(url);
+      if (checkRunsMatch) {
+        const sha = checkRunsMatch[1]!;
+        const fixture = [...prFixtures.values()].find((f) => f.headSha === sha);
+        return new Response(JSON.stringify({ check_runs: fixture?.checkRuns ?? [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      const statusMatch = /\/repos\/acme\/app\/commits\/([^/]+)\/status$/.exec(url);
+      if (statusMatch) {
+        return new Response(JSON.stringify({ state: "success", statuses: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch in done-transition PR gate test: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchStub);
+    return fetchStub;
+  }
+
+  async function createIssueWithPr(prNumber: number, fixture: PrFixture) {
+    prFixtures.set(String(prNumber), fixture);
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: `Ship PR ${prNumber}`,
+        description: `Implements https://github.com/acme/app/pull/${prNumber}`,
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "cloud-user-1",
+      });
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(201);
+    const issueId = createRes.body.id as string;
+
+    const refreshRes = await request(app)
+      .post(`/api/issues/${issueId}/external-objects/refresh`)
+      .send({});
+    expect(refreshRes.status, JSON.stringify(refreshRes.body)).toBe(200);
+
+    return issueId;
+  }
+
+  it("refuses to mark done an issue linked to an open pull request", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(101, {
+      state: "open",
+      merged: false,
+      headSha: "sha-open-101",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#101");
+    expect(res.body.error).toContain("open");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "open",
+      pullRequest: expect.objectContaining({ owner: "acme", repo: "app", number: 101 }),
+    });
+  });
+
+  it("refuses to mark done an issue linked to a merged pull request with red CI", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(102, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-red-102",
+      checkRuns: [
+        { status: "completed", conclusion: "success" },
+        { status: "completed", conclusion: "failure" },
+      ],
+    });
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#102");
+    expect(res.body.error).toContain("checks red");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "checks red",
+      pullRequest: expect.objectContaining({ owner: "acme", repo: "app", number: 102, checksState: "failure" }),
+    });
+  });
+
+  it("refuses to mark done an issue linked to a merged pull request with pending CI", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(103, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-pending-103",
+      checkRuns: [{ status: "in_progress", conclusion: null }],
+    });
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#103");
+    expect(res.body.error).toContain("checks pending");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "checks pending",
+    });
+  });
+
+  it("allows marking done an issue linked to a merged pull request with green CI", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(104, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-green-104",
+      checkRuns: [
+        { status: "completed", conclusion: "success" },
+        { status: "completed", conclusion: "success" },
+      ],
+    });
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+    // Let terminal-status post-commit side effects (e.g. pending interaction
+    // expiry) settle before the embedded Postgres pool tears down.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  });
+
+  it("does not gate issues with no linked pull request", async () => {
+    stubGitHubFetch();
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "No linked PR",
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "cloud-user-1",
+      });
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(201);
+
+    const res = await request(app).patch(`/api/issues/${createRes.body.id}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  });
+});

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -2,7 +2,8 @@ import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { companies, companyMemberships, createDb } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { companies, companyMemberships, createDb, externalObjects } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -308,6 +309,34 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
       code: "done_transition_pr_gate",
       reason: "unverified",
     });
+  });
+
+  it("allows done for a merged+green PR when the forced refresh loses a concurrent-refresh race (AGE-626 Greptile finding)", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(107, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-concurrent-107",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+
+    // Simulate a concurrent refresh already in flight (another request, a
+    // background poller, or another server instance holding the lease) at
+    // the moment the done PATCH tries to force-refresh this same object.
+    // claimObjectRefresh will fail to acquire the lease and the resolver
+    // returns { reason: "refresh_in_progress" } -- but the row it reads back
+    // is still the merged+green snapshot resolved moments ago by
+    // createIssueWithPr's own refresh call, i.e. genuinely fresh. The gate
+    // must not reject this as "unverified" purely because of that race.
+    await db
+      .update(externalObjects)
+      .set({ refreshStartedAt: new Date() })
+      .where(eq(externalObjects.companyId, companyId));
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
   });
 
   it("gates done when the pull request is referenced only from a comment, not the description", async () => {

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -122,7 +122,7 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
           { status: 200, headers: { "content-type": "application/json" } },
         );
       }
-      const checkRunsMatch = /\/repos\/acme\/app\/commits\/([^/]+)\/check-runs$/.exec(url);
+      const checkRunsMatch = /\/repos\/acme\/app\/commits\/([^/]+)\/check-runs(?:\?.*)?$/.exec(url);
       if (checkRunsMatch) {
         const sha = checkRunsMatch[1]!;
         const fixture = [...prFixtures.values()].find((f) => f.headSha === sha);

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -354,6 +354,46 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
     });
   });
 
+  it("refuses done when the same PATCH newly adds a pull-request reference to the description", async () => {
+    stubGitHubFetch();
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Ship PR 109",
+        // No PR reference at creation time -- listForIssue has nothing to
+        // find yet, and this test never calls /external-objects/refresh.
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "cloud-user-1",
+      });
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(201);
+    const issueId = createRes.body.id as string;
+
+    // A single PATCH both introduces the PR reference (in the description)
+    // and requests `done` in the same request. The reference has never been
+    // synced or resolved, so it must not slip through unverified just
+    // because listForIssue (which only reflects previously-persisted text)
+    // doesn't know about it yet.
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "done",
+        description: "Implements https://github.com/acme/app/pull/109",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#109");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "unverified",
+      pullRequest: expect.objectContaining({ owner: "acme", repo: "app", number: 109 }),
+    });
+
+    // Confirm the issue was in fact NOT persisted as done.
+    const getRes = await request(app).get(`/api/issues/${issueId}`);
+    expect(getRes.body.status).toBe("in_progress");
+  });
+
   it("does not gate issues with no linked pull request", async () => {
     stubGitHubFetch();
     const createRes = await request(app)

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -311,7 +311,7 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
     });
   });
 
-  it("allows done for a merged+green PR when the forced refresh loses a concurrent-refresh race (AGE-626 Greptile finding)", async () => {
+  it("allows done for a merged+green PR when a concurrent refresher stamps a fresh resolve while still holding the lease (AGE-626 Greptile finding)", async () => {
     stubGitHubFetch();
     const issueId = await createIssueWithPr(107, {
       state: "closed",
@@ -320,14 +320,55 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
       checkRuns: [{ status: "completed", conclusion: "success" }],
     });
 
-    // Simulate a concurrent refresh already in flight (another request, a
-    // background poller, or another server instance holding the lease) at
-    // the moment the done PATCH tries to force-refresh this same object.
-    // claimObjectRefresh will fail to acquire the lease and the resolver
-    // returns { reason: "refresh_in_progress" } -- but the row it reads back
-    // is still the merged+green snapshot resolved moments ago by
-    // createIssueWithPr's own refresh call, i.e. genuinely fresh. The gate
-    // must not reject this as "unverified" purely because of that race.
+    // Simulate a concurrent refresh in flight (another request, a background
+    // poller, or another server instance) that holds the lease for this
+    // object through the entire done PATCH: every one of this gate's own
+    // force-refresh attempts sees `refresh_in_progress`/`refresh_superseded`,
+    // never `resolved`. But the concurrent holder has *already* stamped a
+    // fresh `lastResolvedAt` at/after this gate's own start -- i.e. it
+    // already captured the PR's current (still merged+green) state during
+    // this very request, it just hasn't released the lease yet. The gate
+    // must trust that timestamp rather than requiring `reason === "resolved"`
+    // from its own attempt, which is what the prior fix incorrectly required
+    // implicitly by trusting any TTL-"fresh" row regardless of *when* it was
+    // last resolved. Deterministic: no real-time race, no flaky timer.
+    await db
+      .update(externalObjects)
+      .set({ refreshStartedAt: new Date() })
+      .where(eq(externalObjects.companyId, companyId));
+    // Set the recorded resolve timestamp comfortably ahead of "now" so it is
+    // guaranteed to be at/after the moment the PATCH handler captures its own
+    // gate-start timestamp a few milliseconds from now, without depending on
+    // real wall-clock race timing (no flaky timer needed).
+    await db
+      .update(externalObjects)
+      .set({ lastResolvedAt: new Date(Date.now() + 60_000) })
+      .where(eq(externalObjects.companyId, companyId));
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("refuses done as unverified when the cached resolve predates this gate's own start, even while the lease is held (AGE-626 Greptile follow-up)", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(1070, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-concurrent-1070",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+
+    // Simulate another instance holding the refresh lease for this object's
+    // entire done-transition gate, and its only recorded resolve is the one
+    // from `createIssueWithPr` -- strictly *before* this gate starts. Merely
+    // being within the object's TTL ("liveness === fresh") must not be enough
+    // to pass here: that cached merged+green snapshot could predate a real
+    // state change (e.g. CI turning red) the lease holder is still in the
+    // middle of capturing, so the gate must fail closed as "unverified"
+    // rather than trust a snapshot it cannot prove is current as of this
+    // request.
     await db
       .update(externalObjects)
       .set({ refreshStartedAt: new Date() })
@@ -335,8 +376,12 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
 
     const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(200);
-    expect(res.body.status).toBe("done");
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#1070");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "unverified",
+    });
   });
 
   it("gates done when the pull request is referenced only from a comment, not the description", async () => {

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -284,6 +284,32 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
     });
   });
 
+  it("refuses done when the forced refresh of a cached merged+green PR cannot reach GitHub", async () => {
+    stubGitHubFetch();
+    const issueId = await createIssueWithPr(106, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-unreachable-106",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+
+    // Simulate GitHub becoming unreachable for the forced refresh triggered
+    // by the done PATCH. The cached snapshot still says merged+green, but
+    // that state can no longer be confirmed -- the gate must not trust it.
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND api.github.com");
+    }));
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#106");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "unverified",
+    });
+  });
+
   it("does not gate issues with no linked pull request", async () => {
     stubGitHubFetch();
     const createRes = await request(app)

--- a/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts
@@ -252,6 +252,38 @@ describeEmbeddedPostgres("done transition external PR gate (AGE-569)", () => {
     await new Promise((resolve) => setTimeout(resolve, 25));
   });
 
+  it("refuses done when the cached PR snapshot is stale and CI has since gone red", async () => {
+    stubGitHubFetch();
+    // The issue's linked PR was resolved once (via the refresh call inside
+    // createIssueWithPr) while CI was green -- that snapshot is now cached.
+    // Flip the fixture to a failing check-run *after* that initial resolve,
+    // simulating CI going red between the cached poll and the done request.
+    // The gate must force a fresh lookup rather than trusting the cache.
+    const issueId = await createIssueWithPr(105, {
+      state: "closed",
+      merged: true,
+      headSha: "sha-stale-105",
+      checkRuns: [{ status: "completed", conclusion: "success" }],
+    });
+    prFixtures.set("105", {
+      state: "closed",
+      merged: true,
+      headSha: "sha-stale-105",
+      checkRuns: [{ status: "completed", conclusion: "failure" }],
+    });
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("acme/app#105");
+    expect(res.body.error).toContain("checks red");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_pr_gate",
+      reason: "checks red",
+      pullRequest: expect.objectContaining({ checksState: "failure" }),
+    });
+  });
+
   it("does not gate issues with no linked pull request", async () => {
     stubGitHubFetch();
     const createRes = await request(app)

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -457,28 +457,43 @@ async function assertNoBlockingLinkedPullRequest(
     // it. If the refresh itself fails, fall back to the last-known snapshot
     // rather than failing the whole transition, but mark every requested
     // object as unconfirmed so a stale "pass" cannot slip through.
+    const gateRefreshStartedAt = new Date();
+    // Bounded retry budget for the case where a *concurrent* refresh (another
+    // request, a background poller, or another server instance) holds the
+    // per-object refresh lease when this gate asks for a forced refresh.
+    // "refresh_in_progress"/"refresh_superseded" alone is not proof the
+    // returned row reflects the PR's *current* GitHub state -- a cached
+    // snapshot can be up to the full TTL window old and could predate a real
+    // state change (e.g. CI turning red) that the lease holder is racing to
+    // capture. Re-attempt the forced refresh a few times with a short delay
+    // so a routine, fast-completing concurrent refresh has a chance to land
+    // and produce a resolve timestamped at or after this gate started, which
+    // is the only thing that proves the row is not stale leftover data from
+    // before this PATCH began. If the lease is still held after the budget is
+    // exhausted, fail closed (unconfirmed) rather than trust an unconfirmed
+    // cached value.
+    const maxConfirmationAttempts = 5;
+    const retryDelayMs = 120;
+    let remainingObjectIds = [...linkedPullRequestObjectIds];
     try {
-      const refreshResults = await externalObjectsSvc.refreshIssueObjects(issueId, {
-        companyId,
-        objectIds: linkedPullRequestObjectIds,
-        force: true,
-      });
-      // A concurrent refresh of the same object (another request, a
-      // background poller, or another server instance) reports
-      // "refresh_in_progress" or "refresh_superseded" instead of "resolved",
-      // but it still returns the latest DB row for that object. If that row's
-      // *current* liveness is "fresh" -- i.e. some resolve completed within
-      // its TTL window, whether this call's or a concurrent one's -- treat it
-      // as confirmed rather than rejecting a merged-and-green PR purely
-      // because of refresh contention.
-      const confirmedIds = new Set(
-        refreshResults
-          .filter((result) => result.reason === "resolved" || result.object.liveness === "fresh")
-          .map((result) => result.object.id),
-      );
-      for (const objectId of linkedPullRequestObjectIds) {
-        if (!confirmedIds.has(objectId)) unconfirmedObjectIds.add(objectId);
+      for (let attempt = 0; attempt < maxConfirmationAttempts && remainingObjectIds.length > 0; attempt++) {
+        if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        const refreshResults = await externalObjectsSvc.refreshIssueObjects(issueId, {
+          companyId,
+          objectIds: remainingObjectIds,
+          force: true,
+        });
+        const confirmedThisAttempt = new Set(
+          refreshResults
+            .filter((result) =>
+              result.reason === "resolved" ||
+              (result.object.lastResolvedAt != null &&
+                new Date(result.object.lastResolvedAt) >= gateRefreshStartedAt))
+            .map((result) => result.object.id),
+        );
+        remainingObjectIds = remainingObjectIds.filter((id) => !confirmedThisAttempt.has(id));
       }
+      for (const objectId of remainingObjectIds) unconfirmedObjectIds.add(objectId);
       groups = await externalObjectsSvc.listForIssue(issueId);
     } catch (err) {
       logger.warn(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -406,33 +406,28 @@ async function assertNoBlockingLinkedPullRequest(
     // back to the text-only signal rather than widening the blast radius of
     // an unrelated infra fault to every done transition in the company.
     let mightReferencePullRequest = textMightReferencePullRequest || candidateNewPullRequestRefs.length > 0;
-    let mentionLookupFailed = false;
     if (!mightReferencePullRequest) {
       try {
         mightReferencePullRequest = await issueHasRecordedPullRequestMention(db, companyId, issueId);
       } catch (mentionLookupErr) {
-        mentionLookupFailed = true;
+        // A double DB fault here (both `listForIssue` above and this
+        // fallback lookup) has no way to distinguish "this issue has a PR
+        // mentioned only in a comment/document that we can't currently
+        // read" from "this issue genuinely has nothing to do with a pull
+        // request and the DB layer it doesn't touch happens to be
+        // unavailable/unimplemented" (e.g. a narrowly-scoped test double, or
+        // an unrelated table outage). Blocking every `done` transition
+        // company-wide on that ambiguity is not a safe default -- it is
+        // exactly the "gate that blocks everything" this ticket warns
+        // against. Fall back to the text-only signal instead: a positive
+        // text/candidate-ref hit is handled above and still fails closed via
+        // the branch below; only the case with zero working signal at all
+        // allows the transition through, matching pre-fix behavior.
         logger.warn(
           { err: mentionLookupErr, issueId },
-          "done-transition PR gate: failed to check recorded pull-request mentions; cannot confirm this issue has no PR reference",
+          "done-transition PR gate: failed to check recorded pull-request mentions; falling back to the text-only signal",
         );
       }
-    }
-    if (!mightReferencePullRequest && mentionLookupFailed) {
-      // Both `listForIssue` and the recorded-mention lookup failed, and
-      // there is no positive text signal either. A pull request mentioned
-      // only from a comment or document could be hiding behind the failed
-      // mention lookup -- with zero working signal we cannot prove this
-      // issue has no linked pull request, so fail closed instead of
-      // assuming there is none.
-      logger.warn(
-        { err, issueId },
-        "done-transition PR gate: failed to resolve linked external objects and could not confirm the issue has no PR reference; blocking the transition",
-      );
-      throw unprocessable(
-        "Cannot mark issue done: this issue's linked pull-request references could not be verified right now",
-        { code: "done_transition_pr_gate", reason: "unverified", pullRequest: null },
-      );
     }
     if (!mightReferencePullRequest) {
       // The gate itself must not turn an unrelated external-objects

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -331,10 +331,27 @@ function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransiti
   return checksState === "failure" ? "checks red" : "checks pending";
 }
 
-const GITHUB_PULL_REQUEST_URL_PATTERN = /https:\/\/(?:www\.)?github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/i;
+const GITHUB_PULL_REQUEST_URL_PATTERN = /https:\/\/(?:www\.)?github\.com\/([^\s/]+)\/([^\s/]+)\/pull\/(\d+)/gi;
 
 function textMightReferenceGitHubPullRequest(...texts: Array<string | null | undefined>): boolean {
-  return texts.some((text) => typeof text === "string" && GITHUB_PULL_REQUEST_URL_PATTERN.test(text));
+  return texts.some((text) => typeof text === "string" && new RegExp(GITHUB_PULL_REQUEST_URL_PATTERN).test(text));
+}
+
+type GitHubPullRequestRef = { owner: string; repo: string; number: number };
+
+function extractGitHubPullRequestRefs(text: string | null | undefined): GitHubPullRequestRef[] {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const refs: GitHubPullRequestRef[] = [];
+  const pattern = new RegExp(GITHUB_PULL_REQUEST_URL_PATTERN);
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text))) {
+    refs.push({ owner: match[1]!, repo: match[2]!, number: Number(match[3]) });
+  }
+  return refs;
+}
+
+function githubPullRequestRefKey(owner: string, repo: string, number: number): string {
+  return `${owner.toLowerCase()}/${repo.toLowerCase()}#${number}`;
 }
 
 /**
@@ -374,6 +391,7 @@ async function assertNoBlockingLinkedPullRequest(
   issueId: string,
   companyId: string,
   textMightReferencePullRequest: boolean,
+  candidateNewPullRequestRefs: GitHubPullRequestRef[],
 ) {
   let groups: Awaited<ReturnType<typeof externalObjectsSvc.listForIssue>>;
   try {
@@ -385,7 +403,7 @@ async function assertNoBlockingLinkedPullRequest(
     // is safe to allow through. That secondary check itself failing falls
     // back to the text-only signal rather than widening the blast radius of
     // an unrelated infra fault to every done transition in the company.
-    let mightReferencePullRequest = textMightReferencePullRequest;
+    let mightReferencePullRequest = textMightReferencePullRequest || candidateNewPullRequestRefs.length > 0;
     if (!mightReferencePullRequest) {
       try {
         mightReferencePullRequest = await issueHasRecordedPullRequestMention(db, companyId, issueId);
@@ -488,6 +506,37 @@ async function assertNoBlockingLinkedPullRequest(
         },
       },
     );
+  }
+
+  if (candidateNewPullRequestRefs.length > 0) {
+    // This same PATCH may be introducing a brand-new PR reference in its
+    // title/description update alongside the `done` status change. listForIssue
+    // above only reflects mentions already synced from the *previously*
+    // persisted text -- a reference that only exists in this request's new
+    // text has not been resolved/verified at all yet. Block on any such
+    // reference we can't already account for among the known linked PRs.
+    const knownPullRequestKeys = new Set(
+      groups
+        .filter((group) => group.object?.objectType === "pull_request")
+        .map((group) => (group.object!.data ?? {}) as Record<string, unknown>)
+        .filter((data) => data.provider === "github")
+        .map((data) => githubPullRequestRefKey(
+          typeof data.owner === "string" ? data.owner : "",
+          typeof data.repo === "string" ? data.repo : "",
+          typeof data.number === "number" ? data.number : -1,
+        )),
+    );
+    for (const ref of candidateNewPullRequestRefs) {
+      if (knownPullRequestKeys.has(githubPullRequestRefKey(ref.owner, ref.repo, ref.number))) continue;
+      throw unprocessable(
+        `Cannot mark issue done: this update newly references pull request ${ref.owner}/${ref.repo}#${ref.number}, which has not been verified as merged and green yet`,
+        {
+          code: "done_transition_pr_gate",
+          reason: "unverified",
+          pullRequest: { owner: ref.owner, repo: ref.repo, number: ref.number, state: null, merged: null, checksState: null },
+        },
+      );
+    }
   }
 }
 
@@ -9515,7 +9564,18 @@ export function issueRoutes(
         typeof updateFields.title === "string" ? updateFields.title : null,
         typeof updateFields.description === "string" ? updateFields.description : null,
       );
-      await assertNoBlockingLinkedPullRequest(db, externalObjectsSvc, existing.id, existing.companyId, mightReferencePullRequest);
+      const candidateNewPullRequestRefs = [
+        ...extractGitHubPullRequestRefs(typeof updateFields.title === "string" ? updateFields.title : null),
+        ...extractGitHubPullRequestRefs(typeof updateFields.description === "string" ? updateFields.description : null),
+      ];
+      await assertNoBlockingLinkedPullRequest(
+        db,
+        externalObjectsSvc,
+        existing.id,
+        existing.companyId,
+        mightReferencePullRequest,
+        candidateNewPullRequestRefs,
+      );
     }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -315,7 +315,7 @@ async function listIssueLinkedCases(db: Db, companyId: string, issueId: string) 
   }));
 }
 
-type DoneTransitionPrGateReason = "open" | "unmerged" | "checks red" | "checks pending";
+type DoneTransitionPrGateReason = "open" | "unmerged" | "checks red" | "checks pending" | "unverified";
 
 function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransitionPrGateReason | null {
   const state = typeof data.state === "string" ? data.state : "unknown";
@@ -333,7 +333,8 @@ function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransiti
 /**
  * Fail-closed guard for the `done` transition (AGE-569): an issue may not be
  * marked `done` while it references a GitHub pull request that is still
- * open/unmerged, or merged with red/pending CI. Board and agent actors are
+ * open/unmerged, merged with red/pending CI, or whose current state could
+ * not be verified (a forced live refresh failed). Board and agent actors are
  * both subject to this gate — there is no bypass flag, matching the
  * fail-closed shape of `scripts/require-issue-claim.sh` and the `.claude/hooks`
  * guards this ticket is modeled on.
@@ -360,24 +361,38 @@ async function assertNoBlockingLinkedPullRequest(
   const linkedPullRequestObjectIds = groups
     .filter((group) => group.object?.objectType === "pull_request")
     .map((group) => group.object!.id);
+  // Objects whose forced refresh did not confirm a fresh resolve (auth
+  // failure, unreachable host, or the refresh call itself throwing). A
+  // cached "merged and green" snapshot for one of these must not be trusted
+  // as current -- track them so the loop below fails closed instead of
+  // silently reusing stale data.
+  const unconfirmedObjectIds = new Set<string>();
   if (linkedPullRequestObjectIds.length > 0) {
     // A cached snapshot can be up to GITHUB_OBJECT_TTL_SECONDS stale. The
     // done gate must reflect the PR's *current* GitHub state, not whatever
     // was last polled -- force a live refresh before evaluating, then re-read
     // it. If the refresh itself fails, fall back to the last-known snapshot
-    // rather than failing the whole transition.
+    // rather than failing the whole transition, but mark every requested
+    // object as unconfirmed so a stale "pass" cannot slip through.
     try {
-      await externalObjectsSvc.refreshIssueObjects(issueId, {
+      const refreshResults = await externalObjectsSvc.refreshIssueObjects(issueId, {
         companyId,
         objectIds: linkedPullRequestObjectIds,
         force: true,
       });
+      const confirmedIds = new Set(
+        refreshResults.filter((result) => result.reason === "resolved").map((result) => result.object.id),
+      );
+      for (const objectId of linkedPullRequestObjectIds) {
+        if (!confirmedIds.has(objectId)) unconfirmedObjectIds.add(objectId);
+      }
       groups = await externalObjectsSvc.listForIssue(issueId);
     } catch (err) {
       logger.warn(
         { err, issueId },
-        "done-transition PR gate: failed to refresh linked pull request state; evaluating last-known snapshot",
+        "done-transition PR gate: failed to refresh linked pull request state; evaluating last-known snapshot as unconfirmed",
       );
+      for (const objectId of linkedPullRequestObjectIds) unconfirmedObjectIds.add(objectId);
     }
   }
   for (const group of groups) {
@@ -385,14 +400,18 @@ async function assertNoBlockingLinkedPullRequest(
     if (!object || object.objectType !== "pull_request") continue;
     const data = (object.data ?? {}) as Record<string, unknown>;
     if (data.provider !== "github") continue;
-    const reason = doneTransitionPrGateReason(data);
+    const reason = doneTransitionPrGateReason(data)
+      ?? (unconfirmedObjectIds.has(object.id) ? "unverified" : null);
     if (!reason) continue;
     const owner = typeof data.owner === "string" ? data.owner : "unknown";
     const repo = typeof data.repo === "string" ? data.repo : "unknown";
     const number = typeof data.number === "number" ? data.number : null;
     const label = number !== null ? `${owner}/${repo}#${number}` : `${owner}/${repo}`;
+    const message = reason === "unverified"
+      ? `Cannot mark issue done: linked pull request ${label}'s merge/CI state could not be verified (GitHub lookup failed)`
+      : `Cannot mark issue done: linked pull request ${label} is ${reason}`;
     throw unprocessable(
-      `Cannot mark issue done: linked pull request ${label} is ${reason}`,
+      message,
       {
         code: "done_transition_pr_gate",
         reason,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -315,6 +315,60 @@ async function listIssueLinkedCases(db: Db, companyId: string, issueId: string) 
   }));
 }
 
+type DoneTransitionPrGateReason = "open" | "unmerged" | "checks red" | "checks pending";
+
+function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransitionPrGateReason | null {
+  const state = typeof data.state === "string" ? data.state : "unknown";
+  const merged = data.merged === true;
+  const checksState = typeof data.checksState === "string" ? data.checksState : null;
+  if (!merged) return state === "open" ? "open" : "unmerged";
+  if (checksState === "failure") return "checks red";
+  if (checksState === "pending") return "checks pending";
+  return null;
+}
+
+/**
+ * Fail-closed guard for the `done` transition (AGE-569): an issue may not be
+ * marked `done` while it references a GitHub pull request that is still
+ * open/unmerged, or merged with red/pending CI. Board and agent actors are
+ * both subject to this gate — there is no bypass flag, matching the
+ * fail-closed shape of `scripts/require-issue-claim.sh` and the `.claude/hooks`
+ * guards this ticket is modeled on.
+ */
+async function assertNoBlockingLinkedPullRequest(
+  externalObjectsSvc: ReturnType<typeof externalObjectService>,
+  issueId: string,
+) {
+  const groups = await externalObjectsSvc.listForIssue(issueId);
+  for (const group of groups) {
+    const object = group.object;
+    if (!object || object.objectType !== "pull_request") continue;
+    const data = (object.data ?? {}) as Record<string, unknown>;
+    if (data.provider !== "github") continue;
+    const reason = doneTransitionPrGateReason(data);
+    if (!reason) continue;
+    const owner = typeof data.owner === "string" ? data.owner : "unknown";
+    const repo = typeof data.repo === "string" ? data.repo : "unknown";
+    const number = typeof data.number === "number" ? data.number : null;
+    const label = number !== null ? `${owner}/${repo}#${number}` : `${owner}/${repo}`;
+    throw unprocessable(
+      `Cannot mark issue done: linked pull request ${label} is ${reason}`,
+      {
+        code: "done_transition_pr_gate",
+        reason,
+        pullRequest: {
+          owner,
+          repo,
+          number,
+          state: typeof data.state === "string" ? data.state : "unknown",
+          merged: data.merged === true,
+          checksState: typeof data.checksState === "string" ? data.checksState : null,
+        },
+      },
+    );
+  }
+}
+
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
 type IssueRouteSnapshot = typeof issueRows.$inferSelect;
@@ -9332,6 +9386,9 @@ export function issueRoutes(
     Object.assign(updateFields, transition.patch);
 
     const nextStatus = updateFields.status ?? existing.status;
+    if (nextStatus === "done" && existing.status !== "done") {
+      await assertNoBlockingLinkedPullRequest(externalObjectsSvc, existing.id);
+    }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -392,6 +392,8 @@ async function assertNoBlockingLinkedPullRequest(
   companyId: string,
   textMightReferencePullRequest: boolean,
   candidateNewPullRequestRefs: GitHubPullRequestRef[],
+  textIsChanging: boolean,
+  effectivePullRequestRefKeys: Set<string>,
 ) {
   let groups: Awaited<ReturnType<typeof externalObjectsSvc.listForIssue>>;
   try {
@@ -481,6 +483,20 @@ async function assertNoBlockingLinkedPullRequest(
     if (!object || object.objectType !== "pull_request") continue;
     const data = (object.data ?? {}) as Record<string, unknown>;
     if (data.provider !== "github") continue;
+    if (textIsChanging) {
+      // This same PATCH is replacing the issue's title and/or description.
+      // If this PR was only ever mentioned there (never in a comment or
+      // document) and the proposed new text no longer references it, it is
+      // being removed by this very request -- not something to gate on.
+      const sourceKinds = new Set(group.mentions.map((mention) => mention.sourceKind));
+      const onlyFromIssueText = [...sourceKinds].every((kind) => kind === "title" || kind === "description");
+      if (onlyFromIssueText) {
+        const owner = typeof data.owner === "string" ? data.owner : "";
+        const repo = typeof data.repo === "string" ? data.repo : "";
+        const number = typeof data.number === "number" ? data.number : -1;
+        if (!effectivePullRequestRefKeys.has(githubPullRequestRefKey(owner, repo, number))) continue;
+      }
+    }
     const reason = doneTransitionPrGateReason(data)
       ?? (unconfirmedObjectIds.has(object.id) ? "unverified" : null);
     if (!reason) continue;
@@ -9568,6 +9584,17 @@ export function issueRoutes(
         ...extractGitHubPullRequestRefs(typeof updateFields.title === "string" ? updateFields.title : null),
         ...extractGitHubPullRequestRefs(typeof updateFields.description === "string" ? updateFields.description : null),
       ];
+      const textIsChanging = updateFields.title !== undefined || updateFields.description !== undefined;
+      const effectiveTitle = updateFields.title !== undefined
+        ? (typeof updateFields.title === "string" ? updateFields.title : null)
+        : existing.title;
+      const effectiveDescription = updateFields.description !== undefined
+        ? (typeof updateFields.description === "string" ? updateFields.description : null)
+        : existing.description;
+      const effectivePullRequestRefKeys = new Set([
+        ...extractGitHubPullRequestRefs(effectiveTitle),
+        ...extractGitHubPullRequestRefs(effectiveDescription),
+      ].map((ref) => githubPullRequestRefKey(ref.owner, ref.repo, ref.number)));
       await assertNoBlockingLinkedPullRequest(
         db,
         externalObjectsSvc,
@@ -9575,6 +9602,8 @@ export function issueRoutes(
         existing.companyId,
         mightReferencePullRequest,
         candidateNewPullRequestRefs,
+        textIsChanging,
+        effectivePullRequestRefKeys,
       );
     }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -322,9 +322,12 @@ function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransiti
   const merged = data.merged === true;
   const checksState = typeof data.checksState === "string" ? data.checksState : null;
   if (!merged) return state === "open" ? "open" : "unmerged";
-  if (checksState === "failure") return "checks red";
-  if (checksState === "pending") return "checks pending";
-  return null;
+  if (checksState === "success") return null;
+  // Fail-closed: block on "failure", "pending", AND on a missing/unknown
+  // checksState (e.g. the GitHub check-runs/status lookup itself failed). A
+  // merged PR whose CI state we cannot positively confirm as green must not
+  // pass silently — that is exactly the false-"done" gap this gate closes.
+  return checksState === "failure" ? "checks red" : "checks pending";
 }
 
 /**
@@ -338,6 +341,7 @@ function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransiti
 async function assertNoBlockingLinkedPullRequest(
   externalObjectsSvc: ReturnType<typeof externalObjectService>,
   issueId: string,
+  companyId: string,
 ) {
   let groups: Awaited<ReturnType<typeof externalObjectsSvc.listForIssue>>;
   try {
@@ -352,6 +356,29 @@ async function assertNoBlockingLinkedPullRequest(
       "done-transition PR gate: failed to resolve linked external objects; allowing the transition",
     );
     return;
+  }
+  const linkedPullRequestObjectIds = groups
+    .filter((group) => group.object?.objectType === "pull_request")
+    .map((group) => group.object!.id);
+  if (linkedPullRequestObjectIds.length > 0) {
+    // A cached snapshot can be up to GITHUB_OBJECT_TTL_SECONDS stale. The
+    // done gate must reflect the PR's *current* GitHub state, not whatever
+    // was last polled -- force a live refresh before evaluating, then re-read
+    // it. If the refresh itself fails, fall back to the last-known snapshot
+    // rather than failing the whole transition.
+    try {
+      await externalObjectsSvc.refreshIssueObjects(issueId, {
+        companyId,
+        objectIds: linkedPullRequestObjectIds,
+        force: true,
+      });
+      groups = await externalObjectsSvc.listForIssue(issueId);
+    } catch (err) {
+      logger.warn(
+        { err, issueId },
+        "done-transition PR gate: failed to refresh linked pull request state; evaluating last-known snapshot",
+      );
+    }
   }
   for (const group of groups) {
     const object = group.object;
@@ -9400,7 +9427,7 @@ export function issueRoutes(
 
     const nextStatus = updateFields.status ?? existing.status;
     if (nextStatus === "done" && existing.status !== "done") {
-      await assertNoBlockingLinkedPullRequest(externalObjectsSvc, existing.id);
+      await assertNoBlockingLinkedPullRequest(externalObjectsSvc, existing.id, existing.companyId);
     }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -330,6 +330,12 @@ function doneTransitionPrGateReason(data: Record<string, unknown>): DoneTransiti
   return checksState === "failure" ? "checks red" : "checks pending";
 }
 
+const GITHUB_PULL_REQUEST_URL_PATTERN = /https:\/\/(?:www\.)?github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/i;
+
+function textMightReferenceGitHubPullRequest(...texts: Array<string | null | undefined>): boolean {
+  return texts.some((text) => typeof text === "string" && GITHUB_PULL_REQUEST_URL_PATTERN.test(text));
+}
+
 /**
  * Fail-closed guard for the `done` transition (AGE-569): an issue may not be
  * marked `done` while it references a GitHub pull request that is still
@@ -343,20 +349,34 @@ async function assertNoBlockingLinkedPullRequest(
   externalObjectsSvc: ReturnType<typeof externalObjectService>,
   issueId: string,
   companyId: string,
+  mightReferencePullRequest: boolean,
 ) {
   let groups: Awaited<ReturnType<typeof externalObjectsSvc.listForIssue>>;
   try {
     groups = await externalObjectsSvc.listForIssue(issueId);
   } catch (err) {
-    // The gate itself must not turn an unrelated external-objects
-    // misconfiguration/outage into a hard failure of every `done`
-    // transition. Only a resolved bad PR state (open/unmerged/red/pending)
-    // blocks below; a failure to even determine that state does not.
+    if (!mightReferencePullRequest) {
+      // The gate itself must not turn an unrelated external-objects
+      // misconfiguration/outage into a hard failure of every `done`
+      // transition. This issue's own text does not look like it references a
+      // GitHub pull request at all, so there is nothing plausible to gate on.
+      logger.warn(
+        { err, issueId },
+        "done-transition PR gate: failed to resolve linked external objects; issue has no PR-like reference, allowing the transition",
+      );
+      return;
+    }
+    // This issue's title/description looks like it references a GitHub pull
+    // request, and we failed to resolve its current state at all. Fail
+    // closed rather than silently letting an unverifiable PR reference pass.
     logger.warn(
       { err, issueId },
-      "done-transition PR gate: failed to resolve linked external objects; allowing the transition",
+      "done-transition PR gate: failed to resolve linked external objects for an issue with a PR-like reference; blocking the transition",
     );
-    return;
+    throw unprocessable(
+      "Cannot mark issue done: this issue references what looks like a GitHub pull request, but its state could not be resolved right now",
+      { code: "done_transition_pr_gate", reason: "unverified", pullRequest: null },
+    );
   }
   const linkedPullRequestObjectIds = groups
     .filter((group) => group.object?.objectType === "pull_request")
@@ -9446,7 +9466,13 @@ export function issueRoutes(
 
     const nextStatus = updateFields.status ?? existing.status;
     if (nextStatus === "done" && existing.status !== "done") {
-      await assertNoBlockingLinkedPullRequest(externalObjectsSvc, existing.id, existing.companyId);
+      const mightReferencePullRequest = textMightReferenceGitHubPullRequest(
+        existing.title,
+        existing.description,
+        typeof updateFields.title === "string" ? updateFields.title : null,
+        typeof updateFields.description === "string" ? updateFields.description : null,
+      );
+      await assertNoBlockingLinkedPullRequest(externalObjectsSvc, existing.id, existing.companyId, mightReferencePullRequest);
     }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -339,7 +339,20 @@ async function assertNoBlockingLinkedPullRequest(
   externalObjectsSvc: ReturnType<typeof externalObjectService>,
   issueId: string,
 ) {
-  const groups = await externalObjectsSvc.listForIssue(issueId);
+  let groups: Awaited<ReturnType<typeof externalObjectsSvc.listForIssue>>;
+  try {
+    groups = await externalObjectsSvc.listForIssue(issueId);
+  } catch (err) {
+    // The gate itself must not turn an unrelated external-objects
+    // misconfiguration/outage into a hard failure of every `done`
+    // transition. Only a resolved bad PR state (open/unmerged/red/pending)
+    // blocks below; a failure to even determine that state does not.
+    logger.warn(
+      { err, issueId },
+      "done-transition PR gate: failed to resolve linked external objects; allowing the transition",
+    );
+    return;
+  }
   for (const group of groups) {
     const object = group.object;
     if (!object || object.objectType !== "pull_request") continue;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -406,15 +406,33 @@ async function assertNoBlockingLinkedPullRequest(
     // back to the text-only signal rather than widening the blast radius of
     // an unrelated infra fault to every done transition in the company.
     let mightReferencePullRequest = textMightReferencePullRequest || candidateNewPullRequestRefs.length > 0;
+    let mentionLookupFailed = false;
     if (!mightReferencePullRequest) {
       try {
         mightReferencePullRequest = await issueHasRecordedPullRequestMention(db, companyId, issueId);
       } catch (mentionLookupErr) {
+        mentionLookupFailed = true;
         logger.warn(
           { err: mentionLookupErr, issueId },
-          "done-transition PR gate: failed to check recorded pull-request mentions; falling back to the text-only signal",
+          "done-transition PR gate: failed to check recorded pull-request mentions; cannot confirm this issue has no PR reference",
         );
       }
+    }
+    if (!mightReferencePullRequest && mentionLookupFailed) {
+      // Both `listForIssue` and the recorded-mention lookup failed, and
+      // there is no positive text signal either. A pull request mentioned
+      // only from a comment or document could be hiding behind the failed
+      // mention lookup -- with zero working signal we cannot prove this
+      // issue has no linked pull request, so fail closed instead of
+      // assuming there is none.
+      logger.warn(
+        { err, issueId },
+        "done-transition PR gate: failed to resolve linked external objects and could not confirm the issue has no PR reference; blocking the transition",
+      );
+      throw unprocessable(
+        "Cannot mark issue done: this issue's linked pull-request references could not be verified right now",
+        { code: "done_transition_pr_gate", reason: "unverified", pullRequest: null },
+      );
     }
     if (!mightReferencePullRequest) {
       // The gate itself must not turn an unrelated external-objects
@@ -486,9 +504,16 @@ async function assertNoBlockingLinkedPullRequest(
         const confirmedThisAttempt = new Set(
           refreshResults
             .filter((result) =>
-              result.reason === "resolved" ||
-              (result.object.lastResolvedAt != null &&
-                new Date(result.object.lastResolvedAt) >= gateRefreshStartedAt))
+              // Do not trust `reason === "resolved"` alone: when this call
+              // joins an already in-flight refresh promise (started by a
+              // concurrent request against the same object, in this same
+              // process), that promise can persist `lastResolvedAt` using a
+              // `now` captured by the *original* caller before this gate
+              // began, even though it settles afterwards. Only the
+              // timestamp comparison proves the row reflects state resolved
+              // at or after this gate started; require it unconditionally.
+              result.object.lastResolvedAt != null &&
+              new Date(result.object.lastResolvedAt) >= gateRefreshStartedAt)
             .map((result) => result.object.id),
         );
         remainingObjectIds = remainingObjectIds.filter((id) => !confirmedThisAttempt.has(id));

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -11,6 +11,7 @@ import {
   companyMemberships,
   documents,
   executionWorkspaces,
+  externalObjectMentions,
   heartbeatRuns,
   issueApprovals,
   issueComments,
@@ -337,6 +338,28 @@ function textMightReferenceGitHubPullRequest(...texts: Array<string | null | und
 }
 
 /**
+ * Whether this issue has ever had a GitHub pull-request reference recorded
+ * against it — from its title/description, or from any comment or document
+ * (external_object_mentions covers all of those source kinds, not just the
+ * issue body itself). Used only to decide how to fail when the live
+ * `listForIssue` lookup itself throws: a plain text scan of title/description
+ * alone would miss a PR linked solely from a comment or a document.
+ */
+async function issueHasRecordedPullRequestMention(db: Db, companyId: string, issueId: string): Promise<boolean> {
+  const row = await db
+    .select({ id: externalObjectMentions.id })
+    .from(externalObjectMentions)
+    .where(and(
+      eq(externalObjectMentions.companyId, companyId),
+      eq(externalObjectMentions.sourceIssueId, issueId),
+      eq(externalObjectMentions.objectType, "pull_request"),
+    ))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+  return row !== null;
+}
+
+/**
  * Fail-closed guard for the `done` transition (AGE-569): an issue may not be
  * marked `done` while it references a GitHub pull request that is still
  * open/unmerged, merged with red/pending CI, or whose current state could
@@ -346,29 +369,49 @@ function textMightReferenceGitHubPullRequest(...texts: Array<string | null | und
  * guards this ticket is modeled on.
  */
 async function assertNoBlockingLinkedPullRequest(
+  db: Db,
   externalObjectsSvc: ReturnType<typeof externalObjectService>,
   issueId: string,
   companyId: string,
-  mightReferencePullRequest: boolean,
+  textMightReferencePullRequest: boolean,
 ) {
   let groups: Awaited<ReturnType<typeof externalObjectsSvc.listForIssue>>;
   try {
     groups = await externalObjectsSvc.listForIssue(issueId);
   } catch (err) {
+    // A plain-text scan of title/description alone would miss a pull request
+    // linked solely from a comment or a document, so also consult the
+    // recorded mention table (covers every source kind) before deciding this
+    // is safe to allow through. That secondary check itself failing falls
+    // back to the text-only signal rather than widening the blast radius of
+    // an unrelated infra fault to every done transition in the company.
+    let mightReferencePullRequest = textMightReferencePullRequest;
+    if (!mightReferencePullRequest) {
+      try {
+        mightReferencePullRequest = await issueHasRecordedPullRequestMention(db, companyId, issueId);
+      } catch (mentionLookupErr) {
+        logger.warn(
+          { err: mentionLookupErr, issueId },
+          "done-transition PR gate: failed to check recorded pull-request mentions; falling back to the text-only signal",
+        );
+      }
+    }
     if (!mightReferencePullRequest) {
       // The gate itself must not turn an unrelated external-objects
       // misconfiguration/outage into a hard failure of every `done`
-      // transition. This issue's own text does not look like it references a
-      // GitHub pull request at all, so there is nothing plausible to gate on.
+      // transition. Nothing on this issue (title, description, or any
+      // recorded comment/document mention) looks like a GitHub pull request,
+      // so there is nothing plausible to gate on.
       logger.warn(
         { err, issueId },
         "done-transition PR gate: failed to resolve linked external objects; issue has no PR-like reference, allowing the transition",
       );
       return;
     }
-    // This issue's title/description looks like it references a GitHub pull
-    // request, and we failed to resolve its current state at all. Fail
-    // closed rather than silently letting an unverifiable PR reference pass.
+    // This issue (its title/description, or a comment/document mention)
+    // looks like it references a GitHub pull request, and we failed to
+    // resolve its current state at all. Fail closed rather than silently
+    // letting an unverifiable PR reference pass.
     logger.warn(
       { err, issueId },
       "done-transition PR gate: failed to resolve linked external objects for an issue with a PR-like reference; blocking the transition",
@@ -9472,7 +9515,7 @@ export function issueRoutes(
         typeof updateFields.title === "string" ? updateFields.title : null,
         typeof updateFields.description === "string" ? updateFields.description : null,
       );
-      await assertNoBlockingLinkedPullRequest(externalObjectsSvc, existing.id, existing.companyId, mightReferencePullRequest);
+      await assertNoBlockingLinkedPullRequest(db, externalObjectsSvc, existing.id, existing.companyId, mightReferencePullRequest);
     }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -463,8 +463,18 @@ async function assertNoBlockingLinkedPullRequest(
         objectIds: linkedPullRequestObjectIds,
         force: true,
       });
+      // A concurrent refresh of the same object (another request, a
+      // background poller, or another server instance) reports
+      // "refresh_in_progress" or "refresh_superseded" instead of "resolved",
+      // but it still returns the latest DB row for that object. If that row's
+      // *current* liveness is "fresh" -- i.e. some resolve completed within
+      // its TTL window, whether this call's or a concurrent one's -- treat it
+      // as confirmed rather than rejecting a merged-and-green PR purely
+      // because of refresh contention.
       const confirmedIds = new Set(
-        refreshResults.filter((result) => result.reason === "resolved").map((result) => result.object.id),
+        refreshResults
+          .filter((result) => result.reason === "resolved" || result.object.liveness === "fresh")
+          .map((result) => result.object.id),
       );
       for (const objectId of linkedPullRequestObjectIds) {
         if (!confirmedIds.has(objectId)) unconfirmedObjectIds.add(objectId);

--- a/server/src/services/external-objects.ts
+++ b/server/src/services/external-objects.ts
@@ -1009,6 +1009,7 @@ export function externalObjectService(
     companyId: string;
     objectIds?: string[];
     actor?: Pick<LogActivityInput, "actorType" | "actorId" | "agentId" | "runId">;
+    force?: boolean;
   }) {
     if (!(await isEnabled())) return [];
     const groups = await listForIssue(issueId);
@@ -1017,7 +1018,7 @@ export function externalObjectService(
       .filter((id) => !input.objectIds || input.objectIds.includes(id));
     const results = [];
     for (const objectId of objectIds) {
-      results.push(await refreshObject(objectId, { companyId: input.companyId, actor: input.actor }));
+      results.push(await refreshObject(objectId, { companyId: input.companyId, actor: input.actor, force: input.force }));
     }
     return results;
   }

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -384,7 +384,14 @@ async function fetchChecksState(input: {
   let checkRunsState: ChecksState | null = null;
   let checkRunsFetchFailed = false;
   try {
-    const checkRunsResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/check-runs`, { headers });
+    // GitHub paginates check-runs (default page size 30). Request the
+    // maximum page size so a repo with a realistic number of checks is
+    // covered by one request, and detect when `total_count` says there is
+    // more data than this single page returned.
+    const checkRunsResponse = await fetchImpl(
+      `${base}/commits/${encodeURIComponent(headSha)}/check-runs?per_page=100`,
+      { headers },
+    );
     if (checkRunsResponse.ok) {
       const body = await safeJson(checkRunsResponse);
       if (body === null) {
@@ -394,7 +401,17 @@ async function fetchChecksState(input: {
         checkRunsFetchFailed = true;
       } else {
         const checkRuns = Array.isArray(body.check_runs) ? (body.check_runs as Array<Record<string, unknown>>) : [];
-        checkRunsState = checksStateFromCheckRuns(checkRuns);
+        const totalCount = typeof body.total_count === "number" ? body.total_count : checkRuns.length;
+        const fromVisiblePage = checksStateFromCheckRuns(checkRuns);
+        if (fromVisiblePage === "success" && totalCount > checkRuns.length) {
+          // The visible page looks all-green, but `total_count` says there
+          // are more check-runs we did not fetch. A failing/pending run on
+          // a later page would otherwise be invisible to this gate -- treat
+          // an incomplete "success" read as unknown rather than confirmed.
+          checkRunsFetchFailed = true;
+        } else {
+          checkRunsState = fromVisiblePage;
+        }
       }
     } else {
       checkRunsFetchFailed = true;

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -337,9 +337,30 @@ function checksStateFromCheckRuns(checkRuns: Array<Record<string, unknown>>): Ch
 
 function checksStateFromCombinedStatus(body: Record<string, unknown> | null): ChecksState | null {
   if (!body) return null;
+  // GitHub's combined-status endpoint reports `state: "pending"` even when no
+  // legacy commit status has ever been posted for this commit (empty
+  // `statuses`). That is "no signal", not a real pending check — only trust
+  // `state` once at least one status exists.
+  const statuses = Array.isArray(body.statuses) ? body.statuses : [];
+  if (statuses.length === 0) return null;
   const state = asString(body.state);
   if (state === "success" || state === "failure" || state === "pending") return state;
+  // The combined-status endpoint also documents an "error" state distinct
+  // from "failure" (e.g. a status reporter itself errored). Treat it the same
+  // as "failure": it is not a confirmed-green signal.
+  if (state === "error") return "failure";
   return null;
+}
+
+const CHECKS_STATE_SEVERITY: Record<ChecksState, number> = { success: 0, pending: 1, failure: 2 };
+
+function worstChecksState(states: Array<ChecksState | null>): ChecksState | null {
+  let worst: ChecksState | null = null;
+  for (const state of states) {
+    if (!state) continue;
+    if (!worst || CHECKS_STATE_SEVERITY[state] > CHECKS_STATE_SEVERITY[worst]) worst = state;
+  }
+  return worst;
 }
 
 async function fetchChecksState(input: {
@@ -354,31 +375,50 @@ async function fetchChecksState(input: {
   if (!headSha) return null;
   const base = `${gitHubApiBase(host)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
 
+  let checkRunsState: ChecksState | null = null;
+  let checkRunsFetchFailed = false;
   try {
     const checkRunsResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/check-runs`, { headers });
     if (checkRunsResponse.ok) {
       const body = await safeJson(checkRunsResponse);
       const checkRuns = Array.isArray(body?.check_runs) ? (body!.check_runs as Array<Record<string, unknown>>) : [];
-      const fromCheckRuns = checksStateFromCheckRuns(checkRuns);
-      if (fromCheckRuns) return fromCheckRuns;
+      checkRunsState = checksStateFromCheckRuns(checkRuns);
+    } else {
+      checkRunsFetchFailed = true;
     }
   } catch {
-    // Fall through to the combined status endpoint below.
+    checkRunsFetchFailed = true;
   }
 
+  let statusState: ChecksState | null = null;
+  let statusFetchFailed = false;
   try {
     const statusResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/status`, { headers });
     if (statusResponse.ok) {
       const body = await safeJson(statusResponse);
-      const fromStatus = checksStateFromCombinedStatus(body);
-      if (fromStatus) return fromStatus;
+      statusState = checksStateFromCombinedStatus(body);
+    } else {
+      statusFetchFailed = true;
     }
   } catch {
-    // No combined status available either — treat as unknown (no CI signal).
+    statusFetchFailed = true;
   }
 
-  // Neither check-runs nor commit statuses reported anything: there is no CI
-  // configured for this commit, so there is nothing to gate on.
+  // Combine both signals rather than trusting check-runs alone: a commit can
+  // have all-green GitHub Checks and a failing/pending legacy commit status
+  // (posted by a non-Checks-API CI integration) at the same time. The worse
+  // of the two known signals wins.
+  const combined = worstChecksState([checkRunsState, statusState]);
+  if (combined) return combined;
+
+  // Neither endpoint returned a usable signal. If either request actually
+  // failed (network error, non-2xx, unreadable body) we cannot say this
+  // commit has no CI configured — do not silently report "success" for an
+  // unknown state; let the caller treat it as "unable to determine".
+  if (checkRunsFetchFailed || statusFetchFailed) return null;
+
+  // Both endpoints were reached successfully and reported nothing: there is
+  // genuinely no CI configured for this commit, so there is nothing to gate on.
   return "success";
 }
 

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -369,16 +369,16 @@ function worstChecksState(states: Array<ChecksState | null>): ChecksState | null
   return worst;
 }
 
-async function fetchChecksState(input: {
+async function fetchChecksStateForSha(input: {
   fetchImpl: FetchLike;
   headers: Record<string, string>;
   host: string;
   owner: string;
   repo: string;
-  headSha: string | null;
-}): Promise<ChecksState | null> {
-  const { fetchImpl, headers, host, owner, repo, headSha } = input;
-  if (!headSha) return null;
+  sha: string | null;
+}): Promise<{ state: ChecksState | null; hadSignal: boolean; fetchFailed: boolean }> {
+  const { fetchImpl, headers, host, owner, repo, sha: headSha } = input;
+  if (!headSha) return { state: null, hadSignal: false, fetchFailed: false };
   const base = `${gitHubApiBase(host)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
 
   let checkRunsState: ChecksState | null = null;
@@ -444,18 +444,64 @@ async function fetchChecksState(input: {
   // of the two known signals wins, and an explicit "failure" from either
   // source is trusted even if the other lookup could not be completed.
   const combined = worstChecksState([checkRunsState, statusState]);
-  if (combined === "failure") return "failure";
+  if (combined === "failure") return { state: "failure", hadSignal: true, fetchFailed: false };
 
   // One of the two lookups did not actually complete (network error, non-2xx,
   // unreadable body). We only have a partial picture of this commit's CI
   // state, so we must not report "pending" or "success" as if we had
   // confirmed both signals -- report unknown and let the caller fail closed.
-  if (checkRunsFetchFailed || statusFetchFailed) return null;
+  if (checkRunsFetchFailed || statusFetchFailed) return { state: null, hadSignal: combined != null, fetchFailed: true };
 
-  if (combined) return combined;
+  if (combined) return { state: combined, hadSignal: true, fetchFailed: false };
 
-  // Both endpoints were reached successfully and reported nothing: there is
-  // genuinely no CI configured for this commit, so there is nothing to gate on.
+  // Both endpoints were reached successfully and reported nothing for this
+  // specific commit: there is genuinely no CI configured against it. Callers
+  // that check more than one SHA (e.g. a merged PR's head SHA and its merge
+  // commit) must not treat this in isolation as "nothing to gate on" --
+  // `hadSignal: false` lets them keep looking at the other SHA before
+  // concluding there is no CI at all.
+  return { state: null, hadSignal: false, fetchFailed: false };
+}
+
+// A merged pull request's `merge_commit_sha` is the commit actually reachable
+// from the base branch, so it takes priority once a PR is merged (see the
+// caller's comment). But some CI setups only ever run checks against the PR's
+// pre-merge `head` SHA (e.g. a `pull_request`-triggered workflow) and never
+// against the merge commit at all -- in that case `fetchChecksStateForSha` on
+// the merge commit alone reports "nothing found", which would wrongly read as
+// "success" and hide a red/pending head-SHA CI run. Check every candidate SHA
+// (merge commit first, then head, when they differ) and combine: an explicit
+// failure/pending signal from either wins, and "success" is only reported
+// once at least one of the SHAs actually had CI configured, or once every SHA
+// was reached and confirmed to have none.
+async function fetchChecksState(input: {
+  fetchImpl: FetchLike;
+  headers: Record<string, string>;
+  host: string;
+  owner: string;
+  repo: string;
+  shas: ReadonlyArray<string | null>;
+}): Promise<ChecksState | null> {
+  const { fetchImpl, headers, host, owner, repo, shas } = input;
+  const uniqueShas = [...new Set(shas.filter((sha): sha is string => Boolean(sha)))];
+  if (uniqueShas.length === 0) return null;
+
+  const results = await Promise.all(
+    uniqueShas.map((sha) => fetchChecksStateForSha({ fetchImpl, headers, host, owner, repo, sha })),
+  );
+
+  const worst = worstChecksState(results.map((result) => result.state));
+  if (worst === "failure") return "failure";
+
+  // Any SHA whose lookup did not actually complete leaves this gate with only
+  // a partial picture -- do not report "pending"/"success" as if every SHA
+  // had been confirmed.
+  if (results.some((result) => result.fetchFailed)) return null;
+
+  if (worst) return worst;
+
+  // Every SHA was reached successfully. If none of them had any CI signal at
+  // all, there is genuinely nothing configured to gate on.
   return "success";
 }
 
@@ -592,20 +638,22 @@ export function createGitHubExternalObjectProvider(
         // post-merge-only check against `main`) can report green on that head
         // SHA while the actual merge commit that landed on the base branch was
         // never checked at all, or was checked and failed. Once a PR is
-        // reported merged, gate on its `merge_commit_sha` -- the commit that is
-        // actually reachable from the base branch -- so "merged" cannot be
-        // satisfied by a PR whose landed commit was red. Fall back to head SHA
-        // only if GitHub did not report a merge commit SHA for some reason.
+        // reported merged, gate on its `merge_commit_sha` first -- the commit
+        // that is actually reachable from the base branch. But some CI setups
+        // never run checks against the merge commit at all (only against the
+        // pre-merge head SHA), so also check the head SHA and combine: an
+        // explicit failure/pending signal from either wins over an absent
+        // signal on the other (see fetchChecksState).
         const merged = (asBoolean(body.merged) ?? false) || Boolean(asString(body.merged_at));
         const mergeCommitSha = asString(body.merge_commit_sha);
-        const checksSha = merged ? (mergeCommitSha ?? headSha) : headSha;
+        const checksShas = merged ? [mergeCommitSha, headSha] : [headSha];
         const checksState = await fetchChecksState({
           fetchImpl,
           headers,
           host: identity.host,
           owner: identity.owner,
           repo: identity.repo,
-          headSha: checksSha,
+          shas: checksShas,
         });
 
         return {

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -188,7 +188,12 @@ function notFoundSnapshot(identity: GitHubObjectIdentity, etag: string | null): 
   };
 }
 
-function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string, unknown>, etag: string | null): ExternalObjectResolverSnapshot {
+function pullRequestSnapshot(
+  identity: GitHubObjectIdentity,
+  body: Record<string, unknown>,
+  etag: string | null,
+  checksState: ChecksState | null,
+): ExternalObjectResolverSnapshot {
   const title = asString(body.title);
   const state = asString(body.state) ?? "unknown";
   const draft = asBoolean(body.draft) ?? false;
@@ -256,6 +261,7 @@ function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string
       ...(headSha ? { headSha } : {}),
       ...(baseRef ? { baseRef } : {}),
       ...(reviewDecision ? { reviewDecision } : {}),
+      ...(checksState ? { checksState } : {}),
     },
   };
 }
@@ -305,6 +311,75 @@ async function safeJson(response: Response) {
   } catch {
     return null;
   }
+}
+
+type ChecksState = "success" | "failure" | "pending";
+
+const FAILING_CHECK_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+
+function checksStateFromCheckRuns(checkRuns: Array<Record<string, unknown>>): ChecksState | null {
+  if (checkRuns.length === 0) return null;
+  let sawIncomplete = false;
+  let sawFailure = false;
+  for (const run of checkRuns) {
+    const status = asString(run.status);
+    if (status !== "completed") {
+      sawIncomplete = true;
+      continue;
+    }
+    const conclusion = asString(run.conclusion);
+    if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) sawFailure = true;
+  }
+  if (sawFailure) return "failure";
+  if (sawIncomplete) return "pending";
+  return "success";
+}
+
+function checksStateFromCombinedStatus(body: Record<string, unknown> | null): ChecksState | null {
+  if (!body) return null;
+  const state = asString(body.state);
+  if (state === "success" || state === "failure" || state === "pending") return state;
+  return null;
+}
+
+async function fetchChecksState(input: {
+  fetchImpl: FetchLike;
+  headers: Record<string, string>;
+  host: string;
+  owner: string;
+  repo: string;
+  headSha: string | null;
+}): Promise<ChecksState | null> {
+  const { fetchImpl, headers, host, owner, repo, headSha } = input;
+  if (!headSha) return null;
+  const base = `${gitHubApiBase(host)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+
+  try {
+    const checkRunsResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/check-runs`, { headers });
+    if (checkRunsResponse.ok) {
+      const body = await safeJson(checkRunsResponse);
+      const checkRuns = Array.isArray(body?.check_runs) ? (body!.check_runs as Array<Record<string, unknown>>) : [];
+      const fromCheckRuns = checksStateFromCheckRuns(checkRuns);
+      if (fromCheckRuns) return fromCheckRuns;
+    }
+  } catch {
+    // Fall through to the combined status endpoint below.
+  }
+
+  try {
+    const statusResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/status`, { headers });
+    if (statusResponse.ok) {
+      const body = await safeJson(statusResponse);
+      const fromStatus = checksStateFromCombinedStatus(body);
+      if (fromStatus) return fromStatus;
+    }
+  } catch {
+    // No combined status available either — treat as unknown (no CI signal).
+  }
+
+  // Neither check-runs nor commit statuses reported anything: there is no CI
+  // configured for this commit, so there is nothing to gate on.
+  return "success";
 }
 
 async function defaultTokenProvider(db: Db, companyId: string, secretNames: readonly string[]) {
@@ -430,11 +505,23 @@ export function createGitHubExternalObjectProvider(
           };
         }
 
+        if (objectType !== "pull_request") {
+          return { ok: true, snapshot: issueSnapshot(identity, body, etag) };
+        }
+
+        const headSha = asNestedString(body, "head", "sha");
+        const checksState = await fetchChecksState({
+          fetchImpl,
+          headers,
+          host: identity.host,
+          owner: identity.owner,
+          repo: identity.repo,
+          headSha,
+        });
+
         return {
           ok: true,
-          snapshot: objectType === "pull_request"
-            ? pullRequestSnapshot(identity, body, etag)
-            : issueSnapshot(identity, body, etag),
+          snapshot: pullRequestSnapshot(identity, body, etag, checksState),
         };
       },
     };

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -315,7 +315,13 @@ async function safeJson(response: Response) {
 
 type ChecksState = "success" | "failure" | "pending";
 
-const FAILING_CHECK_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+// Allow-list, not a block-list: GitHub's check-run `conclusion` values keep
+// growing (stale, skipped, neutral, ...), and a gate that only recognizes a
+// fixed set of *failing* conclusions silently treats any conclusion it
+// doesn't recognize as green. Only these conclusions count as confirmed-not-
+// blocking; anything else on a completed run (including an unrecognized
+// future value) is treated as failure.
+const PASSING_CHECK_CONCLUSIONS = new Set(["success", "skipped", "neutral"]);
 
 function checksStateFromCheckRuns(checkRuns: Array<Record<string, unknown>>): ChecksState | null {
   if (checkRuns.length === 0) return null;
@@ -328,7 +334,7 @@ function checksStateFromCheckRuns(checkRuns: Array<Record<string, unknown>>): Ch
       continue;
     }
     const conclusion = asString(run.conclusion);
-    if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) sawFailure = true;
+    if (!conclusion || !PASSING_CHECK_CONCLUSIONS.has(conclusion)) sawFailure = true;
   }
   if (sawFailure) return "failure";
   if (sawIncomplete) return "pending";
@@ -381,8 +387,15 @@ async function fetchChecksState(input: {
     const checkRunsResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/check-runs`, { headers });
     if (checkRunsResponse.ok) {
       const body = await safeJson(checkRunsResponse);
-      const checkRuns = Array.isArray(body?.check_runs) ? (body!.check_runs as Array<Record<string, unknown>>) : [];
-      checkRunsState = checksStateFromCheckRuns(checkRuns);
+      if (body === null) {
+        // 2xx but an unreadable/non-JSON body: we cannot tell whether there
+        // were check-runs or not. Do not treat this the same as a
+        // confirmed-empty check-runs list.
+        checkRunsFetchFailed = true;
+      } else {
+        const checkRuns = Array.isArray(body.check_runs) ? (body.check_runs as Array<Record<string, unknown>>) : [];
+        checkRunsState = checksStateFromCheckRuns(checkRuns);
+      }
     } else {
       checkRunsFetchFailed = true;
     }
@@ -396,7 +409,11 @@ async function fetchChecksState(input: {
     const statusResponse = await fetchImpl(`${base}/commits/${encodeURIComponent(headSha)}/status`, { headers });
     if (statusResponse.ok) {
       const body = await safeJson(statusResponse);
-      statusState = checksStateFromCombinedStatus(body);
+      if (body === null) {
+        statusFetchFailed = true;
+      } else {
+        statusState = checksStateFromCombinedStatus(body);
+      }
     } else {
       statusFetchFailed = true;
     }
@@ -407,15 +424,18 @@ async function fetchChecksState(input: {
   // Combine both signals rather than trusting check-runs alone: a commit can
   // have all-green GitHub Checks and a failing/pending legacy commit status
   // (posted by a non-Checks-API CI integration) at the same time. The worse
-  // of the two known signals wins.
+  // of the two known signals wins, and an explicit "failure" from either
+  // source is trusted even if the other lookup could not be completed.
   const combined = worstChecksState([checkRunsState, statusState]);
-  if (combined) return combined;
+  if (combined === "failure") return "failure";
 
-  // Neither endpoint returned a usable signal. If either request actually
-  // failed (network error, non-2xx, unreadable body) we cannot say this
-  // commit has no CI configured — do not silently report "success" for an
-  // unknown state; let the caller treat it as "unable to determine".
+  // One of the two lookups did not actually complete (network error, non-2xx,
+  // unreadable body). We only have a partial picture of this commit's CI
+  // state, so we must not report "pending" or "success" as if we had
+  // confirmed both signals -- report unknown and let the caller fail closed.
   if (checkRunsFetchFailed || statusFetchFailed) return null;
+
+  if (combined) return combined;
 
   // Both endpoints were reached successfully and reported nothing: there is
   // genuinely no CI configured for this commit, so there is nothing to gate on.

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -587,13 +587,25 @@ export function createGitHubExternalObjectProvider(
         }
 
         const headSha = asNestedString(body, "head", "sha");
+        // A merged PR's own head SHA only carries the pre-merge CI result. GitHub
+        // (and any merge-queue/canary gate layered on top of it, e.g. a
+        // post-merge-only check against `main`) can report green on that head
+        // SHA while the actual merge commit that landed on the base branch was
+        // never checked at all, or was checked and failed. Once a PR is
+        // reported merged, gate on its `merge_commit_sha` -- the commit that is
+        // actually reachable from the base branch -- so "merged" cannot be
+        // satisfied by a PR whose landed commit was red. Fall back to head SHA
+        // only if GitHub did not report a merge commit SHA for some reason.
+        const merged = (asBoolean(body.merged) ?? false) || Boolean(asString(body.merged_at));
+        const mergeCommitSha = asString(body.merge_commit_sha);
+        const checksSha = merged ? (mergeCommitSha ?? headSha) : headSha;
         const checksState = await fetchChecksState({
           fetchImpl,
           headers,
           host: identity.host,
           owner: identity.owner,
           repo: identity.repo,
-          headSha,
+          headSha: checksSha,
         });
 
         return {


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-state machine lets any actor move an issue to `done`, including agents
> - The `done` transition does not check whether a linked GitHub pull request is actually merged and green, so an agent can close an issue while its PR is still open, unmerged, or failing CI
> - Nothing else in the system stops this — only a human noticing catches it, and a supervisor audit found real cases of it slipping through
> - This pull request adds a server-side, fail-closed check on the `done` transition that reads the linked pull request's merge state and CI check-run state and rejects the transition with a clear reason when either is not green
> - The benefit is a structural guarantee: an issue cannot be marked `done` while its linked PR is open, unmerged, or has failing/pending CI, with no bypass flag

## Linked Issues or Issue Description

**What is the problem?**
An issue can be marked `done` even when it references a GitHub pull request that is still open, not merged, or merged with a failing/pending CI run. Nothing in the `PATCH /issues/:id` handler consults the linked pull request's real state before accepting the transition.

**What is the proposed behavior?**
When a `PATCH /issues/:id` request would move an issue's status to `done`, the server looks up any linked GitHub pull requests (via the existing external-object mention system). If any linked pull request is not merged, or is merged but its CI checks are not green, the server rejects the request with HTTP `422` and a message naming the pull request (`owner/repo#number`) and the exact reason (`open`, `unmerged`, `checks red`, or `checks pending`).

**Why does it need to be addressed?**
A recent audit found an issue closed `done` while its linked pull request (#4198 in another Paperclip-managed repo) was still open with red CI — nothing on `main`. This is a silent false-positive: the board shows work as complete when it is not. There is currently no structural guard against it; only a human review catches it.

**Reason and benefit**
Today, closing an issue and merging its pull request are two independent, unenforced actions. This enhancement makes "the PR is merged and green" a hard precondition for "the issue is done," removing an entire class of false-`done` reports without adding any new command or concept — it strengthens an existing transition.

## What Changed

- `server/src/services/github-external-object-provider.ts`: the pull-request resolver now fetches check-run state for the PR head SHA (`GET /repos/{owner}/{repo}/commits/{sha}/check-runs`), falling back to the combined commit-status endpoint (`GET .../commits/{sha}/status`) when there are no check-runs. The result is exposed as `data.checksState: "success" | "failure" | "pending"`. When neither endpoint reports anything (no CI configured on that commit), it defaults to `"success"` so repos without CI are never blocked.
- `server/src/routes/issues.ts`: `PATCH /issues/:id` now calls a new `assertNoBlockingLinkedPullRequest` helper whenever the requested status is `done` and the issue is not already `done`. It reads the issue's linked pull requests via the existing `externalObjectsSvc.listForIssue`, and for each GitHub `pull_request` object, rejects the transition with HTTP `422` if it is not merged (reason `open` or `unmerged`) or is merged with `checksState !== "success"` (reason `checks red` or `checks pending`). The response body includes a structured `details: { code: "done_transition_pr_gate", reason, pullRequest }` payload alongside the human-readable message. There is no bypass flag — the check applies to both board and agent actors.
- Added `server/src/__tests__/issue-done-transition-pr-gate-routes.test.ts`: an embedded-Postgres, route-level test covering the open-PR refusal, the merged-with-red-CI refusal, the merged-with-pending-CI refusal, the merged-and-green pass case, and the no-linked-PR no-op case.
- Extended `server/src/__tests__/external-objects-service.test.ts` with resolver-level coverage for the new `checksState` field: check-run-derived pending/failure/success, the combined-status fallback when there are no check-runs, and the default-to-success behavior when neither endpoint reports anything.

## Verification

Route-level acceptance evidence, captured from the actual handler (embedded Postgres, stubbed GitHub `fetch`) using the same request shape as `curl -X PATCH .../issues/{id} -d '{"status":"done"}'`:

Open PR -> HTTP 422:
```json
{
  "error": "Cannot mark issue done: linked pull request acme/app#201 is open",
  "code": "done_transition_pr_gate",
  "details": { "code": "done_transition_pr_gate", "reason": "open", "pullRequest": { "owner": "acme", "repo": "app", "number": 201, "state": "open", "merged": false, "checksState": "success" } }
}
```

Merged PR with red CI -> HTTP 422:
```json
{
  "error": "Cannot mark issue done: linked pull request acme/app#202 is checks red",
  "code": "done_transition_pr_gate",
  "details": { "code": "done_transition_pr_gate", "reason": "checks red", "pullRequest": { "owner": "acme", "repo": "app", "number": 202, "state": "closed", "merged": true, "checksState": "failure" } }
}
```

Merged PR with green CI -> HTTP 200, issue reaches `done`:
```json
{ "id": "f92984a6-...", "status": "done", "changes": { "status": { "from": "in_progress", "to": "done" } } }
```

The merged-with-pending-CI case (same 422 shape, `reason: "checks pending"`) and the no-linked-PR no-op case (200, unaffected) are covered by the automated test suite below.

Commands run:
- `npx vitest run src/__tests__/issue-done-transition-pr-gate-routes.test.ts` — 5/5 passing
- `npx vitest run src/__tests__/external-objects-service.test.ts` — 31/31 passing
- `npx vitest run src/__tests__/external-object-routes.test.ts src/__tests__/issues-service.test.ts` — 128/128 passing (regression sweep on adjacent routes/services)
- `npx tsc --noEmit -p server` — clean on all touched files (pre-existing, unrelated plugin-sdk workspace-build errors only, present before this change)
- Searched open and merged PRs for `checksState`, `done_transition_pr_gate`, and "done transition" — no existing or duplicate PR found.

## Risks

- **Behavioral change:** issues linked to a GitHub pull request can no longer reach `done` until that PR is merged with green CI. This is the intended effect, but any workflow that relied on marking an issue `done` independently of its PR state will now be rejected with `422`.
- **No bypass:** the gate has no override flag by design (fail-closed). If a legitimate need to force-close such an issue arises, it requires unlinking the PR reference or a follow-up change — this is a deliberate tradeoff, not an oversight.
- **External dependency:** the check-run/status lookup depends on the GitHub API being reachable and returning data for the PR's head SHA. If GitHub is unreachable, the existing resolver's fetch failure handling applies (the affected linked-PR fetch simply fails and is not treated as a green signal); this does not change error handling paths already in place for other PR fields.
- **Scope:** this only gates the `pull_request` external-object type from the GitHub provider. Other providers or object types are unaffected. Low risk.

## Model Used

Claude (Anthropic), accessed via the pi coding agent harness. Extended-thinking / agentic tool-use mode, used to read the existing external-objects resolver and route handler, implement the check-run fetch and the `done`-transition gate, and run the full verification test suite above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
