### PR TITLE
fix(runtime): adopt running pre-exposure services instead of quarantining them as drift

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -61,7 +61,13 @@ import {
   buildWorkspaceRealizationRequest,
   readWorkspaceRealizationRequest,
 } from "../services/workspace-realization.ts";
-import { deriveViteHmrPort, type Environment, type EnvironmentLease } from "@paperclipai/shared";
+import {
+  deriveViteHmrPort,
+  RUNTIME_EXPOSURE_APP_PORT_MAX,
+  RUNTIME_EXPOSURE_APP_PORT_MIN,
+  type Environment,
+  type EnvironmentLease,
+} from "@paperclipai/shared";
 import { resolvePaperclipConfigPath } from "../paths.ts";
 import type { WorkspaceOperation } from "@paperclipai/shared";
 import type { WorkspaceOperationRecorder } from "../services/workspace-operations.ts";
@@ -7454,6 +7460,42 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
     await expect(fetch(service!.url!)).rejects.toThrow();
   });
 
+  /**
+   * A free loopback port inside the dedicated runtime exposure app range,
+   * falling back to an OS-assigned ephemeral port when the whole range is
+   * busy on this host.
+   *
+   * The adoption test below used to reserve with `listen(0)`, and on Linux CI
+   * the kernel's ephemeral span contains the dedicated range, so roughly one
+   * run in thirty landed in it by accident — the exact shape that made the
+   * startup drift sweep quarantine the row instead of adopting it. Reserving
+   * in-range on purpose turns that once-probabilistic collision into the case
+   * the test always exercises.
+   */
+  async function reserveAdoptionTestPort(): Promise<number> {
+    for (let candidate = RUNTIME_EXPOSURE_APP_PORT_MIN; candidate <= RUNTIME_EXPOSURE_APP_PORT_MAX; candidate += 1) {
+      const probe = net.createServer();
+      const bound = await new Promise<boolean>((resolve) => {
+        probe.once("error", () => resolve(false));
+        probe.listen(candidate, "127.0.0.1", () => resolve(true));
+      });
+      if (!bound) continue;
+      await new Promise<void>((resolve, reject) => {
+        probe.close((error) => error ? reject(error) : resolve());
+      });
+      return candidate;
+    }
+    const fallback = net.createServer();
+    await new Promise<void>((resolve) => fallback.listen(0, "127.0.0.1", resolve));
+    const address = fallback.address();
+    const port = typeof address === "object" && address ? address.port : null;
+    await new Promise<void>((resolve, reject) => {
+      fallback.close((error) => error ? reject(error) : resolve());
+    });
+    if (!port) throw new Error("Failed to reserve pnpm reconciliation test port");
+    return port;
+  }
+
   it("re-adopts a live service whose shell command differs from the surviving process argv", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-pnpm-reconcile-"));
     const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-home-"));
@@ -7462,14 +7504,7 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
     process.env.PAPERCLIP_HOME = paperclipHome;
     process.env.PAPERCLIP_INSTANCE_ID = `runtime-pnpm-reconcile-${randomUUID()}`;
 
-    const portProbe = net.createServer();
-    await new Promise<void>((resolve) => portProbe.listen(0, "127.0.0.1", resolve));
-    const address = portProbe.address();
-    const port = typeof address === "object" && address ? address.port : null;
-    await new Promise<void>((resolve, reject) => {
-      portProbe.close((error) => error ? reject(error) : resolve());
-    });
-    if (!port) throw new Error("Failed to reserve pnpm reconciliation test port");
+    const port = await reserveAdoptionTestPort();
 
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/services/runtime-exposure/port-reservation.test.ts
+++ b/server/src/services/runtime-exposure/port-reservation.test.ts
@@ -320,6 +320,29 @@ describe("regression 3: Serve mapping ownership mismatch is visible and fails cl
     expect(drift).toEqual([]);
   });
 
+  it("does not report a running pre-exposure service's own in-range port as drift", () => {
+    // The row is RUNNING with `exposure: null` — a pre-exposure service whose
+    // configured port happens to sit inside the dedicated range. At startup its
+    // surviving listener is unattributable (the in-memory runtime registry is
+    // empty), which used to read as drift and quarantine the row before the
+    // reconciler could adopt the service.
+    const drift = findExposureReservationDrift({
+      persistedRows: [stoppedTornDownRow({ status: "running", exposure: null })],
+      livePorts: new Set([42001, 52001]),
+    });
+
+    expect(drift).toEqual([]);
+  });
+
+  it("still sweeps a stopped pre-exposure row's reserved pair", () => {
+    const drift = findExposureReservationDrift({
+      persistedRows: [stoppedTornDownRow({ exposure: null })],
+      livePorts: new Set([42001]),
+    });
+
+    expect(drift).toMatchObject([{ port: 42001, reason: "live_listener", conflictingOwner: null }]);
+  });
+
   it("does not report a healthy running lane as drift", () => {
     const drift = findExposureReservationDrift({
       persistedRows: [{

--- a/server/src/services/runtime-exposure/port-reservation.ts
+++ b/server/src/services/runtime-exposure/port-reservation.ts
@@ -185,6 +185,24 @@ function rowClaimsLiveExposure(row: PersistedExposureRowSnapshot): boolean {
   return Boolean(row.exposure) && row.exposure!.state !== "removed";
 }
 
+/**
+ * True when the row itself says nothing of its own should be listening: it is
+ * recorded stopped/failed, its exposure was explicitly torn down, or it never
+ * reached `running` and left only a reserved pair behind.
+ *
+ * A RUNNING row with no exposure state at all is the one shape that must not
+ * count as dormant. Pre-exposure services carry a plain `port` column with
+ * `exposure: null`, and when that port happens to sit inside the dedicated
+ * range, a dormant classification turns the row's own live listener into a
+ * "drift" finding — which the startup sweep then quarantines instead of
+ * adopting, orphaning a healthy surviving service.
+ */
+export function isDormantExposureRow(row: PersistedExposureRowSnapshot): boolean {
+  if (row.status === "stopped" || row.status === "failed") return true;
+  if (row.exposure) return row.exposure.state === "removed";
+  return row.status !== "running";
+}
+
 function rowIdentity(row: PersistedExposureRowSnapshot): ExposureOwnerIdentity {
   return {
     runtimeServiceId: row.id,
@@ -459,8 +477,7 @@ export function findExposureReservationDrift(
 
   const drift: ExposureReservationDrift[] = [];
   for (const row of rows) {
-    const dormant = row.status === "stopped" || row.status === "failed" || !rowClaimsLiveExposure(row);
-    if (!dormant) continue;
+    if (!isDormantExposureRow(row)) continue;
     const owner = rowIdentity(row);
     for (const port of collectRowExposurePorts(row)) {
       const mappingOwner = mappingOwnerByPort.get(port) ?? null;

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -89,6 +89,7 @@ import {
   ExposurePortPairClaims,
   findExposurePairConflict,
   findExposureReservationDrift,
+  isDormantExposureRow,
   isExposureAdoptionPermitted,
   type BrokerMappingSnapshot,
   type ExposureOwnerIdentity,
@@ -4066,13 +4067,12 @@ async function detectPersistedExposureReservationDrift(input: {
     issueId: row.issueId,
   }));
 
-  // Probe only the ports dormant rows actually reserve; a startup sweep must not
-  // walk the whole dedicated range.
+  // Probe only the ports dormant rows actually reserve; a startup sweep must
+  // not walk the whole dedicated range, and a running pre-exposure service's
+  // own port is not a reservation to police at all.
   const candidatePorts = new Set<number>();
   for (const row of snapshots) {
-    if (row.status !== "stopped" && row.status !== "failed" && row.exposure && row.exposure.state !== "removed") {
-      continue;
-    }
+    if (!isDormantExposureRow(row)) continue;
     for (const port of collectRowExposurePorts(row)) candidatePorts.add(port);
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server test suite gates every merge, so a test that fails on unrelated diffs erodes trust in red results.
> - The shell-command adoption test added in [#11744](https://github.com/paperclipai/paperclip/pull/11744) failed on several unrelated PRs per day with `adopted: 0`.
> - The failure is not test-side scheduling luck: the startup exposure-drift sweep misclassifies a RUNNING row that has no exposure state as dormant, and quarantines the row's own live listener as "drift" whenever its port sits inside the dedicated exposure range.
> - The same misclassification would quarantine a real user's surviving pre-exposure service on startup instead of adopting it.
> - This pull request fixes the dormancy classification, pins it with unit tests, and makes the adoption test exercise the in-range collision deterministically instead of one run in thirty.
> - The benefit is a reconciler that adopts what is provably its own, and a test gate that fails only when the product is broken.

## Linked Issues or Issue Description

- [x] I searched open and closed issues and pull requests for this failure and for changes to the drift sweep. I found no duplicate report or fix; the affected code landed recently in [#11744](https://github.com/paperclipai/paperclip/pull/11744) (test) on top of the drift sweep from the leased-pair reservation work.

**What happened?**

The test `workspace-runtime.test.ts > workspace runtime startup reconciliation > re-adopts a live service whose shell command differs from the surviving process argv` failed intermittently on unrelated PRs, always the same way: `reconcilePersistedRuntimeServicesOnStartup` returned `{ reconciled: 1, adopted: 0, stopped: 0, restarted: 0, restartFailed: 0 }` where the test expects `adopted: 1`. Observed on run [32340664555](https://github.com/paperclipai/paperclip/actions/runs/32340664555) (an unrelated test-only PR), and the same day on runs [32374724597](https://github.com/paperclipai/paperclip/actions/runs/32374724597) and [32372961631](https://github.com/paperclipai/paperclip/actions/runs/32372961631) from other unrelated PRs.

The failing run's stderr contains the cause:

```
[workspace-runtime] exposure reservation drift: runtime service 4102b406-… is recorded
stopped/removed, but its reserved port 42055 still has a live loopback listener owned by
an unidentified owner
```

The row was recorded **running**, not stopped/removed — and port 42055 was the OS-assigned ephemeral port the test reserved with `listen(0)`, which happened to land inside the dedicated runtime exposure app range (42000–42999).

**Expected behavior**

A row recorded RUNNING with `exposure: null` is a live pre-exposure lane pending adoption. The startup drift sweep exists to surface rows that claim "nothing here" while the host says otherwise; a running row's own live listener on its configured port is the healthy case, not drift, and reconciliation should adopt the surviving process.

**Steps to reproduce**

Deterministic on any platform:

1. Persist a `workspace_runtime_services` row with `status: "running"`, `exposure: null`, and a `port` inside 42000–42999, with a matching local service registry record and a live process listening on that port (exactly what the adoption test constructs).
2. Run `reconcilePersistedRuntimeServicesOnStartup`.
3. Pre-fix: the drift sweep classifies the row dormant (`!rowClaimsLiveExposure` is true for `exposure: null`), probes its port, finds the service's own listener, cannot attribute it (the in-memory runtime registry is empty at startup, and attribution only consults in-memory runtimes), reports drift, and the reconcile loop quarantines the row — `adopted: 0`.

On CI this fired probabilistically: Linux's default ephemeral range (32768–60999) contains the dedicated range, so `listen(0)` landed in-range roughly one run in thirty. It never reproduced on macOS, whose ephemeral range starts at 49152.

**Paperclip version or commit**

Branched from `master` at `e1ce7a553`.

**Privacy checklist**

I reviewed this description and removed private instance URLs, internal task identifiers, credentials, and user paths.

## What Changed

- `runtime-exposure/port-reservation.ts`: the dormancy decision is extracted into an exported `isDormantExposureRow`. Stopped/failed rows, and rows whose exposure was explicitly torn down (`state: "removed"`), keep exactly today's behavior. A RUNNING row with no exposure state at all is the one shape that no longer counts as dormant. Provisioning/starting rows with no exposure keep their current dormant treatment — a crashed mid-start lane's reserved pair is still worth surfacing.
- `workspace-runtime.ts`: `detectPersistedExposureReservationDrift`'s candidate-port filter now uses the same predicate instead of a hand-rolled near-copy, so the probe set and the drift classification can no longer diverge.
- `port-reservation.test.ts`: two new pins — a running pre-exposure row's own in-range live listener is not drift, and a stopped pre-exposure row's reserved pair is still swept.
- `workspace-runtime.test.ts`: the adoption test now reserves a port inside the dedicated range on purpose (scanning for a free one, falling back to an ephemeral port only when the whole range is busy). The collision that used to hit one run in thirty is now the case the test always exercises.

## Verification

- Reproduced the CI failure deterministically before the fix: with the test forced onto an in-range port on macOS, it fails with the identical `adopted: 0` assertion and the identical drift warning as run [32340664555](https://github.com/paperclipai/paperclip/actions/runs/32340664555).
- After the fix, the same in-range scenario adopts: the test passes 5/5 repeat runs with no drift warning.
- `port-reservation.test.ts` 36/36 (including the two new pins); the leased-pair reservation regression suite (`workspace-runtime-exposure-reservation.test.ts`) 7/7 — the "reconciliation surfaces a removed row whose pair is mapped elsewhere, and adopts nothing" case is unaffected, since removed-exposure rows keep their dormant classification.
- `workspace-runtime.test.ts` and `workspace-runtime-exposure.test.ts` full runs show zero delta against a clean-master baseline on the same host (the handful of failures present are pre-existing local-environment failures on macOS, identical before and after, and pass on Linux CI).
- `pnpm run typecheck` passes in `server/`.

## Risks

- The behavior change is confined to rows that are RUNNING with `exposure: null`: they are no longer probed or reported by the drift sweep, and therefore no longer quarantined at startup. Rows a false-`stopped`/`removed` state was the concern for — the leased-pair regression class — are stopped/failed/removed-exposure rows, and their classification is unchanged and pinned by the existing regression suite.
- A running exposure-null row whose in-range port is genuinely held by someone else is no longer reported as drift; it now flows through ordinary reconciliation, which verifies ownership through the local service registry before adopting and otherwise stops the row and restarts it through the normal allocation path — a stricter outcome than the quarantine branch's leave-everything-as-is.
- The adoption test binds a real in-range port for the duration of one test. Its free-port scan mirrors the allocator's own probe, and the ephemeral fallback keeps the test runnable on a host where the entire range is occupied.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Fable 5 (Claude Code) — model ID `claude-fable-5`, with repository tools and local code execution for reproduction and repeat-run verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
