### PR TITLE
fix(adapter-utils): confine sandbox sync host paths with platform rules

### DIFF
--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1911,6 +1911,89 @@ describe("sandbox managed runtime", () => {
     ).toThrow(/escapes its confinement root|not a confined absolute path/);
   });
 
+  // The `win32` flavour pins the Win32 grammar regardless of the runner
+  // platform, so CI on a POSIX runner still exercises Windows semantics:
+  // drive-letter absolutes, either separator, traversal, and case folding.
+  it("confines Win32 host paths identically on every runner platform", () => {
+    const hostRoot = "C:\\Users\\example\\AppData\\Local\\Temp\\paperclip-sandbox-sync-Tx5GSy";
+    const sandboxRoot = "/opt/paperclip/runtime";
+
+    // The exact staging path that failed under POSIX-only confinement.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{
+          operationId: "inbound",
+          files: [{ sourcePath: `${hostRoot}\\workspace.tar`, targetPath: `${sandboxRoot}/workspace.tar`, kind: "file" as const }],
+        }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "win32", target: "posix" },
+      ),
+    ).not.toThrow();
+
+    // Win32 accepts forward slashes too.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{
+          operationId: "inbound",
+          files: [{ sourcePath: "C:/Users/example/AppData/Local/Temp/paperclip-sandbox-sync-Tx5GSy/workspace.tar", targetPath: `${sandboxRoot}/workspace.tar`, kind: "file" as const }],
+        }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "win32", target: "posix" },
+      ),
+    ).not.toThrow();
+
+    // Windows paths are case-insensitive: a root that differs only in case matches.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{
+          operationId: "inbound",
+          files: [{ sourcePath: "c:\\users\\EXAMPLE\\appdata\\local\\temp\\PAPERCLIP-SANDBOX-SYNC-tx5gsy\\workspace.tar", targetPath: `${sandboxRoot}/workspace.tar`, kind: "file" as const }],
+        }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "win32", target: "posix" },
+      ),
+    ).not.toThrow();
+
+    // A Win32 path outside its declared root is rejected.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: "C:\\Windows\\System32\\config\\SAM", targetPath: `${sandboxRoot}/x.tar`, kind: "file" as const }] }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "win32", target: "posix" },
+      ),
+    ).toThrow(/escapes its confinement root|not a confined absolute path/);
+
+    // `..` traversal is rejected with either separator.
+    for (const sourcePath of [`${hostRoot}\\..\\..\\secrets.tar`, `${hostRoot}/../../secrets.tar`]) {
+      expect(() =>
+        assertSyncOperationsConfined(
+          [{ operationId: "o", files: [{ sourcePath, targetPath: `${sandboxRoot}/x.tar`, kind: "file" as const }] }],
+          { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+          { source: "win32", target: "posix" },
+        ),
+      ).toThrow(/escapes its confinement root|not a confined absolute path/);
+    }
+
+    // A drive-relative path (no root) is not a confined absolute path.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: "Users\\example\\workspace.tar", targetPath: `${sandboxRoot}/x.tar`, kind: "file" as const }] }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "win32", target: "posix" },
+      ),
+    ).toThrow(/not a confined absolute path/);
+
+    // Case folding stays OFF for POSIX: the same case-mismatch that passes under
+    // Win32 rules is an escape under POSIX rules (control for the folding gate).
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: "/TMP/STAGE/x.tar", targetPath: `${sandboxRoot}/x.tar`, kind: "file" as const }] }],
+        { sourceRoots: ["/tmp/stage"], targetRoots: [sandboxRoot] },
+        { source: "posix", target: "posix" },
+      ),
+    ).toThrow(/escapes its confinement root/);
+  });
+
   it("keeps POSIX rules on both sides when the caller gives no flavours", () => {
     expect(() =>
       assertSyncOperationsConfined(

--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1851,6 +1851,82 @@ describe("sandbox managed runtime", () => {
     ).toThrow(/escapes its confinement root|not a confined absolute path/);
   });
 
+  // A Windows host stages its inbound tar in the platform temp directory. That is a
+  // Win32 absolute path. POSIX confinement rejected Paperclip's own staging path and
+  // stopped every sandbox run on a Windows host:
+  // "sync operation source path is not a confined absolute path:
+  //  C:\Users\...\Temp\paperclip-sandbox-sync-XXXXXX\workspace.tar".
+  it("confines a platform-native HOST source path for an inbound operation", () => {
+    const win32 = process.platform === "win32";
+    const hostRoot = win32
+      ? "C:\\Users\\example\\AppData\\Local\\Temp\\paperclip-sandbox-sync-Tx5GSy"
+      : "/tmp/paperclip-sandbox-sync-Tx5GSy";
+    const hostTar = win32 ? `${hostRoot}\\workspace.tar` : `${hostRoot}/workspace.tar`;
+    const sandboxRoot = "/opt/paperclip/runtime";
+
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{
+          operationId: "inbound",
+          files: [{ sourcePath: hostTar, targetPath: `${sandboxRoot}/workspace.tar`, kind: "file" as const }],
+        }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "host", target: "posix" },
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects a host escape and rejects traversal in each flavour", () => {
+    const win32 = process.platform === "win32";
+    const hostRoot = win32 ? "C:\\temp\\stage" : "/tmp/stage";
+    const sep = win32 ? "\\" : "/";
+    const outsideHost = win32 ? "C:\\Windows\\System32\\config\\SAM" : "/etc/passwd";
+    const sandboxRoot = "/opt/paperclip/runtime";
+
+    // The host source is outside its declared root.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: outsideHost, targetPath: `${sandboxRoot}/x.tar`, kind: "file" as const }] }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "host", target: "posix" },
+      ),
+    ).toThrow(/escapes its confinement root|not a confined absolute path/);
+
+    // The host source uses `..` traversal.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: `${hostRoot}${sep}..${sep}..${sep}secrets.tar`, targetPath: `${sandboxRoot}/x.tar`, kind: "file" as const }] }],
+        { sourceRoots: [hostRoot], targetRoots: [sandboxRoot] },
+        { source: "host", target: "posix" },
+      ),
+    ).toThrow(/escapes its confinement root|not a confined absolute path/);
+
+    // The sandbox source of an outbound operation uses `..` traversal.
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: `${sandboxRoot}/../../etc/passwd`, targetPath: `${hostRoot}${sep}out.tar`, kind: "file" as const }] }],
+        { sourceRoots: [sandboxRoot], targetRoots: [hostRoot] },
+        { source: "posix", target: "host" },
+      ),
+    ).toThrow(/escapes its confinement root|not a confined absolute path/);
+  });
+
+  it("keeps POSIX rules on both sides when the caller gives no flavours", () => {
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: "/a/x.tar", targetPath: "/b/x.tar", kind: "file" as const }] }],
+        { sourceRoots: ["/a"], targetRoots: ["/b"] },
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      assertSyncOperationsConfined(
+        [{ operationId: "o", files: [{ sourcePath: "/etc/passwd", targetPath: "/b/x.tar", kind: "file" as const }] }],
+        { sourceRoots: ["/a"], targetRoots: ["/b"] },
+      ),
+    ).toThrow(/escapes its confinement root|not a confined absolute path/);
+  });
+
   // Regression lock: a representative `codex_local` start stages its inbound bytes
   // as TWO `syncIn` operations. The git-history and workspace-overlay tars share
   // ONE merged operation (one native `uploadFiles` round-trip that carries both

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -277,26 +277,51 @@ export interface SandboxManagedRuntimeClient {
 }
 
 /**
+ * Which path grammar one side of a sync mapping speaks. Sandbox paths are always
+ * POSIX. Host paths follow the platform the server runs on, which is Win32 when
+ * Paperclip runs on Windows.
+ */
+export type SyncPathFlavour = "posix" | "host";
+
+/** Path helpers for a flavour. `host` is platform-native (`path`), not POSIX. */
+const pathFlavour = (flavour: SyncPathFlavour): path.PlatformPath =>
+  flavour === "host" ? path : path.posix;
+
+/**
  * Host-side complete-mediation guard for native sync operations. The orchestrator
  * authors every `targetPath`, but the native transport crosses the host↔sandbox
  * trust boundary, so we canonicalize and confine each mapping's source and target
  * to an orchestrator-owned root before handing the operation to a provider.
- * Absolute escapes and `..` traversal are rejected fail-closed. Sandbox and host
- * paths on the server are POSIX.
+ * Absolute escapes and `..` traversal are rejected fail-closed.
+ *
+ * Sandbox paths are POSIX. Host paths are platform-native, so on Windows they are
+ * Win32 (`C:\\Users\\...`), which `path.posix.isAbsolute` rejects. Each caller declares
+ * the flavour of each side. The parameter defaults to POSIX on both sides, so
+ * existing callers and their tests do not change.
  */
 export function assertSyncOperationsConfined(
   operations: SandboxSyncOperation[],
   roots: { sourceRoots: string[]; targetRoots: string[] },
+  flavours: { source: SyncPathFlavour; target: SyncPathFlavour } = { source: "posix", target: "posix" },
 ): void {
-  const confine = (candidate: string, allowed: string[], label: string): void => {
-    const normalized = path.posix.normalize(candidate);
-    if (!path.posix.isAbsolute(normalized) || normalized === ".." || normalized.includes("/../") || normalized.endsWith("/..")) {
+  const confine = (candidate: string, allowed: string[], label: string, flavour: SyncPathFlavour): void => {
+    const p = pathFlavour(flavour);
+    const normalized = p.normalize(candidate);
+    // A confined absolute path keeps no `..` segment after normalization. Any
+    // segment that survives escapes its root. Win32 accepts both separators.
+    const hasTraversal = normalized.split(/[\\/]/).includes("..");
+    if (!p.isAbsolute(normalized) || hasTraversal) {
       throw new Error(`sync operation ${label} path is not a confined absolute path: ${candidate}`);
     }
+    // Windows paths are case-insensitive. A case-sensitive compare rejects a
+    // legitimate root that differs only in case.
+    const caseInsensitive = flavour === "host" && path.sep === "\\";
+    const fold = (value: string): string => (caseInsensitive ? value.toLowerCase() : value);
+    const folded = fold(normalized);
     const within = allowed.some((root) => {
-      const normalizedRoot = path.posix.normalize(root);
-      const prefix = normalizedRoot.endsWith("/") ? normalizedRoot : `${normalizedRoot}/`;
-      return normalized === normalizedRoot || normalized.startsWith(prefix);
+      const normalizedRoot = fold(p.normalize(root));
+      const prefix = normalizedRoot.endsWith(p.sep) ? normalizedRoot : `${normalizedRoot}${p.sep}`;
+      return folded === normalizedRoot || folded.startsWith(prefix);
     });
     if (!within) {
       throw new Error(`sync operation ${label} path escapes its confinement root: ${candidate}`);
@@ -304,8 +329,8 @@ export function assertSyncOperationsConfined(
   };
   for (const operation of operations) {
     for (const mapping of operation.files) {
-      confine(mapping.sourcePath, roots.sourceRoots, "source");
-      confine(mapping.targetPath, roots.targetRoots, "target");
+      confine(mapping.sourcePath, roots.sourceRoots, "source", flavours.source);
+      confine(mapping.targetPath, roots.targetRoots, "target", flavours.target);
     }
   }
 }
@@ -900,10 +925,11 @@ export async function prepareSandboxManagedRuntime(input: {
           ? { postUploadCommands: withRunTimeout(params.postUploadCommands) }
           : {}),
       }];
+      // Inbound: the source is a host path, the target is in the sandbox.
       assertSyncOperationsConfined(operations, {
         sourceRoots: params.sourceRoots,
         targetRoots: params.targetRoots,
-      });
+      }, { source: "host", target: "posix" });
       const upload = makeTransferProgress(
         input.onProgress,
         "Syncing",
@@ -1286,10 +1312,11 @@ export async function prepareSandboxManagedRuntime(input: {
                           kind: "file",
                         }],
                       }];
+                      // Outbound: the source is in the sandbox, the target is a host path.
                       assertSyncOperationsConfined(operations, {
                         sourceRoots: [runtimeRootDir],
                         targetRoots: [tempDir],
-                      });
+                      }, { source: "posix", target: "host" });
                       await input.client.syncOut!(operations);
                       await gitExport.finish(0, 0);
                     } else {
@@ -1340,10 +1367,11 @@ export async function prepareSandboxManagedRuntime(input: {
                       exclude: restoreExclude,
                     }],
                   }];
+                  // Outbound: the source is in the sandbox, the target is a host path.
                   assertSyncOperationsConfined(operations, {
                     sourceRoots: [workspaceRemoteDir],
                     targetRoots: [extractedDir],
-                  });
+                  }, { source: "posix", target: "host" });
                   await fs.mkdir(extractedDir, { recursive: true });
                   const workspaceRestore = makeTransferProgress(
                     restoreSink,

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -279,13 +279,14 @@ export interface SandboxManagedRuntimeClient {
 /**
  * Which path grammar one side of a sync mapping speaks. Sandbox paths are always
  * POSIX. Host paths follow the platform the server runs on, which is Win32 when
- * Paperclip runs on Windows.
+ * Paperclip runs on Windows. Callers pass `host`; `win32` selects the Win32
+ * grammar explicitly so tests exercise it on every runner platform.
  */
-export type SyncPathFlavour = "posix" | "host";
+export type SyncPathFlavour = "posix" | "host" | "win32";
 
 /** Path helpers for a flavour. `host` is platform-native (`path`), not POSIX. */
 const pathFlavour = (flavour: SyncPathFlavour): path.PlatformPath =>
-  flavour === "host" ? path : path.posix;
+  flavour === "host" ? path : flavour === "win32" ? path.win32 : path.posix;
 
 /**
  * Host-side complete-mediation guard for native sync operations. The orchestrator
@@ -314,8 +315,10 @@ export function assertSyncOperationsConfined(
       throw new Error(`sync operation ${label} path is not a confined absolute path: ${candidate}`);
     }
     // Windows paths are case-insensitive. A case-sensitive compare rejects a
-    // legitimate root that differs only in case.
-    const caseInsensitive = flavour === "host" && path.sep === "\\";
+    // legitimate root that differs only in case. The grammar decides: any side
+    // evaluated with Win32 rules folds case, whether the caller reached that
+    // grammar through `host` on a Windows server or through `win32` directly.
+    const caseInsensitive = p.sep === "\\";
     const fold = (value: string): string => (caseInsensitive ? value.toLowerCase() : value);
     const folded = fold(normalized);
     const within = allowed.some((root) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Sandbox environments let an agent run in an isolated computer instead of on the host machine
> - A sandbox run stages the workspace on the host, then syncs it into the sandbox
> - `assertSyncOperationsConfined` guards that sync. It checks both sides of every mapping with `path.posix`
> - Sandbox paths are always POSIX, but host paths follow the host platform. On Windows they are Win32
> - So the guard rejects Paperclip's own staging tar on a Windows host, and every sandbox run stops
> - This pull request gives each caller a way to declare the flavour of each side
> - The benefit is that sandbox environments work on a Windows host, and the confinement rules stay the same

## Linked Issues or Issue Description

**What happened?**

Every agent run assigned to a `driver: "sandbox"` environment fails on a Windows host. The run never reaches the provider. The error is:

```
sync operation source path is not a confined absolute path:
C:\Users\<user>\AppData\Local\Temp\paperclip-sandbox-sync-Tx5GSy\workspace.tar
```

`assertSyncOperationsConfined` in `packages/adapter-utils/src/sandbox-managed-runtime.ts` validates each mapping with `path.posix`:

```ts
const normalized = path.posix.normalize(candidate);
if (!path.posix.isAbsolute(normalized) || ...) {
  throw new Error(`sync operation ${label} path is not a confined absolute path: ${candidate}`);
}
```

The docblock states the assumption: "Sandbox and host paths on the server are POSIX." That is true for the sandbox side. It is not true for the host side on Windows. `path.posix.isAbsolute("C:\\Users\\...")` returns false, so the guard throws fail-closed.

**Expected behavior**

A sandbox run stages its workspace and starts, on any host platform that Paperclip supports.

**Steps to reproduce**

1. Run Paperclip on a Windows host.
2. Install a plugin that registers a `sandbox_provider` environment driver.
3. Create an environment with `driver: "sandbox"` and that provider.
4. Assign an agent to that environment and start a run.
5. The run fails with the error above. The provider's hooks are never called.

**Paperclip version or commit**

`paperclipai` v2026.817.0 (managed CLI), reproduced against `master` source.

**Deployment mode**

Local, `local_trusted`, single instance.

**Agent adapter(s) involved**

Not adapter-specific (core bug). Observed with Claude Code; the guard runs before adapter selection matters.

**Operating system**

Windows 11 Pro 26200. Node 22.

**Additional context**

This is provider-agnostic. The guard runs before `onEnvironmentSyncIn` / `onEnvironmentSyncOut`, so a provider cannot work around it. I first implemented native `docker cp` sync hooks in my own provider specifically to bypass the default base64-tar transport; the failure did not change, because execution never reaches the hooks. Both transports stop at the same line.

**Related work (dedup search)**

I searched the PR list for `sandbox sync windows`, `path.posix host path`, and `assertSyncOperationsConfined`. No open or closed PR addresses host-path confinement flavours. Related, already merged, same subsystem: Refs #10013 (opt-in sandbox file-sync lifecycle hooks), Refs #11749 (route sandbox git-bundle export through native syncOut).

**Privacy checklist**

Paths in this description are redacted or generic. No tokens, keys, or private hostnames appear.

## What Changed

- `assertSyncOperationsConfined` takes a third parameter that declares the path flavour of each side: `{ source, target }`, each `"posix"`, `"host"`, or `"win32"`. Callers use `"host"`; `"win32"` pins the Win32 grammar so tests exercise it on every runner platform.
- The parameter defaults to POSIX on both sides. Existing callers and their tests do not change.
- Confinement now runs with the matching path grammar: `path.posix` for sandbox paths, `path` (platform-native) for host paths.
- The three call sites declare their direction. Inbound staging uses a host source and a sandbox target. The two outbound paths (git bundle export, workspace restore) use a sandbox source and a host target.
- Comparison folds case whenever the grammar in use is Win32 (`p.sep === "\\"`), because Windows paths are case-insensitive and a case-sensitive compare rejects a valid root. POSIX comparison stays case-sensitive.
- Traversal detection splits on both separators, because Win32 accepts either.
- Five new tests in `sandbox-managed-runtime.test.ts`, including a platform-independent Win32 suite.

## Verification

Run the package tests:

```
pnpm vitest run packages/adapter-utils/src/sandbox-managed-runtime.test.ts
```

New coverage:

- The Windows staging path that fails today is accepted when the caller declares a host source.
- A host source outside its declared root is still rejected.
- `..` traversal on the host side is still rejected.
- `..` traversal on the sandbox side of an outbound operation is still rejected.
- With no flavours given, both sides stay POSIX and behave exactly as before.

The `win32` flavour makes Win32 semantics testable on any runner: the Win32 suite covers the exact staging path that failed, forward-slash Win32 paths, case-insensitive root matching, an escape, traversal with either separator, a drive-relative path, and a POSIX control that proves case folding stays off for POSIX paths. It runs identically on POSIX and Windows CI runners.

I also confirmed the behaviour directly against the live failure on a Windows host: the same call that produced the error above is accepted after the change, and each rejection case above still throws.

## Risks

Low risk.

- The new parameter is optional and defaults to the current behaviour, so any caller that does not pass it is unchanged.
- No confinement rule is removed. The absolute-path requirement, `..` rejection, and root containment all still apply. Only the grammar used to evaluate them changes, and only for the side a caller declares as a host path.
- Case folding applies only to host paths on a Windows host. POSIX comparison stays case-sensitive.
- Non-Windows hosts are unaffected: `path` is `path.posix` there, so the host flavour resolves to the same rules as today.

## Model Used

Claude Fable 5 (`claude-fable-5`), via Claude Code, with extended thinking and tool use. The change was authored and verified with a human reviewing each step.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
