### PR TITLE
Guard run provenance FK writes

### DIFF
--- a/server/src/__tests__/activity-log-responsible-user.test.ts
+++ b/server/src/__tests__/activity-log-responsible-user.test.ts
@@ -243,4 +243,97 @@ describeEmbeddedPostgres("logActivity responsible-user stamping", () => {
 
     expect(row?.responsibleUserId).toBe("key-user");
   });
+
+  it("persists null run attribution when the supplied runId is unknown", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const unknownRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "default-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await expect(logActivity(db, activityInput({
+      companyId,
+      actorId: agentId,
+      agentId,
+      entityType: "agent",
+      entityId: agentId,
+      runId: unknownRunId,
+    }), [])).resolves.toBeDefined();
+
+    const row = await db
+      .select({ runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId))
+      .then((rows) => rows[0]);
+
+    expect(row?.runId).toBeNull();
+  });
+
+  it("preserves run attribution when the supplied runId is known", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "default-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {},
+    });
+
+    await logActivity(db, activityInput({
+      companyId,
+      actorId: agentId,
+      agentId,
+      entityType: "agent",
+      entityId: agentId,
+      runId,
+    }), []);
+
+    const row = await db
+      .select({ runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId))
+      .then((rows) => rows[0]);
+
+    expect(row?.runId).toBe(runId);
+  });
 });

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -857,6 +857,42 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(revisions[1]?.snapshot.routine.description).toBe("Run the frog routine");
   });
 
+  it("creates routine and document revisions without run attribution when the actor runId is unknown", async () => {
+    const { agentId, companyId, projectId, svc } = await seedFixture();
+    const unknownRunId = randomUUID();
+
+    const created = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "unknown run routine",
+        description: "Persist this without crashing",
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+      },
+      { agentId, runId: unknownRunId },
+    );
+
+    expect(created.latestRevisionId).toBeTruthy();
+    const [routineRevision] = await db
+      .select({ createdByRunId: routineRevisions.createdByRunId })
+      .from(routineRevisions)
+      .where(eq(routineRevisions.id, created.latestRevisionId!));
+    expect(routineRevision?.createdByRunId).toBeNull();
+
+    const [documentRevision] = await db
+      .select({ createdByRunId: documentRevisions.createdByRunId })
+      .from(documentRevisions)
+      .innerJoin(routineDocuments, eq(routineDocuments.documentId, documentRevisions.documentId))
+      .where(eq(routineDocuments.routineId, created.id));
+    expect(documentRevision?.createdByRunId).toBeNull();
+  });
+
   it("stores routine env in revisions, syncs routine secret bindings, and stamps runs with the dispatch revision", async () => {
     const { agentId, companyId, projectId, svc } = await seedFixture();
     const secrets = secretService(db);

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -148,6 +148,32 @@ export async function resolveResponsibleUserIdForActivity(db: Db, input: LogActi
   return readNonEmptyString(company?.defaultResponsibleUserId);
 }
 
+async function resolveKnownActivityRunId(db: Db, input: Pick<LogActivityInput, "companyId" | "runId">) {
+  const runId = readNonEmptyString(input.runId);
+  if (!runId) return null;
+  if (!isUuidLike(runId)) {
+    logger.warn(
+      { companyId: input.companyId, runId },
+      "activity log runId is not a valid heartbeat run id; recording without run attribution",
+    );
+    return null;
+  }
+  const known = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(and(eq(heartbeatRuns.companyId, input.companyId), eq(heartbeatRuns.id, runId)))
+    .limit(1)
+    .then((rows) => rows.length > 0);
+  if (!known) {
+    logger.warn(
+      { companyId: input.companyId, runId },
+      "activity log runId does not reference a known heartbeat run; recording without run attribution",
+    );
+    return null;
+  }
+  return runId;
+}
+
 export function publishActivity(publication: ActivityPublication) {
   publishLiveEvent({
     companyId: publication.companyId,
@@ -160,6 +186,7 @@ export function publishActivity(publication: ActivityPublication) {
 export async function persistActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = await redactActivityDetails(db, input.details ?? null);
   const responsibleUserId = await resolveResponsibleUserIdForActivity(db, input);
+  const persistedRunId = await resolveKnownActivityRunId(db, input);
   const [activity] = await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -168,7 +195,7 @@ export async function persistActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId: persistedRunId,
     responsibleUserId,
     details: redactedDetails,
   }).returning({ id: activityLog.id });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -49,6 +49,7 @@ import {
   getBuiltinRoutineVariableValues,
   extractRoutineVariableNames,
   interpolateRoutineTemplate,
+  isUuidLike,
   isValidRoutineDateString,
   normalizeAgentUrlKey,
   pluginOperationIssueOriginKind,
@@ -678,6 +679,31 @@ export function routineService(
       .then((rows) => rows[0] ?? null);
   }
 
+  async function resolveKnownRoutineRunId(executor: Db | any, companyId: string, runId: string | null | undefined) {
+    if (!runId) return null;
+    if (!isUuidLike(runId)) {
+      logger.warn(
+        { companyId, runId },
+        "routine revision runId is not a valid heartbeat run id; recording without run attribution",
+      );
+      return null;
+    }
+    const known = await executor
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.id, runId)))
+      .limit(1)
+      .then((rows: Array<{ id: string }>) => rows.length > 0);
+    if (!known) {
+      logger.warn(
+        { companyId, runId },
+        "routine revision runId does not reference a known heartbeat run; recording without run attribution",
+      );
+      return null;
+    }
+    return runId;
+  }
+
   async function getRoutineAgentSummary(
     companyId: string,
     agentId: string,
@@ -937,6 +963,8 @@ export function routineService(
     const snapshot = await buildRoutineRevisionSnapshot(executor, routine);
     const nextRevisionNumber = routine.latestRevisionId ? routine.latestRevisionNumber + 1 : 1;
     const now = new Date();
+    const persistedRunId = await resolveKnownRoutineRunId(executor, routine.companyId, actor.runId);
+    const actorForRevision: Actor = persistedRunId === actor.runId ? actor : { ...actor, runId: persistedRunId };
     const [revision] = await executor
       .insert(routineRevisions)
       .values({
@@ -950,7 +978,7 @@ export function routineService(
         restoredFromRevisionId: options.restoredFromRevisionId ?? null,
         createdByAgentId: actor.agentId ?? null,
         createdByUserId: actor.userId ?? null,
-        createdByRunId: actor.runId ?? null,
+        createdByRunId: persistedRunId,
         responsibleUserId: snapshot.routine.responsibleUserId ?? null,
         createdAt: now,
       })
@@ -972,7 +1000,7 @@ export function routineService(
       latestRevisionNumber: nextRevisionNumber,
       updatedAt: now,
     };
-    await upsertRoutineDescriptionDocument(executor, routineForDocument, actor, {
+    await upsertRoutineDescriptionDocument(executor, routineForDocument, actorForRevision, {
       changeSummary: options.changeSummary ?? null,
     });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server stores activity and routine revision history as the audit trail.
> - Some audit rows can include an optional heartbeat run ID.
> - That run ID is a foreign key to `heartbeat_runs`.
> - A stale or early client can send a run ID before the matching row exists.
> - The write must not fail only because optional run provenance is missing.
> - This pull request stores `null` for unknown run IDs and keeps other attribution unchanged.
> - The benefit is a durable audit write with safe optional provenance.

## Linked Issues or Issue Description

Related public PR: #10296

**What happened?**

Some server writes accepted a caller-supplied run ID and wrote it directly to a foreign-key column.
If the run ID did not exist in `heartbeat_runs`, PostgreSQL rejected the write.
This could turn an otherwise valid activity or routine revision write into a server error.

**Expected behavior**

The server should keep the write.
It should store `null` for optional run provenance when the supplied run ID is missing or malformed.
It should keep agent, user, responsible-user, and activity attribution unchanged.

**Steps to reproduce**

1. Start Paperclip from source at commit `726a3ee71`.
2. Call an activity or routine revision write path with a UUID run ID that is absent from `heartbeat_runs`.
3. Observe the foreign-key failure on the `run_id` or `created_by_run_id` column.

**Paperclip version or commit**

`726a3ee71`

**Deployment mode**

Local dev or self-hosted server with PostgreSQL.

**Installation method**

Built from source.

**Agent adapter(s) involved**

Not adapter-specific.

**Database mode**

External Postgres or embedded Postgres.

**Access context**

Agent and board paths can both reach these service writes.

**Relevant logs or output**

The failing path is a PostgreSQL foreign-key error against `heartbeat_runs`.

**Relevant config (if applicable)**

Not applicable.

**Additional context**

This patch does not remove or weaken any foreign-key constraint.
It only validates optional run provenance before FK-bound inserts.

**Privacy checklist**

No private logs, tokens, file paths, company names, or local task IDs are included.

## What Changed

- Added a company-scoped known-run check before `activity_log.run_id` inserts.
- Added a company-scoped known-run check before routine and document revision `created_by_run_id` inserts.
- Kept live-event and plugin-event payloads unchanged so diagnostics can still see the submitted run ID.
- Added regression coverage for unknown activity run IDs, known activity run IDs, and unknown routine revision run IDs.

## Verification

- `pnpm vitest run server/src/__tests__/activity-log-responsible-user.test.ts server/src/__tests__/routines-service.test.ts`
  - Result: passed with `1 passed | 1 skipped`.
  - Note: the local host skipped embedded Postgres suites, so the new DB-backed cases are present but did not execute here.
- `pnpm --filter @paperclipai/server typecheck`
  - Result: passed.
- `git diff --check`
  - Result: passed.

## Risks

- Low migration risk. This PR does not change schema or migrations.
- Low behavior risk. Unknown run IDs now become `null` only for optional run provenance.
- Existing agent, user, responsible-user, and API-key attribution behavior stays unchanged.
- The run check adds one small lookup on activity and routine revision writes that include a run ID.

## Model Used

OpenAI Codex, GPT-5-based coding agent, with tool use and high reasoning effort in this Paperclip environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
