### PR TITLE
feat(server): enforce connection access permissions

### DIFF
--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -21,7 +21,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { buildPaperclipRuntimeMcpServers } from "../services/heartbeat.js";
+import { buildPaperclipRuntimeMcpServers, createManagedMcpRunConfig } from "../services/heartbeat.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -239,5 +239,85 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       reasonCode: "permitted_connections_not_installed",
       details: expect.objectContaining({ runId, deliveredServerCount: 0 }),
     });
+  });
+
+  it("injects only managed gateways whose profile connections are installed for the agent", async () => {
+    const [company] = await db.insert(companies).values({
+      name: `Managed gateway installs ${randomUUID()}`,
+      issuePrefix: `MG${randomUUID().slice(0, 5).toUpperCase()}`,
+    }).returning();
+    const [agent] = await db.insert(agents).values({
+      companyId: company!.id,
+      name: "Managed Gateway Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    }).returning();
+    const [application] = await db.insert(toolApplications).values({
+      companyId: company!.id,
+      applicationKey: `managed-gateway-${randomUUID().slice(0, 8)}`,
+      name: "Managed Gateway App",
+      type: "mcp_http",
+      status: "active",
+    }).returning();
+    const connections = await db.insert(toolConnections).values([
+      {
+        companyId: company!.id,
+        applicationId: application!.id,
+        name: "Installed gateway connection",
+        uid: `test/${randomUUID()}`,
+        transport: "mcp_remote",
+        status: "active",
+        enabled: true,
+      },
+      {
+        companyId: company!.id,
+        applicationId: application!.id,
+        name: "Uninstalled gateway connection",
+        uid: `test/${randomUUID()}`,
+        transport: "mcp_remote",
+        status: "active",
+        enabled: true,
+      },
+    ]).returning();
+    const profiles = await db.insert(toolProfiles).values(connections.map((connection) => ({
+      companyId: company!.id,
+      profileKey: `gateway:${connection.id}`,
+      name: connection.name,
+      defaultAction: "deny" as const,
+    }))).returning();
+    await db.insert(toolProfileEntries).values(profiles.map((profile, index) => ({
+      companyId: company!.id,
+      profileId: profile.id,
+      selectorType: "connection" as const,
+      effect: "include" as const,
+      connectionId: connections[index]!.id,
+    })));
+    const gateways = await db.insert(toolMcpGateways).values(profiles.map((profile, index) => ({
+      companyId: company!.id,
+      name: `${connections[index]!.name} gateway`,
+      slug: `gateway-${index}-${randomUUID().slice(0, 8)}`,
+      profileId: profile.id,
+      status: "active" as const,
+    }))).returning();
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id,
+      connectionId: connections[0]!.id,
+      targetType: "agent",
+      targetId: agent!.id,
+    });
+
+    const config = await createManagedMcpRunConfig({
+      db,
+      agent: agent!,
+      runId: randomUUID(),
+      config: {},
+      projectId: null,
+      issueId: null,
+    });
+
+    expect(config?.gateways).toHaveLength(1);
+    expect(config?.gateways[0]).toMatchObject({ id: gateways[0]!.id, name: gateways[0]!.name });
+    expect(config?.gateways.some((gateway) => gateway.id === gateways[1]!.id)).toBe(false);
   });
 });

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -23,6 +23,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { buildPaperclipRuntimeMcpServers, createManagedMcpRunConfig } from "../services/heartbeat.js";
+import { createToolGatewayService } from "../services/tool-gateway.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -307,6 +308,18 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
         name: "Allow one uninstalled tool",
         defaultAction: "deny" as const,
       },
+      {
+        companyId: company!.id,
+        profileKey: `gateway:mixed-allow:${randomUUID()}`,
+        name: "Allow both connections by default",
+        defaultAction: "allow" as const,
+      },
+      {
+        companyId: company!.id,
+        profileKey: `gateway:mixed-deny:${randomUUID()}`,
+        name: "Explicitly allow both connections",
+        defaultAction: "deny" as const,
+      },
     ]).returning();
     const uninstalledGatewayToolName = [
       `mcp.${application!.applicationKey}`,
@@ -327,10 +340,17 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
         effect: "include",
         toolName: uninstalledGatewayToolName,
       },
+      ...connections.map((connection) => ({
+        companyId: company!.id,
+        profileId: profiles[3]!.id,
+        selectorType: "connection" as const,
+        effect: "include" as const,
+        connectionId: connection.id,
+      })),
     ]);
     const gateways = await db.insert(toolMcpGateways).values(profiles.map((profile, index) => ({
       companyId: company!.id,
-      name: `${connections[index]!.name} gateway`,
+      name: `${profile.name} gateway`,
       slug: `gateway-${index}-${randomUUID().slice(0, 8)}`,
       profileId: profile.id,
       status: "active" as const,
@@ -365,8 +385,23 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       issueId: null,
     });
 
-    expect(config?.gateways).toHaveLength(1);
-    expect(config?.gateways[0]).toMatchObject({ id: gateways[0]!.id, name: gateways[0]!.name });
+    expect(config?.gateways).toHaveLength(3);
+    expect(config?.gateways.some((gateway) => gateway.id === gateways[0]!.id)).toBe(true);
     expect(config?.gateways.some((gateway) => gateway.id === gateways[1]!.id)).toBe(false);
+    expect(config?.gateways.some((gateway) => gateway.id === gateways[2]!.id)).toBe(true);
+    expect(config?.gateways.some((gateway) => gateway.id === gateways[3]!.id)).toBe(true);
+
+    const mixedGateway = config?.gateways.find((gateway) => gateway.id === gateways[2]!.id);
+    const visibleTools = await createToolGatewayService(db).listToolsForNamedGateway({
+      gatewayId: mixedGateway!.id,
+      bearerToken: mixedGateway!.bearerToken,
+    });
+    expect(visibleTools.some((tool) => tool.connectionId === connections[0]!.id)).toBe(true);
+    expect(visibleTools.some((tool) => tool.connectionId === connections[1]!.id)).toBe(false);
+    await expect(createToolGatewayService(db).executeTool({
+      sessionToken: mixedGateway!.bearerToken,
+      gatewayId: mixedGateway!.id,
+      tool: uninstalledGatewayToolName,
+    })).rejects.toMatchObject({ status: 403, reasonCode: "installation_required" });
   });
 });

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -9,6 +9,7 @@ import {
   heartbeatRuns,
   toolAccessAuditEvents,
   toolApplications,
+  toolCatalogEntries,
   toolConnectionInstalls,
   toolConnections,
   toolMcpGateways,
@@ -241,7 +242,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
     });
   });
 
-  it("injects only managed gateways whose profile connections are installed for the agent", async () => {
+  it("uses canonical gateway profile semantics before injecting installed gateways", async () => {
     const [company] = await db.insert(companies).values({
       name: `Managed gateway installs ${randomUUID()}`,
       issuePrefix: `MG${randomUUID().slice(0, 5).toUpperCase()}`,
@@ -269,6 +270,8 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
         transport: "mcp_remote",
         status: "active",
         enabled: true,
+        healthStatus: "healthy",
+        config: { url: "https://installed-gateway.example.test/mcp" },
       },
       {
         companyId: company!.id,
@@ -278,21 +281,53 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
         transport: "mcp_remote",
         status: "active",
         enabled: true,
+        healthStatus: "healthy",
+        config: { url: "https://uninstalled-gateway.example.test/mcp" },
       },
     ]).returning();
-    const profiles = await db.insert(toolProfiles).values(connections.map((connection) => ({
+    await db.insert(toolCatalogEntries).values(connections.map((connection, index) => ({
       companyId: company!.id,
-      profileKey: `gateway:${connection.id}`,
-      name: connection.name,
-      defaultAction: "deny" as const,
-    }))).returning();
-    await db.insert(toolProfileEntries).values(profiles.map((profile, index) => ({
-      companyId: company!.id,
-      profileId: profile.id,
-      selectorType: "connection" as const,
-      effect: "include" as const,
-      connectionId: connections[index]!.id,
+      applicationId: application!.id,
+      connectionId: connection.id,
+      entryKind: "tool" as const,
+      name: `gateway-tool-${index}`,
+      toolName: index === 0 ? "installed_tool" : "uninstalled_tool",
+      versionHash: randomUUID(),
     })));
+    const profiles = await db.insert(toolProfiles).values([
+      {
+        companyId: company!.id,
+        profileKey: `gateway:allow-excluding-uninstalled:${randomUUID()}`,
+        name: "Allow installed tools",
+        defaultAction: "allow" as const,
+      },
+      {
+        companyId: company!.id,
+        profileKey: `gateway:namespaced-uninstalled:${randomUUID()}`,
+        name: "Allow one uninstalled tool",
+        defaultAction: "deny" as const,
+      },
+    ]).returning();
+    const uninstalledGatewayToolName = [
+      `mcp.${application!.applicationKey}`,
+      `${connections[1]!.id.replaceAll("-", "").slice(0, 8)}:uninstalled-tool`,
+    ].join("-");
+    await db.insert(toolProfileEntries).values([
+      {
+        companyId: company!.id,
+        profileId: profiles[0]!.id,
+        selectorType: "connection",
+        effect: "exclude",
+        connectionId: connections[1]!.id,
+      },
+      {
+        companyId: company!.id,
+        profileId: profiles[1]!.id,
+        selectorType: "tool_name",
+        effect: "include",
+        toolName: uninstalledGatewayToolName,
+      },
+    ]);
     const gateways = await db.insert(toolMcpGateways).values(profiles.map((profile, index) => ({
       companyId: company!.id,
       name: `${connections[index]!.name} gateway`,
@@ -300,6 +335,12 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       profileId: profile.id,
       status: "active" as const,
     }))).returning();
+    await db.insert(toolProfileBindings).values(gateways.map((gateway, index) => ({
+      companyId: company!.id,
+      profileId: profiles[index]!.id,
+      targetType: "gateway" as const,
+      targetId: gateway.id,
+    })));
     await db.insert(toolConnectionInstalls).values({
       companyId: company!.id,
       connectionId: connections[0]!.id,
@@ -307,10 +348,18 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
       targetId: agent!.id,
     });
 
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: company!.id,
+      agentId: agent!.id,
+      status: "running",
+      contextSnapshot: {},
+    });
     const config = await createManagedMcpRunConfig({
       db,
       agent: agent!,
-      runId: randomUUID(),
+      runId,
       config: {},
       projectId: null,
       issueId: null,

--- a/server/src/__tests__/invite-join-grants.test.ts
+++ b/server/src/__tests__/invite-join-grants.test.ts
@@ -75,6 +75,10 @@ describe("human invite roles", () => {
       { permissionKey: "users:manage_permissions", scope: null },
       { permissionKey: "tasks:assign", scope: null },
       { permissionKey: "joins:approve", scope: null },
+      { permissionKey: "tools:manage_connections", scope: null },
+      { permissionKey: "tools:manage_runtime", scope: null },
+      { permissionKey: "tools:use", scope: null },
+      { permissionKey: "tools:admin", scope: null },
     ]);
   });
 
@@ -87,6 +91,10 @@ describe("human invite roles", () => {
       { permissionKey: "users:invite", scope: null },
       { permissionKey: "tasks:assign", scope: null },
       { permissionKey: "joins:approve", scope: null },
+      { permissionKey: "tools:manage_connections", scope: null },
+      { permissionKey: "tools:manage_runtime", scope: null },
+      { permissionKey: "tools:use", scope: null },
+      { permissionKey: "tools:admin", scope: null },
     ]);
   });
 

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -7140,6 +7140,25 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(audits).toHaveLength(2);
     expect(audits.every((audit) => audit.actorType === "user" && audit.actorId === member.userId)).toBe(true);
   });
+
+  it("removes orphaned agent installs during replacement", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { connection } = await createRemoteToolFixture(db, company.id);
+    const service = toolAccessService(db);
+    await service.putConnectionInstalls(connection.id, {
+      installs: [{ targetType: "agent", targetId: agent.id }],
+    });
+    await db.delete(agents).where(eq(agents.id, agent.id));
+
+    const response = await request(createRouteApp(db))
+      .put(`/api/tool-connections/${connection.id}/installs`)
+      .send({ installs: [] });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ connectionId: connection.id, installs: [] });
+    await expect(db.select().from(toolConnectionInstalls)).resolves.toEqual([]);
+  });
 });
 
 describe("classifyRisk", () => {

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -212,6 +212,12 @@ async function allowConnectionForAgent(
   connectionId: string,
   input: { brokerMint?: boolean } = {},
 ) {
+  await db.insert(toolConnectionInstalls).values({
+    companyId,
+    connectionId,
+    targetType: "agent",
+    targetId: agentId,
+  });
   const [profile] = await db.insert(toolProfiles).values({
     companyId,
     profileKey: `broker-${randomUUID()}`,
@@ -540,6 +546,56 @@ describeEmbeddedPostgres("tool access service", () => {
         outcome: "success",
       }),
     ]));
+  });
+
+  it("denies token minting with an actionable error when the requesting agent has no install", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const { connection } = await createBrokerConnection(db, company.id);
+    await allowConnectionForAgent(db, company.id, agent.id, connection.id);
+    await db.delete(toolConnectionInstalls).where(eq(toolConnectionInstalls.connectionId, connection.id));
+    const app = createRouteApp(db, agentJwtActor(company.id, agent.id, run.id));
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const res = await request(app)
+      .post(`/api/agents/me/connections/${encodeURIComponent(connection.uid)}/token`)
+      .set("X-Paperclip-Run-Id", run.id)
+      .send({ scope: "pages:publish:ns/dotta" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      code: "installation_required",
+      connection: { id: connection.id, name: connection.name },
+      remediation: { action: "install_connection", targetType: "agent", targetId: agent.id },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    const [audit] = await db
+      .select()
+      .from(toolAccessAuditEvents)
+      .where(eq(toolAccessAuditEvents.reasonCode, "installation_required"));
+    expect(audit).toMatchObject({ actorType: "agent", actorId: agent.id, outcome: "failure" });
+  });
+
+  it("accepts a company-wide install when minting a token", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const { connection } = await createBrokerConnection(db, company.id, { path: "static" });
+    await allowConnectionForAgent(db, company.id, agent.id, connection.id);
+    await db
+      .update(toolConnectionInstalls)
+      .set({ targetType: "company", targetId: company.id })
+      .where(eq(toolConnectionInstalls.connectionId, connection.id));
+    const app = createRouteApp(db, agentJwtActor(company.id, agent.id, run.id));
+
+    const res = await request(app)
+      .post(`/api/agents/me/connections/${encodeURIComponent(connection.uid)}/token`)
+      .set("X-Paperclip-Run-Id", run.id)
+      .send({ scope: "pages:publish:ns/dotta" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ status: "use_env_lease", connectionId: connection.id });
   });
 
   it("selects scoped credentials for array scopes and fails closed for unknown selectors", async () => {
@@ -3182,7 +3238,11 @@ describeEmbeddedPostgres("tool access service", () => {
     vi.stubEnv("PAPERCLIP_PUBLIC_URL", "http://paperclip.test");
     const company = await createCompany(db);
     const service = toolAccessService(db);
-    const connect = await service.connectGalleryApp(company.id, { galleryKey: "slack", name: "Slack reauth" });
+    const connect = await service.connectGalleryApp(
+      company.id,
+      { galleryKey: "slack", name: "Slack reauth" },
+      { actorType: "user", actorId: "operator-user" },
+    );
     await db
       .update(toolConnections)
       .set({ status: "active", updatedAt: new Date() })
@@ -3258,7 +3318,13 @@ describeEmbeddedPostgres("tool access service", () => {
     vi.stubEnv("PAPERCLIP_PUBLIC_URL", "http://paperclip.test");
     const company = await createCompany(db);
     const service = toolAccessService(db);
-    const connect = await service.connectGalleryApp(company.id, { galleryKey: "slack", name: "Slack bound" });
+    // The initiating operator owns the connection: reconnecting is limited to the
+    // creator or a connection manager, and this case asserts session binding.
+    const connect = await service.connectGalleryApp(
+      company.id,
+      { galleryKey: "slack", name: "Slack bound" },
+      { actorType: "user", actorId: "oauth-operator" },
+    );
     const initiatingActor = boardSessionActor(company.id, "operator", "oauth-operator");
     const initiatingApp = createRouteApp(db, initiatingActor);
     const startRes = await request(initiatingApp)
@@ -7006,6 +7072,73 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(get.body.installs).toEqual(expect.arrayContaining([
       expect.objectContaining({ targetType: "agent", targetId: agent.id }),
     ]));
+  });
+
+  it("limits connection configuration to the creator or a manager with role defaults", async () => {
+    const company = await createCompany(db);
+    const creator = boardSessionActor(company.id, "member", `creator-${randomUUID()}`);
+    const otherMember = boardSessionActor(company.id, "member", `member-${randomUUID()}`);
+    const admin = boardSessionActor(company.id, "admin", `admin-${randomUUID()}`);
+    await grantBoardUser(db, company.id, creator.userId!, [], "member");
+    await grantBoardUser(db, company.id, otherMember.userId!, [], "member");
+    await grantBoardUser(db, company.id, admin.userId!, [], "admin");
+    const connection = await toolAccessService(db).createConnection(company.id, {
+      name: "Creator-owned connection",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+    }, { actorType: "user", actorId: creator.userId! });
+
+    const denied = await request(createRouteApp(db, otherMember))
+      .patch(`/api/tool-connections/${connection.id}`)
+      .send({ name: "Member edit" });
+    expect(denied.status).toBe(403);
+    expect(denied.body.error).toContain("connection creator or a connection manager");
+
+    await request(createRouteApp(db, creator))
+      .patch(`/api/tool-connections/${connection.id}`)
+      .send({ name: "Creator edit" })
+      .expect(200);
+    await request(createRouteApp(db, admin))
+      .patch(`/api/tool-connections/${connection.id}`)
+      .send({ name: "Admin edit" })
+      .expect(200);
+
+    const adminGrants = await db
+      .select()
+      .from(principalPermissionGrants)
+      .where(eq(principalPermissionGrants.principalId, admin.userId!));
+    expect(adminGrants).toEqual([]);
+  });
+
+  it("keeps agent installs self-serve for members with connection access and audits changes", async () => {
+    const company = await createCompany(db);
+    const creator = boardSessionActor(company.id, "member", `creator-${randomUUID()}`);
+    const member = boardSessionActor(company.id, "member", `member-${randomUUID()}`);
+    await grantBoardUser(db, company.id, creator.userId!, [], "member");
+    await grantBoardUser(db, company.id, member.userId!, ["agents:configure"], "member");
+    const agent = await createAgent(db, company.id);
+    const connection = await toolAccessService(db).createConnection(company.id, {
+      name: "Shared organization connection",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+    }, { actorType: "user", actorId: creator.userId! });
+    const app = createRouteApp(db, member);
+
+    await request(app)
+      .put(`/api/tool-connections/${connection.id}/installs`)
+      .send({ installs: [{ targetType: "agent", targetId: agent.id }] })
+      .expect(200);
+    await request(app)
+      .put(`/api/tool-connections/${connection.id}/installs`)
+      .send({ installs: [] })
+      .expect(200);
+
+    const audits = await db
+      .select()
+      .from(toolAccessAuditEvents)
+      .where(eq(toolAccessAuditEvents.action, "connection_installs.changed"));
+    expect(audits).toHaveLength(2);
+    expect(audits.every((audit) => audit.actorType === "user" && audit.actorId === member.userId)).toBe(true);
   });
 });
 

--- a/server/src/routes/tool-access.ts
+++ b/server/src/routes/tool-access.ts
@@ -733,12 +733,16 @@ export function toolAccessRoutes(
             .map((install) => install.targetId),
         )];
         for (const agentId of changedAgentIds) {
+          const installKey = `agent:${agentId}`;
           const [agent] = await db
             .select({ id: agents.id, companyId: agents.companyId })
             .from(agents)
             .where(and(eq(agents.id, agentId), eq(agents.companyId, connection.companyId)))
             .limit(1);
-          if (!agent) throw forbidden("The target agent is not available in this company");
+          if (!agent) {
+            if (!requestedKeys.has(installKey)) continue;
+            throw forbidden("The target agent is not available in this company");
+          }
           const decision = await access.decide({
             actor: req.actor,
             action: "agent_config:update",

--- a/server/src/routes/tool-access.ts
+++ b/server/src/routes/tool-access.ts
@@ -1,7 +1,7 @@
 import { Router, type Request } from "express";
 import type { Db } from "@paperclipai/db";
-import { agents, companies } from "@paperclipai/db";
-import { eq } from "drizzle-orm";
+import { agents, companies, connectionGrants, toolConnectionInstalls } from "@paperclipai/db";
+import { and, eq, or } from "drizzle-orm";
 import {
   CONNECTABLE_APP_DEFINITIONS,
   DEFAULT_OWNERSHIP_AVAILABILITY,
@@ -124,6 +124,71 @@ export function toolAccessRoutes(
     throw forbidden(`Missing permission: ${permissionKey}`);
   }
 
+  function activeToolMembership(req: Request, companyId: string) {
+    assertBoard(req);
+    assertCompanyAccess(req, companyId);
+    if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return null;
+    const membership = Array.isArray(req.actor.memberships)
+      ? req.actor.memberships.find((item) => item.companyId === companyId)
+      : null;
+    if (!membership || membership.status !== "active") {
+      throw forbidden("User does not have active company access");
+    }
+    if (!membership.membershipRole || membership.membershipRole === "viewer") {
+      throw forbidden("Viewer access is read-only");
+    }
+    return membership;
+  }
+
+  async function isToolConnectionManager(req: Request, companyId: string) {
+    const membership = activeToolMembership(req, companyId);
+    if (!membership) return true;
+    if (membership.membershipRole === "owner" || membership.membershipRole === "admin") return true;
+    return Boolean(req.actor.userId && await access.hasPermission(
+      companyId,
+      "user",
+      req.actor.userId,
+      "tools:manage_connections",
+    ));
+  }
+
+  async function assertToolConnectionConfigureAccess(
+    req: Request,
+    connection: { companyId: string; createdByUserId?: string | null },
+  ) {
+    if (await isToolConnectionManager(req, connection.companyId)) return;
+    if (req.actor.userId && connection.createdByUserId === req.actor.userId) return;
+    throw forbidden(
+      "Only the connection creator or a connection manager can configure, reconnect, or delete this connection",
+    );
+  }
+
+  async function assertToolConnectionAccess(
+    req: Request,
+    connection: { id: string; companyId: string; createdByUserId?: string | null },
+  ) {
+    activeToolMembership(req, connection.companyId);
+    if (await isToolConnectionManager(req, connection.companyId)) return;
+    if (req.actor.userId && connection.createdByUserId === req.actor.userId) return;
+    const [grant] = await db
+      .select({ id: connectionGrants.id })
+      .from(connectionGrants)
+      .where(and(
+        eq(connectionGrants.companyId, connection.companyId),
+        eq(connectionGrants.connectionId, connection.id),
+        eq(connectionGrants.status, "active"),
+        or(
+          eq(connectionGrants.kind, "workspace"),
+          req.actor.userId
+            ? and(eq(connectionGrants.kind, "user"), eq(connectionGrants.subjectUserId, req.actor.userId))
+            : eq(connectionGrants.kind, "workspace"),
+        ),
+      ))
+      .limit(1);
+    if (grant) return;
+    throw forbidden("You need access to this connection before you can install it on an agent");
+  }
+
   async function assertBoardAnyToolPermission(req: Request, companyId: string, permissionKeys: PermissionKey[]) {
     assertBoard(req);
     assertCompanyAccess(req, companyId);
@@ -218,18 +283,7 @@ export function toolAccessRoutes(
   });
 
   function assertToolAppMutationAccess(req: Request, companyId: string) {
-    assertBoard(req);
-    assertCompanyAccess(req, companyId);
-    if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
-    const membership = Array.isArray(req.actor.memberships)
-      ? req.actor.memberships.find((item) => item.companyId === companyId)
-      : null;
-    if (!membership || membership.status !== "active") {
-      throw forbidden("User does not have active company access");
-    }
-    if (!membership.membershipRole || membership.membershipRole === "viewer") {
-      throw forbidden("Viewer access is read-only");
-    }
+    activeToolMembership(req, companyId);
   }
 
   router.get("/companies/:companyId/tools/gallery", async (req, res) => {
@@ -291,11 +345,12 @@ export function toolAccessRoutes(
     validate(startConnectionAuthorizationSchema),
     async (req, res) => {
       const companyId = req.params.companyId as string;
-      assertToolAppMutationAccess(req, companyId);
+      activeToolMembership(req, companyId);
       if (!req.actor.userId || req.actor.userId !== req.body.subjectUserId) {
         throw forbidden("Board users may only authorize their own connection subject");
       }
       const existing = await svc.getConnection(req.params.connectionId as string, companyId);
+      await assertToolConnectionAccess(req, existing);
       const result = await svc.startOAuth(companyId, existing.id, {
         redirectUri: oauthRedirectUri(),
         actor: getActorInfo(req),
@@ -310,7 +365,7 @@ export function toolAccessRoutes(
   router.post("/tools/oauth/:connectionId/start", async (req, res) => {
     const existing = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!existing) return;
-    assertToolAppMutationAccess(req, existing.companyId);
+    await assertToolConnectionConfigureAccess(req, existing);
     const result = await svc.startOAuth(existing.companyId, existing.id, {
       redirectUri: oauthRedirectUri(),
       actor: getActorInfo(req),
@@ -328,7 +383,12 @@ export function toolAccessRoutes(
     if (!pendingState || !hasCompanyAccess(req, pendingState.companyId)) {
       throw badRequest("Invalid or expired OAuth state");
     }
-    assertToolAppMutationAccess(req, pendingState.companyId);
+    const pendingConnection = await svc.getConnection(pendingState.connectionId, pendingState.companyId);
+    if (pendingState.subjectUserId && pendingState.subjectUserId === req.actor.userId) {
+      await assertToolConnectionAccess(req, pendingConnection);
+    } else {
+      await assertToolConnectionConfigureAccess(req, pendingConnection);
+    }
     const result = await svc.completeOAuthCallback({
       state,
       code,
@@ -364,8 +424,8 @@ export function toolAccessRoutes(
 
   router.post("/companies/:companyId/tools/apps/:connectionId/finish", validate(finishToolAppSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
-    assertToolAppMutationAccess(req, companyId);
     const existing = await svc.getConnection(req.params.connectionId as string, companyId);
+    await assertToolConnectionConfigureAccess(req, existing);
     const result = await svc.finishGalleryAppConnection(companyId, existing.id, req.body, getActorInfo(req));
     await logActivity(db, {
       companyId,
@@ -538,7 +598,7 @@ export function toolAccessRoutes(
     const companyId = req.params.companyId as string;
     assertToolAppMutationAccess(req, companyId);
     try {
-      const connection = await svc.createConnection(companyId, req.body);
+      const connection = await svc.createConnection(companyId, req.body, getActorInfo(req));
       await logActivity(db, {
         companyId,
         actorType: "user",
@@ -577,7 +637,7 @@ export function toolAccessRoutes(
     assertBoard(req);
     const connection = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!connection) return;
-    await assertBoardToolPermission(req, connection.companyId, "tools:manage_connections");
+    await assertToolConnectionConfigureAccess(req, connection);
     const body = req.body && typeof req.body === "object" ? req.body as Record<string, unknown> : {};
     const credentialSecretRefs = Array.isArray(body.credentialSecretRefs) ? body.credentialSecretRefs : [];
     const providerTenant = body.providerTenant && typeof body.providerTenant === "object"
@@ -604,7 +664,14 @@ export function toolAccessRoutes(
     assertBoard(req);
     const connection = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!connection) return;
-    await assertBoardToolPermission(req, connection.companyId, "tools:manage_connections");
+    const { grants } = await svc.listConnectionGrants(connection.id, connection.companyId);
+    const grantToRevoke = grants.find((grant) => grant.id === req.params.grantId);
+    const canRevokeOwnGrant = Boolean(
+      req.actor.userId
+      && grantToRevoke
+      && (grantToRevoke.subjectUserId === req.actor.userId || grantToRevoke.createdByUserId === req.actor.userId),
+    );
+    if (!canRevokeOwnGrant) await assertToolConnectionConfigureAccess(req, connection);
     const grant = await svc.revokeConnectionGrant(connection.id, req.params.grantId as string, getActorInfo(req));
     await logActivity(db, {
       companyId: connection.companyId,
@@ -641,7 +708,47 @@ export function toolAccessRoutes(
       assertBoard(req);
       const connection = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
       if (!connection) return;
-      await assertBoardToolPermission(req, connection.companyId, "tools:manage_connections");
+      const existingInstalls = await db
+        .select()
+        .from(toolConnectionInstalls)
+        .where(and(
+          eq(toolConnectionInstalls.companyId, connection.companyId),
+          eq(toolConnectionInstalls.connectionId, connection.id),
+        ));
+      const requestedInstalls = req.body.installs as Array<{ targetType: "company" | "agent"; targetId: string }>;
+      const requestedKeys = new Set(requestedInstalls.map((install) => `${install.targetType}:${install.targetId}`));
+      const existingKeys = new Set(existingInstalls.map((install) => `${install.targetType}:${install.targetId}`));
+      const changedInstalls = [
+        ...requestedInstalls.filter((install) => !existingKeys.has(`${install.targetType}:${install.targetId}`)),
+        ...existingInstalls.filter((install) => !requestedKeys.has(`${install.targetType}:${install.targetId}`)),
+      ];
+      if (changedInstalls.some((install) => install.targetType === "company")) {
+        await assertToolConnectionConfigureAccess(req, connection);
+      }
+      if (changedInstalls.some((install) => install.targetType === "agent")) {
+        await assertToolConnectionAccess(req, connection);
+        const changedAgentIds = [...new Set(
+          changedInstalls
+            .filter((install) => install.targetType === "agent")
+            .map((install) => install.targetId),
+        )];
+        for (const agentId of changedAgentIds) {
+          const [agent] = await db
+            .select({ id: agents.id, companyId: agents.companyId })
+            .from(agents)
+            .where(and(eq(agents.id, agentId), eq(agents.companyId, connection.companyId)))
+            .limit(1);
+          if (!agent) throw forbidden("The target agent is not available in this company");
+          const decision = await access.decide({
+            actor: req.actor,
+            action: "agent_config:update",
+            resource: { type: "agent", companyId: connection.companyId, agentId: agent.id },
+          });
+          if (!decision.allowed) {
+            throw forbidden(`You cannot edit agent ${agent.id}, so you cannot change its connection installs`);
+          }
+        }
+      }
       const snapshot = await svc.putConnectionInstalls(connection.id, req.body, getActorInfo(req));
       await logActivity(db, {
         companyId: connection.companyId,
@@ -745,7 +852,7 @@ export function toolAccessRoutes(
   router.patch("/tool-connections/:connectionId", validate(updateToolConnectionSchema), async (req, res) => {
     const existing = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!existing) return;
-    assertToolAppMutationAccess(req, existing.companyId);
+    await assertToolConnectionConfigureAccess(req, existing);
     const connection = await svc.updateConnection(existing.id, req.body);
     const lifecycleChanges = classifyConnectionUpdate(
       { enabled: existing.enabled, config: existing.config },
@@ -789,7 +896,7 @@ export function toolAccessRoutes(
   router.delete("/tool-connections/:connectionId", async (req, res) => {
     const existing = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!existing) return;
-    assertToolAppMutationAccess(req, existing.companyId);
+    await assertToolConnectionConfigureAccess(req, existing);
     const applicationBefore = await svc.getApplication(existing.applicationId);
     const connection = await svc.archiveConnection(existing.id);
     const applicationAfter = await svc.getApplication(existing.applicationId);
@@ -819,7 +926,7 @@ export function toolAccessRoutes(
   router.post("/tool-connections/:connectionId/health-check", async (req, res) => {
     const existing = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!existing) return;
-    assertToolAppMutationAccess(req, existing.companyId);
+    await assertToolConnectionConfigureAccess(req, existing);
     res.json(await svc.checkHealth(existing.id, getActorInfo(req)));
   });
 
@@ -829,7 +936,7 @@ export function toolAccessRoutes(
     async (req, res) => {
       const existing = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
       if (!existing) return;
-      assertToolAppMutationAccess(req, existing.companyId);
+      await assertToolConnectionConfigureAccess(req, existing);
       const result = await svc.reconnectGalleryApp(
         existing.id,
         existing.companyId,
@@ -852,7 +959,7 @@ export function toolAccessRoutes(
   router.post("/tool-connections/:connectionId/catalog/refresh", async (req, res) => {
     const existing = await getAccessibleResource(req, res, svc.getConnection(req.params.connectionId as string), "Tool connection not found");
     if (!existing) return;
-    assertToolAppMutationAccess(req, existing.companyId);
+    await assertToolConnectionConfigureAccess(req, existing);
     res.json(await svc.refreshCatalog(existing.id, getActorInfo(req)));
   });
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -28,6 +28,7 @@ import {
   type TrustPresetResolution,
 } from "./trust-preset-resolver.js";
 import { logger } from "../middleware/logger.js";
+import { grantsForHumanRole, normalizeHumanRole } from "./company-member-roles.js";
 
 export type AuthorizationActor =
   {
@@ -102,6 +103,7 @@ export type AuthorizationDecision = {
     | "allow_local_board"
     | "allow_instance_admin"
     | "allow_explicit_grant"
+    | "allow_role_default"
     | "allow_user_inbox_policy"
     | "allow_direct_change"
     | "allow_consented_change"
@@ -664,6 +666,19 @@ export function authorizationService(db: Db) {
 
     const grant = await findGrant(input.companyId, input.principalType, input.principalId, input.permissionKey);
     if (!grant) {
+      if (
+        input.principalType === "user"
+        && input.permissionKey.startsWith("tools:")
+        && (membership.membershipRole === "owner" || membership.membershipRole === "admin")
+        && grantsForHumanRole(normalizeHumanRole(membership.membershipRole, "operator"))
+          .some((defaultGrant) => defaultGrant.permissionKey === input.permissionKey)
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_role_default",
+          explanation: `Allowed by the ${membership.membershipRole ?? "operator"} membership role.`,
+        });
+      }
       return deny({
         action: input.action,
         reason: "deny_missing_grant",

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -35,6 +35,10 @@ export function grantsForHumanRole(
         { permissionKey: "users:manage_permissions", scope: null },
         { permissionKey: "tasks:assign", scope: null },
         { permissionKey: "joins:approve", scope: null },
+        { permissionKey: "tools:manage_connections", scope: null },
+        { permissionKey: "tools:manage_runtime", scope: null },
+        { permissionKey: "tools:use", scope: null },
+        { permissionKey: "tools:admin", scope: null },
       ];
     case "admin":
       return [
@@ -45,6 +49,10 @@ export function grantsForHumanRole(
         { permissionKey: "users:invite", scope: null },
         { permissionKey: "tasks:assign", scope: null },
         { permissionKey: "joins:approve", scope: null },
+        { permissionKey: "tools:manage_connections", scope: null },
+        { permissionKey: "tools:manage_runtime", scope: null },
+        { permissionKey: "tools:use", scope: null },
+        { permissionKey: "tools:admin", scope: null },
       ];
     case "operator":
       return [{ permissionKey: "tasks:assign", scope: null }];

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -65,10 +65,8 @@ import {
   routines,
   toolMcpGateways,
   toolMcpGatewayTokens,
-  toolCatalogEntries,
   toolConnectionInstalls,
   toolConnections,
-  toolProfileEntries,
   toolProfiles,
   workspaceOperations,
 } from "@paperclipai/db";
@@ -3468,62 +3466,23 @@ function gatewayAppliesToRun(input: {
 async function gatewayConnectionIds(input: {
   db: Db;
   companyId: string;
+  agentId: string;
+  runId: string;
+  issueId: string | null;
+  projectId: string | null;
   gateway: typeof toolMcpGateways.$inferSelect;
 }): Promise<Set<string>> {
   const managedRuntimeConnectionId = readNonEmptyString(input.gateway.metadata?.managedRuntimeConnectionId);
   if (managedRuntimeConnectionId) return new Set([managedRuntimeConnectionId]);
-
-  const [profile, entries, catalog, connections] = await Promise.all([
-    input.db
-      .select({ defaultAction: toolProfiles.defaultAction })
-      .from(toolProfiles)
-      .where(and(eq(toolProfiles.companyId, input.companyId), eq(toolProfiles.id, input.gateway.profileId)))
-      .then((rows) => rows[0] ?? null),
-    input.db
-      .select()
-      .from(toolProfileEntries)
-      .where(and(
-        eq(toolProfileEntries.companyId, input.companyId),
-        eq(toolProfileEntries.profileId, input.gateway.profileId),
-      )),
-    input.db
-      .select({
-        id: toolCatalogEntries.id,
-        connectionId: toolCatalogEntries.connectionId,
-        applicationId: toolCatalogEntries.applicationId,
-        toolName: toolCatalogEntries.toolName,
-        riskLevel: toolCatalogEntries.riskLevel,
-      })
-      .from(toolCatalogEntries)
-      .where(and(eq(toolCatalogEntries.companyId, input.companyId), eq(toolCatalogEntries.status, "active"))),
-    input.db
-      .select({ id: toolConnections.id, applicationId: toolConnections.applicationId })
-      .from(toolConnections)
-      .where(eq(toolConnections.companyId, input.companyId)),
-  ]);
-  if (!profile) return new Set();
-  if (profile.defaultAction === "allow") return new Set(catalog.map((entry) => entry.connectionId));
-
-  const connectionIds = new Set<string>();
-  for (const entry of entries) {
-    if (entry.effect !== "include") continue;
-    if (entry.connectionId) connectionIds.add(entry.connectionId);
-    if (entry.applicationId) {
-      for (const connection of connections) {
-        if (connection.applicationId === entry.applicationId) connectionIds.add(connection.id);
-      }
-    }
-    for (const catalogEntry of catalog) {
-      if (
-        (entry.catalogEntryId && entry.catalogEntryId === catalogEntry.id)
-        || (entry.toolName && entry.toolName === catalogEntry.toolName)
-        || (entry.riskLevel && entry.riskLevel === catalogEntry.riskLevel)
-      ) {
-        connectionIds.add(catalogEntry.connectionId);
-      }
-    }
-  }
-  return connectionIds;
+  const service = createToolGatewayService(input.db);
+  return new Set(await service.listAccessibleConnectionIdsForGatewayContext({
+    companyId: input.companyId,
+    gatewayId: input.gateway.id,
+    agentId: input.agentId,
+    runId: input.runId,
+    issueId: input.issueId,
+    projectId: input.projectId,
+  }));
 }
 
 export async function createManagedMcpRunConfig(input: {
@@ -3567,6 +3526,10 @@ export async function createManagedMcpRunConfig(input: {
     connectionIds: await gatewayConnectionIds({
       db: input.db,
       companyId: input.agent.companyId,
+      agentId: input.agent.id,
+      runId: input.runId,
+      issueId: input.issueId,
+      projectId: input.projectId,
       gateway,
     }),
   }))))

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -65,7 +65,10 @@ import {
   routines,
   toolMcpGateways,
   toolMcpGatewayTokens,
+  toolCatalogEntries,
+  toolConnectionInstalls,
   toolConnections,
+  toolProfileEntries,
   toolProfiles,
   workspaceOperations,
 } from "@paperclipai/db";
@@ -3462,7 +3465,68 @@ function gatewayAppliesToRun(input: {
   return true;
 }
 
-async function createManagedMcpRunConfig(input: {
+async function gatewayConnectionIds(input: {
+  db: Db;
+  companyId: string;
+  gateway: typeof toolMcpGateways.$inferSelect;
+}): Promise<Set<string>> {
+  const managedRuntimeConnectionId = readNonEmptyString(input.gateway.metadata?.managedRuntimeConnectionId);
+  if (managedRuntimeConnectionId) return new Set([managedRuntimeConnectionId]);
+
+  const [profile, entries, catalog, connections] = await Promise.all([
+    input.db
+      .select({ defaultAction: toolProfiles.defaultAction })
+      .from(toolProfiles)
+      .where(and(eq(toolProfiles.companyId, input.companyId), eq(toolProfiles.id, input.gateway.profileId)))
+      .then((rows) => rows[0] ?? null),
+    input.db
+      .select()
+      .from(toolProfileEntries)
+      .where(and(
+        eq(toolProfileEntries.companyId, input.companyId),
+        eq(toolProfileEntries.profileId, input.gateway.profileId),
+      )),
+    input.db
+      .select({
+        id: toolCatalogEntries.id,
+        connectionId: toolCatalogEntries.connectionId,
+        applicationId: toolCatalogEntries.applicationId,
+        toolName: toolCatalogEntries.toolName,
+        riskLevel: toolCatalogEntries.riskLevel,
+      })
+      .from(toolCatalogEntries)
+      .where(and(eq(toolCatalogEntries.companyId, input.companyId), eq(toolCatalogEntries.status, "active"))),
+    input.db
+      .select({ id: toolConnections.id, applicationId: toolConnections.applicationId })
+      .from(toolConnections)
+      .where(eq(toolConnections.companyId, input.companyId)),
+  ]);
+  if (!profile) return new Set();
+  if (profile.defaultAction === "allow") return new Set(catalog.map((entry) => entry.connectionId));
+
+  const connectionIds = new Set<string>();
+  for (const entry of entries) {
+    if (entry.effect !== "include") continue;
+    if (entry.connectionId) connectionIds.add(entry.connectionId);
+    if (entry.applicationId) {
+      for (const connection of connections) {
+        if (connection.applicationId === entry.applicationId) connectionIds.add(connection.id);
+      }
+    }
+    for (const catalogEntry of catalog) {
+      if (
+        (entry.catalogEntryId && entry.catalogEntryId === catalogEntry.id)
+        || (entry.toolName && entry.toolName === catalogEntry.toolName)
+        || (entry.riskLevel && entry.riskLevel === catalogEntry.riskLevel)
+      ) {
+        connectionIds.add(catalogEntry.connectionId);
+      }
+    }
+  }
+  return connectionIds;
+}
+
+export async function createManagedMcpRunConfig(input: {
   db: Db;
   agent: Pick<typeof agents.$inferSelect, "id" | "companyId" | "name" | "adapterType">;
   runId: string;
@@ -3483,12 +3547,33 @@ async function createManagedMcpRunConfig(input: {
     ))
     .orderBy(asc(toolMcpGateways.name));
 
-  const gateways = rows.filter((gateway) => gatewayAppliesToRun({
+  const installRows = await input.db
+    .select({ connectionId: toolConnectionInstalls.connectionId })
+    .from(toolConnectionInstalls)
+    .where(and(
+      eq(toolConnectionInstalls.companyId, input.agent.companyId),
+      sql`((${toolConnectionInstalls.targetType} = 'company' and ${toolConnectionInstalls.targetId} = ${input.agent.companyId}) or (${toolConnectionInstalls.targetType} = 'agent' and ${toolConnectionInstalls.targetId} = ${input.agent.id}))`,
+    ));
+  const installedConnectionIds = new Set(installRows.map((install) => install.connectionId));
+
+  const applicableGateways = rows.filter((gateway) => gatewayAppliesToRun({
     gateway,
     agentId: input.agent.id,
     projectId: input.projectId,
     issueId: input.issueId,
   }));
+  const gateways = (await Promise.all(applicableGateways.map(async (gateway) => ({
+    gateway,
+    connectionIds: await gatewayConnectionIds({
+      db: input.db,
+      companyId: input.agent.companyId,
+      gateway,
+    }),
+  }))))
+    .filter(({ connectionIds }) =>
+      connectionIds.size > 0
+      && [...connectionIds].every((connectionId) => installedConnectionIds.has(connectionId)))
+    .map(({ gateway }) => gateway);
   if (gateways.length === 0) return null;
 
   const service = createToolGatewayService(input.db);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3535,7 +3535,7 @@ export async function createManagedMcpRunConfig(input: {
   }))))
     .filter(({ connectionIds }) =>
       connectionIds.size > 0
-      && [...connectionIds].every((connectionId) => installedConnectionIds.has(connectionId)))
+      && [...connectionIds].some((connectionId) => installedConnectionIds.has(connectionId)))
     .map(({ gateway }) => gateway);
   if (gateways.length === 0) return null;
 

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -5602,7 +5602,11 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
 
   async function peekOAuthState(state: string) {
     const [row] = await db
-      .select({ companyId: toolOauthStates.companyId })
+      .select({
+        companyId: toolOauthStates.companyId,
+        connectionId: toolOauthStates.connectionId,
+        subjectUserId: toolOauthStates.subjectUserId,
+      })
       .from(toolOauthStates)
       .where(eq(toolOauthStates.state, state))
       .limit(1);
@@ -6306,7 +6310,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       return connections;
     },
 
-    createConnection: async (companyId: string, input: CreateToolConnection): Promise<ToolConnection> => {
+    createConnection: async (companyId: string, input: CreateToolConnection, actor?: ActorInfo): Promise<ToolConnection> => {
       let applicationId = input.applicationId;
       let applicationNamespace = input.applicationName ?? input.name;
       const transport = input.transport;
@@ -6335,6 +6339,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       }
       await assertSecretRefs(companyId, [...(input.credentialRefs ?? []), ...(input.credentialSecretRefs ?? [])]);
       const connectionId = randomUUID();
+      const binding = actorBinding(actor);
       const [row] = await db.insert(toolConnections).values({
         id: connectionId,
         companyId,
@@ -6351,6 +6356,8 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         transportConfig: isGoogleSheetsConnectionConfig(config) ? config : input.transportConfig ?? config,
         credentialRefs: input.credentialRefs ?? [],
         credentialSecretRefs: input.credentialSecretRefs ?? [],
+        createdByAgentId: binding.actorType === "agent" ? binding.actorId : null,
+        createdByUserId: binding.actorType === "user" ? binding.actorId : null,
       }).returning();
       await ensureDefaultWorkspaceGrant(row);
       await syncCredentialBindings(row);
@@ -6399,6 +6406,16 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         createdByUserId: binding.actorType === "user" ? binding.actorId : null,
       }).returning();
       if (!grant) throw new Error("Failed to create connection installation");
+      await db.insert(toolAccessAuditEvents).values({
+        companyId: connection.companyId,
+        connectionId: connection.id,
+        actorType: binding.actorType ?? "system",
+        actorId: binding.actorId,
+        action: "connection_grant.created",
+        outcome: "success",
+        reasonCode: "grant_created",
+        details: { grantId: grant.id, kind: grant.kind, isDefault: grant.isDefault },
+      });
       return grant;
     },
 
@@ -6418,6 +6435,16 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         eq(connectionGrants.connectionId, connection.id),
       )).returning();
       if (!grant) throw notFound("Connection grant not found");
+      await db.insert(toolAccessAuditEvents).values({
+        companyId: connection.companyId,
+        connectionId: connection.id,
+        actorType: binding.actorType ?? "system",
+        actorId: binding.actorId,
+        action: "connection_grant.revoked",
+        outcome: "success",
+        reasonCode: "grant_revoked",
+        details: { grantId: grant.id, kind: grant.kind },
+      });
       return grant;
     },
 
@@ -6529,6 +6556,24 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
               .returning({ id: toolProfileBindings.id });
             if (binding) accessExtensions.push({ targetType: install.targetType, targetId: install.targetId, profileId: profile.id });
           }
+        }
+        if (removeIds.length > 0 || additions.length > 0) {
+          const binding = actorBinding(actor);
+          await tx.insert(toolAccessAuditEvents).values({
+            companyId: connection.companyId,
+            connectionId: connection.id,
+            actorType: binding.actorType ?? "system",
+            actorId: binding.actorId,
+            action: "connection_installs.changed",
+            outcome: "success",
+            reasonCode: "installs_changed",
+            details: {
+              added: additions.map((install) => ({ targetType: install.targetType, targetId: install.targetId })),
+              removed: existing
+                .filter((install) => removeIds.includes(install.id))
+                .map((install) => ({ targetType: install.targetType, targetId: install.targetId })),
+            },
+          });
         }
       });
       for (const extension of accessExtensions) {
@@ -7340,6 +7385,29 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         await recordFailure(outcome, errorCode, details);
         throw new HttpError(status, message, { code: errorCode, path, ...details });
       };
+
+      const [install] = await db
+        .select({ id: toolConnectionInstalls.id })
+        .from(toolConnectionInstalls)
+        .where(and(
+          eq(toolConnectionInstalls.companyId, connection.companyId),
+          eq(toolConnectionInstalls.connectionId, connection.id),
+          sql`((${toolConnectionInstalls.targetType} = 'company' and ${toolConnectionInstalls.targetId} = ${connection.companyId}) or (${toolConnectionInstalls.targetType} = 'agent' and ${toolConnectionInstalls.targetId} = ${input.agentId}))`,
+        ))
+        .limit(1);
+      if (!install) {
+        await fail(
+          403,
+          `Connection ${connection.name} must be installed for this agent before it can mint a token`,
+          "denied",
+          "installation_required",
+          {
+            connection: { id: connection.id, uid: connection.uid, name: connection.name },
+            agentId: input.agentId,
+            remediation: { action: "install_connection", targetType: "agent", targetId: input.agentId },
+          },
+        );
+      }
 
       const subject = input.body.subject ?? { type: "app" as const };
       if (subject.type === "user" && subject.userId !== runContext.responsibleUserId) {

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -4844,6 +4844,41 @@ export function createToolGatewayService(
       return tools;
     },
 
+    async listAccessibleConnectionIdsForGatewayContext(input: {
+      companyId: string;
+      gatewayId: string;
+      agentId: string;
+      runId: string;
+      issueId?: string | null;
+      projectId?: string | null;
+    }): Promise<string[]> {
+      await assertAgentInCompany(input.companyId, input.agentId);
+      const now = new Date();
+      const session: ToolGatewaySession = {
+        id: `gateway:${input.gatewayId}`,
+        token: "",
+        companyId: input.companyId,
+        agentId: input.agentId,
+        runId: input.runId,
+        issueId: input.issueId ?? null,
+        projectId: input.projectId ?? null,
+        gatewayId: input.gatewayId,
+        actorType: "agent",
+        actorId: input.agentId,
+        createdAt: now,
+        expiresAt: new Date(now.getTime() + DEFAULT_SESSION_TTL_MS),
+      };
+      const connectedTools = await connectedMcpToolsForCompany(input.companyId);
+      const decisions = await Promise.all(connectedTools.map(async (tool) => ({
+        tool,
+        decision: await policyService.decide(policyInputForTool({ session, tool })),
+      })));
+      return [...new Set(decisions
+        .filter(({ decision }) => decision.allowed || decision.decision === "require_approval")
+        .map(({ tool }) => tool.connectionId)
+        .filter((connectionId): connectionId is string => Boolean(connectionId)))];
+    },
+
     async createSession(input: {
       companyId: string;
       agentId: string;

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -17,6 +17,7 @@ import {
   toolApplications,
   toolCallEvents,
   toolCatalogEntries,
+  toolConnectionInstalls,
   toolConnections,
   toolGatewayRateLimitCounters,
   toolGatewaySessions,
@@ -172,6 +173,7 @@ export interface ToolGatewaySession {
   gatewayName?: string | null;
   gatewayTokenId?: string | null;
   gatewayTokenAllowedActions?: ToolMcpGatewayTokenAction[];
+  enforceConnectionInstalls?: boolean;
   actorType?: "agent" | "user" | "system" | "plugin";
   actorId?: string | null;
   createdAt: Date;
@@ -1893,7 +1895,10 @@ export function createToolGatewayService(
   }
 
   async function searchableOnDemandTools(session: ToolGatewaySession): Promise<ToolGatewayDescriptor[]> {
-    const tools = (await connectedMcpToolsForCompany(session.companyId)).filter(isOnDemandRemoteTool);
+    const tools = (await installedToolsForSession(
+      session,
+      await connectedMcpToolsForCompany(session.companyId),
+    )).filter(isOnDemandRemoteTool);
     const decisions = await Promise.all(tools.map(async (tool) => ({
       tool,
       decision: await policyService.decide(policyInputForTool({ session, tool })),
@@ -1942,7 +1947,10 @@ export function createToolGatewayService(
     if (session.agentId) {
       await assertAgentInCompany(session.companyId, session.agentId);
     }
-    const allConnectedTools = await connectedMcpToolsForCompany(session.companyId);
+    const allConnectedTools = await installedToolsForSession(
+      session,
+      await connectedMcpToolsForCompany(session.companyId),
+    );
     const onDemandTargets = allConnectedTools.filter(isOnDemandRemoteTool);
     const tools = [...allTools(), ...allConnectedTools.filter((tool) => !isOnDemandRemoteTool(tool))].filter(
       (tool) => session.agentId || (tool.providerType !== "paperclip_self" && tool.providerType !== "paperclip_plugin"),
@@ -1969,6 +1977,39 @@ export function createToolGatewayService(
       }
     }
     return visibleTools;
+  }
+
+  async function installedConnectionIdsForSession(session: ToolGatewaySession): Promise<Set<string> | null> {
+    if (!session.enforceConnectionInstalls || !session.agentId) return null;
+    const installs = await db
+      .select({ connectionId: toolConnectionInstalls.connectionId })
+      .from(toolConnectionInstalls)
+      .where(and(
+        eq(toolConnectionInstalls.companyId, session.companyId),
+        sql`((${toolConnectionInstalls.targetType} = 'company' and ${toolConnectionInstalls.targetId} = ${session.companyId}) or (${toolConnectionInstalls.targetType} = 'agent' and ${toolConnectionInstalls.targetId} = ${session.agentId}))`,
+      ));
+    return new Set(installs.map((install) => install.connectionId));
+  }
+
+  async function installedToolsForSession(
+    session: ToolGatewaySession,
+    tools: ToolGatewayDescriptor[],
+  ): Promise<ToolGatewayDescriptor[]> {
+    const installedConnectionIds = await installedConnectionIdsForSession(session);
+    if (!installedConnectionIds) return tools;
+    return tools.filter((tool) => !tool.connectionId || installedConnectionIds.has(tool.connectionId));
+  }
+
+  async function assertToolInstalledForSession(session: ToolGatewaySession, tool: ToolGatewayDescriptor) {
+    if (!tool.connectionId) return;
+    const installedConnectionIds = await installedConnectionIdsForSession(session);
+    if (!installedConnectionIds || installedConnectionIds.has(tool.connectionId)) return;
+    throw new ToolGatewayHttpError(
+      403,
+      "This connection is not installed for the current agent",
+      "installation_required",
+      { connectionId: tool.connectionId },
+    );
   }
 
   async function executeBuiltinTool(session: ToolGatewaySession, tool: ToolGatewayDescriptor, parameters: unknown) {
@@ -3723,6 +3764,7 @@ export function createToolGatewayService(
       gatewayName: row.gateway.name,
       gatewayTokenId: row.token.id || tokenId,
       gatewayTokenAllowedActions: normalizeGatewayTokenActions(row.token.allowedActions),
+      enforceConnectionInstalls: row.token.subjectType === "heartbeat_run",
       actorType: runId ? "agent" : "system",
       actorId: runId ? agentId : row.token.id,
       createdAt: row.token.createdAt,
@@ -5534,6 +5576,8 @@ export function createToolGatewayService(
         tool = targetTool;
         requestedParameters = targetParameters;
       }
+
+      await assertToolInstalledForSession(session, tool);
 
       const argumentValidation = validateToolContent({
         value: requestedParameters,


### PR DESCRIPTION
## Thinking Path

> - Paperclip controls which agents can use company tools and connections.
> - A connection install defines which agents can use a connection.
> - The server did not enforce installs when it made tokens or managed gateway configuration.
> - The server also let any non-viewer configure a connection that another user created.
> - This pull request enforces installs and limits connection configuration to the creator or a manager.
> - The benefit is that runtime access now follows the stored permission model.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

This change improves server authorization for tool connections, connection tokens, and managed MCP gateways.

**Subsystem affected**

`server/` — REST API and orchestration services.

**Current behavior**

The token service checks the company but does not require an agent or company install. Managed MCP configuration can give an agent access to connections that are not installed for that agent. Any active non-viewer can configure, reconnect, or delete a connection that another user created.

**Proposed behavior**

The server requires an agent-specific or company-wide install before it makes a connection token. A managed gateway stays available when it has at least one installed connection. Gateway discovery and direct calls include only installed connections. Direct calls to uninstalled tools fail with `installation_required`. The connection creator and connection managers can configure a connection. Members who have connection access can still install it on agents that they can edit.

**Reason and benefit**

Stored installs must control runtime access. This change closes a permission gap at the token and gateway boundaries. It also keeps the member self-service install flow. It prevents unrelated members from changing connection configuration.

**Breaking changes**

This change denies access that the stored install and creator fields do not authorize. Existing agent-specific and company-wide installs continue to work. Legacy credential resolution does not change.

Prior PR: #11805. That standalone PR was closed for consolidation. This PR carries the rebased commits from the required consolidation workspace.

## What Changed

- Require an agent or company install before the token service makes a connection token.
- Keep managed MCP gateways that have at least one installed connection.
- Limit gateway discovery and direct calls to installed connections.
- Return `installation_required` for direct calls to uninstalled gateway tools.
- Limit connection configuration, reconnect, and delete operations to the creator or a connection manager.
- Keep install and uninstall operations available to members who have connection access and can edit the target agent.
- Give owner and administrator roles the default `tools:*` management permissions.
- Add audit events for connection grant and install changes.
- Add focused server tests for the changed permission paths and mixed gateway installs.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts server/src/__tests__/invite-join-grants.test.ts server/src/__tests__/tool-access-service.test.ts` passed all 143 tests with embedded PostgreSQL.
- `pnpm -r typecheck` passed.
- `pnpm test:run` passed.
- `pnpm build` passed.
- All GitHub checks passed. The optional Storybook visual regression check was skipped because this PR does not request it.
- Greptile reported 5/5 with zero unresolved review threads.

## Risks

- Agents without a stored install now receive an explicit install-required denial. This is an intentional authorization change.
- A mixed managed gateway exposes only its installed connection tools. An incorrect connection filter could hide a permitted tool. The tests cover allow and deny paths for mixed gateways.
- Connection rows without a creator user can be configured only by a manager. This is the fail-closed behavior for legacy rows.

> This change hardens the governed MCP tool access work in `ROADMAP.md`. It does not add a new core feature or UI surface.

## Model Used

- OpenAI Codex, GPT-5. The runtime does not expose a more specific deployment ID or context-window size. The agent used reasoning, repository tools, GitHub tools, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — the attached execution workspace requires this branch name and forbids renaming it
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — existing governed MCP documentation already describes the permission model
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
