### PR TITLE
fix(recovery): preserve source assignee during stranded fallback

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5156,7 +5156,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(sourceIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: sourceAssigneeAgentId,
+      assigneeAgentId: agentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5156,7 +5156,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(sourceIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: agentId,
+      assigneeAgentId: sourceAssigneeAgentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -885,7 +885,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "in_review",
-      assigneeAgentId: coderId,
+      assigneeAgentId: managerId,
       monitorNextCheckAt: null,
     });
     const [assigneeRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, assigneeRunId));
@@ -946,7 +946,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: coderId,
+      assigneeAgentId: managerId,
     });
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -383,6 +383,70 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     },
   );
 
+  it("keeps the current source assignee as the recovery return owner when the latest run came from another agent", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const ceoId = randomUUID();
+    await db.insert(agents).values({
+      id: ceoId,
+      companyId,
+      name: "Claude CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: ceoId,
+        status: "failed",
+        error: "helper recovery run lost the process",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const [updatedIssue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerAgentId: coderId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "process_lost",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      coderId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({
+          issueId: sourceIssue.id,
+          sourceIssueId: sourceIssue.id,
+          recoveryCause: "process_lost",
+        }),
+      }),
+    );
+  });
+
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({
@@ -1228,67 +1292,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     // Dedupe for structured notices is metadata-based: the short body no longer
     // carries the `Recovery action: \`id\`` marker line.
     expect(comments[0]?.body).not.toContain("Recovery action:");
-  expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
-  expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
-  });
-
-  it("preserves the source assignee and creates a recovery issue for manager fallback", async () => {
-    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
-    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
-    const enqueueWakeup = vi.fn(async () => null);
-    const recovery = recoveryService(db, { enqueueWakeup });
-
-    await recovery.escalateStrandedAssignedIssue({
-      issue: sourceIssue,
-      previousStatus: "in_progress",
-      latestRun: {
-        id: randomUUID(),
-        agentId: coderId,
-        status: "failed",
-        error: "worker exited unexpectedly",
-        errorCode: "process_lost",
-        contextSnapshot: { retryReason: "issue_continuation_needed" },
-        livenessState: "needs_followup",
-      },
-      comment: "Automatic continuation recovery failed.",
-    });
-
-    const [updatedSource] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(updatedSource).toMatchObject({
-      status: "blocked",
-      assigneeAgentId: coderId,
-    });
-
-    const recoveryIssues = await db
-      .select()
-      .from(issues)
-      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
-    expect(recoveryIssues).toHaveLength(1);
-    expect(recoveryIssues[0]).toMatchObject({
-      parentId: sourceIssue.id,
-      assigneeAgentId: managerId,
-      originId: sourceIssue.id,
-      status: "todo",
-    });
-
-    const relations = await db
-      .select()
-      .from(issueRelations)
-      .where(and(eq(issueRelations.issueId, recoveryIssues[0]!.id), eq(issueRelations.relatedIssueId, sourceIssue.id)));
-    expect(relations.some((row) => row.type === "blocks")).toBe(true);
-
-    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
-    expect(enqueueWakeup).toHaveBeenCalledWith(
-      managerId,
-      expect.objectContaining({
-        reason: "issue_assigned",
-        payload: expect.objectContaining({
-          issueId: recoveryIssues[0]!.id,
-          sourceIssueId: sourceIssue.id,
-          recoveryCause: "process_lost",
-        }),
-      }),
-    );
+    expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
+    expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -885,7 +885,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "in_review",
-      assigneeAgentId: managerId,
+      assigneeAgentId: coderId,
       monitorNextCheckAt: null,
     });
     const [assigneeRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, assigneeRunId));

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1228,8 +1228,67 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     // Dedupe for structured notices is metadata-based: the short body no longer
     // carries the `Recovery action: \`id\`` marker line.
     expect(comments[0]?.body).not.toContain("Recovery action:");
-    expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
-    expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
+  expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
+  expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
+  });
+
+  it("preserves the source assignee and creates a recovery issue for manager fallback", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "worker exited unexpectedly",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedSource] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedSource).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(1);
+    expect(recoveryIssues[0]).toMatchObject({
+      parentId: sourceIssue.id,
+      assigneeAgentId: managerId,
+      originId: sourceIssue.id,
+      status: "todo",
+    });
+
+    const relations = await db
+      .select()
+      .from(issueRelations)
+      .where(and(eq(issueRelations.issueId, recoveryIssues[0]!.id), eq(issueRelations.relatedIssueId, sourceIssue.id)));
+    expect(relations.some((row) => row.type === "blocks")).toBe(true);
+
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: recoveryIssues[0]!.id,
+          sourceIssueId: sourceIssue.id,
+          recoveryCause: "process_lost",
+        }),
+      }),
+    );
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -946,7 +946,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: managerId,
+      assigneeAgentId: coderId,
     });
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -447,6 +447,38 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
+  it("preserves a newer source assignee when stale recovery re-blocks the issue", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+    const [managerOwnedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+
+    const enqueueWakeup = vi.fn(async () => {
+      await db.update(issues).set({ assigneeAgentId: coderId }).where(eq(issues.id, sourceIssueId));
+      return null;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: managerOwnedIssue!,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: managerId,
+        status: "failed",
+        error: "recovery run lost the process after reassignment",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+  });
+
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2587,7 +2587,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // The issue assignee remains the owner of record even if a helper run
     // executes under another agent during recovery.
     const originalAgentId = input.issue.assigneeAgentId ?? input.latestRun?.agentId;
-    const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
+    const returnOwnerAgentId = originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
       input.recoveryCause === "codex_output_inactivity_monitor";
@@ -3339,21 +3339,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const executionState = parseIssueExecutionState(input.issue.executionState);
-    const stageParticipantAgentId = executionState?.status === "pending" && executionState.currentParticipant?.type === "agent"
-      ? executionState.currentParticipant.agentId
-      : null;
-    const preservesSourceAssignee =
-      Boolean(recoveryAction.ownerAgentId) &&
-      Boolean(input.issue.assigneeAgentId) &&
-      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId &&
-      recoveryAction.ownerAgentId !== stageParticipantAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: preservesSourceAssignee
-        ? input.issue.assigneeAgentId
-        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3502,11 +3490,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .from(issues)
         .where(eq(issues.id, input.issue.id))
         .limit(1);
-      if (
-        currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
-      ) {
+      if (currentIssue && currentIssue.status !== "blocked") {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3510,7 +3510,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
         });
         if (reblocked) return reblocked;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3336,11 +3336,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    let blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const preservesSourceAssignee =
+      Boolean(recoveryAction.ownerAgentId) &&
+      Boolean(input.issue.assigneeAgentId) &&
+      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
+    const takeoverRecoveryIssue = preservesSourceAssignee
+      ? await ensureStrandedIssueRecoveryIssue({
+        issue: input.issue,
+        latestRun: input.latestRun,
+        previousStatus: input.previousStatus,
+        recoveryCause,
+        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      })
+      : null;
+    if (takeoverRecoveryIssue) {
+      blockerIds = [...new Set([...blockerIds, takeoverRecoveryIssue.id])];
+    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      assigneeAgentId: preservesSourceAssignee
+        ? input.issue.assigneeAgentId
+        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3473,14 +3491,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       },
     });
 
-    await enqueueSourceScopedStrandedRecoveryWake({
-      action: recoveryAction,
-      issue: input.issue,
-      latestRun: input.latestRun,
-      recoveryCause,
-    });
+    if (!takeoverRecoveryIssue) {
+      await enqueueSourceScopedStrandedRecoveryWake({
+        action: recoveryAction,
+        issue: input.issue,
+        latestRun: input.latestRun,
+        recoveryCause,
+      });
+    }
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3341,7 +3341,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
       blockedByIssueIds: blockerIds,
     });
     if (!updated) return null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2584,7 +2584,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause: StrandedRecoveryCause;
     preferredOwnerAgentId?: string | null;
   }) {
-    const originalAgentId = input.latestRun?.agentId ?? input.issue.assigneeAgentId;
+    // The issue assignee remains the owner of record even if a helper run
+    // executes under another agent during recovery.
+    const originalAgentId = input.issue.assigneeAgentId ?? input.latestRun?.agentId;
     const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
@@ -3336,23 +3338,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    let blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const preservesSourceAssignee =
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
       recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
-    const takeoverRecoveryIssue = preservesSourceAssignee
-      ? await ensureStrandedIssueRecoveryIssue({
-        issue: input.issue,
-        latestRun: input.latestRun,
-        previousStatus: input.previousStatus,
-        recoveryCause,
-        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
-      })
-      : null;
-    if (takeoverRecoveryIssue) {
-      blockerIds = [...new Set([...blockerIds, takeoverRecoveryIssue.id])];
-    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
@@ -3491,16 +3481,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       },
     });
 
-    if (!takeoverRecoveryIssue) {
-      await enqueueSourceScopedStrandedRecoveryWake({
-        action: recoveryAction,
-        issue: input.issue,
-        latestRun: input.latestRun,
-        recoveryCause,
-      });
-    }
+    await enqueueSourceScopedStrandedRecoveryWake({
+      action: recoveryAction,
+      issue: input.issue,
+      latestRun: input.latestRun,
+      recoveryCause,
+    });
 
-    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3339,10 +3339,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const executionState = parseIssueExecutionState(input.issue.executionState);
+    const stageParticipantAgentId = executionState?.status === "pending" && executionState.currentParticipant?.type === "agent"
+      ? executionState.currentParticipant.agentId
+      : null;
     const preservesSourceAssignee =
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
-      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
+      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId &&
+      recoveryAction.ownerAgentId !== stageParticipantAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3341,6 +3341,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
+      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
       blockedByIssueIds: blockerIds,
     });
     if (!updated) return null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - This change stays inside the server stranded-recovery path for assigned issues.
> - OFM-4569 is specifically about helper recovery runs stealing the standing assignee from the source issue.
> - The source assignee must remain the owner of record for that helper-recovery path.
> - Review-stage recovery is a different contract: when the recovery owner is the current execution participant, the issue must still stay with that participant.
> - This PR therefore preserves the standing assignee only for non-review takeover fallback and leaves the review-participant contract intact.
> - The result is a smaller review surface that matches the issue and the upstream review-stage semantics.

## Linked Issues or Issue Description

Refs #11779
Refs #11782

## What Changed

- Keep `issue.assigneeAgentId` as the source of truth when stranded helper recovery evaluates a run from another agent.
- Exempt the active execution-stage participant from that preservation rule, so review-stage recovery keeps the issue on the current participant.
- Add a regression test for assignee `A`, helper run by agent `B`, and verify the source issue stays assigned to `A`.
- Keep the change scoped to recovery routing and assignee preservation only.

## Verification

- `pnpm vitest run server/src/__tests__/issue-recovery-actions.test.ts --reporter=verbose`
  Result on August 20, 2026: file loads cleanly; embedded Postgres suites are skipped on this host because the probe fails with `listen EPERM: operation not permitted 127.0.0.1` (`1 passed | 45 skipped`).
- `pnpm --filter @paperclipai/server typecheck`
  Result on August 20, 2026: fails on pre-existing unrelated `@paperclipai/plugin-sdk` resolution / plugin typing errors outside this diff.

## Risks

- Low risk. The diff is limited to stranded recovery owner resolution in `server/src/services/recovery/service.ts` and the focused recovery regression coverage.
- Main reviewer check is that helper recovery no longer steals the standing assignee, while execution-review participant recovery still keeps the issue on the participant.

## Model Used

- OpenAI Codex, GPT-5.4, tool-assisted coding in Paperclip runtime with shell and patch tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and documented the exact result above
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
