### PR TITLE
fix(recovery): preserve low-trust boundary on setup failure

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -311,6 +311,7 @@ function createRunContextDb(
     if (keys.includes("entityId")) return [];
     if (keys.includes("contextSnapshot")) return runRows;
     if (keys.includes("agentCompanyId")) return runRows;
+    if (keys.includes("status") && keys.includes("reportsTo")) return mockAgentService.list();
     if (keys.length === 0) {
       const issue = await mockIssueService.getById(issueId);
       return issue ? [issue] : [];

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1902,7 +1902,8 @@ describe("agent issue mutation checkout ownership", () => {
       returnOwnerAgentId: ownerAgentId,
     });
 
-    const res = await request(await createApp(peerActor()))
+    const routeDb = createRunContextDb({}, peerAgentId, "66666666-6666-4666-8666-666666666666");
+    const res = await request(await createApp(peerActor(), routeDb))
       .post(`/api/issues/${issueId}/recovery-actions/resolve`)
       .send({
         actionId: recoveryActionId,
@@ -1911,6 +1912,7 @@ describe("agent issue mutation checkout ownership", () => {
       });
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(routeDb.select).toHaveBeenCalledWith(expect.objectContaining({ id: expect.anything() }));
     expect(mockIssueService.update).toHaveBeenCalledWith(
       issueId,
       expect.not.objectContaining({ assigneeAgentId: expect.anything() }),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -280,7 +280,9 @@ function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
   return {
     id,
     companyId,
+    name: `Agent ${id}`,
     role: "engineer",
+    status: "idle",
     reportsTo: null,
     permissions: { canCreateAgents: false },
     ...overrides,

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1629,6 +1629,47 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
+  it("keeps board recovery active while the recorded return owner is not invokable", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: coderId })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "board",
+      ownerAgentId: null,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "stranded_assigned_issue",
+      fingerprint: "low-trust:paused-reviewer",
+      evidence: { routingFallbackReason: "bounded reviewer is not invokable" },
+      nextAction: "Restore the bounded reviewer before hand-back.",
+      wakePolicy: { type: "board_escalation" },
+    });
+    const enqueueRecoveryActionWakeup = vi.fn(async () => null);
+
+    const response = await request(createApp(undefined, {
+      recoveryActionEnqueueWakeup: enqueueRecoveryActionWakeup,
+    }))
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "todo",
+        resolutionNote: "Try the bounded reviewer again.",
+      });
+
+    expect(response.status, JSON.stringify(response.body)).toBe(409);
+    expect(response.body.details?.code).toBe("recovery_safe_hand_back_owner_not_invokable");
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toMatchObject({ id: action.id });
+    expect(enqueueRecoveryActionWakeup).not.toHaveBeenCalled();
+  });
+
   it("does not enqueue a restored wake when todo status and assignee are unchanged", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -383,6 +383,172 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     },
   );
 
+  it("keeps a low-trust review recovery on its bounded reviewer after setup failure", async () => {
+    const { coderId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const [lowTrustIssue] = await db
+      .update(issues)
+      .set({
+        executionPolicy: {
+          authorizationPolicy: {
+            trustPreset: "low_trust_review",
+            trustBoundary: {
+              mode: "low_trust_review",
+              companyId: sourceIssue.companyId,
+              rootIssueId: sourceIssue.id,
+              issueIds: [sourceIssue.id],
+              allowedAgentIds: [coderId],
+            },
+          },
+        },
+      })
+      .where(eq(issues.id, sourceIssue.id))
+      .returning();
+    const latestRun = {
+      id: randomUUID(),
+      agentId: coderId,
+      status: "failed",
+      error: "adapter setup failed",
+      errorCode: "setup_failed",
+      contextSnapshot: { retryReason: "issue_continuation_needed" },
+      livenessState: "needs_followup",
+    } as const;
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: lowTrustIssue!,
+      previousStatus: "in_progress",
+      latestRun,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(action?.ownerAgentId).toBe(coderId);
+    expect(action?.returnOwnerAgentId).toBe(coderId);
+    expect(updatedIssue?.assigneeAgentId).toBe(coderId);
+    expect(enqueueWakeup).toHaveBeenCalledWith(coderId, expect.objectContaining({
+      reason: "source_scoped_recovery_action",
+    }));
+  });
+
+  it("escalates bounded low-trust recovery to the board without transferring assignment", async () => {
+    const { coderId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const [lowTrustIssue] = await db
+      .update(issues)
+      .set({
+        executionPolicy: {
+          authorizationPolicy: {
+            trustPreset: "low_trust_review",
+            trustBoundary: {
+              mode: "low_trust_review",
+              companyId: sourceIssue.companyId,
+              rootIssueId: sourceIssue.id,
+              issueIds: [sourceIssue.id],
+              allowedAgentIds: [coderId],
+            },
+          },
+        },
+      })
+      .where(eq(issues.id, sourceIssue.id))
+      .returning();
+    const latestRun = {
+      id: randomUUID(),
+      agentId: coderId,
+      status: "failed",
+      error: "adapter setup failed",
+      errorCode: "setup_failed",
+      contextSnapshot: { retryReason: "issue_continuation_needed" },
+      livenessState: "needs_followup",
+    } as const;
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: lowTrustIssue!,
+      previousStatus: "in_progress",
+      latestRun,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(action).toMatchObject({ ownerType: "board", ownerAgentId: null, returnOwnerAgentId: coderId });
+    expect(updatedIssue?.assigneeAgentId).toBe(coderId);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("keeps provider-quota recovery monitor-only inside a low-trust boundary", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const [lowTrustIssue] = await db
+      .update(issues)
+      .set({
+        executionPolicy: {
+          authorizationPolicy: {
+            trustPreset: "low_trust_review",
+            trustBoundary: {
+              mode: "low_trust_review",
+              companyId: sourceIssue.companyId,
+              rootIssueId: sourceIssue.id,
+              issueIds: [sourceIssue.id],
+              allowedAgentIds: [coderId],
+            },
+          },
+        },
+      })
+      .where(eq(issues.id, sourceIssue.id))
+      .returning();
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: coderId,
+      invocationSource: "manual",
+      status: "failed",
+      error: "provider quota exceeded",
+      errorCode: "provider_quota",
+      startedAt: new Date("2026-08-20T20:00:00.000Z"),
+      finishedAt: new Date("2026-08-20T20:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssue.id, retryReason: "provider_quota" },
+      livenessState: "needs_followup",
+    });
+    const latestRun = {
+      id: runId,
+      agentId: coderId,
+      status: "failed",
+      error: "provider quota exceeded",
+      errorCode: "provider_quota",
+      contextSnapshot: { retryReason: "provider_quota" },
+      livenessState: "needs_followup",
+    } as const;
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: lowTrustIssue!,
+      previousStatus: "in_progress",
+      recoveryCause: "provider_quota",
+      latestRun,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerType: "system",
+      ownerAgentId: null,
+      returnOwnerAgentId: coderId,
+      wakePolicy: { type: "monitor_only", reason: "provider_quota" },
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5231,6 +5231,7 @@ export function issueRoutes(
   }
 
   async function assertSafeRecoveryHandBackGates(input: {
+    dbClient: Db;
     req: Request;
     issue: {
       id: string;
@@ -5255,6 +5256,14 @@ export function issueRoutes(
         },
       );
     }
+    // Serialize the final eligibility decision with pause/terminate/status writes.
+    // Without this row lock, a concurrent status update can invalidate the
+    // preflight before this transaction restores the issue and closes recovery.
+    await input.dbClient
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.companyId, input.issue.companyId), eq(agents.id, returnOwnerAgentId)))
+      .for("update");
     const [returnOwner, companyAgents] = await Promise.all([
       agentsSvc.getById(returnOwnerAgentId),
       agentsSvc.list(input.issue.companyId, { includeTerminated: true }),
@@ -6922,6 +6931,7 @@ export function issueRoutes(
           lockedIssue.assigneeAgentId === activeRecoveryAction.returnOwnerAgentId;
         if (safeHandBack) {
           await assertSafeRecoveryHandBackGates({
+            dbClient: tx as unknown as Db,
             req,
             issue: lockedIssue,
             recoveryAction: activeRecoveryAction,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -139,6 +139,7 @@ import {
   workProductService,
 } from "../services/index.js";
 import { assertCanResolveProposal } from "../services/secret-proposal-authorization.js";
+import { evaluateAgentInvokabilityFromDb } from "../services/agent-invokability.js";
 import { buildDocumentReviewContext, buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
   decideIssueReviewPathRecovery,
@@ -5253,6 +5254,20 @@ export function issueRoutes(
           returnOwnerAgentId,
         },
       );
+    }
+    const returnOwner = await db
+      .select()
+      .from(agents)
+      .where(and(eq(agents.companyId, input.issue.companyId), eq(agents.id, returnOwnerAgentId)))
+      .then((rows) => rows[0] ?? null);
+    const invokability = await evaluateAgentInvokabilityFromDb(db, returnOwner);
+    if (!invokability.invokable) {
+      throw conflict("Safe recovery hand-back requires an invokable return owner", {
+        code: "recovery_safe_hand_back_owner_not_invokable",
+        issueId: input.issue.id,
+        returnOwnerAgentId,
+        reason: invokability.reason,
+      });
     }
     const actorRunId = input.req.actor.type === "agent"
       ? input.req.actor.runId?.trim() || null

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -139,7 +139,7 @@ import {
   workProductService,
 } from "../services/index.js";
 import { assertCanResolveProposal } from "../services/secret-proposal-authorization.js";
-import { evaluateAgentInvokabilityFromDb } from "../services/agent-invokability.js";
+import { evaluateAgentInvokability } from "../services/agent-invokability.js";
 import { buildDocumentReviewContext, buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
   decideIssueReviewPathRecovery,
@@ -5255,12 +5255,12 @@ export function issueRoutes(
         },
       );
     }
-    const returnOwner = await db
-      .select()
-      .from(agents)
-      .where(and(eq(agents.companyId, input.issue.companyId), eq(agents.id, returnOwnerAgentId)))
-      .then((rows) => rows[0] ?? null);
-    const invokability = await evaluateAgentInvokabilityFromDb(db, returnOwner);
+    const [returnOwner, companyAgents] = await Promise.all([
+      agentsSvc.getById(returnOwnerAgentId),
+      agentsSvc.list(input.issue.companyId, { includeTerminated: true }),
+    ]);
+    const scopedReturnOwner = returnOwner?.companyId === input.issue.companyId ? returnOwner : null;
+    const invokability = evaluateAgentInvokability(scopedReturnOwner, companyAgents);
     if (!invokability.invokable) {
       throw conflict("Safe recovery hand-back requires an invokable return owner", {
         code: "recovery_safe_hand_back_owner_not_invokable",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5256,20 +5256,22 @@ export function issueRoutes(
         },
       );
     }
-    // Serialize the final eligibility decision with pause/terminate/status writes.
-    // Without this row lock, a concurrent status update can invalidate the
-    // preflight before this transaction restores the issue and closes recovery.
-    await input.dbClient
-      .select({ id: agents.id })
+    // Read the complete eligibility snapshot through the locking transaction.
+    // A shared lock keeps concurrent pause/terminate/org-chain writes behind the
+    // hand-back commit while still allowing independent hand-back readers.
+    const companyAgents = await input.dbClient
+      .select({
+        id: agents.id,
+        companyId: agents.companyId,
+        name: agents.name,
+        status: agents.status,
+        reportsTo: agents.reportsTo,
+      })
       .from(agents)
-      .where(and(eq(agents.companyId, input.issue.companyId), eq(agents.id, returnOwnerAgentId)))
-      .for("update");
-    const [returnOwner, companyAgents] = await Promise.all([
-      agentsSvc.getById(returnOwnerAgentId),
-      agentsSvc.list(input.issue.companyId, { includeTerminated: true }),
-    ]);
-    const scopedReturnOwner = returnOwner?.companyId === input.issue.companyId ? returnOwner : null;
-    const invokability = evaluateAgentInvokability(scopedReturnOwner, companyAgents);
+      .where(eq(agents.companyId, input.issue.companyId))
+      .for("share");
+    const returnOwner = companyAgents.find((agent) => agent.id === returnOwnerAgentId) ?? null;
+    const invokability = evaluateAgentInvokability(returnOwner, companyAgents);
     if (!invokability.invokable) {
       throw conflict("Safe recovery hand-back requires an invokable return owner", {
         code: "recovery_safe_hand_back_owner_not_invokable",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -27,6 +27,7 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  projects,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -86,6 +87,11 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import {
+  LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH,
+  isIssueWithinLowTrustBoundary,
+  resolveCoreTrustPreset,
+} from "../trust-preset-resolver.js";
 import {
   collectDispositionRepairSourceState,
   dispositionRepairDelayMs,
@@ -172,6 +178,7 @@ type LatestIssueRun = Pick<
 > & {
   resultJson?: unknown;
 } | null;
+type RecoveryIssueAncestryRow = Pick<typeof issues.$inferSelect, "id" | "companyId" | "parentId">;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
 type StrandedRecoveryCause =
@@ -2618,6 +2625,57 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       : null;
   }
 
+  async function issueIsWithinRecoveryLowTrustBoundary(input: {
+    issue: typeof issues.$inferSelect;
+    boundary: Parameters<typeof isIssueWithinLowTrustBoundary>[0];
+  }) {
+    if (isIssueWithinLowTrustBoundary(input.boundary, input.issue)) return true;
+    if (!input.boundary.rootIssueId) return false;
+
+    let cursor: string | null = input.issue.id;
+    for (let depth = 0; cursor && depth < LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH; depth += 1) {
+      if (cursor === input.boundary.rootIssueId) return true;
+      const rows: RecoveryIssueAncestryRow[] = await db
+        .select({ id: issues.id, companyId: issues.companyId, parentId: issues.parentId })
+        .from(issues)
+        .where(eq(issues.id, cursor));
+      const row = rows[0] ?? null;
+      if (!row || row.companyId !== input.issue.companyId) return false;
+      cursor = row.parentId;
+    }
+    return false;
+  }
+
+  async function isBoundLowTrustRecovery(input: {
+    issue: typeof issues.$inferSelect;
+    latestRun: LatestIssueRun;
+    originalAgentId: string | null;
+  }) {
+    if (!input.originalAgentId) return false;
+    const agent = await getAgent(input.originalAgentId);
+    if (!agent || agent.companyId !== input.issue.companyId) return false;
+    const project = input.issue.projectId
+      ? await db
+        .select({ companyId: projects.companyId, executionWorkspacePolicy: projects.executionWorkspacePolicy })
+        .from(projects)
+        .where(and(eq(projects.id, input.issue.projectId), eq(projects.companyId, input.issue.companyId)))
+        .then((rows) => rows[0] ?? null)
+      : null;
+    const runExecutionPolicy = parseObject(parseObject(input.latestRun?.contextSnapshot).executionPolicy);
+    const resolution = resolveCoreTrustPreset({
+      companyId: input.issue.companyId,
+      agent: { companyId: agent.companyId, permissions: agent.permissions },
+      project,
+      issue: { companyId: input.issue.companyId, executionPolicy: input.issue.executionPolicy },
+      run: { companyId: input.issue.companyId, executionPolicy: runExecutionPolicy },
+    });
+    if (resolution.kind !== "low_trust_review") return false;
+    if (resolution.boundary.allowedAgentIds?.length && !resolution.boundary.allowedAgentIds.includes(agent.id)) {
+      return false;
+    }
+    return issueIsWithinRecoveryLowTrustBoundary({ issue: input.issue, boundary: resolution.boundary });
+  }
+
   async function resolveStrandedRecoveryRouting(input: {
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
@@ -2642,6 +2700,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ownerAgentId: null,
         returnOwnerAgentId: retryAgentId,
         routingFallbackReason: null,
+      };
+    }
+    if (await isBoundLowTrustRecovery({
+      issue: input.issue,
+      latestRun: input.latestRun,
+      originalAgentId: returnOwnerAgentId,
+    })) {
+      const ownerAgentId = await resolveInvokableRecoveryAgentId(input.issue, returnOwnerAgentId);
+      if (ownerAgentId) {
+        return { ownerAgentId, returnOwnerAgentId, routingFallbackReason: null };
+      }
+      return {
+        ownerAgentId: null,
+        returnOwnerAgentId,
+        routingFallbackReason: "Low-trust review recovery did not transfer ownership because the bounded reviewer is not invokable.",
       };
     }
     if (routeToOriginal) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for teams of AI agents.
> - Recovery routing keeps failed work owned and actionable.
> - Low-trust review places work inside an explicit trust boundary.
> - Setup-failure recovery currently uses the normal manager ladder before it resolves that boundary.
> - This can transfer recovery ownership and source assignment outside the bounded reviewer path.
> - This pull request resolves the effective trust policy before recovery routing.
> - The benefit is that recovery preserves the same low-trust boundary as execution.

## Linked Issues or Issue Description

- Fixes: #11820
- Refs: #11655
- Refs: #11658

## What Changed

- Resolve the effective agent, project, issue, and run trust policy during stranded recovery.
- Keep an invokable bounded reviewer as the recovery owner and source assignee.
- Route recovery to the board when the bounded reviewer is unavailable.
- Preserve the source assignment during board fallback.
- Reject restored hand-back while the recorded return owner remains non-invokable.
- Add regression tests for both reviewer states after `setup_failed`.

## Verification

- RED on current `master`: the two new regression tests failed before the implementation.
- RED for Greptile P1: restoring to a paused return owner returned `200` and resolved the action before the hand-back gate was hardened.
- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts --testNamePattern 'low-trust review recovery|bounded low-trust recovery'` — 2 passed.
- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts --testNamePattern 'low-trust review recovery|bounded low-trust recovery|provider-quota recovery monitor-only inside a low-trust boundary'` — 3 passed.
- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts --testNamePattern 'hands restored work back|keeps board recovery active while the recorded return owner is not invokable'` — 2 passed.
- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts` — 48 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Low risk. The new branch runs only when the effective trust policy is `low_trust_review` and the source issue is inside its company-scoped boundary.
- Standard recovery routing stays unchanged for all other policies.
- A bounded reviewer that cannot be invoked now creates board-owned recovery instead of manager-owned recovery.
- Board restoration remains fail-closed until that recorded reviewer becomes invokable.

## Model Used

OpenAI Codex `gpt-5.6-sol`. The model used repository tools, code execution, test execution, and an independent review agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
