### PR TITLE
fix(task-watchdogs): clear reviewed fingerprint when reusable watchdog reopens

### DIFF
--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -689,6 +689,86 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(revalidated.classification?.state).toBe("live");
   });
 
+  it("clears lastReviewedFingerprint when a reusable watchdog issue is reopened after premature done", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-REOPEN-CLEAR", status: "done" });
+    const childId = await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, watchdogIssueId));
+
+    const reviewed = await service.reconcileTaskWatchdogs({ companyId });
+    expect(reviewed).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    const [stamped] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(stamped?.lastReviewedFingerprint).toBe(stopFingerprint);
+
+    // Premature done left the stamp; reopen the reusable watchdog issue for the same fingerprint.
+    await db
+      .update(issues)
+      .set({ status: "in_progress", updatedAt: new Date() })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: stamped!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(revalidated.allowed).toBe(true);
+    expect(revalidated.classification?.state).toBe("stopped");
+    expect(revalidated.classification?.stopFingerprint).toBe(stopFingerprint);
+
+    const [cleared] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(cleared?.lastReviewedFingerprint).toBeNull();
+    expect(cleared?.lastReviewedStopSnapshot).toBeNull();
+
+    // Same-fingerprint reopen must not re-wake; review stays open on the reusable issue.
+    const afterReopen = await service.reconcileTaskWatchdogs({ companyId });
+    expect(afterReopen).toMatchObject({ checked: 1, triggered: 0 });
+    expect(wakes).toHaveLength(1);
+    void childId;
+  });
+
+  it("keeps completed-review suppression for an unchanged fingerprint while the watchdog issue stays terminal", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-KEEP-REVIEWED", status: "done" });
+    await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: new Date() })
+      .where(eq(issues.id, firstWatchdog!.watchdogIssueId!));
+
+    const reviewed = await service.reconcileTaskWatchdogs({ companyId });
+    expect(reviewed).toMatchObject({ alreadyReviewed: 1 });
+    const again = await service.reconcileTaskWatchdogs({ companyId });
+    expect(again).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    expect(wakes).toHaveLength(1);
+
+    const denied = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: firstWatchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(denied.allowed).toBe(false);
+    expect(denied.classification?.state).toBe("already_reviewed");
+  });
+
   it("does not raise a stopped-subtree review while a freshly-created assigned issue's first run is starting", async () => {
     const companyId = await seedCompany();
     const agentId = await seedAgent(companyId);

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -736,6 +736,50 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     void childId;
   });
 
+  it("clears lastReviewedFingerprint when in_progress reopen has assignee and monitor", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-REOPEN-ASSIGNED-CLEAR", status: "done" });
+    await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, watchdogIssueId));
+    await service.reconcileTaskWatchdogs({ companyId });
+
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        monitorNextCheckAt: new Date(Date.now() + 60_000),
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: firstWatchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(revalidated.allowed).toBe(true);
+    expect(revalidated.classification?.state).toBe("stopped");
+
+    const [cleared] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(cleared?.lastReviewedFingerprint).toBeNull();
+    expect(cleared?.lastReviewedStopSnapshot).toBeNull();
+
+    const afterReopen = await service.reconcileTaskWatchdogs({ companyId });
+    expect(afterReopen).toMatchObject({ checked: 1, triggered: 0 });
+    expect(wakes).toHaveLength(1);
+  });
+
   it("keeps completed-review suppression for an unchanged fingerprint while the watchdog issue stays terminal", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-KEEP-REVIEWED", status: "done" });

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -896,7 +896,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(cleared?.lastReviewedFingerprint).toBeNull();
   });
 
-  it("does not clear lastReviewedFingerprint when in_review still has a review disposition", async () => {
+  it("keeps lastReviewedFingerprint and denies source mutation when in_review has a board review path", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-INREVIEW-KEEP", status: "done" });
     await seedIssue(companyId, { parentId: sourceId, status: "done" });
@@ -927,7 +927,8 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       watchedIssueId: sourceId,
       stopFingerprint,
     });
-    expect(revalidated.allowed).toBe(true);
+    expect(revalidated.allowed).toBe(false);
+    expect(revalidated.classification?.state).toBe("already_reviewed");
 
     const [kept] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(kept?.lastReviewedFingerprint).toBe(stopFingerprint);

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -812,6 +812,87 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(denied.classification?.state).toBe("already_reviewed");
   });
 
+  it("clears lastReviewedFingerprint when in_review has no review disposition", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-INREVIEW-CLEAR", status: "done" });
+    await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, watchdogIssueId));
+    await service.reconcileTaskWatchdogs({ companyId });
+
+    await db
+      .update(issues)
+      .set({
+        status: "in_review",
+        assigneeUserId: null,
+        executionState: null,
+        monitorNextCheckAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: firstWatchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(revalidated.allowed).toBe(true);
+    expect(revalidated.classification?.state).toBe("stopped");
+
+    const [cleared] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(cleared?.lastReviewedFingerprint).toBeNull();
+  });
+
+  it("does not clear lastReviewedFingerprint when in_review still has a review disposition", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-INREVIEW-KEEP", status: "done" });
+    await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, watchdogIssueId));
+    await service.reconcileTaskWatchdogs({ companyId });
+
+    await db
+      .update(issues)
+      .set({
+        status: "in_review",
+        assigneeUserId: "board-reviewer",
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: firstWatchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(revalidated.allowed).toBe(true);
+
+    const [kept] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(kept?.lastReviewedFingerprint).toBe(stopFingerprint);
+
+    const after = await service.reconcileTaskWatchdogs({ companyId });
+    expect(after).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    expect(wakes).toHaveLength(1);
+  });
+
   it("does not raise a stopped-subtree review while a freshly-created assigned issue's first run is starting", async () => {
     const companyId = await seedCompany();
     const agentId = await seedAgent(companyId);

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -769,6 +769,49 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(denied.classification?.state).toBe("already_reviewed");
   });
 
+  it("keeps completed-review suppression when the reusable watchdog issue is cancelled", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-CANCEL-KEEP-REVIEWED", status: "done" });
+    await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: new Date() })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const reviewed = await service.reconcileTaskWatchdogs({ companyId });
+    expect(reviewed).toMatchObject({ alreadyReviewed: 1 });
+
+    await db
+      .update(issues)
+      .set({ status: "cancelled", updatedAt: new Date() })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const afterCancel = await service.reconcileTaskWatchdogs({ companyId });
+    expect(afterCancel).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    expect(wakes).toHaveLength(1);
+
+    const [kept] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(kept?.lastReviewedFingerprint).toBe(stopFingerprint);
+
+    const denied = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: firstWatchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(denied.allowed).toBe(false);
+    expect(denied.classification?.state).toBe("already_reviewed");
+  });
+
   it("does not raise a stopped-subtree review while a freshly-created assigned issue's first run is starting", async () => {
     const companyId = await seedCompany();
     const agentId = await seedAgent(companyId);

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -937,6 +937,48 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(wakes).toHaveLength(1);
   });
 
+  it("clears lastReviewedFingerprint when in_review is assigned to the watchdog agent without a board review path", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-INREVIEW-AGENT-CLEAR", status: "done" });
+    await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const stopFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, watchdogIssueId));
+    await service.reconcileTaskWatchdogs({ companyId });
+
+    await db
+      .update(issues)
+      .set({
+        status: "in_review",
+        assigneeAgentId: agentId,
+        assigneeUserId: null,
+        executionState: null,
+        monitorNextCheckAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, watchdogIssueId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: firstWatchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint,
+    });
+    expect(revalidated.allowed).toBe(true);
+    expect(revalidated.classification?.state).toBe("stopped");
+
+    const [cleared] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(cleared?.lastReviewedFingerprint).toBeNull();
+    expect(cleared?.lastReviewedStopSnapshot).toBeNull();
+  });
+
   it("does not raise a stopped-subtree review while a freshly-created assigned issue's first run is starting", async () => {
     const companyId = await seedCompany();
     const agentId = await seedAgent(companyId);

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1248,6 +1248,20 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     return true;
   }
 
+  async function sameFingerprintWatchdogAllowsSourceMutation(
+    watchdogIssue: IssueRow | null,
+    stopFingerprint: string,
+  ) {
+    if (!watchdogIssue) return false;
+    if (watchdogIssue.originFingerprint !== stopFingerprint) return false;
+    if (isTerminalIssueStatus(watchdogIssue.status) || watchdogIssue.status === "backlog") return false;
+    if (watchdogIssue.status === "in_review") {
+      const hasPendingReviewPath = await watchdogIssueHasPendingReviewPath(watchdogIssue.companyId, watchdogIssue.id);
+      return !isWatchdogReviewDisposition(watchdogIssue, hasPendingReviewPath);
+    }
+    return true;
+  }
+
   /**
    * Premature `done`/`blocked` on a reusable watchdog issue stamps
    * lastReviewedFingerprint. Explicit reopen to todo/in_progress/in_review
@@ -1777,7 +1791,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           .where(and(eq(issues.companyId, watchdog.companyId), eq(issues.id, watchdog.watchdogIssueId)))
           .then((rows) => rows[0] ?? null)
         : null;
-      if (await sameFingerprintWatchdogReviewIsStillOpen(watchdogIssue, classification.stopFingerprint)) {
+      if (await sameFingerprintWatchdogAllowsSourceMutation(watchdogIssue, classification.stopFingerprint)) {
         return {
           allowed: true as const,
           classification: {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1233,6 +1233,59 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     return true;
   }
 
+  /**
+   * Premature `done`/`blocked` on a reusable watchdog issue stamps
+   * lastReviewedFingerprint. Reopening to a non-review disposition must clear
+   * that stamp so the same stop fingerprint is no longer treated as
+   * already_reviewed (which 409s source restore mutations).
+   */
+  async function clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(
+    watchdog: IssueWatchdogRow,
+    opts: { runId?: string | null } = {},
+  ) {
+    if (!watchdog.watchdogIssueId || !watchdog.lastReviewedFingerprint) return watchdog;
+    const watchdogIssue = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, watchdog.companyId), eq(issues.id, watchdog.watchdogIssueId)))
+      .then((rows) => rows[0] ?? null);
+    if (!watchdogIssue) return watchdog;
+    if (watchdogIssue.originFingerprint !== watchdog.lastReviewedFingerprint) return watchdog;
+    const hasPendingReviewPath = watchdogIssue.status === "in_review"
+      ? await watchdogIssueHasPendingReviewPath(watchdog.companyId, watchdogIssue.id)
+      : false;
+    if (isWatchdogReviewDisposition(watchdogIssue, hasPendingReviewPath)) return watchdog;
+
+    const clearedFingerprint = watchdog.lastReviewedFingerprint;
+    const [updated] = await db
+      .update(issueWatchdogs)
+      .set({
+        lastReviewedFingerprint: null,
+        lastReviewedStopSnapshot: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(issueWatchdogs.id, watchdog.id))
+      .returning();
+    await logActivity(db, {
+      companyId: watchdog.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: watchdog.watchdogAgentId,
+      runId: opts.runId ?? null,
+      action: "issue.task_watchdog_fingerprint_review_cleared",
+      entityType: "issue",
+      entityId: watchdog.issueId,
+      details: {
+        source: "task_watchdogs.watchdog_issue_reopened",
+        watchdogId: watchdog.id,
+        watchdogIssueId: watchdogIssue.id,
+        clearedFingerprint,
+        watchdogIssueStatus: watchdogIssue.status,
+      },
+    });
+    return updated ?? { ...watchdog, lastReviewedFingerprint: null, lastReviewedStopSnapshot: null };
+  }
+
   async function watchdogIssueNeedsFreshWake(watchdogIssue: IssueRow) {
     if (watchdogIssue.status !== "in_review") return false;
     const hasPendingReviewPath = await watchdogIssueHasPendingReviewPath(watchdogIssue.companyId, watchdogIssue.id);
@@ -1436,7 +1489,8 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
   }
 
   async function evaluateWatchdog(row: IssueWatchdogRow, opts: { runId?: string | null } = {}) {
-    const watchdog = await markTerminalWatchdogIssueReviewed(row, opts);
+    const stamped = await markTerminalWatchdogIssueReviewed(row, opts);
+    const watchdog = await clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(stamped, opts);
     const sourceIssue = await db
       .select()
       .from(issues)
@@ -1625,7 +1679,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       };
     }
 
-    const watchdog = await db
+    const existingWatchdog = await db
       .select()
       .from(issueWatchdogs)
       .where(and(
@@ -1635,17 +1689,43 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         eq(issueWatchdogs.status, "active"),
       ))
       .then((rows) => rows[0] ?? null);
-    if (!watchdog) {
+    if (!existingWatchdog) {
       return {
         allowed: false as const,
         reason: "Task-watchdog run context is not backed by an active persisted watchdog.",
       };
     }
 
+    // Reopened reusable watchdog issues must not keep a premature reviewed stamp
+    // that turns the same stop fingerprint into already_reviewed (409 on source PATCH).
+    const watchdog = await clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(existingWatchdog);
     const input = await collectClassifierInput(watchdog.companyId, watchdog);
     const classification = classifyTaskWatchdogSubtree(input);
     if (classification.state === "stopped" && classification.stopFingerprint === scope.stopFingerprint) {
       return { allowed: true as const, classification };
+    }
+
+    if (
+      classification.state === "already_reviewed" &&
+      classification.stopFingerprint === scope.stopFingerprint
+    ) {
+      const watchdogIssue = watchdog.watchdogIssueId
+        ? await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, watchdog.companyId), eq(issues.id, watchdog.watchdogIssueId)))
+          .then((rows) => rows[0] ?? null)
+        : null;
+      if (await sameFingerprintWatchdogReviewIsStillOpen(watchdogIssue, classification.stopFingerprint)) {
+        return {
+          allowed: true as const,
+          classification: {
+            ...classification,
+            state: "stopped" as const,
+            reason: "Reusable watchdog issue is open again for this stop fingerprint; source mutations remain in scope.",
+          },
+        };
+      }
     }
 
     return {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1261,6 +1261,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
    * is false unless status is done/blocked/in_review, so assignee, execution,
    * monitor, or a pending path on todo/in_progress is the explicit reopen
    * (assigned in_progress) and must still clear.
+   * in_review counts board review only (assigneeUserId, executionState, monitor,
+   * pending interaction/approval). assigneeAgentId is watchdog ownership, not a
+   * completed review path, so in_review assigned to the watchdog agent without
+   * those signals still clears.
    */
   async function clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(
     watchdog: IssueWatchdogRow,

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -29,6 +29,7 @@ const TASK_WATCHDOG_SUBTREE_MAX_DEPTH = 100;
 const TASK_WATCHDOG_LIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const TASK_WATCHDOG_WAKE_REQUEST_STATUSES = ["queued", "deferred_issue_execution"] as const;
 const TASK_WATCHDOG_TERMINAL_ISSUE_STATUSES = ["done", "cancelled"] as const;
+const TASK_WATCHDOG_REOPEN_ISSUE_STATUSES = ["todo", "in_progress", "in_review"] as const;
 const TASK_WATCHDOG_TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 // Grace window after an issue is created/assigned during which its first
 // assignment run/wake may have been enqueued but is not yet visible to a
@@ -749,6 +750,20 @@ function isWatchdogReviewDisposition(issue: Pick<
   return Boolean(issue.assigneeUserId || issue.executionState || issue.monitorNextCheckAt || hasPendingReviewPath);
 }
 
+function watchdogIssueReopenedFromTerminalReview(issue: Pick<
+  IssueRow,
+  "status" | "assigneeUserId" | "executionState" | "monitorNextCheckAt"
+>, hasPendingReviewPath: boolean) {
+  if (
+    !TASK_WATCHDOG_REOPEN_ISSUE_STATUSES.includes(
+      issue.status as (typeof TASK_WATCHDOG_REOPEN_ISSUE_STATUSES)[number],
+    )
+  ) {
+    return false;
+  }
+  return !isWatchdogReviewDisposition(issue, hasPendingReviewPath);
+}
+
 function isUniqueConstraintConflict(error: unknown, constraintName: string) {
   const queue: unknown[] = [error];
   const messages: string[] = [];
@@ -1235,9 +1250,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
 
   /**
    * Premature `done`/`blocked` on a reusable watchdog issue stamps
-   * lastReviewedFingerprint. Reopening to a non-review disposition must clear
-   * that stamp so the same stop fingerprint is no longer treated as
-   * already_reviewed (which 409s source restore mutations).
+   * lastReviewedFingerprint. Explicit reopen to todo/in_progress/in_review
+   * (without a completed review path) must clear that stamp so the same stop
+   * fingerprint is no longer already_reviewed. cancelled/backlog keep
+   * completed-review suppression. The UPDATE is status-conditional so a
+   * concurrent terminal stamp is not wiped.
    */
   async function clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(
     watchdog: IssueWatchdogRow,
@@ -1254,7 +1271,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     const hasPendingReviewPath = watchdogIssue.status === "in_review"
       ? await watchdogIssueHasPendingReviewPath(watchdog.companyId, watchdogIssue.id)
       : false;
-    if (isWatchdogReviewDisposition(watchdogIssue, hasPendingReviewPath)) return watchdog;
+    if (!watchdogIssueReopenedFromTerminalReview(watchdogIssue, hasPendingReviewPath)) return watchdog;
 
     const clearedFingerprint = watchdog.lastReviewedFingerprint;
     const [updated] = await db
@@ -1264,8 +1281,19 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         lastReviewedStopSnapshot: null,
         updatedAt: new Date(),
       })
-      .where(eq(issueWatchdogs.id, watchdog.id))
+      .where(and(
+        eq(issueWatchdogs.id, watchdog.id),
+        eq(issueWatchdogs.lastReviewedFingerprint, clearedFingerprint),
+        sql`exists (
+          select 1
+          from issues
+          where issues.id = ${watchdog.watchdogIssueId}
+            and issues.company_id = ${watchdog.companyId}
+            and issues.status in ('todo', 'in_progress', 'in_review')
+        )`,
+      ))
       .returning();
+    if (!updated) return watchdog;
     await logActivity(db, {
       companyId: watchdog.companyId,
       actorType: "system",
@@ -1283,7 +1311,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         watchdogIssueStatus: watchdogIssue.status,
       },
     });
-    return updated ?? { ...watchdog, lastReviewedFingerprint: null, lastReviewedStopSnapshot: null };
+    return updated;
   }
 
   async function watchdogIssueNeedsFreshWake(watchdogIssue: IssueRow) {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1253,8 +1253,9 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
    * lastReviewedFingerprint. Explicit reopen to todo/in_progress/in_review
    * (without a completed review path) must clear that stamp so the same stop
    * fingerprint is no longer already_reviewed. cancelled/backlog keep
-   * completed-review suppression. The UPDATE is status-conditional so a
-   * concurrent terminal stamp is not wiped.
+   * completed-review suppression. The UPDATE re-checks reopen status and
+   * in_review disposition so a concurrent terminal or review-path stamp is
+   * not wiped.
    */
   async function clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(
     watchdog: IssueWatchdogRow,
@@ -1289,7 +1290,30 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           from issues
           where issues.id = ${watchdog.watchdogIssueId}
             and issues.company_id = ${watchdog.companyId}
-            and issues.status in ('todo', 'in_progress', 'in_review')
+            and (
+              issues.status in ('todo', 'in_progress')
+              or (
+                issues.status = 'in_review'
+                and issues.assignee_user_id is null
+                and issues.execution_state is null
+                and issues.monitor_next_check_at is null
+                and not exists (
+                  select 1
+                  from issue_thread_interactions
+                  where issue_thread_interactions.company_id = issues.company_id
+                    and issue_thread_interactions.issue_id = issues.id
+                    and issue_thread_interactions.status = 'pending'
+                )
+                and not exists (
+                  select 1
+                  from issue_approvals
+                  inner join approvals on approvals.id = issue_approvals.approval_id
+                  where issue_approvals.company_id = issues.company_id
+                    and issue_approvals.issue_id = issues.id
+                    and approvals.status in ('pending', 'revision_requested')
+                )
+              )
+            )
         )`,
       ))
       .returning();

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1256,6 +1256,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
    * completed-review suppression. The UPDATE re-checks reopen status and
    * in_review disposition so a concurrent terminal or review-path stamp is
    * not wiped.
+   *
+   * todo/in_progress is status-only in the UPDATE: isWatchdogReviewDisposition
+   * is false unless status is done/blocked/in_review, so assignee, execution,
+   * monitor, or a pending path on todo/in_progress is the explicit reopen
+   * (assigned in_progress) and must still clear.
    */
   async function clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal(
     watchdog: IssueWatchdogRow,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Task watchdogs stop a watched subtree and raise a reusable review issue with a stop fingerprint
> - Premature `done`/`blocked` on that reusable issue stamps `lastReviewedFingerprint`
> - Reopening the issue did not clear the stamp, so classify returned `already_reviewed` and source PATCH/comment/create-child 409'd
> - This pull request clears the stamp when the watchdog issue reopens to todo/in_progress/in_review, and it keeps the stamp for cancelled/backlog and for concurrent terminal writes
> - The benefit is source restore after a premature terminal mark works without losing genuine completed-review suppression

## Linked Issues or Issue Description

**What happened?**
Reusable task-watchdog issues that are marked `done` or `blocked` too early stamp `issue_watchdogs.lastReviewedFingerprint`. Reopening the watchdog issue left that stamp in place. The same watchdog run then failed every source mutation with HTTP 409 because `revalidateMutationScope` treated the subtree as `already_reviewed`.

**Expected behavior**
Reopening a reusable watchdog issue after a premature terminal disposition clears the reviewed fingerprint for that stop. Same-fingerprint source mutations are allowed again. A genuinely completed terminal review still suppresses unchanged-fingerprint wakes. A cancelled reusable watchdog issue keeps that suppression.

**Steps to reproduce**
1. Arm a task watchdog and wait until it raises a reusable watchdog issue for a stopped fingerprint.
2. Mark that watchdog issue `done` before source restore finishes.
3. Reopen the watchdog issue to `in_progress`.
4. Attempt a source PATCH/comment under the watchdog run scope for the same stop fingerprint.
5. Observe 409 stale already-reviewed.

**Paperclip version or commit**
`043433ffb62f0db1ed5606071ad5adfaede39635` on this branch.

**Additional context**
Internal fix for premature watchdog terminal stamps that block same-fingerprint restore. No public GitHub issue number.

## What Changed

- Add `clearReviewedFingerprintWhenWatchdogIssueLeavesTerminal` in `task-watchdogs.ts`
- Call it from `evaluateWatchdog` (after terminal review stamping) and from `revalidateMutationScope`
- Clear only for explicit `todo`/`in_progress`/`in_review` reopens; keep the stamp for `cancelled`/`backlog`
- Condition the clear UPDATE on the current fingerprint and reopen status so a concurrent terminal stamp is not wiped
- Safety path: if classification is still `already_reviewed` but the reusable watchdog issue is open for that fingerprint, allow mutation scope
- Tests: reopen after premature done clears stamp and allows revalidate; completed terminal review still suppresses and denies revalidate; cancelled reusable issues keep suppression

## Verification

```
pnpm exec vitest run server/src/__tests__/task-watchdogs-scheduler.test.ts
```

Result: 21 passed (21), including the three reopen/suppression cases.

```
test-evidence:
  sha: 043433ffb62f0db1ed5606071ad5adfaede39635
  command: pnpm exec vitest run server/src/__tests__/task-watchdogs-scheduler.test.ts
  exit: 0
  totals: 21 passed (21)
  worktree: /home/sentinel/workspace/techwright/.worktrees/paperclip-TEC-7080 (clean after commit)
  finished_at: 2026-08-21T14:48:57Z
```

## Risks

- Low. Clear only when the reusable watchdog issue is in `todo`/`in_progress`/`in_review` and still carries the matching origin fingerprint.
- Genuine completed reviews stay stamped, including after cancel.
- The UPDATE no-ops if the issue is no longer in a reopen status, so a concurrent terminal stamp survives.

## Model Used

- Provider: xAI (via OpenCode)
- Model ID: xai/grok-4.6
- Context window: large agent session
- Capabilities: code edit, test run, PR authoring

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
