### PR TITLE
fix(db): hard-cap pg_dump phase and fail wedged backup output streams

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -867,6 +867,10 @@ Environment overrides:
 - `PAPERCLIP_DB_BACKUP_INTERVAL_MINUTES=<minutes>`
 - `PAPERCLIP_DB_BACKUP_RETENTION_DAYS=<days>`
 - `PAPERCLIP_DB_BACKUP_DIR=/absolute/or/~/path`
+- `PAPERCLIP_DB_BACKUP_TIMEOUT_MINUTES=<minutes>` hard-caps a single backup's
+  pg_dump phase (default `30`, minimum `1`). On expiry pg_dump is killed and
+  the backup fails loudly, so a wedged dump can never silently skip later
+  scheduled backups
 - `PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS=<hours>` controls the `/api/health`
   stale-backup warning threshold
 - `PAPERCLIP_DB_BACKUP_ALERT_FILE=/path/to/failure-marker` lets external cron

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -38,6 +38,18 @@ async function createSiblingDatabase(connectionString: string, databaseName: str
   return targetUrl.toString();
 }
 
+function overrideEnv(key: string, value: string): () => void {
+  const original = process.env[key];
+  process.env[key] = value;
+  return () => {
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  };
+}
+
 afterEach(async () => {
   while (cleanups.length > 0) {
     const cleanup = cleanups.pop();
@@ -109,6 +121,67 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
         expect(fs.existsSync(decOld)).toBe(false);
       } finally {
         Date.now = realDateNow;
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "fails the backup instead of hanging when pg_dump outlives the hard timeout",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-dump-timeout-");
+      const fakePgDump = path.join(backupDir, "fake-pg-dump-hang.sh");
+      fs.writeFileSync(fakePgDump, "#!/bin/sh\necho '-- partial dump'\nsleep 60\n", { mode: 0o755 });
+      const restorePgDumpPath = overrideEnv("PAPERCLIP_PG_DUMP_PATH", fakePgDump);
+
+      try {
+        await expect(
+          runDatabaseBackup({
+            connectionString: sourceConnectionString,
+            backupDir,
+            retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+            filenamePrefix: "paperclip-dump-timeout-test",
+            backupEngine: "pg_dump",
+            dumpTimeoutMs: 1_000,
+          }),
+        ).rejects.toThrow(/hard database backup timeout/);
+
+        // The failed attempt must not leave a partial backup artifact behind.
+        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".sql.gz"))).toEqual([]);
+      } finally {
+        restorePgDumpPath();
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "fails the backup when pg_dump exits but its output stream never closes",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-wedged-stream-");
+      const fakePgDump = path.join(backupDir, "fake-pg-dump-wedge.sh");
+      // Reproduces the production wedge: the pg_dump child exits cleanly while
+      // another process keeps the stdout pipe's write end open, so the output
+      // stream never reaches EOF and the pipeline would never settle.
+      fs.writeFileSync(fakePgDump, "#!/bin/sh\nsleep 60 &\nexit 0\n", { mode: 0o755 });
+      const restorePgDumpPath = overrideEnv("PAPERCLIP_PG_DUMP_PATH", fakePgDump);
+
+      try {
+        await expect(
+          runDatabaseBackup({
+            connectionString: sourceConnectionString,
+            backupDir,
+            retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+            filenamePrefix: "paperclip-wedged-stream-test",
+            backupEngine: "pg_dump",
+          }),
+        ).rejects.toThrow(/output stream never closed/);
+
+        expect(fs.readdirSync(backupDir).filter((name) => name.endsWith(".sql.gz"))).toEqual([]);
+      } finally {
+        restorePgDumpPath();
       }
     },
     30_000,

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -20,6 +20,13 @@ export type RunDatabaseBackupOptions = {
   filenamePrefix?: string;
   connectTimeoutSeconds?: number;
   /**
+   * Hard timeout (ms) for the pg_dump dump/stream phase. When it expires the
+   * pg_dump child is killed and the backup rejects, so callers holding an
+   * in-flight guard (e.g. the server's scheduled-backup flag) always settle.
+   * Defaults to 30 minutes; set to 0 to disable.
+   */
+  dumpTimeoutMs?: number;
+  /**
    * @deprecated Migration-journal schemas are included with the normal backup
    * scope. This option is kept for compatibility and no longer changes backup
    * engine selection.
@@ -70,6 +77,13 @@ const DEFAULT_BACKUP_WRITE_BUFFER_BYTES = 1024 * 1024;
 const BACKUP_DATA_CURSOR_ROWS = 100;
 const BACKUP_CLI_STDERR_BYTES = 64 * 1024;
 const BACKUP_BREAKPOINT_DETECT_BYTES = 64 * 1024;
+const DEFAULT_BACKUP_DUMP_TIMEOUT_MS = 30 * 60 * 1000;
+// After pg_dump exits, its stdout must hit EOF as soon as the kernel pipe
+// buffer drains (at most one pipe buffer of unread data can remain). A stream
+// that stays open past this grace period means another process inherited the
+// write end — observed in production as PID 1 holding the fd for hours.
+const PG_DUMP_STREAM_DRAIN_GRACE_MS = 10_000;
+const PG_DUMP_KILL_GRACE_MS = 10_000;
 
 const STATEMENT_BREAKPOINT = "-- paperclip statement breakpoint 69f6f3f1-42fd-46a6-bf17-d1d85f8f3900";
 
@@ -321,6 +335,7 @@ async function runPgDumpBackup(opts: {
   connectionString: string;
   backupFile: string;
   connectTimeout: number;
+  dumpTimeoutMs: number;
 }): Promise<void> {
   const pgDumpBin = process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump";
   const child = spawn(
@@ -342,14 +357,92 @@ async function runPgDumpBackup(opts: {
     },
   );
 
-  if (!child.stdout) {
+  const stdout = child.stdout;
+  if (!stdout) {
+    child.kill("SIGKILL");
     throw new Error("pg_dump did not expose stdout");
   }
 
-  await Promise.all([
-    pipeline(child.stdout, createGzip(), createWriteStream(opts.backupFile)),
-    waitForChildExit(child, pgDumpBin),
-  ]);
+  let stderr = "";
+  child.stderr?.on("data", (chunk) => {
+    stderr = appendCapturedStderr(stderr, chunk);
+  });
+  const stderrSuffix = () => (stderr.trim() ? `: ${stderr.trim()}` : "");
+
+  let childExited = false;
+  let stdoutEnded = false;
+  child.once("exit", () => {
+    childExited = true;
+  });
+  stdout.once("end", () => {
+    stdoutEnded = true;
+  });
+
+  // When a watchdog below fails the backup, prefer its error: it names the
+  // root cause (timeout / wedged stream) while the promise race otherwise
+  // surfaces downstream symptoms (SIGTERM exit, destroyed pipeline).
+  let watchdogError: Error | null = null;
+  const failOutputStream = (err: Error) => {
+    watchdogError ??= err;
+    stdout.destroy(err);
+  };
+
+  const timers = new Set<NodeJS.Timeout>();
+  const later = (fn: () => void, ms: number) => {
+    const timer = setTimeout(() => {
+      timers.delete(timer);
+      fn();
+    }, ms);
+    // A backup watchdog must never keep the process alive on its own.
+    timer.unref?.();
+    timers.add(timer);
+  };
+  const clearWatchdogs = () => {
+    for (const timer of timers) clearTimeout(timer);
+    timers.clear();
+  };
+
+  // Hard timeout: ask pg_dump to stop, escalate to SIGKILL, and fail the
+  // output stream so the pipeline settles instead of waiting forever.
+  if (opts.dumpTimeoutMs > 0) {
+    later(() => {
+      child.kill("SIGTERM");
+      later(() => {
+        child.kill("SIGKILL");
+      }, PG_DUMP_KILL_GRACE_MS);
+      failOutputStream(new Error(
+        `${pgDumpBin} exceeded the hard database backup timeout of ${Math.round(opts.dumpTimeoutMs / 1000)}s and was killed${stderrSuffix()}`,
+      ));
+    }, opts.dumpTimeoutMs);
+  }
+
+  // Wedge watchdog: once pg_dump exits, EOF on stdout follows as soon as the
+  // kernel pipe buffer drains. If another process inherited the write end the
+  // EOF never arrives and the pipeline promise would never settle, which in
+  // turn wedges the server's scheduled-backup in-flight flag — fail instead.
+  child.once("exit", () => {
+    later(() => {
+      if (!stdoutEnded && !stdout.destroyed) {
+        failOutputStream(new Error(
+          `${pgDumpBin} exited but its output stream never closed; treating the backup as failed instead of waiting forever${stderrSuffix()}`,
+        ));
+      }
+    }, PG_DUMP_STREAM_DRAIN_GRACE_MS);
+  });
+
+  try {
+    await Promise.all([
+      pipeline(stdout, createGzip(), createWriteStream(opts.backupFile)),
+      waitForChildExit(child, pgDumpBin),
+    ]);
+  } catch (error) {
+    throw watchdogError ?? error;
+  } finally {
+    clearWatchdogs();
+    if (!childExited) {
+      child.kill("SIGKILL");
+    }
+  }
 }
 
 async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: number): Promise<void> {
@@ -528,6 +621,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const filenamePrefix = opts.filenamePrefix ?? "paperclip";
   const retention = opts.retention;
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
+  const dumpTimeoutMs = Math.max(0, Math.trunc(opts.dumpTimeoutMs ?? DEFAULT_BACKUP_DUMP_TIMEOUT_MS));
   const backupEngine = opts.backupEngine ?? "auto";
   const canUsePgDump = !hasBackupTransforms(opts);
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
@@ -553,6 +647,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           connectionString: opts.connectionString,
           backupFile,
           connectTimeout,
+          dumpTimeoutMs,
         });
         await writer.abort();
         const sizeBytes = statSync(backupFile).size;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -684,6 +684,11 @@ export async function startServer(): Promise<StartedServer> {
     Number(process.env.PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS) ||
       Math.max(26, Math.ceil((config.databaseBackupIntervalMinutes / 60) * 2)),
   );
+  // Hard cap on a single backup's dump phase. A wedged pg_dump must fail
+  // loudly (and reset databaseBackupInFlight via the finally below) instead
+  // of silently skipping every later scheduled backup.
+  const databaseBackupDumpTimeoutMs =
+    Math.max(1, Number(process.env.PAPERCLIP_DB_BACKUP_TIMEOUT_MINUTES) || 30) * 60 * 1000;
   const databaseBackupAlertFile =
     process.env.PAPERCLIP_DB_BACKUP_ALERT_FILE ||
     resolve(config.databaseBackupDir, "..", "health", "db-backup-to-s3.failure");
@@ -720,6 +725,7 @@ export async function startServer(): Promise<StartedServer> {
         backupDir: config.databaseBackupDir,
         retention,
         filenamePrefix: "paperclip",
+        dumpTimeoutMs: databaseBackupDumpTimeoutMs,
       });
       const finishedAt = new Date();
       const response: InstanceDatabaseBackupRunResult = {
@@ -1558,6 +1564,7 @@ export async function startServer(): Promise<StartedServer> {
     logger.info(
       {
         intervalMinutes: config.databaseBackupIntervalMinutes,
+        dumpTimeoutMinutes: Math.round(databaseBackupDumpTimeoutMs / 60000),
         retentionSource: "instance-settings-db",
         backupDir: config.databaseBackupDir,
       },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server takes scheduled database backups with pg_dump and guards them with a `databaseBackupInFlight` flag
> - pg_dump can exit while another process keeps the write end of its stdout pipe open
> - The output stream then never reaches EOF, so the backup promise never settles and the flag stays true forever
> - Every later scheduled backup is skipped silently until a process restart
> - This pull request hard-caps the dump phase and fails a wedged output stream instead of waiting forever
> - The benefit is that a wedged backup fails loudly once, and later backups run on schedule

## Linked Issues or Issue Description

No public issue exists for this. Related open PRs found in the dedup search: Refs #11056, Refs #8318, Refs #8139, Refs #11212. This PR fixes the root cause inside `runDatabaseBackup` itself: it destroys the wedged output stream so the pipeline actually settles, and it detects the dead-child case in seconds instead of waiting for a full timeout. It is independent of the scheduler-level stale-guard in #11056; the two guards can stack.

**What happened?**

A scheduled database backup wedged permanently in production. pg_dump wrote about 1.46 GB of raw SQL in about 30 seconds. Then the stream wedged: the output file mtime froze, no pg_dump child process remained, and PID 1 kept the output fd open for more than 7 hours. `runDatabaseBackup` never settled, so the `databaseBackupInFlight` flag in `server/src/index.ts` stayed true forever. Every later scheduled tick logged `Skipping scheduled database backup because a previous backup is still running`. Six or more consecutive hourly backups were missed. Only a container restart cleared the flag. There was no error log after the wedge — the only signal was the periodic WARN and, eventually, the backup-health maxAge check.

**Expected behavior**

A wedged backup must fail loudly. The in-flight flag must reset through the existing `finally` block. Later scheduled backups must run on time.

**Steps to reproduce**

1. Point `PAPERCLIP_PG_DUMP_PATH` at a script that starts a background process inheriting stdout and then exits 0, for example `#!/bin/sh` followed by `sleep 60 &` and `exit 0`.
2. Call `runDatabaseBackup` with `backupEngine: "pg_dump"`.
3. Without this fix the call never returns. With this fix it rejects with "output stream never closed" about 10 seconds after the fake pg_dump exits.

**Paperclip version or commit**

Fix is based on master `fd106c6`. The wedge was observed on a production deployment built from recent master.

**Deployment mode**

Docker

**Database mode**

External Postgres

## What Changed

- Added a `dumpTimeoutMs` option to `runDatabaseBackup` (default 30 minutes, `0` disables). On expiry the pg_dump child gets SIGTERM, escalates to SIGKILL after a 10 second grace, and the output stream is destroyed with a descriptive error.
- Added a wedge watchdog in `runPgDumpBackup`. Once pg_dump exits, its stdout must reach EOF as soon as the kernel pipe buffer drains. If the stream stays open past a 10 second grace period, the backup fails. This covers the observed case where another process inherited the pipe write end.
- Destroying the output stream settles the gzip pipeline with an error. No pending promise and no fd leak remain.
- The server passes the timeout through from a new `PAPERCLIP_DB_BACKUP_TIMEOUT_MINUTES` env var (default 30, minimum 1). The existing `finally` block then always resets `databaseBackupInFlight`.
- Documented the new env var in `doc/DEVELOPING.md`.
- Added regression tests for the hard timeout and for the wedged-stream case. Both tests also assert that no partial `.sql.gz` artifact is left behind.

## Verification

- `npx vitest run packages/db/src/backup-lib.test.ts -t "hard timeout"` — passes. The backup rejects with `hard database backup timeout` after the configured 1 second test timeout.
- `npx vitest run packages/db/src/backup-lib.test.ts -t "output stream never closes"` — passes. The backup rejects with `output stream never closed` about 10 seconds after the fake pg_dump exits.
- `npx vitest run packages/db/src/backup-lib.test.ts -t "pg_dump"` — the two real-pg_dump backup tests still pass. No regression on the happy path.
- `npx tsc --noEmit` in `packages/db` — clean.

## Risks

- Low risk. The happy path is unchanged apart from two unref'd watchdog timers that are cleared in a `finally` block.
- A backup that legitimately takes more than 30 minutes now fails instead of running forever. Operators can raise `PAPERCLIP_DB_BACKUP_TIMEOUT_MINUTES` or set the option to `0` in code.
- The wedge watchdog only starts after pg_dump has exited, so it cannot kill a healthy dump.
- Behavioral shift: a class of backups that used to hang silently now rejects with a descriptive error. That is the intent of this PR.

## Model Used

- Kimi K3 (Moonshot AI), exact model ID `kimi-k3`, served through OpenCode Go as `opencode-go/kimi-k3`. The model ran as an autonomous OpenCode coding agent with tool use and shell execution: it wrote the patch, wrote the tests, ran the tests, and prepared this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
