### PR TITLE
fix(pi-local): respect message roles in transcripts

### DIFF
--- a/packages/adapters/pi-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/pi-local/src/ui/parse-stdout.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { parsePiStdoutLine } from "./parse-stdout.js";
+
+const ts = "2026-08-20T10:00:00.000Z";
+
+describe("parsePiStdoutLine message_end", () => {
+  it("renders user messages as user transcript entries", () => {
+    const line = JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "## Paperclip Wake Payload" }],
+      },
+    });
+
+    expect(parsePiStdoutLine(line, ts)).toEqual([
+      { kind: "user", ts, text: "## Paperclip Wake Payload" },
+    ]);
+  });
+
+  it("does not duplicate tool-result messages", () => {
+    const line = JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "toolResult",
+        content: [{ type: "text", text: "file contents" }],
+      },
+    });
+
+    expect(parsePiStdoutLine(line, ts)).toEqual([]);
+  });
+
+  it("keeps assistant text and thinking entries", () => {
+    const line = JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "checking" },
+          { type: "text", text: "done" },
+        ],
+      },
+    });
+
+    expect(parsePiStdoutLine(line, ts)).toEqual([
+      { kind: "thinking", ts, text: "checking" },
+      { kind: "assistant", ts, text: "done" },
+    ]);
+  });
+
+  it("ignores unsupported message roles", () => {
+    const line = JSON.stringify({
+      type: "message_end",
+      message: { role: "system", content: "internal message" },
+    });
+
+    expect(parsePiStdoutLine(line, ts)).toEqual([]);
+  });
+});

--- a/packages/adapters/pi-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/pi-local/src/ui/parse-stdout.ts
@@ -225,25 +225,30 @@ export function parsePiStdoutLine(line: string, ts: string): TranscriptEntry[] {
 
   if (type === "message_end") {
     const message = asRecord(parsed.message);
-    if (message) {
-      const content = message.content as string | Array<{ type: string; text?: string; thinking?: string }>;
-      const { text, thinking } = extractTextContent(content);
-      
-      const entries: TranscriptEntry[] = [];
-      
-      // Emit final thinking block if present
-      if (thinking) {
-        entries.push({ kind: "thinking", ts, text: thinking });
-      }
-      
-      // Emit final text block if present
-      if (text) {
-        entries.push({ kind: "assistant", ts, text });
-      }
-      
-      return entries;
+    if (!message) return [];
+
+    const role = asString(message.role);
+    const content = message.content as string | Array<{ type: string; text?: string; thinking?: string }>;
+    const { text, thinking } = extractTextContent(content);
+
+    if (role === "user") {
+      return text ? [{ kind: "user", ts, text }] : [];
     }
-    return [];
+    if (role !== "assistant") return [];
+
+    const entries: TranscriptEntry[] = [];
+
+    // Emit final thinking block if present
+    if (thinking) {
+      entries.push({ kind: "thinking", ts, text: thinking });
+    }
+
+    // Emit final text block if present
+    if (text) {
+      entries.push({ kind: "assistant", ts, text });
+    }
+
+    return entries;
   }
 
   // Tool execution


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and shows their run transcripts
> - The Pi local adapter converts Pi JSON stdout events into transcript entries
> - Pi emits `message_end` events for user, assistant, and tool-result messages
> - The parser marked text from every `message_end` event as assistant output
> - This made the wake payload look like assistant output and repeated tool results
> - This pull request maps user messages to user entries and ignores other non-assistant messages
> - The benefit is correct speaker attribution without a change to assistant output

## Linked Issues or Issue Description

Fixes: #11780

## What Changed

- Read `message.role` before creating transcript entries.
- Render user messages as user entries.
- Ignore tool-result and unsupported roles in `message_end`.
- Add regression tests for user, assistant, tool-result, and unsupported roles.

## Verification

- `pnpm exec vitest run packages/adapters/pi-local/src/ui/parse-stdout.test.ts --config packages/adapters/pi-local/vitest.config.ts` — 4 tests passed.
- `pnpm --filter @paperclipai/adapter-pi-local typecheck` — passed.
- `pnpm --filter @paperclipai/adapter-pi-local build` — passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `pnpm test:run` — 4,498 tests passed, 30 failed, and 5 skipped. The failures are in unrelated server suites on macOS. They cover `/tmp` and `/private/tmp` path differences, workspace runtime checks, and test port allocation. The Pi parser regression tests passed again after the full run.

## Risks

Low risk. This change only affects Pi `message_end` transcript classification. Assistant text and thinking output stay the same.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with a GPT-5-based model. The session used reasoning, tool use, and code execution. The exact model ID and context window were not exposed to the session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
