### PR TITLE
feat(issues): flag non-terminal issues with no assignee/monitor/blocker

### DIFF
--- a/server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts
+++ b/server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts
@@ -251,6 +251,77 @@ describeEmbeddedPostgres("issue list routes livenessInvariantViolation filter", 
     expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([strandedId]);
   });
 
+  it("does not flag a todo issue assigned to a human (assigneeUserId set, assigneeAgentId null)", async () => {
+    // Regression for a board false-positive: a sweep keyed only on
+    // assigneeAgentId==null misread human-assigned issues (assigneeUserId set)
+    // as unassigned/stranded. The invariant requires BOTH assignee columns to
+    // be null before flagging.
+    const companyId = await seedCompany();
+    const humanAssignedId = randomUUID();
+
+    await db.insert(issues).values({
+      id: humanAssignedId,
+      companyId,
+      title: "Parked for a human decision, not stranded",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: null,
+      assigneeUserId: "cloud-user-1",
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ livenessInvariantViolation: "true", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).not.toContain(humanAssignedId);
+  });
+
+  it("treats a due/fired monitor (monitorNextCheckAt in the past, not rescheduled) as no live monitor", async () => {
+    // Regression for the "monitor.status = triggered" false-negative: a
+    // monitor that has already fired but was never rescheduled forward still
+    // has a monitorNextCheckAt column value -- just one in the past. Only a
+    // *future* monitorNextCheckAt counts as a live wake path; a stale/fired
+    // one must count as no monitor, same as null.
+    const companyId = await seedCompany();
+    const strandedId = randomUUID();
+    const liveMonitorId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: strandedId,
+        companyId,
+        title: "Monitor fired an hour ago and was never rescheduled",
+        status: "in_review",
+        priority: "high",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        monitorNextCheckAt: new Date(Date.now() - 60 * 60 * 1000),
+      },
+      {
+        id: liveMonitorId,
+        companyId,
+        title: "Monitor still scheduled in the future",
+        status: "in_review",
+        priority: "high",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+    ]);
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ livenessInvariantViolation: "true", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const flaggedIds = res.body.map((issue: { id: string }) => issue.id);
+    expect(flaggedIds).toContain(strandedId);
+    expect(flaggedIds).not.toContain(liveMonitorId);
+  });
+
   it("returns 400 for a malformed livenessInvariantViolation flag", async () => {
     const companyId = await seedCompany();
 

--- a/server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts
+++ b/server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts
@@ -181,6 +181,16 @@ describeEmbeddedPostgres("issue list routes livenessInvariantViolation filter", 
     const stillBlockedId = randomUUID();
     const resolvedBlockerId = randomUUID();
     const liveBlockerId = randomUUID();
+    const liveBlockerAssigneeId = randomUUID();
+
+    await db.insert(agents).values({
+      id: liveBlockerAssigneeId,
+      companyId,
+      name: "Blocker Owner Agent",
+      role: "engineer",
+      adapter: "claude_local",
+      status: "active",
+    });
 
     await db.insert(issues).values([
       {
@@ -207,9 +217,12 @@ describeEmbeddedPostgres("issue list routes livenessInvariantViolation filter", 
       {
         id: liveBlockerId,
         companyId,
+        // Assigned so this itself does not independently trip the invariant --
+        // its only role here is to be a genuinely live blocker for stillBlockedId.
         title: "Live blocker, still open",
         status: "todo",
         priority: "medium",
+        assigneeAgentId: liveBlockerAssigneeId,
       },
     ]);
 

--- a/server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts
+++ b/server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  issueRelations,
+  issues,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+// AGE-755: a non-terminal issue (todo/in_progress/in_review/blocked) with no
+// assigneeAgentId/assigneeUserId, no scheduled monitor, and no live (non
+// done/cancelled) blocker is stranded -- nothing will ever wake it. This
+// covers the three known-stranded shapes from the board sweep:
+//   1. todo, never assigned
+//   2. in_review after a changes_requested outcome cleared assigneeAgentId
+//   3. blocked with an empty/all-resolved blockedByIssueIds
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue list route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue list routes livenessInvariantViolation filter", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-list-liveness-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function uniqueIssuePrefix() {
+    return `P${randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    return companyId;
+  }
+
+  it("flags a todo issue with no assignee and no monitor (shape 1)", async () => {
+    const companyId = await seedCompany();
+    const strandedId = randomUUID();
+    const healthyAssignedId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Owner Agent",
+      role: "engineer",
+      adapter: "claude_local",
+      status: "active",
+    });
+
+    await db.insert(issues).values([
+      {
+        id: strandedId,
+        companyId,
+        title: "Stranded todo, never assigned",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: healthyAssignedId,
+        companyId,
+        title: "Healthy todo, has an assignee",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ livenessInvariantViolation: "true", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([strandedId]);
+  });
+
+  it("flags an in_review issue left assignee-less after a changes_requested outcome (shape 2)", async () => {
+    const companyId = await seedCompany();
+    const strandedId = randomUUID();
+
+    await db.insert(issues).values({
+      id: strandedId,
+      companyId,
+      title: "In review, changes_requested cleared the assignee",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      executionState: {
+        outcome: "changes_requested",
+        returnAssignee: { type: "agent", agentId: randomUUID() },
+      },
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ livenessInvariantViolation: "true", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([strandedId]);
+  });
+
+  it("flags a blocked issue whose blockedByIssueIds are empty/all resolved (shape 3)", async () => {
+    const companyId = await seedCompany();
+    const strandedId = randomUUID();
+    const stillBlockedId = randomUUID();
+    const resolvedBlockerId = randomUUID();
+    const liveBlockerId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: strandedId,
+        companyId,
+        title: "Blocked with no live blockers left",
+        status: "blocked",
+        priority: "medium",
+      },
+      {
+        id: resolvedBlockerId,
+        companyId,
+        title: "Former blocker, now done",
+        status: "done",
+        priority: "medium",
+      },
+      {
+        id: stillBlockedId,
+        companyId,
+        title: "Genuinely blocked, blocker still open",
+        status: "blocked",
+        priority: "medium",
+      },
+      {
+        id: liveBlockerId,
+        companyId,
+        title: "Live blocker, still open",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    // strandedId's only blocker relation points at a done issue -- stale/resolved,
+    // so strandedId has no *live* blocker despite status=blocked.
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: resolvedBlockerId,
+      relatedIssueId: strandedId,
+      type: "blocks",
+    });
+    // stillBlockedId has a genuinely live (todo) blocker and must NOT be flagged.
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: liveBlockerId,
+      relatedIssueId: stillBlockedId,
+      type: "blocks",
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ livenessInvariantViolation: "true", limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([strandedId]);
+  });
+
+  it("returns 400 for a malformed livenessInvariantViolation flag", async () => {
+    const companyId = await seedCompany();
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ livenessInvariantViolation: "not-a-bool", limit: "20" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "livenessInvariantViolation must be true or false when provided",
+    });
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -379,6 +379,26 @@ function applyCreateIssueStatusDefault(req: Request, res: Response, next: () => 
   next();
 }
 
+// AGE-755: report-only guard rail for the same invariant checked by the
+// liveness sweep (no assignee, no monitor) -- but evaluated at create time so
+// the gap is visible in logs/response immediately instead of only surfacing
+// later via the `livenessInvariantViolation` list filter. Never blocks the
+// create; legitimate unassigned backlog creation is unaffected because
+// `backlog`/`done` are excluded.
+function describeUnownedIssueCreateWarning(
+  issue: { id: string; identifier: string | null; status: string; assigneeAgentId: string | null; assigneeUserId: string | null },
+  executionPolicy: { monitor?: unknown } | null | undefined,
+): string | null {
+  if (issue.status === "backlog" || issue.status === "done" || issue.status === "cancelled") return null;
+  if (issue.assigneeAgentId || issue.assigneeUserId) return null;
+  if (executionPolicy?.monitor) return null;
+  return (
+    `Issue ${issue.identifier ?? issue.id} was created with status "${issue.status}" but no assigneeAgentId, ` +
+    "no assigneeUserId, and no monitor scheduled -- it may violate the no-assignee/no-monitor/no-blocker " +
+    "liveness invariant (AGE-755). Report-only: verify a blocker, assignee, or monitor exists."
+  );
+}
+
 function noopTaskWatchdogService(): TaskWatchdogService {
   return {
     getActiveForIssue: async () => null,
@@ -6020,6 +6040,11 @@ export function issueRoutes(
       res.status(400).json({ error: "includeLiveDescendantSummary must be true or false when provided" });
       return;
     }
+    const livenessInvariantViolation = parseOptionalBooleanQuery(req.query.livenessInvariantViolation);
+    if (livenessInvariantViolation === null) {
+      res.status(400).json({ error: "livenessInvariantViolation must be true or false when provided" });
+      return;
+    }
     if (assigneeAgentFilterRaw !== undefined) {
       if (typeof assigneeAgentFilterRaw !== "string") {
         res.status(422).json({ error: "assigneeAgentId must be a UUID or 'null'" });
@@ -6078,6 +6103,7 @@ export function issueRoutes(
       sortField: sortField === "updated" ? "updated" : undefined,
       sortDir: sortDir === "asc" || sortDir === "desc" ? sortDir : undefined,
       updatedSince: rawUpdatedSince,
+      livenessInvariantViolation: livenessInvariantViolation === true,
     };
     const requestKey = issueListRequestKey({
       req,
@@ -8799,10 +8825,19 @@ export function issueRoutes(
     });
     await queueTaskWatchdogEvaluation(issue, actor.runId);
 
+    const livenessWarning = describeUnownedIssueCreateWarning(issue, executionPolicy);
+    if (livenessWarning) {
+      logger.warn(
+        { issueId: issue.id, companyId, identifier: issue.identifier, status: issue.status },
+        livenessWarning,
+      );
+    }
+
     res.status(201).json({
       ...issue,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+      ...(livenessWarning ? { warnings: [livenessWarning] } : {}),
     });
   });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lte, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -576,6 +576,13 @@ export interface IssueFilters {
   sortDir?: "asc" | "desc";
   /** ISO 8601 timestamp — only return issues with updatedAt strictly after this value. */
   updatedSince?: string;
+  /**
+   * AGE-755: only return non-terminal issues (`todo`/`in_progress`/`in_review`/`blocked`)
+   * that violate the ownership invariant -- no assigneeAgentId, no assigneeUserId,
+   * no live/future `monitorNextCheckAt`, and no unresolved (non `done`/`cancelled`)
+   * blocker via `issue_relations`. Report-only: this never mutates the issue.
+   */
+  livenessInvariantViolation?: boolean;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -5686,6 +5693,24 @@ export function issueService(db: Db) {
         if (Number.isFinite(since.getTime())) {
           conditions.push(gt(issues.updatedAt, since));
         }
+      }
+      if (filters?.livenessInvariantViolation) {
+        conditions.push(
+          and(
+            inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+            isNull(issues.assigneeAgentId),
+            isNull(issues.assigneeUserId),
+            or(isNull(issues.monitorNextCheckAt), lte(issues.monitorNextCheckAt, sql`now()`))!,
+            sql`NOT EXISTS (
+              SELECT 1 FROM ${issueRelations} blocker_rel
+              JOIN ${issues} blocker_issue ON blocker_issue.id = blocker_rel.issue_id
+              WHERE blocker_rel.related_issue_id = ${issues.id}
+                AND blocker_rel.company_id = ${companyId}
+                AND blocker_rel.type = 'blocks'
+                AND blocker_issue.status NOT IN ('done', 'cancelled')
+            )`,
+          )!,
+        );
       }
       if (filters?.excludeRoutineExecutions && !filters?.originKind && !filters?.originId) {
         conditions.push(ne(issues.originKind, "routine_execution"));


### PR DESCRIPTION
## Thinking Path

- Board sweep found 11 `todo` issues with `assigneeAgentId=null` and no monitor (3 P0s), plus an `in_review` + no-assignee shape (a `changes_requested` outcome clearing `assigneeAgentId` with no reassignment) and the known `blocked` + empty-live-blockers shape.
- All three share one root cause: no invariant that every non-terminal issue has an assignee, a live monitor, or a live blocker.
- This ships detection only (`livenessInvariantViolation=true` list filter), matching the existing `staleHours`-filter precedent rather than new cron/scheduler infra, since the acceptance criteria calls for a query/command, not auto-recovery.

## What Changed

- `GET /companies/:companyId/issues?livenessInvariantViolation=true`: returns every issue in `todo`/`in_progress`/`in_review`/`blocked` with no `assigneeAgentId`, no `assigneeUserId`, no live/future `monitorNextCheckAt`, and no unresolved (non `done`/`cancelled`) blocker via `issue_relations`.
- `POST /companies/:companyId/issues`: logs a warning (and returns a `warnings` array) when a non-`backlog`/non-`done`/non-`cancelled` issue is created with no assignee and no monitor. Does not block creation.
- Report-only in both cases -- no auto-assignment, no mutation.

## Verification

- Added `server/src/__tests__/issue-list-liveness-invariant-violation-routes.test.ts` covering all three known shapes (todo-no-assignee, in_review-no-assignee-after-changes_requested, blocked-empty/resolved-blockedByIssueIds) plus a healthy-assigned control and a malformed-flag 400.
- The full vitest suite currently fails to boot on `master` for an unrelated, pre-existing reason: `packages/shared`'s zod v3 to v4 bump (#11719, already on master) left installed `node_modules` still linked to `zod@3.25.76`, so every server test -- including already-merged ones like the `updatedSince` filter test -- throws `z.string(...).guid is not a function` before any test body runs. Confirmed this on an untouched existing test file too, so it's not something this PR introduced.
- Verified the exact SQL condition against a real embedded-Postgres instance with a standalone script that bypasses the poisoned `@paperclipai/shared` import chain (drizzle-orm + `@paperclipai/db` only): 8 fixture issues covering all three stranded shapes plus assigned/monitored/genuinely-blocked controls -- exact match, no false positives or negatives, reproduced 3x.
- Verified the create-time warning helper in isolation against 4 cases (unowned todo fires, assigned todo silent, unowned backlog silent, blocked-with-monitor silent) -- matches expected behavior.
- Follow-up: once `pnpm install` reconciles the zod symlinks (or this PR's CI, which does a clean install, runs), the new test file should be run for real. I did not force a `pnpm install --no-frozen-lockfile` on the shared dev checkout since another agent has unrelated in-flight work there and a lockfile-mutating install was not in scope for this ticket.

## Model Used

Agentic coding harness (Paperclip Software Engineer agent), model not separately disclosed by the harness; report-only code change, no model-generated content shipped beyond the diff itself.

## Risks

- Low risk: additive query param + additive response field + a log line. No existing behavior changes for callers that do not pass the new flag.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (Claude, via Paperclip agent harness)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found for this exact invariant)
- [x] I have described the issue in-PR (see Thinking Path)
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [ ] I have run tests locally and they pass (blocked by the unrelated pre-existing zod environment issue described above; logic verified via a standalone embedded-Postgres script instead -- see Verification)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (inline JSDoc on the new filter/warning)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

