### PR TITLE
Fix routine standing-parent blocker cleanup

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -411,6 +411,54 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(blockerEdges).toEqual([]);
   });
 
+  it("clears legacy routine blocker edges when the parent snapshot is absent", async () => {
+    const { companyId, issueSvc, projectId, routine, svc } = await seedFixture();
+    const originalParent = await issueSvc.create(companyId, {
+      projectId,
+      title: "Original standing target",
+      status: "in_review",
+      priority: "medium",
+    });
+    await db.update(routines).set({ parentIssueId: originalParent.id }).where(eq(routines.id, routine.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).toEqual(expect.any(String));
+
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: run.linkedIssueId!,
+      relatedIssueId: originalParent.id,
+      type: "blocks",
+    });
+    const storedRun = await db
+      .select({ id: routineRuns.id, triggerPayload: routineRuns.triggerPayload })
+      .from(routineRuns)
+      .where(eq(routineRuns.linkedIssueId, run.linkedIssueId!))
+      .then((rows) => rows[0]!);
+    const { executionIssue: _executionIssue, ...legacyPayload } = storedRun.triggerPayload as Record<string, unknown>;
+    await db.update(routineRuns).set({ triggerPayload: legacyPayload }).where(eq(routineRuns.id, storedRun.id));
+
+    const replacementParent = await issueSvc.create(companyId, {
+      projectId,
+      title: "Replacement parent",
+      status: "in_review",
+      priority: "medium",
+    });
+    await db
+      .update(issues)
+      .set({ parentId: replacementParent.id, status: "done" })
+      .where(eq(issues.id, run.linkedIssueId!));
+
+    await svc.syncRunStatusForIssue(run.linkedIssueId!);
+
+    const blockerEdges = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.issueId, run.linkedIssueId!));
+    expect(blockerEdges).toEqual([]);
+  });
+
   it("filters listed routines by project", async () => {
     const { companyId, agentId, projectId, routine, svc } = await seedFixture();
     const otherProjectId = randomUUID();

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -390,6 +390,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       relatedIssueId: parentIssue.id,
       type: "blocks",
     });
+    await db.update(routines).set({ parentIssueId: null }).where(eq(routines.id, routine.id));
     await db.update(issues).set({ status: "done" }).where(eq(issues.id, run.linkedIssueId!));
 
     await svc.syncRunStatusForIssue(run.linkedIssueId!);

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -391,7 +391,16 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       type: "blocks",
     });
     await db.update(routines).set({ parentIssueId: null }).where(eq(routines.id, routine.id));
-    await db.update(issues).set({ status: "done" }).where(eq(issues.id, run.linkedIssueId!));
+    const replacementParent = await issueSvc.create(companyId, {
+      projectId,
+      title: "Replacement parent",
+      status: "in_review",
+      priority: "medium",
+    });
+    await db
+      .update(issues)
+      .set({ parentId: replacementParent.id, status: "done" })
+      .where(eq(issues.id, run.linkedIssueId!));
 
     await svc.syncRunStatusForIssue(run.linkedIssueId!);
 

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -419,7 +419,10 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       status: "in_review",
       priority: "medium",
     });
-    await db.update(routines).set({ parentIssueId: originalParent.id }).where(eq(routines.id, routine.id));
+    await svc.update(routine.id, {
+      parentIssueId: originalParent.id,
+      baseRevisionId: routine.latestRevisionId,
+    }, {});
 
     const run = await svc.runRoutine(routine.id, { source: "manual" });
     expect(run.status).toBe("issue_created");

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -16,6 +16,7 @@ import {
   heartbeatRuns,
   instanceSettings,
   issueInboxArchives,
+  issueRelations,
   issues,
   projectWorkspaces,
   projects,
@@ -367,6 +368,37 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run?.triggerPayload).toMatchObject({
       transientFailure: { clearedAt: expect.any(String) },
     });
+  });
+
+  it("clears a routine execution issue blocker edge to its standing parent on completion", async () => {
+    const { companyId, issueSvc, projectId, routine, svc } = await seedFixture();
+    const parentIssue = await issueSvc.create(companyId, {
+      projectId,
+      title: "Standing readiness target",
+      status: "in_review",
+      priority: "medium",
+    });
+    await db.update(routines).set({ parentIssueId: parentIssue.id }).where(eq(routines.id, routine.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).toEqual(expect.any(String));
+
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: run.linkedIssueId!,
+      relatedIssueId: parentIssue.id,
+      type: "blocks",
+    });
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, run.linkedIssueId!));
+
+    await svc.syncRunStatusForIssue(run.linkedIssueId!);
+
+    const blockerEdges = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.issueId, run.linkedIssueId!));
+    expect(blockerEdges).toEqual([]);
   });
 
   it("filters listed routines by project", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -450,6 +450,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       .then((rows) => rows[0]!);
     const { executionIssue: _executionIssue, ...legacyPayload } = storedRun.triggerPayload as Record<string, unknown>;
     await db.update(routineRuns).set({ triggerPayload: legacyPayload }).where(eq(routineRuns.id, storedRun.id));
+    await db.update(routines).set({ parentIssueId: null }).where(eq(routines.id, routine.id));
 
     const replacementParent = await issueSvc.create(companyId, {
       projectId,

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -431,6 +431,18 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       relatedIssueId: originalParent.id,
       type: "blocks",
     });
+    const unrelatedTarget = await issueSvc.create(companyId, {
+      projectId,
+      title: "Unrelated blocked target",
+      status: "todo",
+      priority: "medium",
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: run.linkedIssueId!,
+      relatedIssueId: unrelatedTarget.id,
+      type: "blocks",
+    });
     const storedRun = await db
       .select({ id: routineRuns.id, triggerPayload: routineRuns.triggerPayload })
       .from(routineRuns)
@@ -456,7 +468,12 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       .select()
       .from(issueRelations)
       .where(eq(issueRelations.issueId, run.linkedIssueId!));
-    expect(blockerEdges).toEqual([]);
+    expect(blockerEdges).toEqual([
+      expect.objectContaining({
+        relatedIssueId: unrelatedTarget.id,
+        type: "blocks",
+      }),
+    ]);
   });
 
   it("filters listed routines by project", async () => {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -126,6 +126,14 @@ function executionIssueTransientFailureClearedAtFromPayload(payload: unknown): s
   return typeof clearedAt === "string" ? clearedAt : null;
 }
 
+function executionIssueParentIdFromPayload(payload: unknown): string | null | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  const executionIssue = (payload as Record<string, unknown>).executionIssue;
+  if (!executionIssue || typeof executionIssue !== "object" || Array.isArray(executionIssue)) return undefined;
+  const parentId = (executionIssue as Record<string, unknown>).parentId;
+  return typeof parentId === "string" ? parentId : parentId === null ? null : undefined;
+}
+
 function legacyExecutionIssueTransientFailureStatus(
   failureReason: string | null,
 ): ExecutionIssueTransientFailureStatus | null {
@@ -1750,7 +1758,10 @@ export function routineService(
     const description = [baseDescription, input.descriptionAppendix]
       .filter((part): part is string => Boolean(part && part.trim()))
       .join("\n\n");
-    const triggerPayload = mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables });
+    const triggerPayload = {
+      ...(mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables }) ?? {}),
+      executionIssue: { parentId: input.routine.parentIssueId },
+    };
     const managedRoutineBinding = await getManagedRoutineBinding(input.routine);
     const managedIssueTemplate = readManagedRoutineIssueTemplate(managedRoutineBinding?.defaultsJson);
     const issueOriginKind = managedIssueTemplate?.surfaceVisibility === "plugin_operation" && managedRoutineBinding
@@ -3199,14 +3210,15 @@ export function routineService(
         const transientFailureStatus = executionIssueTransientFailureStatusFromPayload(run.triggerPayload)
           ?? legacyExecutionIssueTransientFailureStatus(run.failureReason);
         const transientFailureClearedAt = executionIssueTransientFailureClearedAtFromPayload(run.triggerPayload);
+        const standingParentIssueId = executionIssueParentIdFromPayload(run.triggerPayload) ?? issue.parentId;
         return db.transaction(async (tx) => {
-          if (issue.parentId) {
+          if (standingParentIssueId) {
             await tx
               .delete(issueRelations)
               .where(and(
                 eq(issueRelations.companyId, issue.companyId),
                 eq(issueRelations.issueId, issue.id),
-                eq(issueRelations.relatedIssueId, issue.parentId),
+                eq(issueRelations.relatedIssueId, standingParentIssueId),
                 eq(issueRelations.type, "blocks"),
               ));
           }

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -3203,8 +3203,10 @@ export function routineService(
           status: routineRuns.status,
           failureReason: routineRuns.failureReason,
           triggerPayload: routineRuns.triggerPayload,
+          parentIssueId: routines.parentIssueId,
         })
         .from(routineRuns)
+        .innerJoin(routines, eq(routines.id, routineRuns.routineId))
         .where(eq(routineRuns.id, issue.originRunId))
         .then((rows) => rows[0] ?? null);
       if (!run) return null;
@@ -3212,7 +3214,10 @@ export function routineService(
         const transientFailureStatus = executionIssueTransientFailureStatusFromPayload(run.triggerPayload)
           ?? legacyExecutionIssueTransientFailureStatus(run.failureReason);
         const transientFailureClearedAt = executionIssueTransientFailureClearedAtFromPayload(run.triggerPayload);
-        const standingParentIssueId = executionIssueParentIdFromPayload(run.triggerPayload);
+        const snapshottedParentIssueId = executionIssueParentIdFromPayload(run.triggerPayload);
+        const standingParentIssueId = snapshottedParentIssueId === undefined
+          ? run.parentIssueId
+          : snapshottedParentIssueId;
         return db.transaction(async (tx) => {
           if (standingParentIssueId !== null) {
             await tx
@@ -3221,9 +3226,7 @@ export function routineService(
                 eq(issueRelations.companyId, issue.companyId),
                 eq(issueRelations.issueId, issue.id),
                 eq(issueRelations.type, "blocks"),
-                ...(standingParentIssueId === undefined
-                  ? []
-                  : [eq(issueRelations.relatedIssueId, standingParentIssueId)]),
+                eq(issueRelations.relatedIssueId, standingParentIssueId),
               ));
           }
           return finalizeRun(run.id, {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -16,6 +16,7 @@ import {
   goals,
   heartbeatRuns,
   issueInboxArchives,
+  issueRelations,
   issues,
   pluginManagedResources,
   plugins,
@@ -1552,7 +1553,11 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
-  async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
+  async function finalizeRun(
+    runId: string,
+    patch: Partial<typeof routineRuns.$inferInsert>,
+    executor: Pick<Db, "update"> = db,
+  ) {
     return executor
       .update(routineRuns)
       .set({
@@ -3169,6 +3174,7 @@ export function routineService(
       const issue = await db
         .select({
           id: issues.id,
+          companyId: issues.companyId,
           status: issues.status,
           originKind: issues.originKind,
           originRunId: issues.originRunId,
@@ -3183,8 +3189,10 @@ export function routineService(
           status: routineRuns.status,
           failureReason: routineRuns.failureReason,
           triggerPayload: routineRuns.triggerPayload,
+          parentIssueId: routines.parentIssueId,
         })
         .from(routineRuns)
+        .innerJoin(routines, eq(routines.id, routineRuns.routineId))
         .where(eq(routineRuns.id, issue.originRunId))
         .then((rows) => rows[0] ?? null);
       if (!run) return null;
@@ -3192,23 +3200,35 @@ export function routineService(
         const transientFailureStatus = executionIssueTransientFailureStatusFromPayload(run.triggerPayload)
           ?? legacyExecutionIssueTransientFailureStatus(run.failureReason);
         const transientFailureClearedAt = executionIssueTransientFailureClearedAtFromPayload(run.triggerPayload);
-        return finalizeRun(issue.originRunId, {
-          status: "completed",
-          failureReason: null,
-          completedAt: new Date(),
-          ...(transientFailureStatus
-            ? {
-              triggerPayload: {
-                ...(run.triggerPayload ?? {}),
-                transientFailure: {
-                  code: EXECUTION_ISSUE_TRANSIENT_FAILURE_CODE,
-                  status: transientFailureStatus,
-                  reason: executionIssueTransientFailureReason(transientFailureStatus),
-                  clearedAt: transientFailureClearedAt ?? new Date().toISOString(),
+        return db.transaction(async (tx) => {
+          if (run.parentIssueId) {
+            await tx
+              .delete(issueRelations)
+              .where(and(
+                eq(issueRelations.companyId, issue.companyId),
+                eq(issueRelations.issueId, issue.id),
+                eq(issueRelations.relatedIssueId, run.parentIssueId),
+                eq(issueRelations.type, "blocks"),
+              ));
+          }
+          return finalizeRun(run.id, {
+            status: "completed",
+            failureReason: null,
+            completedAt: new Date(),
+            ...(transientFailureStatus
+              ? {
+                triggerPayload: {
+                  ...(run.triggerPayload ?? {}),
+                  transientFailure: {
+                    code: EXECUTION_ISSUE_TRANSIENT_FAILURE_CODE,
+                    status: transientFailureStatus,
+                    reason: executionIssueTransientFailureReason(transientFailureStatus),
+                    clearedAt: transientFailureClearedAt ?? new Date().toISOString(),
+                  },
                 },
-              },
-            }
-            : {}),
+              }
+              : {}),
+          }, tx);
         });
       }
       if (issue.status === "blocked" || issue.status === "cancelled") {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -3175,6 +3175,7 @@ export function routineService(
         .select({
           id: issues.id,
           companyId: issues.companyId,
+          parentId: issues.parentId,
           status: issues.status,
           originKind: issues.originKind,
           originRunId: issues.originRunId,
@@ -3189,10 +3190,8 @@ export function routineService(
           status: routineRuns.status,
           failureReason: routineRuns.failureReason,
           triggerPayload: routineRuns.triggerPayload,
-          parentIssueId: routines.parentIssueId,
         })
         .from(routineRuns)
-        .innerJoin(routines, eq(routines.id, routineRuns.routineId))
         .where(eq(routineRuns.id, issue.originRunId))
         .then((rows) => rows[0] ?? null);
       if (!run) return null;
@@ -3201,13 +3200,13 @@ export function routineService(
           ?? legacyExecutionIssueTransientFailureStatus(run.failureReason);
         const transientFailureClearedAt = executionIssueTransientFailureClearedAtFromPayload(run.triggerPayload);
         return db.transaction(async (tx) => {
-          if (run.parentIssueId) {
+          if (issue.parentId) {
             await tx
               .delete(issueRelations)
               .where(and(
                 eq(issueRelations.companyId, issue.companyId),
                 eq(issueRelations.issueId, issue.id),
-                eq(issueRelations.relatedIssueId, run.parentIssueId),
+                eq(issueRelations.relatedIssueId, issue.parentId),
                 eq(issueRelations.type, "blocks"),
               ));
           }

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1760,7 +1760,9 @@ export function routineService(
       .join("\n\n");
     const triggerPayload = {
       ...(mergeRoutineRunPayload(input.payload, { ...automaticVariables, ...resolvedVariables }) ?? {}),
-      executionIssue: { parentId: input.routine.parentIssueId },
+      ...(input.routine.parentIssueId
+        ? { executionIssue: { parentId: input.routine.parentIssueId } }
+        : {}),
     };
     const managedRoutineBinding = await getManagedRoutineBinding(input.routine);
     const managedIssueTemplate = readManagedRoutineIssueTemplate(managedRoutineBinding?.defaultsJson);
@@ -3210,16 +3212,18 @@ export function routineService(
         const transientFailureStatus = executionIssueTransientFailureStatusFromPayload(run.triggerPayload)
           ?? legacyExecutionIssueTransientFailureStatus(run.failureReason);
         const transientFailureClearedAt = executionIssueTransientFailureClearedAtFromPayload(run.triggerPayload);
-        const standingParentIssueId = executionIssueParentIdFromPayload(run.triggerPayload) ?? issue.parentId;
+        const standingParentIssueId = executionIssueParentIdFromPayload(run.triggerPayload);
         return db.transaction(async (tx) => {
-          if (standingParentIssueId) {
+          if (standingParentIssueId !== null) {
             await tx
               .delete(issueRelations)
               .where(and(
                 eq(issueRelations.companyId, issue.companyId),
                 eq(issueRelations.issueId, issue.id),
-                eq(issueRelations.relatedIssueId, standingParentIssueId),
                 eq(issueRelations.type, "blocks"),
+                ...(standingParentIssueId === undefined
+                  ? []
+                  : [eq(issueRelations.relatedIssueId, standingParentIssueId)]),
               ));
           }
           return finalizeRun(run.id, {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -134,6 +134,11 @@ function executionIssueParentIdFromPayload(payload: unknown): string | null | un
   return typeof parentId === "string" ? parentId : parentId === null ? null : undefined;
 }
 
+function routineRevisionParentIssueIdFromSnapshot(snapshot: unknown): string | null | undefined {
+  const parsed = routineRevisionSnapshotSchema.safeParse(snapshot);
+  return parsed.success ? parsed.data.routine.parentIssueId : undefined;
+}
+
 function legacyExecutionIssueTransientFailureStatus(
   failureReason: string | null,
 ): ExecutionIssueTransientFailureStatus | null {
@@ -3204,9 +3209,11 @@ export function routineService(
           failureReason: routineRuns.failureReason,
           triggerPayload: routineRuns.triggerPayload,
           parentIssueId: routines.parentIssueId,
+          revisionSnapshot: routineRevisions.snapshot,
         })
         .from(routineRuns)
         .innerJoin(routines, eq(routines.id, routineRuns.routineId))
+        .leftJoin(routineRevisions, eq(routineRevisions.id, routineRuns.routineRevisionId))
         .where(eq(routineRuns.id, issue.originRunId))
         .then((rows) => rows[0] ?? null);
       if (!run) return null;
@@ -3215,8 +3222,9 @@ export function routineService(
           ?? legacyExecutionIssueTransientFailureStatus(run.failureReason);
         const transientFailureClearedAt = executionIssueTransientFailureClearedAtFromPayload(run.triggerPayload);
         const snapshottedParentIssueId = executionIssueParentIdFromPayload(run.triggerPayload);
+        const revisionParentIssueId = routineRevisionParentIssueIdFromSnapshot(run.revisionSnapshot);
         const standingParentIssueId = snapshottedParentIssueId === undefined
-          ? run.parentIssueId
+          ? revisionParentIssueId === undefined ? run.parentIssueId : revisionParentIssueId
           : snapshottedParentIssueId;
         return db.transaction(async (tx) => {
           if (standingParentIssueId !== null) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Scheduled routines create execution issues for recurring work
> - A routine can use a standing issue as the parent of each execution issue
> - An execution issue can add a blocker edge to that standing parent during its work
> - Routine completion did not remove that edge
> - The stale edge prevented the standing parent from returning to review
> - This pull request removes the exact execution-issue blocker edge during routine completion
> - The benefit is that recurring monitors can re-arm without an operator clearing the edge

## Linked Issues or Issue Description

**What happened?**

A completed routine execution issue could remain a first-class blocker of the routine's standing parent issue. The parent then failed its status transition because dependency readiness still found the completed cycle's blocker edge.

**Expected behavior**

Routine completion must remove the execution issue's blocker edge to the routine's configured parent. The standing parent must be able to re-arm without manual edge cleanup.

**Steps to reproduce**

1. Create a routine with a standing parent issue.
2. Run the routine and add a `blocks` relation from the execution issue to the standing parent.
3. Complete the execution issue and synchronize the routine run status.
4. Observe that the blocker relation remains before this change.

**Paperclip version or commit**

`5a1ce7a`

**Deployment mode**

Self-hosted server.

The public GitHub search found no duplicate issue or pull request for this exact routine-parent cleanup.

## What Changed

- Load the routine's configured parent when routine execution status is synchronized.
- Delete only the execution issue's `blocks` edge to that parent when the execution issue completes.
- Complete the edge cleanup and routine-run finalization in one database transaction.
- Add an embedded-Postgres regression test for the standing-parent cleanup.

## Verification

- `./node_modules/.bin/vitest run server/src/__tests__/routines-service.test.ts -t "clears a routine execution issue blocker edge to its standing parent on completion" --reporter=verbose`
- Result: 1 test passed and 63 tests were skipped by the focused selector.

## Risks

- Low risk. The delete matches one company, one routine execution issue, one configured parent, and the `blocks` relation type.
- Unrelated blocker edges are not changed.
- There is no schema or migration change.

## Model Used

- OpenAI GPT-5 Codex with reasoning, tool use, terminal execution, and code editing capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
