### PR TITLE
fix(recovery): preserve source assignee on reblock

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5156,7 +5156,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(sourceIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: agentId,
+      assigneeAgentId: sourceAssigneeAgentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -882,7 +882,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: managerId,
+      assigneeAgentId: coderId,
     });
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1276,6 +1276,52 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(recoveryIssues[0]?.status).toBe("blocked");
   });
 
+  it("keeps the original assignee when stranded recovery falls back to another recovery owner", async () => {
+    const { coderId, managerId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "process lost",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Recovery should keep the standing assignee.",
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "process_lost",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({ recoveryCause: "process_lost" }),
+      }),
+    );
+  });
+
   it("exposes active recovery actions on the issue read API", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5850,6 +5850,97 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       executionRunId: successorRunId,
     });
   });
+
+  it("checkout adoption of a stale executionRunId preserves the issue's assigneeAgentId", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const recoveryAgentId = randomUUID();
+    const issueId = randomUUID();
+    const failedExecutionRunId = randomUUID();
+    const recoveryRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "Codex DevOps",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: recoveryAgentId,
+        companyId,
+        name: "Claude CEO",
+        role: "manager",
+        status: "active",
+        adapterType: "claude_code",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: failedExecutionRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "failed",
+        invocationSource: "manual",
+        finishedAt: new Date("2026-06-10T10:05:00.000Z"),
+      },
+      {
+        id: recoveryRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "running",
+        invocationSource: "automation",
+        startedAt: new Date("2026-06-10T10:07:00.000Z"),
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale execution lock keeps standing assignee",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: failedExecutionRunId,
+      executionAgentNameKey: "codexdevops",
+      executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
+    });
+
+    const result = await svc.checkout(issueId, assigneeAgentId, ["todo", "in_progress"], recoveryRunId);
+    expect(result).toBeTruthy();
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId,
+      checkoutRunId: recoveryRunId,
+      executionRunId: recoveryRunId,
+    });
+    expect(row?.assigneeAgentId).not.toBe(recoveryAgentId);
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8179,8 +8179,8 @@ export function issueService(db: Db) {
       }
 
       // Adopt stale executionRunId — if the execution lock points to a terminal/missing run, clear it and proceed.
-      // Only adopts when the caller's expectedStatuses guard still holds; preserves any existing assigneeUserId
-      // and preserves the original startedAt when the issue is already in_progress.
+      // Only adopts when the caller's expectedStatuses guard still holds; preserves the recorded assignee and
+      // any existing assigneeUserId, and preserves the original startedAt when the issue is already in_progress.
       if (
         checkoutRunId &&
         current.executionRunId &&
@@ -8191,7 +8191,6 @@ export function issueService(db: Db) {
         if (stale) {
           const now = new Date();
           const adoptionSet: Record<string, unknown> = {
-            assigneeAgentId: agentId,
             checkoutRunId,
             executionRunId: checkoutRunId,
             executionAgentNameKey: null,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -271,6 +271,9 @@ function resolveStrandedRecoveryCause(
   if (explicitCause) return explicitCause;
   if (isProviderQuotaRecovery(latestRun)) return "provider_quota";
   if (latestRun?.errorCode === "process_lost") return "process_lost";
+  if (latestRun?.errorCode === "adapter_failed" && /process lost/i.test(latestRun.error ?? "")) {
+    return "process_lost";
+  }
   if (latestRun?.errorCode === "codex_output_inactivity_monitor") {
     return "codex_output_inactivity_monitor";
   }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2588,7 +2588,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause: StrandedRecoveryCause;
     preferredOwnerAgentId?: string | null;
   }) {
-    const originalAgentId = input.latestRun?.agentId ?? input.issue.assigneeAgentId;
+    const originalAgentId = input.issue.assigneeAgentId ?? input.latestRun?.agentId;
     const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
@@ -3329,6 +3329,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryOwnerAgentId: input.recoveryOwnerAgentId,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
+    const pendingExecutionState = input.issue.status === "in_review"
+      ? parseIssueExecutionState(input.issue.executionState)
+      : null;
+    const currentParticipant = pendingExecutionState?.status === "pending"
+      ? pendingExecutionState.currentParticipant
+      : null;
+    const returnAssignee = pendingExecutionState?.status === "pending"
+      ? pendingExecutionState.returnAssignee
+      : null;
+    const shouldAssignRecoveryOwner =
+      input.recoveryCause === EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON &&
+      currentParticipant?.type === "agent" &&
+      currentParticipant.agentId === recoveryAction.ownerAgentId &&
+      (returnAssignee?.type !== "agent" || returnAssignee.agentId === recoveryAction.ownerAgentId);
     const isProviderQuotaWait = recoveryCause === "provider_quota" &&
       !recoveryAction.ownerAgentId &&
       Boolean(recoveryAction.returnOwnerAgentId);
@@ -3344,6 +3358,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
+      assigneeAgentId: shouldAssignRecoveryOwner
+        ? recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId
+        : input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3483,7 +3500,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryCause,
     });
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (recoveryAction.ownerAgentId &&
+      (recoveryAction.ownerAgentId === input.issue.assigneeAgentId || shouldAssignRecoveryOwner)) {
       const [currentIssue] = await db
         .select({
           status: issues.status,
@@ -3494,11 +3512,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(1);
       if (
         currentIssue &&
-        currentIssue.status !== "blocked"
+        (currentIssue.status !== "blocked" ||
+          currentIssue.assigneeAgentId !== (
+            shouldAssignRecoveryOwner
+              ? recoveryAction.ownerAgentId
+              : input.issue.assigneeAgentId
+          ))
       ) {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,
+          assigneeAgentId: shouldAssignRecoveryOwner
+            ? recoveryAction.ownerAgentId
+            : input.issue.assigneeAgentId,
         });
         if (reblocked) return reblocked;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3341,7 +3341,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3492,13 +3491,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .limit(1);
       if (
         currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
+        currentIssue.status !== "blocked"
       ) {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
         });
         if (reblocked) return reblocked;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent work and recovers stranded runs.
> - This change is in the server recovery path for stranded assigned issues.
> - Recovery can create a source-scoped recovery action when a run fails under another agent.
> - The bug is that this path can overwrite `issues.assigneeAgentId` with the recovery actor.
> - That breaks standing-sink ownership and causes false ownership changes during review recovery.
> - This pull request keeps the source assignee by default and keeps explicit reassignment only for the narrow review-takeover path.
> - The benefit is stable issue ownership during recovery with the existing review flow preserved.

## Linked Issues or Issue Description

Related PRs searched on GitHub: #11794, #10480.

**What happened?**
Recovery reconciliation could overwrite `issues.assigneeAgentId` with the recovery actor during terminal-run recovery or stale re-block.

**Expected behavior**
Recovery should keep the current source assignee unless the execution-review state still explicitly returns ownership to the same recovery owner.

**Steps to reproduce**
1. Start with an `in_progress` or `in_review` issue assigned to agent A.
2. Let recovery run under agent B after a failed run or stale re-block path.
3. Observe that the source issue assignee switches to B instead of staying on A.

**Paperclip version or commit**
`c0e49c73b`

**Deployment mode**
Built from source (`pnpm` workspace checkout)

## What Changed

- Keep `originalAgentId` anchored to `issue.assigneeAgentId` before falling back to the latest run agent.
- Preserve `assigneeAgentId` on the initial block and on stale re-block for stranded recovery actions.
- Restore explicit reassignment only when the failed execution-review recovery still returns to the same review participant.
- Keep the existing regression coverage for stranded fallback ownership and the execution-review cross-agent path.

## Verification

- `env TMPDIR=/tmp pnpm exec vitest run --project @paperclipai/server --no-file-parallelism --maxWorkers=1 server/src/__tests__/issue-recovery-actions.test.ts server/src/__tests__/issues-service.test.ts`
- `env TMPDIR=/tmp pnpm exec vitest run --project @paperclipai/server server/src/__tests__/heartbeat-process-recovery.test.ts --pool=forks --isolate`
- Local results on Thursday, August 20, 2026: `166 passed` in `issue-recovery-actions` and `issues-service`; `103 passed` in `heartbeat-process-recovery`.

## Risks

Low risk. The change is limited to recovery assignee preservation. The only special case is the explicit execution-review takeover path, and it now requires `returnAssignee` to still point to the same recovery owner.

## Model Used

OpenAI GPT-5 Codex via Codex CLI agent with tool use, shell execution, git, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
