### PR TITLE
ci(release): raise npm publish visibility budget to 10 minutes per package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,14 @@ env:
   # npm accepts a publish immediately, but the registry's CDN can lag packument
   # propagation by several minutes (observed 2.5-4+ minutes on 2026-08-21,
   # which failed four consecutive canary runs mid-loop). Give release.sh's
-  # post-publish visibility poll a 5-minute budget per package instead of its
+  # post-publish visibility poll a 10-minute budget per package instead of its
   # 60-second default; a healthy publish still exits the poll on the first
-  # visible check. The publish jobs' timeout-minutes are sized for several
+  # visible check. (A 5-minute budget missed by seconds on 2026-08-21:
+  # adapter-opencode-local was accepted at 07:02:27 and became visible at
+  # 07:07:40.) The publish jobs' timeout-minutes are sized for several
   # laggard packages; if most of a batch lags the full budget, npm is having
   # a real incident and the job failing is correct.
-  NPM_PUBLISH_VERIFY_ATTEMPTS: "30"
+  NPM_PUBLISH_VERIFY_ATTEMPTS: "60"
   NPM_PUBLISH_VERIFY_DELAY_SECONDS: "10"
 
 jobs:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The release workflow publishes every public package to npm and polls each version's registry visibility before continuing
> - #11834 raised the poll budget from 60 seconds to 5 minutes after npm CDN propagation lag failed four canary runs
> - The very next canary run missed by ten seconds: `adapter-opencode-local@2026.821.0-canary.2` was accepted at 07:02:27 UTC and became visible at 07:07:40, just past the final poll
> - This pull request doubles the per-package budget to 10 minutes
> - The benefit is a release train that survives the one consistently slow package; the 90-minute publish job timeout from #11834 already absorbs it

## Linked Issues or Issue Description

Follow-up to #11834. Evidence in the `Release` run for `16149a75f`: every package's publish became visible within seconds except `adapter-opencode-local`, which has lagged 3-5+ minutes on all of today's runs and exceeded the 5-minute budget by ten seconds on the latest.

## What Changed

- `NPM_PUBLISH_VERIFY_ATTEMPTS` 30 → 60 (with `NPM_PUBLISH_VERIFY_DELAY_SECONDS: "10"`, a 10-minute per-package budget), plus the comment documenting the observed near-miss.

## Verification

- Same env-override plumbing verified in #11834; only the numeric budget changes. The next master push (this merge) exercises the canary path.

## Risks

- Low risk: a genuinely failed publish reports in up to 10 minutes; healthy publishes exit the poll on first visibility.

## Model Used

Claude Fable 5 (Anthropic, `claude-fable-5`) with extended thinking and agentic tool use via the Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (not applicable: numeric workflow env tuning)
- [x] I have updated relevant documentation to reflect my changes (workflow comment updated)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge