### PR TITLE
fix(OLY-117): forward-port off-box process_lost retry fix to origin/master

### DIFF
--- a/packages/db/src/migrations/0226_agent_runtime_failure_counter.sql
+++ b/packages/db/src/migrations/0226_agent_runtime_failure_counter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agent_runtime_state" ADD COLUMN IF NOT EXISTS "consecutive_failure_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent_runtime_state" ADD COLUMN IF NOT EXISTS "last_failure_at" timestamp with time zone;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1569,6 +1569,13 @@
       "when": 1787101144413,
       "tag": "0225_drop_claude_setup_token_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 226,
+      "version": "7",
+      "when": 1787244250465,
+      "tag": "0226_agent_runtime_failure_counter",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_runtime_state.ts
+++ b/packages/db/src/schema/agent_runtime_state.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, bigint, index } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, jsonb, bigint, integer, index } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { companies } from "./companies.js";
 
@@ -17,6 +17,8 @@ export const agentRuntimeState = pgTable(
     totalCachedInputTokens: bigint("total_cached_input_tokens", { mode: "number" }).notNull().default(0),
     totalCostCents: bigint("total_cost_cents", { mode: "number" }).notNull().default(0),
     lastError: text("last_error"),
+    consecutiveFailureCount: integer("consecutive_failure_count").notNull().default(0),
+    lastFailureAt: timestamp("last_failure_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/types/heartbeat.ts
+++ b/packages/shared/src/types/heartbeat.ts
@@ -204,6 +204,8 @@ export interface AgentRuntimeState {
   totalCachedInputTokens: number;
   totalCostCents: number;
   lastError: string | null;
+  consecutiveFailureCount: number;
+  lastFailureAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -492,6 +492,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runErrorCode?: string | null;
     runError?: string | null;
     contextSnapshot?: Record<string, unknown>;
+    runUpdatedAt?: Date;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -550,8 +551,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processLossRetryCount: input?.processLossRetryCount ?? 0,
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
-      startedAt: now,
-      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      startedAt: input?.runUpdatedAt ?? now,
+      updatedAt: input?.runUpdatedAt ?? new Date("2026-03-19T00:00:00.000Z"),
     });
 
     if (input?.includeIssue !== false) {
@@ -1471,6 +1472,140 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(heartbeatRuns)
       .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)));
     expect(retries).toHaveLength(0);
+  });
+
+  it("keeps a freshly started off-box run alive through the zero-threshold startup sweep", async () => {
+    const { runId } = await seedRunFixture({
+      adapterType: "openclaw_gateway",
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+      runUpdatedAt: new Date(Date.now() - 200),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result).toEqual({ reaped: 0, runIds: [] });
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBeNull();
+  });
+
+  it("queues exactly one retry when a stale off-box run has no probeable local process", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      adapterType: "openclaw_gateway",
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result).toEqual({ reaped: 1, runIds: [runId] });
+
+    const failedRun = await heartbeat.getRun(runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+
+    const retries = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)));
+    expect(retries).toHaveLength(1);
+    expect(retries[0]).toMatchObject({
+      agentId,
+      processLossRetryCount: 1,
+    });
+    expect(["queued", "running"]).toContain(retries[0]?.status);
+    expect(retries[0]?.contextSnapshot).toMatchObject({ retryReason: "process_lost" });
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(retries[0]?.id ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("reaps a stale off-box run without another process-loss retry once its budget is spent", async () => {
+    const { companyId, runId } = await seedRunFixture({
+      adapterType: "openclaw_gateway",
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+      processLossRetryCount: 1,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result).toEqual({ reaped: 1, runIds: [runId] });
+
+    const followUps = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)));
+    expect(followUps.filter((row) => (row.processLossRetryCount ?? 0) > 1)).toHaveLength(0);
+    expect(
+      followUps.filter((row) => (row.contextSnapshot as Record<string, unknown> | null)?.retryReason === "process_lost"),
+    ).toHaveLength(0);
+  });
+
+  it("records a rolling failure count on the agent runtime state when runs are reaped", async () => {
+    const { agentId, runId } = await seedRunFixture({
+      adapterType: "openclaw_gateway",
+      agentStatus: "idle",
+      processPid: null,
+      processGroupId: null,
+      processLossRetryCount: 1,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.reapOrphanedRuns();
+
+    const state = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(state?.consecutiveFailureCount).toBe(1);
+    expect(state?.lastFailureAt).toBeTruthy();
+    expect(runId).toBeTruthy();
+  });
+
+  it("clears the rolling failure count once the agent completes a run successfully", async () => {
+    const { companyId, agentId } = await seedAssignedTodoNoRunFixture();
+    await db.insert(agentRuntimeState).values({
+      agentId,
+      companyId,
+      adapterType: "codex_local",
+      stateJson: {},
+      consecutiveFailureCount: 4,
+      lastFailureAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(1);
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+    if (!run?.id) throw new Error("Expected a dispatched run");
+    const settled = await waitForRunToSettle(heartbeat, run.id);
+    expect(settled?.status).toBe("succeeded");
+
+    const state = await waitForValue(async () =>
+      db
+        .select()
+        .from(agentRuntimeState)
+        .where(eq(agentRuntimeState.agentId, agentId))
+        .then((rows) => (rows[0]?.consecutiveFailureCount === 0 ? rows[0] : null))
+    );
+    expect(state?.consecutiveFailureCount).toBe(0);
   });
 
   async function withTempPaperclipHome<T>(fn: (home: string) => Promise<T>): Promise<T> {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -773,6 +773,12 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+// Runs we cannot probe (no local child process to check) need a grace period
+// before we call them lost: a missing pid is the normal case off-box, not
+// evidence of death, and the remote session may still be running.
+const UNPROBEABLE_RUN_STALE_THRESHOLD_MS = 2 * 60 * 1000;
+// Log loudly once an agent's consecutive-failure streak reaches this length.
+const RUNTIME_FAILURE_STREAK_WARN_THRESHOLD = 3;
 // Routes and the scheduler construct separate heartbeatService instances, but
 // they must agree on in-process adapter executions when reaping stale runs.
 const activeRunExecutions = new Set<string>();
@@ -6330,7 +6336,7 @@ async function terminateHeartbeatRunProcess(input: {
 function buildProcessLossMessage(run: {
   processPid: number | null;
   processGroupId: number | null;
-}, options?: { descendantOnly?: boolean }) {
+}, options?: { descendantOnly?: boolean; unprobeableAdapterType?: string }) {
   if (options?.descendantOnly && run.processGroupId) {
     return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
   }
@@ -6339,6 +6345,9 @@ function buildProcessLossMessage(run: {
   }
   if (run.processGroupId) {
     return `Process lost -- process group ${run.processGroupId} is no longer running`;
+  }
+  if (options?.unprobeableAdapterType) {
+    return `Run lost -- ${options.unprobeableAdapterType} has no local process to probe and the run went stale after the control plane lost its handle`;
   }
   return "Process lost -- server may have restarted";
 }
@@ -12923,6 +12932,57 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return trimmed.length > 500 ? `${trimmed.slice(0, 499)}…` : trimmed;
   }
 
+  // Rolling consecutive-failure counter on the agent's runtime state. Runs
+  // reaped as process_lost never reach updateRuntimeState, so without this a
+  // stall-prone agent leaves no trace on its own record.
+  async function recordRuntimeFailureOutcome(
+    agent: typeof agents.$inferSelect,
+    outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+  ) {
+    if (outcome === "cancelled") return;
+    const failed = outcome === "failed" || outcome === "timed_out";
+    const now = new Date();
+
+    const [state] = await db
+      .insert(agentRuntimeState)
+      .values({
+        agentId: agent.id,
+        companyId: agent.companyId,
+        adapterType: agent.adapterType,
+        stateJson: {},
+        consecutiveFailureCount: failed ? 1 : 0,
+        lastFailureAt: failed ? now : null,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: agentRuntimeState.agentId,
+        set: failed
+          ? {
+            consecutiveFailureCount: sql`${agentRuntimeState.consecutiveFailureCount} + 1`,
+            lastFailureAt: now,
+            updatedAt: now,
+          }
+          : {
+            consecutiveFailureCount: 0,
+            updatedAt: now,
+          },
+      })
+      .returning();
+
+    if (failed && (state?.consecutiveFailureCount ?? 0) >= RUNTIME_FAILURE_STREAK_WARN_THRESHOLD) {
+      logger.warn(
+        {
+          agentId: agent.id,
+          companyId: agent.companyId,
+          adapterType: agent.adapterType,
+          consecutiveFailureCount: state?.consecutiveFailureCount,
+        },
+        "agent has a streak of consecutive failed heartbeat runs",
+      );
+    }
+    return state ?? null;
+  }
+
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "interrupted" | "failed" | "cancelled" | "timed_out",
@@ -12931,6 +12991,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ) {
     const existing = await getAgent(agentId);
     if (!existing) return;
+
+    // Record the failure streak before the paused/terminated early return: a
+    // paused agent's failures are exactly the ones we need to be able to see.
+    if (outcome !== "interrupted") {
+      await recordRuntimeFailureOutcome(existing, outcome as "succeeded" | "failed" | "cancelled" | "timed_out");
+    }
 
     if (existing.status === "paused" || existing.status === "terminated") {
       return;
@@ -13472,8 +13538,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { swept: rows.length, destroyed, capped };
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: {
+    staleThresholdMs?: number;
+    unprobeableStaleThresholdMs?: number;
+  }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const unprobeableStaleThresholdMs =
+      opts?.unprobeableStaleThresholdMs ?? UNPROBEABLE_RUN_STALE_THRESHOLD_MS;
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -13515,13 +13586,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
 
-      // Apply staleness threshold to avoid false positives
-      if (staleThresholdMs > 0) {
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+      // Only a tracked local child gives us a liveness probe that can succeed.
+      // Everything else (off-box adapters, or a local run reaped before spawn)
+      // is unprobeable, so absence of a pid proves nothing.
+      const hasProbeableLocalProcess = tracksLocalChild && (!!run.processPid || !!run.processGroupId);
+
+      // Apply staleness threshold to avoid false positives. Unprobeable runs get
+      // a grace period even on the zero-threshold startup sweep.
+      const effectiveStaleThresholdMs = hasProbeableLocalProcess
+        ? staleThresholdMs
+        : Math.max(staleThresholdMs, unprobeableStaleThresholdMs);
+      if (effectiveStaleThresholdMs > 0) {
         const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
-        if (now.getTime() - refTime < staleThresholdMs) continue;
+        if (now.getTime() - refTime < effectiveStaleThresholdMs) continue;
       }
 
-      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
       if (
@@ -13566,15 +13646,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const monitorNextCheckAt = monitorIssueId
         ? monitorNextCheckAtByIssue.get(`${run.companyId}:${monitorIssueId}`)
         : undefined;
-      const monitorDispatchLostWithoutFutureWake =
+      // A monitor dispatch with a future scheduled wake should not be retried:
+      // retrying would double-dispatch and the scheduled wake will already re-run
+      // the issue. Preserve this guard so the load-bearing test stays green.
+      const monitorDispatchWithFutureWake =
         readNonEmptyString(runContext.wakeReason) === "issue_monitor_due" &&
         monitorNextCheckAt !== undefined &&
-        (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= now.getTime());
-      const shouldRetry = (run.processLossRetryCount ?? 0) < 1 && (
-        (tracksLocalChild && (!!run.processPid || !!run.processGroupId)) ||
-        monitorDispatchLostWithoutFutureWake
+        monitorNextCheckAt !== null &&
+        monitorNextCheckAt.getTime() > now.getTime();
+      // Interaction continuation runs have their own infra-retry path
+      // (scheduleInteractionContinuationInfrastructureRetryIfEligible) which is
+      // more appropriate than a raw process-loss retry — don't override it.
+      const eligibleForInfraContinuationRetry = isResolvedInteractionContinuationWakeContext(run.contextSnapshot);
+      // Retry unless the single automatic budget is spent, a future monitor
+      // wake is already scheduled, or the run has a dedicated infra-retry path.
+      // Previously this also required a tracked local child, which meant off-box
+      // adapter runs were failed with no probe that could ever succeed and no
+      // retry at all.
+      const shouldRetry = (run.processLossRetryCount ?? 0) < 1 && !monitorDispatchWithFutureWake && !eligibleForInfraContinuationRetry;
+      const baseMessage = buildProcessLossMessage(
+        run,
+        descendantOnlyCleanup
+          ? { descendantOnly: true }
+          : hasProbeableLocalProcess
+            ? undefined
+            : { unprobeableAdapterType: adapterType },
       );
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
       const unmanagedBackgroundTaskEvidence = descendantOnlyCleanup
         ? {
           kind: "orphaned_process_group_cleanup",


### PR DESCRIPTION
## Summary

Forward-ports the OLY-103 off-box `process_lost` retry fix from local `master` (`d0e9cc76`) onto `origin/master` (~1330 commits ahead). Three scope items:

**1. Retry parity** — `shouldRetry` no longer requires a tracked local child pid. Off-box runs (e.g. `openclaw_gateway`) now get the same single automatic process-loss retry that local runs get. Two guards are preserved:
- Monitor dispatches with a future `monitorNextCheckAt` are excluded (no double-dispatch).
- Interaction continuation runs are excluded so their existing infra-retry path fires instead.

**2. Staleness grace period** — runs without a probeable local process get `UNPROBEABLE_RUN_STALE_THRESHOLD_MS` (2 min) grace on the zero-threshold startup reap, so a control-plane restart doesn't instantly fail a remote session still running.

**3. Failure counter** — `agent_runtime_state` gains `consecutive_failure_count` / `last_failure_at` columns written by `recordRuntimeFailureOutcome` (called from `finalizeAgentStatus` before the paused early-return).

## Verification

`npx vitest run --project '@paperclipai/server' server/src/__tests__/heartbeat-process-recovery.test.ts`

**Result: 108/108 passing**, including 5 new off-box/counter cases and all pre-existing reap tests.

## Files changed

- `packages/db/src/migrations/0226_agent_runtime_failure_counter.sql` — new migration
- `packages/db/src/migrations/meta/_journal.json` — journal entry
- `packages/db/src/schema/agent_runtime_state.ts` — schema columns
- `packages/shared/src/types/heartbeat.ts` — type fields
- `server/src/services/heartbeat.ts` — core logic
- `server/src/__tests__/heartbeat-process-recovery.test.ts` — 5 new test cases

Refs OLY-117