### PR TITLE
fix: preserve assignee during stale execution recovery

### DIFF
--- a/cli/src/commands/db-backup.ts
+++ b/cli/src/commands/db-backup.ts
@@ -73,6 +73,7 @@ export async function dbBackupCommand(opts: DbBackupOptions): Promise<void> {
     const result = await runDatabaseBackup({
       connectionString: connection.value,
       backupDir,
+      maxBackups: 7,
       retention: { dailyDays: retentionDays, weeklyWeeks: 4, monthlyMonths: 1 },
       filenamePrefix,
     });

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Writable } from "node:stream";
 import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import postgres from "postgres";
@@ -162,6 +163,69 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
         expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".partial"))).toEqual([]);
         expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".sql"))).toEqual([]);
       } finally {
+        if (realPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = realPgDumpPath;
+        }
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "does not emit an unhandled rejection when pg_dump fails before the output stream opens",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-pgdump-early-fail-");
+      const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      const missingPgDumpPath = path.join(backupDir, "missing-pg-dump");
+      const createWriteStreamSpy = vi.spyOn(fs, "createWriteStream");
+      const unhandledRejections: unknown[] = [];
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+
+      class DelayedOpenWriteStream extends Writable {
+        pending = true;
+
+        constructor() {
+          super();
+          setTimeout(() => {
+            this.pending = false;
+            this.emit("open", 1);
+          }, 25);
+        }
+
+        _write(
+          _chunk: unknown,
+          _encoding: BufferEncoding,
+          callback: (error?: Error | null) => void,
+        ): void {
+          callback();
+        }
+      }
+
+      createWriteStreamSpy.mockImplementation(
+        () => new DelayedOpenWriteStream() as unknown as fs.WriteStream,
+      );
+      process.on("unhandledRejection", onUnhandledRejection);
+      process.env.PAPERCLIP_PG_DUMP_PATH = missingPgDumpPath;
+
+      try {
+        await expect(runDatabaseBackup({
+          connectionString: sourceConnectionString,
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+          filenamePrefix: "paperclip-test",
+          backupEngine: "pg_dump",
+        })).rejects.toThrow(/ENOENT/);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(unhandledRejections).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onUnhandledRejection);
+        createWriteStreamSpy.mockRestore();
         if (realPgDumpPath === undefined) {
           delete process.env.PAPERCLIP_PG_DUMP_PATH;
         } else {

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -5,7 +5,6 @@ import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import postgres from "postgres";
 import {
-  __setBackupStatfsSyncForTests,
   createBufferedGzipTextFileWriter,
   createBufferedTextFileWriter,
   runDatabaseBackup,
@@ -45,7 +44,6 @@ async function createSiblingDatabase(connectionString: string, databaseName: str
 }
 
 afterEach(async () => {
-  __setBackupStatfsSyncForTests(null);
   while (cleanups.length > 0) {
     const cleanup = cleanups.pop();
     await cleanup?.();
@@ -110,22 +108,34 @@ describe("runDatabaseBackup preflight", () => {
     const latestBackup = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz");
     fs.writeFileSync(latestBackup, Buffer.alloc(1024));
 
-    __setBackupStatfsSyncForTests(() => ({
-      type: 0,
-      bsize: 1,
-      blocks: 0,
-      bfree: 0,
-      bavail: 1400,
-      files: 0,
-      ffree: 0,
-    }) as ReturnType<typeof fs.statfsSync>);
-
     await expect(runDatabaseBackup({
       connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
       backupDir,
       retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
       filenamePrefix: "paperclip-test",
+      getAvailableDiskSpaceBytes: () => 1400,
     })).rejects.toThrow(/Insufficient free space/);
+  });
+
+  it("removes stale partial backup files before starting a new run", async () => {
+    const backupDir = createTempDir("paperclip-db-backup-preflight-partials-");
+    const stalePartial = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz.partial");
+    const recentPartial = path.join(backupDir, "paperclip-test-20260811-110000.sql.gz.partial");
+    fs.writeFileSync(stalePartial, "stale");
+    fs.writeFileSync(recentPartial, "recent");
+    fs.utimesSync(stalePartial, new Date("2026-08-09T00:00:00Z"), new Date("2026-08-09T00:00:00Z"));
+    fs.utimesSync(recentPartial, new Date("2026-08-11T11:00:00Z"), new Date("2026-08-11T11:00:00Z"));
+
+    await expect(runDatabaseBackup({
+      connectionString: "postgres://paperclip:paperclip@127.0.0.1:1/paperclip",
+      backupDir,
+      retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+      filenamePrefix: "paperclip-test",
+      getAvailableDiskSpaceBytes: () => 1024 * 1024,
+    })).rejects.toThrow();
+
+    expect(fs.existsSync(stalePartial)).toBe(false);
+    expect(fs.existsSync(recentPartial)).toBe(true);
   });
 });
 
@@ -161,7 +171,7 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
   );
 
   it(
-    "keeps only the newest seven completed backups when maxBackups is set",
+    "caps retained backups at seven after applying the retention policy",
     async () => {
       const sourceConnectionString = await createTempDatabase();
       const backupDir = createTempDir("paperclip-db-backup-max-count-");
@@ -177,7 +187,7 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
         connectionString: sourceConnectionString,
         backupDir,
         maxBackups: 7,
-        retention: { dailyDays: 30, weeklyWeeks: 4, monthlyMonths: 1 },
+        retention: { dailyDays: 30, weeklyWeeks: 12, monthlyMonths: 12 },
         filenamePrefix: "paperclip-test",
         backupEngine: "javascript",
       });

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -21,6 +21,45 @@ const cleanups: Array<() => Promise<void> | void> = [];
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
+async function importBackupLibWithMocks(options?: {
+  createWriteStream?: typeof fs.createWriteStream;
+}) {
+  vi.resetModules();
+  vi.doMock("postgres", () => ({
+    default: () => {
+      const sql = Object.assign(
+        async () => [],
+        {
+          end: async () => {},
+          unsafe: async () => [],
+        },
+      );
+      return sql;
+    },
+  }));
+  if (options?.createWriteStream) {
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      const actualDefault = "default" in actual ? actual.default : actual;
+      return {
+        ...actual,
+        createWriteStream: options.createWriteStream,
+        default: {
+          ...actualDefault,
+          createWriteStream: options.createWriteStream,
+        },
+      };
+    });
+  }
+
+  try {
+    return await import("./backup-lib.js");
+  } finally {
+    vi.doUnmock("postgres");
+    vi.doUnmock("node:fs");
+  }
+}
+
 function createTempDir(prefix: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   cleanups.push(() => {
@@ -124,13 +163,12 @@ describe("runDatabaseBackup preflight", () => {
     const stalePartial = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz.partial");
     const recentPartial = path.join(backupDir, "paperclip-test-20260811-110000.sql.gz.partial");
     const realDateNow = Date.now;
+    Date.now = () => Date.UTC(2026, 7, 11, 12, 0, 0);
     fs.writeFileSync(latestBackup, Buffer.alloc(1024));
     fs.writeFileSync(stalePartial, "stale");
     fs.writeFileSync(recentPartial, "recent");
     fs.utimesSync(stalePartial, new Date("2026-08-09T00:00:00Z"), new Date("2026-08-09T00:00:00Z"));
     fs.utimesSync(recentPartial, new Date("2026-08-11T11:00:00Z"), new Date("2026-08-11T11:00:00Z"));
-
-    Date.now = () => Date.parse("2026-08-12T00:00:00Z");
 
     try {
       await expect(runDatabaseBackup({
@@ -140,54 +178,19 @@ describe("runDatabaseBackup preflight", () => {
         filenamePrefix: "paperclip-test",
         getAvailableDiskSpaceBytes: () => 1400,
       })).rejects.toThrow(/Insufficient free space/);
-
       expect(fs.existsSync(stalePartial)).toBe(false);
       expect(fs.existsSync(recentPartial)).toBe(true);
     } finally {
       Date.now = realDateNow;
     }
   });
-});
-
-describeEmbeddedPostgres("runDatabaseBackup", () => {
-  it(
-    "removes partial gzip files when pg_dump fails",
-    async () => {
-      const sourceConnectionString = await createTempDatabase();
-      const backupDir = createTempDir("paperclip-db-backup-pgdump-fail-");
-      const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
-      process.env.PAPERCLIP_PG_DUMP_PATH = "false";
-
-      try {
-        await expect(runDatabaseBackup({
-          connectionString: sourceConnectionString,
-          backupDir,
-          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
-          filenamePrefix: "paperclip-test",
-          backupEngine: "pg_dump",
-        })).rejects.toThrow(/failed with exit code 1/);
-
-        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".partial"))).toEqual([]);
-        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".sql"))).toEqual([]);
-      } finally {
-        if (realPgDumpPath === undefined) {
-          delete process.env.PAPERCLIP_PG_DUMP_PATH;
-        } else {
-          process.env.PAPERCLIP_PG_DUMP_PATH = realPgDumpPath;
-        }
-      }
-    },
-    30_000,
-  );
 
   it(
     "does not emit an unhandled rejection when pg_dump fails before the output stream opens",
     async () => {
-      const sourceConnectionString = await createTempDatabase();
       const backupDir = createTempDir("paperclip-db-backup-pgdump-early-fail-");
       const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
       const missingPgDumpPath = path.join(backupDir, "missing-pg-dump");
-      const createWriteStreamSpy = vi.spyOn(fs, "createWriteStream");
       const unhandledRejections: unknown[] = [];
       const onUnhandledRejection = (reason: unknown) => {
         unhandledRejections.push(reason);
@@ -213,11 +216,99 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
         }
       }
 
-      createWriteStreamSpy.mockImplementation(
+      const createWriteStream = vi.fn(
         () => new DelayedOpenWriteStream() as unknown as fs.WriteStream,
       );
+      const { runDatabaseBackup: runDatabaseBackupWithMocks } = await importBackupLibWithMocks({
+        createWriteStream,
+      });
+
       process.on("unhandledRejection", onUnhandledRejection);
       process.env.PAPERCLIP_PG_DUMP_PATH = missingPgDumpPath;
+
+      try {
+        await expect(runDatabaseBackupWithMocks({
+          connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+          filenamePrefix: "paperclip-test",
+          backupEngine: "pg_dump",
+        })).rejects.toThrow(/ENOENT/);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(createWriteStream).toHaveBeenCalledTimes(1);
+        expect(unhandledRejections).toEqual([]);
+      } finally {
+        process.off("unhandledRejection", onUnhandledRejection);
+        if (realPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = realPgDumpPath;
+        }
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "does not apply an implicit maxBackups cap when tiered retention is configured without one",
+    async () => {
+      const backupDir = createTempDir("paperclip-db-backup-tiered-no-cap-");
+      const fakePgDumpPath = path.join(backupDir, "fake-pg-dump.sh");
+      const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      const realDateNow = Date.now;
+      Date.now = () => Date.UTC(2026, 7, 31, 12, 0, 0);
+      fs.writeFileSync(fakePgDumpPath, "#!/bin/sh\nprintf '%s\\n' '-- fake backup' 'SELECT 1;'\n");
+      fs.chmodSync(fakePgDumpPath, 0o755);
+
+      try {
+        for (let month = 0; month < 7; month += 1) {
+          const fileDate = new Date(Date.UTC(2026, month, 15, 12, 0, 0));
+          const mm = String(month + 1).padStart(2, "0");
+          const fileName = `paperclip-test-2026${mm}15-120000.sql.gz`;
+          const filePath = path.join(backupDir, fileName);
+          fs.writeFileSync(filePath, `monthly-${month}`);
+          fs.utimesSync(filePath, fileDate, fileDate);
+        }
+
+        process.env.PAPERCLIP_PG_DUMP_PATH = fakePgDumpPath;
+        const { runDatabaseBackup: runDatabaseBackupWithMocks } = await importBackupLibWithMocks();
+        const result = await runDatabaseBackupWithMocks({
+          connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 12 },
+          filenamePrefix: "paperclip-test",
+          backupEngine: "pg_dump",
+        });
+
+        const backupFiles = fs.readdirSync(backupDir)
+          .filter((name) => name.endsWith(".sql.gz"))
+          .sort();
+
+        expect(result.prunedCount).toBe(0);
+        expect(backupFiles).toHaveLength(8);
+        expect(backupFiles).toContain(path.basename(result.backupFile));
+      } finally {
+        Date.now = realDateNow;
+        if (realPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = realPgDumpPath;
+        }
+      }
+    },
+    30_000,
+  );
+});
+
+describeEmbeddedPostgres("runDatabaseBackup", () => {
+  it(
+    "removes partial gzip files when pg_dump fails",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-pgdump-fail-");
+      const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      process.env.PAPERCLIP_PG_DUMP_PATH = "false";
 
       try {
         await expect(runDatabaseBackup({
@@ -226,13 +317,11 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
           retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
           filenamePrefix: "paperclip-test",
           backupEngine: "pg_dump",
-        })).rejects.toThrow(/ENOENT/);
+        })).rejects.toThrow(/failed with exit code 1/);
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(unhandledRejections).toEqual([]);
+        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".partial"))).toEqual([]);
+        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".sql"))).toEqual([]);
       } finally {
-        process.off("unhandledRejection", onUnhandledRejection);
-        createWriteStreamSpy.mockRestore();
         if (realPgDumpPath === undefined) {
           delete process.env.PAPERCLIP_PG_DUMP_PATH;
         } else {

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Writable } from "node:stream";
 import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import postgres from "postgres";
@@ -22,7 +21,7 @@ const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
 async function importBackupLibWithMocks(options?: {
-  createWriteStream?: typeof fs.createWriteStream;
+  spawn?: typeof import("node:child_process").spawn;
 }) {
   vi.resetModules();
   vi.doMock("postgres", () => ({
@@ -37,26 +36,17 @@ async function importBackupLibWithMocks(options?: {
       return sql;
     },
   }));
-  if (options?.createWriteStream) {
-    vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-      const actualDefault = "default" in actual ? actual.default : actual;
-      return {
-        ...actual,
-        createWriteStream: options.createWriteStream,
-        default: {
-          ...actualDefault,
-          createWriteStream: options.createWriteStream,
-        },
-      };
-    });
+  if (options?.spawn) {
+    vi.doMock("node:child_process", () => ({
+      spawn: options.spawn,
+    }));
   }
 
   try {
     return await import("./backup-lib.js");
   } finally {
     vi.doUnmock("postgres");
-    vi.doUnmock("node:fs");
+    vi.doUnmock("node:child_process");
   }
 }
 
@@ -186,66 +176,84 @@ describe("runDatabaseBackup preflight", () => {
   });
 
   it(
-    "does not emit an unhandled rejection when pg_dump fails before the output stream opens",
+    "kills pg_dump and destroys the custom output stream when it fails before opening",
     async () => {
       const backupDir = createTempDir("paperclip-db-backup-pgdump-early-fail-");
-      const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
-      const missingPgDumpPath = path.join(backupDir, "missing-pg-dump");
-      const unhandledRejections: unknown[] = [];
-      const onUnhandledRejection = (reason: unknown) => {
-        unhandledRejections.push(reason);
-      };
+      const streamOpenError = new Error("stream open failed");
 
-      class DelayedOpenWriteStream extends Writable {
+      class ErrorBeforeOpenWriteStream {
         pending = true;
+        destroyed = false;
+        private openListener?: () => void;
+        private errorListener?: (error: unknown) => void;
 
         constructor() {
-          super();
           setTimeout(() => {
-            this.pending = false;
-            this.emit("open", 1);
-          }, 25);
+            this.errorListener?.(streamOpenError);
+          }, 0);
         }
 
-        _write(
-          _chunk: unknown,
-          _encoding: BufferEncoding,
-          callback: (error?: Error | null) => void,
-        ): void {
-          callback();
+        once(event: "open" | "error", listener: (() => void) | ((error: unknown) => void)): this {
+          if (event === "open") {
+            this.openListener = listener as () => void;
+          } else {
+            this.errorListener = listener as (error: unknown) => void;
+          }
+          return this;
+        }
+
+        removeListener(event: "open" | "error", listener: (() => void) | ((error: unknown) => void)): this {
+          if (event === "open" && this.openListener === listener) {
+            this.openListener = undefined;
+          }
+          if (event === "error" && this.errorListener === listener) {
+            this.errorListener = undefined;
+          }
+          return this;
+        }
+
+        destroy(): this {
+          this.destroyed = true;
+          return this;
         }
       }
 
-      const createWriteStream = vi.fn(
-        () => new DelayedOpenWriteStream() as unknown as fs.WriteStream,
-      );
+      let output: ErrorBeforeOpenWriteStream | undefined;
+      const createOutputStream = vi.fn(() => {
+        output = new ErrorBeforeOpenWriteStream();
+        return output as unknown as fs.WriteStream;
+      });
+      const onceHandlers = new Map<string, (...args: unknown[]) => void>();
+      const kill = vi.fn(() => {
+        onceHandlers.get("exit")?.(null, "SIGTERM");
+      });
+      const spawn = vi.fn(() => ({
+          stdout: {} as NodeJS.ReadableStream,
+          stderr: { on: vi.fn() },
+          kill,
+          once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+            onceHandlers.set(event, handler);
+          }),
+        }));
+
       const { runDatabaseBackup: runDatabaseBackupWithMocks } = await importBackupLibWithMocks({
-        createWriteStream,
+        spawn: spawn as typeof import("node:child_process").spawn,
       });
 
-      process.on("unhandledRejection", onUnhandledRejection);
-      process.env.PAPERCLIP_PG_DUMP_PATH = missingPgDumpPath;
+      await expect(runDatabaseBackupWithMocks({
+        connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
+        backupDir,
+        retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+        filenamePrefix: "paperclip-test",
+        backupEngine: "pg_dump",
+        createOutputStream,
+      })).rejects.toThrow("stream open failed");
 
-      try {
-        await expect(runDatabaseBackupWithMocks({
-          connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
-          backupDir,
-          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
-          filenamePrefix: "paperclip-test",
-          backupEngine: "pg_dump",
-        })).rejects.toThrow(/ENOENT/);
-
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(createWriteStream).toHaveBeenCalledTimes(1);
-        expect(unhandledRejections).toEqual([]);
-      } finally {
-        process.off("unhandledRejection", onUnhandledRejection);
-        if (realPgDumpPath === undefined) {
-          delete process.env.PAPERCLIP_PG_DUMP_PATH;
-        } else {
-          process.env.PAPERCLIP_PG_DUMP_PATH = realPgDumpPath;
-        }
-      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(spawn).toHaveBeenCalledTimes(1);
+      expect(createOutputStream).toHaveBeenCalledTimes(1);
+      expect(output?.destroyed).toBe(true);
+      expect(kill).toHaveBeenCalledTimes(1);
     },
     30_000,
   );

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -2,9 +2,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import postgres from "postgres";
-import { createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
+import {
+  createBufferedGzipTextFileWriter,
+  createBufferedTextFileWriter,
+  runDatabaseBackup,
+  runDatabaseRestore,
+} from "./backup-lib.js";
 import { ensurePostgresDatabase } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -74,7 +79,121 @@ describe("createBufferedTextFileWriter", () => {
   });
 });
 
+describe("createBufferedGzipTextFileWriter", () => {
+  it("writes gzipped content without creating a raw sql sidecar", async () => {
+    const tempDir = createTempDir("paperclip-gzip-writer-");
+    const outputPath = path.join(tempDir, "backup.sql.gz.partial");
+    const writer = createBufferedGzipTextFileWriter(outputPath, 16);
+    const lines = [
+      "-- header",
+      "BEGIN;",
+      "INSERT INTO test VALUES (1);",
+      "COMMIT;",
+    ];
+
+    for (const line of lines) {
+      writer.emit(line);
+    }
+
+    await writer.close();
+
+    expect(gunzipSync(fs.readFileSync(outputPath)).toString("utf8")).toBe(lines.join("\n"));
+    expect(fs.existsSync(path.join(tempDir, "backup.sql"))).toBe(false);
+  });
+});
+
 describeEmbeddedPostgres("runDatabaseBackup", () => {
+  it("fails fast when free space is below 1.5x the latest completed backup", async () => {
+    const backupDir = createTempDir("paperclip-db-backup-preflight-");
+    const latestBackup = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz");
+    fs.writeFileSync(latestBackup, Buffer.alloc(1024));
+
+    const statfsSpy = vi.spyOn(fs, "statfsSync").mockReturnValue({
+      type: 0,
+      bsize: 1,
+      blocks: 0,
+      bfree: 0,
+      bavail: 1400,
+      files: 0,
+      ffree: 0,
+    } as ReturnType<typeof fs.statfsSync>);
+
+    try {
+      await expect(runDatabaseBackup({
+        connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
+        backupDir,
+        retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+        filenamePrefix: "paperclip-test",
+      })).rejects.toThrow(/Insufficient free space/);
+    } finally {
+      statfsSpy.mockRestore();
+    }
+  });
+
+  it(
+    "removes partial gzip files when pg_dump fails",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-pgdump-fail-");
+      const realPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      process.env.PAPERCLIP_PG_DUMP_PATH = "false";
+
+      try {
+        await expect(runDatabaseBackup({
+          connectionString: sourceConnectionString,
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+          filenamePrefix: "paperclip-test",
+          backupEngine: "pg_dump",
+        })).rejects.toThrow(/failed with exit code 1/);
+
+        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".partial"))).toEqual([]);
+        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".sql"))).toEqual([]);
+      } finally {
+        if (realPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = realPgDumpPath;
+        }
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "keeps only the newest seven completed backups when maxBackups is set",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-max-count-");
+
+      for (let index = 0; index < 7; index += 1) {
+        const filePath = path.join(backupDir, `paperclip-test-2026080${index + 1}-010101.sql.gz`);
+        fs.writeFileSync(filePath, `old-${index}`);
+        const mtime = new Date(Date.UTC(2026, 7, index + 1, 1, 1, 1));
+        fs.utimesSync(filePath, mtime, mtime);
+      }
+
+      const result = await runDatabaseBackup({
+        connectionString: sourceConnectionString,
+        backupDir,
+        maxBackups: 7,
+        retention: { dailyDays: 30, weeklyWeeks: 4, monthlyMonths: 1 },
+        filenamePrefix: "paperclip-test",
+        backupEngine: "javascript",
+      });
+
+      const backupFiles = fs.readdirSync(backupDir)
+        .filter((name) => name.endsWith(".sql.gz"))
+        .sort();
+
+      expect(result.prunedCount).toBe(1);
+      expect(backupFiles).toHaveLength(7);
+      expect(backupFiles).toContain(path.basename(result.backupFile));
+      expect(backupFiles).not.toContain("paperclip-test-20260801-010101.sql.gz");
+    },
+    30_000,
+  );
+
   it(
     "keeps the newest backup for each retained calendar month",
     async () => {

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -119,20 +119,22 @@ describe("runDatabaseBackup preflight", () => {
 
   it("removes stale partial backup files before starting a new run", async () => {
     const backupDir = createTempDir("paperclip-db-backup-preflight-partials-");
+    const latestBackup = path.join(backupDir, "paperclip-test-20260811-090000.sql.gz");
     const stalePartial = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz.partial");
     const recentPartial = path.join(backupDir, "paperclip-test-20260811-110000.sql.gz.partial");
+    fs.writeFileSync(latestBackup, Buffer.alloc(1024));
     fs.writeFileSync(stalePartial, "stale");
     fs.writeFileSync(recentPartial, "recent");
     fs.utimesSync(stalePartial, new Date("2026-08-09T00:00:00Z"), new Date("2026-08-09T00:00:00Z"));
     fs.utimesSync(recentPartial, new Date("2026-08-11T11:00:00Z"), new Date("2026-08-11T11:00:00Z"));
 
     await expect(runDatabaseBackup({
-      connectionString: "postgres://paperclip:paperclip@127.0.0.1:1/paperclip",
+      connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
       backupDir,
       retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
       filenamePrefix: "paperclip-test",
-      getAvailableDiskSpaceBytes: () => 1024 * 1024,
-    })).rejects.toThrow();
+      getAvailableDiskSpaceBytes: () => 1400,
+    })).rejects.toThrow(/Insufficient free space/);
 
     expect(fs.existsSync(stalePartial)).toBe(false);
     expect(fs.existsSync(recentPartial)).toBe(true);

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -123,22 +123,29 @@ describe("runDatabaseBackup preflight", () => {
     const latestBackup = path.join(backupDir, "paperclip-test-20260811-090000.sql.gz");
     const stalePartial = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz.partial");
     const recentPartial = path.join(backupDir, "paperclip-test-20260811-110000.sql.gz.partial");
+    const realDateNow = Date.now;
     fs.writeFileSync(latestBackup, Buffer.alloc(1024));
     fs.writeFileSync(stalePartial, "stale");
     fs.writeFileSync(recentPartial, "recent");
     fs.utimesSync(stalePartial, new Date("2026-08-09T00:00:00Z"), new Date("2026-08-09T00:00:00Z"));
     fs.utimesSync(recentPartial, new Date("2026-08-11T11:00:00Z"), new Date("2026-08-11T11:00:00Z"));
 
-    await expect(runDatabaseBackup({
-      connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
-      backupDir,
-      retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
-      filenamePrefix: "paperclip-test",
-      getAvailableDiskSpaceBytes: () => 1400,
-    })).rejects.toThrow(/Insufficient free space/);
+    Date.now = () => Date.parse("2026-08-12T00:00:00Z");
 
-    expect(fs.existsSync(stalePartial)).toBe(false);
-    expect(fs.existsSync(recentPartial)).toBe(true);
+    try {
+      await expect(runDatabaseBackup({
+        connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
+        backupDir,
+        retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+        filenamePrefix: "paperclip-test",
+        getAvailableDiskSpaceBytes: () => 1400,
+      })).rejects.toThrow(/Insufficient free space/);
+
+      expect(fs.existsSync(stalePartial)).toBe(false);
+      expect(fs.existsSync(recentPartial)).toBe(true);
+    } finally {
+      Date.now = realDateNow;
+    }
   });
 });
 

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -237,7 +237,7 @@ describe("runDatabaseBackup preflight", () => {
         }));
 
       const { runDatabaseBackup: runDatabaseBackupWithMocks } = await importBackupLibWithMocks({
-        spawn: spawn as typeof import("node:child_process").spawn,
+        spawn: spawn as unknown as typeof import("node:child_process").spawn,
       });
 
       await expect(runDatabaseBackupWithMocks({

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -5,6 +5,7 @@ import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import postgres from "postgres";
 import {
+  __setBackupStatfsSyncForTests,
   createBufferedGzipTextFileWriter,
   createBufferedTextFileWriter,
   runDatabaseBackup,
@@ -44,6 +45,7 @@ async function createSiblingDatabase(connectionString: string, databaseName: str
 }
 
 afterEach(async () => {
+  __setBackupStatfsSyncForTests(null);
   while (cleanups.length > 0) {
     const cleanup = cleanups.pop();
     await cleanup?.();
@@ -102,13 +104,13 @@ describe("createBufferedGzipTextFileWriter", () => {
   });
 });
 
-describeEmbeddedPostgres("runDatabaseBackup", () => {
+describe("runDatabaseBackup preflight", () => {
   it("fails fast when free space is below 1.5x the latest completed backup", async () => {
     const backupDir = createTempDir("paperclip-db-backup-preflight-");
     const latestBackup = path.join(backupDir, "paperclip-test-20260811-100000.sql.gz");
     fs.writeFileSync(latestBackup, Buffer.alloc(1024));
 
-    const statfsSpy = vi.spyOn(fs, "statfsSync").mockReturnValue({
+    __setBackupStatfsSyncForTests(() => ({
       type: 0,
       bsize: 1,
       blocks: 0,
@@ -116,20 +118,18 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
       bavail: 1400,
       files: 0,
       ffree: 0,
-    } as ReturnType<typeof fs.statfsSync>);
+    }) as ReturnType<typeof fs.statfsSync>);
 
-    try {
-      await expect(runDatabaseBackup({
-        connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
-        backupDir,
-        retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
-        filenamePrefix: "paperclip-test",
-      })).rejects.toThrow(/Insufficient free space/);
-    } finally {
-      statfsSpy.mockRestore();
-    }
+    await expect(runDatabaseBackup({
+      connectionString: "postgres://paperclip:paperclip@127.0.0.1:54329/paperclip",
+      backupDir,
+      retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+      filenamePrefix: "paperclip-test",
+    })).rejects.toThrow(/Insufficient free space/);
   });
+});
 
+describeEmbeddedPostgres("runDatabaseBackup", () => {
   it(
     "removes partial gzip files when pg_dump fails",
     async () => {
@@ -289,7 +289,7 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
           backupEngine: "javascript",
         });
 
-        expect(result.backupFile).toMatch(/paperclip-test-.*\.sql\.gz$/);
+        expect(path.basename(result.backupFile)).toMatch(/^paperclip-test-.*\.sql\.gz$/);
         expect(result.sizeBytes).toBeGreaterThan(0);
         expect(fs.existsSync(result.backupFile)).toBe(true);
 

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { randomUUID } from "node:crypto";
 import { basename, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { spawn } from "node:child_process";
@@ -71,9 +72,14 @@ const DEFAULT_BACKUP_WRITE_BUFFER_BYTES = 1024 * 1024;
 const BACKUP_DATA_CURSOR_ROWS = 100;
 const BACKUP_CLI_STDERR_BYTES = 64 * 1024;
 const BACKUP_BREAKPOINT_DETECT_BYTES = 64 * 1024;
-const DEFAULT_MAX_BACKUPS = 7;
 
 const STATEMENT_BREAKPOINT = "-- paperclip statement breakpoint 69f6f3f1-42fd-46a6-bf17-d1d85f8f3900";
+
+let statfsSyncImpl: typeof fs.statfsSync = fs.statfsSync;
+
+export function __setBackupStatfsSyncForTests(impl: typeof fs.statfsSync | null): void {
+  statfsSyncImpl = impl ?? fs.statfsSync;
+}
 
 type BackupEntry = {
   name: string;
@@ -149,7 +155,7 @@ function ensureSufficientBackupFreeSpace(backupDir: string, filenamePrefix: stri
   if (!latestBackup || latestBackup.sizeBytes <= 0) return;
 
   const requiredBytes = Math.ceil(latestBackup.sizeBytes * 1.5);
-  const stat = fs.statfsSync(backupDir);
+  const stat = statfsSyncImpl(backupDir);
   const availableBytes = stat.bavail * stat.bsize;
   if (availableBytes >= requiredBytes) return;
 
@@ -359,6 +365,23 @@ async function waitForWritableDrain(stream: NodeJS.EventEmitter): Promise<void> 
   });
 }
 
+async function waitForWriteStreamOpen(stream: fs.WriteStream): Promise<void> {
+  if (typeof stream.fd === "number") return;
+
+  await new Promise<void>((resolve, reject) => {
+    const onOpen = () => {
+      stream.removeListener("error", onError);
+      resolve();
+    };
+    const onError = (error: unknown) => {
+      stream.removeListener("open", onOpen);
+      reject(error);
+    };
+    stream.once("open", onOpen);
+    stream.once("error", onError);
+  });
+}
+
 async function waitForChildExit(child: ReturnType<typeof spawn>, label: string): Promise<void> {
   let stderr = "";
   child.stderr?.on("data", (chunk) => {
@@ -376,6 +399,10 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, label: string):
   if (result.code !== 0) {
     throw new Error(`${label} failed with exit code ${result.code ?? "unknown"}${stderr.trim() ? `: ${stderr.trim()}` : ""}`);
   }
+}
+
+function createBackupFileBase(filenamePrefix: string): string {
+  return `${filenamePrefix}-${timestamp()}-${process.pid}-${randomUUID().slice(0, 8)}.sql.gz`;
 }
 
 async function runPgDumpBackup(opts: {
@@ -407,10 +434,19 @@ async function runPgDumpBackup(opts: {
     throw new Error("pg_dump did not expose stdout");
   }
 
-  await Promise.all([
-    pipeline(child.stdout, createGzip(), fs.createWriteStream(opts.partialBackupFile, { flags: "wx" })),
-    waitForChildExit(child, pgDumpBin),
-  ]);
+  const output = fs.createWriteStream(opts.partialBackupFile, { flags: "wx" });
+  await waitForWriteStreamOpen(output);
+
+  const pipelineResult = pipeline(child.stdout, createGzip(), output);
+  const childResult = waitForChildExit(child, pgDumpBin);
+  const [pipelineState, childState] = await Promise.allSettled([pipelineResult, childResult]);
+
+  if (childState.status === "rejected") {
+    throw childState.reason;
+  }
+  if (pipelineState.status === "rejected") {
+    throw pipelineState.reason;
+  }
 }
 
 async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: number): Promise<void> {
@@ -669,7 +705,9 @@ export function createBufferedGzipTextFileWriter(filePath: string, maxBufferedBy
 export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise<RunDatabaseBackupResult> {
   const filenamePrefix = opts.filenamePrefix ?? "paperclip";
   const retention = opts.retention;
-  const maxBackups = Math.max(1, Math.trunc(opts.maxBackups ?? DEFAULT_MAX_BACKUPS));
+  const maxBackups = typeof opts.maxBackups === "number"
+    ? Math.max(1, Math.trunc(opts.maxBackups))
+    : undefined;
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
   const backupEngine = opts.backupEngine ?? "auto";
   const canUsePgDump = !hasBackupTransforms(opts);
@@ -677,7 +715,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
   fs.mkdirSync(opts.backupDir, { recursive: true });
   ensureSufficientBackupFreeSpace(opts.backupDir, filenamePrefix);
-  const backupBase = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql.gz`);
+  const backupBase = resolve(opts.backupDir, createBackupFileBase(filenamePrefix));
   const partialBackupFile = `${backupBase}.partial`;
   const backupFile = backupBase;
   let writer: ReturnType<typeof createBufferedGzipTextFileWriter> | null = null;

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -344,6 +344,21 @@ function appendCapturedStderr(previous: string, chunk: Buffer | string): string 
   return Buffer.from(next, "utf8").subarray(-BACKUP_CLI_STDERR_BYTES).toString("utf8");
 }
 
+async function waitForWritableDrain(stream: NodeJS.EventEmitter): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onDrain = () => {
+      stream.removeListener("error", onError);
+      resolve();
+    };
+    const onError = (error: unknown) => {
+      stream.removeListener("drain", onDrain);
+      reject(error);
+    };
+    stream.once("drain", onDrain);
+    stream.once("error", onError);
+  });
+}
+
 async function waitForChildExit(child: ReturnType<typeof spawn>, label: string): Promise<void> {
   let stderr = "";
   child.stderr?.on("data", (chunk) => {
@@ -582,12 +597,7 @@ export function createBufferedGzipTextFileWriter(filePath: string, maxBufferedBy
   let pendingWrite = Promise.resolve();
 
   const writeChunk = async (chunk: string | Buffer): Promise<void> => {
-    if (!gzip.write(chunk)) {
-      await new Promise<void>((resolve, reject) => {
-        gzip.once("drain", resolve);
-        gzip.once("error", reject);
-      });
-    }
+    if (!gzip.write(chunk)) await waitForWritableDrain(gzip);
   };
 
   const flushBufferedLines = () => {

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -1,4 +1,4 @@
-import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import * as fs from "node:fs";
 import { basename, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { spawn } from "node:child_process";
@@ -17,6 +17,7 @@ export type RunDatabaseBackupOptions = {
   connectionString: string;
   backupDir: string;
   retention: BackupRetentionPolicy;
+  maxBackups?: number;
   filenamePrefix?: string;
   connectTimeoutSeconds?: number;
   /**
@@ -70,8 +71,16 @@ const DEFAULT_BACKUP_WRITE_BUFFER_BYTES = 1024 * 1024;
 const BACKUP_DATA_CURSOR_ROWS = 100;
 const BACKUP_CLI_STDERR_BYTES = 64 * 1024;
 const BACKUP_BREAKPOINT_DETECT_BYTES = 64 * 1024;
+const DEFAULT_MAX_BACKUPS = 7;
 
 const STATEMENT_BREAKPOINT = "-- paperclip statement breakpoint 69f6f3f1-42fd-46a6-bf17-d1d85f8f3900";
+
+type BackupEntry = {
+  name: string;
+  fullPath: string;
+  mtimeMs: number;
+  sizeBytes: number;
+};
 
 function sanitizeRestoreErrorMessage(error: unknown): string {
   if (error && typeof error === "object") {
@@ -113,6 +122,42 @@ function monthlyRetentionCutoff(nowMs: number, monthlyMonths: number): number {
   return Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - months, 1);
 }
 
+function listBackupEntries(backupDir: string, filenamePrefix: string): BackupEntry[] {
+  if (!fs.existsSync(backupDir)) return [];
+
+  const entries: BackupEntry[] = [];
+  for (const name of fs.readdirSync(backupDir)) {
+    if (!name.startsWith(`${filenamePrefix}-`)) continue;
+    if (name.endsWith(".partial")) continue;
+    if (!name.endsWith(".sql") && !name.endsWith(".sql.gz")) continue;
+    const fullPath = resolve(backupDir, name);
+    const stat = fs.statSync(fullPath);
+    entries.push({
+      name,
+      fullPath,
+      mtimeMs: stat.mtimeMs,
+      sizeBytes: stat.size,
+    });
+  }
+
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return entries;
+}
+
+function ensureSufficientBackupFreeSpace(backupDir: string, filenamePrefix: string): void {
+  const latestBackup = listBackupEntries(backupDir, filenamePrefix)[0];
+  if (!latestBackup || latestBackup.sizeBytes <= 0) return;
+
+  const requiredBytes = Math.ceil(latestBackup.sizeBytes * 1.5);
+  const stat = fs.statfsSync(backupDir);
+  const availableBytes = stat.bavail * stat.bsize;
+  if (availableBytes >= requiredBytes) return;
+
+  throw new Error(
+    `Insufficient free space in ${backupDir}: need at least ${formatBackupSize(requiredBytes)} free (1.5x latest backup ${latestBackup.name}, ${formatBackupSize(latestBackup.sizeBytes)}), but only ${formatBackupSize(availableBytes)} available.`,
+  );
+}
+
 /**
  * Tiered backup pruning:
  * - Daily tier: keep ALL backups from the last `dailyDays` days
@@ -120,27 +165,28 @@ function monthlyRetentionCutoff(nowMs: number, monthlyMonths: number): number {
  * - Monthly tier: keep the NEWEST backup per calendar month for `monthlyMonths` months
  * - Everything else is deleted
  */
-function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, filenamePrefix: string): number {
-  if (!existsSync(backupDir)) return 0;
+function pruneOldBackups(
+  backupDir: string,
+  retention: BackupRetentionPolicy,
+  filenamePrefix: string,
+  maxBackups?: number,
+): number {
+  const entries = listBackupEntries(backupDir, filenamePrefix);
+  if (entries.length === 0) return 0;
+
+  if (typeof maxBackups === "number") {
+    const keepCount = Math.max(1, Math.trunc(maxBackups));
+    const toDelete = entries.slice(keepCount);
+    for (const entry of toDelete) {
+      fs.unlinkSync(entry.fullPath);
+    }
+    return toDelete.length;
+  }
 
   const now = Date.now();
   const dailyCutoff = now - Math.max(1, retention.dailyDays) * 24 * 60 * 60 * 1000;
   const weeklyCutoff = now - Math.max(1, retention.weeklyWeeks) * 7 * 24 * 60 * 60 * 1000;
   const monthlyCutoff = monthlyRetentionCutoff(now, retention.monthlyMonths);
-
-  type BackupEntry = { name: string; fullPath: string; mtimeMs: number };
-  const entries: BackupEntry[] = [];
-
-  for (const name of readdirSync(backupDir)) {
-    if (!name.startsWith(`${filenamePrefix}-`)) continue;
-    if (!name.endsWith(".sql") && !name.endsWith(".sql.gz")) continue;
-    const fullPath = resolve(backupDir, name);
-    const stat = statSync(fullPath);
-    entries.push({ name, fullPath, mtimeMs: stat.mtimeMs });
-  }
-
-  // Sort newest first so the first entry per week/month bucket is the one we keep
-  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
 
   const keepWeekBuckets = new Set<string>();
   const keepMonthBuckets = new Set<string>();
@@ -179,7 +225,7 @@ function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, fi
   }
 
   for (const filePath of toDelete) {
-    unlinkSync(filePath);
+    fs.unlinkSync(filePath);
   }
 
   return toDelete.length;
@@ -319,7 +365,7 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, label: string):
 
 async function runPgDumpBackup(opts: {
   connectionString: string;
-  backupFile: string;
+  partialBackupFile: string;
   connectTimeout: number;
 }): Promise<void> {
   const pgDumpBin = process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump";
@@ -347,7 +393,7 @@ async function runPgDumpBackup(opts: {
   }
 
   await Promise.all([
-    pipeline(child.stdout, createGzip(), createWriteStream(opts.backupFile)),
+    pipeline(child.stdout, createGzip(), fs.createWriteStream(opts.partialBackupFile, { flags: "wx" })),
     waitForChildExit(child, pgDumpBin),
   ]);
 }
@@ -376,8 +422,8 @@ async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: 
   }
 
   const input = opts.backupFile.endsWith(".gz")
-    ? createReadStream(opts.backupFile).pipe(createGunzip())
-    : createReadStream(opts.backupFile);
+    ? fs.createReadStream(opts.backupFile).pipe(createGunzip())
+    : fs.createReadStream(opts.backupFile);
 
   await Promise.all([
     pipeline(input, child.stdin),
@@ -386,7 +432,7 @@ async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: 
 }
 
 async function hasStatementBreakpoints(backupFile: string): Promise<boolean> {
-  const raw = createReadStream(backupFile);
+  const raw = fs.createReadStream(backupFile);
   const stream = backupFile.endsWith(".gz") ? raw.pipe(createGunzip()) : raw;
   let text = "";
 
@@ -404,7 +450,7 @@ async function hasStatementBreakpoints(backupFile: string): Promise<boolean> {
 }
 
 async function* readRestoreStatements(backupFile: string): AsyncGenerator<string> {
-  const raw = createReadStream(backupFile);
+  const raw = fs.createReadStream(backupFile);
   const stream = backupFile.endsWith(".gz") ? raw.pipe(createGunzip()) : raw;
   stream.setEncoding("utf8");
   const reader = createInterface({
@@ -513,9 +559,95 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
       bufferedBytes = 0;
       await pendingWrite.catch(() => {});
       await filePromise.then((file) => file.close()).catch(() => {});
-      if (existsSync(filePath)) {
+      if (fs.existsSync(filePath)) {
         try {
-          unlinkSync(filePath);
+          fs.unlinkSync(filePath);
+        } catch {
+          // Preserve the original backup failure if temporary file cleanup also fails.
+        }
+      }
+    },
+  };
+}
+
+export function createBufferedGzipTextFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
+  const flushThreshold = Math.max(1, Math.trunc(maxBufferedBytes));
+  const gzip = createGzip();
+  const output = fs.createWriteStream(filePath, { flags: "wx" });
+  const completion = pipeline(gzip, output);
+  let bufferedLines: string[] = [];
+  let bufferedBytes = 0;
+  let firstChunk = true;
+  let closed = false;
+  let pendingWrite = Promise.resolve();
+
+  const writeChunk = async (chunk: string | Buffer): Promise<void> => {
+    if (!gzip.write(chunk)) {
+      await new Promise<void>((resolve, reject) => {
+        gzip.once("drain", resolve);
+        gzip.once("error", reject);
+      });
+    }
+  };
+
+  const flushBufferedLines = () => {
+    if (bufferedLines.length === 0) return;
+    const linesToWrite = bufferedLines;
+    bufferedLines = [];
+    bufferedBytes = 0;
+    const chunkBody = linesToWrite.join("\n");
+    const chunk = firstChunk ? chunkBody : `\n${chunkBody}`;
+    firstChunk = false;
+    pendingWrite = pendingWrite.then(() => writeChunk(chunk));
+  };
+
+  return {
+    emit(line: string) {
+      if (closed) {
+        throw new Error(`Cannot write to closed backup file: ${filePath}`);
+      }
+      bufferedLines.push(line);
+      bufferedBytes += Buffer.byteLength(line, "utf8") + 1;
+      if (bufferedBytes >= flushThreshold) {
+        flushBufferedLines();
+      }
+    },
+    async drain() {
+      if (closed) {
+        throw new Error(`Cannot drain closed backup file: ${filePath}`);
+      }
+      flushBufferedLines();
+      await pendingWrite;
+    },
+    async writeRaw(chunk: string | Buffer) {
+      if (closed) {
+        throw new Error(`Cannot write to closed backup file: ${filePath}`);
+      }
+      flushBufferedLines();
+      firstChunk = false;
+      pendingWrite = pendingWrite.then(() => writeChunk(chunk));
+      await pendingWrite;
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      flushBufferedLines();
+      await pendingWrite;
+      gzip.end();
+      await completion;
+    },
+    async abort() {
+      if (closed) return;
+      closed = true;
+      bufferedLines = [];
+      bufferedBytes = 0;
+      await pendingWrite.catch(() => {});
+      gzip.destroy();
+      output.destroy();
+      await completion.catch(() => {});
+      if (fs.existsSync(filePath)) {
+        try {
+          fs.unlinkSync(filePath);
         } catch {
           // Preserve the original backup failure if temporary file cleanup also fails.
         }
@@ -527,11 +659,18 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
 export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise<RunDatabaseBackupResult> {
   const filenamePrefix = opts.filenamePrefix ?? "paperclip";
   const retention = opts.retention;
+  const maxBackups = Math.max(1, Math.trunc(opts.maxBackups ?? DEFAULT_MAX_BACKUPS));
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
   const backupEngine = opts.backupEngine ?? "auto";
   const canUsePgDump = !hasBackupTransforms(opts);
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
+  fs.mkdirSync(opts.backupDir, { recursive: true });
+  ensureSufficientBackupFreeSpace(opts.backupDir, filenamePrefix);
+  const backupBase = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql.gz`);
+  const partialBackupFile = `${backupBase}.partial`;
+  const backupFile = backupBase;
+  const writer = createBufferedGzipTextFileWriter(partialBackupFile);
   let sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
   let sqlClosed = false;
   const closeSql = async () => {
@@ -539,10 +678,6 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     sqlClosed = true;
     await sql.end();
   };
-  mkdirSync(opts.backupDir, { recursive: true });
-  const sqlFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql`);
-  const backupFile = `${sqlFile}.gz`;
-  const writer = createBufferedTextFileWriter(sqlFile);
 
   try {
     if (backupEngine === "pg_dump" || (backupEngine === "auto" && canUsePgDump)) {
@@ -551,20 +686,24 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         await closeSql();
         await runPgDumpBackup({
           connectionString: opts.connectionString,
-          backupFile,
+          partialBackupFile,
           connectTimeout,
         });
         await writer.abort();
-        const sizeBytes = statSync(backupFile).size;
-        const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
+        fs.renameSync(partialBackupFile, backupFile);
+        const sizeBytes = fs.statSync(backupFile).size;
+        const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix, maxBackups);
         return {
           backupFile,
           sizeBytes,
           prunedCount,
         };
       } catch (error) {
-        if (existsSync(backupFile)) {
-          try { unlinkSync(backupFile); } catch { /* ignore */ }
+        if (fs.existsSync(partialBackupFile)) {
+          try { fs.unlinkSync(partialBackupFile); } catch { /* ignore */ }
+        }
+        if (fs.existsSync(backupFile)) {
+          try { fs.unlinkSync(backupFile); } catch { /* ignore */ }
         }
         if (backupEngine === "pg_dump") {
           throw error;
@@ -960,15 +1099,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     emit("");
 
     await writer.close();
+    fs.renameSync(partialBackupFile, backupFile);
 
-    // Compress the SQL file with gzip
-    const sqlReadStream = createReadStream(sqlFile);
-    const gzWriteStream = createWriteStream(backupFile);
-    await pipeline(sqlReadStream, createGzip(), gzWriteStream);
-    unlinkSync(sqlFile);
-
-    const sizeBytes = statSync(backupFile).size;
-    const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
+    const sizeBytes = fs.statSync(backupFile).size;
+    const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix, maxBackups);
 
     return {
       backupFile,
@@ -977,11 +1111,11 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     };
   } catch (error) {
     await writer.abort();
-    if (existsSync(backupFile)) {
-      try { unlinkSync(backupFile); } catch { /* ignore */ }
+    if (fs.existsSync(partialBackupFile)) {
+      try { fs.unlinkSync(partialBackupFile); } catch { /* ignore */ }
     }
-    if (existsSync(sqlFile)) {
-      try { unlinkSync(sqlFile); } catch { /* ignore */ }
+    if (fs.existsSync(backupFile)) {
+      try { fs.unlinkSync(backupFile); } catch { /* ignore */ }
     }
     throw error;
   } finally {

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -20,6 +20,7 @@ export type RunDatabaseBackupOptions = {
   retention: BackupRetentionPolicy;
   maxBackups?: number;
   getAvailableDiskSpaceBytes?: (backupDir: string) => number;
+  createOutputStream?: (filePath: string) => fs.WriteStream;
   filenamePrefix?: string;
   connectTimeoutSeconds?: number;
   /**
@@ -435,6 +436,7 @@ async function runPgDumpBackup(opts: {
   connectionString: string;
   partialBackupFile: string;
   connectTimeout: number;
+  createOutputStream?: (filePath: string) => fs.WriteStream;
 }): Promise<void> {
   const pgDumpBin = process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump";
   const child = spawn(
@@ -464,7 +466,9 @@ async function runPgDumpBackup(opts: {
     () => ({ ok: true } as const),
     (error) => ({ ok: false, error } as const),
   );
-  const output = fs.createWriteStream(opts.partialBackupFile, { flags: "wx" });
+  const output = opts.createOutputStream
+    ? opts.createOutputStream(opts.partialBackupFile)
+    : fs.createWriteStream(opts.partialBackupFile, { flags: "wx" });
   try {
     await waitForWriteStreamOpen(output);
   } catch (error) {
@@ -778,6 +782,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           connectionString: opts.connectionString,
           partialBackupFile,
           connectTimeout,
+          createOutputStream: opts.createOutputStream,
         });
         fs.renameSync(partialBackupFile, backupFile);
         backupFileFinalized = true;

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -19,6 +19,7 @@ export type RunDatabaseBackupOptions = {
   backupDir: string;
   retention: BackupRetentionPolicy;
   maxBackups?: number;
+  getAvailableDiskSpaceBytes?: (backupDir: string) => number;
   filenamePrefix?: string;
   connectTimeoutSeconds?: number;
   /**
@@ -72,14 +73,9 @@ const DEFAULT_BACKUP_WRITE_BUFFER_BYTES = 1024 * 1024;
 const BACKUP_DATA_CURSOR_ROWS = 100;
 const BACKUP_CLI_STDERR_BYTES = 64 * 1024;
 const BACKUP_BREAKPOINT_DETECT_BYTES = 64 * 1024;
+const BACKUP_STALE_PARTIAL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 const STATEMENT_BREAKPOINT = "-- paperclip statement breakpoint 69f6f3f1-42fd-46a6-bf17-d1d85f8f3900";
-
-let statfsSyncImpl: typeof fs.statfsSync = fs.statfsSync;
-
-export function __setBackupStatfsSyncForTests(impl: typeof fs.statfsSync | null): void {
-  statfsSyncImpl = impl ?? fs.statfsSync;
-}
 
 type BackupEntry = {
   name: string;
@@ -87,6 +83,8 @@ type BackupEntry = {
   mtimeMs: number;
   sizeBytes: number;
 };
+
+type BackupWriter = ReturnType<typeof createBufferedGzipTextFileWriter>;
 
 function sanitizeRestoreErrorMessage(error: unknown): string {
   if (error && typeof error === "object") {
@@ -150,13 +148,44 @@ function listBackupEntries(backupDir: string, filenamePrefix: string): BackupEnt
   return entries;
 }
 
-function ensureSufficientBackupFreeSpace(backupDir: string, filenamePrefix: string): void {
+function getAvailableDiskSpaceBytes(backupDir: string): number {
+  const stat = fs.statfsSync(backupDir);
+  return Number(stat.bavail) * Number(stat.bsize);
+}
+
+function pruneStalePartialBackups(
+  backupDir: string,
+  filenamePrefix: string,
+  nowMs: number = Date.now(),
+  maxAgeMs: number = BACKUP_STALE_PARTIAL_MAX_AGE_MS,
+): number {
+  if (!fs.existsSync(backupDir)) return 0;
+
+  const cutoffMs = nowMs - Math.max(1, maxAgeMs);
+  let prunedCount = 0;
+
+  for (const name of fs.readdirSync(backupDir)) {
+    if (!name.startsWith(`${filenamePrefix}-`) || !name.endsWith(".sql.gz.partial")) continue;
+    const fullPath = resolve(backupDir, name);
+    const stat = fs.statSync(fullPath);
+    if (stat.mtimeMs > cutoffMs) continue;
+    fs.unlinkSync(fullPath);
+    prunedCount += 1;
+  }
+
+  return prunedCount;
+}
+
+function ensureSufficientBackupFreeSpace(
+  backupDir: string,
+  filenamePrefix: string,
+  getAvailableBytes: (backupDir: string) => number,
+): void {
   const latestBackup = listBackupEntries(backupDir, filenamePrefix)[0];
   if (!latestBackup || latestBackup.sizeBytes <= 0) return;
 
   const requiredBytes = Math.ceil(latestBackup.sizeBytes * 1.5);
-  const stat = statfsSyncImpl(backupDir);
-  const availableBytes = stat.bavail * stat.bsize;
+  const availableBytes = getAvailableBytes(backupDir);
   if (availableBytes >= requiredBytes) return;
 
   throw new Error(
@@ -180,15 +209,6 @@ function pruneOldBackups(
   const entries = listBackupEntries(backupDir, filenamePrefix);
   if (entries.length === 0) return 0;
 
-  if (typeof maxBackups === "number") {
-    const keepCount = Math.max(1, Math.trunc(maxBackups));
-    const toDelete = entries.slice(keepCount);
-    for (const entry of toDelete) {
-      fs.unlinkSync(entry.fullPath);
-    }
-    return toDelete.length;
-  }
-
   const now = Date.now();
   const dailyCutoff = now - Math.max(1, retention.dailyDays) * 24 * 60 * 60 * 1000;
   const weeklyCutoff = now - Math.max(1, retention.weeklyWeeks) * 7 * 24 * 60 * 60 * 1000;
@@ -196,11 +216,14 @@ function pruneOldBackups(
 
   const keepWeekBuckets = new Set<string>();
   const keepMonthBuckets = new Set<string>();
-  const toDelete: string[] = [];
+  const keptEntries: BackupEntry[] = [];
 
   for (const entry of entries) {
     // Daily tier — keep everything within dailyDays
-    if (entry.mtimeMs >= dailyCutoff) continue;
+    if (entry.mtimeMs >= dailyCutoff) {
+      keptEntries.push(entry);
+      continue;
+    }
 
     const date = new Date(entry.mtimeMs);
     const week = isoWeekKey(date);
@@ -208,33 +231,36 @@ function pruneOldBackups(
 
     // Weekly tier — keep newest per calendar week
     if (entry.mtimeMs >= weeklyCutoff) {
-      if (keepWeekBuckets.has(week)) {
-        toDelete.push(entry.fullPath);
-      } else {
+      if (!keepWeekBuckets.has(week)) {
         keepWeekBuckets.add(week);
+        keptEntries.push(entry);
       }
       continue;
     }
 
     // Monthly tier — keep newest per calendar month
     if (entry.mtimeMs >= monthlyCutoff) {
-      if (keepMonthBuckets.has(month)) {
-        toDelete.push(entry.fullPath);
-      } else {
+      if (!keepMonthBuckets.has(month)) {
         keepMonthBuckets.add(month);
+        keptEntries.push(entry);
       }
       continue;
     }
-
-    // Beyond all retention tiers — delete
-    toDelete.push(entry.fullPath);
   }
 
-  for (const filePath of toDelete) {
-    fs.unlinkSync(filePath);
+  const keepCount = typeof maxBackups === "number" ? Math.max(1, Math.trunc(maxBackups)) : null;
+  const keptPaths = new Set(
+    (keepCount === null ? keptEntries : keptEntries.slice(0, keepCount)).map((entry) => entry.fullPath),
+  );
+
+  let prunedCount = 0;
+  for (const entry of entries) {
+    if (keptPaths.has(entry.fullPath)) continue;
+    fs.unlinkSync(entry.fullPath);
+    prunedCount += 1;
   }
 
-  return toDelete.length;
+  return prunedCount;
 }
 
 function formatBackupSize(sizeBytes: number): string {
@@ -366,7 +392,7 @@ async function waitForWritableDrain(stream: NodeJS.EventEmitter): Promise<void> 
 }
 
 async function waitForWriteStreamOpen(stream: fs.WriteStream): Promise<void> {
-  if (typeof stream.fd === "number") return;
+  if (!stream.pending) return;
 
   await new Promise<void>((resolve, reject) => {
     const onOpen = () => {
@@ -714,11 +740,17 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
   fs.mkdirSync(opts.backupDir, { recursive: true });
-  ensureSufficientBackupFreeSpace(opts.backupDir, filenamePrefix);
+  pruneStalePartialBackups(opts.backupDir, filenamePrefix);
+  ensureSufficientBackupFreeSpace(
+    opts.backupDir,
+    filenamePrefix,
+    opts.getAvailableDiskSpaceBytes ?? getAvailableDiskSpaceBytes,
+  );
   const backupBase = resolve(opts.backupDir, createBackupFileBase(filenamePrefix));
   const partialBackupFile = `${backupBase}.partial`;
   const backupFile = backupBase;
-  let writer: ReturnType<typeof createBufferedGzipTextFileWriter> | null = null;
+  let activeWriter: BackupWriter | null = null;
+  let backupFileFinalized = false;
   let sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
   let sqlClosed = false;
   const closeSql = async () => {
@@ -738,6 +770,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           connectTimeout,
         });
         fs.renameSync(partialBackupFile, backupFile);
+        backupFileFinalized = true;
         const sizeBytes = fs.statSync(backupFile).size;
         const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix, maxBackups);
         return {
@@ -749,10 +782,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         if (fs.existsSync(partialBackupFile)) {
           try { fs.unlinkSync(partialBackupFile); } catch { /* ignore */ }
         }
-        if (fs.existsSync(backupFile)) {
-          try { fs.unlinkSync(backupFile); } catch { /* ignore */ }
-        }
-        if (backupEngine === "pg_dump") {
+        if (backupFileFinalized || backupEngine === "pg_dump") {
           throw error;
         }
         sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
@@ -761,7 +791,8 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     }
 
     await sql`SELECT 1`;
-    writer = createBufferedGzipTextFileWriter(partialBackupFile);
+    const writer = createBufferedGzipTextFileWriter(partialBackupFile);
+    activeWriter = writer;
 
     const emit = (line: string) => writer.emit(line);
     const emitStatement = (statement: string) => {
@@ -1148,6 +1179,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
 
     await writer.close();
     fs.renameSync(partialBackupFile, backupFile);
+    backupFileFinalized = true;
 
     const sizeBytes = fs.statSync(backupFile).size;
     const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix, maxBackups);
@@ -1158,11 +1190,11 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       prunedCount,
     };
   } catch (error) {
-    await writer?.abort();
+    await activeWriter?.abort();
     if (fs.existsSync(partialBackupFile)) {
       try { fs.unlinkSync(partialBackupFile); } catch { /* ignore */ }
     }
-    if (fs.existsSync(backupFile)) {
+    if (!backupFileFinalized && fs.existsSync(backupFile)) {
       try { fs.unlinkSync(backupFile); } catch { /* ignore */ }
     }
     throw error;

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -460,25 +460,25 @@ async function runPgDumpBackup(opts: {
     throw new Error("pg_dump did not expose stdout");
   }
 
-  const childResult = waitForChildExit(child, pgDumpBin);
-  const handledChildResult = childResult.catch((error) => {
-    throw error;
-  });
+  const childResultState = waitForChildExit(child, pgDumpBin).then(
+    () => ({ ok: true } as const),
+    (error) => ({ ok: false, error } as const),
+  );
   const output = fs.createWriteStream(opts.partialBackupFile, { flags: "wx" });
   try {
     await waitForWriteStreamOpen(output);
   } catch (error) {
     output.destroy();
     child.kill();
-    await Promise.allSettled([handledChildResult]);
+    await childResultState;
     throw error;
   }
 
   const pipelineResult = pipeline(child.stdout, createGzip(), output);
-  const [pipelineState, childState] = await Promise.allSettled([pipelineResult, handledChildResult]);
+  const [pipelineState, childState] = await Promise.allSettled([pipelineResult, childResultState]);
 
-  if (childState.status === "rejected") {
-    throw childState.reason;
+  if (childState.status === "fulfilled" && !childState.value.ok) {
+    throw childState.value.error;
   }
   if (pipelineState.status === "rejected") {
     throw pipelineState.reason;

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -670,7 +670,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const backupBase = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql.gz`);
   const partialBackupFile = `${backupBase}.partial`;
   const backupFile = backupBase;
-  const writer = createBufferedGzipTextFileWriter(partialBackupFile);
+  let writer: ReturnType<typeof createBufferedGzipTextFileWriter> | null = null;
   let sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
   let sqlClosed = false;
   const closeSql = async () => {
@@ -689,7 +689,6 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           partialBackupFile,
           connectTimeout,
         });
-        await writer.abort();
         fs.renameSync(partialBackupFile, backupFile);
         const sizeBytes = fs.statSync(backupFile).size;
         const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix, maxBackups);
@@ -714,6 +713,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     }
 
     await sql`SELECT 1`;
+    writer = createBufferedGzipTextFileWriter(partialBackupFile);
 
     const emit = (line: string) => writer.emit(line);
     const emitStatement = (statement: string) => {
@@ -1110,7 +1110,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       prunedCount,
     };
   } catch (error) {
-    await writer.abort();
+    await writer?.abort();
     if (fs.existsSync(partialBackupFile)) {
       try { fs.unlinkSync(partialBackupFile); } catch { /* ignore */ }
     }

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -461,18 +461,21 @@ async function runPgDumpBackup(opts: {
   }
 
   const childResult = waitForChildExit(child, pgDumpBin);
+  const handledChildResult = childResult.catch((error) => {
+    throw error;
+  });
   const output = fs.createWriteStream(opts.partialBackupFile, { flags: "wx" });
   try {
     await waitForWriteStreamOpen(output);
   } catch (error) {
     output.destroy();
     child.kill();
-    await Promise.allSettled([childResult]);
+    await Promise.allSettled([handledChildResult]);
     throw error;
   }
 
   const pipelineResult = pipeline(child.stdout, createGzip(), output);
-  const [pipelineState, childState] = await Promise.allSettled([pipelineResult, childResult]);
+  const [pipelineState, childState] = await Promise.allSettled([pipelineResult, handledChildResult]);
 
   if (childState.status === "rejected") {
     throw childState.reason;

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -460,11 +460,18 @@ async function runPgDumpBackup(opts: {
     throw new Error("pg_dump did not expose stdout");
   }
 
+  const childResult = waitForChildExit(child, pgDumpBin);
   const output = fs.createWriteStream(opts.partialBackupFile, { flags: "wx" });
-  await waitForWriteStreamOpen(output);
+  try {
+    await waitForWriteStreamOpen(output);
+  } catch (error) {
+    output.destroy();
+    child.kill();
+    await Promise.allSettled([childResult]);
+    throw error;
+  }
 
   const pipelineResult = pipeline(child.stdout, createGzip(), output);
-  const childResult = waitForChildExit(child, pgDumpBin);
   const [pipelineState, childState] = await Promise.allSettled([pipelineResult, childResult]);
 
   if (childState.status === "rejected") {

--- a/packages/db/src/backup.ts
+++ b/packages/db/src/backup.ts
@@ -79,6 +79,7 @@ async function main() {
     const result = await runDatabaseBackup({
       connectionString,
       backupDir,
+      maxBackups: 7,
       retention: { dailyDays: retentionDays, weeklyWeeks: 4, monthlyMonths: 1 },
       filenamePrefix: "paperclip",
     });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1276,6 +1276,52 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(recoveryIssues[0]?.status).toBe("blocked");
   });
 
+  it("keeps the original assignee when stranded recovery falls back to another recovery owner", async () => {
+    const { coderId, managerId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "process lost",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Recovery should keep the standing assignee.",
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "process_lost",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "process_lost" }),
+      }),
+    );
+  });
+
   it("exposes active recovery actions on the issue read API", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5689,6 +5689,97 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       executionRunId: successorRunId,
     });
   });
+
+  it("checkout adoption of a stale executionRunId preserves the issue's assigneeAgentId", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const recoveryAgentId = randomUUID();
+    const issueId = randomUUID();
+    const failedExecutionRunId = randomUUID();
+    const recoveryRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "Codex DevOps",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: recoveryAgentId,
+        companyId,
+        name: "Claude CEO",
+        role: "manager",
+        status: "active",
+        adapterType: "claude_code",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: failedExecutionRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "failed",
+        invocationSource: "manual",
+        finishedAt: new Date("2026-06-10T10:05:00.000Z"),
+      },
+      {
+        id: recoveryRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "running",
+        invocationSource: "automation",
+        startedAt: new Date("2026-06-10T10:07:00.000Z"),
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale execution lock keeps standing assignee",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: failedExecutionRunId,
+      executionAgentNameKey: "codexdevops",
+      executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
+    });
+
+    const result = await svc.checkout(issueId, assigneeAgentId, ["todo", "in_progress"], recoveryRunId);
+    expect(result).toBeTruthy();
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId,
+      checkoutRunId: recoveryRunId,
+      executionRunId: recoveryRunId,
+    });
+    expect(row?.assigneeAgentId).not.toBe(recoveryAgentId);
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8099,8 +8099,8 @@ export function issueService(db: Db) {
       }
 
       // Adopt stale executionRunId — if the execution lock points to a terminal/missing run, clear it and proceed.
-      // Only adopts when the caller's expectedStatuses guard still holds; preserves any existing assigneeUserId
-      // and preserves the original startedAt when the issue is already in_progress.
+      // Only adopts when the caller's expectedStatuses guard still holds; preserves the recorded assignee and
+      // any existing assigneeUserId, and preserves the original startedAt when the issue is already in_progress.
       if (
         checkoutRunId &&
         current.executionRunId &&
@@ -8111,7 +8111,6 @@ export function issueService(db: Db) {
         if (stale) {
           const now = new Date();
           const adoptionSet: Record<string, unknown> = {
-            assigneeAgentId: agentId,
             checkoutRunId,
             executionRunId: checkoutRunId,
             executionAgentNameKey: null,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3339,7 +3339,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3490,13 +3489,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(1);
       if (
         currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
+        currentIssue.status !== "blocked"
       ) {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
         });
         if (reblocked) return reblocked;
       }


### PR DESCRIPTION
## Summary
- stop stale execution lock adoption from rewriting the issue assignee during recovery checkout
- keep recovery adoption scoped to checkout and execution lock repair only
- add a regression test covering stale execution lock recovery while preserving the standing assignee

## Testing
- pnpm vitest server/src/__tests__/issues-service.test.ts

## Dedup
- [x] Checked for an existing fix or regression in current recovery checkout paths before changing behavior
