### PR TITLE
KEWL-3769: harden run_id FK safety in activity-log and routines

### DIFF
--- a/server/src/__tests__/activity-log-run-provenance.test.ts
+++ b/server/src/__tests__/activity-log-run-provenance.test.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import { logActivity } from "../services/activity-log.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("logActivity run_id provenance (KEWL-3766 / KEWL-3768 / KEWL-3769)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let agentId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-activity-run-provenance-");
+    db = createDb(tempDb.connectionString);
+
+    companyId = randomUUID();
+    agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "default-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("resolves an unknown runId to null instead of throwing an FK violation", async () => {
+    const unknownRunId = randomUUID();
+
+    const activity = await logActivity(db, {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: randomUUID(),
+      agentId,
+      runId: unknownRunId,
+    });
+
+    expect(activity?.id).toBeTruthy();
+
+    const row = await db
+      .select({ runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.id, activity!.id))
+      .then((rows) => rows[0]);
+
+    expect(row?.runId).toBeNull();
+  });
+
+  it("preserves a runId that references a known heartbeat run", async () => {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "running",
+    });
+
+    const activity = await logActivity(db, {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: randomUUID(),
+      agentId,
+      runId,
+    });
+
+    expect(activity?.id).toBeTruthy();
+
+    const row = await db
+      .select({ runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.id, activity!.id))
+      .then((rows) => rows[0]);
+
+    expect(row?.runId).toBe(runId);
+  });
+});

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -442,6 +442,58 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routine.activityGateScope).toBe("company");
   });
 
+  it("creates a routine when the actor's runId does not reference a known heartbeat run (KEWL-3766)", async () => {
+    const { companyId, agentId, projectId, svc } = await seedFixture();
+    const unknownRunId = randomUUID();
+
+    const created = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "unknown run provenance",
+        description: "created by a run id that heartbeat_runs has never heard of",
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+      },
+      { agentId, runId: unknownRunId },
+    );
+
+    expect(created.latestRevisionId).toBeTruthy();
+
+    const revision = await db
+      .select({ createdByRunId: routineRevisions.createdByRunId })
+      .from(routineRevisions)
+      .where(eq(routineRevisions.id, created.latestRevisionId!))
+      .then((rows) => rows[0]);
+    expect(revision?.createdByRunId).toBeNull();
+
+    const routineDocument = await db
+      .select({ documentId: routineDocuments.documentId })
+      .from(routineDocuments)
+      .where(eq(routineDocuments.routineId, created.id))
+      .then((rows) => rows[0]);
+    expect(routineDocument?.documentId).toBeTruthy();
+
+    const document = await db
+      .select({ latestRevisionId: documents.latestRevisionId })
+      .from(documents)
+      .where(eq(documents.id, routineDocument!.documentId))
+      .then((rows) => rows[0]);
+    expect(document?.latestRevisionId).toBeTruthy();
+
+    const documentRevision = await db
+      .select({ createdByRunId: documentRevisions.createdByRunId })
+      .from(documentRevisions)
+      .where(eq(documentRevisions.id, document!.latestRevisionId!))
+      .then((rows) => rows[0]);
+    expect(documentRevision?.createdByRunId).toBeNull();
+  });
+
   it("fires an activity gate for a routine that has never dispatched", async () => {
     const { routine, svc } = await seedFixture();
 

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -90,6 +90,21 @@ function readNonEmptyString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+async function resolveKnownRunId(db: Db, companyId: string, runId: string | null | undefined) {
+  const candidate = readNonEmptyString(runId);
+  if (!candidate || !isUuidLike(candidate)) return null;
+  const known = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.id, candidate)))
+    .then((rows) => rows.length > 0);
+  if (!known) {
+    logger.warn({ runId: candidate }, "activity log runId does not reference a known heartbeat run; recording without run attribution");
+    return null;
+  }
+  return candidate;
+}
+
 export async function resolveResponsibleUserIdForActivity(db: Db, input: LogActivityInput) {
   if (input.responsibleUserIdOverride !== undefined) {
     return readNonEmptyString(input.responsibleUserIdOverride);
@@ -160,6 +175,7 @@ export function publishActivity(publication: ActivityPublication) {
 export async function persistActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = await redactActivityDetails(db, input.details ?? null);
   const responsibleUserId = await resolveResponsibleUserIdForActivity(db, input);
+  const safeRunId = await resolveKnownRunId(db, input.companyId, input.runId);
   const [activity] = await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -168,7 +184,7 @@ export async function persistActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId: safeRunId,
     responsibleUserId,
     details: redactedDetails,
   }).returning({ id: activityLog.id });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -49,6 +49,7 @@ import {
   getBuiltinRoutineVariableValues,
   extractRoutineVariableNames,
   interpolateRoutineTemplate,
+  isUuidLike,
   isValidRoutineDateString,
   normalizeAgentUrlKey,
   pluginOperationIssueOriginKind,
@@ -175,6 +176,21 @@ async function resolveRoutineResponsibleUserId(db: Db, companyId: string, actorU
 type Actor = { agentId?: string | null; userId?: string | null; runId?: string | null };
 type RoutineRow = typeof routines.$inferSelect;
 type RoutineTriggerRow = typeof routineTriggers.$inferSelect;
+
+async function resolveKnownRunId(executor: Db, companyId: string, runId: string | null | undefined) {
+  const candidate = typeof runId === "string" && runId.trim().length > 0 ? runId.trim() : null;
+  if (!candidate || !isUuidLike(candidate)) return null;
+  const known = await executor
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.id, candidate)))
+    .then((rows: unknown[]) => rows.length > 0);
+  if (!known) {
+    logger.warn({ runId: candidate }, "routine revision runId does not reference a known heartbeat run; recording without run attribution");
+    return null;
+  }
+  return candidate;
+}
 
 const ROUTINE_DESCRIPTION_DOCUMENT_KEY = "description" as const;
 
@@ -937,6 +953,8 @@ export function routineService(
     const snapshot = await buildRoutineRevisionSnapshot(executor, routine);
     const nextRevisionNumber = routine.latestRevisionId ? routine.latestRevisionNumber + 1 : 1;
     const now = new Date();
+    const safeRunId = await resolveKnownRunId(executor, routine.companyId, actor.runId);
+    const safeActor: Actor = safeRunId === actor.runId ? actor : { ...actor, runId: safeRunId };
     const [revision] = await executor
       .insert(routineRevisions)
       .values({
@@ -950,7 +968,7 @@ export function routineService(
         restoredFromRevisionId: options.restoredFromRevisionId ?? null,
         createdByAgentId: actor.agentId ?? null,
         createdByUserId: actor.userId ?? null,
-        createdByRunId: actor.runId ?? null,
+        createdByRunId: safeRunId,
         responsibleUserId: snapshot.routine.responsibleUserId ?? null,
         createdAt: now,
       })
@@ -972,7 +990,7 @@ export function routineService(
       latestRevisionNumber: nextRevisionNumber,
       updatedAt: now,
     };
-    await upsertRoutineDescriptionDocument(executor, routineForDocument, actor, {
+    await upsertRoutineDescriptionDocument(executor, routineForDocument, safeActor, {
       changeSummary: options.changeSummary ?? null,
     });
 


### PR DESCRIPTION
## Summary
- `logActivity`/`persistActivity` and `appendRoutineRevision` (+ the document revision it writes via `upsertRoutineDescriptionDocument`) wrote a caller-supplied `runId` straight into FK-bound `*RunId` columns with no existence check against `heartbeat_runs`, crashing on an unknown/stale run id (e.g. a manual `X-Paperclip-Run-Id` header, or a legitimate race before the `heartbeat_runs` insert lands).
- Adds `resolveKnownRunId(db, companyId, runId)` in both `server/src/services/activity-log.ts` and `server/src/services/routines.ts`: verifies the run exists before use, falls back to `null` with a `logger.warn` on an unknown id, never throws.
- Only the optional run-provenance attribution degrades — agent/user attribution and the FK constraint itself are untouched.

This ports the pattern validated in KEWL-3768 (54/54 tests passing there) onto current `origin/master`, whose `activity-log.ts`/`routines.ts` have since diverged substantially (persistActivity/publishActivity split, postCommitPublications batching, ~1500 lines of unrelated `routines-service.test.ts` growth) — the original diff didn't apply cleanly, so this is a fresh, re-verified implementation against current master.

## Test plan
- [x] `npx tsc --noEmit` in `server/` — 0 errors
- [x] New `server/src/__tests__/activity-log-run-provenance.test.ts` (2 tests, embedded Postgres): unknown runId → `null` without throwing; known runId preserved
- [x] New case in `server/src/__tests__/routines-service.test.ts`: routine creation with an unknown `actor.runId` succeeds, `routineRevisions.createdByRunId` and `documentRevisions.createdByRunId` both resolve to `null`
- [x] Full existing `activity-log-responsible-user.test.ts` (9 tests) and `routines-service.test.ts` (64 tests) suites pass
- [x] Broader regression pass: `routines-routes`, `routines-e2e`, `issue-activity-events-routes`, `routine-run-telemetry`, `routine-document-annotation-routes`, `plugin-managed-routines`, `qa-routine-secrets-e2e` (43 tests) — all pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)