### PR TITLE
feat(issues): add atomic conditional queue dispatch

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1784,6 +1784,7 @@ export {
   issueReviewRequestSchema,
   issueExecutionWorkspaceSettingsSchema,
   checkoutIssueSchema,
+  conditionalQueueClaimSchema,
   issueCommentAuthorTypeSchema,
   issueCommentPresentationSchema,
   issueCommentMetadataRowSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1785,6 +1785,8 @@ export {
   issueExecutionWorkspaceSettingsSchema,
   checkoutIssueSchema,
   conditionalQueueClaimSchema,
+  conditionalQueueApprovalMarkerSchema,
+  conditionalQueueWakeReservationSchema,
   issueCommentAuthorTypeSchema,
   issueCommentPresentationSchema,
   issueCommentMetadataRowSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -421,6 +421,8 @@ export {
   issueExecutionWorkspaceSettingsSchema,
   checkoutIssueSchema,
   conditionalQueueClaimSchema,
+  conditionalQueueApprovalMarkerSchema,
+  conditionalQueueWakeReservationSchema,
   issueCommentAuthorTypeSchema,
   issueCommentPresentationSchema,
   issueCommentMetadataRowSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -420,6 +420,7 @@ export {
   issueReviewRequestSchema,
   issueExecutionWorkspaceSettingsSchema,
   checkoutIssueSchema,
+  conditionalQueueClaimSchema,
   issueCommentAuthorTypeSchema,
   issueCommentPresentationSchema,
   issueCommentMetadataRowSchema,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -592,6 +592,18 @@ export const checkoutIssueSchema = z.object({
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;
 
+/** A governed, compare-and-swap claim used by the unattended queue loader. */
+export const conditionalQueueClaimSchema = z.object({
+  companyId: z.string().uuid(),
+  expectedUpdatedAt: z.string().datetime(),
+  approvalId: z.string().uuid(),
+  approvalMarker: z.string().trim().min(1).max(200),
+  scopeDigest: z.string().trim().regex(/^[a-f0-9]{64}$/i),
+  targetAgentId: z.string().uuid(),
+});
+
+export type ConditionalQueueClaim = z.infer<typeof conditionalQueueClaimSchema>;
+
 const commentMetadataLabelSchema = z.string().trim().min(1).max(120);
 const commentMetadataTextSchema = z.string().trim().min(1).max(2000);
 

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -604,6 +604,35 @@ export const conditionalQueueClaimSchema = z.object({
 
 export type ConditionalQueueClaim = z.infer<typeof conditionalQueueClaimSchema>;
 
+/** CAS-gated approval marker write for the unattended queue loader. */
+export const conditionalQueueApprovalMarkerSchema = z.object({
+  companyId: z.string().uuid(),
+  expectedIssueUpdatedAt: z.string().datetime(),
+  approvalId: z.string().uuid(),
+  approvalMarker: z.string().trim().min(1).max(200),
+  scopeDigest: z.string().trim().regex(/^[a-f0-9]{64}$/i),
+  targetAgentId: z.string().uuid(),
+  // This is approved with the marker, rather than accepted from an
+  // unattended caller, so a loader cannot raise its own fleet limit.
+  maxDispatches: z.number().int().min(1).max(50),
+  expiresAt: z.string().datetime(),
+});
+
+export type ConditionalQueueApprovalMarker = z.infer<typeof conditionalQueueApprovalMarkerSchema>;
+
+/** Atomically reserves an approved assigned queue card for one wake attempt. */
+export const conditionalQueueWakeReservationSchema = z.object({
+  companyId: z.string().uuid(),
+  expectedUpdatedAt: z.string().datetime(),
+  approvalId: z.string().uuid(),
+  approvalMarker: z.string().trim().min(1).max(200),
+  scopeDigest: z.string().trim().regex(/^[a-f0-9]{64}$/i),
+  targetAgentId: z.string().uuid(),
+  idempotencyKey: z.string().trim().min(1).max(300),
+});
+
+export type ConditionalQueueWakeReservation = z.infer<typeof conditionalQueueWakeReservationSchema>;
+
 const commentMetadataLabelSchema = z.string().trim().min(1).max(120);
 const commentMetadataTextSchema = z.string().trim().min(1).max(2000);
 

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -596,6 +596,7 @@ export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;
 export const conditionalQueueClaimSchema = z.object({
   companyId: z.string().uuid(),
   expectedUpdatedAt: z.string().datetime(),
+  expectedApprovalUpdatedAt: z.string().datetime(),
   approvalId: z.string().uuid(),
   approvalMarker: z.string().trim().min(1).max(200),
   scopeDigest: z.string().trim().regex(/^[a-f0-9]{64}$/i),
@@ -608,6 +609,7 @@ export type ConditionalQueueClaim = z.infer<typeof conditionalQueueClaimSchema>;
 export const conditionalQueueApprovalMarkerSchema = z.object({
   companyId: z.string().uuid(),
   expectedIssueUpdatedAt: z.string().datetime(),
+  expectedApprovalUpdatedAt: z.string().datetime(),
   approvalId: z.string().uuid(),
   approvalMarker: z.string().trim().min(1).max(200),
   scopeDigest: z.string().trim().regex(/^[a-f0-9]{64}$/i),
@@ -616,6 +618,7 @@ export const conditionalQueueApprovalMarkerSchema = z.object({
   // unattended caller, so a loader cannot raise its own fleet limit.
   maxDispatches: z.number().int().min(1).max(50),
   expiresAt: z.string().datetime(),
+  dispatcherAgentId: z.string().uuid().optional().nullable(),
 });
 
 export type ConditionalQueueApprovalMarker = z.infer<typeof conditionalQueueApprovalMarkerSchema>;
@@ -624,6 +627,7 @@ export type ConditionalQueueApprovalMarker = z.infer<typeof conditionalQueueAppr
 export const conditionalQueueWakeReservationSchema = z.object({
   companyId: z.string().uuid(),
   expectedUpdatedAt: z.string().datetime(),
+  expectedApprovalUpdatedAt: z.string().datetime(),
   approvalId: z.string().uuid(),
   approvalMarker: z.string().trim().min(1).max(200),
   scopeDigest: z.string().trim().regex(/^[a-f0-9]{64}$/i),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm";
 import {
   activityLog,
   agents,
+  approvals,
   companies,
   createDb,
   documentRevisions,
@@ -16,6 +17,7 @@ import {
   instanceSettings,
   issueComments,
   issueInboxArchives,
+  issueApprovals,
   issueDocuments,
   issuePlanDecompositions,
   issueReadStates,
@@ -304,6 +306,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueApprovals);
     await db.delete(issueComments);
     await db.delete(issueThreadInteractions);
     await db.delete(issueRelations);
@@ -320,6 +323,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(instanceSettings);
+    await db.delete(approvals);
     await db.delete(companies);
   });
 
@@ -692,6 +696,48 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       .from(activityLog)
       .where(eq(activityLog.action, "issue.thread_interaction_expired"));
     expect(logged).toHaveLength(0);
+
+  async function seedConditionalQueueClaim() {
+    const companyId = await seedAssignableAgentCompany();
+    const targetAgentId = randomUUID();
+    await db.insert(agents).values(agentRow(companyId, { id: targetAgentId, name: "Idle queue target", status: "idle" }));
+    const issue = await svc.create(companyId, { title: "Queue candidate", description: null, status: "todo", priority: "medium", assigneeAgentId: null });
+    const approvalId = randomUUID();
+    const marker = "queue-loader-approved";
+    const scopeDigest = "a".repeat(64);
+    await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "approved", payload: {
+      queueClaim: { approvalMarker: marker, scopeDigest, targetAgentId, expiresAt: "2099-01-01T00:00:00.000Z" },
+    } });
+    await db.insert(issueApprovals).values({ companyId, issueId: issue.id, approvalId });
+    return { companyId, targetAgentId, issue, approvalId, marker, scopeDigest };
+  }
+
+  it("atomically conditionally claims only an approved, idle todo", async () => {
+    const input = await seedConditionalQueueClaim();
+    const claimed = await svc.conditionalQueueClaim({
+      issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(),
+      approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId,
+    });
+    expect(claimed).toMatchObject({ id: input.issue.id, status: "in_progress", assigneeAgentId: input.targetAgentId, assigneeUserId: null });
+  });
+
+  it("leaves the issue untouched when status, assignee, scope, expiry, or target load changes", async () => {
+    const scenarios = ["status", "assignee", "scope", "expiry", "target-load"] as const;
+    for (const scenario of scenarios) {
+      const input = await seedConditionalQueueClaim();
+      if (scenario === "status") await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, input.issue.id));
+      if (scenario === "assignee") await db.update(issues).set({ assigneeUserId: "board-user" }).where(eq(issues.id, input.issue.id));
+      if (scenario === "scope") await db.update(approvals).set({ payload: { queueClaim: { approvalMarker: input.marker, scopeDigest: "b".repeat(64), targetAgentId: input.targetAgentId, expiresAt: "2099-01-01T00:00:00.000Z" } } }).where(eq(approvals.id, input.approvalId));
+      if (scenario === "expiry") await db.update(approvals).set({ payload: { queueClaim: { approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, expiresAt: "2000-01-01T00:00:00.000Z" } } }).where(eq(approvals.id, input.approvalId));
+      if (scenario === "target-load") await svc.create(input.companyId, { title: "Already running", description: null, status: "in_progress", priority: "medium", assigneeAgentId: input.targetAgentId });
+      await expect(svc.conditionalQueueClaim({
+        issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(),
+        approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId,
+      })).rejects.toMatchObject({ status: 409 });
+      const persisted = await db.select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId, assigneeUserId: issues.assigneeUserId }).from(issues).where(eq(issues.id, input.issue.id)).then((rows) => rows[0]);
+      expect(persisted?.assigneeAgentId).toBeNull();
+      expect(persisted?.status).not.toBe("in_progress");
+    }
   });
 
   it("rejects moving an existing terminated assignment into progress without clearing it", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -698,6 +698,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       .from(activityLog)
       .where(eq(activityLog.action, "issue.thread_interaction_expired"));
     expect(logged).toHaveLength(0);
+  });
 
   async function seedConditionalQueueClaim() {
     const companyId = await seedAssignableAgentCompany();
@@ -707,20 +708,40 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     const approvalId = randomUUID();
     const marker = "queue-loader-approved";
     const scopeDigest = "a".repeat(64);
-    await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "approved", payload: {
-      queueClaim: { approvalMarker: marker, scopeDigest, targetAgentId, maxDispatches: 1, expiresAt: "2099-01-01T00:00:00.000Z" },
+    const authority = { actorType: "agent" as const, actorId: randomUUID(), responsibleUserId: "manny-user" };
+    const approvalUpdatedAt = new Date("2026-08-21T00:00:00.000Z");
+    await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "approved", updatedAt: approvalUpdatedAt, payload: {
+      queueClaim: { approvalMarker: marker, scopeDigest, targetAgentId, maxDispatches: 1, expiresAt: "2099-01-01T00:00:00.000Z", authority: { ...authority, dispatcherAgentId: null } },
     } });
     await db.insert(issueApprovals).values({ companyId, issueId: issue.id, approvalId });
-    return { companyId, targetAgentId, issue, approvalId, marker, scopeDigest };
+    return { companyId, targetAgentId, issue, approvalId, marker, scopeDigest, authority, approvalUpdatedAt };
   }
 
   it("atomically conditionally claims only an approved, idle todo", async () => {
     const input = await seedConditionalQueueClaim();
     const claimed = await svc.conditionalQueueClaim({
       issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(),
-      approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId,
+      expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, authority: input.authority,
     });
     expect(claimed).toMatchObject({ id: input.issue.id, status: "in_progress", assigneeAgentId: input.targetAgentId, assigneeUserId: null });
+  });
+
+  it("rejects a queue claim from a principal that was not approved or delegated", async () => {
+    const input = await seedConditionalQueueClaim();
+    await expect(svc.conditionalQueueClaim({
+      issueId: input.issue.id,
+      companyId: input.companyId,
+      expectedUpdatedAt: input.issue.updatedAt.toISOString(),
+      expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(),
+      approvalId: input.approvalId,
+      approvalMarker: input.marker,
+      scopeDigest: input.scopeDigest,
+      targetAgentId: input.targetAgentId,
+      authority: { actorType: "agent", actorId: randomUUID(), responsibleUserId: null },
+    })).rejects.toMatchObject({ status: 403, details: { code: "queue_authority_mismatch" } });
+    const persisted = await db.select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId })
+      .from(issues).where(eq(issues.id, input.issue.id)).then((rows) => rows[0]);
+    expect(persisted).toMatchObject({ status: "todo", assigneeAgentId: null });
   });
 
   it("leaves the issue untouched when status, assignee, scope, expiry, or target load changes", async () => {
@@ -734,7 +755,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       if (scenario === "target-load") await svc.create(input.companyId, { title: "Already running", description: null, status: "in_progress", priority: "medium", assigneeAgentId: input.targetAgentId });
       await expect(svc.conditionalQueueClaim({
         issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(),
-        approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId,
+        expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, authority: input.authority,
       })).rejects.toMatchObject({ status: 409 });
       const persisted = await db.select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId, assigneeUserId: issues.assigneeUserId }).from(issues).where(eq(issues.id, input.issue.id)).then((rows) => rows[0]);
       expect(persisted?.assigneeAgentId).toBeNull();
@@ -748,9 +769,10 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.insert(agents).values(agentRow(companyId, { id: targetAgentId, name: "Manny-approved target", status: "idle" }));
     const issue = await svc.create(companyId, { title: "Marker candidate", description: null, status: "todo", priority: "medium", assigneeAgentId: null });
     const approvalId = randomUUID();
-    await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "pending", payload: {} });
+    const approvalUpdatedAt = new Date("2026-08-21T00:00:00.000Z");
+    await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "pending", updatedAt: approvalUpdatedAt, payload: {} });
     await db.insert(issueApprovals).values({ companyId, issueId: issue.id, approvalId });
-    const markerInput = { issueId: issue.id, companyId, expectedIssueUpdatedAt: issue.updatedAt.toISOString(), approvalId, approvalMarker: "manny-marker", scopeDigest: "c".repeat(64), targetAgentId, maxDispatches: 2, expiresAt: "2099-01-01T00:00:00.000Z" };
+    const markerInput = { issueId: issue.id, companyId, expectedIssueUpdatedAt: issue.updatedAt.toISOString(), expectedApprovalUpdatedAt: approvalUpdatedAt.toISOString(), approvalId, approvalMarker: "manny-marker", scopeDigest: "c".repeat(64), targetAgentId, maxDispatches: 2, expiresAt: "2099-01-01T00:00:00.000Z", dispatcherAgentId: null, authority: { actorType: "agent" as const, actorId: randomUUID(), responsibleUserId: "manny-user" } };
     const marked = await svc.conditionalQueueApprovalMarker(markerInput);
     expect((marked.payload as any).queueClaim).toMatchObject({ approvalMarker: "manny-marker", targetAgentId });
     await db.update(issues).set({ description: "concurrent scope edit", updatedAt: new Date(issue.updatedAt.getTime() + 60_000) }).where(eq(issues.id, issue.id));
@@ -761,22 +783,24 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
 
   it("atomically reserves exactly one approved sole-card wake and is idempotent", async () => {
     const input = await seedConditionalQueueClaim();
-    const claimed = await svc.conditionalQueueClaim({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId });
-    const reservationInput = { issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: claimed.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, idempotencyKey: `conditional-wake:${input.issue.id}:${input.scopeDigest}`, requestedByUserId: "manny-user" };
+    const claimed = await svc.conditionalQueueClaim({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(), expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, authority: input.authority });
+    const reservationInput = { issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: claimed.updatedAt.toISOString(), expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, idempotencyKey: `conditional-queue-wake:${input.issue.id}:${input.approvalId}:${input.approvalUpdatedAt.toISOString()}`, authority: input.authority };
+    await expect(svc.conditionalQueueWakeReservation({ ...reservationInput, idempotencyKey: "caller-controlled-key" })).rejects.toMatchObject({ status: 412, details: { code: "wake_idempotency_key_mismatch" } });
     const first = await svc.conditionalQueueWakeReservation(reservationInput);
     const second = await svc.conditionalQueueWakeReservation(reservationInput);
     expect(second.id).toBe(first.id);
     const persisted = await db.select({ id: agentWakeupRequests.id, requestedByActorId: agentWakeupRequests.requestedByActorId }).from(agentWakeupRequests).where(eq(agentWakeupRequests.id, first.id)).then((rows) => rows[0]);
-    expect(persisted).toMatchObject({ id: first.id, requestedByActorId: "manny-user" });
+    expect(persisted).toMatchObject({ id: first.id, requestedByActorId: input.authority.actorId });
     await svc.create(input.companyId, { title: "Concurrent second card", description: null, status: "todo", priority: "medium", assigneeAgentId: input.targetAgentId });
-    await expect(svc.conditionalQueueWakeReservation({ ...reservationInput, idempotencyKey: `${reservationInput.idempotencyKey}:changed` })).rejects.toMatchObject({ status: 409, details: { code: "target_not_sole_card" } });
+    await db.delete(agentWakeupRequests).where(eq(agentWakeupRequests.id, first.id));
+    await expect(svc.conditionalQueueWakeReservation(reservationInput)).rejects.toMatchObject({ status: 409, details: { code: "target_not_sole_card" } });
   });
 
   it("enforces the approval-bound fleet dispatch cap without mutating on rejection", async () => {
     const input = await seedConditionalQueueClaim();
-    const claimed = await svc.conditionalQueueClaim({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId });
+    const claimed = await svc.conditionalQueueClaim({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(), expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, authority: input.authority });
     await db.insert(agentWakeupRequests).values({ companyId: input.companyId, agentId: input.targetAgentId, source: "automation", triggerDetail: "system", reason: "other-approved-dispatch", status: "queued", idempotencyKey: `existing:${input.issue.id}` });
-    await expect(svc.conditionalQueueWakeReservation({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: claimed.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, idempotencyKey: `conditional-wake:${input.issue.id}:${input.scopeDigest}`, requestedByUserId: "manny-user" })).rejects.toMatchObject({ status: 409, details: { code: "max_dispatches_reached" } });
+    await expect(svc.conditionalQueueWakeReservation({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: claimed.updatedAt.toISOString(), expectedApprovalUpdatedAt: input.approvalUpdatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, idempotencyKey: `conditional-queue-wake:${input.issue.id}:${input.approvalId}:${input.approvalUpdatedAt.toISOString()}`, authority: input.authority })).rejects.toMatchObject({ status: 409, details: { code: "max_dispatches_reached" } });
     const reservations = await db.select({ id: agentWakeupRequests.id }).from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, input.companyId));
     expect(reservations).toHaveLength(1);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import {
   activityLog,
+  agentWakeupRequests,
   agents,
   approvals,
   companies,
@@ -320,6 +321,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(projectWorkspaces);
     await db.delete(projects);
     await db.delete(goals);
+    await db.delete(agentWakeupRequests);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(instanceSettings);
@@ -706,7 +708,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     const marker = "queue-loader-approved";
     const scopeDigest = "a".repeat(64);
     await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "approved", payload: {
-      queueClaim: { approvalMarker: marker, scopeDigest, targetAgentId, expiresAt: "2099-01-01T00:00:00.000Z" },
+      queueClaim: { approvalMarker: marker, scopeDigest, targetAgentId, maxDispatches: 1, expiresAt: "2099-01-01T00:00:00.000Z" },
     } });
     await db.insert(issueApprovals).values({ companyId, issueId: issue.id, approvalId });
     return { companyId, targetAgentId, issue, approvalId, marker, scopeDigest };
@@ -727,8 +729,8 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       const input = await seedConditionalQueueClaim();
       if (scenario === "status") await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, input.issue.id));
       if (scenario === "assignee") await db.update(issues).set({ assigneeUserId: "board-user" }).where(eq(issues.id, input.issue.id));
-      if (scenario === "scope") await db.update(approvals).set({ payload: { queueClaim: { approvalMarker: input.marker, scopeDigest: "b".repeat(64), targetAgentId: input.targetAgentId, expiresAt: "2099-01-01T00:00:00.000Z" } } }).where(eq(approvals.id, input.approvalId));
-      if (scenario === "expiry") await db.update(approvals).set({ payload: { queueClaim: { approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, expiresAt: "2000-01-01T00:00:00.000Z" } } }).where(eq(approvals.id, input.approvalId));
+      if (scenario === "scope") await db.update(approvals).set({ payload: { queueClaim: { approvalMarker: input.marker, scopeDigest: "b".repeat(64), targetAgentId: input.targetAgentId, maxDispatches: 1, expiresAt: "2099-01-01T00:00:00.000Z" } } }).where(eq(approvals.id, input.approvalId));
+      if (scenario === "expiry") await db.update(approvals).set({ payload: { queueClaim: { approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, maxDispatches: 1, expiresAt: "2000-01-01T00:00:00.000Z" } } }).where(eq(approvals.id, input.approvalId));
       if (scenario === "target-load") await svc.create(input.companyId, { title: "Already running", description: null, status: "in_progress", priority: "medium", assigneeAgentId: input.targetAgentId });
       await expect(svc.conditionalQueueClaim({
         issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(),
@@ -738,6 +740,45 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       expect(persisted?.assigneeAgentId).toBeNull();
       expect(persisted?.status).not.toBe("in_progress");
     }
+  });
+
+  it("conditionally writes a linked approval marker without clobbering a concurrent issue edit", async () => {
+    const companyId = await seedAssignableAgentCompany();
+    const targetAgentId = randomUUID();
+    await db.insert(agents).values(agentRow(companyId, { id: targetAgentId, name: "Manny-approved target", status: "idle" }));
+    const issue = await svc.create(companyId, { title: "Marker candidate", description: null, status: "todo", priority: "medium", assigneeAgentId: null });
+    const approvalId = randomUUID();
+    await db.insert(approvals).values({ id: approvalId, companyId, type: "request_board_approval", status: "pending", payload: {} });
+    await db.insert(issueApprovals).values({ companyId, issueId: issue.id, approvalId });
+    const markerInput = { issueId: issue.id, companyId, expectedIssueUpdatedAt: issue.updatedAt.toISOString(), approvalId, approvalMarker: "manny-marker", scopeDigest: "c".repeat(64), targetAgentId, maxDispatches: 2, expiresAt: "2099-01-01T00:00:00.000Z" };
+    const marked = await svc.conditionalQueueApprovalMarker(markerInput);
+    expect((marked.payload as any).queueClaim).toMatchObject({ approvalMarker: "manny-marker", targetAgentId });
+    await db.update(issues).set({ description: "concurrent scope edit", updatedAt: new Date(issue.updatedAt.getTime() + 60_000) }).where(eq(issues.id, issue.id));
+    await expect(svc.conditionalQueueApprovalMarker(markerInput)).rejects.toMatchObject({ status: 412 });
+    const persisted = await db.select({ description: issues.description }).from(issues).where(eq(issues.id, issue.id)).then((rows) => rows[0]);
+    expect(persisted?.description).toBe("concurrent scope edit");
+  });
+
+  it("atomically reserves exactly one approved sole-card wake and is idempotent", async () => {
+    const input = await seedConditionalQueueClaim();
+    const claimed = await svc.conditionalQueueClaim({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId });
+    const reservationInput = { issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: claimed.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, idempotencyKey: `conditional-wake:${input.issue.id}:${input.scopeDigest}`, requestedByUserId: "manny-user" };
+    const first = await svc.conditionalQueueWakeReservation(reservationInput);
+    const second = await svc.conditionalQueueWakeReservation(reservationInput);
+    expect(second.id).toBe(first.id);
+    const persisted = await db.select({ id: agentWakeupRequests.id, requestedByActorId: agentWakeupRequests.requestedByActorId }).from(agentWakeupRequests).where(eq(agentWakeupRequests.id, first.id)).then((rows) => rows[0]);
+    expect(persisted).toMatchObject({ id: first.id, requestedByActorId: "manny-user" });
+    await svc.create(input.companyId, { title: "Concurrent second card", description: null, status: "todo", priority: "medium", assigneeAgentId: input.targetAgentId });
+    await expect(svc.conditionalQueueWakeReservation({ ...reservationInput, idempotencyKey: `${reservationInput.idempotencyKey}:changed` })).rejects.toMatchObject({ status: 409, details: { code: "target_not_sole_card" } });
+  });
+
+  it("enforces the approval-bound fleet dispatch cap without mutating on rejection", async () => {
+    const input = await seedConditionalQueueClaim();
+    const claimed = await svc.conditionalQueueClaim({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: input.issue.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId });
+    await db.insert(agentWakeupRequests).values({ companyId: input.companyId, agentId: input.targetAgentId, source: "automation", triggerDetail: "system", reason: "other-approved-dispatch", status: "queued", idempotencyKey: `existing:${input.issue.id}` });
+    await expect(svc.conditionalQueueWakeReservation({ issueId: input.issue.id, companyId: input.companyId, expectedUpdatedAt: claimed.updatedAt.toISOString(), approvalId: input.approvalId, approvalMarker: input.marker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, idempotencyKey: `conditional-wake:${input.issue.id}:${input.scopeDigest}`, requestedByUserId: "manny-user" })).rejects.toMatchObject({ status: 409, details: { code: "max_dispatches_reached" } });
+    const reservations = await db.select({ id: agentWakeupRequests.id }).from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, input.companyId));
+    expect(reservations).toHaveLength(1);
   });
 
   it("rejects moving an existing terminated assignment into progress without clearing it", async () => {

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -29,6 +29,10 @@ export function conflict(message: string, details?: unknown) {
   return new HttpError(409, message, details);
 }
 
+export function preconditionFailed(message: string, details?: unknown) {
+  return new HttpError(412, message, details);
+}
+
 export function unprocessable(message: string, details?: unknown) {
   return new HttpError(422, message, details);
 }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -40,6 +40,7 @@ import {
   createIssueLabelSchema,
   createAcceptedPlanDecompositionSchema,
   checkoutIssueSchema,
+  conditionalQueueClaimSchema,
   createDocumentAnnotationCommentSchema,
   createDocumentAnnotationThreadSchema,
   createChildIssueSchema,
@@ -10731,6 +10732,23 @@ export function issueRoutes(
     }
 
     res.json(updated);
+  });
+
+  router.post("/issues/:id/conditional-queue-claim", validate(conditionalQueueClaimSchema), async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
+    assertCompanyAccess(req, existing.companyId);
+    if (req.body.companyId !== existing.companyId) { res.status(409).json({ error: "Issue does not belong to company" }); return; }
+    await assertCanAssignTasks(req, existing.companyId, {
+      issueId: existing.id, projectId: existing.projectId, parentIssueId: existing.parentId,
+      assigneeAgentId: req.body.targetAgentId, assigneeUserId: null,
+    });
+    const claimed = await svc.conditionalQueueClaim({ issueId: id, ...req.body });
+    const actor = getActorInfo(req);
+    await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
+      action: "issue.conditionally_queue_claimed", entityType: "issue", entityId: id, details: { targetAgentId: req.body.targetAgentId, approvalId: req.body.approvalId } });
+    res.json(claimed);
   });
 
   router.post("/issues/:id/release", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -41,6 +41,8 @@ import {
   createAcceptedPlanDecompositionSchema,
   checkoutIssueSchema,
   conditionalQueueClaimSchema,
+  conditionalQueueApprovalMarkerSchema,
+  conditionalQueueWakeReservationSchema,
   createDocumentAnnotationCommentSchema,
   createDocumentAnnotationThreadSchema,
   createChildIssueSchema,
@@ -10749,6 +10751,39 @@ export function issueRoutes(
     await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
       action: "issue.conditionally_queue_claimed", entityType: "issue", entityId: id, details: { targetAgentId: req.body.targetAgentId, approvalId: req.body.approvalId } });
     res.json(claimed);
+  });
+
+  // These endpoints are deliberately board-only: the approval marker and its
+  // resulting dispatch authority must be attributable to an authenticated
+  // board principal, never to an implicit queue-loader caller.
+  router.post("/issues/:id/conditional-queue-approval-marker", validate(conditionalQueueApprovalMarkerSchema), async (req, res) => {
+    assertBoard(req);
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
+    assertCompanyAccess(req, existing.companyId);
+    if (req.body.companyId !== existing.companyId) { res.status(409).json({ error: "Issue does not belong to company" }); return; }
+    const marker = await svc.conditionalQueueApprovalMarker({ issueId: id, ...req.body });
+    const actor = getActorInfo(req);
+    await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
+      action: "approval.conditionally_queue_marked", entityType: "approval", entityId: marker.id,
+      details: { issueId: id, scopeDigest: req.body.scopeDigest, targetAgentId: req.body.targetAgentId } });
+    res.json(marker);
+  });
+
+  router.post("/issues/:id/conditional-queue-wake-reservation", validate(conditionalQueueWakeReservationSchema), async (req, res) => {
+    assertBoard(req);
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
+    assertCompanyAccess(req, existing.companyId);
+    if (req.body.companyId !== existing.companyId) { res.status(409).json({ error: "Issue does not belong to company" }); return; }
+    const actor = getActorInfo(req);
+    const reservation = await svc.conditionalQueueWakeReservation({ issueId: id, ...req.body, requestedByUserId: actor.actorId });
+    await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
+      action: "issue.conditionally_queue_wake_reserved", entityType: "issue", entityId: id,
+      details: { targetAgentId: req.body.targetAgentId, approvalId: req.body.approvalId, idempotencyKey: req.body.idempotencyKey } });
+    res.status(201).json(reservation);
   });
 
   router.post("/issues/:id/release", async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -159,7 +159,7 @@ import { logger } from "../middleware/logger.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { createRequestPromiseMemo } from "../lib/request-promise-memo.js";
-import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
+import { assertBoard, assertBoardOrAgent, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
@@ -2762,6 +2762,23 @@ function logIssueListRequest(input: {
       visibilityHint: input.req.header("x-paperclip-tab-visible") ?? null,
     }, "safe authenticated GET observed");
   });
+}
+
+function governedQueueActor(req: Request) {
+  assertBoardOrAgent(req);
+  const actor = getActorInfo(req);
+  if (actor.actorType === "user" && actor.actorSource === "local_implicit") {
+    throw forbidden("Conditional queue dispatch requires an explicitly authenticated principal", {
+      code: "conditional_queue_explicit_authority_required",
+    });
+  }
+  return {
+    actorType: actor.actorType,
+    actorId: actor.actorId,
+    responsibleUserId: req.actor.type === "agent"
+      ? req.actor.onBehalfOfUserId ?? null
+      : actor.actorId,
+  };
 }
 
 export function issueRoutes(
@@ -10737,6 +10754,7 @@ export function issueRoutes(
   });
 
   router.post("/issues/:id/conditional-queue-claim", validate(conditionalQueueClaimSchema), async (req, res) => {
+    const authority = governedQueueActor(req);
     const id = req.params.id as string;
     const existing = await svc.getById(id);
     if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
@@ -10746,24 +10764,24 @@ export function issueRoutes(
       issueId: existing.id, projectId: existing.projectId, parentIssueId: existing.parentId,
       assigneeAgentId: req.body.targetAgentId, assigneeUserId: null,
     });
-    const claimed = await svc.conditionalQueueClaim({ issueId: id, ...req.body });
+    const claimed = await svc.conditionalQueueClaim({ issueId: id, ...req.body, authority });
     const actor = getActorInfo(req);
     await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
       action: "issue.conditionally_queue_claimed", entityType: "issue", entityId: id, details: { targetAgentId: req.body.targetAgentId, approvalId: req.body.approvalId } });
     res.json(claimed);
   });
 
-  // These endpoints are deliberately board-only: the approval marker and its
-  // resulting dispatch authority must be attributable to an authenticated
-  // board principal, never to an implicit queue-loader caller.
+  // All three operations require an explicit authenticated principal. The
+  // marker records that principal and any named dispatcher; later claim/wake
+  // calls must prove the same authority inside the transaction.
   router.post("/issues/:id/conditional-queue-approval-marker", validate(conditionalQueueApprovalMarkerSchema), async (req, res) => {
-    assertBoard(req);
+    const authority = governedQueueActor(req);
     const id = req.params.id as string;
     const existing = await svc.getById(id);
     if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
     assertCompanyAccess(req, existing.companyId);
     if (req.body.companyId !== existing.companyId) { res.status(409).json({ error: "Issue does not belong to company" }); return; }
-    const marker = await svc.conditionalQueueApprovalMarker({ issueId: id, ...req.body });
+    const marker = await svc.conditionalQueueApprovalMarker({ issueId: id, ...req.body, authority });
     const actor = getActorInfo(req);
     await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
       action: "approval.conditionally_queue_marked", entityType: "approval", entityId: marker.id,
@@ -10772,14 +10790,14 @@ export function issueRoutes(
   });
 
   router.post("/issues/:id/conditional-queue-wake-reservation", validate(conditionalQueueWakeReservationSchema), async (req, res) => {
-    assertBoard(req);
+    const authority = governedQueueActor(req);
     const id = req.params.id as string;
     const existing = await svc.getById(id);
     if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
     assertCompanyAccess(req, existing.companyId);
     if (req.body.companyId !== existing.companyId) { res.status(409).json({ error: "Issue does not belong to company" }); return; }
     const actor = getActorInfo(req);
-    const reservation = await svc.conditionalQueueWakeReservation({ issueId: id, ...req.body, requestedByUserId: actor.actorId });
+    const reservation = await svc.conditionalQueueWakeReservation({ issueId: id, ...req.body, authority });
     await logActivity(db, { companyId: existing.companyId, actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId,
       action: "issue.conditionally_queue_wake_reserved", entityType: "issue", entityId: id,
       details: { targetAgentId: req.body.targetAgentId, approvalId: req.body.approvalId, idempotencyKey: req.body.idempotencyKey } });

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -30,7 +30,9 @@ import {
   createIssueLabelSchema,
   addIssueCommentSchema,
   checkoutIssueSchema,
+  conditionalQueueApprovalMarkerSchema,
   conditionalQueueClaimSchema,
+  conditionalQueueWakeReservationSchema,
   linkIssueApprovalSchema,
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
@@ -535,6 +537,10 @@ const responses = {
   },
   conflict: {
     description: "Conflict",
+    content: { "application/json": { schema: ErrorSchema } },
+  },
+  preconditionFailed: {
+    description: "Precondition failed",
     content: { "application/json": { schema: ErrorSchema } },
   },
   unprocessable: {
@@ -2482,6 +2488,30 @@ registry.registerPath({
     body: jsonBody(conditionalQueueClaimSchema),
   },
   responses: { 200: r.ok(), 401: r.unauthorized, 409: r.conflict, 412: r.preconditionFailed },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/issues/{id}/conditional-queue-approval-marker",
+  tags: ["issues"],
+  summary: "Conditionally bind an authenticated authority and scope to a queue approval",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: jsonBody(conditionalQueueApprovalMarkerSchema),
+  },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 409: r.conflict, 412: r.preconditionFailed },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/issues/{id}/conditional-queue-wake-reservation",
+  tags: ["issues"],
+  summary: "Atomically reserve an approved queue wake under the fleet cap",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: jsonBody(conditionalQueueWakeReservationSchema),
+  },
+  responses: { 201: r.ok(), 401: r.unauthorized, 403: r.forbidden, 409: r.conflict, 412: r.preconditionFailed },
 });
 
 registry.registerPath({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -30,6 +30,7 @@ import {
   createIssueLabelSchema,
   addIssueCommentSchema,
   checkoutIssueSchema,
+  conditionalQueueClaimSchema,
   linkIssueApprovalSchema,
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
@@ -2469,6 +2470,18 @@ registry.registerPath({
     body: jsonBody(checkoutIssueSchema),
   },
   responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/issues/{id}/conditional-queue-claim",
+  tags: ["issues"],
+  summary: "Atomically claim an approved queue issue for an idle agent",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: jsonBody(conditionalQueueClaimSchema),
+  },
+  responses: { 200: r.ok(), 401: r.unauthorized, 409: r.conflict, 412: r.preconditionFailed },
 });
 
 registry.registerPath({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -65,7 +65,7 @@ import {
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
-import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
+import { conflict, HttpError, notFound, preconditionFailed, unprocessable } from "../errors.js";
 import { isForeignKeyViolation } from "../db-errors.js";
 import { logger } from "../middleware/logger.js";
 import { parseObject } from "../adapters/utils.js";
@@ -4403,6 +4403,80 @@ export function issueService(db: Db) {
     return title.trim().replace(/\s+/g, " ").toLowerCase();
   }
 
+  async function conditionalQueueClaim(input: {
+    issueId: string;
+    companyId: string;
+    expectedUpdatedAt: string;
+    approvalId: string;
+    approvalMarker: string;
+    scopeDigest: string;
+    targetAgentId: string;
+  }) {
+    const expectedUpdatedAt = new Date(input.expectedUpdatedAt);
+    if (Number.isNaN(expectedUpdatedAt.getTime())) throw preconditionFailed("Invalid expectedUpdatedAt");
+
+    return db.transaction(async (tx) => {
+      // Lock all facts which make this claim eligible before reading them. The
+      // predicate lock on the target's open work makes competing queue claims
+      // serialize instead of both observing an idle agent.
+      const issue = await tx.select().from(issues)
+        .where(and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId)))
+        .for("update").then((rows) => rows[0] ?? null);
+      if (!issue) throw conflict("Issue does not belong to company", { code: "issue_company_mismatch" });
+      if (issue.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
+        throw preconditionFailed("Issue version no longer matches", { code: "stale_issue_version" });
+      }
+      if (issue.status !== "todo" || issue.assigneeAgentId !== null || issue.assigneeUserId !== null) {
+        throw conflict("Issue is no longer an unassigned todo", { code: "issue_not_claimable" });
+      }
+
+      const approval = await tx.select().from(approvals)
+        .where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId)))
+        .for("update").then((rows) => rows[0] ?? null);
+      const linkedApproval = approval && await tx.select({ approvalId: issueApprovals.approvalId }).from(issueApprovals)
+        .where(and(eq(issueApprovals.companyId, input.companyId), eq(issueApprovals.issueId, input.issueId), eq(issueApprovals.approvalId, input.approvalId)))
+        .for("update").then((rows) => rows[0] ?? null);
+      const claim = approval?.payload && typeof approval.payload === "object"
+        ? (approval.payload as Record<string, unknown>).queueClaim as Record<string, unknown> | undefined
+        : undefined;
+      const expiresAt = typeof claim?.expiresAt === "string" ? new Date(claim.expiresAt) : null;
+      if (
+        !approval || !linkedApproval || approval.status !== "approved" || !claim ||
+        claim.approvalMarker !== input.approvalMarker || claim.scopeDigest !== input.scopeDigest ||
+        claim.targetAgentId !== input.targetAgentId || !expiresAt || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()
+      ) {
+        throw conflict("Queue-claim approval is absent, mismatched, or expired", { code: "approval_precondition_failed" });
+      }
+
+      const target = await tx.select({ id: agents.id, status: agents.status }).from(agents)
+        .where(and(eq(agents.id, input.targetAgentId), eq(agents.companyId, input.companyId)))
+        .for("update").then((rows) => rows[0] ?? null);
+      if (!target || target.status !== "idle") throw conflict("Target agent is not idle", { code: "target_not_idle" });
+      const targetLoad = await tx.select({ id: issues.id }).from(issues)
+        .where(and(eq(issues.companyId, input.companyId), eq(issues.assigneeAgentId, input.targetAgentId), inArray(issues.status, ["todo", "in_progress"])))
+        .for("update").then((rows) => rows[0] ?? null);
+      if (targetLoad) throw conflict("Target agent already has execution load", { code: "target_has_execution_load" });
+
+      const now = new Date();
+      const claimed = await tx.update(issues).set({
+        assigneeAgentId: input.targetAgentId, assigneeUserId: null, status: "in_progress", startedAt: now, updatedAt: now,
+      }).where(and(
+        eq(issues.id, input.issueId),
+        eq(issues.companyId, input.companyId),
+        eq(issues.status, "todo"),
+        isNull(issues.assigneeAgentId),
+        isNull(issues.assigneeUserId),
+        // API timestamps are ISO milliseconds while Postgres may retain
+        // microseconds; compare the representable API version, not a value a
+        // caller cannot send back losslessly.
+        sql`date_trunc('milliseconds', ${issues.updatedAt}) = ${expectedUpdatedAt.toISOString()}`,
+      )).returning()
+        .then((rows) => rows[0] ?? null);
+      if (!claimed) throw preconditionFailed("Issue changed while claim was evaluated", { code: "claim_compare_and_swap_failed" });
+      return claimed;
+    });
+  }
+
   async function getIssueByUuid(id: string) {
     const row = await db
       .select()
@@ -5451,6 +5525,7 @@ export function issueService(db: Db) {
   }
 
   return {
+    conditionalQueueClaim,
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
     addStopRelayCommentIfNeeded,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4477,6 +4477,70 @@ export function issueService(db: Db) {
     });
   }
 
+  async function conditionalQueueApprovalMarker(input: {
+    issueId: string; companyId: string; expectedIssueUpdatedAt: string; approvalId: string;
+    approvalMarker: string; scopeDigest: string; targetAgentId: string; maxDispatches: number; expiresAt: string;
+  }) {
+    const expectedUpdatedAt = new Date(input.expectedIssueUpdatedAt);
+    const expiresAt = new Date(input.expiresAt);
+    if (Number.isNaN(expectedUpdatedAt.getTime()) || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()) {
+      throw preconditionFailed("Invalid conditional approval-marker input");
+    }
+    return db.transaction(async (tx) => {
+      const issue = await tx.select().from(issues).where(and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
+      if (!issue) throw conflict("Issue does not belong to company", { code: "issue_company_mismatch" });
+      if (issue.updatedAt.getTime() !== expectedUpdatedAt.getTime()) throw preconditionFailed("Issue version no longer matches", { code: "stale_issue_version" });
+      const approval = await tx.select().from(approvals).where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
+      const linked = approval && await tx.select({ approvalId: issueApprovals.approvalId }).from(issueApprovals).where(and(eq(issueApprovals.companyId, input.companyId), eq(issueApprovals.issueId, input.issueId), eq(issueApprovals.approvalId, input.approvalId))).for("update").then((rows) => rows[0] ?? null);
+      if (!approval || !linked || approval.status !== "pending") throw conflict("Approval is not a linked pending approval", { code: "approval_not_markable" });
+      const payload = typeof approval.payload === "object" && approval.payload ? approval.payload as Record<string, unknown> : {};
+      const now = new Date();
+      const updated = await tx.update(approvals).set({ payload: { ...payload, queueClaim: { approvalMarker: input.approvalMarker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, maxDispatches: input.maxDispatches, expiresAt: expiresAt.toISOString() } }, updatedAt: now }).where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId), eq(approvals.status, "pending"))).returning().then((rows) => rows[0] ?? null);
+      if (!updated) throw preconditionFailed("Approval changed while marker was evaluated", { code: "approval_marker_compare_and_swap_failed" });
+      return updated;
+    });
+  }
+
+  async function conditionalQueueWakeReservation(input: {
+    issueId: string; companyId: string; expectedUpdatedAt: string; approvalId: string; approvalMarker: string;
+    scopeDigest: string; targetAgentId: string; idempotencyKey: string; requestedByUserId: string;
+  }) {
+    const expectedUpdatedAt = new Date(input.expectedUpdatedAt);
+    if (Number.isNaN(expectedUpdatedAt.getTime())) throw preconditionFailed("Invalid expectedUpdatedAt");
+    return db.transaction(async (tx) => {
+      // Serialize fleet-cap decisions at the company row. A per-target lock is
+      // insufficient: two idle targets could otherwise both pass the cap.
+      const company = await tx.select({ id: companies.id }).from(companies)
+        .where(eq(companies.id, input.companyId)).for("update").then((rows) => rows[0] ?? null);
+      if (!company) throw conflict("Issue does not belong to company", { code: "issue_company_mismatch" });
+      const issue = await tx.select().from(issues).where(and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
+      if (!issue) throw conflict("Issue does not belong to company", { code: "issue_company_mismatch" });
+      if (issue.updatedAt.getTime() !== expectedUpdatedAt.getTime()) throw preconditionFailed("Issue version no longer matches", { code: "stale_issue_version" });
+      if (issue.status !== "in_progress" || issue.assigneeAgentId !== input.targetAgentId || issue.assigneeUserId !== null) throw conflict("Issue is not exactly assigned to the target agent", { code: "issue_not_wakeable" });
+      const approval = await tx.select().from(approvals).where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
+      const linked = approval && await tx.select({ approvalId: issueApprovals.approvalId }).from(issueApprovals).where(and(eq(issueApprovals.companyId, input.companyId), eq(issueApprovals.issueId, input.issueId), eq(issueApprovals.approvalId, input.approvalId))).for("update").then((rows) => rows[0] ?? null);
+      const claim = approval?.payload && typeof approval.payload === "object" ? (approval.payload as Record<string, unknown>).queueClaim as Record<string, unknown> | undefined : undefined;
+      const expiresAt = typeof claim?.expiresAt === "string" ? new Date(claim.expiresAt) : null;
+      const maxDispatches = typeof claim?.maxDispatches === "number" && Number.isInteger(claim.maxDispatches) && claim.maxDispatches >= 1 && claim.maxDispatches <= 50 ? claim.maxDispatches : null;
+      if (!approval || !linked || approval.status !== "approved" || !claim || claim.approvalMarker !== input.approvalMarker || claim.scopeDigest !== input.scopeDigest || claim.targetAgentId !== input.targetAgentId || !maxDispatches || !expiresAt || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()) throw conflict("Wake approval is absent, mismatched, or expired", { code: "approval_precondition_failed" });
+      const target = await tx.select({ id: agents.id, status: agents.status }).from(agents).where(and(eq(agents.id, input.targetAgentId), eq(agents.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
+      if (!target || target.status !== "idle") throw conflict("Target agent is not idle", { code: "target_not_idle" });
+      const activeCards = await tx.select({ id: issues.id }).from(issues).where(and(eq(issues.companyId, input.companyId), eq(issues.assigneeAgentId, input.targetAgentId), inArray(issues.status, ["todo", "in_progress"]))).for("update");
+      if (activeCards.length !== 1 || activeCards[0]?.id !== input.issueId) throw conflict("Target agent does not have this sole active card", { code: "target_not_sole_card" });
+      const existing = await tx.select().from(agentWakeupRequests).where(and(eq(agentWakeupRequests.companyId, input.companyId), eq(agentWakeupRequests.agentId, input.targetAgentId), eq(agentWakeupRequests.idempotencyKey, input.idempotencyKey))).for("update").then((rows) => rows[0] ?? null);
+      if (existing) return existing;
+      // The reservation is the durable dispatch intent. Count every live
+      // reservation/run-linked wake so callers cannot bypass MAX_DISPATCHES by
+      // racing different targets before the dispatcher consumes the queue.
+      const fleetDispatches = await tx.select({ id: agentWakeupRequests.id }).from(agentWakeupRequests)
+        .where(and(eq(agentWakeupRequests.companyId, input.companyId), inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"])))
+        .for("update");
+      if (fleetDispatches.length >= maxDispatches) throw conflict("Approved fleet dispatch limit is reached", { code: "max_dispatches_reached" });
+      const now = new Date();
+      return tx.insert(agentWakeupRequests).values({ companyId: input.companyId, agentId: input.targetAgentId, source: "automation", triggerDetail: "system", reason: "conditional_queue_claim", payload: { issueId: input.issueId, approvalId: input.approvalId, approvalMarker: input.approvalMarker, scopeDigest: input.scopeDigest, maxDispatches }, status: "queued", requestedByActorType: "user", requestedByActorId: input.requestedByUserId, idempotencyKey: input.idempotencyKey, updatedAt: now }).returning().then((rows) => rows[0]);
+    });
+  }
+
   async function getIssueByUuid(id: string) {
     const row = await db
       .select()
@@ -5526,6 +5590,8 @@ export function issueService(db: Db) {
 
   return {
     conditionalQueueClaim,
+    conditionalQueueApprovalMarker,
+    conditionalQueueWakeReservation,
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
     addStopRelayCommentIfNeeded,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -65,7 +65,7 @@ import {
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
-import { conflict, HttpError, notFound, preconditionFailed, unprocessable } from "../errors.js";
+import { conflict, forbidden, HttpError, notFound, preconditionFailed, unprocessable } from "../errors.js";
 import { isForeignKeyViolation } from "../db-errors.js";
 import { logger } from "../middleware/logger.js";
 import { parseObject } from "../adapters/utils.js";
@@ -4395,6 +4395,38 @@ async function countBlockedInboxIssues(dbOrTx: any, companyId: string, filters?:
   }, 0);
 }
 
+type GovernedQueueActor = {
+  actorType: "user" | "agent";
+  actorId: string;
+  responsibleUserId: string | null;
+};
+
+function queueAuthorityMatches(claim: Record<string, unknown>, actor: GovernedQueueActor) {
+  const authority = claim.authority;
+  if (!authority || typeof authority !== "object" || Array.isArray(authority)) return false;
+  const persisted = authority as Record<string, unknown>;
+  if (persisted.actorType === actor.actorType && persisted.actorId === actor.actorId) return true;
+  if (persisted.dispatcherAgentId === actor.actorId && actor.actorType === "agent") return true;
+  return persisted.actorType === "user"
+    && typeof persisted.actorId === "string"
+    && actor.actorType === "agent"
+    && actor.responsibleUserId === persisted.actorId;
+}
+
+function expectedQueueWakeIdempotencyKey(issueId: string, approvalId: string, approvedRevision: Date) {
+  return `conditional-queue-wake:${issueId}:${approvalId}:${approvedRevision.toISOString()}`;
+}
+
+function isSerializationFailure(error: unknown) {
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && current && typeof current === "object"; depth += 1) {
+    const candidate = current as { code?: unknown; cause?: unknown };
+    if (candidate.code === "40001") return true;
+    current = candidate.cause;
+  }
+  return false;
+}
+
 export function issueService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -4407,15 +4439,21 @@ export function issueService(db: Db) {
     issueId: string;
     companyId: string;
     expectedUpdatedAt: string;
+    expectedApprovalUpdatedAt: string;
     approvalId: string;
     approvalMarker: string;
     scopeDigest: string;
     targetAgentId: string;
+    authority: GovernedQueueActor;
   }) {
     const expectedUpdatedAt = new Date(input.expectedUpdatedAt);
-    if (Number.isNaN(expectedUpdatedAt.getTime())) throw preconditionFailed("Invalid expectedUpdatedAt");
+    const expectedApprovalUpdatedAt = new Date(input.expectedApprovalUpdatedAt);
+    if (Number.isNaN(expectedUpdatedAt.getTime()) || Number.isNaN(expectedApprovalUpdatedAt.getTime())) {
+      throw preconditionFailed("Invalid conditional queue claim revision");
+    }
 
-    return db.transaction(async (tx) => {
+    try {
+      return await db.transaction(async (tx) => {
       // Lock all facts which make this claim eligible before reading them. The
       // predicate lock on the target's open work makes competing queue claims
       // serialize instead of both observing an idle agent.
@@ -4440,12 +4478,18 @@ export function issueService(db: Db) {
         ? (approval.payload as Record<string, unknown>).queueClaim as Record<string, unknown> | undefined
         : undefined;
       const expiresAt = typeof claim?.expiresAt === "string" ? new Date(claim.expiresAt) : null;
+      if (approval && approval.updatedAt.getTime() !== expectedApprovalUpdatedAt.getTime()) {
+        throw preconditionFailed("Approval version no longer matches", { code: "stale_approval_version" });
+      }
       if (
         !approval || !linkedApproval || approval.status !== "approved" || !claim ||
         claim.approvalMarker !== input.approvalMarker || claim.scopeDigest !== input.scopeDigest ||
         claim.targetAgentId !== input.targetAgentId || !expiresAt || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()
       ) {
         throw conflict("Queue-claim approval is absent, mismatched, or expired", { code: "approval_precondition_failed" });
+      }
+      if (!queueAuthorityMatches(claim, input.authority)) {
+        throw forbidden("Queue-claim authority does not match the approved principal", { code: "queue_authority_mismatch" });
       }
 
       const target = await tx.select({ id: agents.id, status: agents.status }).from(agents)
@@ -4473,17 +4517,25 @@ export function issueService(db: Db) {
       )).returning()
         .then((rows) => rows[0] ?? null);
       if (!claimed) throw preconditionFailed("Issue changed while claim was evaluated", { code: "claim_compare_and_swap_failed" });
-      return claimed;
-    });
+        return claimed;
+      }, { isolationLevel: "serializable" });
+    } catch (error) {
+      if (isSerializationFailure(error)) {
+        throw conflict("Queue-claim facts changed concurrently", { code: "queue_claim_serialization_conflict" });
+      }
+      throw error;
+    }
   }
 
   async function conditionalQueueApprovalMarker(input: {
-    issueId: string; companyId: string; expectedIssueUpdatedAt: string; approvalId: string;
+    issueId: string; companyId: string; expectedIssueUpdatedAt: string; expectedApprovalUpdatedAt: string; approvalId: string;
     approvalMarker: string; scopeDigest: string; targetAgentId: string; maxDispatches: number; expiresAt: string;
+    dispatcherAgentId?: string | null; authority: GovernedQueueActor;
   }) {
     const expectedUpdatedAt = new Date(input.expectedIssueUpdatedAt);
+    const expectedApprovalUpdatedAt = new Date(input.expectedApprovalUpdatedAt);
     const expiresAt = new Date(input.expiresAt);
-    if (Number.isNaN(expectedUpdatedAt.getTime()) || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()) {
+    if (Number.isNaN(expectedUpdatedAt.getTime()) || Number.isNaN(expectedApprovalUpdatedAt.getTime()) || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()) {
       throw preconditionFailed("Invalid conditional approval-marker input");
     }
     return db.transaction(async (tx) => {
@@ -4493,21 +4545,30 @@ export function issueService(db: Db) {
       const approval = await tx.select().from(approvals).where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
       const linked = approval && await tx.select({ approvalId: issueApprovals.approvalId }).from(issueApprovals).where(and(eq(issueApprovals.companyId, input.companyId), eq(issueApprovals.issueId, input.issueId), eq(issueApprovals.approvalId, input.approvalId))).for("update").then((rows) => rows[0] ?? null);
       if (!approval || !linked || approval.status !== "pending") throw conflict("Approval is not a linked pending approval", { code: "approval_not_markable" });
+      if (approval.updatedAt.getTime() !== expectedApprovalUpdatedAt.getTime()) throw preconditionFailed("Approval version no longer matches", { code: "stale_approval_version" });
       const payload = typeof approval.payload === "object" && approval.payload ? approval.payload as Record<string, unknown> : {};
       const now = new Date();
-      const updated = await tx.update(approvals).set({ payload: { ...payload, queueClaim: { approvalMarker: input.approvalMarker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, maxDispatches: input.maxDispatches, expiresAt: expiresAt.toISOString() } }, updatedAt: now }).where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId), eq(approvals.status, "pending"))).returning().then((rows) => rows[0] ?? null);
+      const updated = await tx.update(approvals).set({ payload: { ...payload, queueClaim: { approvalMarker: input.approvalMarker, scopeDigest: input.scopeDigest, targetAgentId: input.targetAgentId, maxDispatches: input.maxDispatches, expiresAt: expiresAt.toISOString(), authority: { ...input.authority, dispatcherAgentId: input.dispatcherAgentId ?? null } } }, updatedAt: now }).where(and(eq(approvals.id, input.approvalId), eq(approvals.companyId, input.companyId), eq(approvals.status, "pending"), sql`date_trunc('milliseconds', ${approvals.updatedAt}) = ${expectedApprovalUpdatedAt.toISOString()}`)).returning().then((rows) => rows[0] ?? null);
       if (!updated) throw preconditionFailed("Approval changed while marker was evaluated", { code: "approval_marker_compare_and_swap_failed" });
       return updated;
     });
   }
 
   async function conditionalQueueWakeReservation(input: {
-    issueId: string; companyId: string; expectedUpdatedAt: string; approvalId: string; approvalMarker: string;
-    scopeDigest: string; targetAgentId: string; idempotencyKey: string; requestedByUserId: string;
+    issueId: string; companyId: string; expectedUpdatedAt: string; expectedApprovalUpdatedAt: string; approvalId: string; approvalMarker: string;
+    scopeDigest: string; targetAgentId: string; idempotencyKey: string; authority: GovernedQueueActor;
   }) {
     const expectedUpdatedAt = new Date(input.expectedUpdatedAt);
-    if (Number.isNaN(expectedUpdatedAt.getTime())) throw preconditionFailed("Invalid expectedUpdatedAt");
-    return db.transaction(async (tx) => {
+    const expectedApprovalUpdatedAt = new Date(input.expectedApprovalUpdatedAt);
+    if (Number.isNaN(expectedUpdatedAt.getTime()) || Number.isNaN(expectedApprovalUpdatedAt.getTime())) {
+      throw preconditionFailed("Invalid conditional wake revision");
+    }
+    const expectedIdempotencyKey = expectedQueueWakeIdempotencyKey(input.issueId, input.approvalId, expectedApprovalUpdatedAt);
+    if (input.idempotencyKey !== expectedIdempotencyKey) {
+      throw preconditionFailed("Wake idempotency key is not bound to the issue and approved revision", { code: "wake_idempotency_key_mismatch" });
+    }
+    try {
+      return await db.transaction(async (tx) => {
       // Serialize fleet-cap decisions at the company row. A per-target lock is
       // insufficient: two idle targets could otherwise both pass the cap.
       const company = await tx.select({ id: companies.id }).from(companies)
@@ -4522,7 +4583,9 @@ export function issueService(db: Db) {
       const claim = approval?.payload && typeof approval.payload === "object" ? (approval.payload as Record<string, unknown>).queueClaim as Record<string, unknown> | undefined : undefined;
       const expiresAt = typeof claim?.expiresAt === "string" ? new Date(claim.expiresAt) : null;
       const maxDispatches = typeof claim?.maxDispatches === "number" && Number.isInteger(claim.maxDispatches) && claim.maxDispatches >= 1 && claim.maxDispatches <= 50 ? claim.maxDispatches : null;
+      if (approval && approval.updatedAt.getTime() !== expectedApprovalUpdatedAt.getTime()) throw preconditionFailed("Approval version no longer matches", { code: "stale_approval_version" });
       if (!approval || !linked || approval.status !== "approved" || !claim || claim.approvalMarker !== input.approvalMarker || claim.scopeDigest !== input.scopeDigest || claim.targetAgentId !== input.targetAgentId || !maxDispatches || !expiresAt || Number.isNaN(expiresAt.getTime()) || expiresAt <= new Date()) throw conflict("Wake approval is absent, mismatched, or expired", { code: "approval_precondition_failed" });
+      if (!queueAuthorityMatches(claim, input.authority)) throw forbidden("Queue-wake authority does not match the approved principal", { code: "queue_authority_mismatch" });
       const target = await tx.select({ id: agents.id, status: agents.status }).from(agents).where(and(eq(agents.id, input.targetAgentId), eq(agents.companyId, input.companyId))).for("update").then((rows) => rows[0] ?? null);
       if (!target || target.status !== "idle") throw conflict("Target agent is not idle", { code: "target_not_idle" });
       const activeCards = await tx.select({ id: issues.id }).from(issues).where(and(eq(issues.companyId, input.companyId), eq(issues.assigneeAgentId, input.targetAgentId), inArray(issues.status, ["todo", "in_progress"]))).for("update");
@@ -4537,8 +4600,14 @@ export function issueService(db: Db) {
         .for("update");
       if (fleetDispatches.length >= maxDispatches) throw conflict("Approved fleet dispatch limit is reached", { code: "max_dispatches_reached" });
       const now = new Date();
-      return tx.insert(agentWakeupRequests).values({ companyId: input.companyId, agentId: input.targetAgentId, source: "automation", triggerDetail: "system", reason: "conditional_queue_claim", payload: { issueId: input.issueId, approvalId: input.approvalId, approvalMarker: input.approvalMarker, scopeDigest: input.scopeDigest, maxDispatches }, status: "queued", requestedByActorType: "user", requestedByActorId: input.requestedByUserId, idempotencyKey: input.idempotencyKey, updatedAt: now }).returning().then((rows) => rows[0]);
-    });
+        return tx.insert(agentWakeupRequests).values({ companyId: input.companyId, agentId: input.targetAgentId, source: "automation", triggerDetail: "system", reason: "conditional_queue_claim", payload: { issueId: input.issueId, approvalId: input.approvalId, approvalMarker: input.approvalMarker, scopeDigest: input.scopeDigest, maxDispatches, approvedRevision: expectedApprovalUpdatedAt.toISOString() }, status: "queued", requestedByActorType: input.authority.actorType, requestedByActorId: input.authority.actorId, idempotencyKey: input.idempotencyKey, updatedAt: now }).returning().then((rows) => rows[0]);
+      }, { isolationLevel: "serializable" });
+    } catch (error) {
+      if (isSerializationFailure(error)) {
+        throw conflict("Queue-wake facts changed concurrently", { code: "queue_wake_serialization_conflict" });
+      }
+      throw error;
+    }
   }
 
   async function getIssueByUuid(id: string) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue service controls task state and agent execution.
> - An approved queue item needs one atomic claim before an agent can start work.
> - Separate reads and writes can let two dispatchers act on stale approval or capacity data.
> - The server must bind each claim to an authenticated authority and an exact approval revision.
> - This pull request adds governed marker, claim, and wake operations in serializable transactions.
> - The benefit is deterministic queue dispatch with explicit conflict and precondition responses.

## Linked Issues or Issue Description

**Subsystem affected**

Cross-cutting. The change affects `server/` REST orchestration and `packages/shared` validators.

**Problem or motivation**

The API has no single operation that validates an approved queue condition, checks fleet capacity, and reserves a wake atomically. A dispatcher can read valid state and then act after the approval or fleet state changes.

**Proposed solution**

Add three issue operations. One operation records a conditional queue marker. One operation claims the approved item. One operation reserves the agent wake. Bind all operations to the authenticated authority, the exact approval revision, and compare-and-set state. Run claim and wake in PostgreSQL serializable transactions. Return explicit conflict or precondition errors when state changes.

**Alternatives considered**

The client can perform separate reads and writes, but that design keeps a race window. A database migration can add a separate queue table, but the current issue and approval rows already hold the required state. The smaller service change avoids a migration.

**Roadmap alignment**

`ROADMAP.md` includes queue-style work streams and approval work. This pull request is a narrow server primitive for those areas. It does not add a new scheduler or user interface. Maintainer direction is welcome if this primitive overlaps active roadmap work.

**Additional context**

I searched open pull requests and issues for conditional queue dispatch and atomic queue claim. I found no close implementation match.

## What Changed

- Add shared request validators for marker, claim, and wake operations.
- Add REST routes and OpenAPI descriptions for all three operations.
- Require an authenticated user or agent principal for every operation.
- Store the server-derived authority and optional delegated dispatcher on the marker.
- Bind claim and wake to the exact approval revision and idempotency key.
- Use compare-and-set updates and serializable transactions for claim and wake.
- Map PostgreSQL serialization conflicts to HTTP 409.
- Add issue-service tests for authority, approval revision, idempotency, sole-card selection, and fleet capacity.

## Verification

- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts --reporter=dot` passed 126 tests.
- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts --reporter=dot` passed 5 tests.
- `pnpm -r typecheck` passed for all workspaces.
- `pnpm build` passed for all workspaces.
- `git diff --check` passed.
- The full test command is not green in this isolated Linux worktree. Six `workspace-runtime.test.ts` cases fail outside the changed subsystem. Five failures use a fixture config that does not satisfy the current config schema. One failure cannot identify the owner of a Linux listener. The focused tests and compilation checks above pass.

## Risks

- The new operations change core issue-service behavior, so reviewers should check the authority model.
- Serializable transactions can cause more conflict responses during concurrent dispatch. Clients must retry after a fresh read.
- The marker uses existing issue metadata. No database migration is required.
- The endpoints are additive. Existing issue routes do not change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5. The model used reasoning, repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
