### PR TITLE
fix(cli): FAI-9971 stop worktree:make treating local refs as remotes

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -42,6 +42,8 @@ import {
   resolveWorktreeReseedSource,
   resolveWorktreeReseedTargetPaths,
   resolveGitWorktreeAddArgs,
+  resolveGitWorktreeCreatePlan,
+  prepareWorktreeStartPoint,
   resolvePnpmInstallInvocation,
   resolveCurrentWorktreeEndpoint,
   resolveWorktreeSeedMigrationRevision,
@@ -398,6 +400,111 @@ describe("worktree helpers", () => {
       }),
     ).toEqual(["worktree", "add", "-b", "my-worktree", "/tmp/my-worktree", "origin/main"]);
   });
+
+  it("plans branch-first worktree creation so git never runs the -b code path for new branches", () => {
+    expect(
+      resolveGitWorktreeCreatePlan({ branchName: "wt", targetPath: "/tmp/wt", branchExists: false }),
+    ).toEqual({
+      branchArgs: ["branch", "wt", "HEAD"],
+      addArgs: ["worktree", "add", "/tmp/wt", "wt"],
+    });
+    expect(
+      resolveGitWorktreeCreatePlan({ branchName: "wt", targetPath: "/tmp/wt", branchExists: false, startPoint: "origin/main" }),
+    ).toEqual({
+      branchArgs: ["branch", "wt", "origin/main"],
+      addArgs: ["worktree", "add", "/tmp/wt", "wt"],
+    });
+    expect(
+      resolveGitWorktreeCreatePlan({ branchName: "wt", targetPath: "/tmp/wt", branchExists: true }),
+    ).toEqual({ addArgs: ["worktree", "add", "/tmp/wt", "wt"] });
+    // An explicit start point on an existing branch still has to be rejected by
+    // git, but via `git branch` rather than the `-b` code path.
+    expect(
+      resolveGitWorktreeCreatePlan({ branchName: "wt", targetPath: "/tmp/wt", branchExists: true, startPoint: "origin/main" }),
+    ).toEqual({
+      branchArgs: ["branch", "wt", "origin/main"],
+      addArgs: ["worktree", "add", "/tmp/wt", "wt"],
+    });
+  });
+
+  it("fetches a start point only when its prefix names a configured remote", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-start-point-"));
+    const repo = path.join(root, "repo");
+    const remote = path.join(root, "remote.git");
+    fs.mkdirSync(repo, { recursive: true });
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: repo, stdio: ["ignore", "pipe", "pipe"] }).toString("utf8").trim();
+    try {
+      execFileSync("git", ["init", "-q", "--bare", remote], { stdio: "ignore" });
+      git("init", "-q", "-b", "main");
+      git("config", "user.email", "test@example.com");
+      git("config", "user.name", "Test");
+      fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      const headSha = git("rev-parse", "HEAD");
+      git("branch", "feature/local-only");
+      git("remote", "add", "origin", remote);
+      git("push", "-q", "origin", "main");
+      // Drop the remote-tracking ref so `origin/main` only resolves after a fetch.
+      git("update-ref", "-d", "refs/remotes/origin/main");
+      git("checkout", "-q", "--detach", headSha);
+
+      // Local refs must resolve without any fetch. Pre-fix these were split on
+      // "/" and their first segment fetched as a remote, so `HEAD` died with
+      // `fatal: 'HEAD' does not appear to be a git repository`.
+      for (const localRef of ["HEAD", "main", "feature/local-only", headSha]) {
+        expect(() => prepareWorktreeStartPoint(repo, localRef)).not.toThrow();
+      }
+      expect(fs.existsSync(path.join(repo, ".git", "refs", "remotes", "origin", "main"))).toBe(false);
+
+      // Remote refs keep the documented fetch-then-resolve behaviour.
+      expect(() => prepareWorktreeStartPoint(repo, "origin/main")).not.toThrow();
+      expect(git("rev-parse", "origin/main")).toBe(headSha);
+
+      expect(() => prepareWorktreeStartPoint(repo, "does-not-exist")).toThrow(
+        /not a known local revision/,
+      );
+      expect(() => prepareWorktreeStartPoint(repo, "origin/does-not-exist")).toThrow(
+        /does not exist on remote "origin" after fetch/,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("worktree:make rejects an unknown start point before creating any branch, directory, or worktree", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-start-point-partial-"));
+    const repo = path.join(root, "repo");
+    const home = path.join(root, "home");
+    fs.mkdirSync(repo, { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: repo, stdio: ["ignore", "pipe", "pipe"] }).toString("utf8").trim();
+    const previousCwd = process.cwd();
+    const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(home);
+    try {
+      git("init", "-q", "-b", "main");
+      git("config", "user.email", "test@example.com");
+      git("config", "user.name", "Test");
+      fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      process.chdir(repo);
+
+      await expect(
+        worktreeMakeCommand("fai-9971-bad", { startPoint: "does-not-exist", seed: false } as never),
+      ).rejects.toThrow(/not a known local revision/);
+
+      expect(fs.existsSync(resolveWorktreeMakeTargetPath("fai-9971-bad"))).toBe(false);
+      expect(git("worktree", "list", "--porcelain")).not.toContain("fai-9971-bad");
+      expect(git("branch", "--list", "paperclip-fai-9971-bad")).toBe("");
+    } finally {
+      process.chdir(previousCwd);
+      homedirSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
 
   it("rewrites auth URLs only when they already include a port", () => {
     expect(rewriteLocalUrlPort("http://127.0.0.1:3100", 3110)).toBe("http://127.0.0.1:3110/");

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -537,6 +537,76 @@ function localBranchExists(cwd: string, branchName: string): boolean {
   }
 }
 
+function listGitRemotes(cwd: string): string[] {
+  try {
+    return execFileSync("git", ["remote"], { cwd, stdio: ["ignore", "pipe", "ignore"] })
+      .toString("utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function gitRevisionExists(cwd: string, revision: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "--quiet", `${revision}^{commit}`], {
+      cwd,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify a `--start-point` value. Only refs whose first path segment names a
+ * configured remote (e.g. `origin/main`) are fetched; everything else (`HEAD`,
+ * `main`, `feature/x`, a SHA, `v1.2.3`) is a local revision and is never fetched.
+ */
+function classifyWorktreeStartPoint(
+  startPoint: string,
+  remotes: readonly string[],
+): { kind: "remote"; remote: string } | { kind: "local" } {
+  const slashIndex = startPoint.indexOf("/");
+  if (slashIndex > 0) {
+    const candidate = startPoint.slice(0, slashIndex);
+    if (remotes.includes(candidate)) return { kind: "remote", remote: candidate };
+  }
+  return { kind: "local" };
+}
+
+/**
+ * Resolve an explicit `--start-point` to a commit, fetching first only when the
+ * ref is prefixed with a configured remote. Throws if the ref does not resolve,
+ * so callers can reject a bad start point before creating any branch,
+ * directory, or worktree entry.
+ */
+export function prepareWorktreeStartPoint(cwd: string, startPoint: string): void {
+  const classified = classifyWorktreeStartPoint(startPoint, listGitRemotes(cwd));
+  if (classified.kind === "remote") {
+    try {
+      execFileSync("git", ["fetch", classified.remote], {
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to fetch from remote "${classified.remote}": ${extractExecSyncErrorMessage(error) ?? String(error)}`,
+      );
+    }
+  }
+  if (gitRevisionExists(cwd, startPoint)) return;
+  throw new Error(
+    classified.kind === "remote"
+      ? `Start point "${startPoint}" does not exist on remote "${classified.remote}" after fetch.`
+      : `Start point "${startPoint}" is not a known local revision (branch, tag, commit, or HEAD). `
+        + `Use a remote ref such as "origin/main", or an existing local ref.`,
+  );
+}
+
 export function resolveGitWorktreeAddArgs(input: {
   branchName: string;
   targetPath: string;
@@ -548,6 +618,32 @@ export function resolveGitWorktreeAddArgs(input: {
   }
   const commitish = input.startPoint ?? "HEAD";
   return ["worktree", "add", "-b", input.branchName, input.targetPath, commitish];
+}
+
+/**
+ * Two-step worktree creation plan for `worktree:make`.
+ *
+ * `git worktree add -b <branch> ...` spawns an internal branch-creation step that
+ * fails with `fatal: '$GIT_DIR' too big` on git-for-windows when the common git
+ * dir is deeply nested (observed at 198 chars). Creating the branch first and
+ * then adding the worktree on the existing branch avoids that code path and
+ * behaves identically on other platforms.
+ */
+export function resolveGitWorktreeCreatePlan(input: {
+  branchName: string;
+  targetPath: string;
+  branchExists: boolean;
+  startPoint?: string;
+}): { branchArgs?: string[]; addArgs: string[] } {
+  if (input.branchExists && !input.startPoint) {
+    return { addArgs: ["worktree", "add", input.targetPath, input.branchName] };
+  }
+  // With an explicit start point and an existing branch, `git branch` refuses to
+  // clobber the branch — the same rejection `worktree add -b` produced before.
+  return {
+    branchArgs: ["branch", input.branchName, input.startPoint ?? "HEAD"],
+    addArgs: ["worktree", "add", input.targetPath, input.branchName],
+  };
 }
 
 function readPidFilePort(postmasterPidFile: string): number | null {
@@ -2672,38 +2768,47 @@ export async function worktreeMakeCommand(nameArg: string, opts: WorktreeMakeOpt
     throw new Error(`Target path already exists: ${targetPath}`);
   }
 
-  mkdirSync(path.dirname(targetPath), { recursive: true });
+  // Validate the start point before any filesystem or git mutation so a bad
+  // ref leaves no partial state behind.
   if (startPoint) {
-    const [remote] = startPoint.split("/", 1);
-    try {
-      execFileSync("git", ["fetch", remote], {
-        cwd: sourceCwd,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-    } catch (error) {
-      throw new Error(
-        `Failed to fetch from remote "${remote}": ${extractExecSyncErrorMessage(error) ?? String(error)}`,
-      );
-    }
+    prepareWorktreeStartPoint(sourceCwd, startPoint);
   }
 
-  const worktreeArgs = resolveGitWorktreeAddArgs({
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+
+  const plan = resolveGitWorktreeCreatePlan({
     branchName: name,
     targetPath,
-    branchExists: !startPoint && localBranchExists(sourceCwd, name),
+    branchExists: localBranchExists(sourceCwd, name),
     startPoint,
   });
 
   const spinner = p.spinner();
   spinner.start(`Creating git worktree at ${targetPath}...`);
+  let createdBranch = false;
   try {
-    execFileSync("git", worktreeArgs, {
+    if (plan.branchArgs) {
+      execFileSync("git", plan.branchArgs, {
+        cwd: sourceCwd,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      createdBranch = true;
+    }
+    execFileSync("git", plan.addArgs, {
       cwd: sourceCwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
     spinner.stop(`Created git worktree at ${targetPath}.`);
   } catch (error) {
     spinner.stop(pc.red("Failed to create git worktree."));
+    if (createdBranch) {
+      // Roll back the branch we just created so a failed add leaves no partial state.
+      try {
+        execFileSync("git", ["branch", "-D", name], { cwd: sourceCwd, stdio: "ignore" });
+      } catch {
+        // best effort
+      }
+    }
     throw new Error(extractExecSyncErrorMessage(error) ?? String(error));
   }
 
@@ -4479,7 +4584,7 @@ export function registerWorktreeCommands(program: Command): void {
     .command("worktree:make")
     .description("Create ~/NAME as a git worktree, then initialize an isolated Paperclip instance inside it")
     .argument("<name>", "Worktree name — auto-prefixed with paperclip- if needed (created at ~/paperclip-NAME)")
-    .option("--start-point <ref>", "Remote ref to base the new branch on (env: PAPERCLIP_WORKTREE_START_POINT)")
+    .option("--start-point <ref>", "Ref to base the new branch on: a remote ref like origin/main (fetched first) or a local ref such as HEAD, a branch, tag, or commit (env: PAPERCLIP_WORKTREE_START_POINT)")
     .option("--instance <id>", "Explicit isolated instance id")
     .option("--home <path>", `Home root for worktree instances (env: PAPERCLIP_WORKTREES_DIR, default: ${DEFAULT_WORKTREE_HOME})`)
     .option("--from-config <path>", "Source config.json to seed from")

--- a/docs/deploy/local-development.md
+++ b/docs/deploy/local-development.md
@@ -92,6 +92,14 @@ pnpm paperclipai run
 pnpm paperclipai doctor
 ```
 
+By default the new branch starts at the current `HEAD`. Use `--start-point` to pick a different base. A ref whose first segment names a configured remote is fetched first; every other ref is resolved locally, with no fetch:
+
+```sh
+npx paperclipai worktree:make local-lab --start-point origin/master   # fetches origin, then branches
+npx paperclipai worktree:make local-lab --start-point HEAD            # local ref
+npx paperclipai worktree:make local-lab --start-point 6ef1c733e       # local commit
+```
+
 If the experiment gets noisy, repair or reseed the worktree without touching the main branch:
 
 ```sh


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The CLI gives each agent an isolated checkout through `paperclipai worktree:make`
> - `worktree:make` splits the `--start-point` value on `/` and fetches the first part as a remote name
> - Local refs have no remote prefix, so the command fetches a remote that does not exist and stops
> - An agent that works from a detached HEAD cannot make an isolated worktree at all
> - This pull request fetches only for refs that start with a configured remote, and validates every ref before it changes any state
> - The benefit is that `--start-point HEAD`, a local branch, or a commit SHA now works, and a bad ref leaves no partial state

## Linked Issues or Issue Description

No public issue exists. The bug report follows below.

Related, but a different subsystem and not a duplicate: #5384 fetches origin in the server workspace runtime. This pull request changes the CLI command.

**What happened?**

`paperclipai worktree:make <name> --start-point HEAD` stops with this error:

```
Failed to fetch from remote "HEAD": fatal: 'HEAD' does not appear to be a git repository
```

The command reads every `--start-point` value as `<remote>/<ref>`:

```ts
const [remote] = startPoint.split("/", 1);
execFileSync("git", ["fetch", remote], ...)
```

`String.split("/", 1)` returns the whole value when the value has no `/`. The command therefore fetches a remote named `HEAD`. A local branch name and a bare commit SHA fail the same way. A local branch that contains a `/`, such as `feature/login`, fetches a remote named `feature`.

**Expected behavior**

The command must fetch only when the first part of the ref names a configured remote. `origin/main` must still fetch. `HEAD`, `main`, `feature/login`, `v1.2.3`, and a commit SHA must resolve locally. A ref that does not resolve must stop the command before it creates a directory, a branch, or a worktree entry.

**Steps to reproduce**

1. Open a clean checkout of this repository.
2. Run `git checkout --detach HEAD`.
3. Run `pnpm paperclipai worktree:make my-worktree --start-point HEAD --no-seed`.
4. The command stops with the error above.

**Paperclip version or commit**

`master` at `599ad7016`.

**Deployment mode**

Local self-hosted instance.

**Installation method**

Repository checkout with `pnpm`.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Database mode**

Not applicable. The failure happens before any database access, and it reproduces with `--no-seed`.

**Access context**

Local CLI use by the owner of the checkout.

## What Changed

- `worktree:make` now compares the first part of `--start-point` against the output of `git remote`. It fetches only on a match. All other refs are local refs, and they are never fetched.
- `worktree:make` now verifies the ref with `git rev-parse --verify <ref>^{commit}` before it creates a directory, a branch, or a worktree. A bad ref gets a clear message, and no partial state stays behind.
- `worktree:make` now creates the branch first, then adds the worktree on that branch. It no longer uses `git worktree add -b`. The `-b` form starts an internal branch step that stops with `fatal: '$GIT_DIR' too big` on git for Windows when the common git directory is deeply nested. This was reproduced with a 198 character common directory and git 2.53.0.windows.1. Without this change the reported command still fails after the fetch fix, so both changes ship together.
- `worktree:make` deletes the branch that it created if the worktree add step then fails.
- The `--start-point` help text now says that local refs are accepted.

## Verification

Automated tests, in `cli/src/__tests__/worktree.test.ts`:

- `fetches a start point only when its prefix names a configured remote` builds a real temporary repository and a real local bare remote. It asserts that `HEAD`, `main`, `feature/local-only`, and a commit SHA resolve. It then asserts that `refs/remotes/origin/main` is still absent, which proves that no fetch ran. It asserts that `origin/main` resolves, and that the fetch wrote the tracking ref. It asserts that an unknown local ref and an unknown remote ref give different messages.
- `worktree:make rejects an unknown start point before creating any branch, directory, or worktree` asserts that no directory, no branch, and no worktree entry stays behind.
- `plans branch-first worktree creation ...` covers the argument plan for a new branch, a new branch with a start point, an existing branch, and an existing branch with a start point.

Run them with:

```
cd cli && npx vitest run src/__tests__/worktree.test.ts -t "start point"
```

Both new tests fail against the old logic. This was confirmed by restoring the old helper body:

```
AssertionError: expected [Function] to not throw an error but 'Error: Failed to fetch from remote "H...' was thrown
Error: Failed to fetch from remote "HEAD": fatal: 'HEAD' does not appear to be a git repository
```

Manual check, in the detached checkout that showed the bug:

- `worktree:make pr-verify --start-point HEAD --no-seed` now prints `Created git worktree at ...` and `Worktree ready.`
- `worktree:make pr-badref --start-point does-not-exist --no-seed` now prints `Start point "does-not-exist" is not a known local revision (branch, tag, commit, or HEAD).` No directory, no branch, and no worktree entry was created.

`npx tsc --noEmit` in `cli` reports no error in either changed file. The full `worktree.test.ts` file shows the same 8 pre-existing environment failures before and after the change. Those failures need an embedded Postgres server, which this Windows machine does not run. The passing count goes from 55 to 58.

## Risks

Low risk. The change is limited to the `worktree:make` command in the CLI.

- A ref that is both a local ref and a remote-prefixed ref keeps the old behaviour, because a configured remote name still wins.
- A start point that names an existing branch was rejected before, and it is still rejected. The message now comes from `git branch` instead of from `git worktree add -b`.
- The branch-first order changes which git commands run. `git branch` plus `git worktree add` gives the same result as `git worktree add -b` on all platforms.
- No database change. No API change. No configuration change.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5[1m]`, 1M token context window, extended thinking enabled, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — the branch name and the commit subject carry a tracker id, because the internal merge gate of my team matches on it. Tell me if you want the branch renamed, and I will open a replacement pull request.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
