### PR TITLE
fix(runtime): suppress pidless heartbeat silence alarms

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -288,14 +288,14 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
   });
 
-  it("treats queued pid-less runs as not applicable while preserving stalled-process alerts", async () => {
+  it("does not escalate stale pid-less runs with no output while preserving stalled-process alerts", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const stale = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
     });
     await db.update(heartbeatRuns).set({
-      processStartedAt: null,
+      processStartedAt: new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000),
       processPid: null,
       processGroupId: null,
       lastOutputAt: null,
@@ -322,10 +322,15 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId: stale.companyId });
 
     expect(result).toMatchObject({ scanned: 1, created: 1, escalated: 0 });
-    const [queuedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, stale.runId));
-    expect(queuedRun).toMatchObject({ status: "running", processStartedAt: null, lastOutputAt: null });
+    const [pidlessRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, stale.runId));
+    expect(pidlessRun).toMatchObject({
+      status: "running",
+      processPid: null,
+      processGroupId: null,
+      lastOutputAt: null,
+    });
     const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
-    await expect(recovery.buildRunOutputSilence(queuedRun!, now)).resolves.toMatchObject({
+    await expect(recovery.buildRunOutputSilence(pidlessRun!, now)).resolves.toMatchObject({
       level: "not_applicable",
       silenceStartedAt: null,
       silenceAgeMs: null,

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -288,6 +288,59 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
   });
 
+  it("treats queued pid-less runs as not applicable while preserving stalled-process alerts", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const stale = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    await db.update(heartbeatRuns).set({
+      processStartedAt: null,
+      processPid: null,
+      processGroupId: null,
+      lastOutputAt: null,
+    }).where(eq(heartbeatRuns.id, stale.runId));
+
+    const stalledRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: stalledRunId,
+      companyId: stale.companyId,
+      agentId: stale.coderId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt: new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000),
+      processStartedAt: new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000),
+      processPid: process.pid,
+      lastOutputAt: null,
+      lastOutputSeq: 0,
+      lastOutputStream: null,
+      contextSnapshot: {},
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId: stale.companyId });
+
+    expect(result).toMatchObject({ scanned: 1, created: 1, escalated: 0 });
+    const [queuedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, stale.runId));
+    expect(queuedRun).toMatchObject({ status: "running", processStartedAt: null, lastOutputAt: null });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+    await expect(recovery.buildRunOutputSilence(queuedRun!, now)).resolves.toMatchObject({
+      level: "not_applicable",
+      silenceStartedAt: null,
+      silenceAgeMs: null,
+    });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, stale.companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.originId).toBe(stalledRunId);
+
+    const [stalledRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, stalledRunId));
+    await expect(recovery.buildRunOutputSilence(stalledRun!, now)).resolves.toMatchObject({ level: "suspicious" });
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4926,6 +4926,8 @@ export function agentRoutes(
       lastOutputSeq: heartbeatRuns.lastOutputSeq,
       lastOutputStream: heartbeatRuns.lastOutputStream,
       lastOutputBytes: heartbeatRuns.lastOutputBytes,
+      processPid: heartbeatRuns.processPid,
+      processGroupId: heartbeatRuns.processGroupId,
       processStartedAt: heartbeatRuns.processStartedAt,
       issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
     };
@@ -5150,6 +5152,8 @@ export function agentRoutes(
         lastOutputSeq: heartbeatRuns.lastOutputSeq,
         lastOutputStream: heartbeatRuns.lastOutputStream,
         lastOutputBytes: heartbeatRuns.lastOutputBytes,
+        processPid: heartbeatRuns.processPid,
+        processGroupId: heartbeatRuns.processGroupId,
         processStartedAt: heartbeatRuns.processStartedAt,
       })
       .from(heartbeatRuns)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2433,6 +2433,8 @@ const heartbeatRunIssueSummaryColumns = {
   createdAt: heartbeatRuns.createdAt,
   agentId: heartbeatRuns.agentId,
   logBytes: heartbeatRuns.logBytes,
+  processPid: heartbeatRuns.processPid,
+  processGroupId: heartbeatRunProcessGroupIdColumn,
   processStartedAt: heartbeatRuns.processStartedAt,
   livenessState: heartbeatRuns.livenessState,
   livenessReason: heartbeatRuns.livenessReason,
@@ -13812,7 +13814,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
-      "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processStartedAt" | "startedAt" | "createdAt"
+      "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processPid" | "processGroupId" | "processStartedAt" | "startedAt" | "createdAt"
     >,
     now = new Date(),
   ) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1455,7 +1455,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
-      "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processStartedAt" | "startedAt" | "createdAt"
+      "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processPid" | "processGroupId" | "processStartedAt" | "startedAt" | "createdAt"
     >,
     now = new Date(),
   ): Promise<RunOutputSilenceSummary> {
@@ -1463,10 +1463,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       latestActiveOutputQuietUntilDecision(run.companyId, run.id, now),
       findOpenStaleRunEvaluation(run.companyId, run.id),
     ]);
-    const isQueuedWithoutProcess = run.processStartedAt == null && run.lastOutputAt == null;
-    const silenceStartedAt = isQueuedWithoutProcess ? null : silenceStartedAtForRun(run);
-    const silenceAgeMs = run.status === "running" && !isQueuedWithoutProcess ? silenceAgeMsForRun(run, now) : null;
-    const level = run.status !== "running" || isQueuedWithoutProcess
+    const isPidlessWithoutOutput = run.processPid == null && run.processGroupId == null && run.lastOutputAt == null;
+    const silenceStartedAt = isPidlessWithoutOutput ? null : silenceStartedAtForRun(run);
+    const silenceAgeMs = run.status === "running" && !isPidlessWithoutOutput ? silenceAgeMsForRun(run, now) : null;
+    const level = run.status !== "running" || isPidlessWithoutOutput
       ? "not_applicable"
       : quietUntilDecision
         ? "snoozed"
@@ -2316,7 +2316,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         and(
           opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
           eq(heartbeatRuns.status, "running"),
-          or(isNotNull(heartbeatRuns.processStartedAt), isNotNull(heartbeatRuns.lastOutputAt)),
+          or(
+            isNotNull(heartbeatRuns.processPid),
+            isNotNull(heartbeatRuns.processGroupId),
+            isNotNull(heartbeatRuns.lastOutputAt),
+          ),
           sql`coalesce(${heartbeatRuns.lastOutputAt}, ${heartbeatRuns.processStartedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${suspicionBefore.toISOString()}::timestamptz`,
         ),
       )

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -1463,9 +1463,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       latestActiveOutputQuietUntilDecision(run.companyId, run.id, now),
       findOpenStaleRunEvaluation(run.companyId, run.id),
     ]);
-    const silenceStartedAt = silenceStartedAtForRun(run);
-    const silenceAgeMs = run.status === "running" ? silenceAgeMsForRun(run, now) : null;
-    const level = run.status !== "running"
+    const isQueuedWithoutProcess = run.processStartedAt == null && run.lastOutputAt == null;
+    const silenceStartedAt = isQueuedWithoutProcess ? null : silenceStartedAtForRun(run);
+    const silenceAgeMs = run.status === "running" && !isQueuedWithoutProcess ? silenceAgeMsForRun(run, now) : null;
+    const level = run.status !== "running" || isQueuedWithoutProcess
       ? "not_applicable"
       : quietUntilDecision
         ? "snoozed"
@@ -2315,6 +2316,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         and(
           opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
           eq(heartbeatRuns.status, "running"),
+          or(isNotNull(heartbeatRuns.processStartedAt), isNotNull(heartbeatRuns.lastOutputAt)),
           sql`coalesce(${heartbeatRuns.lastOutputAt}, ${heartbeatRuns.processStartedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${suspicionBefore.toISOString()}::timestamptz`,
         ),
       )


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat runtime records agent execution and recovery state.
> - The output watchdog used launch timestamps as evidence of live execution.
> - A failed wake could therefore leave a pid-less, silent row that looked live.
> - The watchdog could create recovery work while the server was healthy.
> - This pull request requires process identity or output before the silence watchdog classifies a run as live.
> - The benefit is fewer false recovery alerts without hiding genuinely stalled processes.

## Linked Issues or Issue Description

**What happened?**

A wake that failed before process identity or output was persisted could leave a stale `running` heartbeat row. The silence watchdog classified the row as live and created a stale-run evaluation even when the runtime was healthy.

**Expected behavior**

The orphan reaper must reclaim failed launches. The silence watchdog must not escalate a pid-less row with no output on its own. It must continue to alert for a silent run that has a PID or process-group identity.

**Steps to reproduce**

1. Create a stale `running` heartbeat row.
2. Set `process_pid`, `process_group_id`, and `last_output_at` to null.
3. Leave an old `process_started_at` value on the row.
4. Run the active-output watchdog scan.
5. Observe that the old classifier creates a stale-run evaluation.

**Paperclip version or commit**

Reproduced before commit `93c1d28e287d8bd879df397d1f2901e3c4822528`.

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Not adapter-specific. Automation and continuation recovery wakes exposed the defect.

## What Changed

- Require a PID, process group, or recorded output before the silence watchdog scans a `running` row.
- Return `not_applicable` for pid-less rows that have no output, even when `process_started_at` exists.
- Preserve silence alerts for identity-bearing runs with stale output.
- Include process identity in heartbeat summary queries used to build watchdog status.
- Add a focused regression test for the false-positive shape.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts -t "does not escalate stale pid-less runs" --reporter=dot`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts -t "retries a plan-approval continuation lost as process_lost before agent start" --reporter=dot`

## Risks

- Low risk. The classifier may defer a silence alert until a remote run records its first output when it has no local process identity.
- The orphan reaper remains responsible for terminalizing launches that never acquire process identity.
- There is no schema or migration change.

> This fix supports the completed Self-healing runs and Enforced Outcomes roadmap areas. It does not add a new roadmap feature.

## Model Used

- OpenAI Codex, GPT-5 model family, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
