### PR TITLE
fix: reconcile covered final execution review

### DIFF
--- a/server/src/__tests__/issue-stalled-review-decision-routes.test.ts
+++ b/server/src/__tests__/issue-stalled-review-decision-routes.test.ts
@@ -14,6 +14,7 @@ import {
   heartbeatRuns,
   issueApprovals,
   issueComments,
+  issueExecutionDecisions,
   issueInboxArchives,
   issueRecoveryActions,
   issueThreadInteractions,
@@ -51,6 +52,7 @@ describeEmbeddedPostgres("stalled review decision routes", () => {
     await db.delete(issueApprovals);
     await db.delete(approvals);
     await db.delete(issueComments);
+    await db.delete(issueExecutionDecisions);
     await db.delete(issueRecoveryActions);
     await db.delete(activityLog);
     await db.delete(heartbeatRuns);
@@ -622,5 +624,27 @@ describeEmbeddedPostgres("stalled review decision routes", () => {
       request(app(actor)).post(`/api/issues/${raceIssueId}/stalled-review-decision`).send({ action: "approve" }),
     ]);
     expect(results.map((result) => result.status).sort()).toEqual([200, 409]);
+  });
+
+  it("finalizes a covered final review only when the pending participant already left approval evidence", async () => {
+    const seeded = await seedCompany("REC");
+    const issueId = await seedReview({ companyId: seeded.companyId, assigneeAgentId: seeded.assigneeAgentId, identifier: "REC-1" });
+    const firstStageId = randomUUID();
+    const finalStageId = randomUUID();
+    await db.update(issues).set({
+      executionPolicy: { mode: "normal", commentRequired: true, stages: [
+        { id: firstStageId, type: "review", approvalsNeeded: 1, participants: [{ id: randomUUID(), type: "agent", agentId: seeded.peerAgentId }] },
+        { id: finalStageId, type: "approval", approvalsNeeded: 1, participants: [{ id: randomUUID(), type: "agent", agentId: seeded.assigneeAgentId }] },
+      ] },
+      executionState: { status: "pending", currentStageId: finalStageId, currentStageIndex: 1, currentStageType: "approval", currentParticipant: { type: "agent", agentId: seeded.assigneeAgentId }, returnAssignee: { type: "agent", agentId: seeded.peerAgentId }, completedStageIds: [firstStageId], lastDecisionId: null, lastDecisionOutcome: null },
+    }).where(eq(issues.id, issueId));
+    await db.insert(issueThreadInteractions).values({ companyId: seeded.companyId, issueId, kind: "request_confirmation", status: "pending", continuationPolicy: "none", payload: { version: 1, prompt: "covered path" } });
+    await db.insert(issueComments).values({ companyId: seeded.companyId, issueId, body: "## Review: APPROVED\n\nFinal signoff.", authorAgentId: seeded.assigneeAgentId });
+
+    const response = await request(app(boardActor(seeded.companyId, seeded.memberUserId)))
+      .post(`/api/issues/${issueId}/stalled-review-decision`).send({ action: "approve" }).expect(200);
+
+    expect(response.body.issue).toMatchObject({ status: "done", executionState: { status: "completed", completedStageIds: [firstStageId, finalStageId], lastDecisionOutcome: "approved" } });
+    expect(await db.select().from(issueExecutionDecisions).where(eq(issueExecutionDecisions.issueId, issueId))).toHaveLength(1);
   });
 });

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2234,7 +2234,7 @@ registry.registerPath({
   method: "post",
   path: "/api/issues/{id}/stalled-review-decision",
   tags: ["issues"],
-  summary: "Resolve a stalled issue review",
+  summary: "Resolve a stalled or final covered issue review",
   request: {
     params: z.object({ id: z.string() }),
     body: jsonBody(stalledReviewDecisionSchema),

--- a/server/src/services/stalled-review-decisions.ts
+++ b/server/src/services/stalled-review-decisions.ts
@@ -1,10 +1,12 @@
-import { and, eq } from "drizzle-orm";
-import { issues, type Db } from "@paperclipai/db";
+import { randomUUID } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+import { issueComments, issueExecutionDecisions, issues, type Db } from "@paperclipai/db";
 import type { StalledReviewDecisionAction } from "@paperclipai/shared";
 import { conflict, notFound } from "../errors.js";
 import { logActivity } from "./activity-log.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { issueService } from "./issues.js";
+import { applyIssueExecutionPolicyTransition, normalizeIssueExecutionPolicy, parseIssueExecutionState } from "./issue-execution-policy.js";
 
 export interface StalledReviewDecisionActor {
   userId: string;
@@ -17,6 +19,11 @@ export interface DecideStalledReviewInput {
   action: StalledReviewDecisionAction;
   note?: string;
   actor: StalledReviewDecisionActor;
+}
+
+function isApprovalEvidence(body: string) {
+  const heading = body.replace(/\r\n?/g, "\n").match(/(?:^|\n)##\s*Review:\s*([^\n]*)/i)?.[1] ?? "";
+  return /\bAPPROVED\b/i.test(heading) && !/\b(?:NOT|REJECT(?:ED|ING|S)?|DENY|DENIED|BLOCK(?:ED|ING|S)?|CHANGES?\s+REQUESTED)\b/i.test(heading);
 }
 
 export function stalledReviewDecisionService(db: Db) {
@@ -46,12 +53,41 @@ export function stalledReviewDecisionService(db: Db) {
       const reviewAttention = await svc
         .listReviewAttention(lockedIssue.companyId, [lockedIssue])
         .then((rows) => rows.get(lockedIssue.id));
-      if (reviewAttention?.state !== "stalled") {
+      const executionState = parseIssueExecutionState(lockedIssue.executionState);
+      const policy = normalizeIssueExecutionPolicy(lockedIssue.executionPolicy);
+      const activeStage = executionState?.currentStageId
+        ? policy?.stages.find((stage) => stage.id === executionState.currentStageId) ?? null
+        : null;
+      const participantAgentId = executionState?.currentParticipant?.type === "agent"
+        ? executionState.currentParticipant.agentId ?? null
+        : null;
+      const evidence = executionState?.status === "pending" && participantAgentId
+        ? await tx.select().from(issueComments)
+          .where(and(eq(issueComments.issueId, lockedIssue.id), eq(issueComments.authorAgentId, participantAgentId)))
+          .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+          .then((rows) => rows.find((row) => isApprovalEvidence(row.body)) ?? null)
+        : null;
+      const coveredFinalApproval = input.action === "approve" && reviewAttention?.state === "covered" &&
+        Boolean(activeStage && policy && executionState && evidence && !executionState.completedStageIds.includes(activeStage.id) &&
+          policy.stages.every((stage) => stage.id === activeStage.id || executionState.completedStageIds.includes(stage.id)));
+      if (reviewAttention?.state !== "stalled" && !coveredFinalApproval) {
         throw conflict("Issue is no longer a stalled review", {
           issueId: lockedIssue.id,
           reviewAttentionState: reviewAttention?.state ?? "none",
         });
       }
+
+      const recoveredTransition = coveredFinalApproval && executionState && policy && activeStage && evidence && participantAgentId
+        ? applyIssueExecutionPolicyTransition({
+            issue: lockedIssue,
+            policy,
+            requestedStatus: "done",
+            requestedAssigneePatch: {},
+            actor: { agentId: participantAgentId },
+            commentBody: evidence.body,
+          })
+        : null;
+      const decisionId = recoveredTransition?.decision ? randomUUID() : null;
 
       const comment = input.note
         ? await svc.addComment(
@@ -66,8 +102,19 @@ export function stalledReviewDecisionService(db: Db) {
       const updated = await svc.update(lockedIssue.id, {
         status,
         actorUserId: input.actor.userId,
+        ...(recoveredTransition?.patch ?? {}),
+        ...(decisionId ? { executionState: { ...(recoveredTransition!.patch.executionState as object), lastDecisionId: decisionId } } : {}),
       }, tx);
       if (!updated) throw notFound("Issue not found");
+      if (decisionId && recoveredTransition?.decision) {
+        await tx.insert(issueExecutionDecisions).values({
+          id: decisionId, companyId: updated.companyId, issueId: updated.id,
+          stageId: recoveredTransition.decision.stageId, stageType: recoveredTransition.decision.stageType,
+          actorAgentId: participantAgentId, actorUserId: null,
+          outcome: recoveredTransition.decision.outcome, body: recoveredTransition.decision.body,
+          createdByRunId: null,
+        });
+      }
 
       if (comment) {
         await logActivity(txDb, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for agent work.
> - Review policies record the required review stages for an issue.
> - The review recovery service handles an issue when its review path needs a board decision.
> - A final pending stage can already have an approval comment from its exact agent participant.
> - The issue can then remain covered but cannot finalize through the supported recovery route.
> - This pull request permits that route only after it verifies the final stage and all earlier completed stages.
> - The benefit is an auditable completion path that keeps all required reviews.

## Linked Issues or Issue Description

Related public work: #10671, #10675, and #11686.

**What happened?**

A final review stage can have valid approval evidence but remain pending. The review is covered, so the stalled-review route returns a conflict. No supported route records the final execution decision.

**Expected behavior**

The recovery route must finalize the issue only when the pending final-stage participant left approval evidence and every prior stage completed.

**Steps to reproduce**

1. Create an issue with two execution review stages.
2. Complete the first stage.
3. Set the final stage as pending for an agent.
4. Add an approved review comment from that same agent.
5. Mark the review as covered.
6. Request an approve decision.

**Paperclip version or commit**

`master` at `cbe6395c` before this pull request.

**Deployment mode**

Core server behavior. It is not deployment-specific.

## What Changed

- Permit finalization from the existing recovery route only for a covered final review with exact participant approval evidence.
- Use the normal execution-policy transition and record the resulting execution decision.
- Add a synthetic embedded-Postgres regression test for the recovered final stage.
- Update the OpenAPI operation summary to describe this supported recovery case.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-stalled-review-decision-routes.test.ts` — 11 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --cached --check` — passed before commit.

## Risks

- Low risk. The new path requires a pending final stage, exact agent evidence, and completion of every earlier stage.
- The recovery route stays unavailable for other covered reviews.
- No schema, migration, permission, or deployment change occurs.

> This work aligns with the completed Agent Reviews and Approvals and Enforced Outcomes roadmap items. It does not add a new roadmap capability.

## Model Used

OpenAI Codex, GPT-5 family. The runtime does not expose the exact deployment ID or context-window size. The run used reasoning, repository tools, code execution, and GitHub CLI access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge