### PR TITLE
feat(adapters): add OpenRouter as first-party adapter (@paperclipai/adapter-openrouter)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -44,6 +44,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-openrouter": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -10,6 +10,8 @@ import { printHermesStreamEvent } from "@paperclipai/hermes-paperclip-adapter/cl
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { formatEvent as openrouterFormatEvent } from "@paperclipai/adapter-openrouter/cli";
+import { type as openrouterType, label as openrouterLabel } from "@paperclipai/adapter-openrouter";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -68,6 +70,16 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const openrouterCLIAdapter: CLIAdapterModule = {
+  type: openrouterType,
+  formatStdoutEvent: (line: string, _debug: boolean) => {
+    const formatted = openrouterFormatEvent(line);
+    if (formatted !== null) {
+      console.log(formatted);
+    }
+  },
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     claudeLocalCLIAdapter,
@@ -81,6 +93,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     hermesGatewayCLIAdapter,
     hermesLocalCLIAdapter,
     openclawGatewayCLIAdapter,
+    openrouterCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,
   ].map((a) => [a.type, a]),

--- a/packages/adapters/openrouter/.gitignore
+++ b/packages/adapters/openrouter/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+README.md.bak

--- a/packages/adapters/openrouter/.npmignore
+++ b/packages/adapters/openrouter/.npmignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+.env
+*.log

--- a/packages/adapters/openrouter/LICENSE
+++ b/packages/adapters/openrouter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Talha Mahmood
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/adapters/openrouter/README.md
+++ b/packages/adapters/openrouter/README.md
@@ -1,0 +1,377 @@
+# @paperclipai/adapter-openrouter
+
+**OpenRouter adapter for Paperclip** — give every agent a real tool-calling loop, access to 300+ models (free & paid), and full Paperclip-API integration through a single API key.
+
+> If it can receive a heartbeat, it's hired. Now it can think with *any* model — and actually *do* things.
+
+[![Status: Verified working end-to-end](https://img.shields.io/badge/status-verified%20working-brightgreen)]()
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)]()
+[![Built for Paperclip](https://img.shields.io/badge/built%20for-Paperclip-8b5cf6)]()
+
+---
+
+## What This Does
+
+Connects Paperclip agents to [OpenRouter](https://openrouter.ai) with a complete agent runtime built directly into the adapter — no CLI subprocess, no wrapper, no missing capabilities.
+
+### Agent capabilities
+
+- **Multi-turn tool-calling loop** — model calls tools, adapter executes them, results feed back, loop continues until the model is done or `maxTurns` is hit
+- **Built-in Paperclip API tools** — 8 tools wired to Paperclip's REST API so agents can read issues, post comments, update status, create sub-issues, hire teammates, and request approvals
+- **Auto issue state management** — issues move to `in_progress` when work starts and `done` / `blocked` when it finishes
+- **Final output posted as a comment** — every run leaves a comment on the issue so other agents and humans can see the result
+- **Smart issue checkout** — automatically detects when Paperclip's heartbeat already pre-locked the issue and skips redundant API calls
+- **Skill loading** — drops `SKILL.md` files into the agent's system prompt at runtime
+- **Reasoning support** — DeepSeek R1, QwQ, and other thinking models emit `thinking` transcript entries separately from the final answer
+- **Approval gating** — `hire_agent` and other mutating tools route through Paperclip's approval system by default (override with `autoApprove: true`)
+- **Repeat-call loop break** — detects when a model gets stuck calling the same tool with the same args and breaks the loop with a clear error
+
+### Model access
+
+- **300+ models** from OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, and more
+- **50+ free models** — Llama 4 Maverick, Gemma 3, DeepSeek V3, Qwen3 235B, gpt-oss-120b, etc.
+- **Auto-routing** — let OpenRouter pick the cheapest/fastest model per request
+- **Fallback routing** — automatic provider failover on 5xx errors
+- **Cost tracking** — real USD cost per generation, fed into Paperclip's budget system
+- **Dynamic model discovery** — fetches the model list live from OpenRouter
+
+---
+
+## Verified Working
+
+This adapter has been tested end-to-end against a real running Paperclip instance with a real CEO agent on the PanicButton company. Every tool in the suite has been exercised in production runs:
+
+| Run | Issue | Tools fired | Outcome |
+|---|---|---|---|
+| **CRE-4** | Status report and delegation | `list_issues`, `get_issue`, `add_comment`, `create_sub_issue` ×3, `update_issue_status` | ✅ Status report posted, 3 sub-issues created (CRE-5/6/7), parent moved to in_progress |
+| **CRE-15** | Hire flow | `get_issue`, `hire_agent`, `add_comment` | ✅ Approval row created in Paperclip, rendered in UI Approvals panel, human approved, **agent "Bob" materialized in org chart** |
+| **CRE-16** | Comment + status | `get_issue`, `add_comment`, `update_issue_status` | ✅ Comment landed, status moved to done |
+| **CRE-25** | Final clean run | `get_issue`, `add_comment`, `update_issue_status` | ✅ Six tool calls, zero warnings, $0.0035 cost, ~10s end to end |
+
+**Tested models:**
+- ✅ `openai/gpt-4o-mini` — best-in-class function calling, ~$0.003 per multi-tool run
+- ✅ `openai/gpt-oss-120b:free` — reliable function calling, free tier
+- ⚠️ `stepfun/step-3.5-flash:free` — fakes tool calls as XML text, **not recommended** (model issue, not adapter)
+
+---
+
+## Quick Start
+
+### 1. Get an OpenRouter API Key
+
+Go to <https://openrouter.ai/keys> and create a key. Free models work with $0 balance, but OpenRouter caps free-tier accounts at 50 requests per day total. Adding $5 in credits unlocks 1000 free-model requests/day and also lets you use paid models.
+
+### 2. Enable the adapter (built-in)
+
+The adapter ships in-repo as `@paperclipai/adapter-openrouter`. Enable it from your Paperclip repo root:
+
+```bash
+pnpm install
+pnpm -r build
+```
+
+### 3. Apply registry wiring
+
+You need to register the adapter in 3 places:
+
+- `server/src/adapters/registry.ts` — add `openrouterAdapter` with `supportsLocalAgentJwt: true`
+- `server/src/adapters/builtin-adapter-types.ts` — add `"openrouter"` to the type union
+- `ui/src/adapters/registry.ts` + `ui/src/adapters/adapter-display-registry.ts` — register the UI side
+
+See `REGISTRY_PATCHES.md` for the exact diffs. Then:
+```bash
+cd ../../..   # back to paperclip root
+pnpm install
+pnpm -r build
+```
+
+### 4. Set credentials
+
+Three environment variables are required:
+```bash
+# Your OpenRouter API key (sk-or-v1-...)
+export OPENROUTER_API_KEY="sk-or-v1-your-key-here"
+
+# Required for Paperclip to mint agent JWTs that the adapter uses
+# to call Paperclip's own API. Any random 32-byte hex string works.
+export PAPERCLIP_AGENT_JWT_SECRET="$(openssl rand -hex 32)"
+
+# Where the adapter should reach Paperclip's API. Default is correct
+# for local dev.
+export PAPERCLIP_API_URL="http://localhost:3100"
+```
+
+Persist them in `~/.bashrc` or `.paperclip/.env`.
+
+### 5. Hire an agent
+
+In the Paperclip UI → Org Chart → Hire Agent:
+
+1. **Adapter Type**: OpenRouter
+2. **Model**: any OpenRouter model id, e.g. `openai/gpt-4o-mini` (recommended for tools) or `openai/gpt-oss-120b:free`
+3. **Test Environment**: validates your key and lists available models
+
+Then create an issue and assign it to the new agent. Watch the live run view — you'll see structured `tool_call` and `tool_result` entries as the model works.
+
+---
+
+## Architecture
+packages/adapters/openrouter/
+├── package.json
+├── README.md
+├── REGISTRY_PATCHES.md
+└── src/
+├── index.ts                 # Root metadata, types, OpenRouter constants
+├── server/
+│   ├── index.ts             # Server barrel — execute, sessionCodec, detectModel, listSkills, syncSkills
+│   ├── execute.ts           # Multi-turn tool loop, issue state mgmt, cost tracking, repeat-call protection
+│   ├── paperclip-api.ts     # HTTP client for Paperclip's REST API (auth via ctx.authToken JWT)
+│   ├── tools.ts             # 8 OpenAI-format tool definitions + handlers
+│   ├── transcript.ts        # Typed TranscriptEntry emitters (init, assistant, thinking, tool_call, tool_result, result)
+│   ├── skills.ts            # Filesystem-based SKILL.md loader
+│   └── test.ts              # Environment diagnostics + dynamic model fetch
+├── ui/
+│   ├── index.ts
+│   ├── parse-stdout.ts      # Stdout JSON lines → TranscriptEntry[]
+│   └── build-config.ts      # Form values → adapterConfig JSON
+└── cli/
+├── index.ts
+└── format-event.ts      # Terminal pretty-print for paperclipai run --watch
+
+### How a run works
+
+1. Paperclip's heartbeat dispatcher wakes the agent and calls `execute(ctx)`
+2. Adapter loads skills from disk and prepends them to the system prompt
+3. Adapter renders Paperclip's wake payload as the user message
+4. If `ctx.authToken` is present, adapter constructs a `PaperclipApi` client and the 8 tool handlers
+5. **Issue lock acquisition** — adapter checks if Paperclip's heartbeat already stamped the issue's `executionRunId` to this run; if yes, skip checkout, otherwise call `POST /api/issues/:id/checkout`
+6. Issue is moved to `in_progress`
+7. Tool loop runs:
+   - Call OpenRouter `chat/completions` with `tools` array
+   - Model returns either text (done) or tool calls
+   - Each tool call is executed against Paperclip's API
+   - Results are fed back as `role: "tool"` messages
+   - Loop until no more tool calls, `maxTurns` is hit, or repeat-call protection trips
+8. Final assistant text is posted as a comment on the issue
+9. Issue is moved to `done` (success), `blocked` (max_turns / error / repeat loop)
+10. Adapter fetches the OpenRouter generation cost and returns the full result with usage + costUsd
+
+### Built-in tools
+
+| Tool | What it does |
+|---|---|
+| `get_issue` | Fetch full details of an issue (title, description, status, comments) |
+| `update_issue_status` | Move an issue to backlog / todo / in_progress / blocked / done / cancelled |
+| `add_comment` | Post a comment on an issue (markdown body) |
+| `list_comments` | List all comments on an issue |
+| `create_sub_issue` | Create a child issue, optionally assigned to a teammate |
+| `list_issues` | List company issues, filterable by status / assignee |
+| `hire_agent` | Hire a new agent (routes through approval by default) |
+| `request_approval` | Open a generic approval request for any human-gated action |
+
+All tools call Paperclip's REST API authenticated as the agent (via `ctx.authToken`), so every action is attributed correctly in the audit log.
+
+---
+
+## Configuration Reference
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `model` | string | `openrouter/auto` | OpenRouter model id. Use `:free` suffix for free tier. |
+| `apiKey` | string | env var | Your OpenRouter API key (`sk-or-v1-...`) |
+| `systemPrompt` | string | sensible default | System message prepended to all requests |
+| `temperature` | number | `0.7` | Sampling temperature (0–2) |
+| `maxTokens` | number | `4096` | Max completion tokens per turn |
+| `topP` | number | `1` | Nucleus sampling threshold |
+| `reasoning` | boolean | `false` | Enable extended thinking (model must support it) |
+| `transforms` | string[] | — | OpenRouter transforms, e.g. `["middle-out"]` |
+| `route` | string | `fallback` | `"fallback"` or `"no-fallback"` |
+| `httpReferer` | string | `https://paperclip.ing` | App URL for OpenRouter leaderboards |
+| `xTitle` | string | `Paperclip` | App name for OpenRouter leaderboards |
+| `maxTurns` | number | `25` | Max tool-loop turns per run |
+| `autoApprove` | boolean | `false` | Skip approval gates for `hire_agent` and similar mutating tools |
+| `skillsDir` | string | `~/.openrouter-adapter/skills` | Override path to skills directory |
+
+---
+
+## Example Configs
+
+### Production-grade CEO on a paid model
+```json
+{
+  "name": "ceo",
+  "adapterType": "openrouter",
+  "adapterConfig": {
+    "model": "openai/gpt-4o-mini",
+    "temperature": 0.3,
+    "maxTokens": 4096,
+    "maxTurns": 30,
+    "systemPrompt": "You are the CEO. Define strategy, delegate, and ship."
+  }
+}
+```
+
+### Free-tier agent on gpt-oss-120b
+```json
+{
+  "name": "researcher",
+  "adapterType": "openrouter",
+  "adapterConfig": {
+    "model": "openai/gpt-oss-120b:free",
+    "temperature": 0.7,
+    "maxTurns": 20
+  }
+}
+```
+
+### Frontier coding agent
+```json
+{
+  "name": "senior-engineer",
+  "adapterType": "openrouter",
+  "adapterConfig": {
+    "model": "anthropic/claude-sonnet-4-6",
+    "temperature": 0.0,
+    "maxTokens": 16384,
+    "maxTurns": 50,
+    "route": "fallback"
+  }
+}
+```
+
+### Reasoning agent with auto-routing
+```json
+{
+  "name": "strategist",
+  "adapterType": "openrouter",
+  "adapterConfig": {
+    "model": "openrouter/auto",
+    "reasoning": true,
+    "transforms": ["middle-out"]
+  }
+}
+```
+
+---
+
+## Cost Tracking
+
+After each completion the adapter queries OpenRouter's `/api/v1/generation` endpoint to get the real USD cost and accurate token counts, then returns them in `AdapterExecutionResult`. Paperclip deducts this from the agent's monthly budget. At 80% utilization → soft warning; at 100% → agent auto-pauses.
+
+Free models report `$0.00` and don't eat into your budget.
+
+---
+
+## Skills
+
+Drop a directory containing a `SKILL.md` into the skills root and the adapter loads it into the system prompt at runtime:
+~/.openrouter-adapter/skills/
+├── customer-research/
+│   └── SKILL.md
+└── crypto-security/
+└── SKILL.md
+
+Override the root with `adapterConfig.skillsDir` per-agent or `PAPERCLIP_SKILLS_DIR` env var.
+
+> v1 loads every skill in the root. Per-agent skill selection (matching Paperclip's "desired skills" registry) is planned for v3.
+
+---
+
+## How It Differs From Other Adapters
+
+| Feature | claude-local / codex-local | openrouter (this adapter) |
+|---|---|---|
+| Execution | Spawns local CLI subprocess | Pure HTTP, in-process tool loop |
+| Tool loop | Handled by the CLI binary | Implemented in TypeScript inside the adapter |
+| Models | Single provider | 300+ across all providers |
+| Free models | ❌ | ✅ (50+) |
+| Auto-routing | ❌ | ✅ |
+| Local install | Requires CLI binary | Zero install — just Node 18+ |
+| Cost tracking | Native token counting | OpenRouter Generation API |
+| Paperclip API tools | Provided by the CLI's MCP support | Built into the adapter |
+| Run lock acquisition | Via heartbeat pre-checkout | Heartbeat pre-checkout + adapter fallback |
+
+---
+
+## Known Limitations
+
+The adapter is verified working end-to-end, but there are some real-world rough edges you should be aware of:
+
+### Model-specific quirks
+
+- **Free models silently rate-limit.** OpenRouter caps free-tier accounts at **50 requests per day total** across all free models. Heavy testing will exhaust this quickly. Adding $5 in credits unlocks 1000/day. The error is a clear 429 with `Rate limit exceeded: free-models-per-day`.
+- **Some free models fake tool calls.** `stepfun/step-3.5-flash:free` is trained on a different tool format and emits `<tool_call>...</tool_call>` as literal text instead of structured `tool_calls` arrays. The adapter cannot recover from this — it's a model issue. Use `openai/gpt-oss-120b:free` or `openai/gpt-4o-mini` instead.
+- **Reasoning model token counts vary.** DeepSeek R1 and QwQ emit reasoning tokens that don't always show up in OpenRouter's usage report. Cost tracking falls back to the `/generation` endpoint for accuracy.
+
+### Adapter-specific limitations (deferred to v3)
+
+- **No token streaming inside the tool loop.** v1 is non-streaming throughout for reliability — most free models stream tool calls poorly. Streaming is planned for v3.
+- **No async approval-callback resume.** When `hire_agent` creates an approval, the run completes; it does not pause and wait for the human decision. The approval is processed when the agent next wakes.
+- **No multimodal / vision attachment handling.** Issues with image attachments are passed as text descriptions only. Vision support is planned for v3.
+- **No per-agent desired-skill filtering.** v1 loads every skill in the root directory. Per-agent skill selection (matching Paperclip's skill registry) is planned for v3.
+- **No per-model capability detection.** The adapter sends `tools` to every model. Models that don't support function calling will fail or hallucinate. v3 will probe model capabilities and skip the `tools` array when unsupported.
+- **Repeat-call detection is conservative.** The adapter breaks the loop after 3 identical consecutive calls. This protects against runaway loops but may also fire on legitimate retries — adjust `maxTurns` if needed.
+
+### Paperclip integration notes
+
+- **Paperclip core needs `supportsLocalAgentJwt: true`** on the openrouter adapter entry in `server/src/adapters/registry.ts`. Without this, `ctx.authToken` will be `undefined` and tool calls will be disabled. See `REGISTRY_PATCHES.md`.
+- **Three env vars are required**, not just the API key. `OPENROUTER_API_KEY`, `PAPERCLIP_AGENT_JWT_SECRET`, and `PAPERCLIP_API_URL` must all be set in the same shell that runs `pnpm dev:server`.
+- **Issue checkout has been observed to "fail" cosmetically** when `expectedStatuses` doesn't include the issue's current status. The adapter's default list (`backlog`, `todo`, `in_progress`, `in_review`, `blocked`) covers all pre-terminal statuses. If Paperclip ever adds new ones, update `paperclip-api.ts`.
+
+---
+
+## Roadmap
+
+### v1 — MVP (one-shot, no tools)
+- Basic OpenRouter integration ✅
+- Streaming text generation ✅
+- Cost tracking ✅
+
+### v2 — Current release ✅
+- Multi-turn tool loop ✅
+- 8 built-in Paperclip API tools ✅
+- Issue state management ✅
+- Issue checkout with smart pre-lock detection ✅
+- Final-output-as-comment ✅
+- Skill loading ✅
+- Reasoning support ✅
+- `sessionCodec`, `detectModel`, `listSkills`, `syncSkills` ✅
+- Cost tracking via Generation API ✅
+- Repeat-call loop break ✅
+- Approval gating for `hire_agent` and friends ✅
+- **End-to-end verified against live Paperclip** ✅
+
+### v3 — Planned
+- Token streaming inside the tool loop
+- Async approval-callback resume (pause run → wait → continue)
+- Per-agent desired-skill filtering (integrate with Paperclip's skill registry)
+- Multimodal attachment support (vision models)
+- Per-model capability detection (skip `tools` for models that can't handle them)
+- Per-model rate-limit backoff for free tier
+- `getQuotaWindows` integration with OpenRouter `/key`
+- Compaction strategy for long conversations
+
+---
+
+## Contributing
+
+PRs welcome. The adapter lives in-repo at `packages/adapters/openrouter` of the Paperclip repository:
+```bash
+cd packages/adapters/openrouter
+pnpm install
+pnpm typecheck
+pnpm build
+```
+
+Run the test suite (when one exists):
+```bash
+pnpm test
+```
+
+To test against a live Paperclip instance, enable the built-in adapter in your Paperclip checkout, then trigger a run.
+
+---
+
+## License
+
+MIT — same as Paperclip.

--- a/packages/adapters/openrouter/REGISTRY_PATCHES.md
+++ b/packages/adapters/openrouter/REGISTRY_PATCHES.md
@@ -1,0 +1,114 @@
+# Registry Integration Patches
+
+Exact code to add to Paperclip's three registry files.
+Apply these after copying the adapter to `packages/adapters/openrouter/`.
+
+---
+
+## 1. Server Registry
+
+**File:** `server/src/adapters/registry.ts`
+
+Add this import at the top:
+
+```typescript
+import { execute as openrouterExecute } from "@paperclipai/adapter-openrouter/server";
+import { test as openrouterTest } from "@paperclipai/adapter-openrouter/server";
+import { type as openrouterType, label as openrouterLabel, models as openrouterModels } from "@paperclipai/adapter-openrouter";
+```
+
+Add this entry to the `adapters` record:
+
+```typescript
+  [openrouterType]: {
+    type: openrouterType,
+    label: openrouterLabel,
+    models: openrouterModels,
+    execute: openrouterExecute,
+    test: openrouterTest,
+  },
+```
+
+---
+
+## 2. UI Registry
+
+**File:** `ui/src/adapters/registry.ts`
+
+Add this import at the top:
+
+```typescript
+import { parseStdout as openrouterParseStdout, buildConfig as openrouterBuildConfig, configFields as openrouterConfigFields } from "@paperclipai/adapter-openrouter/ui";
+import { type as openrouterType, label as openrouterLabel, models as openrouterModels } from "@paperclipai/adapter-openrouter";
+```
+
+Add this entry to the `adapters` record:
+
+```typescript
+  [openrouterType]: {
+    type: openrouterType,
+    label: openrouterLabel,
+    models: openrouterModels,
+    parseStdout: openrouterParseStdout,
+    buildConfig: openrouterBuildConfig,
+    configFields: openrouterConfigFields,
+  },
+```
+
+---
+
+## 3. CLI Registry
+
+**File:** `cli/src/adapters/registry.ts`
+
+Add this import at the top:
+
+```typescript
+import { formatEvent as openrouterFormatEvent } from "@paperclipai/adapter-openrouter/cli";
+import { type as openrouterType, label as openrouterLabel } from "@paperclipai/adapter-openrouter";
+```
+
+Add this entry to the `adapters` record:
+
+```typescript
+  [openrouterType]: {
+    type: openrouterType,
+    label: openrouterLabel,
+    formatEvent: openrouterFormatEvent,
+  },
+```
+
+---
+
+## 4. Workspace Dependencies
+
+**File:** `server/package.json` — add to `dependencies`:
+
+```json
+"@paperclipai/adapter-openrouter": "workspace:*"
+```
+
+**File:** `cli/package.json` — add to `dependencies`:
+
+```json
+"@paperclipai/adapter-openrouter": "workspace:*"
+```
+
+**File:** `ui/package.json` — add to `dependencies`:
+
+```json
+"@paperclipai/adapter-openrouter": "workspace:*"
+```
+
+---
+
+## 5. Rebuild
+
+```bash
+pnpm install
+pnpm build
+pnpm dev  # or pnpm dev:server
+```
+
+The "OpenRouter" option will now appear in the adapter type dropdown
+during agent creation and in the onboarding wizard.

--- a/packages/adapters/openrouter/package.json
+++ b/packages/adapters/openrouter/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-openrouter",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/openrouter"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/openrouter/paperclip.plugin.json
+++ b/packages/adapters/openrouter/paperclip.plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://paperclipai.com/schemas/plugin-manifest.json",
+  "type": "adapter",
+  "id": "openrouter",
+  "name": "OpenRouter Adapter",
+  "description": "Use any OpenRouter model (300+ models) with Paperclip",
+  "version": "0.3.1",
+  "entry": {
+    "adapter": "./src/index.ts"
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "model": {
+        "type": "string",
+        "description": "OpenRouter model ID (e.g., z-ai/glm-4-32b)",
+        "default": "anthropic/claude-3.5-sonnet"
+      },
+      "maxTokens": {
+        "type": "number",
+        "description": "Maximum tokens to generate",
+        "default": 4096
+      }
+    }
+  }
+}

--- a/packages/adapters/openrouter/src/cli/format-event.ts
+++ b/packages/adapters/openrouter/src/cli/format-event.ts
@@ -1,0 +1,110 @@
+// ─────────────────────────────────────────────────────────────────
+// @paperclipai/adapter-openrouter — CLI Format Event
+// Pretty-prints stdout for `paperclipai run --watch` in terminal
+// ─────────────────────────────────────────────────────────────────
+
+// NOTE: picocolors is a peer dep — import dynamically to avoid
+// breaking server/ui bundles that don't need it.
+
+interface FormatOptions {
+  verbose?: boolean;
+}
+
+/**
+ * Format a single stdout line for terminal display.
+ * Called by Paperclip CLI's --watch mode.
+ */
+export function formatEvent(
+  line: string,
+  _opts?: FormatOptions
+): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  // SSE data lines — extract content
+  if (trimmed.startsWith("data: ")) {
+    const data = trimmed.slice(6);
+    if (data === "[DONE]") return null;
+
+    try {
+      const parsed = JSON.parse(data);
+
+      // Reasoning
+      const reasoning =
+        parsed.choices?.[0]?.delta?.reasoning_content ||
+        parsed.choices?.[0]?.delta?.reasoning;
+      if (reasoning) {
+        return `💭 ${reasoning}`;
+      }
+
+      // Content
+      const content = parsed.choices?.[0]?.delta?.content;
+      if (content) return content;
+
+      // Usage summary at end
+      if (parsed.usage) {
+        const u = parsed.usage;
+        return `\n📊 ${u.prompt_tokens || 0} in / ${u.completion_tokens || 0} out tokens`;
+      }
+
+      return null;
+    } catch {
+      return data;
+    }
+  }
+
+  // Error lines
+  if (
+    trimmed.includes("error") ||
+    trimmed.includes("Error") ||
+    trimmed.includes("OPENROUTER")
+  ) {
+    return `❌ ${trimmed}`;
+  }
+
+  // Info lines
+  if (trimmed.startsWith("[openrouter]")) {
+    return `🔀 ${trimmed}`;
+  }
+
+  // Default: pass through
+  return trimmed;
+}
+
+/**
+ * Format a run summary for terminal display.
+ */
+export function formatRunSummary(result: {
+  success: boolean;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+  };
+  metadata?: Record<string, unknown>;
+}): string {
+  const lines: string[] = [];
+
+  if (result.success) {
+    lines.push("✅ OpenRouter run completed");
+  } else {
+    lines.push("❌ OpenRouter run failed");
+  }
+
+  if (result.metadata?.model) {
+    lines.push(`   Model: ${result.metadata.model}`);
+  }
+
+  if (result.usage) {
+    lines.push(
+      `   Tokens: ${result.usage.inputTokens.toLocaleString()} in / ${result.usage.outputTokens.toLocaleString()} out`
+    );
+    if (result.usage.costUsd > 0) {
+      lines.push(`   Cost: $${result.usage.costUsd.toFixed(6)}`);
+    } else {
+      lines.push("   Cost: $0.00 (free model)");
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/adapters/openrouter/src/cli/index.ts
+++ b/packages/adapters/openrouter/src/cli/index.ts
@@ -1,0 +1,2 @@
+// CLI-side exports
+export { formatEvent, formatRunSummary } from "./format-event.js";

--- a/packages/adapters/openrouter/src/index.ts
+++ b/packages/adapters/openrouter/src/index.ts
@@ -1,0 +1,120 @@
+// ─────────────────────────────────────────────────────────────────
+// @paperclipai/adapter-openrouter — Root Metadata (src/index.ts)
+// Shared across server · ui · cli — keep dependency-free
+// ─────────────────────────────────────────────────────────────────
+
+export const type = "openrouter" as const;
+export const label = "OpenRouter";
+
+// ── Static fallback models (shown when API is unreachable) ──────
+export const models = [
+  // Free tier
+  { id: "openrouter/auto",                       label: "Auto (best free route)" },
+  { id: "meta-llama/llama-4-maverick:free",       label: "Llama 4 Maverick (free)" },
+  { id: "meta-llama/llama-4-scout:free",          label: "Llama 4 Scout (free)" },
+  { id: "google/gemma-3-27b-it:free",             label: "Gemma 3 27B (free)" },
+  { id: "deepseek/deepseek-chat-v3-0324:free",    label: "DeepSeek V3 0324 (free)" },
+  { id: "qwen/qwen3-235b-a22b:free",              label: "Qwen3 235B (free)" },
+  { id: "mistralai/mistral-small-3.2-24b-instruct:free", label: "Mistral Small 3.2 (free)" },
+
+  // Paid — frontier
+  { id: "anthropic/claude-sonnet-4-6",            label: "Claude Sonnet 4.6" },
+  { id: "anthropic/claude-opus-4-6",              label: "Claude Opus 4.6" },
+  { id: "openai/gpt-4.1",                        label: "GPT-4.1" },
+  { id: "openai/o4-mini",                         label: "o4-mini" },
+  { id: "google/gemini-2.5-pro-preview",          label: "Gemini 2.5 Pro" },
+  { id: "google/gemini-2.5-flash-preview",        label: "Gemini 2.5 Flash" },
+  { id: "deepseek/deepseek-r1",                   label: "DeepSeek R1" },
+  { id: "meta-llama/llama-4-maverick",            label: "Llama 4 Maverick" },
+
+  // Paid — mid-tier
+  { id: "anthropic/claude-haiku-4-5",             label: "Claude Haiku 4.5" },
+  { id: "openai/gpt-4.1-mini",                   label: "GPT-4.1 Mini" },
+  { id: "mistralai/mistral-medium-3",             label: "Mistral Medium 3" },
+  { id: "qwen/qwen3-235b-a22b",                  label: "Qwen3 235B" },
+];
+
+// ── OpenRouter API constants ────────────────────────────────────
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const OPENROUTER_MODELS_ENDPOINT = `${OPENROUTER_BASE_URL}/models`;
+export const OPENROUTER_CHAT_ENDPOINT = `${OPENROUTER_BASE_URL}/chat/completions`;
+export const OPENROUTER_GENERATION_ENDPOINT = `${OPENROUTER_BASE_URL}/generation`;
+
+// ── Adapter documentation ───────────────────────────────────────
+export const agentConfigurationDoc = `# openrouter adapter configuration
+
+## Use when
+- You want access to 300+ models (free AND paid) from a single API key
+- You want to use OpenRouter's auto-routing for cost-optimized inference
+- You need models not available via native adapters (Llama, Qwen, Mistral, DeepSeek, etc.)
+- You want to compare outputs across multiple providers without separate API keys
+
+## Core fields
+- \`model\` (string) — OpenRouter model ID, e.g. "anthropic/claude-sonnet-4-6"
+  Use "openrouter/auto" to let OpenRouter pick the best model automatically.
+  Append ":free" to any model ID for free-tier routing.
+- \`apiKey\` (string) — Your OpenRouter API key (sk-or-v1-...)
+  Can also be set via OPENROUTER_API_KEY env var.
+- \`systemPrompt\` (string, optional) — System prompt prepended to all messages.
+- \`temperature\` (number, optional) — Sampling temperature (0-2). Default: 0.7
+- \`maxTokens\` (number, optional) — Max completion tokens. Default: 4096
+- \`topP\` (number, optional) — Nucleus sampling. Default: 1
+- \`stream\` (boolean, optional) — Enable SSE streaming. Default: true
+- \`reasoning\` (boolean, optional) — Enable extended thinking for supported models.
+- \`transforms\` (string[], optional) — OpenRouter transforms, e.g. ["middle-out"]
+- \`route\` (string, optional) — "fallback" (default) or "no-fallback"
+- \`httpReferer\` (string, optional) — Your app URL for OpenRouter leaderboards
+- \`xTitle\` (string, optional) — Your app name for OpenRouter leaderboards
+
+## Don't use when
+- You already have a direct API key for a single provider and only need that one model
+- You need local/offline inference (use ollama or process adapter instead)
+`;
+
+// ── Types ───────────────────────────────────────────────────────
+export interface OpenRouterModel {
+  id: string;
+  name: string;
+  pricing: {
+    prompt: string;
+    completion: string;
+    request?: string;
+    image?: string;
+  };
+  context_length: number;
+  top_provider?: {
+    max_completion_tokens?: number;
+    is_moderated?: boolean;
+  };
+  per_request_limits?: Record<string, string> | null;
+  architecture?: {
+    modality: string;
+    tokenizer: string;
+    instruct_type: string | null;
+  };
+}
+
+export interface OpenRouterConfig {
+  model: string;
+  apiKey?: string;
+  systemPrompt?: string;
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  stream?: boolean;
+  reasoning?: boolean;
+  transforms?: string[];
+  route?: "fallback" | "no-fallback";
+  httpReferer?: string;
+  xTitle?: string;
+  /** Max tool-loop turns per run. Default 25. */
+  maxTurns?: number;
+  /** Skip approval gates for hire_agent and similar mutating tools. Default false. */
+  autoApprove?: boolean;
+  /** Override path to skills directory. Defaults to ~/.openrouter-adapter/skills. */
+  skillsDir?: string;
+  /** Absolute path to a markdown file that will be read at runtime and
+   * prepended to the system prompt. Takes precedence over systemPrompt
+   * if both are set. */
+  instructionsFilePath?: string;
+}

--- a/packages/adapters/openrouter/src/server/config-schema.ts
+++ b/packages/adapters/openrouter/src/server/config-schema.ts
@@ -1,0 +1,103 @@
+/**
+ * Declarative config schema for the OpenRouter adapter.
+ *
+ * Lets Paperclip's UI render the agent-config form without shipping a
+ * bespoke React component. Mirrors the fields declared in
+ * src/ui/build-config.ts so both paths stay in sync.
+ */
+
+import type { AdapterConfigSchema } from "@paperclipai/adapter-utils";
+import { models } from "../index.js";
+
+export function getConfigSchema(): AdapterConfigSchema {
+  return {
+    fields: [
+      {
+        key: "apiKey",
+        label: "OpenRouter API Key",
+        type: "text",
+        required: true,
+        hint: "Get a key at https://openrouter.ai/keys (sk-or-...). Prefer the OPENROUTER_API_KEY env var / Paperclip secret provider.",
+      },
+      {
+        key: "model",
+        label: "Model",
+        type: "combobox",
+        required: true,
+        default: "openrouter/auto",
+        options: models.map((m) => ({ label: m.label, value: m.id })),
+        hint: "Select a model or use openrouter/auto for auto-routing. Append :free for the free tier.",
+      },
+      {
+        key: "systemPrompt",
+        label: "System Prompt",
+        type: "textarea",
+        hint: "Optional base instructions prepended to the wake payload.",
+      },
+      {
+        key: "temperature",
+        label: "Temperature",
+        type: "number",
+        default: 0.7,
+        hint: "Sampling temperature, 0–2.",
+      },
+      {
+        key: "maxTokens",
+        label: "Max Tokens",
+        type: "number",
+        default: 4096,
+        hint: "Maximum completion tokens per turn.",
+      },
+      {
+        key: "topP",
+        label: "Top P",
+        type: "number",
+        default: 1,
+        hint: "Nucleus sampling cutoff, 0–1.",
+      },
+      {
+        key: "stream",
+        label: "Enable Streaming",
+        type: "toggle",
+        default: true,
+      },
+      {
+        key: "reasoning",
+        label: "Enable Reasoning",
+        type: "toggle",
+        default: false,
+        hint: "Only works with models that support extended thinking (DeepSeek R1, QwQ, etc.).",
+      },
+      {
+        key: "route",
+        label: "Routing Strategy",
+        type: "select",
+        default: "fallback",
+        options: [
+          { value: "fallback", label: "Fallback (auto-retry with other providers)" },
+          { value: "no-fallback", label: "No Fallback (single provider only)" },
+        ],
+      },
+      {
+        key: "maxTurns",
+        label: "Max Tool-Loop Turns",
+        type: "number",
+        default: 25,
+        hint: "Maximum model tool-calls per run before the loop stops.",
+      },
+      {
+        key: "autoApprove",
+        label: "Auto-Approve Mutating Tools",
+        type: "toggle",
+        default: false,
+        hint: "When on, hire_agent and similar actions skip the approval gate. Default off (approvals on).",
+      },
+      {
+        key: "instructionsFilePath",
+        label: "Instructions File Path",
+        type: "text",
+        hint: "Optional absolute path to a markdown file read at runtime and prepended to the system prompt.",
+      },
+    ],
+  };
+}

--- a/packages/adapters/openrouter/src/server/execute.ts
+++ b/packages/adapters/openrouter/src/server/execute.ts
@@ -1,0 +1,636 @@
+/**
+ * OpenRouter adapter execute() — multi-turn tool loop.
+ *
+ * Responsibilities:
+ *   - Build messages from Paperclip wake context + skills
+ *   - Run a tool-calling loop against OpenRouter's chat/completions endpoint
+ *   - Manage issue state (in_progress at start, done/blocked at end)
+ *   - Post the final assistant output as an issue comment
+ *   - Emit typed TranscriptEntry lines so the run viewer renders properly
+ *   - Track usage and cost via OpenRouter's /generation endpoint
+ *
+ * Out of scope for v1 (deferred to v3):
+ *   - Token streaming inside the tool loop (non-streaming is more reliable
+ *     for tool calls on free models)
+ *   - Approval gate handling (we route hire_agent through approvals, but we
+ *     don't yet pause-and-resume runs on async approval callbacks)
+ *   - Workspace runtime env vars (we have no child process to pass them to)
+ *   - Attachment / multimodal handling
+ */
+
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+  UsageSummary,
+} from "@paperclipai/adapter-utils";
+import fs from "node:fs/promises";
+import {
+  renderPaperclipWakePrompt,
+} from "@paperclipai/adapter-utils/server-utils";
+
+import {
+  OPENROUTER_CHAT_ENDPOINT,
+  OPENROUTER_GENERATION_ENDPOINT,
+  type OpenRouterConfig,
+} from "../index.js";
+import { PaperclipApi } from "./paperclip-api.js";
+import { buildTools, toolSchemas, findTool, type Tool } from "./tools.js";
+import { loadSkills, renderSkillsForPrompt } from "./skills.js";
+import {
+  emitInit,
+  emitAssistant,
+  emitThinking,
+  emitToolCall,
+  emitToolResult,
+  emitResult,
+  emitSystem,
+  writeRawStderr,
+  type OnLog,
+} from "./transcript.js";
+
+// ----- types matching OpenRouter / OpenAI chat completions -----
+
+interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | null;
+  name?: string;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+}
+
+interface ChatCompletionResponse {
+  id: string;
+  choices: Array<{
+    finish_reason: string | null;
+    message: {
+      role: "assistant";
+      content: string | null;
+      reasoning?: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: "function";
+        function: { name: string; arguments: string };
+      }>;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+// ----- helpers -----
+
+const DEFAULT_MAX_TURNS = 25;
+const DEFAULT_SYSTEM_PROMPT =
+  "You are an AI agent working inside Paperclip, an autonomous company orchestration system. " +
+  "When you receive a wake payload, your job is to EXECUTE the assigned task — not describe it. " +
+  "Use the tools available to you to read context, post comments, update status, and delegate work. " +
+  "When finished, call update_issue_status with status='done' and post a summary comment.";
+
+/**
+ * Resolve the OpenRouter API key. The Paperclip agent JWT (ctx.authToken) is
+ * NEVER a valid OpenRouter key — it is used only for Paperclip API calls via
+ * PaperclipApi. This guard fails loudly if the resolved key ever equals the
+ * agent JWT or looks like a JWT, so a misconfigured adapterConfig cannot leak
+ * the JWT to OpenRouter.
+ */
+function resolveApiKey(config: OpenRouterConfig, authToken?: string): string {
+  const key = config.apiKey || process.env.OPENROUTER_API_KEY || "";
+  if (!key) {
+    throw new Error(
+      "OpenRouter API key not found. Set adapterConfig.apiKey or OPENROUTER_API_KEY env var.",
+    );
+  }
+  // A Paperclip agent JWT is a 3-segment base64url token. Never send it to
+  // OpenRouter: a matching value in adapterConfig would be a misconfiguration.
+  if (authToken && key === authToken) {
+    throw new Error(
+      "Refusing to use the Paperclip agent JWT as the OpenRouter API key. Set adapterConfig.apiKey or OPENROUTER_API_KEY to a real OpenRouter key (sk-or-...).",
+    );
+  }
+  if (key.split(".").length === 3 && key.split(".").every((seg) => /^[A-Za-z0-9_-]+$/.test(seg))) {
+    throw new Error(
+      "Resolved OpenRouter API key looks like a JWT. Refusing to send the Paperclip agent JWT to OpenRouter — set a real OpenRouter key (sk-or-...) in adapterConfig.apiKey or OPENROUTER_API_KEY.",
+    );
+  }
+  return key;
+}
+
+function resolveBillingType(config: OpenRouterConfig): "api" | "subscription" {
+  // OpenRouter is always API-key based.
+  if (config.apiKey || process.env.OPENROUTER_API_KEY) return "api";
+  return "api";
+}
+
+function buildHeaders(apiKey: string, config: OpenRouterConfig): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    "HTTP-Referer": config.httpReferer || "https://paperclip.ing",
+    "X-Title": config.xTitle || "Paperclip",
+  };
+}
+
+function extractCurrentIssueId(context: Record<string, unknown>): string | null {
+  const candidates = [
+    context.taskId,
+    context.issueId,
+    context.wakeTaskId,
+    (context.paperclipWake as Record<string, unknown> | undefined)?.taskId,
+    (context.paperclipWake as Record<string, unknown> | undefined)?.issueId,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim().length > 0) return c.trim();
+  }
+  return null;
+}
+
+function safeParseToolArgs(raw: string): Record<string, unknown> {
+  if (!raw || typeof raw !== "string") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function callOpenRouter(
+  apiKey: string,
+  config: OpenRouterConfig,
+  messages: ChatMessage[],
+  tools: Tool[],
+): Promise<ChatCompletionResponse> {
+  const body: Record<string, unknown> = {
+    model: config.model || "openrouter/auto",
+    messages,
+    max_tokens: config.maxTokens ?? 4096,
+    temperature: config.temperature ?? 0.7,
+    top_p: config.topP ?? 1,
+    stream: false,
+  };
+  if (tools.length > 0) {
+    body.tools = toolSchemas(tools);
+    body.tool_choice = "auto";
+  }
+  if (config.reasoning) body.reasoning = { effort: "high" };
+  if (config.transforms?.length) body.transforms = config.transforms;
+  if (config.route) body.route = config.route;
+
+  const response = await fetch(OPENROUTER_CHAT_ENDPOINT, {
+    method: "POST",
+    headers: buildHeaders(apiKey, config),
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(`OpenRouter API error (${response.status}): ${errText}`);
+  }
+
+  const json = (await response.json()) as ChatCompletionResponse;
+  return json;
+}
+
+async function fetchGenerationCost(
+  generationId: string,
+  apiKey: string,
+): Promise<{ costUsd: number | null; inputTokens: number; outputTokens: number }> {
+  const fallback = { costUsd: null as number | null, inputTokens: 0, outputTokens: 0 };
+  try {
+    // OpenRouter's /generation endpoint takes a moment to populate.
+    await new Promise((r) => setTimeout(r, 1500));
+    const res = await fetch(`${OPENROUTER_GENERATION_ENDPOINT}?id=${encodeURIComponent(generationId)}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) return fallback;
+    const data = (await res.json()) as { data?: Record<string, unknown> };
+    const d = data.data ?? {};
+    return {
+      costUsd: typeof d.total_cost === "number" ? d.total_cost : null,
+      inputTokens: typeof d.tokens_prompt === "number" ? d.tokens_prompt : 0,
+      outputTokens: typeof d.tokens_completion === "number" ? d.tokens_completion : 0,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+// ----- main -----
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const config = (ctx.agent.adapterConfig ?? ctx.config) as unknown as OpenRouterConfig & {
+    maxTurns?: number;
+    autoApprove?: boolean;
+  };
+  const { context, onLog, agent, authToken } = ctx;
+
+  const model = config.model || "openrouter/auto";
+  const maxTurns = typeof config.maxTurns === "number" && config.maxTurns > 0 ? config.maxTurns : DEFAULT_MAX_TURNS;
+  const autoApprove = config.autoApprove === true;
+
+  // Tool handlers need a Paperclip API client. If we have no authToken,
+  // tools are disabled (model can still respond, just can't act).
+  let api: PaperclipApi | null = null;
+  let tools: Tool[] = [];
+  const currentIssueId = extractCurrentIssueId(context);
+  const companyId = agent.companyId;
+
+  if (authToken) {
+    api = new PaperclipApi({ authToken });
+    tools = buildTools({
+      api,
+      agentId: agent.id,
+      companyId,
+      currentIssueId,
+      autoApprove,
+    });
+  } else {
+    await writeRawStderr(
+      onLog,
+      "[openrouter] No authToken on context — tool calls disabled. Agent can only generate text.",
+    );
+  }
+
+  // Emit init early so the run viewer renders the header.
+  await emitInit(onLog, { model, sessionId: ctx.runId });
+
+  // ----- build messages -----
+
+  const messages: ChatMessage[] = [];
+
+  // System prompt = base + skills + optional instructions file
+  let systemContent = config.systemPrompt || DEFAULT_SYSTEM_PROMPT;
+
+  // If instructionsFilePath is set, read the file and use it as the base.
+  // This mirrors the behavior of claude-local / codex-local / etc., letting
+  // operators version-control long agent instructions in a markdown file
+  // instead of pasting them into the inline systemPrompt field.
+  const instructionsFilePath = (config as unknown as Record<string, unknown>).instructionsFilePath;
+  if (typeof instructionsFilePath === "string" && instructionsFilePath.trim().length > 0) {
+    try {
+      const fileContent = await fs.readFile(instructionsFilePath.trim(), "utf8");
+      if (fileContent.trim().length > 0) {
+        systemContent = fileContent.trim();
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await writeRawStderr(
+        onLog,
+        `[openrouter] could not read instructionsFilePath ${instructionsFilePath}: ${reason}. Falling back to systemPrompt.`,
+      );
+    }
+  }
+  try {
+    const skills = await loadSkills({ agentConfig: config as unknown as Record<string, unknown>, onLog });
+    if (skills.length > 0) {
+      systemContent = `${systemContent}\n\n${renderSkillsForPrompt(skills)}`;
+      await emitSystem(onLog, `Loaded ${skills.length} skill(s): ${skills.map((s) => s.name).join(", ")}`);
+    }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await writeRawStderr(onLog, `[openrouter] skill loading error (continuing): ${reason}`);
+  }
+  messages.push({ role: "system", content: systemContent });
+
+  // User prompt = Paperclip wake payload rendered as text
+  const resumedSession = !!ctx.runtime.sessionId;
+  let wakePrompt = "";
+  const wakePayload =
+    (context.paperclipWake as Record<string, unknown> | undefined) ?? context;
+  try {
+    wakePrompt = renderPaperclipWakePrompt(wakePayload, { resumedSession }) || "";
+  } catch {
+    wakePrompt = "";
+  }
+  messages.push({
+    role: "user",
+    content: wakePrompt || JSON.stringify(context),
+  });
+
+  // ----- check out issue (acquire run lock) -----
+  //
+  // Paperclip's sameRunLock check rejects any write to an issue (comments,
+  // status changes, etc.) unless the issue's checkoutRunId matches the
+  // calling run id. The CLI adapters get this for free because Paperclip's
+  // wake handler pre-checks-out the issue for them; pure-HTTP adapters
+  // don't, so we have to do it ourselves before any tool can mutate state.
+  //
+  // If checkout fails (issue locked by another live run, project paused,
+  // etc.), we log and proceed without tools — same graceful degradation
+  // we apply when authToken is missing.
+
+  // If Paperclip's heartbeat dispatcher already stamped this run as the
+  // issue's executionRunId, the lock is effectively held by us already and
+  // an explicit checkout call would be redundant (and on some Paperclip
+  // versions, return a validation error). Detect that and skip.
+  const preLocked = (() => {
+    const wakeIssue = (context.paperclipWake as Record<string, unknown> | undefined)?.issue as
+      | Record<string, unknown>
+      | undefined;
+    const ctxIssue = (context.issue as Record<string, unknown> | undefined) ?? wakeIssue;
+    const execRunId =
+      typeof ctxIssue?.executionRunId === "string" ? ctxIssue.executionRunId : null;
+    return !!execRunId && execRunId === ctx.runId;
+  })();
+
+  let issueLocked = preLocked;
+  if (api && currentIssueId && !preLocked) {
+    try {
+      await api.checkoutIssue(currentIssueId, agent.id);
+      issueLocked = true;
+    } catch (err) {
+      // Best-effort: many runs are dispatched by the heartbeat which already
+      // holds the lock for us, so a checkout failure is not necessarily
+      // fatal. We try the writes anyway and let Paperclip enforce the real
+      // ownership check at write time.
+      const reason = err instanceof Error ? err.message : String(err);
+      await writeRawStderr(
+        onLog,
+        `[openrouter] checkout call failed for ${currentIssueId}: ${reason}. Continuing — Paperclip may still accept writes if the heartbeat pre-locked the issue.`,
+      );
+      issueLocked = true;
+    }
+  }
+
+  // ----- mark issue in_progress -----
+
+  if (api && currentIssueId && issueLocked) {
+    try {
+      await api.updateIssue(currentIssueId, { status: "in_progress" });
+    } catch (err) {
+      // Don't fail the run for status updates.
+      const reason = err instanceof Error ? err.message : String(err);
+      await writeRawStderr(onLog, `[openrouter] could not set issue in_progress: ${reason}`);
+    }
+  }
+
+  // ----- tool loop -----
+
+  let apiKey: string;
+  try {
+    apiKey = resolveApiKey(config, authToken);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await writeRawStderr(onLog, `[openrouter] ${reason}\n`);
+    if (api && currentIssueId) {
+      await api
+        .updateIssue(currentIssueId, { status: "blocked", statusReason: reason })
+        .catch(() => undefined);
+    }
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: reason,
+      errorCode: "missing_api_key",
+      usage: { inputTokens: 0, outputTokens: 0 },
+      model,
+      provider: "openrouter",
+      biller: "openrouter",
+      billingType: resolveBillingType(config),
+    };
+  }
+
+  let lastGenerationId: string | undefined;
+  let totalUsage: UsageSummary = { inputTokens: 0, outputTokens: 0 };
+  let finalAssistantText = "";
+  let turn = 0;
+  let stoppedReason: "completed" | "max_turns" | "error" | "repeat_loop" = "completed";
+  let runError: { message: string; code: string } | null = null;
+  // Repeat-call detection: if the model calls the same tool with the same args
+  // three times in a row, break the loop. Prevents 20+ retries when the model
+  // misreads an error message and keeps "fixing" it the same wrong way.
+  const recentCalls: string[] = [];
+  const REPEAT_THRESHOLD = 3;
+
+  try {
+    while (turn < maxTurns) {
+      turn += 1;
+
+      let response: ChatCompletionResponse;
+      try {
+        response = await callOpenRouter(apiKey, config, messages, tools);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        runError = { message: reason, code: "openrouter_request_failed" };
+        stoppedReason = "error";
+        break;
+      }
+
+      lastGenerationId = response.id || lastGenerationId;
+      if (response.usage) {
+        totalUsage = {
+          inputTokens: totalUsage.inputTokens + (response.usage.prompt_tokens ?? 0),
+          outputTokens: totalUsage.outputTokens + (response.usage.completion_tokens ?? 0),
+        };
+      }
+
+      const choice = response.choices?.[0];
+      if (!choice) {
+        runError = { message: "OpenRouter returned no choices", code: "openrouter_empty_response" };
+        stoppedReason = "error";
+        break;
+      }
+
+      const msg = choice.message;
+      const reasoning = typeof msg.reasoning === "string" ? msg.reasoning : "";
+      const text = typeof msg.content === "string" ? msg.content : "";
+      const toolCalls = msg.tool_calls ?? [];
+
+      if (reasoning) {
+        await emitThinking(onLog, reasoning);
+      }
+      if (text) {
+        await emitAssistant(onLog, text);
+        finalAssistantText = text;
+      }
+
+      // No tool calls => model is done.
+      if (toolCalls.length === 0) {
+        stoppedReason = "completed";
+        break;
+      }
+
+      // Add the assistant message (with tool_calls) so the model sees its own request.
+      messages.push({
+        role: "assistant",
+        content: text,
+        tool_calls: toolCalls.map((tc) => ({
+          id: tc.id,
+          type: "function",
+          function: { name: tc.function.name, arguments: tc.function.arguments },
+        })),
+      });
+
+      // Execute each tool call and append the results.
+      for (const tc of toolCalls) {
+        const toolName = tc.function.name;
+        const args = safeParseToolArgs(tc.function.arguments);
+        await emitToolCall(onLog, { name: toolName, input: args, toolUseId: tc.id });
+
+        const tool = findTool(tools, toolName);
+        let resultContent: string;
+        let isError: boolean;
+        if (!tool) {
+          resultContent = JSON.stringify({ error: `Unknown tool: ${toolName}` });
+          isError = true;
+        } else {
+          try {
+            const out = await tool.execute(args);
+            resultContent = out.content;
+            isError = out.isError;
+          } catch (err) {
+            resultContent = JSON.stringify({
+              error: err instanceof Error ? err.message : String(err),
+            });
+            isError = true;
+          }
+        }
+
+        await emitToolResult(onLog, {
+          toolUseId: tc.id,
+          toolName,
+          content: resultContent,
+          isError,
+        });
+
+        messages.push({
+          role: "tool",
+          tool_call_id: tc.id,
+          content: resultContent,
+        });
+
+        // Track repeat calls
+        const callSig = `${toolName}::${JSON.stringify(args)}`;
+        recentCalls.push(callSig);
+        if (recentCalls.length > REPEAT_THRESHOLD) recentCalls.shift();
+        if (
+          recentCalls.length === REPEAT_THRESHOLD &&
+          recentCalls.every((s) => s === callSig)
+        ) {
+          await writeRawStderr(
+            onLog,
+            `[openrouter] Tool "${toolName}" called ${REPEAT_THRESHOLD}x with identical args — breaking loop.`,
+          );
+          runError = {
+            message: `Tool "${toolName}" was called ${REPEAT_THRESHOLD} times in a row with identical arguments. The model is stuck in a retry loop.`,
+            code: "tool_repeat_loop",
+          };
+          stoppedReason = "repeat_loop";
+          break;
+        }
+      }
+      if (stoppedReason === "repeat_loop") break;
+    }
+
+    if (turn >= maxTurns && stoppedReason !== "error") {
+      stoppedReason = "max_turns";
+      await writeRawStderr(onLog, `[openrouter] hit max_turns (${maxTurns}), stopping`);
+    }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    runError = { message: reason, code: "openrouter_loop_failed" };
+    stoppedReason = "error";
+  }
+
+  // ----- post-loop: cost, comment, status -----
+
+  let costUsd: number | null = null;
+  if (lastGenerationId) {
+    const cost = await fetchGenerationCost(lastGenerationId, apiKey);
+    costUsd = cost.costUsd;
+    // Prefer the generation endpoint's token counts when present (more accurate).
+    if (cost.inputTokens > 0 || cost.outputTokens > 0) {
+      totalUsage = { inputTokens: cost.inputTokens, outputTokens: cost.outputTokens };
+    }
+  }
+
+  // Post the final assistant text as a comment so other agents can see it.
+  if (api && currentIssueId && finalAssistantText.trim().length > 0) {
+    try {
+      await api.addIssueComment(currentIssueId, { body: finalAssistantText });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await writeRawStderr(onLog, `[openrouter] could not post final comment: ${reason}`);
+    }
+  }
+
+  // Update issue status based on outcome.
+  if (api && currentIssueId) {
+    let nextStatus: string | null = null;
+    let statusReason: string | null = null;
+    if (stoppedReason === "completed") {
+      nextStatus = "done";
+    } else if (stoppedReason === "max_turns") {
+      nextStatus = "blocked";
+      statusReason = `Hit max_turns (${maxTurns}) without completing`;
+    } else if (stoppedReason === "repeat_loop" && runError) {
+      nextStatus = "blocked";
+      statusReason = runError.message;
+    } else if (stoppedReason === "error" && runError) {
+      nextStatus = "blocked";
+      statusReason = runError.message;
+    }
+    if (nextStatus) {
+      try {
+        await api.updateIssue(currentIssueId, { status: nextStatus, statusReason });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        await writeRawStderr(onLog, `[openrouter] could not update final status: ${reason}`);
+      }
+    }
+  }
+
+  // Emit the final result transcript entry.
+  await emitResult(onLog, {
+    text: finalAssistantText,
+    inputTokens: totalUsage.inputTokens,
+    outputTokens: totalUsage.outputTokens,
+    costUsd: costUsd ?? 0,
+    subtype: stoppedReason,
+    isError: stoppedReason === "error",
+    errors: runError ? [runError.message] : [],
+  });
+
+  if (stoppedReason === "error" && runError) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: runError.message,
+      errorCode: runError.code,
+      usage: totalUsage,
+      model,
+      provider: "openrouter",
+      biller: "openrouter",
+      billingType: resolveBillingType(config),
+      costUsd,
+      sessionId: lastGenerationId ?? null,
+      sessionDisplayId: lastGenerationId ?? null,
+      sessionParams: lastGenerationId ? { lastGenerationId } : null,
+    };
+  }
+
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    usage: totalUsage,
+    model,
+    provider: "openrouter",
+    biller: "openrouter",
+    billingType: resolveBillingType(config),
+    costUsd,
+    sessionId: lastGenerationId ?? null,
+    sessionDisplayId: lastGenerationId ?? null,
+    sessionParams: lastGenerationId ? { lastGenerationId } : null,
+    summary: finalAssistantText.slice(0, 500),
+  };
+}

--- a/packages/adapters/openrouter/src/server/index.ts
+++ b/packages/adapters/openrouter/src/server/index.ts
@@ -1,0 +1,144 @@
+/**
+ * Server barrel for the OpenRouter adapter.
+ *
+ * Exposes everything Paperclip's server-side registry expects from a
+ * fully-featured adapter:
+ *   - execute             — the agent run loop (tool-calling)
+ *   - testEnvironment     — env diagnostics + model fetch
+ *   - sessionCodec        — persist/restore lastGenerationId across heartbeats
+ *   - detectModel         — read OPENROUTER_MODEL env if present
+ *   - listSkills          — minimal stub (filesystem scan)
+ *   - syncSkills          — no-op (skills are managed externally)
+ *
+ * Optional hooks not implemented (deferred to v3):
+ *   - getQuotaWindows     — OpenRouter exposes /key endpoint, can be added
+ *   - onHireApproved      — only used by cloud adapters
+ */
+
+import path from "node:path";
+import fs from "node:fs/promises";
+import type {
+  AdapterSessionCodec,
+  AdapterSkillContext,
+  AdapterSkillSnapshot,
+} from "@paperclipai/adapter-utils";
+
+export { execute } from "./execute.js";
+export { testEnvironment, listOpenRouterModels } from "./test.js";
+export { getConfigSchema } from "./config-schema.js";
+
+// ----- sessionCodec -----
+
+/**
+ * OpenRouter doesn't have first-class server-side sessions; we persist the
+ * last generation id so the run viewer can show a stable display id and
+ * future versions can chain conversations across heartbeats.
+ */
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    const obj = raw as Record<string, unknown>;
+    const id = typeof obj.lastGenerationId === "string" ? obj.lastGenerationId : null;
+    if (!id) return null;
+    return { lastGenerationId: id };
+  },
+  serialize(params) {
+    if (!params || typeof params !== "object") return null;
+    const id = typeof params.lastGenerationId === "string" ? params.lastGenerationId : null;
+    if (!id) return null;
+    return { lastGenerationId: id };
+  },
+  getDisplayId(params) {
+    if (!params || typeof params !== "object") return null;
+    const id = (params as Record<string, unknown>).lastGenerationId;
+    return typeof id === "string" ? id : null;
+  },
+};
+
+// ----- detectModel -----
+
+/**
+ * Best-effort detection: read OPENROUTER_MODEL or fall back to "openrouter/auto".
+ * Other adapters read from on-disk CLI configs; OpenRouter has none, so env
+ * is the only meaningful source.
+ */
+export async function detectModel(): Promise<{
+  model: string;
+  provider: string;
+  source: string;
+} | null> {
+  const fromEnv = process.env.OPENROUTER_MODEL;
+  if (fromEnv && fromEnv.trim().length > 0) {
+    return { model: fromEnv.trim(), provider: "openrouter", source: "env:OPENROUTER_MODEL" };
+  }
+  return { model: "openrouter/auto", provider: "openrouter", source: "default" };
+}
+
+// ----- listSkills / syncSkills -----
+
+/**
+ * Minimal skill listing. We scan the same root our skill loader uses
+ * (~/.openrouter-adapter/skills by default) and report each subdirectory
+ * containing a SKILL.md as an external skill.
+ *
+ * v1 doesn't track desired-vs-installed because we don't sync from
+ * Paperclip's managed skill store yet — that's a v3 feature.
+ */
+function defaultSkillsRoot(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || ".";
+  return path.join(home, ".openrouter-adapter", "skills");
+}
+
+export async function listSkills(_ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  const root = process.env.PAPERCLIP_SKILLS_DIR?.trim() || defaultSkillsRoot();
+  const snapshot: AdapterSkillSnapshot = {
+    adapterType: "openrouter",
+    supported: true,
+    mode: "ephemeral",
+    desiredSkills: [],
+    entries: [],
+    warnings: [],
+  };
+
+  let entries: import("node:fs").Dirent[] = [];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    snapshot.warnings.push(`Skills root ${root} not present.`);
+    return snapshot;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const skillDir = path.join(root, entry.name);
+    const skillMd = path.join(skillDir, "SKILL.md");
+    let hasSkillMd = true;
+    try {
+      await fs.access(skillMd);
+    } catch {
+      hasSkillMd = false;
+    }
+    if (!hasSkillMd) continue;
+    snapshot.entries.push({
+      key: entry.name,
+      runtimeName: entry.name,
+      desired: true,
+      managed: false,
+      state: "external",
+      origin: "external_unknown",
+      sourcePath: skillDir,
+      targetPath: skillDir,
+    });
+  }
+
+  return snapshot;
+}
+
+export async function syncSkills(
+  ctx: AdapterSkillContext,
+  _desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  // v1: skills are managed externally (operator drops them in skillsRoot).
+  // We just return the current listing — no copy/sync work.
+  return listSkills(ctx);
+}

--- a/packages/adapters/openrouter/src/server/paperclip-api.ts
+++ b/packages/adapters/openrouter/src/server/paperclip-api.ts
@@ -1,0 +1,196 @@
+/**
+ * Thin HTTP client for the Paperclip API.
+ *
+ * Used by tool handlers to call Paperclip as the agent (not the server).
+ * Auth is per-call: pass the agent's authToken from AdapterExecutionContext.
+ *
+ * Base URL resolution order:
+ *   1. explicit baseUrl arg
+ *   2. PAPERCLIP_API_URL env var
+ *   3. http://localhost:3100 (default Paperclip dev port)
+ */
+
+export interface PaperclipApiOptions {
+  baseUrl?: string;
+  authToken: string;
+  /** Optional fetch impl override for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export class PaperclipApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+    public readonly endpoint: string,
+  ) {
+    super(message);
+    this.name = "PaperclipApiError";
+  }
+}
+
+function resolveBaseUrl(explicit?: string): string {
+  if (explicit && explicit.trim().length > 0) return explicit.replace(/\/+$/, "");
+  const fromEnv = process.env.PAPERCLIP_API_URL;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv.replace(/\/+$/, "");
+  return "http://localhost:3100";
+}
+
+export class PaperclipApi {
+  private readonly baseUrl: string;
+  private readonly authToken: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: PaperclipApiOptions) {
+    this.baseUrl = resolveBaseUrl(opts.baseUrl);
+    this.authToken = opts.authToken;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private async request<T = unknown>(
+    method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE",
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.authToken}`,
+      Accept: "application/json",
+    };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new PaperclipApiError(
+        `Network error calling Paperclip API: ${reason}`,
+        0,
+        null,
+        `${method} ${path}`,
+      );
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    let parsed: unknown = null;
+    if (contentType.includes("application/json")) {
+      try {
+        parsed = await response.json();
+      } catch {
+        parsed = null;
+      }
+    } else {
+      try {
+        parsed = await response.text();
+      } catch {
+        parsed = null;
+      }
+    }
+
+    if (!response.ok) {
+      const message =
+        (parsed && typeof parsed === "object" && "error" in parsed && typeof (parsed as any).error === "string"
+          ? (parsed as any).error
+          : null) ?? `Paperclip API ${response.status} ${response.statusText}`;
+      throw new PaperclipApiError(message, response.status, parsed, `${method} ${path}`);
+    }
+
+    return parsed as T;
+  }
+
+  // ----- Issues -----
+
+  getIssue(issueId: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/api/issues/${encodeURIComponent(issueId)}`);
+  }
+
+  updateIssue(issueId: string, patch: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("PATCH", `/api/issues/${encodeURIComponent(issueId)}`, patch);
+  }
+
+  listCompanyIssues(companyId: string, query?: Record<string, string>): Promise<Record<string, unknown>> {
+    const qs = query && Object.keys(query).length > 0 ? `?${new URLSearchParams(query).toString()}` : "";
+    return this.request("GET", `/api/companies/${encodeURIComponent(companyId)}/issues${qs}`);
+  }
+
+  createIssue(companyId: string, issue: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("POST", `/api/companies/${encodeURIComponent(companyId)}/issues`, issue);
+  }
+
+  getHeartbeatContext(issueId: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/api/issues/${encodeURIComponent(issueId)}/heartbeat-context`);
+  }
+
+  /**
+   * Acquire the issue lock for the current run. Required before any
+   * write operation (add_comment, update status) on an issue, otherwise
+   * Paperclip's sameRunLock check rejects with 409 "Issue run ownership
+   * conflict". The run id is read by Paperclip from the JWT claims, so
+   * we only need to send agentId + expectedStatuses in the body.
+   */
+  /**
+   * Default checkout statuses: every pre-terminal status an issue can
+   * be in when a run picks it up. Excludes "done" and "cancelled" since
+   * a finished issue should not be re-checked-out by a new run.
+   *
+   * Source of truth: ISSUE_STATUSES in @paperclipai/shared/constants.
+   * Keep this list in sync if Paperclip ever adds new statuses.
+   */
+  checkoutIssue(
+    issueId: string,
+    agentId: string,
+    expectedStatuses: string[] = [
+      "backlog",
+      "todo",
+      "in_progress",
+      "in_review",
+      "blocked",
+    ],
+  ): Promise<Record<string, unknown>> {
+    return this.request("POST", `/api/issues/${encodeURIComponent(issueId)}/checkout`, {
+      agentId,
+      expectedStatuses,
+    });
+  }
+
+
+  // ----- Comments -----
+
+  listIssueComments(issueId: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/api/issues/${encodeURIComponent(issueId)}/comments`);
+  }
+
+  addIssueComment(issueId: string, body: { body: string; [k: string]: unknown }): Promise<Record<string, unknown>> {
+    return this.request("POST", `/api/issues/${encodeURIComponent(issueId)}/comments`, body);
+  }
+
+  // ----- Agents -----
+
+  /**
+   * List all agents in a company. Returns the array directly (no envelope).
+   * Used by the list_agents tool so a CEO can discover teammate IDs before
+   * delegating work via create_sub_issue or update_issue_status.
+   */
+  listCompanyAgents(companyId: string): Promise<Record<string, unknown>[]> {
+    return this.request("GET", `/api/companies/${encodeURIComponent(companyId)}/agents`);
+  }
+
+  hireAgent(companyId: string, hire: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("POST", `/api/companies/${encodeURIComponent(companyId)}/agent-hires`, hire);
+  }
+
+  wakeAgent(agentId: string, body: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("POST", `/api/agents/${encodeURIComponent(agentId)}/wakeup`, body);
+  }
+
+  // ----- Approvals -----
+
+  createApproval(companyId: string, approval: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("POST", `/api/companies/${encodeURIComponent(companyId)}/approvals`, approval);
+  }
+}

--- a/packages/adapters/openrouter/src/server/server-index.ts
+++ b/packages/adapters/openrouter/src/server/server-index.ts
@@ -1,0 +1,4 @@
+// Server-side exports
+export { execute } from "./execute.js";
+export { testEnvironment, listOpenRouterModels } from "./test.js";
+export { getConfigSchema } from "./config-schema.js";

--- a/packages/adapters/openrouter/src/server/skills.ts
+++ b/packages/adapters/openrouter/src/server/skills.ts
@@ -1,0 +1,107 @@
+/**
+ * Skill loading for the OpenRouter adapter.
+ *
+ * Reads SKILL.md files from a skills directory and returns their contents
+ * for injection into the system prompt.
+ *
+ * Discovery order for the skills root:
+ *   1. agentConfig.skillsDir (per-agent override)
+ *   2. PAPERCLIP_SKILLS_DIR env var (server-wide override)
+ *   3. ~/.openrouter-adapter/skills (default managed root)
+ *
+ * v1 design: scan the root, load every subdirectory that contains a SKILL.md,
+ * inject all of them. We do NOT yet integrate with Paperclip's "desired skills"
+ * registry — that requires API access and is deferred to v3. For now, the
+ * operator controls which skills an agent gets by what they put in the
+ * skills directory.
+ *
+ * Failure mode: best-effort. Missing directory or unreadable files log a
+ * warning and return what we have. Skill loading never fails the run.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OnLog } from "./transcript.js";
+import { writeRawStderr } from "./transcript.js";
+
+export interface LoadedSkill {
+  name: string;
+  path: string;
+  content: string;
+}
+
+export interface LoadSkillsParams {
+  agentConfig: Record<string, unknown>;
+  onLog: OnLog;
+}
+
+function resolveSkillsRoot(agentConfig: Record<string, unknown>): string {
+  const fromConfig = typeof agentConfig.skillsDir === "string" ? agentConfig.skillsDir.trim() : "";
+  if (fromConfig) return fromConfig;
+  const fromEnv = process.env.PAPERCLIP_SKILLS_DIR;
+  if (fromEnv && fromEnv.trim()) return fromEnv.trim();
+  const home = process.env.HOME || process.env.USERPROFILE || ".";
+  return path.join(home, ".openrouter-adapter", "skills");
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadSkills(params: LoadSkillsParams): Promise<LoadedSkill[]> {
+  const { agentConfig, onLog } = params;
+  const root = resolveSkillsRoot(agentConfig);
+
+  if (!(await pathExists(root))) {
+    // Not an error — most agents won't have skills configured.
+    return [];
+  }
+
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await writeRawStderr(onLog, `[openrouter] could not read skills root ${root}: ${reason}`);
+    return [];
+  }
+
+  const loaded: LoadedSkill[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const skillName = entry.name;
+    const skillMdPath = path.join(root, skillName, "SKILL.md");
+    if (!(await pathExists(skillMdPath))) continue;
+    try {
+      const content = await fs.readFile(skillMdPath, "utf8");
+      loaded.push({ name: skillName, path: skillMdPath, content });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await writeRawStderr(onLog, `[openrouter] failed to read skill "${skillName}": ${reason}`);
+    }
+  }
+
+  return loaded;
+}
+
+/**
+ * Render loaded skills as a single block of text suitable for prepending to
+ * the system prompt. Each skill is wrapped in a fenced section so the model
+ * can tell where one ends and the next begins.
+ */
+export function renderSkillsForPrompt(skills: LoadedSkill[]): string {
+  if (skills.length === 0) return "";
+  const blocks = skills.map((s) => `## Skill: ${s.name}\n\n${s.content.trim()}`);
+  return [
+    "# Available Skills",
+    "",
+    "The following skills are available to you. Read them carefully and apply them when relevant.",
+    "",
+    blocks.join("\n\n---\n\n"),
+  ].join("\n");
+}

--- a/packages/adapters/openrouter/src/server/test.ts
+++ b/packages/adapters/openrouter/src/server/test.ts
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────────────────
+// @paperclipai/adapter-openrouter — Server Test (Environment Check)
+// Matches real Paperclip AdapterEnvironmentTestContext / Result
+// ─────────────────────────────────────────────────────────────────
+
+import type {
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+  AdapterEnvironmentCheck,
+} from "@paperclipai/adapter-utils";
+import {
+  OPENROUTER_MODELS_ENDPOINT,
+  type OpenRouterConfig,
+  type OpenRouterModel,
+} from "../index.js";
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = ctx.config as unknown as OpenRouterConfig;
+
+  // ── 1. Check API key ──────────────────────────────────────────
+  const apiKey =
+    config.apiKey ||
+    process.env.OPENROUTER_API_KEY;
+
+  if (!apiKey) {
+    checks.push({
+      code: "openrouter_api_key_missing",
+      level: "error",
+      message: "No OpenRouter API key found",
+      detail: "Set adapterConfig.apiKey or OPENROUTER_API_KEY environment variable.",
+      hint: "Get a key at https://openrouter.ai/keys",
+    });
+    return {
+      adapterType: "openrouter",
+      status: "fail",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  if (!apiKey.startsWith("sk-or-")) {
+    checks.push({
+      code: "openrouter_api_key_format",
+      level: "warn",
+      message: "API key does not start with \"sk-or-\"",
+      hint: "Ensure this is a valid OpenRouter key.",
+    });
+  }
+
+  checks.push({
+    code: "openrouter_api_key_found",
+    level: "info",
+    message: `API key found: ${apiKey.slice(0, 12)}...${apiKey.slice(-4)}`,
+  });
+
+  // ── 2. Test API connectivity & fetch models ───────────────────
+  try {
+    const res = await fetch(OPENROUTER_MODELS_ENDPOINT, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      checks.push({
+        code: "openrouter_api_error",
+        level: "error",
+        message: `OpenRouter API returned ${res.status}`,
+        detail: errText.slice(0, 200),
+      });
+      return {
+        adapterType: "openrouter",
+        status: "fail",
+        checks,
+        testedAt: new Date().toISOString(),
+      };
+    }
+
+    const data = (await res.json()) as { data: OpenRouterModel[] };
+    const allModels = data.data || [];
+
+    const freeModels = allModels.filter(
+      (m) =>
+        m.id.endsWith(":free") ||
+        (m.pricing?.prompt === "0" && m.pricing?.completion === "0")
+    );
+
+    checks.push({
+      code: "openrouter_connected",
+      level: "info",
+      message: `Connected — ${allModels.length} models available (${freeModels.length} free)`,
+    });
+
+    // ── 3. Validate selected model ──────────────────────────────
+    const selectedModel = config.model || "openrouter/auto";
+
+    if (selectedModel === "openrouter/auto") {
+      checks.push({
+        code: "openrouter_model_auto",
+        level: "info",
+        message: "Using auto-routing — OpenRouter selects the best model per request",
+      });
+    } else {
+      const model = allModels.find((m) => m.id === selectedModel);
+      if (model) {
+        const promptCost = parseFloat(model.pricing?.prompt || "0") * 1_000_000;
+        const completionCost = parseFloat(model.pricing?.completion || "0") * 1_000_000;
+        checks.push({
+          code: "openrouter_model_found",
+          level: "info",
+          message: `Model "${selectedModel}" — $${promptCost.toFixed(2)}/$${completionCost.toFixed(2)} per 1M tokens, ${model.context_length?.toLocaleString()} ctx`,
+        });
+      } else {
+        checks.push({
+          code: "openrouter_model_not_found",
+          level: "warn",
+          message: `Model "${selectedModel}" not found — may be deprecated or misspelled`,
+        });
+      }
+    }
+
+    const hasErrors = checks.some((c) => c.level === "error");
+    const hasWarnings = checks.some((c) => c.level === "warn");
+
+    return {
+      adapterType: "openrouter",
+      status: hasErrors ? "fail" : hasWarnings ? "warn" : "pass",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  } catch (err: any) {
+    checks.push({
+      code: "openrouter_connection_failed",
+      level: "error",
+      message: `Failed to connect to OpenRouter: ${err.message || err}`,
+    });
+    return {
+      adapterType: "openrouter",
+      status: "fail",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+}
+
+/**
+ * Fetch all models from OpenRouter — used by listModels() for dynamic model picker.
+ */
+export async function listOpenRouterModels(): Promise<{ id: string; label: string }[]> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) return [];
+
+  try {
+    const res = await fetch(OPENROUTER_MODELS_ENDPOINT, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) return [];
+
+    const data = (await res.json()) as { data: OpenRouterModel[] };
+    return (data.data || [])
+      .sort((a, b) => {
+        const aFree = a.id.endsWith(":free") || (a.pricing?.prompt === "0" && a.pricing?.completion === "0");
+        const bFree = b.id.endsWith(":free") || (b.pricing?.prompt === "0" && b.pricing?.completion === "0");
+        if (aFree && !bFree) return -1;
+        if (!aFree && bFree) return 1;
+        return (a.name || a.id).localeCompare(b.name || b.id);
+      })
+      .map((m) => ({
+        id: m.id,
+        label: m.name || m.id,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/packages/adapters/openrouter/src/server/tools.ts
+++ b/packages/adapters/openrouter/src/server/tools.ts
@@ -1,0 +1,417 @@
+/**
+ * Tool definitions and handlers for the OpenRouter adapter.
+ *
+ * Architecture:
+ *   - Each tool = { schema (sent to the model), execute (called by the loop) }
+ *   - buildTools(ctx) closes over agent/company/issue identity so the model
+ *     cannot spoof IDs by passing them as arguments
+ *   - Errors during execute() are caught and returned as { isError: true }
+ *     tool results so the model can recover; only programmer errors throw
+ *
+ * The schema format matches OpenAI function-calling, which OpenRouter
+ * normalizes for any provider that supports tools.
+ */
+
+import { PaperclipApi, PaperclipApiError } from "./paperclip-api.js";
+
+export interface ToolSchema {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface ToolExecutionResult {
+  content: string;
+  isError: boolean;
+}
+
+export interface Tool {
+  schema: ToolSchema;
+  execute: (args: Record<string, unknown>) => Promise<ToolExecutionResult>;
+}
+
+export interface BuildToolsContext {
+  api: PaperclipApi;
+  agentId: string;
+  companyId: string;
+  /** The issue this run is working on, if any. Tools default to this when no id is supplied. */
+  currentIssueId: string | null;
+  /** When false, hire_agent and similar mutating actions go through request_approval first. */
+  autoApprove: boolean;
+}
+
+// ----- helpers -----
+
+function ok(content: string | Record<string, unknown>): ToolExecutionResult {
+  return {
+    content: typeof content === "string" ? content : JSON.stringify(content),
+    isError: false,
+  };
+}
+
+function fail(message: string, detail?: unknown): ToolExecutionResult {
+  const body: Record<string, unknown> = { error: message };
+  if (detail !== undefined) body.detail = detail;
+  return { content: JSON.stringify(body), isError: true };
+}
+
+async function safeCall<T>(label: string, fn: () => Promise<T>): Promise<ToolExecutionResult> {
+  try {
+    const result = await fn();
+    return ok(result as Record<string, unknown>);
+  } catch (err) {
+    if (err instanceof PaperclipApiError) {
+      return fail(`${label} failed: ${err.message}`, { status: err.status, body: err.body });
+    }
+    const reason = err instanceof Error ? err.message : String(err);
+    return fail(`${label} failed: ${reason}`);
+  }
+}
+
+function asString(v: unknown, fallback = ""): string {
+  return typeof v === "string" && v.length > 0 ? v : fallback;
+}
+
+// ----- tool builders -----
+
+function getIssueTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "get_issue",
+        description:
+          "Fetch the full details of an issue (title, description, status, comments, attachments). " +
+          "Defaults to the current issue if no id is supplied.",
+        parameters: {
+          type: "object",
+          properties: {
+            issue_id: {
+              type: "string",
+              description: "Issue id. Omit to use the current issue.",
+            },
+          },
+        },
+      },
+    },
+    execute: async (args) => {
+      const id = asString(args.issue_id, ctx.currentIssueId ?? "");
+      if (!id) return fail("No issue_id supplied and no current issue.");
+      return safeCall("get_issue", () => ctx.api.getIssue(id));
+    },
+  };
+}
+
+function updateIssueStatusTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "update_issue_status",
+        description:
+          "Move an issue to a new status. Valid statuses: open, in_progress, blocked, done, cancelled. " +
+          "Defaults to the current issue.",
+        parameters: {
+          type: "object",
+          properties: {
+            issue_id: { type: "string", description: "Issue id. Omit to use the current issue." },
+            status: {
+              type: "string",
+              enum: ["open", "in_progress", "blocked", "done", "cancelled"],
+            },
+            reason: { type: "string", description: "Optional explanation." },
+          },
+          required: ["status"],
+        },
+      },
+    },
+    execute: async (args) => {
+      const id = asString(args.issue_id, ctx.currentIssueId ?? "");
+      if (!id) return fail("No issue_id supplied and no current issue.");
+      const status = asString(args.status);
+      if (!status) return fail("status is required.");
+      return safeCall("update_issue_status", () =>
+        ctx.api.updateIssue(id, { status, statusReason: args.reason ?? null }),
+      );
+    },
+  };
+}
+
+function addCommentTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "add_comment",
+        description:
+          "Post a comment on an issue. Use this to share progress, results, or questions with " +
+          "other agents and humans. Defaults to the current issue.",
+        parameters: {
+          type: "object",
+          properties: {
+            issue_id: { type: "string", description: "Issue id. Omit to use the current issue." },
+            body: { type: "string", description: "Comment body in Markdown." },
+          },
+          required: ["body"],
+        },
+      },
+    },
+    execute: async (args) => {
+      const id = asString(args.issue_id, ctx.currentIssueId ?? "");
+      if (!id) return fail("No issue_id supplied and no current issue.");
+      const body = asString(args.body);
+      if (!body) return fail("body is required.");
+      return safeCall("add_comment", () => ctx.api.addIssueComment(id, { body }));
+    },
+  };
+}
+
+function listCommentsTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "list_comments",
+        description: "List all comments on an issue. Defaults to the current issue.",
+        parameters: {
+          type: "object",
+          properties: {
+            issue_id: { type: "string", description: "Issue id. Omit to use the current issue." },
+          },
+        },
+      },
+    },
+    execute: async (args) => {
+      const id = asString(args.issue_id, ctx.currentIssueId ?? "");
+      if (!id) return fail("No issue_id supplied and no current issue.");
+      return safeCall("list_comments", () => ctx.api.listIssueComments(id));
+    },
+  };
+}
+
+function createSubIssueTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "create_sub_issue",
+        description:
+          "Create a child issue under a parent (defaults to the current issue). Use this to break work " +
+          "into smaller pieces or delegate to a teammate by setting assigneeId.",
+        parameters: {
+          type: "object",
+          properties: {
+            parent_issue_id: { type: "string", description: "Parent issue id. Omit to use current issue." },
+            title: { type: "string" },
+            description: { type: "string" },
+            assignee_agent_id: { type: "string", description: "Optional agent id to assign to." },
+            priority: { type: "string", enum: ["low", "normal", "high", "urgent"] },
+          },
+          required: ["title"],
+        },
+      },
+    },
+    execute: async (args) => {
+      const parentId = asString(args.parent_issue_id, ctx.currentIssueId ?? "");
+      const title = asString(args.title);
+      if (!title) return fail("title is required.");
+      const payload: Record<string, unknown> = {
+        title,
+        description: args.description ?? "",
+        parentId: parentId || undefined,
+        assigneeAgentId: args.assignee_agent_id ?? undefined,
+        priority: args.priority ?? undefined,
+      };
+      return safeCall("create_sub_issue", () => ctx.api.createIssue(ctx.companyId, payload));
+    },
+  };
+}
+
+function listIssuesTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "list_issues",
+        description: "List issues in the current company, optionally filtered by status or assignee.",
+        parameters: {
+          type: "object",
+          properties: {
+            status: { type: "string" },
+            assignee_agent_id: { type: "string" },
+            limit: { type: "number", description: "Max results, default 20." },
+          },
+        },
+      },
+    },
+    execute: async (args) => {
+      const query: Record<string, string> = {};
+      if (typeof args.status === "string") query.status = args.status;
+      if (typeof args.assignee_agent_id === "string") query.assigneeAgentId = args.assignee_agent_id;
+      query.limit = String(typeof args.limit === "number" ? args.limit : 20);
+      return safeCall("list_issues", () => ctx.api.listCompanyIssues(ctx.companyId, query));
+    },
+  };
+}
+
+function hireAgentTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "hire_agent",
+        description:
+          "Hire a new agent into the company. By default this creates an approval request that a human " +
+          "must approve before the agent is created. Use this when you need a new role on your team.",
+        parameters: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            role: { type: "string", description: "Job title, e.g. 'Senior Engineer'." },
+            mission: { type: "string", description: "What this agent is responsible for." },
+            adapter_type: {
+              type: "string",
+              description: "Adapter to use, e.g. 'openrouter', 'claude_local'.",
+              default: "openrouter",
+            },
+            model: { type: "string", description: "Model id, e.g. 'stepfun/step-3.5-flash:free'." },
+            reports_to_agent_id: { type: "string", description: "Manager agent id." },
+          },
+          required: ["name", "role", "mission"],
+        },
+      },
+    },
+    execute: async (args) => {
+      const payload: Record<string, unknown> = {
+        name: args.name,
+        role: args.role,
+        mission: args.mission,
+        adapterType: args.adapter_type ?? "openrouter",
+        model: args.model,
+        reportsToAgentId: args.reports_to_agent_id,
+        requestedByAgentId: ctx.agentId,
+      };
+
+      if (ctx.autoApprove) {
+        return safeCall("hire_agent", () => ctx.api.hireAgent(ctx.companyId, payload));
+      }
+
+      // Default path: route through approvals so a human signs off.
+      return safeCall("hire_agent (approval)", () =>
+        ctx.api.createApproval(ctx.companyId, {
+          type: "hire_agent",
+          requestedByAgentId: ctx.agentId,
+          payload: { ...payload, summary: `Hire ${args.name} as ${args.role}` },
+        }),
+      );
+    },
+  };
+}
+
+function listAgentsTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "list_agents",
+        description:
+          "List all agents (teammates) in the current company. Returns each agent's id, name, " +
+          "role, title, adapter type, model, and status. Use this BEFORE delegating work with " +
+          "create_sub_issue or hire_agent so you can reference real agent ids instead of guessing.",
+        parameters: {
+          type: "object",
+          properties: {},
+        },
+      },
+    },
+    execute: async () => {
+      return safeCall("list_agents", async () => {
+        const agents = await ctx.api.listCompanyAgents(ctx.companyId);
+        // Trim to fields the model actually needs — full agent objects can be huge
+        // and waste context window on hundreds of irrelevant runtime config keys.
+        return agents.map((a) => ({
+          id: a.id,
+          name: a.name,
+          role: a.role,
+          title: a.title,
+          adapterType: a.adapterType,
+          model: (a.adapterConfig as Record<string, unknown> | undefined)?.model ?? null,
+          status: a.status,
+          reportsToAgentId: a.reportsToAgentId ?? null,
+        }));
+      });
+    },
+  };
+}
+
+function requestApprovalTool(ctx: BuildToolsContext): Tool {
+  return {
+    schema: {
+      type: "function",
+      function: {
+        name: "request_approval",
+        description:
+          "Open an approval request for an action that requires human sign-off. " +
+          "Only three types are currently supported by Paperclip: hire_agent, " +
+          "approve_ceo_strategy, budget_override_required. For hiring, prefer the " +
+          "dedicated hire_agent tool instead.",
+        parameters: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["hire_agent", "approve_ceo_strategy", "budget_override_required"],
+              description: "Approval type — must be one of the three supported values.",
+            },
+            summary: { type: "string", description: "One-line summary for the operator." },
+            payload: { type: "object", description: "Structured payload describing the action." },
+          },
+          required: ["type", "summary"],
+        },
+      },
+    },
+    execute: async (args) => {
+      const type = asString(args.type);
+      const summary = asString(args.summary);
+      if (!type) return fail("type is required and must be hire_agent / approve_ceo_strategy / budget_override_required.");
+      if (!summary) return fail("summary is required.");
+      const payload = (args.payload && typeof args.payload === "object" ? args.payload : {}) as Record<string, unknown>;
+      return safeCall("request_approval", () =>
+        ctx.api.createApproval(ctx.companyId, {
+          type,
+          requestedByAgentId: ctx.agentId,
+          payload: { ...payload, summary },
+        }),
+      );
+    },
+  };
+}
+
+// ----- public API -----
+
+export function buildTools(ctx: BuildToolsContext): Tool[] {
+  return [
+    getIssueTool(ctx),
+    updateIssueStatusTool(ctx),
+    addCommentTool(ctx),
+    listCommentsTool(ctx),
+    createSubIssueTool(ctx),
+    listIssuesTool(ctx),
+    listAgentsTool(ctx),
+    hireAgentTool(ctx),
+    requestApprovalTool(ctx),
+  ];
+}
+
+/** Get the schemas to send to the model. */
+export function toolSchemas(tools: Tool[]): ToolSchema[] {
+  return tools.map((t) => t.schema);
+}
+
+/** Look up a tool by name. Returns null if not found. */
+export function findTool(tools: Tool[], name: string): Tool | null {
+  return tools.find((t) => t.schema.function.name === name) ?? null;
+}

--- a/packages/adapters/openrouter/src/server/transcript.ts
+++ b/packages/adapters/openrouter/src/server/transcript.ts
@@ -1,0 +1,136 @@
+/**
+ * Typed TranscriptEntry emitters.
+ *
+ * Paperclip's run viewer expects each transcript entry as a single-line JSON
+ * object on stdout. The UI's parseStdout module turns those lines into
+ * TranscriptEntry objects (see adapter-utils/types.ts).
+ *
+ * Every emit() call writes exactly one line ending in "\n".
+ *
+ * Why a wrapper instead of inline JSON.stringify everywhere:
+ *   - guarantees the entry shape matches the discriminated union
+ *   - one place to add tracing / debug prefixes later
+ *   - prevents accidentally splitting an entry across two onLog calls
+ */
+
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+export type OnLog = (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+async function emit(onLog: OnLog, entry: TranscriptEntry): Promise<void> {
+  await onLog("stdout", `${JSON.stringify(entry)}\n`);
+}
+
+export async function emitInit(
+  onLog: OnLog,
+  params: { model: string; sessionId: string },
+): Promise<void> {
+  await emit(onLog, {
+    kind: "init",
+    ts: nowIso(),
+    model: params.model,
+    sessionId: params.sessionId,
+  });
+}
+
+export async function emitAssistant(
+  onLog: OnLog,
+  text: string,
+  opts: { delta?: boolean } = {},
+): Promise<void> {
+  await emit(onLog, {
+    kind: "assistant",
+    ts: nowIso(),
+    text,
+    delta: opts.delta ?? false,
+  });
+}
+
+export async function emitThinking(
+  onLog: OnLog,
+  text: string,
+  opts: { delta?: boolean } = {},
+): Promise<void> {
+  await emit(onLog, {
+    kind: "thinking",
+    ts: nowIso(),
+    text,
+    delta: opts.delta ?? false,
+  });
+}
+
+export async function emitToolCall(
+  onLog: OnLog,
+  params: { name: string; input: unknown; toolUseId?: string },
+): Promise<void> {
+  await emit(onLog, {
+    kind: "tool_call",
+    ts: nowIso(),
+    name: params.name,
+    input: params.input,
+    toolUseId: params.toolUseId,
+  });
+}
+
+export async function emitToolResult(
+  onLog: OnLog,
+  params: { toolUseId: string; toolName?: string; content: string; isError: boolean },
+): Promise<void> {
+  await emit(onLog, {
+    kind: "tool_result",
+    ts: nowIso(),
+    toolUseId: params.toolUseId,
+    toolName: params.toolName,
+    content: params.content,
+    isError: params.isError,
+  });
+}
+
+export async function emitResult(
+  onLog: OnLog,
+  params: {
+    text: string;
+    inputTokens: number;
+    outputTokens: number;
+    cachedTokens?: number;
+    costUsd?: number;
+    subtype?: string;
+    isError?: boolean;
+    errors?: string[];
+  },
+): Promise<void> {
+  await emit(onLog, {
+    kind: "result",
+    ts: nowIso(),
+    text: params.text,
+    inputTokens: params.inputTokens,
+    outputTokens: params.outputTokens,
+    cachedTokens: params.cachedTokens ?? 0,
+    costUsd: params.costUsd ?? 0,
+    subtype: params.subtype ?? "success",
+    isError: params.isError ?? false,
+    errors: params.errors ?? [],
+  });
+}
+
+export async function emitSystem(onLog: OnLog, text: string): Promise<void> {
+  await emit(onLog, { kind: "system", ts: nowIso(), text });
+}
+
+export async function emitStderr(onLog: OnLog, text: string): Promise<void> {
+  // stderr entries also live in the transcript union; they go on stdout as JSON
+  // (the actual stderr stream is reserved for raw adapter diagnostics).
+  await emit(onLog, { kind: "stderr", ts: nowIso(), text });
+}
+
+/**
+ * Raw stderr write — bypasses the JSON envelope. Use for adapter-level
+ * diagnostics that should appear in the run log but not in the transcript.
+ */
+export async function writeRawStderr(onLog: OnLog, text: string): Promise<void> {
+  await onLog("stderr", text.endsWith("\n") ? text : `${text}\n`);
+}

--- a/packages/adapters/openrouter/src/ui/build-config.ts
+++ b/packages/adapters/openrouter/src/ui/build-config.ts
@@ -1,0 +1,152 @@
+// ─────────────────────────────────────────────────────────────────
+// @paperclipai/adapter-openrouter — UI Build Config
+// Converts onboarding/settings form values → adapterConfig JSON
+// ─────────────────────────────────────────────────────────────────
+
+export interface OpenRouterFormValues {
+  model?: string;
+  apiKey?: string;
+  systemPrompt?: string;
+  temperature?: string;
+  maxTokens?: string;
+  topP?: string;
+  stream?: string | boolean;
+  reasoning?: string | boolean;
+  transforms?: string;
+  route?: string;
+  httpReferer?: string;
+  xTitle?: string;
+}
+
+/**
+ * Convert UI form values into the adapterConfig object
+ * stored in the Paperclip database for this agent.
+ */
+export function buildConfig(
+  formValues: OpenRouterFormValues
+): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+
+  // Required
+  config.model = formValues.model || "openrouter/auto";
+
+  // API key (stored as secret via Paperclip's secret provider)
+  if (formValues.apiKey) {
+    config.apiKey = formValues.apiKey;
+  }
+
+  // Optional text fields
+  if (formValues.systemPrompt) {
+    config.systemPrompt = formValues.systemPrompt;
+  }
+
+  // Numeric fields
+  if (formValues.temperature !== undefined && formValues.temperature !== "") {
+    config.temperature = parseFloat(formValues.temperature);
+  }
+  if (formValues.maxTokens !== undefined && formValues.maxTokens !== "") {
+    config.maxTokens = parseInt(formValues.maxTokens, 10);
+  }
+  if (formValues.topP !== undefined && formValues.topP !== "") {
+    config.topP = parseFloat(formValues.topP);
+  }
+
+  // Boolean fields
+  config.stream = formValues.stream === true || formValues.stream === "true";
+  if (formValues.reasoning === true || formValues.reasoning === "true") {
+    config.reasoning = true;
+  }
+
+  // Transforms (comma-separated string → array)
+  if (formValues.transforms) {
+    config.transforms = formValues.transforms
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  // Route
+  if (formValues.route && ["fallback", "no-fallback"].includes(formValues.route)) {
+    config.route = formValues.route;
+  }
+
+  // Leaderboard attribution
+  if (formValues.httpReferer) config.httpReferer = formValues.httpReferer;
+  if (formValues.xTitle) config.xTitle = formValues.xTitle;
+
+  return config;
+}
+
+/**
+ * Define the config form fields for Paperclip's UI.
+ * Each field maps to a form input in the agent configuration panel.
+ */
+export const configFields = [
+  {
+    key: "apiKey",
+    label: "OpenRouter API Key",
+    type: "password" as const,
+    placeholder: "sk-or-v1-...",
+    required: true,
+    helpText: "Get your key at https://openrouter.ai/keys",
+  },
+  {
+    key: "model",
+    label: "Model",
+    type: "select" as const,
+    placeholder: "openrouter/auto",
+    required: true,
+    helpText:
+      'Select a model or use "openrouter/auto" for auto-routing. Models are loaded dynamically from OpenRouter.',
+    dynamic: true, // signals UI to fetch models from test() endpoint
+  },
+  {
+    key: "systemPrompt",
+    label: "System Prompt",
+    type: "textarea" as const,
+    placeholder: "You are a helpful assistant working for {{company_name}}...",
+    required: false,
+  },
+  {
+    key: "temperature",
+    label: "Temperature",
+    type: "number" as const,
+    placeholder: "0.7",
+    required: false,
+    min: 0,
+    max: 2,
+    step: 0.1,
+  },
+  {
+    key: "maxTokens",
+    label: "Max Tokens",
+    type: "number" as const,
+    placeholder: "4096",
+    required: false,
+    min: 1,
+    max: 200000,
+  },
+  {
+    key: "stream",
+    label: "Enable Streaming",
+    type: "toggle" as const,
+    defaultValue: true,
+  },
+  {
+    key: "reasoning",
+    label: "Enable Reasoning (extended thinking)",
+    type: "toggle" as const,
+    defaultValue: false,
+    helpText: "Only works with models that support reasoning (DeepSeek R1, QwQ, etc.)",
+  },
+  {
+    key: "route",
+    label: "Routing Strategy",
+    type: "select" as const,
+    options: [
+      { value: "fallback", label: "Fallback (auto-retry with other providers)" },
+      { value: "no-fallback", label: "No Fallback (single provider only)" },
+    ],
+    defaultValue: "fallback",
+  },
+];

--- a/packages/adapters/openrouter/src/ui/index.ts
+++ b/packages/adapters/openrouter/src/ui/index.ts
@@ -1,0 +1,5 @@
+// UI-side exports
+export { parseStdout } from "./parse-stdout.js";
+export { buildConfig, configFields } from "./build-config.js";
+export type { OpenRouterFormValues } from "./build-config.js";
+export type { TranscriptEntry } from "./parse-stdout.js";

--- a/packages/adapters/openrouter/src/ui/index.ts
+++ b/packages/adapters/openrouter/src/ui/index.ts
@@ -1,5 +1,4 @@
 // UI-side exports
-export { parseStdout } from "./parse-stdout.js";
+export { createOpenRouterStdoutParser, parseOpenRouterStdoutLine } from "./parse-stdout.js";
 export { buildConfig, configFields } from "./build-config.js";
 export type { OpenRouterFormValues } from "./build-config.js";
-export type { TranscriptEntry } from "./parse-stdout.js";

--- a/packages/adapters/openrouter/src/ui/parse-stdout.ts
+++ b/packages/adapters/openrouter/src/ui/parse-stdout.ts
@@ -1,0 +1,112 @@
+// ─────────────────────────────────────────────────────────────────
+// @paperclipai/adapter-openrouter — UI Parse Stdout
+// Converts raw stdout into transcript entries for the run viewer
+// ─────────────────────────────────────────────────────────────────
+
+export interface TranscriptEntry {
+  type: "text" | "thinking" | "tool_call" | "tool_result" | "error" | "info";
+  content: string;
+  timestamp?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Parse stdout lines from an OpenRouter adapter run into
+ * transcript entries for Paperclip's run viewer UI.
+ */
+export function parseStdout(stdout: string): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = [];
+  const lines = stdout.split("\n");
+
+  let currentBlock = "";
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    // Track code blocks to avoid splitting them
+    if (line.trim().startsWith("```")) {
+      inCodeBlock = !inCodeBlock;
+    }
+
+    // SSE stream data lines
+    if (line.startsWith("data: ")) {
+      const data = line.slice(6).trim();
+      if (data === "[DONE]") {
+        if (currentBlock.trim()) {
+          entries.push({ type: "text", content: currentBlock.trim() });
+          currentBlock = "";
+        }
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(data);
+
+        // Reasoning / thinking content
+        const reasoning =
+          parsed.choices?.[0]?.delta?.reasoning_content ||
+          parsed.choices?.[0]?.delta?.reasoning;
+        if (reasoning) {
+          entries.push({
+            type: "thinking",
+            content: reasoning,
+            metadata: { model: parsed.model },
+          });
+          continue;
+        }
+
+        // Regular content
+        const content = parsed.choices?.[0]?.delta?.content;
+        if (content) {
+          currentBlock += content;
+        }
+
+        // Tool calls
+        const toolCalls = parsed.choices?.[0]?.delta?.tool_calls;
+        if (toolCalls?.length) {
+          for (const tc of toolCalls) {
+            entries.push({
+              type: "tool_call",
+              content: `${tc.function?.name || "tool"}(${tc.function?.arguments || ""})`,
+              metadata: { toolCallId: tc.id },
+            });
+          }
+        }
+      } catch {
+        // Not JSON — treat as raw text
+        if (data) currentBlock += data;
+      }
+      continue;
+    }
+
+    // Error lines
+    if (
+      line.includes("OpenRouter API error") ||
+      line.includes("Error:") ||
+      line.includes("error")
+    ) {
+      entries.push({ type: "error", content: line });
+      continue;
+    }
+
+    // Info lines (model selection, cost)
+    if (
+      line.includes("[openrouter]") ||
+      line.includes("model:") ||
+      line.includes("tokens:") ||
+      line.includes("cost:")
+    ) {
+      entries.push({ type: "info", content: line });
+      continue;
+    }
+
+    // Regular output
+    currentBlock += line + "\n";
+  }
+
+  // Flush remaining
+  if (currentBlock.trim()) {
+    entries.push({ type: "text", content: currentBlock.trim() });
+  }
+
+  return entries;
+}

--- a/packages/adapters/openrouter/src/ui/parse-stdout.ts
+++ b/packages/adapters/openrouter/src/ui/parse-stdout.ts
@@ -1,112 +1,109 @@
 // ─────────────────────────────────────────────────────────────────
 // @paperclipai/adapter-openrouter — UI Parse Stdout
-// Converts raw stdout into transcript entries for the run viewer
+// Converts raw OpenRouter SSE stdout lines into Paperclip's shared
+// transcript entry shape for the run viewer.
 // ─────────────────────────────────────────────────────────────────
 
-export interface TranscriptEntry {
-  type: "text" | "thinking" | "tool_call" | "tool_result" | "error" | "info";
-  content: string;
-  timestamp?: number;
-  metadata?: Record<string, unknown>;
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
 }
 
-/**
- * Parse stdout lines from an OpenRouter adapter run into
- * transcript entries for Paperclip's run viewer UI.
- */
-export function parseStdout(stdout: string): TranscriptEntry[] {
-  const entries: TranscriptEntry[] = [];
-  const lines = stdout.split("\n");
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
 
-  let currentBlock = "";
-  let inCodeBlock = false;
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
 
-  for (const line of lines) {
-    // Track code blocks to avoid splitting them
-    if (line.trim().startsWith("```")) {
-      inCodeBlock = !inCodeBlock;
-    }
-
-    // SSE stream data lines
-    if (line.startsWith("data: ")) {
-      const data = line.slice(6).trim();
-      if (data === "[DONE]") {
-        if (currentBlock.trim()) {
-          entries.push({ type: "text", content: currentBlock.trim() });
-          currentBlock = "";
-        }
-        continue;
-      }
-
-      try {
-        const parsed = JSON.parse(data);
-
-        // Reasoning / thinking content
-        const reasoning =
-          parsed.choices?.[0]?.delta?.reasoning_content ||
-          parsed.choices?.[0]?.delta?.reasoning;
-        if (reasoning) {
-          entries.push({
-            type: "thinking",
-            content: reasoning,
-            metadata: { model: parsed.model },
-          });
-          continue;
-        }
-
-        // Regular content
-        const content = parsed.choices?.[0]?.delta?.content;
-        if (content) {
-          currentBlock += content;
-        }
-
-        // Tool calls
-        const toolCalls = parsed.choices?.[0]?.delta?.tool_calls;
-        if (toolCalls?.length) {
-          for (const tc of toolCalls) {
-            entries.push({
-              type: "tool_call",
-              content: `${tc.function?.name || "tool"}(${tc.function?.arguments || ""})`,
-              metadata: { toolCallId: tc.id },
-            });
-          }
-        }
-      } catch {
-        // Not JSON — treat as raw text
-        if (data) currentBlock += data;
-      }
-      continue;
-    }
-
-    // Error lines
-    if (
-      line.includes("OpenRouter API error") ||
-      line.includes("Error:") ||
-      line.includes("error")
-    ) {
-      entries.push({ type: "error", content: line });
-      continue;
-    }
-
-    // Info lines (model selection, cost)
-    if (
-      line.includes("[openrouter]") ||
-      line.includes("model:") ||
-      line.includes("tokens:") ||
-      line.includes("cost:")
-    ) {
-      entries.push({ type: "info", content: line });
-      continue;
-    }
-
-    // Regular output
-    currentBlock += line + "\n";
+function parseSseData(data: string, ts: string): TranscriptEntry[] {
+  if (data === "[DONE]") {
+    return [{ kind: "system", ts, text: "run completed" }];
   }
 
-  // Flush remaining
-  if (currentBlock.trim()) {
-    entries.push({ type: "text", content: currentBlock.trim() });
+  const parsed = asRecord(safeJsonParse(data));
+  if (!parsed) {
+    return data ? [{ kind: "stdout", ts, text: data }] : [];
+  }
+
+  const choice = asRecord((parsed.choices as unknown[] | undefined)?.[0]);
+  const delta = asRecord(choice?.delta);
+  const entries: TranscriptEntry[] = [];
+
+  const reasoning = asString(delta?.reasoning_content) || asString(delta?.reasoning);
+  if (reasoning) {
+    entries.push({ kind: "thinking", ts, text: reasoning, delta: true });
+  }
+
+  const content = asString(delta?.content);
+  if (content) {
+    entries.push({ kind: "assistant", ts, text: content, delta: true });
+  }
+
+  const toolCalls = delta?.tool_calls as unknown[] | undefined;
+  if (toolCalls?.length) {
+    for (const raw of toolCalls) {
+      const tc = asRecord(raw);
+      const fn = asRecord(tc?.function);
+      const argsText = asString(fn?.arguments);
+      entries.push({
+        kind: "tool_call",
+        ts,
+        name: asString(fn?.name, "tool"),
+        input: safeJsonParse(argsText) ?? argsText,
+        toolUseId: asString(tc?.id) || undefined,
+      });
+    }
   }
 
   return entries;
+}
+
+function parseLineInternal(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("data: ")) {
+    return parseSseData(trimmed.slice(6).trim(), ts);
+  }
+
+  if (trimmed.includes("OpenRouter API error") || /error/i.test(trimmed)) {
+    return [{ kind: "stderr", ts, text: line }];
+  }
+
+  if (
+    trimmed.startsWith("[openrouter]") ||
+    trimmed.startsWith("model:") ||
+    trimmed.startsWith("tokens:") ||
+    trimmed.startsWith("cost:")
+  ) {
+    return [{ kind: "system", ts, text: line }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}
+
+export function createOpenRouterStdoutParser() {
+  return {
+    parseLine(line: string, ts: string): TranscriptEntry[] {
+      return parseLineInternal(line, ts);
+    },
+    reset() {
+      // Stateless line-by-line parser today — nothing to reset. Kept as a
+      // factory (matching the other streaming adapters) so buffering state
+      // can be added later without changing the registration shape.
+    },
+  };
+}
+
+// Stateless fallback for callers that haven't migrated to the stateful factory.
+export function parseOpenRouterStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  return parseLineInternal(line, ts);
 }

--- a/packages/adapters/openrouter/tsconfig.json
+++ b/packages/adapters/openrouter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local
+      '@paperclipai/adapter-openrouter':
+        specifier: workspace:*
+        version: link:../packages/adapters/openrouter
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -789,6 +789,9 @@ importers:
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local
+      '@paperclipai/adapter-openrouter':
+        specifier: workspace:*
+        version: link:../packages/adapters/openrouter
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local
@@ -961,6 +964,9 @@ importers:
       '@paperclipai/adapter-opencode-local':
         specifier: workspace:*
         version: link:../packages/adapters/opencode-local
+      '@paperclipai/adapter-openrouter':
+        specifier: workspace:*
+        version: link:../packages/adapters/openrouter
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/openrouter:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.13.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/pi-local:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -5482,6 +5498,9 @@ packages:
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
@@ -8698,6 +8717,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici-types@8.10.0:
     resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
@@ -13468,6 +13490,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
@@ -17440,6 +17466,8 @@ snapshots:
 
   undici-types@7.16.0:
     optional: true
+
+  undici-types@7.18.2: {}
 
   undici-types@8.10.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -53,6 +53,7 @@
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-openrouter": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -13,6 +13,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "hermes_local",
   "openclaw_gateway",
   "opencode_local",
+  "openrouter",
   "pi_local",
   "process",
   "http",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -127,6 +127,17 @@ import {
   agentConfigurationDoc as piAgentConfigurationDoc,
   modelProfiles as piModelProfiles,
 } from "@paperclipai/adapter-pi-local";
+import {
+  execute as openrouterExecute,
+  testEnvironment as openrouterTestEnvironment,
+  sessionCodec as openrouterSessionCodec,
+  detectModel as openrouterDetectModel,
+  listSkills as openrouterListSkills,
+  syncSkills as openrouterSyncSkills,
+  listOpenRouterModels,
+  getConfigSchema as getOpenRouterConfigSchema,
+} from "@paperclipai/adapter-openrouter/server";
+import { agentConfigurationDoc as openrouterAgentConfigurationDoc, models as openrouterModels } from "@paperclipai/adapter-openrouter";
 import { BUILTIN_ADAPTER_TYPES } from "./builtin-adapter-types.js";
 import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
@@ -466,6 +477,24 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
+const openrouterAdapter: ServerAdapterModule = {
+  type: "openrouter",
+  execute: openrouterExecute,
+  testEnvironment: openrouterTestEnvironment,
+  sessionCodec: openrouterSessionCodec,
+  detectModel: openrouterDetectModel,
+  listSkills: openrouterListSkills,
+  syncSkills: openrouterSyncSkills,
+  models: openrouterModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  listModels: listOpenRouterModels,
+  getConfigSchema: getOpenRouterConfigSchema,
+  agentConfigurationDoc: openrouterAgentConfigurationDoc,
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>();
 
 // For builtin types that are overridden by an external adapter, we keep the
@@ -484,6 +513,7 @@ function registerBuiltInAdapters() {
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
+    openrouterAdapter,
     cursorCloudAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
+    "@paperclipai/adapter-openrouter": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/hermes-paperclip-adapter": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -140,6 +140,12 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     icon: Cpu,
     comingSoon: true,
   },
+  openrouter: {
+    label: "OpenRouter",
+    description: "Unified API for 300+ LLMs",
+    icon: Bot,
+    recommended: true,
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/ui/src/adapters/openrouter/index.ts
+++ b/ui/src/adapters/openrouter/index.ts
@@ -1,0 +1,16 @@
+import type { UIAdapterModule } from "../types";
+import { SchemaConfigFields } from "../schema-config-fields";
+import {
+  buildConfig,
+  createOpenRouterStdoutParser,
+  parseOpenRouterStdoutLine,
+} from "@paperclipai/adapter-openrouter/ui";
+
+export const openRouterUIAdapter: UIAdapterModule = {
+  type: "openrouter",
+  label: "OpenRouter",
+  parseStdoutLine: parseOpenRouterStdoutLine,
+  createStdoutParser: createOpenRouterStdoutParser,
+  ConfigFields: SchemaConfigFields,
+  buildAdapterConfig: buildConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -10,6 +10,7 @@ import { hermesLocalUIAdapter } from "./hermes-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
+import { openRouterUIAdapter } from "./openrouter";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
 import { loadDynamicParser, invalidateDynamicParser, setDynamicParserResultNotifier } from "./dynamic-loader";
@@ -65,6 +66,7 @@ function registerBuiltInUIAdapters() {
     openClawGatewayUIAdapter,
     processUIAdapter,
     httpUIAdapter,
+    openRouterUIAdapter,
   ]) {
     builtinTypes.add(adapter.type);
     builtinAdaptersByType.set(adapter.type, adapter);


### PR DESCRIPTION
## What

Ships OpenRouter as a first-party adapter under `packages/adapters/openrouter` (package `@paperclipai/adapter-openrouter`), plus CLI registry wiring for `paperclipai run --watch`.

- Restores the in-process multi-turn tool loop (`src/server/execute.ts`)
- Auth separation: `ctx.authToken` (agent JWT) is used ONLY via `PaperclipApi`; the OpenRouter key comes from `adapterConfig.apiKey` / `OPENROUTER_API_KEY`, with `resolveApiKey` guards rejecting JWT-shaped keys
- 8 Paperclip tools, transcript/skill/approval integration, `getConfigSchema` for UI render

## Verification

- `pnpm --filter @paperclipai/adapter-openrouter typecheck` exit 0
- `pnpm --filter @paperclipai/adapter-openrouter build` exit 0
- Code-reviewed and approved on [PSVA-1172](/PSVA/issues/PSVA-1172)

## Commits

- `59dd91ba5` feat(adapters): ship openrouter as first-party @paperclipai/adapter-openrouter
- `2070a1bcf` feat(cli): add OpenRouter adapter to CLI registry

## Follow-ups

- Registry wiring for server + UI tracked in [PSVA-1175](/PSVA/issues/PSVA-1175).