### PR TITLE
fix(issues): stop refusing every board write from a generic heartbeat run

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import {
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+  CROSS_ISSUE_INFLUENCE_LIMIT,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
 
@@ -112,5 +113,78 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.runId, runId)));
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_observed")).toHaveLength(20);
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_cap_rejected")).toHaveLength(1);
+  });
+
+  // Regression: a run whose context snapshot has no issueId/taskId — i.e. every
+  // scheduled heartbeat, as opposed to an issue-scoped wake — used to throw
+  // `cross_issue_influence_run_context_required` here, which made generic
+  // heartbeats read-only across the whole board and stranded issues in
+  // `blocked` because agents could not record their own completed work. Only
+  // the issue-scoped snapshot was ever covered, which is how that shipped.
+  it("counts writes from a run with no source issue instead of refusing them", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const targetIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Heartbeat Coder",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      // The shape a scheduled heartbeat actually has: a real, live, agent-owned
+      // run row, with nothing naming a source issue.
+      contextSnapshot: { trigger: "schedule" },
+    });
+
+    const input = {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId,
+      targetIssueIdentifier: "CAP-3",
+      kind: "update" as const,
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    };
+
+    const first = await observeCrossIssueInfluence(db, input);
+    expect(first).not.toBeNull();
+    expect(first?.allowed).toBe(true);
+    expect(first?.count).toBe(1);
+
+    // Still contained: with no source issue there is nothing to be exempt from,
+    // so every write counts and the cap still closes at 20.
+    for (let i = 0; i < CROSS_ISSUE_INFLUENCE_LIMIT - 1; i += 1) {
+      await observeCrossIssueInfluence(db, input);
+    }
+    const overCap = await observeCrossIssueInfluence(db, input);
+    expect(overCap?.allowed).toBe(false);
+    expect(overCap?.count).toBe(CROSS_ISSUE_INFLUENCE_LIMIT + 1);
+
+    const recorded = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(and(eq(activityLog.companyId, companyId), eq(activityLog.runId, runId)));
+    expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_observed"))
+      .toHaveLength(CROSS_ISSUE_INFLUENCE_LIMIT);
+    expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_cap_rejected"))
+      .toHaveLength(1);
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -198,19 +198,31 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
+  // A run with no source issue is a scheduled heartbeat, not a broken request:
+  // the run row exists and is owned by this agent, there is simply no issue that
+  // woke it. Refusing here is what made generic heartbeats read-only board-wide.
+  // The two cases above — no run row at all, and an attacker-controlled run id —
+  // are the real fail-closed cases and still are.
+  it("counts, rather than refuses, a run with no source issue", async () => {
     const fake = counterDb(0, { contextSnapshot: {} });
 
-    await expect(observeCrossIssueInfluence(fake.db as never, {
+    const decision = await observeCrossIssueInfluence(fake.db as never, {
       companyId: "22222222-2222-4222-8222-222222222222",
       runId: "11111111-1111-4111-8111-111111111111",
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
       kind: "update",
-    })).rejects.toMatchObject({
-      status: 403,
-      details: { code: "cross_issue_influence_run_context_required" },
     });
-    expect(fake.inserted).toEqual([]);
+
+    // Not exempted (that needs a source issue to match against) — counted, so
+    // the 20-write cap still contains a runaway heartbeat.
+    expect(decision).not.toBeNull();
+    expect(decision?.allowed).toBe(true);
+    expect(decision?.count).toBe(1);
+    expect(fake.inserted).toHaveLength(1);
+    expect(fake.inserted[0]).toMatchObject({
+      action: "issue.cross_issue_influence_observed",
+      details: { sourceIssueId: null },
+    });
   });
 });

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -109,11 +109,27 @@ export async function observeCrossIssueInfluence(
       throw crossIssueInfluenceRunContextError();
     }
 
+    // A generic heartbeat run has no source issue: it was woken by the schedule
+    // rather than by an issue, so its context snapshot carries no issueId/taskId.
+    // That is NOT a missing run context — the run row was just found above, is
+    // live, and is owned by this agent and company — so it must not raise
+    // `cross_issue_influence_run_context_required`. Doing so made every generic
+    // heartbeat read-only board-wide: an agent could not even close its own
+    // finished task, and the 403 it got back advised sending an
+    // `X-Paperclip-Run-Id` header that the request already carried and that
+    // cannot help, because the run was never the problem.
+    //
+    // Instead, treat "no source issue" as "nothing to be exempt from". The
+    // self-write exemption below needs a source issue to compare against, so it
+    // simply does not apply, and every write from such a run counts against the
+    // same 20-write cap — exactly the containment the cap exists to provide.
+    // Spray stays bounded; ordinary work is no longer refused.
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
-      sourceIssueId === input.targetIssueId ||
-      (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      sourceIssueId &&
+      (sourceIssueId === input.targetIssueId ||
+        (input.targetIssueIdentifier &&
+          sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase()))
     ) {
       return null;
     }


### PR DESCRIPTION
## Problem

`observeCrossIssueInfluence` refuses **every** issue write from a generically-woken heartbeat run.

`readRunSourceIssueId()` reads only `contextSnapshot.issueId` / `contextSnapshot.taskId`. A run woken by the schedule rather than by an issue has neither:

```json
{"actorId":"local-board","wakeSource":"on_demand","triggeredBy":"board","wakeTriggerDetail":"manual"}
```

So `sourceIssueId` is `null` and `server/src/services/cross-issue-influence-limit.ts:112-113` throws `cross_issue_influence_run_context_required`. The run row itself was just fetched under `FOR UPDATE` and verified to belong to this agent and company — the run context is *present and valid*. There is simply no issue that woke it.

The practical effect is that a scheduled heartbeat is read-only board-wide. An agent cannot comment on, or close, an issue **assigned to itself**, because the self-write exemption on the next line is never reached.

The 403's remedy text compounds it: it advises sending `X-Paperclip-Run-Id`. Reproduced with a valid header present — same 403. The header was never the problem, so the advice sends readers down a dead end. (I lost a working session to this before tracing it to the line.)

## Fix

Treat "no source issue" as **nothing to be exempt from**, not as a broken request.

The self-write exemption needs a source issue to compare against, so it simply does not apply. Every write from such a run then falls through to the normal counting path and counts against the same 20-write cap — which is exactly the containment the cap exists to provide. Spray stays bounded; ordinary work stops being refused.

The two genuine fail-closed cases are untouched and still throw: **no run row at all**, and a **run id that does not belong to this agent/company**.

`sourceIssueId: null` is recorded in the `activityLog` details, so the audit trail still names who acted, on what, under which run.

## Relationship to #11701

#11701 addresses the same 403 with a narrower remedy: a comment-only self-report path for unbound runs whose target is assigned to the same agent, with everything else still denied.

This PR is the broader alternative and is offered as such — maintainers should take whichever fits the intended containment model:

- **#11701** keeps the "unbound runs are exceptional" stance and carves out one safe verb. It leaves `PATCH` denied, so an agent still cannot move its own finished issue to `done` from a scheduled heartbeat.
- **This PR** treats unbound runs as ordinary and relies on the existing cap for containment. It needs no per-verb allowlist and no second assignee revalidation, because it does not grant an exemption — it counts.

They are not mergeable together as-is; both edit `cross-issue-influence-limit.ts`. Happy to rebase onto #11701 and reduce this to the `PATCH` gap if the narrower stance is preferred.

## Tests

`server/src/__tests__/cross-issue-influence-limit.test.ts` — the existing "fails closed when the persisted run has no source issue" case is inverted to assert it now *counts* rather than refuses, and asserts the activity row lands with `sourceIssueId: null` and `count: 1`. The two real fail-closed cases keep their existing assertions.

`server/src/__tests__/cross-issue-influence-limit-postgres.test.ts` — adds coverage against a real run row with an empty context snapshot.

```
✓ server/src/__tests__/cross-issue-influence-limit.test.ts (10 tests) — 10 passed
```

Observed on the new path, cap enforcing and the write allowed:

```
event=cross_issue_influence_cap sourceIssueId=null count=1 cap=20 mode=enforce allowed=true
```
