### PR TITLE
Refresh secret bindings before agent dispatch

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -423,7 +423,7 @@ Local adapters require their corresponding CLI/session setup on the machine runn
 
 ## Config Freshness
 
-Agent, project, environment, secret, skill, and workspace config edits are sampled at the next run boundary. A heartbeat that is already running finishes with the config it started with.
+Agent, project, environment, secret, skill, and workspace config edits are sampled at the next run boundary. A heartbeat that is already running finishes with the config it started with. Before adapter dispatch, if secret validation finds a missing agent binding and the compatible agent adapter config changed after the run snapshot, Paperclip refreshes that config and retries validation once. A real missing binding, an incompatible concurrent change, or a second failure still stops as `configuration_incomplete`.
 
 When effective run config changes, Paperclip may intentionally skip a saved adapter session, refresh persisted workspace runtime config, replace a reused execution workspace, or avoid reusing a sandbox/environment lease. Fresh execution can lose adapter-specific session, workspace, or sandbox state; correctness of the next run's config takes priority over continuity. Plain environment values affect freshness through value hashes; run result JSON and workspace operation logs expose only the non-sensitive freshness decision categories, without storing secret values, full env maps, provider credentials, or private path details.
 

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -509,6 +509,18 @@ describe("resolveWithSecretBindingConfigRefresh", () => {
       ...initialConfig,
       command: "claude-beta",
     })).toBe(false);
+    expect(isSecretRefOnlyConfigChange(initialConfig, {
+      command: "claude",
+      env: {
+        CLAUDE_CODE_OAUTH_TOKEN: {
+          type: "secret_ref",
+          secretId: "secret-token-4",
+          version: 2,
+          projectionClass: "token",
+          projectionAllowlistKey: "CLAUDE_CODE_OAUTH_TOKEN",
+        },
+      },
+    })).toBe(false);
   });
 
   it("retries once with a refreshed config when an agent secret binding changes during pre-dispatch", async () => {

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -4,14 +4,17 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildSkillMentionHref } from "@paperclipai/shared";
 import {
+  ConfigurationIncompleteFailure,
   LOW_TRUST_REVIEW_PRESET,
   applyRunScopedMentionedSkillKeys,
   buildReferencedProjectRunObservability,
   buildRunWorkspaceHints,
   extractMentionedSkillIdsFromSources,
+  isSecretRefOnlyConfigChange,
   resolveAdditionalProjectWorkspace,
   resolveAdditionalRunWorkspaces,
   resolveExecutionRunAdapterConfig,
+  resolveWithSecretBindingConfigRefresh,
   type ResolveAdditionalProjectWorkspaceDeps,
   type ResolveAdditionalRunWorkspacesOptions,
   type ResolvedAdditionalWorkspace,
@@ -475,6 +478,140 @@ describe("resolveExecutionRunAdapterConfig", () => {
       consumerType: "project",
       consumerId: "project-1",
     });
+  });
+});
+
+describe("resolveWithSecretBindingConfigRefresh", () => {
+  it("accepts only secret-reference changes as compatible refreshes", () => {
+    const initialConfig = {
+      command: "claude",
+      env: {
+        CLAUDE_CODE_OAUTH_TOKEN: {
+          type: "secret_ref",
+          secretId: "secret-token-5",
+          version: "latest",
+        },
+      },
+    };
+
+    expect(isSecretRefOnlyConfigChange(initialConfig, {
+      command: "claude",
+      env: {
+        CLAUDE_CODE_OAUTH_TOKEN: {
+          type: "secret_ref",
+          secretId: "secret-token-4",
+          version: 2,
+        },
+      },
+    })).toBe(true);
+    expect(isSecretRefOnlyConfigChange(initialConfig, initialConfig)).toBe(false);
+    expect(isSecretRefOnlyConfigChange(initialConfig, {
+      ...initialConfig,
+      command: "claude-beta",
+    })).toBe(false);
+  });
+
+  it("retries once with a refreshed config when an agent secret binding changes during pre-dispatch", async () => {
+    const staleSnapshot = {
+      env: {
+        CLAUDE_CODE_OAUTH_TOKEN: {
+          type: "secret_ref",
+          secretId: "secret-token-5",
+          version: "latest",
+        },
+      },
+    };
+    const refreshedSnapshot = {
+      env: {
+        CLAUDE_CODE_OAUTH_TOKEN: {
+          type: "secret_ref",
+          secretId: "secret-token-4",
+          version: "latest",
+        },
+      },
+    };
+    const resolve = vi.fn(async (snapshot: typeof staleSnapshot) => {
+      const binding = snapshot.env.CLAUDE_CODE_OAUTH_TOKEN;
+      if (binding.secretId === "secret-token-5") {
+        throw new ConfigurationIncompleteFailure("configuration incomplete: binding missing", {
+          configurationIncomplete: {
+            reason: "secret_binding_missing",
+            missingBindings: [{ secretId: binding.secretId }],
+          },
+        });
+      }
+      return { resolvedSecretId: binding.secretId };
+    });
+    const refreshSnapshot = vi.fn().mockResolvedValue(refreshedSnapshot);
+
+    const result = await resolveWithSecretBindingConfigRefresh({
+      initialSnapshot: staleSnapshot,
+      resolve,
+      refreshSnapshot,
+    });
+
+    expect(result).toEqual({
+      value: { resolvedSecretId: "secret-token-4" },
+      snapshot: refreshedSnapshot,
+      refreshed: true,
+    });
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(refreshSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("does not refresh for a stable configuration-incomplete failure", async () => {
+    const failure = new ConfigurationIncompleteFailure("configuration incomplete: credential missing", {
+      configurationIncomplete: {
+        reason: "codex_credentials_missing",
+      },
+    });
+    const refreshSnapshot = vi.fn();
+
+    await expect(resolveWithSecretBindingConfigRefresh({
+      initialSnapshot: { command: "codex" },
+      resolve: vi.fn().mockRejectedValue(failure),
+      refreshSnapshot,
+    })).rejects.toBe(failure);
+    expect(refreshSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original missing-binding failure when no compatible config changed", async () => {
+    const failure = new ConfigurationIncompleteFailure("configuration incomplete: binding missing", {
+      configurationIncomplete: {
+        reason: "secret_binding_missing",
+      },
+    });
+
+    await expect(resolveWithSecretBindingConfigRefresh({
+      initialSnapshot: { command: "claude" },
+      resolve: vi.fn().mockRejectedValue(failure),
+      refreshSnapshot: vi.fn().mockResolvedValue(null),
+    })).rejects.toBe(failure);
+  });
+
+  it("does not loop when the refreshed config still has a missing binding", async () => {
+    const firstFailure = new ConfigurationIncompleteFailure("configuration incomplete: old binding missing", {
+      configurationIncomplete: {
+        reason: "secret_binding_missing",
+      },
+    });
+    const refreshedFailure = new ConfigurationIncompleteFailure("configuration incomplete: new binding missing", {
+      configurationIncomplete: {
+        reason: "secret_binding_missing",
+      },
+    });
+    const resolve = vi.fn()
+      .mockRejectedValueOnce(firstFailure)
+      .mockRejectedValueOnce(refreshedFailure);
+    const refreshSnapshot = vi.fn().mockResolvedValue({ command: "claude", revision: 2 });
+
+    await expect(resolveWithSecretBindingConfigRefresh({
+      initialSnapshot: { command: "claude", revision: 1 },
+      resolve,
+      refreshSnapshot,
+    })).rejects.toBe(refreshedFailure);
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(refreshSnapshot).toHaveBeenCalledOnce();
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1907,7 +1907,11 @@ function normalizeSecretRefsForConfigComparison(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(normalizeSecretRefsForConfigComparison);
   if (!value || typeof value !== "object") return value;
   const record = value as Record<string, unknown>;
-  if (record.type === "secret_ref") return { type: "secret_ref" };
+  if (record.type === "secret_ref") {
+    return Object.fromEntries(
+      Object.entries(record).filter(([key]) => key !== "secretId" && key !== "version"),
+    );
+  }
   return Object.fromEntries(
     Object.entries(record).map(([key, entry]) => [key, normalizeSecretRefsForConfigComparison(entry)]),
   );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1897,6 +1897,53 @@ function isConfigurationIncompleteFailure(error: unknown): error is Configuratio
   return error instanceof ConfigurationIncompleteFailure;
 }
 
+function isSecretBindingMissingConfigurationFailure(error: unknown) {
+  if (!isConfigurationIncompleteFailure(error)) return false;
+  const configurationIncomplete = parseObject(error.resultJson.configurationIncomplete);
+  return configurationIncomplete.reason === "secret_binding_missing";
+}
+
+function normalizeSecretRefsForConfigComparison(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeSecretRefsForConfigComparison);
+  if (!value || typeof value !== "object") return value;
+  const record = value as Record<string, unknown>;
+  if (record.type === "secret_ref") return { type: "secret_ref" };
+  return Object.fromEntries(
+    Object.entries(record).map(([key, entry]) => [key, normalizeSecretRefsForConfigComparison(entry)]),
+  );
+}
+
+export function isSecretRefOnlyConfigChange(initialConfig: unknown, latestConfig: unknown) {
+  const initialFingerprint = stableStringifyForFingerprint(initialConfig);
+  const latestFingerprint = stableStringifyForFingerprint(latestConfig);
+  return initialFingerprint !== latestFingerprint &&
+    stableStringifyForFingerprint(normalizeSecretRefsForConfigComparison(initialConfig)) ===
+      stableStringifyForFingerprint(normalizeSecretRefsForConfigComparison(latestConfig));
+}
+
+export async function resolveWithSecretBindingConfigRefresh<TSnapshot, TValue>(input: {
+  initialSnapshot: TSnapshot;
+  resolve: (snapshot: TSnapshot) => Promise<TValue>;
+  refreshSnapshot: () => Promise<TSnapshot | null>;
+}) {
+  try {
+    return {
+      value: await input.resolve(input.initialSnapshot),
+      snapshot: input.initialSnapshot,
+      refreshed: false,
+    };
+  } catch (error) {
+    if (!isSecretBindingMissingConfigurationFailure(error)) throw error;
+    const refreshedSnapshot = await input.refreshSnapshot();
+    if (!refreshedSnapshot) throw error;
+    return {
+      value: await input.resolve(refreshedSnapshot),
+      snapshot: refreshedSnapshot,
+      refreshed: true,
+    };
+  }
+}
+
 export function isConfigurationIncompleteFailedRun(
   run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode"> | null | undefined,
 ) {
@@ -14599,13 +14646,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
       }
     }
-    const workspaceManagedConfig = buildExecutionWorkspaceAdapterConfig({
-      agentConfig: config,
-      projectPolicy: projectExecutionWorkspacePolicy,
-      issueSettings: issueExecutionWorkspaceSettings,
-      mode: requestedExecutionWorkspaceMode,
-      legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
-    });
     let adapterModelProfiles: AdapterModelProfileDefinition[] = [];
     let profileResolutionFallbackReason: string | null = null;
     try {
@@ -14637,13 +14677,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } else {
       delete context.paperclipModelProfile;
     }
-    const mergedConfig = mergeModelProfileAdapterConfig({
-      baseConfig: workspaceManagedConfig,
-      modelProfile: modelProfileApplication,
-      issueAdapterConfig: issueAssigneeOverrides?.adapterConfig ?? null,
-    });
-    const configSnapshot = buildExecutionWorkspaceConfigSnapshot(mergedConfig, selectedEnvironmentId);
-    const executionRunConfig = stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
+    const buildDispatchConfigSnapshot = (agentConfig: Record<string, unknown>) => {
+      const workspaceManagedConfig = buildExecutionWorkspaceAdapterConfig({
+        agentConfig,
+        projectPolicy: projectExecutionWorkspacePolicy,
+        issueSettings: issueExecutionWorkspaceSettings,
+        mode: requestedExecutionWorkspaceMode,
+        legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
+      });
+      const mergedConfig = mergeModelProfileAdapterConfig({
+        baseConfig: workspaceManagedConfig,
+        modelProfile: modelProfileApplication,
+        issueAdapterConfig: issueAssigneeOverrides?.adapterConfig ?? null,
+      });
+      return {
+        mergedConfig,
+        configSnapshot: buildExecutionWorkspaceConfigSnapshot(mergedConfig, selectedEnvironmentId),
+        executionRunConfig: stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig),
+      };
+    };
+    const initialDispatchConfigSnapshot = buildDispatchConfigSnapshot(config);
     const runScopedMentionedSkillKeys = await resolveRunScopedMentionedSkillKeys({
       db,
       companyId: agent.companyId,
@@ -14654,33 +14707,79 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueId,
       explicitRunScopedSkillKeys: runScopedMentionedSkillKeys,
     });
-    const { resolvedConfig, secretKeys, secretManifest } = await resolveExecutionRunAdapterConfig({
-      companyId: agent.companyId,
-      agentId: agent.id,
-      adapterType: agent.adapterType,
-      issueId,
-      heartbeatRunId: run.id,
-      environmentId: selectedEnvironmentForConfig?.id ?? null,
-      environmentEnv: selectedEnvironmentForConfig?.envVars ?? null,
-      environmentDriver: selectedEnvironmentForConfig?.driver ?? null,
-      projectId: projectContext?.id ?? null,
-      routineId: routineEnvContext.routineId,
-      responsibleUserId,
-      executionRunConfig,
-      projectEnv: projectContext?.env ?? null,
-      routineEnv: routineEnvContext.env,
-      secretsSvc,
-      trustPreset,
-      requiredScopedEnvBinding: pushCapabilityPreflightRequired
-        ? {
-            keys: [...PUSH_CAPABILITY_ENV_KEYS],
-            consumerScopes: ["agent", "project"],
-            reason: "push_write_credential_missing",
-            remediation:
-              "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at project or agent scope.",
-          }
-        : undefined,
+    const resolveDispatchConfigSnapshot = (snapshot: typeof initialDispatchConfigSnapshot) =>
+      resolveExecutionRunAdapterConfig({
+        companyId: agent.companyId,
+        agentId: agent.id,
+        adapterType: agent.adapterType,
+        issueId,
+        heartbeatRunId: run.id,
+        environmentId: selectedEnvironmentForConfig?.id ?? null,
+        environmentEnv: selectedEnvironmentForConfig?.envVars ?? null,
+        environmentDriver: selectedEnvironmentForConfig?.driver ?? null,
+        projectId: projectContext?.id ?? null,
+        routineId: routineEnvContext.routineId,
+        responsibleUserId,
+        executionRunConfig: snapshot.executionRunConfig,
+        projectEnv: projectContext?.env ?? null,
+        routineEnv: routineEnvContext.env,
+        secretsSvc,
+        trustPreset,
+        requiredScopedEnvBinding: pushCapabilityPreflightRequired
+          ? {
+              keys: [...PUSH_CAPABILITY_ENV_KEYS],
+              consumerScopes: ["agent", "project"],
+              reason: "push_write_credential_missing",
+              remediation:
+                "GitHub PR workflow requires GH_TOKEN or GITHUB_TOKEN bound at project or agent scope.",
+            }
+          : undefined,
+      });
+    const dispatchConfigResolution = await resolveWithSecretBindingConfigRefresh({
+      initialSnapshot: initialDispatchConfigSnapshot,
+      resolve: resolveDispatchConfigSnapshot,
+      refreshSnapshot: async () => {
+        const latestAgent = await getAgent(agent.id);
+        if (
+          !latestAgent ||
+          latestAgent.companyId !== agent.companyId ||
+          latestAgent.adapterType !== agent.adapterType ||
+          latestAgent.defaultEnvironmentId !== agent.defaultEnvironmentId ||
+          stableStringifyForFingerprint(latestAgent.runtimeConfig) !==
+            stableStringifyForFingerprint(agent.runtimeConfig) ||
+          stableStringifyForFingerprint(latestAgent.permissions) !==
+            stableStringifyForFingerprint(agent.permissions)
+        ) {
+          return null;
+        }
+        const latestConfig = parseObject(latestAgent.adapterConfig);
+        if (!isSecretRefOnlyConfigChange(config, latestConfig)) {
+          return null;
+        }
+        logger.info(
+          {
+            event: "agent_config_refreshed_after_secret_binding_race",
+            companyId: agent.companyId,
+            agentId: agent.id,
+            runId: run.id,
+            initialConfigUpdatedAt: agent.updatedAt,
+            refreshedConfigUpdatedAt: latestAgent.updatedAt,
+          },
+          "Agent config changed during pre-dispatch secret validation; retrying once with the current config",
+        );
+        return buildDispatchConfigSnapshot(latestConfig);
+      },
     });
+    const { configSnapshot, mergedConfig } = dispatchConfigResolution.snapshot;
+    const { resolvedConfig, secretKeys, secretManifest } = dispatchConfigResolution.value;
+    if (dispatchConfigResolution.refreshed) {
+      context.paperclipConfigRefresh = {
+        reason: "secret_binding_changed_during_predispatch",
+        source: "agent_adapter_config",
+      };
+    } else {
+      delete context.paperclipConfigRefresh;
+    }
     if (secretManifest.length > 0) {
       context.paperclipSecrets = {
         manifest: secretManifest,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service prepares agent configuration before adapter dispatch
> - Agent configuration saves update secret references and binding rows in one transaction
> - A run can hold an old config snapshot while a save replaces its old binding
> - The old snapshot then reports a missing binding although the current agent config is valid
> - This pull request refreshes a compatible config once before it reports that failure
> - The benefit is fewer false credential blockers without a weaker binding gate

## Linked Issues or Issue Description

Refs #11146. That issue covers stale secret versions after rotation. This pull request fixes a different concurrent config-rebind case.

**What happened?**

A heartbeat run can load an agent config before a board save changes a `secret_ref`. The save replaces the agent binding in the same transaction. The old run snapshot then validates its old reference against the new binding rows. It stops with `configuration_incomplete` although the current agent config has a valid binding.

**Expected behavior**

Paperclip must use the current compatible secret reference before adapter dispatch. It must keep the existing fail-closed result when no compatible config change exists.

**Steps to reproduce**

1. Configure an agent with a managed secret reference.
2. Start a heartbeat and pause it before secret validation.
3. Save the agent with a different managed secret reference.
4. Resume the heartbeat.
5. Observe that the old config snapshot has no current binding.

**Paperclip version or commit**

The affected production path exists in `2026.722.0`. This change is based on `0fa318b8d`.

**Deployment mode**

Self-hosted server with embedded PostgreSQL.

## What Changed

- Retry only a `secret_binding_missing` pre-dispatch failure.
- Read the current agent config and accept only a `secret_ref`-only change.
- Require the same adapter, runtime config, permissions, and default environment.
- Retry validation once and keep all later failures fail-closed.
- Record only a value-free refresh reason in logs and run context.
- Document the one-time pre-dispatch refresh rule.

## Verification

- `npx --yes node@22 node_modules/vitest/vitest.mjs run server/src/__tests__/heartbeat-project-env.test.ts` - 40 tests passed.
- `npx --yes node@22 node_modules/typescript/bin/tsc -p server/tsconfig.json --noEmit` - passed.
- The tests cover a stale-to-current reference refresh, non-binding failures, unchanged config, incompatible config, and the one-retry limit.

## Risks

- Low risk. The extra agent read happens only after a missing-binding result.
- The retry rejects all non-secret config changes.
- Revert commit `4ffc4543c` to restore the previous behavior.

## Model Used

- OpenAI Codex with GPT-5. The exact deployment revision is not exposed. The primary adapter used tool calls and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge