### PR TITLE
fix(issues): require explicit reopen/resume to un-close a terminal issue via comment

### DIFF
--- a/server/src/__tests__/issue-comment-only-patch-status-e2e.test.ts
+++ b/server/src/__tests__/issue-comment-only-patch-status-e2e.test.ts
@@ -1,0 +1,133 @@
+// AGE-759 regression: a comment-only PATCH /api/issues/{id} must never
+// silently change `status`. Reported as: PATCH { comment } on a `done`
+// issue flipped its status to `todo` with no `status` field in the
+// request body. Verified end-to-end here against a real Postgres-backed
+// issue, with the assertion made against a *subsequent GET* (and a direct
+// DB read), not just the PATCH response body.
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { companies, companyMemberships, createDb, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres comment-only PATCH status tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("AGE-759: comment-only PATCH never mutates issue status", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-comment-only-patch-status-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompanyAndMember() {
+    const companyId = randomUUID();
+    const issuePrefix = `PC${randomUUID().replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "AGE-759 comment-only PATCH company",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    return { companyId, issuePrefix };
+  }
+
+  async function seedIssue(
+    companyId: string,
+    issuePrefix: string,
+    status: "done" | "cancelled" | "in_review" | "todo",
+  ) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: Math.floor(Math.random() * 1_000_000),
+      identifier: `${issuePrefix}-${issueId.slice(0, 8)}`,
+      title: `Comment-only PATCH status regression (${status})`,
+      status,
+      priority: "medium",
+      createdByUserId: "cloud-user-1",
+    });
+    return issueId;
+  }
+
+  it.each(["done", "cancelled", "in_review", "todo"] as const)(
+    "leaves a %s issue's status unchanged after a comment-only PATCH, verified by a subsequent GET and a direct DB read",
+    async (status) => {
+      const { companyId, issuePrefix } = await seedCompanyAndMember();
+      const issueId = await seedIssue(companyId, issuePrefix, status);
+      const app = createApp(companyId);
+
+      const patchRes = await request(app)
+        .patch(`/api/issues/${issueId}`)
+        .send({ comment: "operator note — no status field in this request" });
+
+      expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+      expect(patchRes.body.status).toBe(status);
+
+      const getRes = await request(app).get(`/api/issues/${issueId}`);
+      expect(getRes.status, JSON.stringify(getRes.body)).toBe(200);
+      expect(getRes.body.status).toBe(status);
+
+      const stored = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(stored?.status).toBe(status);
+    },
+  );
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -450,7 +450,12 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  // AGE-759 regression: reassigning to an agent on a done issue must NOT by
+  // itself flip status back to todo. The web UI already sends an explicit
+  // `reopen: true` flag whenever it means to reopen (see
+  // `shouldImplicitlyReopenComment` in IssueChatThread.tsx); a plain
+  // comment + reassignment with no explicit flag must leave status alone.
+  it("does not implicitly reopen a done issue via the PATCH comment path just because it reassigns to an agent", async () => {
     const issue = makeIssue("done");
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
@@ -459,6 +464,27 @@ describe.sequential("issue comment reopen routes", () => {
     const res = await request(await installActor(createApp()))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+    const patch = mockIssueService.update.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch.assigneeAgentId).toBe("33333333-3333-4333-8333-333333333333");
+    expect(patch.status).toBeUndefined();
+  });
+
+  it("reopens a done issue via the PATCH comment path when reassigning to an agent with explicit reopen=true", async () => {
+    const issue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+      makeIssueUpdateReceipt(issue, patch));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "hello",
+        reopen: true,
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -480,6 +506,41 @@ describe.sequential("issue comment reopen routes", () => {
           status: "todo",
         }),
       }),
+    );
+  });
+
+  // AGE-759 regression suite: PATCH /api/issues/:id with only { comment }
+  // must never change status. This is verified two ways: (1) the update
+  // call made to the issue service must not carry a status field, and
+  // (2) re-fetching the issue from the (now-updated) store afterward
+  // — the same `svc.getById` call the GET /api/issues/:id route makes as
+  // its first, authoritative step — still returns the original status.
+  // This proves persisted state is unchanged, not just the PATCH response.
+  describe("AGE-759: comment-only PATCH never changes status", () => {
+    it.each(["done", "cancelled", "in_review", "todo"] as const)(
+      "leaves a %s issue's status unchanged after a comment-only PATCH, verified by re-fetch",
+      async (status) => {
+        let stored = makeIssue(status);
+        mockIssueService.getById.mockImplementation(async () => stored);
+        mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+          stored = { ...stored, ...patch };
+          return makeIssueUpdateReceipt(stored, patch);
+        });
+
+        const app = await installActor(createApp());
+        const patchRes = await request(app)
+          .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+          .send({ comment: "operator note, no status field" });
+
+        expect(patchRes.status).toBe(200);
+        if (mockIssueService.update.mock.calls.length > 0) {
+          const patch = mockIssueService.update.mock.calls[0][1] as Record<string, unknown>;
+          expect(patch.status).toBeUndefined();
+        }
+
+        const refetched = await mockIssueService.getById("11111111-1111-4111-8111-111111111111");
+        expect(refetched.status).toBe(status);
+      },
     );
   });
 
@@ -560,7 +621,10 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  // AGE-759 regression: a comment-only POST on a done issue with an
+  // assigned agent must NOT silently reopen it. Explicit `reopen`/`resume`
+  // is required to move a terminal issue back to todo.
+  it("does not implicitly reopen a done issue via POST comments when an agent is assigned but no reopen flag is sent", async () => {
     const issue = makeIssue("done");
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
@@ -569,6 +633,20 @@ describe.sequential("issue comment reopen routes", () => {
     const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("reopens a done issue via POST comments with an explicit reopen flag when an agent is assigned", async () => {
+    const issue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+      makeIssueUpdateReceipt(issue, patch));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "hello", reopen: true });
 
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -1447,7 +1525,11 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("still implicitly reopens done issues via POST comments when the comment runId differs from the issue's owning run", async () => {
+  // AGE-759 regression: a plain comment from a different run than the one
+  // that owns the issue still must NOT reopen a done issue without an
+  // explicit reopen/resume flag. Only the flag decides reopening now, not
+  // whether the commenting run differs from the owning run.
+  it("does not implicitly reopen done issues via POST comments when the comment runId differs from the issue's owning run and no reopen flag is sent", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),
       checkoutRunId: "run-owning",
@@ -1470,10 +1552,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "Real human follow-up — please reopen" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen done issues via the PATCH comment path when actor runId matches the issue's checkout run", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1876,10 +1876,22 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   ) {
     return false;
   }
-  // Only human comments should implicitly reopen finished work.
+  // Only human comments should implicitly move work back to todo.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  // AGE-759: a plain comment must never silently reopen a *terminal*
+  // (done/cancelled) issue. Every client that intentionally wants that
+  // (the web UI's own `shouldImplicitlyReopenComment` heuristic, the
+  // `resume: true` contract agents are instructed to use) already sends an
+  // explicit `reopen`/`resume` flag on the same request, so requiring that
+  // flag here costs those callers nothing while closing the silent-reopen
+  // hole for every other caller (curl, scripts, cross-issue audit notes)
+  // that only sends `{ comment }`. Terminal-state reopening is handled by
+  // `explicitMoveToTodoRequested` (reopen/resume) at the call site, not by
+  // this function. A `blocked` issue is not terminal — it is mid-flight,
+  // waiting on an external nudge — so the plain "please continue" comment
+  // convenience remains for that status only.
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }


### PR DESCRIPTION
## Thinking Path

> - The board reported that `PATCH /api/issues/{id}` with only `{"comment": "..."}` silently flips a `done`/`cancelled` issue's status back to `todo` (AGE-568, reproduced by accident on AGE-693).
> - `objectWithoutDefaults(...).partial()` already makes `status` genuinely optional in the update schema, so this wasn't a schema-default coercion bug.
> - The actual cause is an independent route-handler heuristic, `shouldImplicitlyMoveCommentedIssueToTodo`, that infers "reopen intent" from side signals (comment present + user-type actor + assignee present + done/cancelled/blocked) instead of an explicit field.
> - The web UI already computes the identical condition client-side and sends `reopen: true` explicitly whenever it means to reopen (`shouldImplicitlyReopenComment` in `IssueChatThread.tsx` / `CommentThread.tsx` / `TaskChatComposer.tsx`). Company-wide agent instructions also document `resume: true` as the sanctioned way to restart a completed issue via comment.
> - So the server-side inference for *terminal* (done/cancelled) states was pure duplication that only mattered for callers who don't send the flag — exactly the silent-reopen bug.
> - This PR narrows the heuristic to `blocked` issues only (a mid-flight, non-terminal "please continue" nudge, out of scope for this bug and left unchanged) and requires `reopen: true`/`resume: true` to move a `done`/`cancelled` issue back to `todo` via comment.

## Linked Issues or Issue Description

Reported by the board on AGE-568, reproduced by accident on AGE-693 (internal Paperclip company board issues, not GitHub issues — no public GitHub issue exists for this yet).

**What happened?**

```
PATCH /api/issues/{uuid}
{"comment": "...operator note..."}
```
No `status` field in the body — yet a `done` issue's status flipped to `todo`.

**Expected behavior**

Comment appended, `status` untouched, unless the caller explicitly asks to reopen via `reopen: true` or `resume: true`.

**Steps to reproduce**

1. Have a `done` (or `cancelled`) issue with an assigned agent.
2. PATCH it with only `{"comment": "..."}` as a `user`-type actor (board key / local-implicit / cloud tenant / session — any non-agent caller, not just the web UI).
3. Observe status flips to `todo` with no `status`/`reopen`/`resume` field ever sent.

**Environment**

Paperclip server, `PATCH /api/issues/:id` and `POST /api/issues/:id/comments` routes.

- [x] I searched open PRs for `shouldImplicitlyMoveCommentedIssueToTodo`, `comment-only PATCH`, `implicitly reopen`, `AGE-759`, `AGE-568`, `AGE-693`; no duplicate PR found. The only related existing coverage is the pre-existing `server/src/__tests__/issue-comment-reopen-routes.test.ts`, which this PR updates rather than duplicates.

## What Changed

- `shouldImplicitlyMoveCommentedIssueToTodo` (server/src/routes/issues.ts) no longer treats a `done`/`cancelled` issue as reopenable from a plain comment; it now only applies to `blocked` issues. Moving a terminal issue back to `todo` requires the request to explicitly send `reopen: true` or `resume: true` — a contract both the web UI and the sanctioned agent `resume: true` convention already honor.
- Rewrote the three existing tests in `issue-comment-reopen-routes.test.ts` that asserted implicit closed-issue reopening *without* an explicit flag; added matching explicit-flag variants proving the sanctioned `reopen: true` / `resume: true` path still works unchanged.
- Added an `it.each` regression in the same file covering comment-only PATCH on `done`/`cancelled`/`in_review`/`todo`, verified via the mocked service's re-fetch.
- Added a new real embedded-Postgres end-to-end regression test file, `server/src/__tests__/issue-comment-only-patch-status-e2e.test.ts`, that seeds a real issue via the DB, PATCHes it with only `{ comment }`, then verifies status is unchanged via a subsequent real `GET` request *and* a direct DB read — not just the PATCH response body.

## Verification

- `npx vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issue-comment-only-patch-status-e2e.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-identifier-routes.test.ts` — 194/194 passed.
- `npx tsc -p server/tsconfig.json --noEmit` — no new type errors introduced by this change (pre-existing unrelated `plugin-worker-manager.ts` errors from a stale `@paperclipai/plugin-sdk` build are present on `master` too and untouched by this PR).

## Risks

- Low-to-medium: this narrows an existing, deliberately-designed "implicit reopen via human comment" convenience for `done`/`cancelled` issues down to requiring an explicit `reopen`/`resume` flag. The web UI (the primary caller of this convenience) is unaffected because it already sends the flag explicitly. Any third-party/API/script caller that relied on the *undocumented* implicit inference (rather than the documented `reopen`/`resume` fields) will need to start sending `reopen: true` or `resume: true` — this is the intended fix, not a side effect.
- The `blocked`-issue "please continue" comment convenience is intentionally left unchanged, since it is out of scope for this bug report and not part of its acceptance criteria.
- Rollback is a single commit revert.

## Model Used

Claude (Anthropic), agentic coding session via Paperclip issue AGE-759, with tool use, code execution, and repository/test inspection.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and described the search above
- [x] I have described the issue in-PR following the bug template
- [x] I have not referenced internal/instance-local Paperclip issues or links in a way that leaks private data (internal issue IDs AGE-568/AGE-693/AGE-759 are referenced only as identifiers, per existing repo convention of citing internal tracking without exposing private content)
- [x] My branch name describes the change and does not contain an internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered documentation; no user-facing documentation change is required
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green (pending first CI run)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
