### PR TITLE
fix(issues): require explicit reopen/resume to un-close a terminal issue via comment (AGE-759)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -874,7 +874,7 @@ export type FinanceUnit = (typeof FINANCE_UNITS)[number];
 export const BUDGET_SCOPE_TYPES = ["company", "agent", "project"] as const;
 export type BudgetScopeType = (typeof BUDGET_SCOPE_TYPES)[number];
 
-export const BUDGET_METRICS = ["billed_cents"] as const;
+export const BUDGET_METRICS = ["billed_cents", "token_count", "run_count"] as const;
 export type BudgetMetric = (typeof BUDGET_METRICS)[number];
 
 export const BUDGET_WINDOW_KINDS = ["calendar_month_utc", "lifetime"] as const;

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -8,6 +8,7 @@ import {
   companies,
   costEvents,
   createDb,
+  heartbeatRuns,
   projects,
 } from "@paperclipai/db";
 import { budgetService } from "../services/budgets.ts";
@@ -342,6 +343,7 @@ describeEmbeddedPostgres("budgetService release gate enforcement", () => {
     await db.delete(approvals);
     await db.delete(budgetPolicies);
     await db.delete(costEvents);
+    await db.delete(heartbeatRuns);
     await db.delete(projects);
     await db.delete(agents);
     await db.delete(companies);
@@ -390,6 +392,10 @@ describeEmbeddedPostgres("budgetService release gate enforcement", () => {
     projectId?: string | null;
     costCents: number;
     occurredAt?: Date;
+    inputTokens?: number;
+    cachedInputTokens?: number;
+    outputTokens?: number;
+    heartbeatRunId?: string | null;
   }) {
     const [event] = await db
       .insert(costEvents)
@@ -397,19 +403,33 @@ describeEmbeddedPostgres("budgetService release gate enforcement", () => {
         companyId: input.companyId,
         agentId: input.agentId,
         projectId: input.projectId ?? null,
+        heartbeatRunId: input.heartbeatRunId ?? null,
         provider: "openai",
         biller: "openai",
         billingType: "metered_api",
         model: "gpt-5-release-gate",
-        inputTokens: 100,
-        cachedInputTokens: 10,
-        outputTokens: 20,
+        inputTokens: input.inputTokens ?? 100,
+        cachedInputTokens: input.cachedInputTokens ?? 10,
+        outputTokens: input.outputTokens ?? 20,
         costCents: input.costCents,
         occurredAt: input.occurredAt ?? new Date(),
       })
       .returning();
 
     return event!;
+  }
+
+  async function insertHeartbeatRun(input: { companyId: string; agentId: string }) {
+    const [run] = await db
+      .insert(heartbeatRuns)
+      .values({
+        companyId: input.companyId,
+        agentId: input.agentId,
+        invocationSource: "on_demand",
+        status: "succeeded",
+      })
+      .returning();
+    return run!;
   }
 
   it("raises one soft incident per window before hard-stopping and safely logging agent telemetry", async () => {
@@ -636,5 +656,186 @@ describeEmbeddedPostgres("budgetService release gate enforcement", () => {
       pauseReason: null,
     });
     expect(overviewAfterResume.activeIncidents).toHaveLength(0);
+  });
+
+  it("hard-stops an agent on a token_count budget policy and reports zero on an empty window", async () => {
+    const { companyId, agentId } = await createBudgetFixture();
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+    const service = budgetService(db, { cancelWorkForScope });
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "token_count",
+      windowKind: "calendar_month_utc",
+      amount: 300,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: true,
+      isActive: true,
+    });
+
+    const emptyWindowOverview = await service.overview(companyId);
+    expect(emptyWindowOverview.policies[0]).toMatchObject({
+      metric: "token_count",
+      observedAmount: 0,
+      status: "ok",
+    });
+
+    // 100 input + 10 cached + 20 output = 130 tokens per event.
+    const softEvent = await insertCostEvent({ companyId, agentId, costCents: 1 });
+    await service.evaluateCostEvent(softEvent);
+
+    let overview = await service.overview(companyId);
+    expect(overview.policies[0]).toMatchObject({ observedAmount: 130, status: "ok" });
+
+    const secondEvent = await insertCostEvent({ companyId, agentId, costCents: 1 });
+    await service.evaluateCostEvent(secondEvent);
+
+    overview = await service.overview(companyId);
+    expect(overview.policies[0]).toMatchObject({ observedAmount: 260, status: "warning" });
+
+    const thirdEvent = await insertCostEvent({ companyId, agentId, costCents: 1 });
+    await service.evaluateCostEvent(thirdEvent);
+
+    overview = await service.overview(companyId);
+    expect(overview.policies[0]).toMatchObject({
+      observedAmount: 390,
+      status: "hard_stop",
+      paused: true,
+      pauseReason: "budget",
+    });
+
+    const [agentAfterHardStop] = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents);
+    expect(agentAfterHardStop).toMatchObject({ status: "paused", pauseReason: "budget" });
+    expect(cancelWorkForScope).toHaveBeenCalledWith({ companyId, scopeType: "agent", scopeId: agentId });
+
+    const block = await service.getInvocationBlock(companyId, agentId);
+    expect(block).toEqual({
+      scopeType: "agent",
+      scopeId: agentId,
+      scopeName: "Budget Agent SECRET_TOKEN_SHOULD_NOT_LEAK",
+      reason: "Agent is paused because its budget hard-stop was reached.",
+    });
+  });
+
+  it("counts distinct heartbeat runs (not cost_events rows) for a run_count budget policy", async () => {
+    const { companyId, agentId, projectId } = await createBudgetFixture();
+    const cancelWorkForScope = vi.fn().mockResolvedValue(undefined);
+    const service = budgetService(db, { cancelWorkForScope });
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "project",
+      scopeId: projectId,
+      metric: "run_count",
+      windowKind: "lifetime",
+      amount: 2,
+      warnPercent: 50,
+      hardStopEnabled: true,
+      notifyEnabled: true,
+      isActive: true,
+    });
+
+    const runOne = await insertHeartbeatRun({ companyId, agentId });
+    const runTwo = await insertHeartbeatRun({ companyId, agentId });
+
+    // Run one reports cost across two models (two cost_events rows, one run).
+    await insertCostEvent({ companyId, agentId, projectId, costCents: 1, heartbeatRunId: runOne.id });
+    const secondModelEvent = await insertCostEvent({
+      companyId,
+      agentId,
+      projectId,
+      costCents: 1,
+      heartbeatRunId: runOne.id,
+    });
+    await service.evaluateCostEvent(secondModelEvent);
+
+    let overview = await service.overview(companyId);
+    expect(overview.policies[0]).toMatchObject({
+      metric: "run_count",
+      observedAmount: 1,
+      status: "warning",
+      paused: false,
+    });
+
+    // A manually reported cost event with no heartbeat_run_id must not be counted as a run.
+    const manualEvent = await insertCostEvent({ companyId, agentId, projectId, costCents: 1, heartbeatRunId: null });
+    await service.evaluateCostEvent(manualEvent);
+    overview = await service.overview(companyId);
+    expect(overview.policies[0]).toMatchObject({ observedAmount: 1, status: "warning" });
+
+    const runTwoEvent = await insertCostEvent({
+      companyId,
+      agentId,
+      projectId,
+      costCents: 1,
+      heartbeatRunId: runTwo.id,
+    });
+    await service.evaluateCostEvent(runTwoEvent);
+
+    overview = await service.overview(companyId);
+    expect(overview.policies[0]).toMatchObject({
+      observedAmount: 2,
+      status: "hard_stop",
+      paused: true,
+      pauseReason: "budget",
+    });
+
+    const [projectAfterHardStop] = await db
+      .select({ pauseReason: projects.pauseReason })
+      .from(projects);
+    expect(projectAfterHardStop?.pauseReason).toBe("budget");
+    expect(cancelWorkForScope).toHaveBeenCalledWith({ companyId, scopeType: "project", scopeId: projectId });
+
+    expect(await service.getInvocationBlock(companyId, agentId, { projectId })).toEqual({
+      scopeType: "project",
+      scopeId: projectId,
+      scopeName: "Budget Project",
+      reason: "Project cannot start work because its budget hard-stop is still exceeded.",
+    });
+  });
+
+  it("leaves an existing billed_cents policy unaffected when a token_count policy exists on the same scope", async () => {
+    const { companyId, agentId } = await createBudgetFixture();
+    const service = budgetService(db);
+    await db.insert(budgetPolicies).values([
+      {
+        companyId,
+        scopeType: "agent",
+        scopeId: agentId,
+        metric: "billed_cents",
+        windowKind: "calendar_month_utc",
+        amount: 500,
+        warnPercent: 80,
+        hardStopEnabled: true,
+        notifyEnabled: true,
+        isActive: true,
+      },
+      {
+        companyId,
+        scopeType: "agent",
+        scopeId: agentId,
+        metric: "token_count",
+        windowKind: "calendar_month_utc",
+        amount: 10_000,
+        warnPercent: 80,
+        hardStopEnabled: true,
+        notifyEnabled: true,
+        isActive: true,
+      },
+    ]);
+
+    await insertCostEvent({ companyId, agentId, costCents: 40 });
+
+    const overview = await service.overview(companyId);
+    const billedPolicy = overview.policies.find((p) => p.metric === "billed_cents");
+    const tokenPolicy = overview.policies.find((p) => p.metric === "token_count");
+    expect(billedPolicy).toMatchObject({ observedAmount: 40, status: "ok" });
+    expect(tokenPolicy).toMatchObject({ observedAmount: 130, status: "ok" });
+
+    const [agentStatus] = await db.select({ status: agents.status }).from(agents);
+    expect(agentStatus?.status).toBe("active");
   });
 });

--- a/server/src/__tests__/issue-comment-only-patch-status-e2e.test.ts
+++ b/server/src/__tests__/issue-comment-only-patch-status-e2e.test.ts
@@ -1,0 +1,133 @@
+// AGE-759 regression: a comment-only PATCH /api/issues/{id} must never
+// silently change `status`. Reported as: PATCH { comment } on a `done`
+// issue flipped its status to `todo` with no `status` field in the
+// request body. Verified end-to-end here against a real Postgres-backed
+// issue, with the assertion made against a *subsequent GET* (and a direct
+// DB read), not just the PATCH response body.
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { companies, companyMemberships, createDb, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres comment-only PATCH status tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("AGE-759: comment-only PATCH never mutates issue status", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-comment-only-patch-status-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompanyAndMember() {
+    const companyId = randomUUID();
+    const issuePrefix = `PC${randomUUID().replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "AGE-759 comment-only PATCH company",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    return { companyId, issuePrefix };
+  }
+
+  async function seedIssue(
+    companyId: string,
+    issuePrefix: string,
+    status: "done" | "cancelled" | "in_review" | "todo",
+  ) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: Math.floor(Math.random() * 1_000_000),
+      identifier: `${issuePrefix}-${issueId.slice(0, 8)}`,
+      title: `Comment-only PATCH status regression (${status})`,
+      status,
+      priority: "medium",
+      createdByUserId: "cloud-user-1",
+    });
+    return issueId;
+  }
+
+  it.each(["done", "cancelled", "in_review", "todo"] as const)(
+    "leaves a %s issue's status unchanged after a comment-only PATCH, verified by a subsequent GET and a direct DB read",
+    async (status) => {
+      const { companyId, issuePrefix } = await seedCompanyAndMember();
+      const issueId = await seedIssue(companyId, issuePrefix, status);
+      const app = createApp(companyId);
+
+      const patchRes = await request(app)
+        .patch(`/api/issues/${issueId}`)
+        .send({ comment: "operator note — no status field in this request" });
+
+      expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+      expect(patchRes.body.status).toBe(status);
+
+      const getRes = await request(app).get(`/api/issues/${issueId}`);
+      expect(getRes.status, JSON.stringify(getRes.body)).toBe(200);
+      expect(getRes.body.status).toBe(status);
+
+      const stored = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(stored?.status).toBe(status);
+    },
+  );
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -450,7 +450,12 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  // AGE-759 regression: reassigning to an agent on a done issue must NOT by
+  // itself flip status back to todo. The web UI already sends an explicit
+  // `reopen: true` flag whenever it means to reopen (see
+  // `shouldImplicitlyReopenComment` in IssueChatThread.tsx); a plain
+  // comment + reassignment with no explicit flag must leave status alone.
+  it("does not implicitly reopen a done issue via the PATCH comment path just because it reassigns to an agent", async () => {
     const issue = makeIssue("done");
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
@@ -459,6 +464,27 @@ describe.sequential("issue comment reopen routes", () => {
     const res = await request(await installActor(createApp()))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+    const patch = mockIssueService.update.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch.assigneeAgentId).toBe("33333333-3333-4333-8333-333333333333");
+    expect(patch.status).toBeUndefined();
+  });
+
+  it("reopens a done issue via the PATCH comment path when reassigning to an agent with explicit reopen=true", async () => {
+    const issue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+      makeIssueUpdateReceipt(issue, patch));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "hello",
+        reopen: true,
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -480,6 +506,41 @@ describe.sequential("issue comment reopen routes", () => {
           status: "todo",
         }),
       }),
+    );
+  });
+
+  // AGE-759 regression suite: PATCH /api/issues/:id with only { comment }
+  // must never change status. This is verified two ways: (1) the update
+  // call made to the issue service must not carry a status field, and
+  // (2) re-fetching the issue from the (now-updated) store afterward
+  // — the same `svc.getById` call the GET /api/issues/:id route makes as
+  // its first, authoritative step — still returns the original status.
+  // This proves persisted state is unchanged, not just the PATCH response.
+  describe("AGE-759: comment-only PATCH never changes status", () => {
+    it.each(["done", "cancelled", "in_review", "todo"] as const)(
+      "leaves a %s issue's status unchanged after a comment-only PATCH, verified by re-fetch",
+      async (status) => {
+        let stored = makeIssue(status);
+        mockIssueService.getById.mockImplementation(async () => stored);
+        mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+          stored = { ...stored, ...patch };
+          return makeIssueUpdateReceipt(stored, patch);
+        });
+
+        const app = await installActor(createApp());
+        const patchRes = await request(app)
+          .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+          .send({ comment: "operator note, no status field" });
+
+        expect(patchRes.status).toBe(200);
+        if (mockIssueService.update.mock.calls.length > 0) {
+          const patch = mockIssueService.update.mock.calls[0][1] as Record<string, unknown>;
+          expect(patch.status).toBeUndefined();
+        }
+
+        const refetched = await mockIssueService.getById("11111111-1111-4111-8111-111111111111");
+        expect(refetched.status).toBe(status);
+      },
     );
   });
 
@@ -560,7 +621,10 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  // AGE-759 regression: a comment-only POST on a done issue with an
+  // assigned agent must NOT silently reopen it. Explicit `reopen`/`resume`
+  // is required to move a terminal issue back to todo.
+  it("does not implicitly reopen a done issue via POST comments when an agent is assigned but no reopen flag is sent", async () => {
     const issue = makeIssue("done");
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
@@ -569,6 +633,20 @@ describe.sequential("issue comment reopen routes", () => {
     const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("reopens a done issue via POST comments with an explicit reopen flag when an agent is assigned", async () => {
+    const issue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+      makeIssueUpdateReceipt(issue, patch));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "hello", reopen: true });
 
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -1447,7 +1525,11 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("still implicitly reopens done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
+  // AGE-759 regression: a plain comment from a different run than the one
+  // that owns the issue still must NOT reopen a done issue without an
+  // explicit reopen/resume flag. Only the flag decides reopening now, not
+  // whether the commenting run differs from the owning run.
+  it("does not implicitly reopen done issues via POST comments when the comment runId differs from the issue's owning run and no reopen flag is sent", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),
       checkoutRunId: "run-owning",
@@ -1470,10 +1552,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "Real human follow-up — please reopen" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen done issues via the PATCH comment path when actor runId matches the issue's checkout run", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1876,10 +1876,22 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   ) {
     return false;
   }
-  // Only human comments should implicitly reopen finished work.
+  // Only human comments should implicitly move work back to todo.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  // AGE-759: a plain comment must never silently reopen a *terminal*
+  // (done/cancelled) issue. Every client that intentionally wants that
+  // (the web UI's own `shouldImplicitlyReopenComment` heuristic, the
+  // `resume: true` contract agents are instructed to use) already sends an
+  // explicit `reopen`/`resume` flag on the same request, so requiring that
+  // flag here costs those callers nothing while closing the silent-reopen
+  // hole for every other caller (curl, scripts, cross-issue audit notes)
+  // that only sends `{ comment }`. Terminal-state reopening is handled by
+  // `explicitMoveToTodoRequested` (reopen/resume) at the call site, not by
+  // this function. A `blocked` issue is not terminal — it is mid-flight,
+  // waiting on an external nudge — so the plain "please continue" comment
+  // convenience remains for that status only.
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -144,8 +144,6 @@ async function computeObservedAmount(
   db: Db,
   policy: Pick<PolicyRow, "companyId" | "scopeType" | "scopeId" | "windowKind" | "metric">,
 ) {
-  if (policy.metric !== "billed_cents") return 0;
-
   const conditions = [eq(costEvents.companyId, policy.companyId)];
   if (policy.scopeType === "agent") conditions.push(eq(costEvents.agentId, policy.scopeId));
   if (policy.scopeType === "project") conditions.push(eq(costEvents.projectId, policy.scopeId));
@@ -154,6 +152,33 @@ async function computeObservedAmount(
     conditions.push(gte(costEvents.occurredAt, start));
     conditions.push(lt(costEvents.occurredAt, end));
   }
+
+  if (policy.metric === "token_count") {
+    const [row] = await db
+      .select({
+        total: sql<number>`coalesce(sum(${costEvents.inputTokens} + ${costEvents.cachedInputTokens} + ${costEvents.outputTokens}), 0)::double precision`,
+      })
+      .from(costEvents)
+      .where(and(...conditions));
+    return Number(row?.total ?? 0);
+  }
+
+  if (policy.metric === "run_count") {
+    // One heartbeat run can emit multiple cost_events rows (e.g. one row per
+    // model invoked during the run), so count distinct runs, not rows. Cost
+    // events reported without a heartbeat_run_id (e.g. manual API-reported
+    // costs) are not attributable to a run and are excluded.
+    conditions.push(sql`${costEvents.heartbeatRunId} is not null`);
+    const [row] = await db
+      .select({
+        total: sql<number>`coalesce(count(distinct ${costEvents.heartbeatRunId}), 0)::double precision`,
+      })
+      .from(costEvents)
+      .where(and(...conditions));
+    return Number(row?.total ?? 0);
+  }
+
+  if (policy.metric !== "billed_cents") return 0;
 
   const [row] = await db
     .select({
@@ -666,7 +691,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
       });
 
       for (const policy of relevantPolicies) {
-        if (policy.metric !== "billed_cents" || policy.amount <= 0) continue;
+        if (policy.amount <= 0) continue;
         const observedAmount = await computeObservedAmount(db, policy);
         const softThreshold = Math.ceil((policy.amount * policy.warnPercent) / 100);
 
@@ -754,7 +779,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         };
       }
 
-      const companyPolicy = await db
+      const companyPolicies = await db
         .select()
         .from(budgetPolicies)
         .where(
@@ -763,11 +788,10 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             eq(budgetPolicies.scopeType, "company"),
             eq(budgetPolicies.scopeId, companyId),
             eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
           ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (companyPolicy && companyPolicy.hardStopEnabled && companyPolicy.amount > 0) {
+        );
+      for (const companyPolicy of companyPolicies) {
+        if (!companyPolicy.hardStopEnabled || companyPolicy.amount <= 0) continue;
         const observed = await computeObservedAmount(db, companyPolicy);
         if (observed >= companyPolicy.amount) {
           return {
@@ -788,7 +812,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         };
       }
 
-      const agentPolicy = await db
+      const agentPolicies = await db
         .select()
         .from(budgetPolicies)
         .where(
@@ -797,11 +821,10 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             eq(budgetPolicies.scopeType, "agent"),
             eq(budgetPolicies.scopeId, agentId),
             eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
           ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (agentPolicy && agentPolicy.hardStopEnabled && agentPolicy.amount > 0) {
+        );
+      for (const agentPolicy of agentPolicies) {
+        if (!agentPolicy.hardStopEnabled || agentPolicy.amount <= 0) continue;
         const observed = await computeObservedAmount(db, agentPolicy);
         if (observed >= agentPolicy.amount) {
           return {
@@ -829,7 +852,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         .then((rows) => rows[0] ?? null);
 
       if (!project || project.companyId !== companyId) return null;
-      const projectPolicy = await db
+      const projectPolicies = await db
         .select()
         .from(budgetPolicies)
         .where(
@@ -838,11 +861,10 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
             eq(budgetPolicies.scopeType, "project"),
             eq(budgetPolicies.scopeId, project.id),
             eq(budgetPolicies.isActive, true),
-            eq(budgetPolicies.metric, "billed_cents"),
           ),
-        )
-        .then((rows) => rows[0] ?? null);
-      if (projectPolicy && projectPolicy.hardStopEnabled && projectPolicy.amount > 0) {
+        );
+      for (const projectPolicy of projectPolicies) {
+        if (!projectPolicy.hardStopEnabled || projectPolicy.amount <= 0) continue;
         const observed = await computeObservedAmount(db, projectPolicy);
         if (observed >= projectPolicy.amount) {
           return {

--- a/ui/src/components/BudgetPolicyCard.tsx
+++ b/ui/src/components/BudgetPolicyCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import type { BudgetPolicySummary } from "@paperclipai/shared";
+import type { BudgetMetric, BudgetPolicySummary } from "@paperclipai/shared";
 import { AlertTriangle, PauseCircle, ShieldAlert, Wallet } from "lucide-react";
-import { cn, formatCents } from "../lib/utils";
+import { cn, formatCents, formatNumber } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -16,6 +16,44 @@ function parseDollarInput(value: string) {
   const parsed = Number(normalized);
   if (!Number.isFinite(parsed) || parsed < 0) return null;
   return Math.round(parsed * 100);
+}
+
+function integerInputValue(value: number) {
+  return String(Math.max(0, Math.round(value)));
+}
+
+function parseIntegerInput(value: string) {
+  const normalized = value.trim();
+  if (normalized.length === 0) return 0;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) return null;
+  return parsed;
+}
+
+function draftInputValue(metric: BudgetMetric, amount: number) {
+  return metric === "billed_cents" ? centsInputValue(amount) : integerInputValue(amount);
+}
+
+function parseDraftInput(metric: BudgetMetric, value: string) {
+  return metric === "billed_cents" ? parseDollarInput(value) : parseIntegerInput(value);
+}
+
+function formatMetricAmount(metric: BudgetMetric, value: number) {
+  if (metric === "billed_cents") return formatCents(value);
+  if (metric === "token_count") return `${formatNumber(value)} tok`;
+  return `${formatNumber(value)} ${value === 1 ? "run" : "runs"}`;
+}
+
+function metricInputLabel(metric: BudgetMetric) {
+  if (metric === "billed_cents") return "Budget (USD)";
+  if (metric === "token_count") return "Budget (tokens)";
+  return "Budget (runs)";
+}
+
+function metricInvalidCopy(metric: BudgetMetric) {
+  return metric === "billed_cents"
+    ? "Enter a valid non-negative dollar amount."
+    : "Enter a valid non-negative whole number.";
 }
 
 function windowLabel(windowKind: BudgetPolicySummary["windowKind"]) {
@@ -41,13 +79,13 @@ export function BudgetPolicyCard({
   compact?: boolean;
   variant?: "card" | "plain";
 }) {
-  const [draftBudget, setDraftBudget] = useState(centsInputValue(summary.amount));
+  const [draftBudget, setDraftBudget] = useState(draftInputValue(summary.metric, summary.amount));
 
   useEffect(() => {
-    setDraftBudget(centsInputValue(summary.amount));
-  }, [summary.amount]);
+    setDraftBudget(draftInputValue(summary.metric, summary.amount));
+  }, [summary.amount, summary.metric]);
 
-  const parsedDraft = parseDollarInput(draftBudget);
+  const parsedDraft = parseDraftInput(summary.metric, draftBudget);
   const canSave = typeof parsedDraft === "number" && parsedDraft !== summary.amount && Boolean(onSave);
   const progress = summary.amount > 0 ? Math.min(100, summary.utilizationPercent) : 0;
   const StatusIcon = summary.status === "hard_stop" ? ShieldAlert : summary.status === "warning" ? AlertTriangle : Wallet;
@@ -57,7 +95,7 @@ export function BudgetPolicyCard({
     <div className="grid gap-6 sm:grid-cols-2">
       <div>
         <div className="text-(length:--text-micro) uppercase tracking-(--tracking-caps) text-muted-foreground">Observed</div>
-        <div className="mt-2 text-xl font-semibold tabular-nums">{formatCents(summary.observedAmount)}</div>
+        <div className="mt-2 text-xl font-semibold tabular-nums">{formatMetricAmount(summary.metric, summary.observedAmount)}</div>
         <div className="mt-1 text-xs text-muted-foreground">
           {summary.amount > 0 ? `${summary.utilizationPercent}% of limit` : "No cap configured"}
         </div>
@@ -65,7 +103,7 @@ export function BudgetPolicyCard({
       <div>
         <div className="text-(length:--text-micro) uppercase tracking-(--tracking-caps) text-muted-foreground">Budget</div>
         <div className="mt-2 text-xl font-semibold tabular-nums">
-          {summary.amount > 0 ? formatCents(summary.amount) : "Disabled"}
+          {summary.amount > 0 ? formatMetricAmount(summary.metric, summary.amount) : "Disabled"}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
           Soft alert at {summary.warnPercent}%{summary.paused && summary.pauseReason ? ` · ${summary.pauseReason} pause` : ""}
@@ -76,7 +114,7 @@ export function BudgetPolicyCard({
     <div className="grid gap-3 sm:grid-cols-2">
       <div className="rounded-xl border border-border/70 bg-black/[0.18] px-4 py-3">
         <div className="text-(length:--text-micro) uppercase tracking-(--tracking-caps) text-muted-foreground">Observed</div>
-        <div className="mt-2 text-xl font-semibold tabular-nums">{formatCents(summary.observedAmount)}</div>
+        <div className="mt-2 text-xl font-semibold tabular-nums">{formatMetricAmount(summary.metric, summary.observedAmount)}</div>
         <div className="mt-1 text-xs text-muted-foreground">
           {summary.amount > 0 ? `${summary.utilizationPercent}% of limit` : "No cap configured"}
         </div>
@@ -84,7 +122,7 @@ export function BudgetPolicyCard({
       <div className="rounded-xl border border-border/70 bg-black/[0.18] px-4 py-3">
         <div className="text-(length:--text-micro) uppercase tracking-(--tracking-caps) text-muted-foreground">Budget</div>
         <div className="mt-2 text-xl font-semibold tabular-nums">
-          {summary.amount > 0 ? formatCents(summary.amount) : "Disabled"}
+          {summary.amount > 0 ? formatMetricAmount(summary.metric, summary.amount) : "Disabled"}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
           Soft alert at {summary.warnPercent}%{summary.paused && summary.pauseReason ? ` · ${summary.pauseReason} pause` : ""}
@@ -97,7 +135,7 @@ export function BudgetPolicyCard({
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>Remaining</span>
-        <span>{summary.amount > 0 ? formatCents(summary.remainingAmount) : "Unlimited"}</span>
+        <span>{summary.amount > 0 ? formatMetricAmount(summary.metric, summary.remainingAmount) : "Unlimited"}</span>
       </div>
       <div className={cn("h-2 overflow-hidden rounded-full", isPlain ? "bg-border/70" : "bg-muted/70")}>
         <div
@@ -135,14 +173,15 @@ export function BudgetPolicyCard({
     <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-end", isPlain ? "" : "rounded-xl border border-border/70 bg-background/50 p-3")}>
       <div className="min-w-0 flex-1">
         <label className="text-(length:--text-micro) uppercase tracking-(--tracking-caps) text-muted-foreground">
-          Budget (USD)
+          {metricInputLabel(summary.metric)}
         </label>
         <Input
           value={draftBudget}
           onChange={(event) => setDraftBudget(event.target.value)}
           className="mt-2"
-          inputMode="decimal"
-          placeholder="0.00"
+          inputMode={summary.metric === "billed_cents" ? "decimal" : "numeric"}
+          step={summary.metric === "billed_cents" ? "0.01" : "1"}
+          placeholder={summary.metric === "billed_cents" ? "0.00" : "0"}
         />
       </div>
       <Button
@@ -187,7 +226,7 @@ export function BudgetPolicyCard({
         {pausedPane}
         {saveSection}
         {parsedDraft === null ? (
-          <p className="text-xs text-destructive">Enter a valid non-negative dollar amount.</p>
+          <p className="text-xs text-destructive">{metricInvalidCopy(summary.metric)}</p>
         ) : null}
       </div>
     );
@@ -216,7 +255,7 @@ export function BudgetPolicyCard({
         {pausedPane}
         {saveSection}
         {parsedDraft === null ? (
-          <p className="text-xs text-destructive">Enter a valid non-negative dollar amount.</p>
+          <p className="text-xs text-destructive">{metricInvalidCopy(summary.metric)}</p>
         ) : null}
       </CardContent>
     </Card>


### PR DESCRIPTION
fix(issues): require explicit reopen/resume to un-close a terminal issue via comment (AGE-759)

## What happened

PATCH /api/issues/{id} and POST /api/issues/{id}/comments both ran an
independent, undocumented heuristic (shouldImplicitlyMoveCommentedIssueToTodo)
that inferred "the caller wants to reopen this issue" purely from
{ comment present, actor is a "user"-type actor, issue is done/cancelled,
issue has an assignee }. No status, reopen, or resume field was required
in the request body.

A comment-only PATCH ({"comment": "..."}) on a done/cancelled issue would
therefore silently flip status back to "todo" whenever the caller
authenticated as a "user"-type actor (board key, local-implicit, cloud
tenant, session -- this includes any API/script caller, not just the web
UI) and the issue still had an assignee. Reported on AGE-568 and
reproduced by accident on AGE-693.

## Root cause

objectWithoutDefaults(...).partial() already makes status genuinely
optional on the update schema (absent = no schema-level coercion). The
actual defect was in route-handler logic, not schema defaults: a second,
independent inference path recomputed "should this reopen" from side
signals instead of trusting only the explicit reopen/resume flags the
schema already exposes for this exact purpose.

The web UI already computes the identical condition client-side
(shouldImplicitlyReopenComment in IssueChatThread.tsx / CommentThread.tsx
/ TaskChatComposer.tsx) and sends reopen: true explicitly whenever it
means to reopen. Company-wide agent instructions also document
resume: true as the sanctioned way to restart a completed issue via
comment. Both of those explicit paths are untouched by this change. The
server-side heuristic was pure duplication that only mattered for
callers who don't send the flag -- which is exactly the silent-reopen
bug.

## Fix

shouldImplicitlyMoveCommentedIssueToTodo no longer treats a done/cancelled
issue as reopenable from a plain comment; it now only applies to blocked
issues (a mid-flight, non-terminal "please continue" nudge, out of this
ticket's scope and unaffected). Moving a terminal issue back to todo now
requires the request to explicitly say so via reopen: true or resume: true.

## Tests

- Rewrote the three existing tests that asserted implicit closed-issue
  reopening without an explicit flag; added matching explicit-flag
  variants proving the sanctioned reopen: true / resume: true path
  still works unchanged.
- Added an it.each regression covering comment-only PATCH on
  done/cancelled/in_review/todo, verified via the mocked service's
  re-fetch (server/src/__tests__/issue-comment-reopen-routes.test.ts).
- Added a real embedded-Postgres end-to-end regression
  (issue-comment-only-patch-status-e2e.test.ts) that seeds a real issue,
  PATCHes with only { comment }, then verifies status is unchanged via
  a subsequent GET *and* a direct DB read -- not just the PATCH response.

All 194 tests across the touched route/mutation test files pass.
