### PR TITLE
fix(secrets): fail the run when a granted env binding never reaches it

### DIFF
--- a/server/src/__tests__/heartbeat-secret-delivery-gate.test.ts
+++ b/server/src/__tests__/heartbeat-secret-delivery-gate.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConfigurationIncompleteFailure,
+  resolveExecutionRunAdapterConfig,
+} from "../services/heartbeat.ts";
+
+/**
+ * BRO-2367 — a grant is not proof of delivery.
+ *
+ * An agent can hold an `env.<KEY>` secret binding and still start a run without
+ * that key, because the binding row and the adapter config can drift apart. The
+ * run then dies inside the agent with an opaque provider error ("OpenAI API key
+ * is missing"), which is recorded as `adapter_failed` — a configuration fault
+ * wearing a runtime fault's clothes. The gate below turns that silent absence
+ * into a named, pre-dispatch configuration failure.
+ */
+describe("resolveExecutionRunAdapterConfig delivery gate", () => {
+  const undeliveredBinding = (envKey: string, consumerId: string, consumerType = "agent") => ({
+    consumerType,
+    consumerId,
+    configPath: `env.${envKey}`,
+    envKey,
+    bindingType: "secret_ref" as const,
+    secretId: "secret-1",
+    secretName: envKey,
+    errorCode: "binding_not_delivered" as const,
+  });
+
+  const passThroughSecretsSvc = (env: Record<string, string>) => ({
+    resolveAdapterConfigForRuntime: vi.fn().mockResolvedValue({
+      config: { env },
+      secretKeys: new Set<string>(),
+      manifest: [],
+    }),
+    resolveEnvBindings: vi.fn().mockResolvedValue({
+      env: {},
+      secretKeys: new Set<string>(),
+      manifest: [],
+    }),
+  });
+
+  it("fails the run when a declared env binding never reaches the run environment", async () => {
+    const collectUndeliveredEnvBindings = vi
+      .fn()
+      .mockResolvedValue([undeliveredBinding("OPENAI_API_KEY", "agent-1")]);
+
+    const call = resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: {} },
+      secretsSvc: {
+        ...passThroughSecretsSvc({}),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    await expect(call).rejects.toBeInstanceOf(ConfigurationIncompleteFailure);
+    await call.catch((err: ConfigurationIncompleteFailure) => {
+      expect(err.message).toContain("OPENAI_API_KEY did not reach the run environment");
+      expect(err.resultJson).toMatchObject({
+        configurationIncomplete: {
+          reason: "secret_binding_not_delivered",
+          agentId: "agent-1",
+          missingBindings: [expect.objectContaining({ configPath: "env.OPENAI_API_KEY" })],
+        },
+      });
+    });
+
+    expect(collectUndeliveredEnvBindings).toHaveBeenCalledWith(
+      "company-1",
+      { consumerType: "agent", consumerId: "agent-1" },
+      [],
+    );
+  });
+
+  it("never puts a secret value in the failure it raises", async () => {
+    const call = resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: { UNRELATED: "sk-live-do-not-log" } },
+      secretsSvc: {
+        ...passThroughSecretsSvc({ UNRELATED: "sk-live-do-not-log" }),
+        collectUndeliveredEnvBindings: vi
+          .fn()
+          .mockResolvedValue([undeliveredBinding("OPENAI_API_KEY", "agent-1")]),
+      } as any,
+    });
+
+    await expect(call).rejects.toThrow(ConfigurationIncompleteFailure);
+    await call.catch((err: ConfigurationIncompleteFailure) => {
+      const serialized = `${err.message}${JSON.stringify(err.resultJson)}`;
+      expect(serialized).not.toContain("sk-live-do-not-log");
+      expect(serialized).toContain("OPENAI_API_KEY");
+    });
+  });
+
+  it("passes the fully resolved env keys so a plain value at the same key counts as delivered", async () => {
+    const collectUndeliveredEnvBindings = vi.fn().mockResolvedValue([]);
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: { OPENAI_API_KEY: "resolved" } },
+      secretsSvc: {
+        ...passThroughSecretsSvc({ OPENAI_API_KEY: "resolved" }),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    expect(collectUndeliveredEnvBindings).toHaveBeenCalledWith(
+      "company-1",
+      { consumerType: "agent", consumerId: "agent-1" },
+      ["OPENAI_API_KEY"],
+    );
+    expect(result.resolvedConfig.env).toMatchObject({ OPENAI_API_KEY: "resolved" });
+  });
+
+  it("checks every consumer scope that contributed env to the run", async () => {
+    const collectUndeliveredEnvBindings = vi.fn().mockResolvedValue([]);
+
+    await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      projectId: "project-1",
+      environmentId: "environment-1",
+      routineId: "routine-1",
+      executionRunConfig: { env: {} },
+      secretsSvc: {
+        ...passThroughSecretsSvc({}),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    expect(collectUndeliveredEnvBindings.mock.calls.map((call) => call[1])).toEqual([
+      { consumerType: "agent", consumerId: "agent-1" },
+      { consumerType: "project", consumerId: "project-1" },
+      { consumerType: "environment", consumerId: "environment-1" },
+      { consumerType: "routine", consumerId: "routine-1" },
+    ]);
+  });
+
+  it("skips the gate when the secrets service does not implement it", async () => {
+    await expect(
+      resolveExecutionRunAdapterConfig({
+        companyId: "company-1",
+        agentId: "agent-1",
+        executionRunConfig: { env: {} },
+        secretsSvc: passThroughSecretsSvc({}) as any,
+      }),
+    ).resolves.toMatchObject({ resolvedConfig: { env: {} } });
+  });
+});

--- a/server/src/__tests__/secrets-service-undelivered-env-bindings.test.ts
+++ b/server/src/__tests__/secrets-service-undelivered-env-bindings.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  companySecretBindings,
+  companySecretProviderConfigs,
+  companySecretVersions,
+  companySecrets,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { secretService } from "../services/secrets.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres undelivered-binding tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/**
+ * BRO-2367 — the inverse of the config walk. These cover the case a
+ * config-walking check structurally cannot see: the binding row is present and
+ * the run env is not.
+ */
+describeEmbeddedPostgres("secretService.collectUndeliveredEnvBindings", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+  const previousKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+  const secretsTmpDir = path.join(os.tmpdir(), `paperclip-undelivered-bindings-${randomUUID()}`);
+
+  beforeAll(async () => {
+    mkdirSync(secretsTmpDir, { recursive: true });
+    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = path.join(secretsTmpDir, "master.key");
+    const started = await startEmbeddedPostgresTestDatabase("undelivered-bindings");
+    stopDb = started.cleanup;
+    db = createDb(started.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(companySecretBindings);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecrets);
+    await db.delete(companySecretProviderConfigs);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await stopDb?.();
+    if (previousKeyFile === undefined) {
+      delete process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+    } else {
+      process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = previousKeyFile;
+    }
+    rmSync(secretsTmpDir, { recursive: true, force: true });
+  });
+
+  async function seed(configPaths: string[], required = true) {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const secrets = secretService(db);
+    const secret = await secrets.create(companyId, {
+      name: "OPENAI_API_KEY",
+      provider: "local_encrypted",
+      value: "sk-test-never-logged",
+    });
+    const agentId = randomUUID();
+    await db.insert(companySecretBindings).values(
+      configPaths.map((configPath) => ({
+        companyId,
+        secretId: secret.id,
+        targetType: "agent" as const,
+        targetId: agentId,
+        configPath,
+        required,
+      })),
+    );
+    return { companyId, agentId, secretId: secret.id, secrets };
+  }
+
+  it("reports a granted env binding whose key is absent from the run env", async () => {
+    const { companyId, agentId, secretId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    const undelivered = await secrets.collectUndeliveredEnvBindings(
+      companyId,
+      { consumerType: "agent", consumerId: agentId },
+      ["PATH", "HOME"],
+    );
+
+    expect(undelivered).toEqual([
+      expect.objectContaining({
+        consumerType: "agent",
+        consumerId: agentId,
+        configPath: "env.OPENAI_API_KEY",
+        envKey: "OPENAI_API_KEY",
+        bindingType: "secret_ref",
+        secretId,
+        secretName: "OPENAI_API_KEY",
+        errorCode: "binding_not_delivered",
+      }),
+    ]);
+    // The value is never carried on the finding.
+    expect(JSON.stringify(undelivered)).not.toContain("sk-test-never-logged");
+  });
+
+  it("reports nothing when the key is present in the run env", async () => {
+    const { companyId, agentId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        ["OPENAI_API_KEY"],
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("ignores API-only access.<ALIAS> grants, which are fetched over the agent API by design", async () => {
+    const { companyId, agentId, secrets } = await seed(["access.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("ignores an optional binding, which the run is allowed to start without", async () => {
+    const { companyId, agentId, secrets } = await seed(["env.OPENAI_API_KEY"], false);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("scopes the check to the consumer it was asked about", async () => {
+    const { companyId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: randomUUID() },
+        [],
+      ),
+    ).resolves.toEqual([]);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -805,7 +805,10 @@ type RuntimeConfigSecretResolver = Pick<
   | "resolveEnvBindings"
   | "collectMissingRuntimeBindings"
   | "collectMissingAdapterConfigRuntimeBindings"
->;
+>
+  // Optional so existing partial test doubles keep type-checking; the delivery
+  // gate is skipped (not silently passed) when a double omits it.
+  & Partial<Pick<ReturnType<typeof secretService>, "collectUndeliveredEnvBindings">>;
 
 function formatMissingBindingForOperator(missing: MissingRuntimeBinding): string {
   if (missing.bindingType === "user_secret_ref") {
@@ -822,6 +825,18 @@ function formatMissingBindingForOperator(missing: MissingRuntimeBinding): string
     ? `"${missing.secretName}"`
     : missing.secretId ?? "unknown";
   return `secret ${secretLabel} not bound at ${missing.consumerType} ${missing.configPath}`;
+}
+
+function formatUndeliveredBindingForOperator(missing: MissingRuntimeBinding): string {
+  const secretLabel = missing.secretName
+    ? `"${missing.secretName}"`
+    : missing.secretId ?? "unknown";
+  return (
+    `secret ${secretLabel} is granted to ${missing.consumerType} ${missing.consumerId} at ` +
+    `${missing.configPath} but ${missing.envKey} did not reach the run environment. ` +
+    `Re-save the ${missing.consumerType}'s configuration so ${missing.configPath} is declared there, ` +
+    `then run again`
+  );
 }
 
 function isConfiguredEnvBindingValue(binding: unknown) {
@@ -1172,6 +1187,48 @@ export async function resolveExecutionRunAdapterConfig(input: {
     };
     for (const key of routineEnvResolution.secretKeys) {
       secretKeys.add(key);
+    }
+  }
+  // Delivery gate: every declared env binding must be present in the run env.
+  //
+  // The checks above walk the *config* and fail when a ref has no binding. They
+  // cannot see the opposite drift — a binding row that exists while its
+  // `env.<KEY>` config entry is gone. That run dispatches with the credential
+  // silently absent and dies inside the agent with an opaque provider error
+  // ("OpenAI API key is missing"), so a configuration fault is recorded as
+  // `adapter_failed`. A grant is not proof of delivery; this is the check that
+  // makes the run prove it, before dispatch, naming keys and never values.
+  if (input.secretsSvc.collectUndeliveredEnvBindings) {
+    const deliveredEnvKeys = Object.keys(parseObject(resolvedConfig.env));
+    const undelivered: MissingRuntimeBinding[] = [];
+    for (const consumer of [
+      input.agentId ? { consumerType: "agent" as const, consumerId: input.agentId } : null,
+      input.projectId ? { consumerType: "project" as const, consumerId: input.projectId } : null,
+      input.environmentId ? { consumerType: "environment" as const, consumerId: input.environmentId } : null,
+      input.routineId ? { consumerType: "routine" as const, consumerId: input.routineId } : null,
+    ]) {
+      if (!consumer) continue;
+      undelivered.push(
+        ...(await input.secretsSvc.collectUndeliveredEnvBindings(
+          input.companyId,
+          consumer,
+          deliveredEnvKeys,
+        )),
+      );
+    }
+    if (undelivered.length > 0) {
+      const detail = undelivered.map(formatUndeliveredBindingForOperator).join("; ");
+      throw new ConfigurationIncompleteFailure(`configuration incomplete: ${detail}`, {
+        configurationIncomplete: {
+          reason: "secret_binding_not_delivered",
+          companyId: input.companyId,
+          agentId: input.agentId ?? null,
+          issueId: input.issueId ?? null,
+          projectId: input.projectId ?? null,
+          routineId: input.routineId ?? null,
+          missingBindings: undelivered,
+        },
+      });
     }
   }
   // Pre-dispatch credential gate for codex_local: a managed Codex home with no

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -689,6 +689,7 @@ type RuntimeSecretResolution = {
 
 type SecretResolutionErrorCode =
   | "binding_missing"
+  | "binding_not_delivered"
   | "secret_deleted"
   | "secret_inactive"
   | "secret_scope_invalid"
@@ -5114,6 +5115,66 @@ export function secretService(db: Db) {
       }
 
       return [...missingSecretBindings, ...missingUserSecretBindings];
+    },
+
+    /**
+     * The inverse of {@link collectMissingRuntimeBindings}. That one walks the
+     * config and asks "is this ref bound?"; this one walks the *bindings* and
+     * asks "did this grant actually reach the run?".
+     *
+     * A grant is not proof of delivery. A binding row can exist while the
+     * matching `env.<KEY>` entry has been dropped from the adapter config, and
+     * nothing on the config-walking side can see that — the run dispatches with
+     * the credential silently absent and dies later inside the agent with an
+     * opaque provider error ("API key is missing"), which reads as a runtime
+     * fault rather than the configuration fault it is.
+     *
+     * `deliveredEnvKeys` is the key set of the fully resolved run env, so a
+     * plain (non-secret) value at the same key still counts as delivered.
+     */
+    collectUndeliveredEnvBindings: async (
+      companyId: string,
+      context: Pick<SecretBindingContext, "consumerType" | "consumerId">,
+      deliveredEnvKeys: Iterable<string>,
+    ): Promise<MissingRuntimeBinding[]> => {
+      const consumerType = missingRuntimeConsumerType(context.consumerType);
+      const rows = await db
+        .select()
+        .from(companySecretBindings)
+        .where(and(
+          eq(companySecretBindings.companyId, companyId),
+          eq(companySecretBindings.targetType, consumerType),
+          eq(companySecretBindings.targetId, context.consumerId),
+          eq(companySecretBindings.required, true),
+          like(companySecretBindings.configPath, "env.%"),
+        ));
+      if (rows.length === 0) return [];
+
+      const delivered = new Set(deliveredEnvKeys);
+      const undelivered = rows.filter((row) => {
+        const envKey = row.configPath.slice("env.".length);
+        return ENV_KEY_RE.test(envKey) && !delivered.has(envKey);
+      });
+      if (undelivered.length === 0) return [];
+
+      const secretRows = await Promise.all(
+        [...new Set(undelivered.map((row) => row.secretId))].map(async (secretId) => [
+          secretId,
+          await getById(secretId).catch(() => null),
+        ] as const),
+      );
+      const secretsById = new Map(secretRows);
+
+      return undelivered.map((row) => ({
+        consumerType,
+        consumerId: context.consumerId,
+        configPath: row.configPath,
+        envKey: row.configPath.slice("env.".length),
+        bindingType: "secret_ref" as const,
+        secretId: row.secretId,
+        secretName: secretsById.get(row.secretId)?.name ?? null,
+        errorCode: "binding_not_delivered" as const,
+      }));
     },
 
     collectMissingAdapterConfigRuntimeBindings: async (


### PR DESCRIPTION
## Problem

A grant is not proof of delivery. Agents were reporting a credential missing at run time while holding the binding for it, and the run surfaced as `adapter_failed` with an opaque provider error:

```
{"type":"error","error":{"name":"ProviderAuthError","data":{"providerID":"openrouter",
 "message":"OpenRouter API key is missing. Pass it using the 'apiKey' parameter or the
 OPENROUTER_API_KEY environment variable."}}}
```

That message points the operator at the agent runtime. The fault is one layer up, in configuration — and nothing in the dispatch path said so.

The existing pre-dispatch check (`collectMissingRuntimeBindings`) walks the **adapter config** and fails when a declared `secret_ref` has no binding row. It structurally cannot see the opposite drift: a **binding row that exists while its `env.<KEY>` config entry is gone**. That run dispatches with the credential silently absent. Silent absence is the defect.

## Change

`secretService.collectUndeliveredEnvBindings` — the inverse walk. Given the key set of the fully resolved run env, it returns every required `env.*` binding for a consumer whose key is not in that set.

`resolveExecutionRunAdapterConfig` runs it across all four consumer scopes (agent, project, environment, routine) after env resolution and before dispatch. Any finding raises `ConfigurationIncompleteFailure` with reason `secret_binding_not_delivered`, routed to a human owner like the other configuration-incomplete blockers, naming the env key and the config path to restore.

This mirrors the shape of the existing `codex_local` pre-dispatch credential gate, which was added for the same reason: *"making a configuration problem look like a runtime failure."*

Deliberately **not** failures:
- `access.<ALIAS>` grants — API-only by design, fetched over the agent secrets API, never injected as env.
- `required: false` bindings — the run is allowed to start without them.

Findings carry key **names**, never values; a test asserts no secret value can reach the raised error.

## Verification

- `server` typecheck clean.
- New `heartbeat-secret-delivery-gate.test.ts` (5 cases) passes; all 4 behavioural cases were confirmed to **fail** with the gate disabled, so they are not vacuous.
- `heartbeat-project-env.test.ts` and the adjacent secrets suites still pass (40 tests).
- New `secrets-service-undelivered-env-bindings.test.ts` (5 cases) covers the query against embedded Postgres. That harness cannot start on the authoring host — every pre-existing embedded-Postgres suite skips there identically — so the query was additionally exercised **read-only against a live 19-secret, 14-agent instance**: it reported zero findings across the whole company (no false positives), and correctly reported all four of one agent's granted-but-undelivered keys, with none of the delivered ones, when handed a drifted env key set.

## Category safeguard

The gate itself *is* the category safeguard: it converts the entire class of "credential declared but absent from the run" from a silent dispatch into a named, pre-dispatch configuration failure, for every adapter and every consumer scope at once, rather than fixing the one binding that happened to be noticed.