### PR TITLE
feat(agents): add a read-only roster drift audit

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -328,6 +328,23 @@ export function registerAgentCommands(program: Command): void {
 
   addCommonClientOptions(
     agent
+      .command("audit-roster")
+      .description("Compare the configured agent roster with live agents")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .option("--manifest <json>", "Repository roster manifest as JSON")
+      .action(async (opts: AgentListOptions & { manifest?: string }) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const query = opts.manifest ? `?manifest=${encodeURIComponent(opts.manifest)}` : "";
+          const result = await ctx.api.get(apiPath`/api/companies/${ctx.companyId}/agents/audit-roster${query}`);
+          printOutput(result, { json: ctx.json });
+        } catch (err) { handleCommandError(err); }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
       .command("get")
       .description("Get one agent")
       .argument("<agentId>", "Agent ID")

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2,7 +2,7 @@ import { Router, type NextFunction, type Request, type Response } from "express"
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
-import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
+import { agents as agentsTable, companies, costEvents, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
 import {
   agentSkillSyncSchema,
@@ -68,6 +68,7 @@ import {
   collectAgentAdapterWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { auditRoster, type RosterManifestEntry } from "../services/roster-audit.js";
 import { environmentService } from "../services/environments.js";
 import { resolveEnvironmentExecutionTarget } from "../services/environment-execution-target.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
@@ -2831,6 +2832,24 @@ export function agentRoutes(
       res.json(snapshot);
     },
   );
+
+  router.get("/companies/:companyId/agents/audit-roster", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    assertBoard(req);
+    let manifest: RosterManifestEntry[] = [];
+    const rawManifest = typeof req.query.manifest === "string" ? req.query.manifest : process.env.PAPERCLIP_AGENT_MANIFEST;
+    if (rawManifest) {
+      try {
+        const parsed = JSON.parse(rawManifest);
+        manifest = Array.isArray(parsed) ? parsed.filter((entry): entry is RosterManifestEntry => entry && typeof entry.name === "string") : [];
+      } catch { res.status(400).json({ error: "manifest must be a JSON array" }); return; }
+    }
+    const live = await db.select({ id: agentsTable.id, name: agentsTable.name, role: agentsTable.role, status: agentsTable.status }).from(agentsTable).where(eq(agentsTable.companyId, companyId));
+    const costRows = await db.select({ agentId: costEvents.agentId }).from(costEvents).where(eq(costEvents.companyId, companyId)).groupBy(costEvents.agentId);
+    const costIds = new Set(costRows.map((row) => row.agentId));
+    res.json(auditRoster(manifest, live.map((agent) => ({ ...agent, hasCostHistory: costIds.has(agent.id) }))));
+  });
 
   router.get("/companies/:companyId/agents", async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -68,7 +68,7 @@ import {
   collectAgentAdapterWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
-import { auditRoster, type RosterManifestEntry } from "../services/roster-audit.js";
+import { auditRoster, parseRosterManifest, type RosterManifestEntry } from "../services/roster-audit.js";
 import { environmentService } from "../services/environments.js";
 import { resolveEnvironmentExecutionTarget } from "../services/environment-execution-target.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
@@ -2840,10 +2840,13 @@ export function agentRoutes(
     let manifest: RosterManifestEntry[] = [];
     const rawManifest = typeof req.query.manifest === "string" ? req.query.manifest : process.env.PAPERCLIP_AGENT_MANIFEST;
     if (rawManifest) {
+      let parsed: unknown;
       try {
-        const parsed = JSON.parse(rawManifest);
-        manifest = Array.isArray(parsed) ? parsed.filter((entry): entry is RosterManifestEntry => entry && typeof entry.name === "string") : [];
+        parsed = JSON.parse(rawManifest);
       } catch { res.status(400).json({ error: "manifest must be a JSON array" }); return; }
+      const result = parseRosterManifest(parsed);
+      if (!result.ok) { res.status(400).json({ error: result.error }); return; }
+      manifest = result.manifest;
     }
     const live = await db.select({ id: agentsTable.id, name: agentsTable.name, role: agentsTable.role, status: agentsTable.status }).from(agentsTable).where(eq(agentsTable.companyId, companyId));
     const costRows = await db.select({ agentId: costEvents.agentId }).from(costEvents).where(eq(costEvents.companyId, companyId)).groupBy(costEvents.agentId);

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -852,6 +852,7 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "POST /api/companies/{companyId}/members/{memberId}/archive",
   "PATCH /api/companies/{companyId}/members/{memberId}/permissions",
   "GET /api/companies/{companyId}/user-directory",
+  "GET /api/companies/{companyId}/agents/audit-roster",
   "POST /api/execution-workspaces/{id}/reconcile-branch",
   "POST /api/execution-workspaces/{id}/login-handoff",
   "GET /api/board-api-keys",
@@ -1686,6 +1687,25 @@ registry.registerPath({
   summary: "List agents in a company",
   request: { params: z.object({ companyId: z.string() }) },
   responses: { 200: r.ok(), 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/companies/{companyId}/agents/audit-roster",
+  tags: ["agents"],
+  summary: "Compare the configured agent roster with the live agents of a company",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: z.object({
+      manifest: z
+        .string()
+        .optional()
+        .describe(
+          "Repository roster manifest as a JSON array of objects with a name, an optional id, and an optional role. The server reads the PAPERCLIP_AGENT_MANIFEST environment variable when this is absent.",
+        ),
+    }),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
 });
 
 registry.registerPath({

--- a/server/src/services/roster-audit.test.ts
+++ b/server/src/services/roster-audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { auditRoster } from "./roster-audit.js";
+import { auditRoster, parseRosterManifest } from "./roster-audit.js";
 
 describe("roster audit", () => {
   it("reports drift without recommending destructive actions", () => {
@@ -15,5 +15,106 @@ describe("roster audit", () => {
     expect(report.agentsWithNoCostHistory).toHaveLength(1);
     expect(report.agentsInError).toHaveLength(1);
     expect(report.remediation.action).toBe("operator_review_only");
+  });
+
+  it("counts a matched agent once, so a roster that agrees reports no duplicate role", () => {
+    const report = auditRoster(
+      [{ id: "a-1", name: "CEO", role: "lead" }, { name: "Engineer", role: "engineer" }],
+      [
+        { id: "a-1", name: "CEO", role: "lead", status: "idle", hasCostHistory: true },
+        { id: "a-2", name: "Engineer", role: "engineer", status: "idle", hasCostHistory: true },
+      ],
+    );
+    expect(report.duplicateRoleFamilies).toEqual([]);
+    expect(report.repoOnlyAgents).toEqual([]);
+    expect(report.dbOnlyAgents).toEqual([]);
+  });
+
+  it("still reports a role two distinct agents hold", () => {
+    const report = auditRoster(
+      [{ id: "a-1", name: "First", role: "engineer" }],
+      [
+        { id: "a-1", name: "First", role: "engineer", status: "idle", hasCostHistory: true },
+        { id: "a-2", name: "Second", role: "Engineer", status: "idle", hasCostHistory: true },
+      ],
+    );
+    expect(report.duplicateRoleFamilies).toEqual([{ role: "engineer", count: 2 }]);
+  });
+
+  it("reports a stale manifest id on both sides, even when the name still agrees", () => {
+    const report = auditRoster(
+      [{ id: "stale-id", name: "CEO", role: "lead" }],
+      [{ id: "live-id", name: "CEO", role: "lead", status: "idle", hasCostHistory: true }],
+    );
+    expect(report.repoOnlyAgents).toEqual([{ id: "stale-id", name: "CEO", role: "lead" }]);
+    expect(report.dbOnlyAgents.map((agent) => agent.id)).toEqual(["live-id"]);
+  });
+
+  it("matches on name only when one live agent carries it", () => {
+    const ambiguous = auditRoster(
+      [{ name: "Engineer", role: "engineer" }],
+      [
+        { id: "a-1", name: "Engineer", role: "engineer", status: "idle", hasCostHistory: true },
+        { id: "a-2", name: "engineer", role: "engineer", status: "idle", hasCostHistory: true },
+      ],
+    );
+    expect(ambiguous.repoOnlyAgents).toHaveLength(1);
+    expect(ambiguous.dbOnlyAgents.map((agent) => agent.id)).toEqual(["a-1", "a-2"]);
+
+    const unambiguous = auditRoster(
+      [{ name: " engineer " }],
+      [{ id: "a-1", name: "Engineer", role: "engineer", status: "idle", hasCostHistory: true }],
+    );
+    expect(unambiguous.repoOnlyAgents).toEqual([]);
+    expect(unambiguous.dbOnlyAgents).toEqual([]);
+  });
+});
+
+describe("roster manifest validation", () => {
+  it("accepts a well formed manifest", () => {
+    const result = parseRosterManifest([
+      { name: "CEO", id: "a-1", role: "lead" },
+      { name: "Engineer", role: null },
+      { name: "Designer" },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      manifest: [
+        { id: "a-1", name: "CEO", role: "lead" },
+        { name: "Engineer", role: null },
+        { name: "Designer" },
+      ],
+    });
+  });
+
+  it("refuses a root that is not an array", () => {
+    for (const value of [{ name: "CEO" }, "CEO", 7, null]) {
+      expect(parseRosterManifest(value)).toEqual({ ok: false, error: "manifest must be a JSON array" });
+    }
+  });
+
+  it("refuses a member that is not an object", () => {
+    expect(parseRosterManifest(["CEO"])).toEqual({ ok: false, error: "manifest entry 0 must be an object" });
+    expect(parseRosterManifest([null])).toEqual({ ok: false, error: "manifest entry 0 must be an object" });
+    expect(parseRosterManifest([[]])).toEqual({ ok: false, error: "manifest entry 0 must be an object" });
+  });
+
+  it("refuses a member whose name, id, or role has the wrong type", () => {
+    expect(parseRosterManifest([{ name: 7 }]).ok).toBe(false);
+    expect(parseRosterManifest([{ name: "   " }]).ok).toBe(false);
+    expect(parseRosterManifest([{ name: "CEO", id: 7 }]).ok).toBe(false);
+    expect(parseRosterManifest([{ name: "CEO", id: "" }]).ok).toBe(false);
+    // This one reached role.trim() on a number and answered the operator with a 500.
+    expect(parseRosterManifest([{ name: "A", role: 123 }])).toEqual({
+      ok: false,
+      error: "manifest entry 0 must have a role that is a string, or null, or no role",
+    });
+  });
+
+  it("names the entry that is at fault", () => {
+    expect(parseRosterManifest([{ name: "CEO" }, { role: "engineer" }])).toEqual({
+      ok: false,
+      error: "manifest entry 1 must have a name that is a string and is not empty",
+    });
   });
 });

--- a/server/src/services/roster-audit.test.ts
+++ b/server/src/services/roster-audit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { auditRoster } from "./roster-audit.js";
+
+describe("roster audit", () => {
+  it("reports drift without recommending destructive actions", () => {
+    const report = auditRoster(
+      [{ id: "repo-1", name: "CEO", role: "lead" }, { name: "Missing", role: "engineer" }],
+      [
+        { id: "repo-1", name: "CEO", role: "lead", status: "idle", hasCostHistory: true },
+        { id: "db-1", name: "Live", role: "engineer", status: "error", hasCostHistory: false },
+      ],
+    );
+    expect(report.repoOnlyAgents).toHaveLength(1);
+    expect(report.dbOnlyAgents).toHaveLength(1);
+    expect(report.agentsWithNoCostHistory).toHaveLength(1);
+    expect(report.agentsInError).toHaveLength(1);
+    expect(report.remediation.action).toBe("operator_review_only");
+  });
+});

--- a/server/src/services/roster-audit.test.ts
+++ b/server/src/services/roster-audit.test.ts
@@ -50,6 +50,24 @@ describe("roster audit", () => {
     expect(report.dbOnlyAgents.map((agent) => agent.id)).toEqual(["live-id"]);
   });
 
+  it("reports a manifest that lists one agent twice, by id or by name", () => {
+    const byId = auditRoster(
+      [{ id: "a-1", name: "CEO", role: "lead" }, { id: "a-1", name: "CEO copy", role: "lead" }],
+      [{ id: "a-1", name: "CEO", role: "lead", status: "idle", hasCostHistory: true }],
+    );
+    expect(byId.repoOnlyAgents).toEqual([{ id: "a-1", name: "CEO copy", role: "lead" }]);
+    expect(byId.dbOnlyAgents).toEqual([]);
+    expect(byId.duplicateRoleFamilies).toEqual([{ role: "lead", count: 2 }]);
+
+    const byName = auditRoster(
+      [{ name: "CEO", role: "lead" }, { name: " ceo ", role: "lead" }],
+      [{ id: "a-1", name: "CEO", role: "lead", status: "idle", hasCostHistory: true }],
+    );
+    expect(byName.repoOnlyAgents).toEqual([{ name: " ceo ", role: "lead" }]);
+    expect(byName.dbOnlyAgents).toEqual([]);
+    expect(byName.duplicateRoleFamilies).toEqual([{ role: "lead", count: 2 }]);
+  });
+
   it("matches on name only when one live agent carries it", () => {
     const ambiguous = auditRoster(
       [{ name: "Engineer", role: "engineer" }],

--- a/server/src/services/roster-audit.ts
+++ b/server/src/services/roster-audit.ts
@@ -72,15 +72,19 @@ export function auditRoster(manifest: RosterManifestEntry[], live: LiveRosterEnt
   for (const entry of manifest) {
     const byName = liveByName.get(normalizeName(entry.name)) ?? [];
     const match = entry.id ? liveById.get(entry.id) : byName.length === 1 ? byName[0] : undefined;
-    if (!match) {
+    // One live agent answers for one manifest entry. A second entry that claims
+    // an agent an earlier entry already claimed is a duplicate listing, which is
+    // drift in its own right. Letting it match as well would hide it from both
+    // lists and drop the role it declares.
+    if (!match || matchedLiveIds.has(match.id)) {
       repoOnlyAgents.push(entry);
       countRole(entry.role);
       continue;
     }
+    matchedLiveIds.add(match.id);
     // The live role is the role the agent holds now. What the repository intends
     // for it is a different question, and the drift lists answer that one.
-    if (!matchedLiveIds.has(match.id)) countRole(match.role);
-    matchedLiveIds.add(match.id);
+    countRole(match.role);
   }
 
   const dbOnlyAgents = live.filter((agent) => !matchedLiveIds.has(agent.id));

--- a/server/src/services/roster-audit.ts
+++ b/server/src/services/roster-audit.ts
@@ -1,16 +1,91 @@
 export type RosterManifestEntry = { id?: string; name: string; role?: string | null };
 export type LiveRosterEntry = { id: string; name: string; role: string | null; status: string; hasCostHistory: boolean };
 
-export function auditRoster(manifest: RosterManifestEntry[], live: LiveRosterEntry[]) {
-  const names = new Set(manifest.map((entry) => entry.name.trim().toLowerCase()));
-  const ids = new Set(manifest.flatMap((entry) => entry.id ? [entry.id] : []));
-  const dbOnlyAgents = live.filter((agent) => !ids.has(agent.id) && !names.has(agent.name.trim().toLowerCase()));
-  const repoOnlyAgents = manifest.filter((entry) => !live.some((agent) => (entry.id && entry.id === agent.id) || entry.name.trim().toLowerCase() === agent.name.trim().toLowerCase()));
-  const roleCounts = new Map<string, number>();
-  for (const entry of [...manifest, ...live]) {
-    const role = (entry.role ?? "general").trim().toLowerCase();
-    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
+const normalizeName = (name: string) => name.trim().toLowerCase();
+const normalizeRole = (role: string | null | undefined) => (role ?? "general").trim().toLowerCase();
+
+/**
+ * Validate a roster manifest that arrives as untrusted JSON.
+ *
+ * The audit reads `name`, `id` and `role` off every member. A member that does
+ * not carry those in the expected shape must be refused here, because the two
+ * alternatives are both wrong: dropping it without a word understates the drift
+ * the report exists to show, and letting it through reaches `role.trim()` on a
+ * number and answers a read-only operator query with a 500.
+ */
+export function parseRosterManifest(
+  value: unknown,
+): { ok: true; manifest: RosterManifestEntry[] } | { ok: false; error: string } {
+  if (!Array.isArray(value)) return { ok: false, error: "manifest must be a JSON array" };
+  const manifest: RosterManifestEntry[] = [];
+  for (const [index, member] of value.entries()) {
+    if (typeof member !== "object" || member === null || Array.isArray(member)) {
+      return { ok: false, error: `manifest entry ${index} must be an object` };
+    }
+    const entry = member as Record<string, unknown>;
+    if (typeof entry.name !== "string" || entry.name.trim() === "") {
+      return { ok: false, error: `manifest entry ${index} must have a name that is a string and is not empty` };
+    }
+    if (entry.id !== undefined && (typeof entry.id !== "string" || entry.id.trim() === "")) {
+      return { ok: false, error: `manifest entry ${index} must have an id that is a string and is not empty, or no id` };
+    }
+    if (entry.role !== undefined && entry.role !== null && typeof entry.role !== "string") {
+      return { ok: false, error: `manifest entry ${index} must have a role that is a string, or null, or no role` };
+    }
+    manifest.push({
+      ...(entry.id === undefined ? {} : { id: entry.id as string }),
+      name: entry.name,
+      ...(entry.role === undefined ? {} : { role: entry.role as string | null }),
+    });
   }
+  return { ok: true, manifest };
+}
+
+/**
+ * Compare a repository roster manifest with the live agents of one company.
+ *
+ * A manifest entry matches by identifier when it states one, and by normalized
+ * name when it does not. A stated identifier is authoritative: an entry that
+ * points at an identifier no live agent holds is drift, and a name that still
+ * agrees must not conceal it. A name matches only when exactly one live agent
+ * carries it, because two agents of one name cannot tell an operator which of
+ * them the entry meant.
+ */
+export function auditRoster(manifest: RosterManifestEntry[], live: LiveRosterEntry[]) {
+  const liveById = new Map(live.map((agent) => [agent.id, agent]));
+  const liveByName = new Map<string, LiveRosterEntry[]>();
+  for (const agent of live) {
+    const key = normalizeName(agent.name);
+    liveByName.set(key, [...(liveByName.get(key) ?? []), agent]);
+  }
+
+  const matchedLiveIds = new Set<string>();
+  const repoOnlyAgents: RosterManifestEntry[] = [];
+  // A matched pair is one agent, not two. Counting both representations is what
+  // reported every ordinary one-to-one roster as a duplicate role family.
+  const roleCounts = new Map<string, number>();
+  const countRole = (role: string | null | undefined) => {
+    const key = normalizeRole(role);
+    roleCounts.set(key, (roleCounts.get(key) ?? 0) + 1);
+  };
+
+  for (const entry of manifest) {
+    const byName = liveByName.get(normalizeName(entry.name)) ?? [];
+    const match = entry.id ? liveById.get(entry.id) : byName.length === 1 ? byName[0] : undefined;
+    if (!match) {
+      repoOnlyAgents.push(entry);
+      countRole(entry.role);
+      continue;
+    }
+    // The live role is the role the agent holds now. What the repository intends
+    // for it is a different question, and the drift lists answer that one.
+    if (!matchedLiveIds.has(match.id)) countRole(match.role);
+    matchedLiveIds.add(match.id);
+  }
+
+  const dbOnlyAgents = live.filter((agent) => !matchedLiveIds.has(agent.id));
+  for (const agent of dbOnlyAgents) countRole(agent.role);
+
   return {
     dbOnlyAgents,
     repoOnlyAgents,

--- a/server/src/services/roster-audit.ts
+++ b/server/src/services/roster-audit.ts
@@ -1,0 +1,22 @@
+export type RosterManifestEntry = { id?: string; name: string; role?: string | null };
+export type LiveRosterEntry = { id: string; name: string; role: string | null; status: string; hasCostHistory: boolean };
+
+export function auditRoster(manifest: RosterManifestEntry[], live: LiveRosterEntry[]) {
+  const names = new Set(manifest.map((entry) => entry.name.trim().toLowerCase()));
+  const ids = new Set(manifest.flatMap((entry) => entry.id ? [entry.id] : []));
+  const dbOnlyAgents = live.filter((agent) => !ids.has(agent.id) && !names.has(agent.name.trim().toLowerCase()));
+  const repoOnlyAgents = manifest.filter((entry) => !live.some((agent) => (entry.id && entry.id === agent.id) || entry.name.trim().toLowerCase() === agent.name.trim().toLowerCase()));
+  const roleCounts = new Map<string, number>();
+  for (const entry of [...manifest, ...live]) {
+    const role = (entry.role ?? "general").trim().toLowerCase();
+    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
+  }
+  return {
+    dbOnlyAgents,
+    repoOnlyAgents,
+    duplicateRoleFamilies: [...roleCounts].filter(([, count]) => count > 1).map(([role, count]) => ({ role, count })),
+    agentsWithNoCostHistory: live.filter((agent) => !agent.hasCostHistory),
+    agentsInError: live.filter((agent) => agent.status === "error"),
+    remediation: { action: "operator_review_only", note: "No agents were deleted, terminated, or quarantined." },
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - An instance builds a roster of agents over time, and that roster drifts away from what the operator expects
> - An agent can exist in the database but not in the operator's manifest, or sit in an error state, or never report any cost
> - Finding that drift today needs manual database inspection, which operators do rarely and inconsistently
> - This pull request adds a read-only audit that reports the drift through an endpoint and a CLI command
> - The benefit is that an operator can see roster drift without opening a database console, and the audit itself changes nothing

## Linked Issues or Issue Description

**Problem / motivation**

There is no supported way to answer simple operational questions about a roster. An operator who wants to know which agents exist in the database but not in their own manifest, which agents are stuck in an error state, or which agents have never produced a cost event, has to query the database by hand.

Because it is awkward, it is not done, and a roster quietly accumulates agents that nobody meant to keep.

**Proposed solution**

Add a read-only audit that takes an optional manifest and reports five things: agents only in the database, agents only in the manifest, duplicate role families, agents with no cost history, and agents in an error state.

The audit is a report. It deletes nothing, terminates nothing and quarantines nothing. The response says so explicitly in a `remediation` field, so an operator or an agent reading the output cannot mistake it for an action.

**Alternatives considered**

Adding automatic cleanup was rejected. Deciding that an agent is unwanted needs a person. A report that a person acts on is the right first step, and it can be built on later.

**Roadmap alignment**

This is an additive read-only operator surface. It changes no existing behaviour and adds no migration.

**Related pull requests**

This was first opened as one large pull request, #11784, together with lease and wake fixes and a pricing catalogue. It is now split so each part is one logical change. I searched for existing roster or agent audit work and found none that overlaps. #9740 adds runtime and wake audit attribution, which is a different subject.

## What Changed

- Add `server/src/services/roster-audit.ts` with a pure `auditRoster` function.
- Add `GET /companies/:companyId/agents/audit-roster`. It requires company access and board authority, and it accepts an optional manifest as a JSON array, from the query string or from the `PAPERCLIP_AGENT_MANIFEST` environment variable.
- Add a CLI command that calls the endpoint.
- Match a manifest entry to a live agent by id when an id is given, and otherwise by name, compared case-insensitively and with surrounding spaces removed.
- Add a test for the drift categories.
- Register the route in the OpenAPI document, as a board-only operation. The mounted-route coverage test requires it.

Changes made in review:

- Reconcile the two sides into matched pairs before counting roles, and count each distinct agent once. Walking the manifest and the live rows as one list counted a matched agent twice, so every roster that agreed with its manifest reported all of its roles as duplicate families.
- Treat an identifier the manifest states as authoritative. An entry that names an identifier no live agent holds is roster-only, and the live agent whose name it shadowed is database-only, so an identifier mismatch shows on both sides instead of being hidden by the name.
- Match on a name only when exactly one live agent carries it, and let one live agent answer for one manifest entry. A second entry that claims an agent an earlier entry already claimed is roster-only, so a manifest that lists one agent twice is reported instead of disappearing.
- Validate the manifest as a whole and return `400` naming the entry at fault. A non-array root became an empty manifest and reported the whole live roster as drift, a malformed member was dropped without a word, and an entry such as `{"name":"A","role":123}` reached `role.trim()` and returned `500`.

## Verification

Run on Node 24.11.0 with pnpm 9.15.4.

- `pnpm exec vitest run server/src/services/roster-audit.test.ts` — 11 tests passed. They cover the drift categories, a matched roster reporting no duplicate role, a role two distinct agents really hold, a stale manifest identifier showing on both sides, an ambiguous name, a manifest that lists one agent twice by identifier and by name, and the manifest validation cases.
- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts` — 5 tests passed, including the mounted-route coverage test.
- `pnpm --filter @paperclipai/shared typecheck` passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/cli typecheck` passed.
- `pnpm --filter @paperclipai/db check:migrations` passed.
- `pnpm install --frozen-lockfile` exits 0.

To check by hand: call the endpoint with no manifest and confirm every live agent is reported as database-only. Call it again with a manifest that names one live agent and confirm that agent moves out of `dbOnlyAgents`.

## Risks

Low risk. The endpoint reads only. It adds no migration and changes no existing route.

The response includes agent names, roles and status values, so it is gated behind board authority and a company access check in the same way as the other agent routes.

A malformed manifest returns `400` and does not fall back to the environment variable, so a typo produces an error rather than a quietly different result.

A manifest entry that states an identifier is matched on that identifier alone. An operator whose manifest carries stale identifiers will see those entries reported as roster-only, and the live agents they name reported as database-only. That is the intent: an identifier mismatch is drift, and the earlier behaviour hid it behind the name.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context window, extended thinking enabled, with tool use for repository search, edits, test runs and git operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

