### PR TITLE
feat(server): allow startup built-in reconciliation opt-out

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -886,6 +886,21 @@ DB backups are not full instance filesystem backups. For full local disaster
 recovery, also back up local storage files and the local encrypted secrets key if
 those providers are enabled.
 
+## Built-In Agent Startup Reconciliation
+
+By default, startup reconciles existing built-in agents and their default
+configuration across companies. To leave existing built-in-agent state unchanged
+during startup, set:
+
+```sh
+PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP=0
+```
+
+The variable accepts only `0` or `1` and defaults to `1`. Setting it to `0`
+skips only the automatic startup reconciliation; manual built-in-agent ensure,
+provision, reset, routine, and API operations are unchanged. Any other value
+fails startup with a validation error.
+
 ## Secrets in Dev
 
 Agent env vars now support secret references. By default, secret values are stored with local encryption and only secret refs are persisted in agent config.

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -8,6 +8,7 @@ const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL
 const ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
+const ORIGINAL_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP = process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP;
 
 const {
   createAppMock,
@@ -32,6 +33,7 @@ const {
   resolveHeartbeatSchedulingSuppressionMock,
   routineServiceFactoryMock,
   routineServiceMock,
+  reconcileBuiltInAgentsOnStartupMock,
 } = vi.hoisted(() => {
   const createAppMock = vi.fn(async () => ((_: unknown, __: unknown) => {}) as never);
   const createBetterAuthInstanceMock = vi.fn(() => ({}));
@@ -109,6 +111,16 @@ const {
     tickScheduledTriggers: vi.fn(async () => ({ triggered: 0 })),
   };
   const routineServiceFactoryMock = vi.fn(() => routineServiceMock);
+  const reconcileBuiltInAgentsOnStartupMock = vi.fn(async () => ({
+    scanned: 0,
+    reconciled: 0,
+    unknown: 0,
+    duplicates: 0,
+    autoEnsured: 0,
+    pendingApprovals: 0,
+    defaultGrantsEnsured: 0,
+    companyFailures: 0,
+  }));
   const feedbackExportServiceMock = {
     flushPendingFeedbackTraces: vi.fn(async () => ({ attempted: 0, sent: 0, failed: 0 })),
   };
@@ -147,6 +159,7 @@ const {
     resolveHeartbeatSchedulingSuppressionMock,
     routineServiceFactoryMock,
     routineServiceMock,
+    reconcileBuiltInAgentsOnStartupMock,
   };
 });
 
@@ -293,12 +306,7 @@ vi.mock("../services/index.js", () => ({
     failed: 0,
     seededAgentIds: [],
   })),
-  reconcileBuiltInAgentsOnStartup: vi.fn(async () => ({
-    scanned: 0,
-    reconciled: 0,
-    unknown: 0,
-    duplicates: 0,
-  })),
+  reconcileBuiltInAgentsOnStartup: reconcileBuiltInAgentsOnStartupMock,
   reconcilePersistedRuntimeServicesOnStartup: vi.fn(async () => ({ reconciled: 0 })),
   resolveHeartbeatSchedulingSuppression: resolveHeartbeatSchedulingSuppressionMock,
   routineService: routineServiceFactoryMock,
@@ -350,9 +358,18 @@ vi.mock("../auth/better-auth.js", () => ({
 
 import { startServer } from "../index.ts";
 
+afterEach(() => {
+  if (ORIGINAL_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP === undefined) {
+    delete process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP;
+  } else {
+    process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP = ORIGINAL_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP;
+  }
+});
+
 describe("startServer feedback export wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP;
     process.env.PAPERCLIP_DECISION_SIGNING_SECRET = "fedcba9876543210fedcba9876543210";
     process.env.PAPERCLIP_AGENT_JWT_SECRET = "0123456789abcdef0123456789abcdef";
     loadConfigMock.mockReturnValue(buildTestConfig());
@@ -458,6 +475,7 @@ describe("startServer feedback export wiring", () => {
     const started = await startServer();
 
     expect(started.server).toBe(fakeServer);
+    expect(reconcileBuiltInAgentsOnStartupMock).toHaveBeenCalledTimes(1);
     expect(feedbackServiceFactoryMock).toHaveBeenCalledTimes(1);
     expect(createAppMock).toHaveBeenCalledTimes(1);
     expect(createAppMock.mock.calls[0]?.[1]).toMatchObject({
@@ -466,6 +484,47 @@ describe("startServer feedback export wiring", () => {
       serverPort: 3210,
     });
   });
+
+  it("skips built-in agent startup reconciliation when explicitly disabled", async () => {
+    process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP = "0";
+
+    const started = await startServer();
+
+    expect(started.server).toBe(fakeServer);
+    expect(reconcileBuiltInAgentsOnStartupMock).not.toHaveBeenCalled();
+    expect(createAppMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps built-in agent startup reconciliation enabled when explicitly set to one", async () => {
+    process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP = "1";
+
+    await startServer();
+
+    expect(reconcileBuiltInAgentsOnStartupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["", "true", "2", "secret-value"])(
+    "rejects invalid PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP=%j without exposing its value",
+    async (value) => {
+      process.env.PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP = value;
+
+      let caught: unknown;
+      try {
+        await startServer();
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toBe(
+        'PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP must be "0" or "1" when set',
+      );
+      if (value.length > 0) expect(message).not.toContain(value);
+      expect(loadConfigMock).not.toHaveBeenCalled();
+      expect(reconcileBuiltInAgentsOnStartupMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps routine ticks and setup cleanup active when heartbeat scheduling is suppressed", async () => {
     loadConfigMock.mockReturnValue(buildTestConfig({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -142,10 +142,21 @@ export interface StartedServer {
   databaseUrl: string;
 }
 
+const RECONCILE_BUILT_IN_AGENTS_ON_STARTUP_ENV = "PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP";
+
+export function parseBuiltInAgentStartupReconciliationEnv(
+  value = process.env[RECONCILE_BUILT_IN_AGENTS_ON_STARTUP_ENV],
+): boolean {
+  if (value === undefined || value === "1") return true;
+  if (value === "0") return false;
+  throw new Error(`${RECONCILE_BUILT_IN_AGENTS_ON_STARTUP_ENV} must be "0" or "1" when set`);
+}
+
 export async function startServer(): Promise<StartedServer> {
   // Tracing must be active (or have failed and logged) before the first DB
   // connection or the HTTP server exists — see instrumentation.ts.
   await instrumentationReady;
+  const reconcileBuiltInAgentsOnStartupEnabled = parseBuiltInAgentStartupReconciliationEnv();
   ensureDecisionSigningSecret();
   let config = loadConfig();
   initTelemetry({ enabled: config.telemetryEnabled });
@@ -916,24 +927,26 @@ export async function startServer(): Promise<StartedServer> {
       logger.error({ err }, "startup reconciliation of codex_local managed homes failed");
     });
 
-  void reconcileBuiltInAgentsOnStartup(db as any)
-    .then((result) => {
-      if (
-        result.reconciled > 0
-        || result.unknown > 0
-        || result.duplicates > 0
-        || result.autoEnsured > 0
-        || result.companyFailures > 0
-      ) {
-        logger.warn(
-          result,
-          "startup reconciliation of built-in agents complete",
-        );
-      }
-    })
-    .catch((err) => {
-      logger.error({ err }, "startup reconciliation of built-in agents failed");
-    });
+  if (reconcileBuiltInAgentsOnStartupEnabled) {
+    void reconcileBuiltInAgentsOnStartup(db as any)
+      .then((result) => {
+        if (
+          result.reconciled > 0
+          || result.unknown > 0
+          || result.duplicates > 0
+          || result.autoEnsured > 0
+          || result.companyFailures > 0
+        ) {
+          logger.warn(
+            result,
+            "startup reconciliation of built-in agents complete",
+          );
+        }
+      })
+      .catch((err) => {
+        logger.error({ err }, "startup reconciliation of built-in agents failed");
+      });
+  }
 
   // Force the instance onto the Kubernetes sandbox provider when configured via
   // env (PAPERCLIP_EXECUTION_MODE=kubernetes). Runs BEFORE the heartbeat resumes


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server reconciles built-in agents when it starts.
> - This operation can change existing built-in-agent state.
> - Some managed upgrades must start the server without changing this state.
> - This pull request adds a strict startup-only opt-out.
> - The benefit is safe existing-data startup while the default behavior stays the same.

## Linked Issues or Issue Description

**What happened?**

The server always calls built-in-agent reconciliation during startup. An operator cannot start an existing database while preserving all marked built-in-agent state.

**Expected behavior**

An explicit environment setting must skip only automatic startup reconciliation. The default startup and all manual operations must keep their current behavior.

**Steps to reproduce**

1. Start Paperclip from commit `599ad7016c34a3b869716129cc0ea5a94b87920f` with an existing marked built-in agent.
2. Observe that startup always calls `reconcileBuiltInAgentsOnStartup`.
3. Observe that no supported setting can skip this call.

**Paperclip version or commit**

`599ad7016c34a3b869716129cc0ea5a94b87920f`

## What Changed

- Add `PAPERCLIP_RECONCILE_BUILT_IN_AGENTS_ON_STARTUP=0|1`.
- Keep the default value at `1`.
- Reject invalid values before configuration or reconciliation starts.
- Skip only the automatic startup call when the value is `0`.
- Add startup tests and operator documentation.

## Verification

- `pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts` passes 22 tests.
- `pnpm -r typecheck` passes all workspaces.
- A full local `pnpm test:run` exposed existing macOS and Node 26 failures in unrelated workspace-runtime and skill-import suites. Canonical CI must provide the aggregate result.

## Risks

The default path is unchanged. The disabled path deliberately leaves existing built-in-agent state untouched during startup. Invalid values fail startup with a fixed message that does not include the supplied value.

This change does not disable manual ensure, provision, reset, routine, API, or new-company behavior.

## Model Used

OpenAI Codex, GPT-5 family. The exact deployment ID is not exposed. The model used reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge