### PR TITLE
fix(codex): retry after subscription account rotation

### DIFF
--- a/doc/plans/2026-08-21-codex-credential-session-identity.md
+++ b/doc/plans/2026-08-21-codex-credential-session-identity.md
@@ -1,0 +1,25 @@
+# Codex credential-aware ACP session identity
+
+## Goal
+
+Prevent Paperclip from resuming a Codex ACP session after the effective ChatGPT subscription account changes. Preserve normal session continuity when the same account merely refreshes or rotates its OAuth tokens.
+
+## Design
+
+During Codex managed-home preparation, read the effective `auth.json` and derive a non-secret credential identity. For subscription authentication, the stable input is `tokens.account_id`; Paperclip hashes it with a domain-separated SHA-256 digest before it enters any reusable runtime state. Raw account identifiers and token material must never enter session parameters, logs, fingerprints, or telemetry.
+
+The derived hash is included only in the Codex runtime identity already consumed by the ACP session fingerprint. The shared compatibility check therefore behaves as it does for other fingerprint changes: the same credential identity resumes normally, while a changed identity misses the previous session and starts fresh. A token refresh for the same account does not change the hash.
+
+Fresh Codex ACP sessions continue through Paperclip's existing prompt path, which supplies current task context, wake context, workspace state, and continuation summary. This change does not attempt cross-account provider-session resume.
+
+## Non-goals
+
+- No automatic account selection or rotation.
+- No `codex-auth` dependency or private quota API calls.
+- No database, scheduler, recovery-policy, UI, or adapter-configuration changes.
+- No behavior change for API-key auth or non-Codex adapters.
+- No raw credential identity persistence or logging.
+
+## Verification
+
+Tests must prove that identical subscription accounts with different refreshed token bytes produce the same identity and resumable session, different accounts produce different fingerprints and fresh sessions, malformed/API-key credentials add no subscription identity, and emitted session metadata contains neither raw account IDs nor token bytes.

--- a/doc/plans/2026-08-21-codex-quota-watcher-handoff.md
+++ b/doc/plans/2026-08-21-codex-quota-watcher-handoff.md
@@ -1,0 +1,67 @@
+# Codex quota watcher handoff
+
+## Goal
+
+Allow an opted-in Codex ACP run that fails on ChatGPT subscription quota to continue once an external credential watcher, such as `codex-auth`, switches the effective subscription account. Paperclip observes the credential change and retries the same task once; it does not select or rotate accounts itself.
+
+## Chosen boundary
+
+Account inventory, quota thresholds, candidate scoring, and credential mutation remain owned by the external watcher. Paperclip owns only the run-level handoff:
+
+1. Read the effective Codex subscription credential identity before the ACP attempt.
+2. Run the existing Codex ACP executor and apply the existing failure classification.
+3. On a confirmed `provider_quota` result, wait for a configured, bounded interval while polling the effective `auth.json` identity.
+4. Retry only when a different, valid subscription identity appears.
+5. Retry at most once, using the original Paperclip execution context.
+
+The credential-aware session fingerprint already guarantees that a different account starts a fresh provider session while the existing Paperclip prompt path carries task, wake, workspace, and continuation context forward.
+
+## Configuration
+
+Add one Codex ACP adapter setting: `quotaRotationWaitSec`.
+
+- `0` or absent: disabled, preserving existing behavior.
+- Positive values: wait for an externally managed account switch after a provider-quota failure.
+- Clamp the effective value to a small implementation maximum so configuration cannot create an unbounded adapter wait.
+
+The create/edit UI exposes this only with the ACP engine fields. Paperclip does not enable or configure `codex-auth`, and the setting does not apply to the CLI engine, API-key billing, or other adapters.
+
+## Data flow and privacy
+
+The retry wrapper resolves the same effective host Codex home used by the ACP preparation path and reads its `auth.json` through the existing hash-only subscription identity helper. It keeps only digests in memory. Raw account IDs and token bytes do not enter logs, result metadata, session parameters, or telemetry.
+
+The first identity is captured before the initial attempt so a watcher switch that occurs during the failed request is still detected. A missing, malformed, API-key, or unreadable credential disables the handoff for that run. A transient disappearance of `auth.json` never counts as a successful switch; the new identity must be non-null and different.
+
+## Error handling and observability
+
+- Non-quota failures return immediately.
+- Disabled configuration returns the existing classified result unchanged.
+- No baseline subscription identity returns the existing result unchanged.
+- A wait timeout returns the original quota result unchanged, including its reset metadata.
+- A detected identity change emits a non-secret log line and retries once.
+- The retry result is terminal even if it also reports provider quota; there is no loop.
+- The retried result carries a small non-secret marker that the credential handoff occurred.
+
+Paperclip never invokes a shell rotation command, reads the external watcher's registry, calls private quota APIs, or assumes a specific watcher implementation.
+
+## Verification
+
+Red/green tests must prove:
+
+- the default and zero value do not wait or retry;
+- non-quota and API-key failures do not wait or retry;
+- a same-account token refresh does not retry;
+- a changed account retries once with the original context;
+- a change that occurs during the first attempt is detected immediately;
+- a timeout returns the original quota result unchanged;
+- a second quota failure does not cause another wait or retry;
+- raw account and token markers do not appear in logs or result/session metadata;
+- existing credential-aware session tests still start fresh on account change and retain task context.
+
+## Non-goals
+
+- Native Paperclip multi-account storage or selection.
+- A dependency on `codex-auth` or its registry schema.
+- Automatic installation or configuration of an external watcher.
+- Cross-account provider-session resume.
+- CLI-engine retry, API-key failover, or changes to global recovery policy.

--- a/packages/adapter-utils/src/acpx-engine/codex-credential-identity.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/codex-credential-identity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { deriveCodexSubscriptionCredentialIdentity } from "./codex-credential-identity.js";
+
+function subscriptionAuth(accountId: string, marker: string): string {
+  return JSON.stringify({
+    tokens: {
+      account_id: accountId,
+      id_token: `id-${marker}`,
+      access_token: `access-${marker}`,
+      refresh_token: `refresh-${marker}`,
+    },
+  });
+}
+
+describe("deriveCodexSubscriptionCredentialIdentity", () => {
+  it("is stable across token refreshes for the same account", () => {
+    const before = deriveCodexSubscriptionCredentialIdentity(
+      subscriptionAuth("acct-same", "before"),
+    );
+    const after = deriveCodexSubscriptionCredentialIdentity(subscriptionAuth("acct-same", "after"));
+
+    expect(before).toEqual(expect.stringMatching(/^[a-f0-9]{64}$/));
+    expect(after).toBe(before);
+  });
+
+  it("changes when the subscription account changes", () => {
+    const first = deriveCodexSubscriptionCredentialIdentity(subscriptionAuth("acct-first", "one"));
+    const second = deriveCodexSubscriptionCredentialIdentity(subscriptionAuth("acct-second", "two"));
+
+    expect(first).not.toBe(second);
+  });
+
+  it("does not derive a subscription identity from malformed or API-key credentials", () => {
+    expect(deriveCodexSubscriptionCredentialIdentity("not-json")).toBeNull();
+    expect(
+      deriveCodexSubscriptionCredentialIdentity(
+        JSON.stringify({ OPENAI_API_KEY: "sk-secret" }),
+      ),
+    ).toBeNull();
+    expect(
+      deriveCodexSubscriptionCredentialIdentity(
+        JSON.stringify({ tokens: { account_id: "acct-only" } }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not expose raw account or token material", () => {
+    const identity = deriveCodexSubscriptionCredentialIdentity(
+      subscriptionAuth("RAW-ACCOUNT-SENTINEL", "RAW-TOKEN-SENTINEL"),
+    );
+
+    expect(identity).not.toContain("RAW-ACCOUNT-SENTINEL");
+    expect(identity).not.toContain("RAW-TOKEN-SENTINEL");
+  });
+});

--- a/packages/adapter-utils/src/acpx-engine/codex-credential-identity.ts
+++ b/packages/adapter-utils/src/acpx-engine/codex-credential-identity.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const CODEX_SUBSCRIPTION_IDENTITY_DOMAIN = "paperclip:codex-subscription-account:v1\0";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Derive a non-secret, stable session identity from a Codex subscription
+ * credential. OAuth token rotation for the same account produces the same
+ * digest; a different account produces a different digest. Raw account and
+ * token values never leave this function.
+ */
+export function deriveCodexSubscriptionCredentialIdentity(
+  authJson: string | Buffer,
+): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(typeof authJson === "string" ? authJson : authJson.toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+  const auth = parsed as Record<string, unknown>;
+  if (readNonEmptyString(auth.OPENAI_API_KEY)) return null;
+
+  const tokens = auth.tokens;
+  if (tokens === null || typeof tokens !== "object" || Array.isArray(tokens)) return null;
+  const tokenRecord = tokens as Record<string, unknown>;
+  const accountId = readNonEmptyString(tokenRecord.account_id);
+  const hasTokenMaterial = ["id_token", "access_token", "refresh_token"].some((key) =>
+    readNonEmptyString(tokenRecord[key]),
+  );
+  if (!accountId || !hasTokenMaterial) return null;
+
+  return createHash("sha256")
+    .update(CODEX_SUBSCRIPTION_IDENTITY_DOMAIN)
+    .update(accountId)
+    .digest("hex");
+}
+
+export async function readCodexSubscriptionCredentialIdentity(
+  codexHome: string,
+): Promise<string | null> {
+  const authJson = await fs.readFile(path.join(codexHome, "auth.json")).catch(() => null);
+  return authJson ? deriveCodexSubscriptionCredentialIdentity(authJson) : null;
+}

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -76,6 +76,7 @@ import {
   type AcpRuntimeUsageBreakdown,
   type AcpRuntimeUsageCost,
 } from "acpx/runtime";
+import { readCodexSubscriptionCredentialIdentity } from "./codex-credential-identity.js";
 import {
   DEFAULT_ACP_ENGINE_AGENT,
   DEFAULT_ACP_ENGINE_MODE,
@@ -1013,6 +1014,7 @@ async function prepareCodexSkillRuntime(input: {
   companyId: string;
   config: Record<string, unknown>;
   env: Record<string, string>;
+  inheritsHostEnvironment: boolean;
   moduleDir: string;
   onLog: AdapterExecutionContext["onLog"];
   // Step-timing seam: threaded from `buildRuntime` so the nested
@@ -1090,6 +1092,18 @@ async function prepareCodexSkillRuntime(input: {
   await writeManagedCodexSkillsManifest(skillsHome, selectedSkills.map((entry) => entry.runtimeName));
 
   input.env.CODEX_HOME = effectiveCodexHome;
+  const hasConfiguredApiKeyOverride = Object.prototype.hasOwnProperty.call(
+    input.env,
+    "OPENAI_API_KEY",
+  );
+  const configuredApiKey = input.env.OPENAI_API_KEY?.trim();
+  const inheritedApiKey = input.inheritsHostEnvironment && !hasConfiguredApiKeyOverride
+    ? process.env.OPENAI_API_KEY?.trim()
+    : undefined;
+  const credentialIdentityHash =
+    configuredApiKey || inheritedApiKey
+      ? null
+      : await readCodexSubscriptionCredentialIdentity(effectiveCodexHome);
 
   return {
     identity: {
@@ -1099,6 +1113,7 @@ async function prepareCodexSkillRuntime(input: {
       selectedSkills: selectedSkills.map((entry) => entry.runtimeName).sort(),
       codexHome: effectiveCodexHome,
       skillsHome,
+      ...(credentialIdentityHash ? { credentialIdentityHash } : {}),
     },
     commandNotes: [`Prepared ACPX Codex skill home at ${skillsHome}.`],
   };
@@ -1766,6 +1781,7 @@ async function buildRuntime(input: {
         companyId: agent.companyId,
         config,
         env,
+        inheritsHostEnvironment: !executionTargetIsRemote,
         moduleDir: input.engine.moduleDir,
         onLog: input.ctx.onLog,
         onEvent: input.ctx.onEvent,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -572,6 +572,7 @@ export interface CreateConfigValues {
   codexAcpNonInteractivePermissions?: "deny" | "fail";
   codexAcpStateDir?: string;
   codexAcpWarmHandleIdleMs?: number;
+  codexAcpQuotaRotationWaitSec?: number;
   geminiEngine?: "auto" | "cli" | "acp";
   geminiAcpAgentCommand?: string;
   geminiAcpMode?: "persistent" | "oneshot";

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -118,6 +118,7 @@ Operational fields:
 - nonInteractivePermissions (string, optional): ACP non-interactive permission fallback when engine="acp"; deny or fail
 - stateDir (string, optional): ACP state directory override when engine="acp"
 - warmHandleIdleMs (number, optional): warm ACP process idle timeout when engine="acp"; defaults to 0
+- quotaRotationWaitSec (number, optional): disabled at 0. When ACP fails on ChatGPT subscription quota, wait up to this many seconds for an external credential watcher to switch the effective account, then retry once. Values above 300 are clamped.
 
 Notes:
 - filesystemScope and networkScope are spawn-level confinement and are orthogonal to Codex approval/sandbox flags. Both require Bubblewrap on the host and select the CLI engine in auto mode; engine="acp" is rejected because ACP confinement is not yet supported. networkScope="allowlist" injects HTTP_PROXY/HTTPS_PROXY for the CLI while its private network namespace blocks direct sockets, so every required provider/API hostname must be listed explicitly.

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -1230,6 +1230,186 @@ describe("codex_local ACP lane", () => {
     expect(runtimes).toHaveLength(2);
     expect(runtimes[1]?.ensureInputs[0]?.resumeSessionId).toBe("acp-1");
   });
+
+  it("keeps the Codex ACP session when the same subscription account refreshes tokens", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-same-credential-");
+    const codexHome = path.join(root, "codex-home");
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-same", OLDER_REFRESH, "before-refresh"),
+      { mode: 0o600 },
+    );
+    const runtimes: FakeRuntime[] = [];
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options);
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+
+    const first = await execute(buildContext(root));
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-same", NEWER_REFRESH, "after-refresh"),
+      { mode: 0o600 },
+    );
+    const second = await execute(buildContext(root, {
+      runtime: {
+        sessionId: first.sessionId ?? null,
+        sessionParams: first.sessionParams ?? null,
+        sessionDisplayId: first.sessionDisplayId ?? null,
+        taskKey: "PAP-1",
+      },
+    }));
+
+    expect(second.exitCode).toBe(0);
+    expect(runtimes).toHaveLength(2);
+    expect(runtimes[1]?.ensureInputs[0]?.resumeSessionId).toBe("acp-1");
+  });
+
+  it("starts a fresh Codex ACP session when the subscription account changes", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-changed-credential-");
+    const codexHome = path.join(root, "codex-home");
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-before", OLDER_REFRESH, "before-account"),
+      { mode: 0o600 },
+    );
+    const runtimes: FakeRuntime[] = [];
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options);
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+
+    const first = await execute(buildContext(root));
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-after", NEWER_REFRESH, "after-account"),
+      { mode: 0o600 },
+    );
+    const second = await execute(buildContext(root, {
+      runtime: {
+        sessionId: first.sessionId ?? null,
+        sessionParams: first.sessionParams ?? null,
+        sessionDisplayId: first.sessionDisplayId ?? null,
+        taskKey: "PAP-1",
+      },
+      context: {
+        issueId: "issue-1",
+        paperclipTaskMarkdown: "Credential-aware continuation context",
+        paperclipWorkspace: {
+          cwd: root,
+          source: "project_workspace",
+          workspaceId: "workspace-1",
+        },
+      },
+    }));
+
+    expect(second.exitCode).toBe(0);
+    expect(runtimes).toHaveLength(2);
+    expect(runtimes[1]?.ensureInputs[0]?.resumeSessionId).toBeUndefined();
+    expect(runtimes[1]?.startInputs[0]?.text).toContain("Credential-aware continuation context");
+    expect(JSON.stringify(first.sessionParams)).not.toContain("acct-before");
+    expect(JSON.stringify(second.sessionParams)).not.toContain("acct-after");
+    expect(JSON.stringify(first.sessionParams)).not.toContain("before-account");
+    expect(JSON.stringify(second.sessionParams)).not.toContain("after-account");
+  });
+
+  it("ignores subscription identity when a local run authenticates with an API key", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-api-key-credential-");
+    const codexHome = path.join(root, "codex-home");
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-before", OLDER_REFRESH, "before-account"),
+      { mode: 0o600 },
+    );
+    process.env.OPENAI_API_KEY = "sk-api-key-auth";
+    const runtimes: FakeRuntime[] = [];
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options);
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+
+    const first = await execute(buildContext(root));
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-after", NEWER_REFRESH, "after-account"),
+      { mode: 0o600 },
+    );
+    const second = await execute(buildContext(root, {
+      runtime: {
+        sessionId: first.sessionId ?? null,
+        sessionParams: first.sessionParams ?? null,
+        sessionDisplayId: first.sessionDisplayId ?? null,
+        taskKey: "PAP-1",
+      },
+    }));
+
+    expect(second.exitCode).toBe(0);
+    expect(runtimes).toHaveLength(2);
+    expect(runtimes[1]?.ensureInputs[0]?.resumeSessionId).toBe("acp-1");
+  });
+
+  it("uses subscription identity when an empty adapter API key suppresses the host key", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-empty-api-key-");
+    const codexHome = path.join(root, "codex-home");
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-before", OLDER_REFRESH, "before-account"),
+      { mode: 0o600 },
+    );
+    process.env.OPENAI_API_KEY = "sk-suppressed-host-key";
+    const runtimes: FakeRuntime[] = [];
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options);
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const buildSubscriptionContext = (
+      overrides: Partial<AdapterExecutionContext> = {},
+    ): AdapterExecutionContext => {
+      const context = buildContext(root, overrides);
+      return {
+        ...context,
+        config: {
+          ...context.config,
+          env: { CODEX_HOME: codexHome, OPENAI_API_KEY: "" },
+        },
+      };
+    };
+
+    const first = await execute(buildSubscriptionContext());
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      subscriptionAuthJson("acct-after", NEWER_REFRESH, "after-account"),
+      { mode: 0o600 },
+    );
+    const second = await execute(buildSubscriptionContext({
+      runtime: {
+        sessionId: first.sessionId ?? null,
+        sessionParams: first.sessionParams ?? null,
+        sessionDisplayId: first.sessionDisplayId ?? null,
+        taskKey: "PAP-1",
+      },
+    }));
+
+    expect(second.exitCode).toBe(0);
+    expect(runtimes).toHaveLength(2);
+    expect(runtimes[1]?.ensureInputs[0]?.resumeSessionId).toBeUndefined();
+  });
 });
 
 describe("resolveCodexAcpBillingIdentity", () => {

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -1179,6 +1179,32 @@ describe("codex_local ACP lane", () => {
     expect(result.resultJson).not.toHaveProperty("codexCredentialTelemetry");
   });
 
+  it("classifies ACP subscription usage-limit failures as provider quota", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-provider-quota-");
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(
+        options,
+        [],
+        {
+          status: "failed",
+          error: {
+            message:
+              "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:33 PM.",
+          },
+        } as unknown as FakeRuntimeTurnResult,
+      ) as never,
+    });
+
+    const result = await execute(buildContext(root));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("provider_quota");
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.retryNotBefore).toEqual(expect.any(String));
+    expect(result.resultJson?.errorFamily).toBe("provider_quota");
+    expect(result.resultJson?.providerQuotaRetryNotBefore).toBe(result.retryNotBefore);
+  });
+
   it("resumes compatible ACP sessions on later Codex ACP runs", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-resume-");
     const runtimes: FakeRuntime[] = [];

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -93,6 +93,16 @@ function subscriptionAuthJson(accountId: string, lastRefresh: string, marker: st
   );
 }
 
+function providerQuotaTerminal(): FakeRuntimeTurnResult {
+  return {
+    status: "failed",
+    error: {
+      message:
+        "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:33 PM.",
+    },
+  } as unknown as FakeRuntimeTurnResult;
+}
+
 // Enumerate the host staged-home temp dirs `stageCodexHomeForSync` created for a
 // given runId (`paperclip-codex-home-sync-<runId>-<random>` under os.tmpdir()).
 // A unique per-test runId scopes the match to this run's staging dirs only, so
@@ -1203,6 +1213,262 @@ describe("codex_local ACP lane", () => {
     expect(result.retryNotBefore).toEqual(expect.any(String));
     expect(result.resultJson?.errorFamily).toBe("provider_quota");
     expect(result.resultJson?.providerQuotaRetryNotBefore).toBe(result.retryNotBefore);
+  });
+
+  it("keeps quota watcher handoff disabled when quotaRotationWaitSec is absent", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-handoff-disabled-");
+    let identityReads = 0;
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => {
+          identityReads += 1;
+          return "identity-unused";
+        },
+      },
+      createRuntime: (options: FakeRuntimeOptions) =>
+        new FakeRuntime(options, [], providerQuotaTerminal()) as never,
+    });
+
+    const result = await execute(buildContext(root));
+
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.resultJson).not.toHaveProperty("quotaCredentialHandoff");
+    expect(identityReads).toBe(0);
+  });
+
+  it("does not use subscription quota handoff for API-key-authenticated ACP runs", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-handoff-api-key-");
+    process.env.OPENAI_API_KEY = "sk-api-key-auth";
+    let identityReads = 0;
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => {
+          identityReads += 1;
+          return "identity-unused";
+        },
+      },
+      createRuntime: (options: FakeRuntimeOptions) =>
+        new FakeRuntime(options, [], providerQuotaTerminal()) as never,
+    });
+    const context = buildContext(root);
+    context.config = { ...context.config, quotaRotationWaitSec: 75 };
+
+    const result = await execute(context);
+
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.resultJson).not.toHaveProperty("quotaCredentialHandoff");
+    expect(identityReads).toBe(0);
+  });
+
+  it("retries once after the external watcher changes the subscription identity", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-handoff-");
+    const runtimes: FakeRuntime[] = [];
+    const identities = ["identity-before", "identity-after"];
+    const logs: string[] = [];
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => identities.shift() ?? "identity-after",
+        sleep: async () => {
+          throw new Error("identity changed before polling sleep");
+        },
+        now: () => 0,
+      },
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(
+          options,
+          [],
+          runtimes.length === 0 ? providerQuotaTerminal() : undefined,
+        );
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const context = buildContext(root, {
+      onLog: async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+    });
+    context.config = { ...context.config, quotaRotationWaitSec: 75 };
+
+    const result = await execute(context);
+
+    expect(result.exitCode).toBe(0);
+    expect(runtimes).toHaveLength(2);
+    expect(runtimes[1]?.startInputs[0]?.text).toContain("Task context");
+    expect(result.resultJson?.quotaCredentialHandoff).toEqual({
+      attempted: true,
+      credentialChanged: true,
+    });
+    expect(logs.join("\n")).not.toContain("identity-before");
+    expect(logs.join("\n")).not.toContain("identity-after");
+  });
+
+  it("returns the original quota failure unchanged when the watcher does not switch accounts", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-timeout-");
+    const runtimes: FakeRuntime[] = [];
+    const sleeps: number[] = [];
+    let now = 0;
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => "identity-same",
+        sleep: async (ms: number) => {
+          sleeps.push(ms);
+          now += ms;
+        },
+        now: () => now,
+      },
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options, [], providerQuotaTerminal());
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const context = buildContext(root);
+    context.config = { ...context.config, quotaRotationWaitSec: 2 };
+
+    const result = await execute(context);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.retryNotBefore).toEqual(expect.any(String));
+    expect(result.resultJson).not.toHaveProperty("quotaCredentialHandoff");
+    expect(runtimes).toHaveLength(1);
+    expect(sleeps).toEqual([1_000, 1_000]);
+  });
+
+  it("caps the configured credential watcher wait at five minutes", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-wait-cap-");
+    let now = 0;
+    let sleptMs = 0;
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => "identity-same",
+        sleep: async (ms: number) => {
+          sleptMs += ms;
+          now += ms;
+        },
+        now: () => now,
+      },
+      createRuntime: (options: FakeRuntimeOptions) =>
+        new FakeRuntime(options, [], providerQuotaTerminal()) as never,
+    });
+    const context = buildContext(root);
+    context.config = { ...context.config, quotaRotationWaitSec: 999 };
+
+    const result = await execute(context);
+
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(sleptMs).toBe(300_000);
+  });
+
+  it("returns the quota failure when the credential identity cannot be read", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-identity-read-error-");
+    const runtimes: FakeRuntime[] = [];
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => {
+          throw new Error("simulated credential read failure");
+        },
+        sleep: async () => {
+          throw new Error("missing identity must not enter the wait loop");
+        },
+      },
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options, [], providerQuotaTerminal());
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const context = buildContext(root);
+    context.config = { ...context.config, quotaRotationWaitSec: 75 };
+
+    const result = await execute(context);
+
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.resultJson).not.toHaveProperty("quotaCredentialHandoff");
+    expect(runtimes).toHaveLength(1);
+  });
+
+  it("does not loop when the one credential-handoff retry also hits provider quota", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-handoff-terminal-");
+    const runtimes: FakeRuntime[] = [];
+    const identities = ["identity-before", "identity-after", "identity-third"];
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        readCredentialIdentity: async () => identities.shift() ?? "identity-third",
+        sleep: async () => {},
+        now: () => 0,
+      },
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options, [], providerQuotaTerminal());
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const context = buildContext(root);
+    context.config = { ...context.config, quotaRotationWaitSec: 75 };
+
+    const result = await execute(context);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.resultJson?.quotaCredentialHandoff).toEqual({
+      attempted: true,
+      credentialChanged: true,
+    });
+    expect(runtimes).toHaveLength(2);
+  });
+
+  it("detects a watcher account switch that occurs during the failed ACP attempt", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-quota-switch-during-attempt-");
+    const codexHome = path.join(root, "codex-home");
+    const authPath = path.join(codexHome, "auth.json");
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      authPath,
+      subscriptionAuthJson("acct-before", OLDER_REFRESH, "before-account"),
+      { mode: 0o600 },
+    );
+    const runtimes: FakeRuntime[] = [];
+    const execute = createCodexAcpExecutor({
+      quotaRotationDeps: {
+        sleep: async () => {
+          throw new Error("account changed during the first attempt");
+        },
+      },
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(
+          options,
+          [],
+          runtimes.length === 0 ? providerQuotaTerminal() : undefined,
+        );
+        if (runtimes.length === 0) {
+          const ensureSession = runtime.ensureSession.bind(runtime);
+          runtime.ensureSession = async (input) => {
+            const handle = await ensureSession(input);
+            await fs.writeFile(
+              authPath,
+              subscriptionAuthJson("acct-after", NEWER_REFRESH, "after-account"),
+              { mode: 0o600 },
+            );
+            return handle;
+          };
+        }
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const context = buildContext(root);
+    context.config = { ...context.config, quotaRotationWaitSec: 75 };
+
+    const result = await execute(context);
+
+    expect(result.exitCode).toBe(0);
+    expect(runtimes).toHaveLength(2);
+    expect(runtimes[1]?.ensureInputs[0]?.resumeSessionId).toBeUndefined();
+    expect(JSON.stringify(result.sessionParams)).not.toContain("acct-before");
+    expect(JSON.stringify(result.sessionParams)).not.toContain("acct-after");
+    expect(JSON.stringify(result.sessionParams)).not.toContain("after-account");
   });
 
   it("resumes compatible ACP sessions on later Codex ACP runs", async () => {

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -36,7 +36,11 @@ import {
   parseObject,
 } from "@paperclipai/adapter-utils/server-utils";
 import { normalizeCodexModel } from "../index.js";
-import { classifyCodexAuthRefreshFailure } from "./parse.js";
+import {
+  classifyCodexAuthRefreshFailure,
+  extractCodexRetryNotBefore,
+  isCodexProviderQuotaError,
+} from "./parse.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import {
@@ -285,25 +289,47 @@ function withCodexAcpDefaults(options: CodexAcpExecutorOptions): AcpxEngineExecu
   };
 }
 
-function withCodexAuthRefreshFailureClassification(result: AdapterExecutionResult): AdapterExecutionResult {
+function withCodexAcpFailureClassification(result: AdapterExecutionResult): AdapterExecutionResult {
   if ((result.exitCode ?? 0) === 0) return result;
   const resultJson = parseObject(result.resultJson);
   const stopReason = asString(resultJson.stopReason, "");
+  const errorMessage = [result.errorMessage ?? "", result.summary ?? "", stopReason]
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
   const authFailure = classifyCodexAuthRefreshFailure({
-    errorMessage: [result.errorMessage ?? "", result.summary ?? "", stopReason]
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .join("\n"),
+    errorMessage,
   });
-  if (!authFailure) return result;
+  if (authFailure) {
+    return {
+      ...result,
+      errorCode: authFailure,
+      errorFamily: authFailure,
+      resultJson: {
+        ...(result.resultJson ?? {}),
+        errorFamily: authFailure,
+      },
+    };
+  }
 
+  if (!isCodexProviderQuotaError({ errorMessage })) return result;
+
+  const retryNotBefore = extractCodexRetryNotBefore({ errorMessage })?.toISOString() ?? null;
   return {
     ...result,
-    errorCode: authFailure,
-    errorFamily: authFailure,
+    errorCode: "provider_quota",
+    errorFamily: "provider_quota",
+    retryNotBefore,
     resultJson: {
       ...(result.resultJson ?? {}),
-      errorFamily: authFailure,
+      errorFamily: "provider_quota",
+      ...(retryNotBefore
+        ? {
+            retryNotBefore,
+            transientRetryNotBefore: retryNotBefore,
+            providerQuotaRetryNotBefore: retryNotBefore,
+          }
+        : {}),
     },
   };
 }
@@ -355,7 +381,7 @@ export function createCodexAcpExecutor(options: CodexAcpExecutorOptions = {}): C
       ...ctx,
       config: buildCodexAcpConfig(ctx.config),
     });
-    return withCodexAuthRefreshFailureClassification(result);
+    return withCodexAcpFailureClassification(result);
   };
 }
 

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_ACP_ENGINE_PERMISSION_MODE,
   DEFAULT_ACP_ENGINE_WARM_HANDLE_IDLE_MS,
 } from "@paperclipai/adapter-utils/acpx-engine/constants";
+import { readCodexSubscriptionCredentialIdentity } from "@paperclipai/adapter-utils/acpx-engine/codex-credential-identity";
 import type {
   AcpxEngineExecutorOptions,
   AcpxRemoteManagedHomeContext,
@@ -45,6 +46,7 @@ import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import {
   evaluateCodexCredentialReadiness,
+  resolveManagedCodexHomeDir,
   resolveSharedCodexHomeDir,
   stageCodexHomeForSync,
 } from "./codex-home.js";
@@ -66,10 +68,20 @@ type CodexEngineResolutionInput =
   Pick<AdapterExecutionContext, "config"> &
   Partial<Pick<AdapterExecutionContext, "executionTarget" | "executionTransport">>;
 
-type CodexAcpExecutorOptions = Omit<
+type CodexAcpEngineOptions = Omit<
   AcpxEngineExecutorOptions,
   "adapterType" | "moduleDir" | "packageRootDir"
 >;
+
+interface CodexQuotaRotationDeps {
+  readCredentialIdentity: (ctx: AdapterExecutionContext) => Promise<string | null>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+type CodexAcpExecutorOptions = CodexAcpEngineOptions & {
+  quotaRotationDeps?: Partial<CodexQuotaRotationDeps>;
+};
 
 type CodexAcpExecutor = (ctx: AdapterExecutionContext) => Promise<AdapterExecutionResult>;
 
@@ -278,7 +290,7 @@ async function prepareCodexRemoteManagedHome(
   };
 }
 
-function withCodexAcpDefaults(options: CodexAcpExecutorOptions): AcpxEngineExecutorOptions {
+function withCodexAcpDefaults(options: CodexAcpEngineOptions): AcpxEngineExecutorOptions {
   return {
     resolveBillingIdentity: resolveCodexAcpBillingIdentity,
     prepareRemoteManagedHome: prepareCodexRemoteManagedHome,
@@ -286,6 +298,69 @@ function withCodexAcpDefaults(options: CodexAcpExecutorOptions): AcpxEngineExecu
     adapterType: "codex_local",
     moduleDir,
     packageRootDir,
+  };
+}
+
+const CODEX_QUOTA_ROTATION_POLL_MS = 1_000;
+const MAX_CODEX_QUOTA_ROTATION_WAIT_SEC = 300;
+
+function resolveCodexQuotaRotationWaitSec(config: Record<string, unknown>): number {
+  const configured = asNumber(config.quotaRotationWaitSec, 0);
+  if (!Number.isFinite(configured) || configured <= 0) return 0;
+  return Math.min(configured, MAX_CODEX_QUOTA_ROTATION_WAIT_SEC);
+}
+
+function resolveCodexCredentialHome(ctx: AdapterExecutionContext): string {
+  const envConfig = parseObject(parseObject(ctx.config).env);
+  const configuredHome = asString(envConfig.CODEX_HOME, "").trim();
+  return configuredHome
+    ? path.resolve(configuredHome)
+    : resolveManagedCodexHomeDir(process.env, ctx.agent.companyId);
+}
+
+async function readEffectiveCodexCredentialIdentity(
+  ctx: AdapterExecutionContext,
+): Promise<string | null> {
+  return readCodexSubscriptionCredentialIdentity(resolveCodexCredentialHome(ctx));
+}
+
+function readAttemptCredentialIdentity(result: AdapterExecutionResult): string | null {
+  const sessionParams = parseObject(result.sessionParams);
+  const skills = parseObject(sessionParams.skills);
+  const identity = asString(skills.credentialIdentityHash, "").trim();
+  return identity || null;
+}
+
+async function waitForChangedCodexCredential(input: {
+  baselineIdentity: string;
+  waitSec: number;
+  readCredentialIdentity: () => Promise<string | null>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}): Promise<boolean> {
+  const deadline = input.now() + input.waitSec * 1_000;
+  while (true) {
+    const currentIdentity = await input.readCredentialIdentity();
+    if (currentIdentity && currentIdentity !== input.baselineIdentity) return true;
+
+    const remainingMs = deadline - input.now();
+    if (remainingMs <= 0) return false;
+    await input.sleep(Math.min(CODEX_QUOTA_ROTATION_POLL_MS, remainingMs));
+  }
+}
+
+function markCodexQuotaCredentialHandoff(
+  result: AdapterExecutionResult,
+): AdapterExecutionResult {
+  return {
+    ...result,
+    resultJson: {
+      ...(result.resultJson ?? {}),
+      quotaCredentialHandoff: {
+        attempted: true,
+        credentialChanged: true,
+      },
+    },
   };
 }
 
@@ -369,19 +444,79 @@ export function resolveCodexAcpBillingIdentity(
 }
 
 export function createCodexAcpExecutor(options: CodexAcpExecutorOptions = {}): CodexAcpExecutor {
+  const {
+    quotaRotationDeps,
+    ...engineOptions
+  } = options;
+  const readCredentialIdentity =
+    quotaRotationDeps?.readCredentialIdentity ?? readEffectiveCodexCredentialIdentity;
+  const readCredentialIdentitySafely = async (
+    ctx: AdapterExecutionContext,
+  ): Promise<string | null> => {
+    try {
+      return await readCredentialIdentity(ctx);
+    } catch {
+      return null;
+    }
+  };
+  const sleep = quotaRotationDeps?.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const now = quotaRotationDeps?.now ?? (() => Date.now());
   let executor: CodexAcpExecutor | null = null;
   return async (ctx) => {
     let currentExecutor = executor;
     if (!currentExecutor) {
       const { createAcpxEngineExecutor } = await import("@paperclipai/adapter-utils/acpx-engine/execute");
-      currentExecutor = createAcpxEngineExecutor(withCodexAcpDefaults(options));
+      currentExecutor = createAcpxEngineExecutor(withCodexAcpDefaults(engineOptions));
       executor = currentExecutor;
     }
-    const result = await currentExecutor({
+    const quotaRotationWaitSec = resolveCodexQuotaRotationWaitSec(ctx.config);
+    const subscriptionHandoffEnabled =
+      quotaRotationWaitSec > 0 && resolveCodexAcpBillingIdentity(ctx).billingType === "subscription";
+    const preAttemptIdentity = subscriptionHandoffEnabled
+      ? await readCredentialIdentitySafely(ctx)
+      : null;
+    const executionContext = {
       ...ctx,
       config: buildCodexAcpConfig(ctx.config),
+    };
+    const result = withCodexAcpFailureClassification(
+      await currentExecutor(executionContext),
+    );
+    if (!subscriptionHandoffEnabled || result.errorFamily !== "provider_quota") {
+      return result;
+    }
+
+    const baselineIdentity = readAttemptCredentialIdentity(result) ?? preAttemptIdentity;
+    if (!baselineIdentity) return result;
+
+    await ctx.onLog(
+      "stderr",
+      `[paperclip] Codex subscription quota reached; waiting up to ${quotaRotationWaitSec}s for an external credential watcher to switch accounts.\n`,
+    );
+    const credentialChanged = await waitForChangedCodexCredential({
+      baselineIdentity,
+      waitSec: quotaRotationWaitSec,
+      readCredentialIdentity: () => readCredentialIdentitySafely(ctx),
+      sleep,
+      now,
     });
-    return withCodexAcpFailureClassification(result);
+    if (!credentialChanged) {
+      await ctx.onLog(
+        "stderr",
+        "[paperclip] Codex credential watcher handoff timed out; returning the original provider-quota failure.\n",
+      );
+      return result;
+    }
+
+    await ctx.onLog(
+      "stderr",
+      "[paperclip] Codex credential watcher changed the subscription account; retrying once with a fresh credential-aware session.\n",
+    );
+    const retry = withCodexAcpFailureClassification(
+      await currentExecutor(executionContext),
+    );
+    return markCodexQuotaCredentialHandoff(retry);
   };
 }
 

--- a/packages/adapters/codex-local/src/server/config-schema.ts
+++ b/packages/adapters/codex-local/src/server/config-schema.ts
@@ -68,6 +68,14 @@ export function getConfigSchema(): AdapterConfigSchema {
         hint: "Defaults to 0, which closes the ACP process after each run while retaining persistent session state.",
         meta: acpVisible,
       },
+      {
+        key: "quotaRotationWaitSec",
+        label: "Quota rotation wait seconds",
+        type: "number",
+        default: 0,
+        hint: "Disabled at 0. After a subscription quota failure, wait this long for an external credential watcher to switch accounts, then retry once.",
+        meta: acpVisible,
+      },
     ],
   };
 }

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -213,6 +213,17 @@ describe("isCodexTransientUpstreamError", () => {
     );
   });
 
+  it("extracts retry time from the generic subscription usage-limit message", () => {
+    const errorMessage =
+      "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 3:33 PM.";
+    const now = new Date(2026, 7, 21, 13, 27, 0);
+
+    expect(isCodexProviderQuotaError({ errorMessage })).toBe(true);
+    expect(extractCodexRetryNotBefore({ errorMessage }, now)?.getTime()).toBe(
+      new Date(2026, 7, 21, 15, 33, 0, 0).getTime(),
+    );
+  });
+
   it("classifies model-capacity messages as provider quota without reset metadata", () => {
     const errorMessage = "The requested model is at capacity. Please try again later.";
 

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -9,7 +9,7 @@ const CODEX_TRANSIENT_UPSTREAM_RE =
   /(?:we(?:'|’)re\s+currently\s+experiencing\s+high\s+demand|temporary\s+errors|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|server\s+overloaded|service\s+unavailable|try\s+again\s+later)/i;
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
 const CODEX_USAGE_LIMIT_RE =
-  /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
+  /you(?:'|’)ve hit your usage limit(?: for .+?)?\.[^\n]*?\btry again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
 const CODEX_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve hit your usage limit|usage limit|model (?:is )?at capacity|at capacity for this model|capacity limit)/i;
 const CODEX_REFRESH_TOKEN_REUSED_RE =

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -47,6 +47,28 @@ describe("buildCodexLocalConfig", () => {
     expect(buildCodexLocalConfig(makeValues({ codexEngine: "acp" }))).toMatchObject({ engine: "acp" });
   });
 
+  it("persists quota watcher handoff only for an explicitly selected ACP engine", () => {
+    expect(
+      buildCodexLocalConfig(
+        makeValues({
+          codexEngine: "acp",
+          codexAcpQuotaRotationWaitSec: 75,
+        }),
+      ),
+    ).toMatchObject({
+      engine: "acp",
+      quotaRotationWaitSec: 75,
+    });
+    expect(
+      buildCodexLocalConfig(
+        makeValues({
+          codexEngine: "cli",
+          codexAcpQuotaRotationWaitSec: 75,
+        }),
+      ),
+    ).not.toHaveProperty("quotaRotationWaitSec");
+  });
+
   it("persists the fastMode toggle into adapter config", () => {
     const config = buildCodexLocalConfig(
       makeValues({

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -33,6 +33,7 @@ export function buildCodexLocalConfig(v: CreateConfigValues): Record<string, unk
     ac.nonInteractivePermissions = v.codexAcpNonInteractivePermissions ?? "deny";
     if (v.codexAcpStateDir) ac.stateDir = v.codexAcpStateDir;
     ac.warmHandleIdleMs = v.codexAcpWarmHandleIdleMs ?? 0;
+    ac.quotaRotationWaitSec = v.codexAcpQuotaRotationWaitSec ?? 0;
   }
   ac.timeoutSec = 0;
   ac.graceSec = 15;

--- a/ui/src/adapters/codex-local/config-fields.tsx
+++ b/ui/src/adapters/codex-local/config-fields.tsx
@@ -181,6 +181,32 @@ export function CodexLocalConfigFields({
               />
             )}
           </Field>
+          <Field
+            label="Quota rotation wait seconds"
+            hint="Disabled at 0. After a subscription quota failure, wait for an external credential watcher to switch accounts, then retry once. A 75-second wait covers the watcher API fallback cycle."
+          >
+            {isCreate ? (
+              <input
+                type="number"
+                min={0}
+                max={300}
+                className={inputClass}
+                value={values!.codexAcpQuotaRotationWaitSec ?? 0}
+                onChange={(e) => set!({ codexAcpQuotaRotationWaitSec: Number(e.target.value) })}
+              />
+            ) : (
+              <DraftNumberInput
+                value={eff(
+                  "adapterConfig",
+                  "quotaRotationWaitSec",
+                  Number(config.quotaRotationWaitSec ?? 0),
+                )}
+                onCommit={(v) => mark("adapterConfig", "quotaRotationWaitSec", Math.max(0, v || 0))}
+                immediate
+                className={inputClass}
+              />
+            )}
+          </Field>
         </>
       )}
       {!hideInstructionsFile && (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Codex local adapter runs Codex subscription sessions through ACP
> - A subscription account can reach its usage limit during an active task
> - An external credential watcher can then switch the active Codex account
> - Paperclip did not detect this credential change or retry the failed run
> - This pull request adds credential-aware sessions and one bounded retry after a detected account change
> - The benefit is that a task can continue with the same Paperclip context after an external account rotation

## Linked Issues or Issue Description

**Agent or provider**

Codex CLI with subscription authentication through the existing Codex local ACP adapter.

**Why this adapter is useful**

Codex subscription accounts have usage limits. Operators can use an external credential watcher to rotate the active account. Paperclip must detect the new credential identity before it can create a fresh provider session and retry the same task.

**How the agent is invoked**

Paperclip invokes Codex through the existing ACP command. The adapter reads the local Codex authentication file only to compute a one-way identity hash. It does not select accounts or write credentials.

**Additional context**

The feature is disabled by default. Set `quotaRotationWaitSec` to a value from 1 to 300 seconds to enable the handoff wait. The recommended value is 75 seconds. API-key runs do not use this behavior.

## What Changed

- Classify Codex ACP usage-limit responses as provider quota failures.
- Add a hash-only Codex credential identity reader.
- Include the credential identity in the ACP session key for subscription runs.
- Reset the provider session after the external account identity changes.
- Wait for a configured account change after a confirmed quota failure.
- Retry the same task once with its existing Paperclip task and workspace context.
- Add the `quotaRotationWaitSec` field to the Codex adapter configuration UI.
- Add tests for quota classification, identity changes, disabled behavior, timeouts, API-key exclusion, unreadable credentials, and the bounded retry.
- Add design documents for credential-aware sessions and quota watcher handoff.

## Verification

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -r typecheck` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm build` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec vitest run packages/adapter-utils/src/acpx-engine packages/adapters/codex-local/src/server packages/adapters/codex-local/src/ui` passed with 634 tests and 1 skipped test.
- `pnpm test:run` completed with 4,525 passed tests, 5 skipped tests, and 31 failed tests in 9 unchanged server test files. Most failures compare `/tmp` with the macOS canonical path `/private/tmp`. Other failures use temporary worktree, port, or config fixtures. This branch does not change `server/`, `scripts/`, `cli/`, or `packages/shared/`.
- A live quota exhaustion and external account rotation remains a manual validation step. The feature is disabled by default.

## Risks

- The retry can delay a confirmed subscription quota failure by the configured wait value.
- The adapter retries only once after it detects a valid credential identity change.
- The adapter returns the original quota result when the wait expires or the credential identity cannot be read.
- The adapter does not change API-key behavior.
- The adapter does not run account-switch commands or modify credential files.
- The full local suite has unrelated macOS fixture failures. GitHub CI must validate the complete suite before merge.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with a GPT-5 family model assisted with this change. The runtime did not expose the exact model ID or context-window size. The agent used reasoning, repository inspection, shell tools, code editing, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

