### PR TITLE
fix(server): treat a scheduled future monitor as a covered in_review blocker path

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -101,6 +101,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originFingerprint?: string | null;
     executionState?: Record<string, unknown> | null;
     description?: string | null;
+    monitorNextCheckAt?: Date | null;
   }) {
     const id = input.id ?? randomUUID();
     await db.insert(issues).values({
@@ -118,6 +119,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       originFingerprint: input.originFingerprint ?? "default",
       executionState: input.executionState ?? null,
       description: input.description ?? null,
+      monitorNextCheckAt: input.monitorNextCheckAt ?? null,
     });
     return id;
   }
@@ -428,6 +430,50 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention).toMatchObject({
       state: "covered",
       stalledBlockerCount: 0,
+    });
+  });
+
+  it("does not flag an in_review leaf as stalled when it has a future scheduled monitor", async () => {
+    const { companyId, agentId } = await createCompany("PBM");
+    const parentId = await insertIssue({ companyId, identifier: "PBM-1", title: "Parent", status: "blocked" });
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBM-2",
+      title: "Monitor-covered review leaf",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() + 12 * 60 * 60 * 1000),
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      stalledBlockerCount: 0,
+    });
+  });
+
+  it("still flags an in_review leaf as stalled when its scheduled monitor is already in the past", async () => {
+    const { companyId, agentId } = await createCompany("PBN");
+    const parentId = await insertIssue({ companyId, identifier: "PBN-1", title: "Parent", status: "blocked" });
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBN-2",
+      title: "Expired monitor review leaf",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "stalled",
+      reason: "stalled_review",
+      stalledBlockerCount: 1,
+      sampleStalledBlockerIdentifier: "PBN-2",
     });
   });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2627,6 +2627,10 @@ async function listIssueBlockerAttentionMap(
     : [];
   const agentsById = new Map(agentRows.map((agent) => [agent.id, agent]));
 
+  // Captured once so every node classified within this call sees the same
+  // deadline snapshot. Without this, a monitor could expire mid-traversal and
+  // make sibling/ancestor nodes disagree on covered/stalled for the same run.
+  const classificationReferenceNow = Date.now();
   type PathClassification = {
     covered: boolean;
     stalled: boolean;
@@ -2658,7 +2662,7 @@ async function listIssueBlockerAttentionMap(
     }
     if (node.status === "in_review") {
       const hasScheduledMonitor = Boolean(
-        node.monitorNextCheckAt && node.monitorNextCheckAt.getTime() > Date.now(),
+        node.monitorNextCheckAt && node.monitorNextCheckAt.getTime() > classificationReferenceNow,
       );
       const hasWaitingPath =
         activeIssueIds.has(node.id) || Boolean(node.assigneeUserId) || hasScheduledMonitor;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1938,13 +1938,14 @@ type IssueBlockerAttentionNode = {
   executionRunId?: string | null;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  monitorNextCheckAt?: Date | null;
 };
 type IssueBlockerAttentionInputNode =
   Pick<
     IssueBlockerAttentionNode,
     "id" | "companyId" | "parentId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId"
   >
-  & { executionRunId?: string | null };
+  & { executionRunId?: string | null; monitorNextCheckAt?: Date | null };
 
 type IssueBlockerAttentionEdge = {
   issueId: string;
@@ -2375,6 +2376,7 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -2399,6 +2401,7 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
         })
         .from(issues)
         .where(
@@ -2437,6 +2440,7 @@ async function listIssueBlockerAttentionMap(
           executionRunId: row.executionRunId,
           assigneeAgentId: row.assigneeAgentId,
           assigneeUserId: row.assigneeUserId,
+          monitorNextCheckAt: row.monitorNextCheckAt,
         });
         nextFrontier.add(row.blockerIssueId);
       }
@@ -2653,7 +2657,11 @@ async function listIssueBlockerAttentionMap(
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.status === "in_review") {
-      const hasWaitingPath = activeIssueIds.has(node.id) || Boolean(node.assigneeUserId);
+      const hasScheduledMonitor = Boolean(
+        node.monitorNextCheckAt && node.monitorNextCheckAt.getTime() > Date.now(),
+      );
+      const hasWaitingPath =
+        activeIssueIds.has(node.id) || Boolean(node.assigneeUserId) || hasScheduledMonitor;
       if (hasWaitingPath) {
         return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
       }


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The blocker-graph liveness classifier decides if a blocked issue's chain is genuinely being worked, or has gone stale
> - The classifier only recognized an active heartbeat run, a pending wake request, or a human assignee as proof that an `in_review` blocker is alive
> - A monitor-covered `in_review` issue that is waiting on a future-scheduled re-check (the documented "genuine external wait, re-check later" pattern) produces none of those three signals until the monitor actually fires
> - So the classifier fell through to `stalled: true` for a leaf that was in fact live and self-documenting, and that false signal rolled up through the blocker graph onto ancestor issues
> - This pull request teaches the classifier to also treat a future `monitorNextCheckAt` on an `in_review` node as a covered, live path
> - The benefit is fewer false "stalled" rollups on issues that are genuinely being tracked by a scheduled monitor, which keeps the anti-false-done/stalled signals trustworthy

## Linked Issues or Issue Description

<!-- No public GitHub issue exists for this internal-tracker bug. Bug report fields below, per .github/ISSUE_TEMPLATE/bug_report.yml -->

**What happened?**
`blockerAttention.classifyPath` in `server/src/services/issues.ts` classifies a blocker node with `status === "in_review"` as covered only when it has an active heartbeat run, a pending wake request, or a human assignee. It never inspects `monitorNextCheckAt`. An `in_review` issue waiting on a future-scheduled monitor (no active run, no wake request) is therefore misclassified as `stalled`, and that false signal rolls up to ancestor issues in the blocker graph.

**Expected behavior**
An `in_review` blocker node with a future `monitorNextCheckAt` should be treated as a covered, live path, the same as an active run, pending wake request, or human assignee.

**Steps to reproduce**
1. Create issue B with `status: in_review` and an `executionPolicy.monitor` scheduled for a future `monitorNextCheckAt`, no active heartbeat run and no pending wake request.
2. Create issue A with `status: blocked`, `blockedBy: [B]`.
3. Call `listIssueBlockerAttentionMap` for A.
4. Observe `blockerAttention.state: "stalled"` on A, even though B is genuinely live and tracked by its scheduled monitor.

**Paperclip version or commit**
`1e456547a0547a8d5464da2e8dc1bbf6f42c1681` (master, at PR open time)

**Deployment mode**
Self-hosted server

**Screenshots / Logs**
See regression tests added in this PR for exact before/after object shapes (`stalled: true` before, `stalled: false` after, for the future-monitor case).

## What Changed

- Loaded `monitorNextCheckAt` alongside the other blocker-graph node fields in `listIssueBlockerAttentionMap` (both the explicit-blocker and child-row queries) in `server/src/services/issues.ts`.
- In `classifyPath`, treat an `in_review` node with a future `monitorNextCheckAt` as a covered waiting path, same as an active run or human assignee.
- Captured one `classificationReferenceNow` timestamp before traversal so every node visited in one blocker-attention calculation compares against the same "now", instead of calling `Date.now()` per node (fixes a Greptile finding).
- Left the existing behavior unchanged for an `in_review` node whose `monitorNextCheckAt` is already in the past — it still classifies as `stalled` (no monitor firing yet is a real staleness signal, not a false positive).

## Verification

- Added 2 regression tests to `server/src/__tests__/issue-blocker-attention.test.ts`:
  - "does not flag an in_review leaf as stalled when it has a future scheduled monitor" — now `covered`.
  - "still flags an in_review leaf as stalled when its scheduled monitor is already in the past" — remains `stalled` (no regression on prior semantics).
- Ran the full suite locally: `npx vitest run server/src/__tests__/issue-blocker-attention.test.ts` → 27 passed (25 existing + 2 new).
- Ran `tsc --noEmit` locally — clean.
- CI: Typecheck, Build, and all General/Verify/e2e test shards pass (see check runs on this PR).

## Risks

Low risk. The change only widens the set of paths `classifyPath` treats as "covered" for `in_review` nodes with a future-scheduled monitor; it does not change behavior for any node without `executionPolicy.monitor`/`monitorNextCheckAt`, and does not change the existing expired-monitor semantics. No schema or migration changes — `monitorNextCheckAt` is an existing column, only newly selected in these two queries.

## Model Used

Claude (Anthropic), via the `pi_local` adapter running as the "Software Engineer" agent role, extended-thinking/tool-use enabled (multi-step code read, edit, and test-run tool calls).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found for this internal-tracker bug)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs affected; internal classifier behavior only)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
