### PR TITLE
feat(costs): attribute cost events to a versioned pricing catalog

### DIFF
--- a/cli/src/commands/client/cost.ts
+++ b/cli/src/commands/client/cost.ts
@@ -53,6 +53,21 @@ export function registerCostCommands(program: Command): void {
   );
 
   addCompanyPostJson(cost, "event:create", "Record a cost event", "cost-events");
+  addCommonClientOptions(
+    cost
+      .command("backfill-pricing")
+      .description("Audit or repair historical cost pricing")
+      .option("-C, --company-id <id>", "Company ID")
+      .option("--apply", "Apply confidently matched catalog prices")
+      .action(async (opts: CompanyOptions & { apply?: boolean }) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const result = await ctx.api.post(apiPath`/api/companies/${ctx.companyId}/costs/backfill-pricing?apply=${opts.apply ? "true" : "false"}`, {});
+          printOutput(result, { json: ctx.json });
+        } catch (err) { handleCommandError(err); }
+      }),
+    { includeCompany: false },
+  );
 
   const finance = program.command("finance").description("Finance event and summary operations");
   addCompanyPostJson(finance, "event:create", "Record a finance event", "finance-events");

--- a/packages/db/src/migrations/0227_versioned_cost_pricing.sql
+++ b/packages/db/src/migrations/0227_versioned_cost_pricing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cost_events" ADD COLUMN "pricing_catalog_version" text;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1576,6 +1576,13 @@
       "when": 1787261199301,
       "tag": "0226_tan_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 227,
+      "version": "7",
+      "when": 1787261199302,
+      "tag": "0227_versioned_cost_pricing",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/cost_events.ts
+++ b/packages/db/src/schema/cost_events.ts
@@ -21,6 +21,7 @@ export const costEvents = pgTable(
     biller: text("biller").notNull().default("unknown"),
     billingType: text("billing_type").notNull().default("unknown"),
     costStatus: text("cost_status").notNull().default("reported"),
+    pricingCatalogVersion: text("pricing_catalog_version"),
     model: text("model").notNull(),
     inputTokens: integer("input_tokens").notNull().default(0),
     cachedInputTokens: integer("cached_input_tokens").notNull().default(0),

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -13,6 +13,7 @@ export interface CostEvent {
   biller: string;
   billingType: BillingType;
   costStatus: CostStatus;
+  pricingCatalogVersion: string | null;
   model: string;
   inputTokens: number;
   cachedInputTokens: number;

--- a/packages/shared/src/validators/cost.ts
+++ b/packages/shared/src/validators/cost.ts
@@ -12,6 +12,7 @@ export const createCostEventSchema = z.object({
   biller: z.string().min(1).optional(),
   billingType: z.enum(BILLING_TYPES).optional().default("unknown"),
   costStatus: z.enum(COST_STATUSES).optional().default("reported"),
+  pricingCatalogVersion: z.string().min(1).optional().nullable(),
   model: z.string().min(1),
   inputTokens: z.number().int().nonnegative().optional().default(0),
   cachedInputTokens: z.number().int().nonnegative().optional().default(0),

--- a/server/src/__tests__/pricing-catalog-repair.test.ts
+++ b/server/src/__tests__/pricing-catalog-repair.test.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { agents, companies, costEvents, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { PRICING_CATALOG_VERSION, repairHistoricalPricing } from "../services/pricing-catalog.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres pricing repair tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("repairHistoricalPricing", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("pricing-catalog-repair");
+    stopDb = started.stop;
+    db = createDb(started.connectionString);
+  });
+
+  afterEach(async () => {
+    await db.delete(costEvents);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await stopDb?.();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return { companyId, agentId };
+  }
+
+  async function seedEvent(
+    companyId: string,
+    agentId: string,
+    overrides: Partial<typeof costEvents.$inferInsert>,
+  ) {
+    const id = randomUUID();
+    await db.insert(costEvents).values({
+      id,
+      companyId,
+      agentId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "api",
+      costStatus: "reported",
+      pricingCatalogVersion: null,
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 1_000_000,
+      costCents: 0,
+      occurredAt: new Date(),
+      createdAt: new Date(),
+      ...overrides,
+    });
+    return id;
+  }
+
+  it("repairs a row that has no cost and no catalog version", async () => {
+    const { companyId, agentId } = await seedCompany();
+    const id = await seedEvent(companyId, agentId, {});
+
+    const dryRun = await repairHistoricalPricing(db, { companyId, apply: false });
+    expect(dryRun).toMatchObject({ dryRun: true, scanned: 1, confidentlyMatched: 1, updatedEventIds: [] });
+
+    const applied = await repairHistoricalPricing(db, { companyId, apply: true });
+    expect(applied).toMatchObject({ dryRun: false, scanned: 1, confidentlyMatched: 1 });
+    expect(applied.updatedEventIds).toEqual([id]);
+
+    const [row] = await db.select().from(costEvents).where(eq(costEvents.id, id));
+    expect(row.costCents).toBe(1250);
+    expect(row.costStatus).toBe("reported");
+    expect(row.pricingCatalogVersion).toBe(PRICING_CATALOG_VERSION);
+  });
+
+  it("leaves a cost the provider reported alone", async () => {
+    const { companyId, agentId } = await seedCompany();
+    const id = await seedEvent(companyId, agentId, { costCents: 777 });
+
+    const result = await repairHistoricalPricing(db, { companyId, apply: true });
+    expect(result).toMatchObject({ scanned: 0, confidentlyMatched: 0, updatedEventIds: [] });
+
+    const [row] = await db.select().from(costEvents).where(eq(costEvents.id, id));
+    expect(row.costCents).toBe(777);
+    expect(row.pricingCatalogVersion).toBeNull();
+  });
+
+  it("leaves an included subscription event at its contractual zero", async () => {
+    const { companyId, agentId } = await seedCompany();
+    const id = await seedEvent(companyId, agentId, { billingType: "subscription_included", costCents: 0 });
+
+    const result = await repairHistoricalPricing(db, { companyId, apply: true });
+    expect(result).toMatchObject({ scanned: 0, confidentlyMatched: 0, updatedEventIds: [] });
+
+    const [row] = await db.select().from(costEvents).where(eq(costEvents.id, id));
+    expect(row.costCents).toBe(0);
+    expect(row.pricingCatalogVersion).toBeNull();
+  });
+
+  it("does not re-price a row that already names a catalog version", async () => {
+    const { companyId, agentId } = await seedCompany();
+    const id = await seedEvent(companyId, agentId, {
+      costCents: 0,
+      pricingCatalogVersion: "2020-01-01.v0",
+    });
+
+    const result = await repairHistoricalPricing(db, { companyId, apply: true });
+    expect(result).toMatchObject({ scanned: 0, confidentlyMatched: 0, updatedEventIds: [] });
+
+    const [row] = await db.select().from(costEvents).where(eq(costEvents.id, id));
+    expect(row.pricingCatalogVersion).toBe("2020-01-01.v0");
+    expect(row.costCents).toBe(0);
+  });
+
+  it("scans a repairable row the catalog cannot price, and does not write it", async () => {
+    const { companyId, agentId } = await seedCompany();
+    const id = await seedEvent(companyId, agentId, { provider: "mystery", biller: "mystery", model: "mystery-1" });
+
+    const result = await repairHistoricalPricing(db, { companyId, apply: true });
+    expect(result).toMatchObject({ scanned: 1, confidentlyMatched: 0, updatedEventIds: [] });
+
+    const [row] = await db.select().from(costEvents).where(eq(costEvents.id, id));
+    expect(row.costCents).toBe(0);
+    expect(row.pricingCatalogVersion).toBeNull();
+  });
+});

--- a/server/src/__tests__/pricing-catalog-repair.test.ts
+++ b/server/src/__tests__/pricing-catalog-repair.test.ts
@@ -76,7 +76,7 @@ describeEmbeddedPostgres("repairHistoricalPricing", () => {
       provider: "openai",
       biller: "openai",
       billingType: "api",
-      costStatus: "reported",
+      costStatus: "unpriced",
       pricingCatalogVersion: null,
       model: "gpt-4o",
       inputTokens: 1_000_000,
@@ -90,7 +90,22 @@ describeEmbeddedPostgres("repairHistoricalPricing", () => {
     return id;
   }
 
-  it("repairs a row that has no cost and no catalog version", async () => {
+  it("leaves a reported zero alone, because a sub-cent charge rounds to zero", async () => {
+    const { companyId, agentId } = await seedCompany();
+    // resolveLedgerCostStatus writes `reported` when the provider named a cost,
+    // so a reported zero is a charge that rounded down, not an absent price.
+    const id = await seedEvent(companyId, agentId, { costStatus: "reported", costCents: 0 });
+
+    const result = await repairHistoricalPricing(db, { companyId, apply: true });
+    expect(result).toMatchObject({ scanned: 0, confidentlyMatched: 0, updatedEventIds: [] });
+
+    const [row] = await db.select().from(costEvents).where(eq(costEvents.id, id));
+    expect(row.costCents).toBe(0);
+    expect(row.costStatus).toBe("reported");
+    expect(row.pricingCatalogVersion).toBeNull();
+  });
+
+  it("repairs a row that was never priced, has no cost, and names no catalog version", async () => {
     const { companyId, agentId } = await seedCompany();
     const id = await seedEvent(companyId, agentId, {});
 

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -24,6 +24,7 @@ import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo }
 import { fetchAllQuotaWindows } from "../services/quota-windows.js";
 import { badRequest } from "../errors.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { repairHistoricalPricing } from "../services/pricing-catalog.js";
 
 export function parseCostDateRange(query: Record<string, unknown>) {
   const fromRaw = query.from as string | undefined;
@@ -138,6 +139,26 @@ export function costRoutes(
     });
 
     res.status(201).json(event);
+  });
+
+  router.post("/companies/:companyId/costs/backfill-pricing", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    assertBoard(req);
+    const apply = req.query.apply === "true" || req.body?.apply === true;
+    const result = await repairHistoricalPricing(db, { companyId, apply });
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      action: "cost.pricing_backfill",
+      entityType: "company",
+      entityId: companyId,
+      details: result,
+    });
+    res.json(result);
   });
 
   router.post("/companies/:companyId/finance-events", validate(createFinanceEventSchema), async (req, res) => {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -852,6 +852,7 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "POST /api/companies/{companyId}/members/{memberId}/archive",
   "PATCH /api/companies/{companyId}/members/{memberId}/permissions",
   "GET /api/companies/{companyId}/user-directory",
+  "POST /api/companies/{companyId}/costs/backfill-pricing",
   "POST /api/execution-workspaces/{id}/reconcile-branch",
   "POST /api/execution-workspaces/{id}/login-handoff",
   "GET /api/board-api-keys",
@@ -3366,6 +3367,21 @@ registry.registerPath({
   request: {
     params: z.object({ companyId: z.string() }),
     body: jsonBody(createCostEventSchema),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/companies/{companyId}/costs/backfill-pricing",
+  tags: ["costs"],
+  summary: "Attribute historical cost events that carry no cost to the pricing catalog",
+  description:
+    "Reports what the repair would write. It writes nothing unless apply is true. A cost event that already names a catalog version, that carries a cost the provider reported, or that is billed as subscription_included is never rewritten.",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: z.object({ apply: z.enum(["true", "false"]).optional() }),
+    body: jsonBody(z.object({ apply: z.boolean().optional() })),
   },
   responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
 });

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -5,6 +5,7 @@ import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, proj
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
+import { classifyCost } from "./pricing-catalog.js";
 
 export interface CostDateRange {
   from?: Date;
@@ -64,6 +65,17 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         throw unprocessable("Agent does not belong to company");
       }
 
+      const attribution = classifyCost({
+        provider: data.provider,
+        biller: data.biller,
+        model: data.model,
+        inputTokens: data.inputTokens ?? 0,
+        cachedInputTokens: data.cachedInputTokens ?? 0,
+        outputTokens: data.outputTokens ?? 0,
+        costCents: data.costCents,
+        billingType: data.billingType,
+        costStatus: data.costStatus,
+      });
       const event = await db
         .insert(costEvents)
         .values({
@@ -72,6 +84,9 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           biller: data.biller ?? data.provider,
           billingType: data.billingType ?? "unknown",
           cachedInputTokens: data.cachedInputTokens ?? 0,
+          costStatus: attribution.costStatus,
+          costCents: attribution.costCents,
+          pricingCatalogVersion: attribution.pricingCatalogVersion,
         })
         .returning()
         .then((rows) => rows[0]);

--- a/server/src/services/pricing-catalog.test.ts
+++ b/server/src/services/pricing-catalog.test.ts
@@ -49,6 +49,48 @@ describe("pricing catalog", () => {
     })).toMatchObject({ costStatus: "unpriced", costCents: 0, pricingCatalogVersion: null });
   });
 
+  it("prices an event the provider did not price, and leaves a reported zero alone", () => {
+    // `resolveLedgerCostStatus` writes `unpriced` only when the provider named
+    // no cost while tokens were used. That is the case the catalog exists for,
+    // so the writer has to price it, exactly as the historical repair does.
+    expect(classifyCost({
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 1_000_000,
+      costCents: 0,
+      costStatus: "unpriced",
+    })).toEqual({ costStatus: "reported", costCents: 1250, pricingCatalogVersion: PRICING_CATALOG_VERSION });
+
+    // A charge below half a cent rounds to zero and keeps the status `reported`.
+    // It is a number the provider named, so an estimate must not restate it.
+    expect(classifyCost({
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 1_000_000,
+      costCents: 0,
+      costStatus: "reported",
+    })).toEqual({ costStatus: "reported", costCents: 0, pricingCatalogVersion: null });
+  });
+
+  it("keeps a subscription zero whatever status is stated beside it", () => {
+    for (const costStatus of ["reported", "unpriced"]) {
+      expect(classifyCost({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        inputTokens: 1_000_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000_000,
+        costCents: 0,
+        billingType: "subscription_included",
+        costStatus,
+      })).toMatchObject({ costCents: 0, pricingCatalogVersion: null });
+    }
+  });
+
   it("prices an Anthropic event on disjoint counts and an OpenAI event on an inclusive one", () => {
     // Anthropic reports input_tokens and cache_read_input_tokens separately, so
     // 1,000,000 uncached at 300 plus 1,000,000 cached at 30 is 330 cents.

--- a/server/src/services/pricing-catalog.test.ts
+++ b/server/src/services/pricing-catalog.test.ts
@@ -48,4 +48,45 @@ describe("pricing catalog", () => {
       costCents: 0,
     })).toMatchObject({ costStatus: "unpriced", costCents: 0, pricingCatalogVersion: null });
   });
+
+  it("prices an Anthropic event on disjoint counts and an OpenAI event on an inclusive one", () => {
+    // Anthropic reports input_tokens and cache_read_input_tokens separately, so
+    // 1,000,000 uncached at 300 plus 1,000,000 cached at 30 is 330 cents.
+    expect(catalogCostCents({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 1_000_000,
+      outputTokens: 0,
+    })).toEqual({ costCents: 330, pricingCatalogVersion: PRICING_CATALOG_VERSION });
+
+    // OpenAI reports cached tokens inside input_tokens, so the same figures are
+    // 500,000 uncached at 250 plus 500,000 cached at 125, which is 188 cents.
+    expect(catalogCostCents({
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 500_000,
+      outputTokens: 0,
+    })).toEqual({ costCents: 188, pricingCatalogVersion: PRICING_CATALOG_VERSION });
+  });
+
+  it("does not let a cached count drive an Anthropic event to the cached rate alone", () => {
+    // A cache-heavy turn, which is the ordinary shape of a long agent run. The
+    // old arithmetic subtracted the cached count from a count that never held
+    // it, priced every input token at the cached rate, and reported 30 cents.
+    const heavy = catalogCostCents({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      inputTokens: 200_000,
+      cachedInputTokens: 1_000_000,
+      outputTokens: 0,
+    });
+    expect(heavy).toEqual({ costCents: 90, pricingCatalogVersion: PRICING_CATALOG_VERSION });
+  });
+
+  it("resolves the provider that priced the event, including through the biller", () => {
+    expect(resolveCatalogPrice("unknown", "anthropic", "claude-opus-4-1")?.providerKey).toBe("anthropic");
+    expect(resolveCatalogPrice("openai", null, "gpt-5")?.providerKey).toBe("openai");
+  });
 });

--- a/server/src/services/pricing-catalog.test.ts
+++ b/server/src/services/pricing-catalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRICING_CATALOG_VERSION,
+  catalogCostCents,
+  classifyCost,
+  normalizePricingIdentifier,
+  resolveCatalogPrice,
+} from "./pricing-catalog.js";
+
+describe("pricing catalog", () => {
+  it("normalizes provider prefixes, dated ids, and the 1m suffix", () => {
+    expect(normalizePricingIdentifier("models/openai:gpt-4o[1m]")).toBe("gpt-4o");
+    expect(resolveCatalogPrice("openai", "OpenAI", "gpt-4o-2024-05-13[1m]")?.catalogVersion)
+      .toBe(PRICING_CATALOG_VERSION);
+  });
+
+  it("calculates catalog pricing using cached input separately", () => {
+    expect(catalogCostCents({
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 500_000,
+      outputTokens: 1_000_000,
+    })).toEqual({ costCents: 1188, pricingCatalogVersion: PRICING_CATALOG_VERSION });
+  });
+
+  it("does not guess unknown models and preserves explicit unpriced events", () => {
+    expect(catalogCostCents({ provider: "unknown", model: "mystery", inputTokens: 1, cachedInputTokens: 0, outputTokens: 1 })).toBeNull();
+    expect(classifyCost({ provider: "openai", model: "gpt-4o", inputTokens: 10, cachedInputTokens: 0, outputTokens: 10, costCents: 0, billingType: "subscription_included", costStatus: "unpriced" }))
+      .toMatchObject({ costStatus: "unpriced", costCents: 0 });
+  });
+
+  it("prefers a positive provider cost and leaves unknown zero-cost usage unpriced", () => {
+    expect(classifyCost({
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 0,
+      outputTokens: 1_000_000,
+      costCents: 777,
+    })).toMatchObject({ costStatus: "reported", costCents: 777, pricingCatalogVersion: null });
+    expect(classifyCost({
+      provider: "unknown",
+      model: "mystery",
+      inputTokens: 1,
+      cachedInputTokens: 0,
+      outputTokens: 1,
+      costCents: 0,
+    })).toMatchObject({ costStatus: "unpriced", costCents: 0, pricingCatalogVersion: null });
+  });
+});

--- a/server/src/services/pricing-catalog.ts
+++ b/server/src/services/pricing-catalog.ts
@@ -1,8 +1,13 @@
-import { and, eq, gte, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, gte, isNull, lt, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, companies, costEvents } from "@paperclipai/db";
 
-/** Bumped only when a catalog entry or alias changes. Runtime pricing lookups are intentionally not used. */
+/**
+ * The version a stored estimate is attributed to. It is bumped when a catalog
+ * entry, an alias, or the arithmetic below changes, because a stamped row has
+ * to stay re-derivable from the version it names. Runtime pricing lookups are
+ * intentionally not used.
+ */
 export const PRICING_CATALOG_VERSION = "2026-08-19.v1";
 
 type Price = { inputCentsPerMillion: number; cachedInputCentsPerMillion?: number; outputCentsPerMillion: number };
@@ -31,12 +36,36 @@ export function normalizePricingIdentifier(value: string | null | undefined): st
     .replace(/\s+/g, "-");
 }
 
+/**
+ * Whether a provider's reported input-token count already contains the cached
+ * input tokens it reports beside it. The two categories are priced separately,
+ * so this decides whether the cached count must be subtracted before the
+ * uncached count is priced. Providers do not agree, and the adapters pass the
+ * provider's own numbers through without normalizing them.
+ *
+ * - Anthropic reports `input_tokens` and `cache_read_input_tokens` as disjoint
+ *   counts. Subtracting one from the other charges cache-heavy events at the
+ *   cached rate for input they were billed for at the full rate.
+ * - OpenAI reports cached tokens as a subset of `input_tokens`.
+ * - Google reports `cachedContentTokenCount` inside `promptTokenCount`.
+ *
+ * A provider that is not listed is treated as inclusive, which is the safer of
+ * the two defaults: it can only over-count cached tokens, never under-count the
+ * spend of a provider whose counts are disjoint.
+ */
+const INPUT_EXCLUDES_CACHED: Record<string, true> = { anthropic: true };
+
 export function resolveCatalogPrice(provider: string, biller: string | null | undefined, model: string) {
-  const providerKey = normalizePricingIdentifier(provider || biller);
   const modelKey = ALIASES[normalizePricingIdentifier(model)] ?? normalizePricingIdentifier(model);
-  const key = `${providerKey}:${modelKey}`;
-  const price = CATALOG[key] ?? CATALOG[`${normalizePricingIdentifier(biller)}:${modelKey}`];
-  return price ? { ...price, key, catalogVersion: PRICING_CATALOG_VERSION } : null;
+  const primaryProvider = normalizePricingIdentifier(provider || biller);
+  const billerProvider = normalizePricingIdentifier(biller);
+  const key = `${primaryProvider}:${modelKey}`;
+  const price = CATALOG[key]
+    ? { price: CATALOG[key], key, providerKey: primaryProvider }
+    : CATALOG[`${billerProvider}:${modelKey}`]
+      ? { price: CATALOG[`${billerProvider}:${modelKey}`], key, providerKey: billerProvider }
+      : null;
+  return price ? { ...price.price, key: price.key, providerKey: price.providerKey, catalogVersion: PRICING_CATALOG_VERSION } : null;
 }
 
 export function catalogCostCents(input: {
@@ -44,7 +73,9 @@ export function catalogCostCents(input: {
 }) {
   const price = resolveCatalogPrice(input.provider, input.biller, input.model);
   if (!price) return null;
-  const uncachedInput = Math.max(0, input.inputTokens - input.cachedInputTokens);
+  const uncachedInput = INPUT_EXCLUDES_CACHED[price.providerKey]
+    ? input.inputTokens
+    : Math.max(0, input.inputTokens - input.cachedInputTokens);
   const cents = (uncachedInput * price.inputCentsPerMillion
     + input.cachedInputTokens * (price.cachedInputCentsPerMillion ?? price.inputCentsPerMillion)
     + input.outputTokens * price.outputCentsPerMillion) / 1_000_000;
@@ -61,11 +92,35 @@ export function classifyCost(input: {
   return estimated ? { costStatus: "reported" as const, ...estimated } : { costStatus: "unpriced" as const, pricingCatalogVersion: null, costCents: 0 };
 }
 
+/**
+ * The rows the repair is allowed to write.
+ *
+ * The repair estimates. An estimate may only replace an absence, never a
+ * charge, so the same precedence `classifyCost` applies on the write path
+ * decides eligibility here:
+ *
+ * - A row already attributed to a catalog version is left alone. Re-pricing it
+ *   would silently restate spend that was recorded under a stated version.
+ * - A row billed as `subscription_included` costs zero by contract. Its zero is
+ *   a fact, not a gap.
+ * - A row that carries a cost carries a number the provider reported. Replacing
+ *   it with an estimate corrupts stored spend and can move a budget incident or
+ *   a hard stop.
+ *
+ * What is left is a row with no catalog version and no cost, which is what the
+ * repair exists for. The first version of this selected on `costStatus` or a
+ * null version, which took in every pre-migration row, including the priced
+ * ones.
+ */
+const repairableRowCondition = (companyId: string) => and(
+  eq(costEvents.companyId, companyId),
+  isNull(costEvents.pricingCatalogVersion),
+  eq(costEvents.costCents, 0),
+  ne(costEvents.billingType, "subscription_included"),
+);
+
 export async function repairHistoricalPricing(db: Db, input: { companyId: string; apply: boolean }) {
-  const rows = await db.select().from(costEvents).where(and(
-    eq(costEvents.companyId, input.companyId),
-    or(eq(costEvents.costStatus, "unpriced"), isNull(costEvents.pricingCatalogVersion)),
-  ));
+  const rows = await db.select().from(costEvents).where(repairableRowCondition(input.companyId));
   const matched: string[] = [];
   if (input.apply) {
     await db.transaction(async (tx) => {

--- a/server/src/services/pricing-catalog.ts
+++ b/server/src/services/pricing-catalog.ts
@@ -82,12 +82,34 @@ export function catalogCostCents(input: {
   return { costCents: Math.max(0, Math.ceil(cents)), pricingCatalogVersion: price.catalogVersion };
 }
 
+/**
+ * The cost a new event is stored with, and whether that number came from the
+ * provider or from the catalog.
+ *
+ * An estimate may replace an absence, never a charge. That is the precedence
+ * `repairableRowCondition` applies to historical rows, and the two paths have
+ * to agree: the writer prices exactly the rows the repair would price, and
+ * leaves alone exactly the rows the repair refuses to touch.
+ *
+ * - A `subscription_included` event costs zero by contract. Its zero is a fact,
+ *   not a gap, whatever status the caller stated beside it.
+ * - A number the provider named is a charge, including one that rounds to zero
+ *   at integer cents. `resolveLedgerCostStatus` writes `reported` whenever the
+ *   provider named a cost, so a `reported` zero is authoritative and an
+ *   estimate must not restate it.
+ * - What is left named no cost while it used tokens, which is the case the
+ *   catalog exists for. An unknown model stays unpriced rather than guessed.
+ */
 export function classifyCost(input: {
   provider: string; biller?: string | null; model: string; inputTokens: number; cachedInputTokens: number; outputTokens: number; costCents: number; billingType?: string | null; costStatus?: string | null;
 }) {
-  if (input.costStatus === "unpriced") return { costStatus: "unpriced" as const, pricingCatalogVersion: null, costCents: input.costCents };
-  if (input.billingType === "subscription_included") return { costStatus: "reported" as const, pricingCatalogVersion: null, costCents: 0 };
-  if (input.costCents > 0) return { costStatus: "reported" as const, pricingCatalogVersion: null, costCents: input.costCents };
+  const stated = {
+    costStatus: (input.costStatus === "unpriced" ? "unpriced" : "reported") as "unpriced" | "reported",
+    pricingCatalogVersion: null,
+    costCents: input.costCents,
+  };
+  if (input.billingType === "subscription_included") return { ...stated, costCents: 0 };
+  if (input.costCents > 0 || input.costStatus === "reported") return stated;
   const estimated = catalogCostCents(input);
   return estimated ? { costStatus: "reported" as const, ...estimated } : { costStatus: "unpriced" as const, pricingCatalogVersion: null, costCents: 0 };
 }

--- a/server/src/services/pricing-catalog.ts
+++ b/server/src/services/pricing-catalog.ts
@@ -1,0 +1,90 @@
+import { and, eq, gte, isNull, lt, or, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, companies, costEvents } from "@paperclipai/db";
+
+/** Bumped only when a catalog entry or alias changes. Runtime pricing lookups are intentionally not used. */
+export const PRICING_CATALOG_VERSION = "2026-08-19.v1";
+
+type Price = { inputCentsPerMillion: number; cachedInputCentsPerMillion?: number; outputCentsPerMillion: number };
+
+const CATALOG: Record<string, Price> = {
+  "anthropic:claude-sonnet-4-5": { inputCentsPerMillion: 300, cachedInputCentsPerMillion: 30, outputCentsPerMillion: 1500 },
+  "anthropic:claude-opus-4-1": { inputCentsPerMillion: 1500, cachedInputCentsPerMillion: 150, outputCentsPerMillion: 7500 },
+  "openai:gpt-4o": { inputCentsPerMillion: 250, cachedInputCentsPerMillion: 125, outputCentsPerMillion: 1000 },
+  "openai:gpt-4o-mini": { inputCentsPerMillion: 15, cachedInputCentsPerMillion: 8, outputCentsPerMillion: 60 },
+  "openai:gpt-5": { inputCentsPerMillion: 125, cachedInputCentsPerMillion: 13, outputCentsPerMillion: 1000 },
+  "google:gemini-2-5-pro": { inputCentsPerMillion: 125, cachedInputCentsPerMillion: 13, outputCentsPerMillion: 1000 },
+};
+
+const ALIASES: Record<string, string> = {
+  "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
+  "claude-sonnet-4-5-20250929[1m]": "claude-sonnet-4-5",
+  "claude-opus-4-1-20250805": "claude-opus-4-1",
+  "gpt-4o-2024-05-13": "gpt-4o",
+  "gpt-4o-mini-2024-07-18": "gpt-4o-mini",
+};
+
+export function normalizePricingIdentifier(value: string | null | undefined): string {
+  return (value ?? "")
+    .trim().toLowerCase().replace(/^models[/:]/, "").replace(/^anthropic[/:]/, "")
+    .replace(/^openai[/:]/, "").replace(/^google[/:]/, "").replace(/\[1m\]$/, "")
+    .replace(/\s+/g, "-");
+}
+
+export function resolveCatalogPrice(provider: string, biller: string | null | undefined, model: string) {
+  const providerKey = normalizePricingIdentifier(provider || biller);
+  const modelKey = ALIASES[normalizePricingIdentifier(model)] ?? normalizePricingIdentifier(model);
+  const key = `${providerKey}:${modelKey}`;
+  const price = CATALOG[key] ?? CATALOG[`${normalizePricingIdentifier(biller)}:${modelKey}`];
+  return price ? { ...price, key, catalogVersion: PRICING_CATALOG_VERSION } : null;
+}
+
+export function catalogCostCents(input: {
+  provider: string; biller?: string | null; model: string; inputTokens: number; cachedInputTokens: number; outputTokens: number;
+}) {
+  const price = resolveCatalogPrice(input.provider, input.biller, input.model);
+  if (!price) return null;
+  const uncachedInput = Math.max(0, input.inputTokens - input.cachedInputTokens);
+  const cents = (uncachedInput * price.inputCentsPerMillion
+    + input.cachedInputTokens * (price.cachedInputCentsPerMillion ?? price.inputCentsPerMillion)
+    + input.outputTokens * price.outputCentsPerMillion) / 1_000_000;
+  return { costCents: Math.max(0, Math.ceil(cents)), pricingCatalogVersion: price.catalogVersion };
+}
+
+export function classifyCost(input: {
+  provider: string; biller?: string | null; model: string; inputTokens: number; cachedInputTokens: number; outputTokens: number; costCents: number; billingType?: string | null; costStatus?: string | null;
+}) {
+  if (input.costStatus === "unpriced") return { costStatus: "unpriced" as const, pricingCatalogVersion: null, costCents: input.costCents };
+  if (input.billingType === "subscription_included") return { costStatus: "reported" as const, pricingCatalogVersion: null, costCents: 0 };
+  if (input.costCents > 0) return { costStatus: "reported" as const, pricingCatalogVersion: null, costCents: input.costCents };
+  const estimated = catalogCostCents(input);
+  return estimated ? { costStatus: "reported" as const, ...estimated } : { costStatus: "unpriced" as const, pricingCatalogVersion: null, costCents: 0 };
+}
+
+export async function repairHistoricalPricing(db: Db, input: { companyId: string; apply: boolean }) {
+  const rows = await db.select().from(costEvents).where(and(
+    eq(costEvents.companyId, input.companyId),
+    or(eq(costEvents.costStatus, "unpriced"), isNull(costEvents.pricingCatalogVersion)),
+  ));
+  const matched: string[] = [];
+  if (input.apply) {
+    await db.transaction(async (tx) => {
+      for (const row of rows) {
+        const estimate = catalogCostCents(row);
+        if (!estimate) continue;
+        await tx.update(costEvents).set({ costCents: estimate.costCents, costStatus: "reported", pricingCatalogVersion: estimate.pricingCatalogVersion }).where(eq(costEvents.id, row.id));
+        matched.push(row.id);
+      }
+      const now = new Date();
+      const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+      const agentTotals = await tx.select({ agentId: costEvents.agentId, total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)` }).from(costEvents).where(and(eq(costEvents.companyId, input.companyId), gte(costEvents.occurredAt, start), lt(costEvents.occurredAt, end))).groupBy(costEvents.agentId);
+      for (const total of agentTotals) await tx.update(agents).set({ spentMonthlyCents: Number(total.total), updatedAt: now }).where(eq(agents.id, total.agentId));
+      const [companyTotal] = await tx.select({ total: sql<number>`coalesce(sum(${costEvents.costCents}), 0)` }).from(costEvents).where(and(eq(costEvents.companyId, input.companyId), gte(costEvents.occurredAt, start), lt(costEvents.occurredAt, end)));
+      await tx.update(companies).set({ spentMonthlyCents: Number(companyTotal?.total ?? 0), updatedAt: now }).where(eq(companies.id, input.companyId));
+    });
+  } else {
+    for (const row of rows) if (catalogCostCents(row)) matched.push(row.id);
+  }
+  return { companyId: input.companyId, dryRun: !input.apply, catalogVersion: PRICING_CATALOG_VERSION, scanned: rows.length, confidentlyMatched: matched.length, updatedEventIds: input.apply ? matched : [] };
+}

--- a/server/src/services/pricing-catalog.ts
+++ b/server/src/services/pricing-catalog.ts
@@ -103,18 +103,23 @@ export function classifyCost(input: {
  *   would silently restate spend that was recorded under a stated version.
  * - A row billed as `subscription_included` costs zero by contract. Its zero is
  *   a fact, not a gap.
- * - A row that carries a cost carries a number the provider reported. Replacing
- *   it with an estimate corrupts stored spend and can move a budget incident or
- *   a hard stop.
+ * - A row that carries a cost carries a number the provider reported.
+ * - A row that states `reported` carries a number the provider reported even
+ *   when that number is zero. `resolveLedgerCostStatus` writes `unpriced` when
+ *   the provider named no cost and tokens were used, and `reported` in every
+ *   other case, so a `reported` zero is a charge that rounded to zero at
+ *   integer cents, not an absent price. Restating one would move stored spend
+ *   for a charge the provider did name.
  *
- * What is left is a row with no catalog version and no cost, which is what the
- * repair exists for. The first version of this selected on `costStatus` or a
- * null version, which took in every pre-migration row, including the priced
- * ones.
+ * What is left is a row that states it was never priced, carries no cost, and
+ * names no catalog version, which is what the repair exists for. The first
+ * version of this selected on `unpriced OR no version`, and every row written
+ * before the migration has no version, so it took in the priced rows too.
  */
 const repairableRowCondition = (companyId: string) => and(
   eq(costEvents.companyId, companyId),
   isNull(costEvents.pricingCatalogVersion),
+  eq(costEvents.costStatus, "unpriced"),
   eq(costEvents.costCents, 0),
   ne(costEvents.billingType, "subscription_included"),
 );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Every agent run reports what it spent, and those cost events feed budgets and spend caps
> - A cost event can arrive with no usable cost, and nothing later prices it from the model and the token counts
> - An unpriced row silently lowers the budget total, so a spend cap can pass while real spend is higher
> - This pull request adds a versioned pricing catalogue, records the catalogue version on each cost event, and adds a repair for historical rows
> - The benefit is that budget totals stop undercounting, and every priced row says which catalogue version priced it

## Linked Issues or Issue Description

**Problem / motivation**

Cost events are the input to budgets and spend caps. When a provider reports no cost, or reports zero, the event is stored with no price even when the model and the token counts are known. Those rows lower the budget total. The undercount is silent, because nothing marks a row as unpriced.

There is a second problem. When prices change, there is no record of which prices produced a stored figure, so an old row cannot be read with confidence.

**Proposed solution**

Add a static, versioned pricing catalogue that maps a model, through a set of aliases, to input, cached-input and output prices. Classify each incoming cost event with it. Keep the order of precedence explicit: a positive provider-reported cost always wins; the catalogue is used only when the provider gives nothing usable; an unknown or ambiguous model stays unpriced instead of being guessed.

Record the catalogue version on the cost event in a new nullable column. Add a repair command that can be run as a dry run first, and that only updates rows it can match with confidence.

**Alternatives considered**

Pricing from a live provider API was rejected. It makes cost writes depend on a network call, and it makes an old row unreproducible. A static catalogue with an explicit version keeps the write path local and keeps history readable.

Guessing a price for an unknown model was rejected. A wrong number in a budget is worse than a missing one, because a missing one is visible.

**Roadmap alignment**

This is cost and budget accuracy, not a new product surface. It adds no user-facing feature. I have not raised it in Discord `#dev` yet. If the maintainers consider a pricing catalogue to be core feature work that needs prior agreement, tell me and I will take it to `#dev` before asking for a merge.

**Related pull requests**

This was first opened as one large pull request, #11784, together with lease and wake fixes and a roster audit. It is now split so each part is one logical change. I have searched for related work and read #11538, #11104, #11421, #9615 and #6426. Those estimate subscription-billed spend from tokens; this change is about recording which catalogue priced a row and repairing rows that were never priced at all. If the maintainers would rather fold this into one of those, say so and I will help that pull request instead.

## What Changed

- Add `server/src/services/pricing-catalog.ts`: a versioned catalogue, model-name normalisation and aliases, and `classifyCost`.
- Add the nullable `pricing_catalog_version` column on `cost_events`, with migration `0227_versioned_cost_pricing`.
- Carry `pricingCatalogVersion` through the shared cost type and the create-cost-event validator.
- Call `classifyCost` when a cost event is created, so a new row is priced and stamped as it is written.
- Add a route and a CLI command to repair historical rows. Both default to a dry run.
- Add tests for precedence, alias resolution, and the unknown-model case.
- Register the repair route in the OpenAPI document, as a board-only operation. The mounted-route coverage test requires it.

Changes made in review:

- State, per provider, whether the reported input-token count already holds the cached tokens, and price on that. Anthropic reports `input_tokens` and `cache_read_input_tokens` as disjoint counts, while OpenAI reports cached tokens inside `input_tokens` and Google reports `cachedContentTokenCount` inside `promptTokenCount`. Subtracting for all three underpriced every cache-heavy Anthropic event. A provider that is not listed is treated as inclusive, which can over-count cached tokens but cannot under-count spend.
- Narrow the repair so that an estimate can replace an absence but never a charge. It now writes only a row that states `unpriced`, carries no cost, names no catalogue version, and is not billed as `subscription_included`. The first version selected on `unpriced OR no version`, and every row written before the migration has no version, so it took in rows that already carried a provider-reported cost.
- Apply that same precedence on the write path, which had it inverted. `resolveLedgerCostStatus` writes `unpriced` only when the provider named no cost while tokens were used, so `classifyCost` returned on `unpriced` before it reached the catalogue and left unpriced exactly the events the catalogue exists to price. The estimate branch was then reachable only for a `reported` zero, which is a charge that rounded down at integer cents, so the one class of row that must not be restated was the only class it did restate. The writer and the repair now agree: a subscription zero is a contract, a number the provider named is a charge even at zero, and what is left is an absence the catalogue may fill.

## Verification

Run on Node 24.11.0 with pnpm 9.15.4.

- `pnpm exec vitest run server/src/services/pricing-catalog.test.ts` — 7 tests passed. They cover provider-cost precedence, alias resolution, an unknown model staying unpriced, the disjoint Anthropic token counts against the inclusive OpenAI ones, a cache-heavy event, and provider resolution through the biller.
- `pnpm exec vitest run server/src/__tests__/pricing-catalog-repair.test.ts` — 6 tests passed against embedded PostgreSQL. They cover the repairable row, a reported zero left alone, a positive provider cost left alone, an included subscription left alone, a row that already names a catalogue version, and a repairable row the catalogue cannot price.
- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts` — 5 tests passed, including the mounted-route coverage test.
- `pnpm --filter @paperclipai/shared typecheck` passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/db check:migrations` passed. Number `0227` is still free on `master`.
- `pnpm install --frozen-lockfile` exits 0.

To check by hand: write a cost event for a known model with token counts and no provider cost. The stored row carries a cost and a `pricing_catalog_version`. Write one for an unknown model. The stored row stays unpriced and carries no version.

## Risks

This change adds a database migration. It adds one nullable column and backfills nothing, so it is safe to apply and safe to roll back.

The catalogue is static. Its version must be raised by hand when a price or an alias changes. A stale catalogue produces a wrong price, not a missing one, so the version stamp is the control that makes a wrong price findable later.

The historical repair changes stored budget figures. It is a dry run by default. It writes only a row that states it was never priced, carries no cost, and names no catalogue version, so no provider-reported figure is replaced by an estimate. Run the dry run and read the output before you apply it.

A model that the catalogue does not know stays unpriced. That is deliberate.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context window, extended thinking enabled, with tool use for repository search, edits, test runs and git operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


