### PR TITLE
fix(recovery): preserve explicit recovery owners

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3913,6 +3913,64 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(recoveryIssues).toHaveLength(0);
   });
 
+  it("skips missing-disposition escalation for plugin-managed issue lifecycles", async () => {
+    const { companyId, agentId, runId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+    });
+    const sourceRunId = randomUUID();
+    await db
+      .update(issues)
+      .set({ originKind: "plugin:paperclip.workflow-engine" })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "finish_successful_run_handoff",
+          sourceRunId,
+          resumeFromRunId: sourceRunId,
+          handoffRequired: true,
+          handoffReason: "successful_run_missing_state",
+          missingDisposition: "clear_next_step",
+          handoffAttempt: 1,
+          maxHandoffAttempts: 1,
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThan(0);
+    expect(result.issueIds).toEqual([]);
+    const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(sourceIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+    });
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(0);
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.filter((wakeup) => wakeup.reason === "finish_successful_run_handoff")).toHaveLength(0);
+  });
+
   it("redacts secret-bearing successful-run detected progress before handoff disclosure", async () => {
     const { agentId, runId, issueId } = await seedQueuedIssueRunFixture();
     const bearerSecret = "live-bearer-token-value";

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5156,7 +5156,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(sourceIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: agentId,
+      assigneeAgentId: sourceAssigneeAgentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1328,7 +1328,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const relations = await db
       .select()
       .from(issueRelations)
-      .where(and(eq(issueRelations.issueId, sourceIssue.id), eq(issueRelations.relatedIssueId, recoveryIssues[0]!.id)));
+      .where(and(eq(issueRelations.issueId, recoveryIssues[0]!.id), eq(issueRelations.relatedIssueId, sourceIssue.id)));
     expect(relations.some((row) => row.type === "blocks")).toBe(true);
 
     expect(enqueueWakeup).toHaveBeenCalledTimes(1);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1450,6 +1450,52 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(recoveryIssues[0]?.status).toBe("blocked");
   });
 
+  it("keeps the original assignee when stranded recovery falls back to another recovery owner", async () => {
+    const { coderId, managerId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "process lost",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Recovery should keep the standing assignee.",
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "process_lost",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "process_lost" }),
+      }),
+    );
+  });
+
   it("exposes active recovery actions on the issue read API", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1368,6 +1368,58 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
+  it("preserves existing blockers when takeover recovery adds its own blocking edge", async () => {
+    const { companyId, managerId, coderId, sourceIssueId, sourceIssue, prefix } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const externalBlockerId = randomUUID();
+    await db.insert(issues).values({
+      id: externalBlockerId,
+      companyId,
+      title: "External blocker",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: externalBlockerId,
+      relatedIssueId: sourceIssueId,
+      type: "blocks",
+    });
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "worker exited unexpectedly",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(1);
+
+    const blockerEdges = await db
+      .select({ blockerIssueId: issueRelations.issueId })
+      .from(issueRelations)
+      .where(and(eq(issueRelations.companyId, companyId), eq(issueRelations.relatedIssueId, sourceIssueId)));
+    expect(blockerEdges.map((row) => row.blockerIssueId).sort()).toEqual(
+      [externalBlockerId, recoveryIssues[0]!.id].sort(),
+    );
+  });
+
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {
     const { companyId, managerId, sourceIssueId, prefix } = await seedCompany();
     const recoveryIssueId = randomUUID();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -272,7 +272,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(await svc.getActiveForIssue(randomUUID(), sourceIssueId)).toBeNull();
   });
 
-  it("escalates stranded assigned work into a source action instead of a recovery issue", async () => {
+  it("escalates stranded assigned work into a manager-owned recovery issue without stealing the source assignee", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     const enqueueWakeup = vi.fn(async () => null);
     const recovery = recoveryService(db, { enqueueWakeup });
@@ -317,15 +317,22 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
+      assigneeAgentId: coderId,
     });
     const recoveryIssues = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
-    expect(recoveryIssues).toHaveLength(0);
-    expect(enqueueWakeup).toHaveBeenCalledTimes(2);
+    expect(recoveryIssues).toHaveLength(1);
+    expect(recoveryIssues[0]).toMatchObject({
+      parentId: sourceIssue.id,
+      assigneeAgentId: managerId,
+      originId: sourceIssue.id,
+      status: "todo",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
     expect(enqueueWakeup.mock.calls[0]?.[1]?.payload).toMatchObject({
-      issueId: sourceIssue.id,
+      issueId: recoveryIssues[0]!.id,
       sourceIssueId: sourceIssue.id,
       recoveryCause: "stranded_assigned_issue",
     });
@@ -371,15 +378,36 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         .from(issueRecoveryActions)
         .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
       expect(action?.ownerAgentId).toBe(expectedOwnerId);
-      expect(enqueueWakeup).toHaveBeenCalledWith(
-        expectedOwnerId,
-        expect.objectContaining({
-          reason: "source_scoped_recovery_action",
-          payload: expect.objectContaining({
-            recoveryCause: explicitCause ?? (errorCode === "adapter_failed" ? "stranded_assigned_issue" : errorCode),
+      const expectedCause = explicitCause ?? (errorCode === "adapter_failed" ? "stranded_assigned_issue" : errorCode);
+      if (expectedOwner === "coder") {
+        expect(enqueueWakeup).toHaveBeenCalledWith(
+          expectedOwnerId,
+          expect.objectContaining({
+            reason: "source_scoped_recovery_action",
+            payload: expect.objectContaining({
+              recoveryCause: expectedCause,
+            }),
           }),
-        }),
-      );
+        );
+      } else {
+        const recoveryIssues = await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.originKind, "stranded_issue_recovery"), eq(issues.originId, sourceIssue.id)));
+        expect(recoveryIssues).toHaveLength(1);
+        expect(recoveryIssues[0]?.assigneeAgentId).toBe(expectedOwnerId);
+        expect(enqueueWakeup).toHaveBeenCalledWith(
+          expectedOwnerId,
+          expect.objectContaining({
+            reason: "issue_assigned",
+            payload: expect.objectContaining({
+              issueId: recoveryIssues[0]!.id,
+              sourceIssueId: sourceIssue.id,
+              recoveryCause: expectedCause,
+            }),
+          }),
+        );
+      }
     },
   );
 
@@ -415,6 +443,15 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       },
     });
 
+    const [updatedIssue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
     const [action] = await db
       .select()
       .from(issueRecoveryActions)
@@ -435,6 +472,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         }),
       }),
     );
+    expect(enqueueWakeup).not.toHaveBeenCalledWith(ceoId, expect.anything());
   });
 
   it("stands down while the latest run was cancelled by a board operator", async () => {
@@ -1100,11 +1138,15 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       attemptCount: 2,
     });
     expect(actionRows[0]?.evidence).toMatchObject({ latestRunId: secondLatestRun.id });
-    expect(enqueueWakeup).toHaveBeenCalledTimes(2);
-    expect(enqueueWakeup.mock.calls[1]?.[1]?.payload).toMatchObject({
-      issueId: sourceIssue.id,
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(1);
+    expect(enqueueWakeup.mock.calls[0]?.[1]?.payload).toMatchObject({
+      issueId: recoveryIssues[0]!.id,
       sourceIssueId: sourceIssue.id,
-      strandedRunId: secondLatestRun.id,
       recoveryCause: "stranded_assigned_issue",
     });
   });
@@ -1216,12 +1258,21 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       tone: "danger",
       title: "Workspace validation failed",
     });
-    expect(enqueueWakeup).toHaveBeenCalledTimes(2);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(1);
     expect(enqueueWakeup).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        reason: "source_scoped_recovery_action",
-        payload: expect.objectContaining({ recoveryCause: "workspace_validation_failed" }),
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: recoveryIssues[0]!.id,
+          sourceIssueId: sourceIssue.id,
+          recoveryCause: "workspace_validation_failed",
+        }),
       }),
     );
   });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1536,13 +1536,13 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       ownerAgentId: managerId,
       previousOwnerAgentId: coderId,
       returnOwnerAgentId: coderId,
-      cause: "process_lost",
+      cause: "stranded_assigned_issue",
     });
     expect(enqueueWakeup).toHaveBeenCalledWith(
       managerId,
       expect.objectContaining({
-        reason: "source_scoped_recovery_action",
-        payload: expect.objectContaining({ recoveryCause: "process_lost" }),
+        reason: "issue_assigned",
+        payload: expect.objectContaining({ recoveryCause: "stranded_assigned_issue" }),
       }),
     );
   });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -383,6 +383,60 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     },
   );
 
+  it("keeps the current source assignee as the recovery return owner when the latest run came from another agent", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    const ceoId = randomUUID();
+    await db.insert(agents).values({
+      id: ceoId,
+      companyId,
+      name: "Claude CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: ceoId,
+        status: "failed",
+        error: "helper recovery run lost the process",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerAgentId: coderId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "process_lost",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      coderId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({
+          issueId: sourceIssue.id,
+          recoveryCause: "process_lost",
+        }),
+      }),
+    );
+  });
+
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -936,8 +936,31 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: managerId,
+      assigneeAgentId: coderId,
     });
+    const [takeoverIssue] = await db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, companyId),
+        eq(issues.originKind, "stranded_issue_recovery"),
+        eq(issues.originId, sourceIssueId),
+      ));
+    expect(takeoverIssue).toMatchObject({
+      assigneeAgentId: managerId,
+      parentId: sourceIssueId,
+      status: "todo",
+    });
+    const [blockerLink] = await db
+      .select()
+      .from(issueRelations)
+      .where(and(
+        eq(issueRelations.companyId, companyId),
+        eq(issueRelations.issueId, takeoverIssue!.id),
+        eq(issueRelations.relatedIssueId, sourceIssueId),
+        eq(issueRelations.type, "blocks"),
+      ));
+    expect(blockerLink).toBeTruthy();
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");
     const [action] = await db.select().from(issueRecoveryActions);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -938,7 +938,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "blocked",
       assigneeAgentId: coderId,
     });
-    const [takeoverIssue] = await db
+    const recoveryIssues = await db
       .select()
       .from(issues)
       .where(and(
@@ -946,21 +946,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         eq(issues.originKind, "stranded_issue_recovery"),
         eq(issues.originId, sourceIssueId),
       ));
-    expect(takeoverIssue).toMatchObject({
-      assigneeAgentId: managerId,
-      parentId: sourceIssueId,
-      status: "todo",
-    });
-    const [blockerLink] = await db
-      .select()
-      .from(issueRelations)
-      .where(and(
-        eq(issueRelations.companyId, companyId),
-        eq(issueRelations.issueId, takeoverIssue!.id),
-        eq(issueRelations.relatedIssueId, sourceIssueId),
-        eq(issueRelations.type, "blocks"),
-      ));
-    expect(blockerLink).toBeTruthy();
+    expect(recoveryIssues).toHaveLength(0);
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");
     const [action] = await db.select().from(issueRecoveryActions);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1232,6 +1232,65 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
   });
 
+  it("preserves the source assignee and creates a recovery issue for manager fallback", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "worker exited unexpectedly",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedSource] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedSource).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(1);
+    expect(recoveryIssues[0]).toMatchObject({
+      parentId: sourceIssue.id,
+      assigneeAgentId: managerId,
+      originId: sourceIssue.id,
+      status: "todo",
+    });
+
+    const relations = await db
+      .select()
+      .from(issueRelations)
+      .where(and(eq(issueRelations.issueId, sourceIssue.id), eq(issueRelations.relatedIssueId, recoveryIssues[0]!.id)));
+    expect(relations.some((row) => row.type === "blocks")).toBe(true);
+
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: recoveryIssues[0]!.id,
+          sourceIssueId: sourceIssue.id,
+          recoveryCause: "process_lost",
+        }),
+      }),
+    );
+  });
+
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {
     const { companyId, managerId, sourceIssueId, prefix } = await seedCompany();
     const recoveryIssueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5871,10 +5871,12 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       updatedAt: now,
     });
 
-    expect(buildStaleExecutionLockAdoptionSet({
+    const ownedAdoptionSet = buildStaleExecutionLockAdoptionSet({
       assigneeAgentId: agentId,
       status: "in_progress",
-    }, randomUUID(), checkoutRunId, now)).toMatchObject({
+    }, randomUUID(), checkoutRunId, now);
+
+    expect(ownedAdoptionSet).toMatchObject({
       checkoutRunId,
       executionRunId: checkoutRunId,
       executionAgentNameKey: null,
@@ -5882,6 +5884,7 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       status: "in_progress",
       updatedAt: now,
     });
+    expect(ownedAdoptionSet).not.toHaveProperty("assigneeAgentId");
   });
 });
 
@@ -6122,6 +6125,8 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     expect(persistedClaims).toHaveLength(1);
     expect(persistedClaims[0]?.requestedChildCount).toBe(2);
     expect(persistedClaims[0]?.childIssueIds).toEqual(first.childIssueIds);
+    expect((persistedClaims[0]?.requestedChildren as Array<Record<string, unknown>> | undefined)?.[1])
+      .not.toHaveProperty("assigneeAgentId");
 
     const childrenRows = await db
       .select({ id: issues.id, title: issues.title })

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5942,6 +5942,82 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
     expect(row?.assigneeAgentId).not.toBe(recoveryAgentId);
   });
+
+  it("checkout adoption of a stale executionRunId does not auto-assign an unowned issue", async () => {
+    const companyId = randomUUID();
+    const recoveryAgentId = randomUUID();
+    const issueId = randomUUID();
+    const failedExecutionRunId = randomUUID();
+    const recoveryRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: recoveryAgentId,
+      companyId,
+      name: "Claude CEO",
+      role: "manager",
+      status: "active",
+      adapterType: "claude_code",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: failedExecutionRunId,
+        companyId,
+        agentId: recoveryAgentId,
+        status: "failed",
+        invocationSource: "manual",
+        finishedAt: new Date("2026-06-10T10:05:00.000Z"),
+      },
+      {
+        id: recoveryRunId,
+        companyId,
+        agentId: recoveryAgentId,
+        status: "running",
+        invocationSource: "automation",
+        startedAt: new Date("2026-06-10T10:07:00.000Z"),
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale execution lock keeps source issue unowned",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: failedExecutionRunId,
+      executionAgentNameKey: "claudeceo",
+      executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
+    });
+
+    const result = await svc.checkout(issueId, recoveryAgentId, ["todo", "in_progress"], recoveryRunId);
+    expect(result).toBeTruthy();
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: null,
+      checkoutRunId: recoveryRunId,
+      executionRunId: recoveryRunId,
+    });
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5757,19 +5757,17 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
-  it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
-    // Regression for PR #2482 checkout-adoption review finding: any adoption
-    // helper that re-locks an existing in_progress issue (e.g. when the prior
-    // checkout/execution run is terminal) must not strip the row's
-    // assigneeUserId. We exercise this via the adoptStaleCheckoutRun path,
-    // which fires when checkoutRunId points at a terminal run while
-    // executionRunId still points at a different, non-terminal run.
+  it("checkout adoption of an unowned stale execution lock assigns the actor", async () => {
+    // Regression for OFM-4569 review finding: the stale execution-lock adoption
+    // path is the one branch where checkout is allowed for an unowned
+    // in_progress issue, so it must explicitly stamp assigneeAgentId for the
+    // actor when executionRunId points at a terminal or missing run.
     const companyId = randomUUID();
     const agentId = randomUUID();
     const userId = randomUUID();
     const issueId = randomUUID();
     const failedCheckoutRunId = randomUUID();
-    const queuedExecutionRunId = randomUUID();
+    const staleExecutionRunId = randomUUID();
     const successorRunId = randomUUID();
 
     await db.insert(companies).values({
@@ -5799,11 +5797,12 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
         finishedAt: new Date("2026-06-10T10:05:00.000Z"),
       },
       {
-        id: queuedExecutionRunId,
+        id: staleExecutionRunId,
         companyId,
         agentId,
-        status: "queued",
+        status: "failed",
         invocationSource: "manual",
+        finishedAt: new Date("2026-06-10T10:06:00.000Z"),
       },
       {
         id: successorRunId,
@@ -5820,10 +5819,10 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       title: "Stale checkout lock with user co-assignee",
       status: "in_progress",
       priority: "medium",
-      assigneeAgentId: agentId,
+      assigneeAgentId: null,
       assigneeUserId: userId,
       checkoutRunId: failedCheckoutRunId,
-      executionRunId: queuedExecutionRunId,
+      executionRunId: staleExecutionRunId,
       executionAgentNameKey: "codexcoder",
       executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
     });
@@ -5845,7 +5844,7 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toMatchObject({
       status: "in_progress",
       assigneeAgentId: agentId,
-      assigneeUserId: userId,
+      assigneeUserId: null,
       checkoutRunId: successorRunId,
       executionRunId: successorRunId,
     });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -32,7 +32,6 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { instanceSettingsService } from "../services/instance-settings.ts";
 import {
-  buildStaleExecutionLockAdoptionSet,
   clampIssueListLimit,
   deriveIssueCommentRunLogAttribution,
   ISSUE_LIST_MAX_LIMIT,
@@ -5851,40 +5850,6 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       checkoutRunId: successorRunId,
       executionRunId: successorRunId,
     });
-  });
-
-  it("buildStaleExecutionLockAdoptionSet stamps the actor only for unowned issues", () => {
-    const now = new Date("2026-06-10T10:07:00.000Z");
-    const checkoutRunId = randomUUID();
-    const agentId = randomUUID();
-
-    expect(buildStaleExecutionLockAdoptionSet({
-      assigneeAgentId: null,
-      status: "in_progress",
-    }, agentId, checkoutRunId, now)).toMatchObject({
-      assigneeAgentId: agentId,
-      checkoutRunId,
-      executionRunId: checkoutRunId,
-      executionAgentNameKey: null,
-      executionLockedAt: now,
-      status: "in_progress",
-      updatedAt: now,
-    });
-
-    const ownedAdoptionSet = buildStaleExecutionLockAdoptionSet({
-      assigneeAgentId: agentId,
-      status: "in_progress",
-    }, randomUUID(), checkoutRunId, now);
-
-    expect(ownedAdoptionSet).toMatchObject({
-      checkoutRunId,
-      executionRunId: checkoutRunId,
-      executionAgentNameKey: null,
-      executionLockedAt: now,
-      status: "in_progress",
-      updatedAt: now,
-    });
-    expect(ownedAdoptionSet).not.toHaveProperty("assigneeAgentId");
   });
 
   it("checkout adoption of a stale executionRunId preserves the issue's assigneeAgentId", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -32,6 +32,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { instanceSettingsService } from "../services/instance-settings.ts";
 import {
+  buildStaleExecutionLockAdoptionSet,
   clampIssueListLimit,
   deriveIssueCommentRunLogAttribution,
   ISSUE_LIST_MAX_LIMIT,
@@ -5757,17 +5758,19 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
-  it("checkout adoption of an unowned stale execution lock assigns the actor", async () => {
-    // Regression for OFM-4569 review finding: the stale execution-lock adoption
-    // path is the one branch where checkout is allowed for an unowned
-    // in_progress issue, so it must explicitly stamp assigneeAgentId for the
-    // actor when executionRunId points at a terminal or missing run.
+  it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
+    // Regression for PR #2482 checkout-adoption review finding: any adoption
+    // helper that re-locks an existing in_progress issue (e.g. when the prior
+    // checkout/execution run is terminal) must not strip the row's
+    // assigneeUserId. We exercise this via the adoptStaleCheckoutRun path,
+    // which fires when checkoutRunId points at a terminal run while
+    // executionRunId still points at a different, non-terminal run.
     const companyId = randomUUID();
     const agentId = randomUUID();
     const userId = randomUUID();
     const issueId = randomUUID();
     const failedCheckoutRunId = randomUUID();
-    const staleExecutionRunId = randomUUID();
+    const queuedExecutionRunId = randomUUID();
     const successorRunId = randomUUID();
 
     await db.insert(companies).values({
@@ -5797,10 +5800,10 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
         finishedAt: new Date("2026-06-10T10:05:00.000Z"),
       },
       {
-        id: staleExecutionRunId,
+        id: queuedExecutionRunId,
         companyId,
         agentId,
-        status: "failed",
+        status: "queued",
         invocationSource: "manual",
         finishedAt: new Date("2026-06-10T10:06:00.000Z"),
       },
@@ -5819,10 +5822,10 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       title: "Stale checkout lock with user co-assignee",
       status: "in_progress",
       priority: "medium",
-      assigneeAgentId: null,
+      assigneeAgentId: agentId,
       assigneeUserId: userId,
       checkoutRunId: failedCheckoutRunId,
-      executionRunId: staleExecutionRunId,
+      executionRunId: queuedExecutionRunId,
       executionAgentNameKey: "codexcoder",
       executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
     });
@@ -5844,9 +5847,40 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toMatchObject({
       status: "in_progress",
       assigneeAgentId: agentId,
-      assigneeUserId: null,
+      assigneeUserId: userId,
       checkoutRunId: successorRunId,
       executionRunId: successorRunId,
+    });
+  });
+
+  it("buildStaleExecutionLockAdoptionSet stamps the actor only for unowned issues", () => {
+    const now = new Date("2026-06-10T10:07:00.000Z");
+    const checkoutRunId = randomUUID();
+    const agentId = randomUUID();
+
+    expect(buildStaleExecutionLockAdoptionSet({
+      assigneeAgentId: null,
+      status: "in_progress",
+    }, agentId, checkoutRunId, now)).toMatchObject({
+      assigneeAgentId: agentId,
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: null,
+      executionLockedAt: now,
+      status: "in_progress",
+      updatedAt: now,
+    });
+
+    expect(buildStaleExecutionLockAdoptionSet({
+      assigneeAgentId: agentId,
+      status: "in_progress",
+    }, randomUUID(), checkoutRunId, now)).toMatchObject({
+      checkoutRunId,
+      executionRunId: checkoutRunId,
+      executionAgentNameKey: null,
+      executionLockedAt: now,
+      status: "in_progress",
+      updatedAt: now,
     });
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5886,6 +5886,97 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
     expect(ownedAdoptionSet).not.toHaveProperty("assigneeAgentId");
   });
+
+  it("checkout adoption of a stale executionRunId preserves the issue's assigneeAgentId", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const recoveryAgentId = randomUUID();
+    const issueId = randomUUID();
+    const failedExecutionRunId = randomUUID();
+    const recoveryRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "Codex DevOps",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: recoveryAgentId,
+        companyId,
+        name: "Claude CEO",
+        role: "manager",
+        status: "active",
+        adapterType: "claude_code",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: failedExecutionRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "failed",
+        invocationSource: "manual",
+        finishedAt: new Date("2026-06-10T10:05:00.000Z"),
+      },
+      {
+        id: recoveryRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "running",
+        invocationSource: "automation",
+        startedAt: new Date("2026-06-10T10:07:00.000Z"),
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale execution lock keeps standing assignee",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: failedExecutionRunId,
+      executionAgentNameKey: "codexdevops",
+      executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
+    });
+
+    const result = await svc.checkout(issueId, assigneeAgentId, ["todo", "in_progress"], recoveryRunId);
+    expect(result).toBeTruthy();
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId,
+      checkoutRunId: recoveryRunId,
+      executionRunId: recoveryRunId,
+    });
+    expect(row?.assigneeAgentId).not.toBe(recoveryAgentId);
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8191,7 +8191,7 @@ export function issueService(db: Db) {
         if (stale) {
           const now = new Date();
           const adoptionSet: Record<string, unknown> = {
-            assigneeAgentId: agentId,
+            assigneeAgentId: current.assigneeAgentId,
             checkoutRunId,
             executionRunId: checkoutRunId,
             executionAgentNameKey: null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8179,8 +8179,8 @@ export function issueService(db: Db) {
       }
 
       // Adopt stale executionRunId — if the execution lock points to a terminal/missing run, clear it and proceed.
-      // Only adopts when the caller's expectedStatuses guard still holds; preserves any existing assigneeUserId
-      // and preserves the original startedAt when the issue is already in_progress.
+      // Only adopts when the caller's expectedStatuses guard still holds, stamps an assignee for previously
+      // unowned issues, and preserves the original startedAt when the issue is already in_progress.
       if (
         checkoutRunId &&
         current.executionRunId &&
@@ -8191,7 +8191,6 @@ export function issueService(db: Db) {
         if (stale) {
           const now = new Date();
           const adoptionSet: Record<string, unknown> = {
-            assigneeAgentId: agentId,
             checkoutRunId,
             executionRunId: checkoutRunId,
             executionAgentNameKey: null,
@@ -8199,6 +8198,9 @@ export function issueService(db: Db) {
             status: "in_progress",
             updatedAt: now,
           };
+          if (current.assigneeAgentId == null) {
+            adoptionSet.assigneeAgentId = agentId;
+          }
           if (current.status !== "in_progress") {
             adoptionSet.startedAt = now;
           }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -164,29 +164,6 @@ const ISSUE_CREATE_IDEMPOTENCY_KEY_CLEANUP_BATCH_SIZE = 500;
 const DELETED_ISSUE_COMMENT_BODY = "";
 const ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS = ["issue.tree_hold_wakeup_deferred"] as const;
 
-export function buildStaleExecutionLockAdoptionSet(
-  current: Pick<typeof issues.$inferSelect, "assigneeAgentId" | "status">,
-  agentId: string,
-  checkoutRunId: string,
-  now: Date,
-): Record<string, unknown> {
-  const adoptionSet: Record<string, unknown> = {
-    checkoutRunId,
-    executionRunId: checkoutRunId,
-    executionAgentNameKey: null,
-    executionLockedAt: now,
-    status: "in_progress",
-    updatedAt: now,
-  };
-  if (current.assigneeAgentId == null) {
-    adoptionSet.assigneeAgentId = agentId;
-  }
-  if (current.status !== "in_progress") {
-    adoptionSet.startedAt = now;
-  }
-  return adoptionSet;
-}
-
 function wakeRequestTargetsIssue(issueId: string) {
   return sql`(
     ${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}
@@ -8202,8 +8179,8 @@ export function issueService(db: Db) {
       }
 
       // Adopt stale executionRunId — if the execution lock points to a terminal/missing run, clear it and proceed.
-      // Only adopts when the caller's expectedStatuses guard still holds, stamps an assignee for previously
-      // unowned issues, and preserves the original startedAt when the issue is already in_progress.
+      // Only adopts when the caller's expectedStatuses guard still holds; preserves any existing assigneeUserId
+      // and preserves the original startedAt when the issue is already in_progress.
       if (
         checkoutRunId &&
         current.executionRunId &&
@@ -8213,7 +8190,18 @@ export function issueService(db: Db) {
         const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
         if (stale) {
           const now = new Date();
-          const adoptionSet = buildStaleExecutionLockAdoptionSet(current, agentId, checkoutRunId, now);
+          const adoptionSet: Record<string, unknown> = {
+            assigneeAgentId: agentId,
+            checkoutRunId,
+            executionRunId: checkoutRunId,
+            executionAgentNameKey: null,
+            executionLockedAt: now,
+            status: "in_progress",
+            updatedAt: now,
+          };
+          if (current.status !== "in_progress") {
+            adoptionSet.startedAt = now;
+          }
           const adopted = await db
             .update(issues)
             .set(adoptionSet)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -164,6 +164,29 @@ const ISSUE_CREATE_IDEMPOTENCY_KEY_CLEANUP_BATCH_SIZE = 500;
 const DELETED_ISSUE_COMMENT_BODY = "";
 const ISSUE_WAKE_DIAGNOSTICS_ACTIVITY_ACTIONS = ["issue.tree_hold_wakeup_deferred"] as const;
 
+export function buildStaleExecutionLockAdoptionSet(
+  current: Pick<typeof issues.$inferSelect, "assigneeAgentId" | "status">,
+  agentId: string,
+  checkoutRunId: string,
+  now: Date,
+): Record<string, unknown> {
+  const adoptionSet: Record<string, unknown> = {
+    checkoutRunId,
+    executionRunId: checkoutRunId,
+    executionAgentNameKey: null,
+    executionLockedAt: now,
+    status: "in_progress",
+    updatedAt: now,
+  };
+  if (current.assigneeAgentId == null) {
+    adoptionSet.assigneeAgentId = agentId;
+  }
+  if (current.status !== "in_progress") {
+    adoptionSet.startedAt = now;
+  }
+  return adoptionSet;
+}
+
 function wakeRequestTargetsIssue(issueId: string) {
   return sql`(
     ${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}
@@ -8190,20 +8213,7 @@ export function issueService(db: Db) {
         const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
         if (stale) {
           const now = new Date();
-          const adoptionSet: Record<string, unknown> = {
-            checkoutRunId,
-            executionRunId: checkoutRunId,
-            executionAgentNameKey: null,
-            executionLockedAt: now,
-            status: "in_progress",
-            updatedAt: now,
-          };
-          if (current.assigneeAgentId == null) {
-            adoptionSet.assigneeAgentId = agentId;
-          }
-          if (current.status !== "in_progress") {
-            adoptionSet.startedAt = now;
-          }
+          const adoptionSet = buildStaleExecutionLockAdoptionSet(current, agentId, checkoutRunId, now);
           const adopted = await db
             .update(issues)
             .set(adoptionSet)

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -58,6 +58,7 @@ import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   buildSuccessfulRunHandoffExhaustedNotice,
+  isPluginManagedIssueLifecycle,
   noticeMetadataReferencesRecoveryAction,
   type SuccessfulRunHandoffNotice,
 } from "./successful-run-handoff.js";
@@ -2525,8 +2526,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function resolveStrandedIssueRecoveryOwnerAgentId(
     issue: typeof issues.$inferSelect,
+    preferredOwnerAgentId?: string | null,
   ) {
     const candidateIds: string[] = [];
+    if (preferredOwnerAgentId) candidateIds.push(preferredOwnerAgentId);
     if (issue.assigneeAgentId) {
       const assignee = await getAgent(issue.assigneeAgentId);
       if (assignee?.reportsTo) candidateIds.push(assignee.reportsTo);
@@ -2579,6 +2582,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
     recoveryCause: StrandedRecoveryCause;
+    preferredOwnerAgentId?: string | null;
   }) {
     // The source issue assignee remains the source of truth for who owns the
     // work. A recovery/helper run may execute under a different agent, but that
@@ -2592,7 +2596,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       const retryAgentId = await resolveInvokableRecoveryAgentId(input.issue, originalAgentId);
       if (!retryAgentId) {
         return {
-          ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(input.issue),
+          ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(
+            input.issue,
+            input.preferredOwnerAgentId,
+          ),
           returnOwnerAgentId: originalAgentId,
           routingFallbackReason: "The original assignee is not invokable; quota recovery fell through to the manager ladder.",
         };
@@ -2609,13 +2616,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         return { ownerAgentId, returnOwnerAgentId: originalAgentId, routingFallbackReason: null };
       }
       return {
-        ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(input.issue),
+        ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(
+          input.issue,
+          input.preferredOwnerAgentId,
+        ),
         returnOwnerAgentId: originalAgentId,
         routingFallbackReason: "The original assignee is not invokable; recovery fell through to the manager ladder.",
       };
     }
     return {
-      ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(input.issue),
+      ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(
+        input.issue,
+        input.preferredOwnerAgentId,
+      ),
       returnOwnerAgentId,
       routingFallbackReason: null,
     };
@@ -2868,6 +2881,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     previousStatus: StrandedPreviousStatus;
     recoveryCause?: StrandedRecoveryCause;
+    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
@@ -2875,6 +2889,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issue: input.issue,
       latestRun: input.latestRun,
       recoveryCause,
+      preferredOwnerAgentId: input.recoveryOwnerAgentId,
     });
     const ownerAgentId = routing.ownerAgentId;
     const now = new Date();
@@ -3339,6 +3354,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       previousStatus: input.previousStatus,
       latestRun: input.latestRun,
       recoveryCause,
+      recoveryOwnerAgentId: input.recoveryOwnerAgentId,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const isProviderQuotaWait = recoveryCause === "provider_quota" &&
@@ -4157,6 +4173,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
       const handoffEvidence = isExhaustedSuccessfulRunHandoff(latestRun);
       if (handoffEvidence) {
+        if (isPluginManagedIssueLifecycle(issue)) {
+          result.skipped += 1;
+          continue;
+        }
         if (!handoffEvidence.exhausted) {
           result.skipped += 1;
           continue;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3363,6 +3363,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const wakePolicyType = typeof recoveryAction.wakePolicy === "object" &&
+        recoveryAction.wakePolicy &&
+        "type" in recoveryAction.wakePolicy &&
+        typeof recoveryAction.wakePolicy.type === "string"
+      ? recoveryAction.wakePolicy.type
+      : null;
     const preservesSourceAssignee =
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
@@ -3375,7 +3381,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
-    const takeoverRecoveryIssue = preservesSourceAssignee
+    const takeoverRecoveryIssue = preservesSourceAssignee && wakePolicyType === "wake_owner"
       ? await ensureStrandedIssueRecoveryIssue({
         issue: input.issue,
         latestRun: input.latestRun,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2713,6 +2713,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     previousStatus: StrandedPreviousStatus;
     recoveryCause?: StrandedRecoveryCause;
+    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
@@ -2720,7 +2721,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
 
-    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(
+      input.issue,
+      input.recoveryOwnerAgentId,
+    );
     if (!ownerAgentId) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -3225,6 +3229,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return existingUnresolvedBlockerIssues(companyId, issueId).then((rows) => rows.map((row) => row.id));
   }
 
+  async function ensureBlockingEdge(companyId: string, blockerIssueId: string, blockedIssueId: string) {
+    await db
+      .insert(issueRelations)
+      .values({
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      })
+      .onConflictDoNothing({
+        target: [
+          issueRelations.companyId,
+          issueRelations.issueId,
+          issueRelations.relatedIssueId,
+          issueRelations.type,
+        ],
+      });
+  }
+
   async function resolveContinuationWaitingOnReview(issue: typeof issues.$inferSelect) {
     const existingBlockers = await existingUnresolvedBlockerIssues(issue.companyId, issue.id);
     const openChildren = await db
@@ -3299,6 +3322,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     comment?: string;
     notice?: StrandedRecoveryNoticeSeed | null;
     recoveryCause?: StrandedRecoveryCause;
+    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) {
@@ -3329,11 +3353,40 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const wakePolicyType = typeof recoveryAction.wakePolicy === "object" &&
+        recoveryAction.wakePolicy &&
+        "type" in recoveryAction.wakePolicy &&
+        typeof recoveryAction.wakePolicy.type === "string"
+      ? recoveryAction.wakePolicy.type
+      : null;
+    const preservesSourceAssignee =
+      Boolean(recoveryAction.ownerAgentId) &&
+      Boolean(input.issue.assigneeAgentId) &&
+      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
+      assigneeAgentId: preservesSourceAssignee
+        ? input.issue.assigneeAgentId
+        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
+    const takeoverRecoveryIssue = preservesSourceAssignee && wakePolicyType === "wake_owner"
+      ? await ensureStrandedIssueRecoveryIssue({
+        issue: input.issue,
+        latestRun: input.latestRun,
+        previousStatus: input.previousStatus,
+        recoveryCause,
+        recoveryOwnerAgentId: recoveryAction.ownerAgentId,
+        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      })
+      : null;
+    const blockerIdsWithTakeover = takeoverRecoveryIssue
+      ? [...new Set([...blockerIds, takeoverRecoveryIssue.id])]
+      : blockerIds;
+    if (takeoverRecoveryIssue) {
+      await ensureBlockingEdge(input.issue.companyId, takeoverRecoveryIssue.id, input.issue.id);
+    }
     if (isProviderQuotaWait) return updated;
 
     const recoveryOwner = recoveryAction.ownerAgentId ? await getAgent(recoveryAction.ownerAgentId) : null;
@@ -3460,18 +3513,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         recoveryOwnerAgentId: recoveryAction.ownerAgentId,
         previousOwnerAgentId: recoveryAction.previousOwnerAgentId,
         returnOwnerAgentId: recoveryAction.returnOwnerAgentId,
-        blockerIssueIds: blockerIds,
+        blockerIssueIds: blockerIdsWithTakeover,
       },
     });
 
-    await enqueueSourceScopedStrandedRecoveryWake({
-      action: recoveryAction,
-      issue: input.issue,
-      latestRun: input.latestRun,
-      recoveryCause,
-    });
+    if (!takeoverRecoveryIssue) {
+      await enqueueSourceScopedStrandedRecoveryWake({
+        action: recoveryAction,
+        issue: input.issue,
+        latestRun: input.latestRun,
+        recoveryCause,
+      });
+    }
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3336,11 +3336,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    let blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const preservesSourceAssignee =
+      Boolean(recoveryAction.ownerAgentId) &&
+      Boolean(input.issue.assigneeAgentId) &&
+      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
+    const takeoverRecoveryIssue = preservesSourceAssignee
+      ? await ensureStrandedIssueRecoveryIssue({
+        issue: input.issue,
+        latestRun: input.latestRun,
+        previousStatus: input.previousStatus,
+        recoveryCause,
+        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      })
+      : null;
+    if (takeoverRecoveryIssue) {
+      blockerIds = [...new Set([...blockerIds, takeoverRecoveryIssue.id])];
+    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      assigneeAgentId: preservesSourceAssignee
+        ? input.issue.assigneeAgentId
+        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3473,14 +3491,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       },
     });
 
-    await enqueueSourceScopedStrandedRecoveryWake({
-      action: recoveryAction,
-      issue: input.issue,
-      latestRun: input.latestRun,
-      recoveryCause,
-    });
+    if (!takeoverRecoveryIssue) {
+      await enqueueSourceScopedStrandedRecoveryWake({
+        action: recoveryAction,
+        issue: input.issue,
+        latestRun: input.latestRun,
+        recoveryCause,
+      });
+    }
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3368,7 +3368,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const wakePolicyType = typeof recoveryAction.wakePolicy === "object" &&
         recoveryAction.wakePolicy &&
         "type" in recoveryAction.wakePolicy &&
@@ -3379,14 +3378,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
       recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
-    const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
-      blockedByIssueIds: blockerIds,
-      assigneeAgentId: preservesSourceAssignee
-        ? input.issue.assigneeAgentId
-        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
-    });
-    if (!updated) return null;
     const takeoverRecoveryIssue = preservesSourceAssignee && wakePolicyType === "wake_owner"
       ? await ensureStrandedIssueRecoveryIssue({
         issue: input.issue,
@@ -3397,12 +3388,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
       })
       : null;
-    const blockerIdsWithTakeover = takeoverRecoveryIssue
-      ? [...new Set([...blockerIds, takeoverRecoveryIssue.id])]
-      : blockerIds;
     if (takeoverRecoveryIssue) {
       await ensureBlockingEdge(input.issue.companyId, takeoverRecoveryIssue.id, input.issue.id);
     }
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const updated = await issuesSvc.update(input.issue.id, {
+      status: "blocked",
+      blockedByIssueIds: blockerIds,
+      assigneeAgentId: preservesSourceAssignee
+        ? input.issue.assigneeAgentId
+        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+    });
+    if (!updated) return null;
     if (isProviderQuotaWait) return updated;
 
     const recoveryOwner = recoveryAction.ownerAgentId ? await getAgent(recoveryAction.ownerAgentId) : null;
@@ -3529,7 +3526,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         recoveryOwnerAgentId: recoveryAction.ownerAgentId,
         previousOwnerAgentId: recoveryAction.previousOwnerAgentId,
         returnOwnerAgentId: recoveryAction.returnOwnerAgentId,
-        blockerIssueIds: blockerIdsWithTakeover,
+        blockerIssueIds: blockerIds,
       },
     });
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3363,40 +3363,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const wakePolicyType = typeof recoveryAction.wakePolicy === "object" &&
-        recoveryAction.wakePolicy &&
-        "type" in recoveryAction.wakePolicy &&
-        typeof recoveryAction.wakePolicy.type === "string"
-      ? recoveryAction.wakePolicy.type
-      : null;
-    const preservesSourceAssignee =
-      Boolean(recoveryAction.ownerAgentId) &&
-      Boolean(input.issue.assigneeAgentId) &&
-      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: preservesSourceAssignee
-        ? input.issue.assigneeAgentId
-        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
-    const takeoverRecoveryIssue = preservesSourceAssignee && wakePolicyType === "wake_owner"
-      ? await ensureStrandedIssueRecoveryIssue({
-        issue: input.issue,
-        latestRun: input.latestRun,
-        previousStatus: input.previousStatus,
-        recoveryCause,
-        recoveryOwnerAgentId: recoveryAction.ownerAgentId,
-        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
-      })
-      : null;
-    const blockerIdsWithTakeover = takeoverRecoveryIssue
-      ? [...new Set([...blockerIds, takeoverRecoveryIssue.id])]
-      : blockerIds;
-    if (takeoverRecoveryIssue) {
-      await ensureBlockingEdge(input.issue.companyId, takeoverRecoveryIssue.id, input.issue.id);
-    }
     if (isProviderQuotaWait) return updated;
 
     const recoveryOwner = recoveryAction.ownerAgentId ? await getAgent(recoveryAction.ownerAgentId) : null;
@@ -3523,20 +3494,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         recoveryOwnerAgentId: recoveryAction.ownerAgentId,
         previousOwnerAgentId: recoveryAction.previousOwnerAgentId,
         returnOwnerAgentId: recoveryAction.returnOwnerAgentId,
-        blockerIssueIds: blockerIdsWithTakeover,
+        blockerIssueIds: blockerIds,
       },
     });
 
-    if (!takeoverRecoveryIssue) {
-      await enqueueSourceScopedStrandedRecoveryWake({
-        action: recoveryAction,
-        issue: input.issue,
-        latestRun: input.latestRun,
-        recoveryCause,
-      });
-    }
+    await enqueueSourceScopedStrandedRecoveryWake({
+      action: recoveryAction,
+      issue: input.issue,
+      latestRun: input.latestRun,
+      recoveryCause,
+    });
 
-    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,
@@ -3547,13 +3516,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(1);
       if (
         currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
+        currentIssue.status !== "blocked"
       ) {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
         });
         if (reblocked) return reblocked;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2720,6 +2720,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     previousStatus: StrandedPreviousStatus;
     recoveryCause?: StrandedRecoveryCause;
+    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
@@ -2727,7 +2728,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
 
-    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(
+      input.issue,
+      input.recoveryOwnerAgentId,
+    );
     if (!ownerAgentId) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -3234,6 +3238,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return existingUnresolvedBlockerIssues(companyId, issueId).then((rows) => rows.map((row) => row.id));
   }
 
+  async function ensureBlockingEdge(companyId: string, blockerIssueId: string, blockedIssueId: string) {
+    await db
+      .insert(issueRelations)
+      .values({
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      })
+      .onConflictDoNothing({
+        target: [
+          issueRelations.companyId,
+          issueRelations.issueId,
+          issueRelations.relatedIssueId,
+          issueRelations.type,
+        ],
+      });
+  }
+
   async function resolveContinuationWaitingOnReview(issue: typeof issues.$inferSelect) {
     const existingBlockers = await existingUnresolvedBlockerIssues(issue.companyId, issue.id);
     const openChildren = await db
@@ -3339,23 +3362,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    let blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const preservesSourceAssignee =
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
       recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
-    const takeoverRecoveryIssue = preservesSourceAssignee
-      ? await ensureStrandedIssueRecoveryIssue({
-        issue: input.issue,
-        latestRun: input.latestRun,
-        previousStatus: input.previousStatus,
-        recoveryCause,
-        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
-      })
-      : null;
-    if (takeoverRecoveryIssue) {
-      blockerIds = [...new Set([...blockerIds, takeoverRecoveryIssue.id])];
-    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
@@ -3364,6 +3375,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
+    const takeoverRecoveryIssue = preservesSourceAssignee
+      ? await ensureStrandedIssueRecoveryIssue({
+        issue: input.issue,
+        latestRun: input.latestRun,
+        previousStatus: input.previousStatus,
+        recoveryCause,
+        recoveryOwnerAgentId: recoveryAction.ownerAgentId,
+        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      })
+      : null;
+    const blockerIdsWithTakeover = takeoverRecoveryIssue
+      ? [...new Set([...blockerIds, takeoverRecoveryIssue.id])]
+      : blockerIds;
+    if (takeoverRecoveryIssue) {
+      await ensureBlockingEdge(input.issue.companyId, takeoverRecoveryIssue.id, input.issue.id);
+    }
     if (isProviderQuotaWait) return updated;
 
     const recoveryOwner = recoveryAction.ownerAgentId ? await getAgent(recoveryAction.ownerAgentId) : null;
@@ -3490,7 +3517,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         recoveryOwnerAgentId: recoveryAction.ownerAgentId,
         previousOwnerAgentId: recoveryAction.previousOwnerAgentId,
         returnOwnerAgentId: recoveryAction.returnOwnerAgentId,
-        blockerIssueIds: blockerIds,
+        blockerIssueIds: blockerIdsWithTakeover,
       },
     });
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -270,6 +270,9 @@ function resolveStrandedRecoveryCause(
   if (explicitCause) return explicitCause;
   if (isProviderQuotaRecovery(latestRun)) return "provider_quota";
   if (latestRun?.errorCode === "process_lost") return "process_lost";
+  if (latestRun?.errorCode === "adapter_failed" && /process lost/i.test(latestRun.error ?? "")) {
+    return "process_lost";
+  }
   if (latestRun?.errorCode === "codex_output_inactivity_monitor") {
     return "codex_output_inactivity_monitor";
   }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2584,7 +2584,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause: StrandedRecoveryCause;
     preferredOwnerAgentId?: string | null;
   }) {
-    const originalAgentId = input.latestRun?.agentId ?? input.issue.assigneeAgentId;
+    // The source issue assignee remains the source of truth for who owns the
+    // work. A recovery/helper run may execute under a different agent, but that
+    // must not silently steal the task on restore.
+    const originalAgentId = input.issue.assigneeAgentId ?? input.latestRun?.agentId;
     const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -58,7 +58,6 @@ import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   buildSuccessfulRunHandoffExhaustedNotice,
-  isPluginManagedIssueLifecycle,
   noticeMetadataReferencesRecoveryAction,
   type SuccessfulRunHandoffNotice,
 } from "./successful-run-handoff.js";
@@ -270,9 +269,6 @@ function resolveStrandedRecoveryCause(
   if (explicitCause) return explicitCause;
   if (isProviderQuotaRecovery(latestRun)) return "provider_quota";
   if (latestRun?.errorCode === "process_lost") return "process_lost";
-  if (latestRun?.errorCode === "adapter_failed" && /process lost/i.test(latestRun.error ?? "")) {
-    return "process_lost";
-  }
   if (latestRun?.errorCode === "codex_output_inactivity_monitor") {
     return "codex_output_inactivity_monitor";
   }
@@ -2529,10 +2525,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function resolveStrandedIssueRecoveryOwnerAgentId(
     issue: typeof issues.$inferSelect,
-    preferredOwnerAgentId?: string | null,
   ) {
     const candidateIds: string[] = [];
-    if (preferredOwnerAgentId) candidateIds.push(preferredOwnerAgentId);
     if (issue.assigneeAgentId) {
       const assignee = await getAgent(issue.assigneeAgentId);
       if (assignee?.reportsTo) candidateIds.push(assignee.reportsTo);
@@ -2585,7 +2579,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
     recoveryCause: StrandedRecoveryCause;
-    preferredOwnerAgentId?: string | null;
   }) {
     // The source issue assignee remains the source of truth for who owns the
     // work. A recovery/helper run may execute under a different agent, but that
@@ -2622,10 +2615,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       };
     }
     return {
-      ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(
-        input.issue,
-        input.preferredOwnerAgentId,
-      ),
+      ownerAgentId: await resolveStrandedIssueRecoveryOwnerAgentId(input.issue),
       returnOwnerAgentId,
       routingFallbackReason: null,
     };
@@ -2723,7 +2713,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     previousStatus: StrandedPreviousStatus;
     recoveryCause?: StrandedRecoveryCause;
-    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
@@ -2731,10 +2720,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
 
-    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(
-      input.issue,
-      input.recoveryOwnerAgentId,
-    );
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     if (!ownerAgentId) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -2878,7 +2864,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     previousStatus: StrandedPreviousStatus;
     recoveryCause?: StrandedRecoveryCause;
-    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
@@ -2886,7 +2871,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issue: input.issue,
       latestRun: input.latestRun,
       recoveryCause,
-      preferredOwnerAgentId: input.recoveryOwnerAgentId,
     });
     const ownerAgentId = routing.ownerAgentId;
     const now = new Date();
@@ -3241,25 +3225,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return existingUnresolvedBlockerIssues(companyId, issueId).then((rows) => rows.map((row) => row.id));
   }
 
-  async function ensureBlockingEdge(companyId: string, blockerIssueId: string, blockedIssueId: string) {
-    await db
-      .insert(issueRelations)
-      .values({
-        companyId,
-        issueId: blockerIssueId,
-        relatedIssueId: blockedIssueId,
-        type: "blocks",
-      })
-      .onConflictDoNothing({
-        target: [
-          issueRelations.companyId,
-          issueRelations.issueId,
-          issueRelations.relatedIssueId,
-          issueRelations.type,
-        ],
-      });
-  }
-
   async function resolveContinuationWaitingOnReview(issue: typeof issues.$inferSelect) {
     const existingBlockers = await existingUnresolvedBlockerIssues(issue.companyId, issue.id);
     const openChildren = await db
@@ -3334,7 +3299,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     comment?: string;
     notice?: StrandedRecoveryNoticeSeed | null;
     recoveryCause?: StrandedRecoveryCause;
-    recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) {
@@ -3351,7 +3315,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       previousStatus: input.previousStatus,
       latestRun: input.latestRun,
       recoveryCause,
-      recoveryOwnerAgentId: input.recoveryOwnerAgentId,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const isProviderQuotaWait = recoveryCause === "provider_quota" &&
@@ -3933,7 +3896,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               latestRun: participantLatestRun,
               notice: buildExecutionReviewParticipantUnavailableNoticeSeed(),
               recoveryCause: EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON,
-              recoveryOwnerAgentId: participantAgentId,
             });
             if (updated) {
               result.escalated += 1;
@@ -3974,7 +3936,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             previousStatus: "in_review",
             latestRun: participantLatestRun,
             recoveryCause: "configuration_incomplete",
-            recoveryOwnerAgentId: participantAgentId,
             comment:
               "Paperclip classified the active review participant's latest adapter failure as " +
               "`configuration_incomplete`. Moving the issue to `blocked` with the configuration fix " +
@@ -4000,7 +3961,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             latestRun: participantLatestRun,
             notice: buildExecutionReviewParticipantUnavailableNoticeSeed(),
             recoveryCause: EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON,
-            recoveryOwnerAgentId: participantAgentId,
           });
           if (updated) {
             result.escalated += 1;
@@ -4018,7 +3978,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             latestRun: participantLatestRun,
             notice: buildExecutionReviewParticipantRecoveryNoticeSeed(),
             recoveryCause: EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON,
-            recoveryOwnerAgentId: participantAgentId,
           });
           if (updated) {
             result.escalated += 1;
@@ -4143,10 +4102,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
       const handoffEvidence = isExhaustedSuccessfulRunHandoff(latestRun);
       if (handoffEvidence) {
-        if (isPluginManagedIssueLifecycle(issue)) {
-          result.skipped += 1;
-          continue;
-        }
         if (!handoffEvidence.exhausted) {
           result.skipped += 1;
           continue;


### PR DESCRIPTION
## Summary
- restore explicit `recoveryOwnerAgentId` routing as an opt-in for recovery ownership while keeping the source issue assignee unchanged
- keep successful-run handoff recovery out of plugin-managed issue lifecycles
- add a regression test that plugin-managed missing-disposition cases stay on the source issue instead of escalating into generic recovery

## Issue Description
A terminal-run recovery path could still lose the intended recovery owner override after earlier assignee-preservation changes, and the same branch had accidentally removed the plugin-managed successful-handoff guard. The required behavior for this scope is:
- recovery must not rewrite `assigneeAgentId` on the source issue
- explicit recovery ownership stays opt-in and only affects the recovery action / recovery issue owner
- plugin-managed lifecycles stay out of generic successful-run handoff escalation

## What Changed
- thread `recoveryOwnerAgentId` back through `recovery/service.ts` as an explicit owner preference instead of using recovery-run ownership to rewrite the source assignee
- restore `isPluginManagedIssueLifecycle` gating before missing-disposition escalation
- cover the plugin-managed skip path in `heartbeat-process-recovery.test.ts`

## Verification
- `pnpm -C paperclip-ofm-4274 --filter @paperclipai/server exec vitest run src/__tests__/issue-recovery-actions.test.ts src/__tests__/heartbeat-process-recovery.test.ts -t "keeps the standing assignee|blocks failed execution-review recovery under the reviewer when the source assignee differs|skips missing-disposition escalation for plugin-managed issue lifecycles"`
- Result on August 20, 2026: Vitest starts, but both suites abort during import on existing unrelated failure `TypeError: setExpensiveWorkspaceGitExecutor is not a function` from `src/services/workspace-git-operation-scheduler.ts` before the targeted recovery tests execute.

## Risks
- Low. Scope is limited to recovery owner routing and the successful-handoff plugin-managed guard.
- The source issue assignee remains the source of truth; only recovery ownership selection regains the explicit override.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
