### PR TITLE
fix(secrets): fail the run when a granted env binding never reaches it

### DIFF
--- a/server/src/__tests__/heartbeat-secret-delivery-gate.test.ts
+++ b/server/src/__tests__/heartbeat-secret-delivery-gate.test.ts
@@ -3,6 +3,7 @@ import {
   ConfigurationIncompleteFailure,
   resolveExecutionRunAdapterConfig,
 } from "../services/heartbeat.ts";
+import { LOW_TRUST_REVIEW_PRESET } from "../services/trust-preset-resolver.ts";
 
 /**
  * BRO-2367 — a grant is not proof of delivery.
@@ -70,6 +71,7 @@ describe("resolveExecutionRunAdapterConfig delivery gate", () => {
       "company-1",
       { consumerType: "agent", consumerId: "agent-1" },
       [],
+      { allowedBindingIds: null },
     );
   });
 
@@ -111,8 +113,48 @@ describe("resolveExecutionRunAdapterConfig delivery gate", () => {
       "company-1",
       { consumerType: "agent", consumerId: "agent-1" },
       ["OPENAI_API_KEY"],
+      { allowedBindingIds: null },
     );
     expect(result.resolvedConfig.env).toMatchObject({ OPENAI_API_KEY: "resolved" });
+  });
+
+  /**
+   * A low-trust run is deliberately narrowed to `allowedSecretBindingIds`. A
+   * binding outside that boundary is one the run must NOT receive — resolution
+   * rejects it as `binding_not_allowed` when the config declares it. If the gate
+   * demanded delivery of it anyway, a run that is correctly withholding the
+   * credential would abort as `configuration_incomplete`.
+   */
+  it("carries the low-trust boundary into the gate so a forbidden binding is not required", async () => {
+    const collectUndeliveredEnvBindings = vi.fn().mockResolvedValue([]);
+
+    await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: {} },
+      trustPreset: {
+        kind: "low_trust_review",
+        preset: LOW_TRUST_REVIEW_PRESET,
+        boundary: {
+          mode: LOW_TRUST_REVIEW_PRESET,
+          companyId: "company-1",
+          issueIds: ["issue-1"],
+          allowedSecretBindingIds: ["binding-1"],
+        },
+        sourcePresets: {},
+      } as any,
+      secretsSvc: {
+        ...passThroughSecretsSvc({}),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    expect(collectUndeliveredEnvBindings).toHaveBeenCalledWith(
+      "company-1",
+      { consumerType: "agent", consumerId: "agent-1" },
+      [],
+      { allowedBindingIds: ["binding-1"] },
+    );
   });
 
   it("checks every consumer scope that contributed env to the run", async () => {

--- a/server/src/__tests__/heartbeat-secret-delivery-gate.test.ts
+++ b/server/src/__tests__/heartbeat-secret-delivery-gate.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConfigurationIncompleteFailure,
+  resolveExecutionRunAdapterConfig,
+} from "../services/heartbeat.ts";
+
+/**
+ * BRO-2367 — a grant is not proof of delivery.
+ *
+ * An agent can hold an `env.<KEY>` secret binding and still start a run without
+ * that key, because the binding row and the adapter config can drift apart. The
+ * run then dies inside the agent with an opaque provider error ("OpenAI API key
+ * is missing"), which is recorded as `adapter_failed` — a configuration fault
+ * wearing a runtime fault's clothes. The gate below turns that silent absence
+ * into a named, pre-dispatch configuration failure.
+ */
+describe("resolveExecutionRunAdapterConfig delivery gate", () => {
+  const undeliveredBinding = (envKey: string, consumerId: string, consumerType = "agent") => ({
+    consumerType,
+    consumerId,
+    configPath: `env.${envKey}`,
+    envKey,
+    bindingType: "secret_ref" as const,
+    secretId: "secret-1",
+    secretName: envKey,
+    errorCode: "binding_not_delivered" as const,
+  });
+
+  const passThroughSecretsSvc = (env: Record<string, string>) => ({
+    resolveAdapterConfigForRuntime: vi.fn().mockResolvedValue({
+      config: { env },
+      secretKeys: new Set<string>(),
+      manifest: [],
+    }),
+    resolveEnvBindings: vi.fn().mockResolvedValue({
+      env: {},
+      secretKeys: new Set<string>(),
+      manifest: [],
+    }),
+  });
+
+  it("fails the run when a declared env binding never reaches the run environment", async () => {
+    const collectUndeliveredEnvBindings = vi
+      .fn()
+      .mockResolvedValue([undeliveredBinding("OPENAI_API_KEY", "agent-1")]);
+
+    const call = resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: {} },
+      secretsSvc: {
+        ...passThroughSecretsSvc({}),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    await expect(call).rejects.toBeInstanceOf(ConfigurationIncompleteFailure);
+    await call.catch((err: ConfigurationIncompleteFailure) => {
+      expect(err.message).toContain("OPENAI_API_KEY did not reach the run environment");
+      expect(err.resultJson).toMatchObject({
+        configurationIncomplete: {
+          reason: "secret_binding_not_delivered",
+          agentId: "agent-1",
+          missingBindings: [expect.objectContaining({ configPath: "env.OPENAI_API_KEY" })],
+        },
+      });
+    });
+
+    expect(collectUndeliveredEnvBindings).toHaveBeenCalledWith(
+      "company-1",
+      { consumerType: "agent", consumerId: "agent-1" },
+      [],
+    );
+  });
+
+  it("never puts a secret value in the failure it raises", async () => {
+    const call = resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: { UNRELATED: "sk-live-do-not-log" } },
+      secretsSvc: {
+        ...passThroughSecretsSvc({ UNRELATED: "sk-live-do-not-log" }),
+        collectUndeliveredEnvBindings: vi
+          .fn()
+          .mockResolvedValue([undeliveredBinding("OPENAI_API_KEY", "agent-1")]),
+      } as any,
+    });
+
+    await expect(call).rejects.toThrow(ConfigurationIncompleteFailure);
+    await call.catch((err: ConfigurationIncompleteFailure) => {
+      const serialized = `${err.message}${JSON.stringify(err.resultJson)}`;
+      expect(serialized).not.toContain("sk-live-do-not-log");
+      expect(serialized).toContain("OPENAI_API_KEY");
+    });
+  });
+
+  it("passes the fully resolved env keys so a plain value at the same key counts as delivered", async () => {
+    const collectUndeliveredEnvBindings = vi.fn().mockResolvedValue([]);
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      executionRunConfig: { env: { OPENAI_API_KEY: "resolved" } },
+      secretsSvc: {
+        ...passThroughSecretsSvc({ OPENAI_API_KEY: "resolved" }),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    expect(collectUndeliveredEnvBindings).toHaveBeenCalledWith(
+      "company-1",
+      { consumerType: "agent", consumerId: "agent-1" },
+      ["OPENAI_API_KEY"],
+    );
+    expect(result.resolvedConfig.env).toMatchObject({ OPENAI_API_KEY: "resolved" });
+  });
+
+  it("checks every consumer scope that contributed env to the run", async () => {
+    const collectUndeliveredEnvBindings = vi.fn().mockResolvedValue([]);
+
+    await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      projectId: "project-1",
+      environmentId: "environment-1",
+      routineId: "routine-1",
+      executionRunConfig: { env: {} },
+      secretsSvc: {
+        ...passThroughSecretsSvc({}),
+        collectUndeliveredEnvBindings,
+      } as any,
+    });
+
+    expect(collectUndeliveredEnvBindings.mock.calls.map((call) => call[1])).toEqual([
+      { consumerType: "agent", consumerId: "agent-1" },
+      { consumerType: "project", consumerId: "project-1" },
+      { consumerType: "environment", consumerId: "environment-1" },
+      { consumerType: "routine", consumerId: "routine-1" },
+    ]);
+  });
+
+  it("skips the gate when the secrets service does not implement it", async () => {
+    await expect(
+      resolveExecutionRunAdapterConfig({
+        companyId: "company-1",
+        agentId: "agent-1",
+        executionRunConfig: { env: {} },
+        secretsSvc: passThroughSecretsSvc({}) as any,
+      }),
+    ).resolves.toMatchObject({ resolvedConfig: { env: {} } });
+  });
+});

--- a/server/src/__tests__/secrets-service-undelivered-env-bindings.test.ts
+++ b/server/src/__tests__/secrets-service-undelivered-env-bindings.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  companySecretBindings,
+  companySecretProviderConfigs,
+  companySecretVersions,
+  companySecrets,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { secretService } from "../services/secrets.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres undelivered-binding tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/**
+ * BRO-2367 — the inverse of the config walk. These cover the case a
+ * config-walking check structurally cannot see: the binding row is present and
+ * the run env is not.
+ */
+describeEmbeddedPostgres("secretService.collectUndeliveredEnvBindings", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+  const previousKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+  const secretsTmpDir = path.join(os.tmpdir(), `paperclip-undelivered-bindings-${randomUUID()}`);
+
+  beforeAll(async () => {
+    mkdirSync(secretsTmpDir, { recursive: true });
+    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = path.join(secretsTmpDir, "master.key");
+    const started = await startEmbeddedPostgresTestDatabase("undelivered-bindings");
+    stopDb = started.cleanup;
+    db = createDb(started.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(companySecretBindings);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecrets);
+    await db.delete(companySecretProviderConfigs);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await stopDb?.();
+    if (previousKeyFile === undefined) {
+      delete process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+    } else {
+      process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = previousKeyFile;
+    }
+    rmSync(secretsTmpDir, { recursive: true, force: true });
+  });
+
+  async function seed(configPaths: string[], required = true) {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const secrets = secretService(db);
+    const secret = await secrets.create(companyId, {
+      name: "OPENAI_API_KEY",
+      provider: "local_encrypted",
+      value: "sk-test-never-logged",
+    });
+    const agentId = randomUUID();
+    await db.insert(companySecretBindings).values(
+      configPaths.map((configPath) => ({
+        companyId,
+        secretId: secret.id,
+        targetType: "agent" as const,
+        targetId: agentId,
+        configPath,
+        required,
+      })),
+    );
+    return { companyId, agentId, secretId: secret.id, secrets };
+  }
+
+  it("reports a granted env binding whose key is absent from the run env", async () => {
+    const { companyId, agentId, secretId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    const undelivered = await secrets.collectUndeliveredEnvBindings(
+      companyId,
+      { consumerType: "agent", consumerId: agentId },
+      ["PATH", "HOME"],
+    );
+
+    expect(undelivered).toEqual([
+      expect.objectContaining({
+        consumerType: "agent",
+        consumerId: agentId,
+        configPath: "env.OPENAI_API_KEY",
+        envKey: "OPENAI_API_KEY",
+        bindingType: "secret_ref",
+        secretId,
+        secretName: "OPENAI_API_KEY",
+        errorCode: "binding_not_delivered",
+      }),
+    ]);
+    // The value is never carried on the finding.
+    expect(JSON.stringify(undelivered)).not.toContain("sk-test-never-logged");
+  });
+
+  it("reports nothing when the key is present in the run env", async () => {
+    const { companyId, agentId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        ["OPENAI_API_KEY"],
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("ignores API-only access.<ALIAS> grants, which are fetched over the agent API by design", async () => {
+    const { companyId, agentId, secrets } = await seed(["access.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("ignores an optional binding, which the run is allowed to start without", async () => {
+    const { companyId, agentId, secrets } = await seed(["env.OPENAI_API_KEY"], false);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("scopes the check to the consumer it was asked about", async () => {
+    const { companyId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: randomUUID() },
+        [],
+      ),
+    ).resolves.toEqual([]);
+  });
+});

--- a/server/src/__tests__/secrets-service-undelivered-env-bindings.test.ts
+++ b/server/src/__tests__/secrets-service-undelivered-env-bindings.test.ts
@@ -80,7 +80,7 @@ describeEmbeddedPostgres("secretService.collectUndeliveredEnvBindings", () => {
       value: "sk-test-never-logged",
     });
     const agentId = randomUUID();
-    await db.insert(companySecretBindings).values(
+    const bindings = await db.insert(companySecretBindings).values(
       configPaths.map((configPath) => ({
         companyId,
         secretId: secret.id,
@@ -89,8 +89,8 @@ describeEmbeddedPostgres("secretService.collectUndeliveredEnvBindings", () => {
         configPath,
         required,
       })),
-    );
-    return { companyId, agentId, secretId: secret.id, secrets };
+    ).returning();
+    return { companyId, agentId, secretId: secret.id, secrets, bindings };
   }
 
   it("reports a granted env binding whose key is absent from the run env", async () => {
@@ -164,5 +164,48 @@ describeEmbeddedPostgres("secretService.collectUndeliveredEnvBindings", () => {
         [],
       ),
     ).resolves.toEqual([]);
+  });
+
+  it("ignores a binding outside the low-trust boundary, which the run must not receive", async () => {
+    const { companyId, agentId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+        { allowedBindingIds: [randomUUID()] },
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("still reports a binding inside the low-trust boundary", async () => {
+    const { companyId, agentId, secrets, bindings } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+        { allowedBindingIds: bindings.map((binding) => binding.id) },
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ configPath: "env.OPENAI_API_KEY", errorCode: "binding_not_delivered" }),
+    ]);
+  });
+
+  it("requires every binding when no boundary is in effect", async () => {
+    const { companyId, agentId, secrets } = await seed(["env.OPENAI_API_KEY"]);
+
+    await expect(
+      secrets.collectUndeliveredEnvBindings(
+        companyId,
+        { consumerType: "agent", consumerId: agentId },
+        [],
+        { allowedBindingIds: null },
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ configPath: "env.OPENAI_API_KEY" }),
+    ]);
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1198,6 +1198,11 @@ export async function resolveExecutionRunAdapterConfig(input: {
   // ("OpenAI API key is missing"), so a configuration fault is recorded as
   // `adapter_failed`. A grant is not proof of delivery; this is the check that
   // makes the run prove it, before dispatch, naming keys and never values.
+  //
+  // The low-trust boundary is carried through: a run can only be required to
+  // hold a credential it is allowed to hold. Demanding delivery of a binding
+  // outside `allowedSecretBindingIds` would abort a run that is correctly
+  // withholding it.
   if (input.secretsSvc.collectUndeliveredEnvBindings) {
     const deliveredEnvKeys = Object.keys(parseObject(resolvedConfig.env));
     const undelivered: MissingRuntimeBinding[] = [];
@@ -1213,6 +1218,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
           input.companyId,
           consumer,
           deliveredEnvKeys,
+          { allowedBindingIds: lowTrustAllowedBindingIds ?? null },
         )),
       );
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -805,7 +805,10 @@ type RuntimeConfigSecretResolver = Pick<
   | "resolveEnvBindings"
   | "collectMissingRuntimeBindings"
   | "collectMissingAdapterConfigRuntimeBindings"
->;
+>
+  // Optional so existing partial test doubles keep type-checking; the delivery
+  // gate is skipped (not silently passed) when a double omits it.
+  & Partial<Pick<ReturnType<typeof secretService>, "collectUndeliveredEnvBindings">>;
 
 function formatMissingBindingForOperator(missing: MissingRuntimeBinding): string {
   if (missing.bindingType === "user_secret_ref") {
@@ -822,6 +825,18 @@ function formatMissingBindingForOperator(missing: MissingRuntimeBinding): string
     ? `"${missing.secretName}"`
     : missing.secretId ?? "unknown";
   return `secret ${secretLabel} not bound at ${missing.consumerType} ${missing.configPath}`;
+}
+
+function formatUndeliveredBindingForOperator(missing: MissingRuntimeBinding): string {
+  const secretLabel = missing.secretName
+    ? `"${missing.secretName}"`
+    : missing.secretId ?? "unknown";
+  return (
+    `secret ${secretLabel} is granted to ${missing.consumerType} ${missing.consumerId} at ` +
+    `${missing.configPath} but ${missing.envKey} did not reach the run environment. ` +
+    `Re-save the ${missing.consumerType}'s configuration so ${missing.configPath} is declared there, ` +
+    `then run again`
+  );
 }
 
 function isConfiguredEnvBindingValue(binding: unknown) {
@@ -1172,6 +1187,48 @@ export async function resolveExecutionRunAdapterConfig(input: {
     };
     for (const key of routineEnvResolution.secretKeys) {
       secretKeys.add(key);
+    }
+  }
+  // Delivery gate: every declared env binding must be present in the run env.
+  //
+  // The checks above walk the *config* and fail when a ref has no binding. They
+  // cannot see the opposite drift — a binding row that exists while its
+  // `env.<KEY>` config entry is gone. That run dispatches with the credential
+  // silently absent and dies inside the agent with an opaque provider error
+  // ("OpenAI API key is missing"), so a configuration fault is recorded as
+  // `adapter_failed`. A grant is not proof of delivery; this is the check that
+  // makes the run prove it, before dispatch, naming keys and never values.
+  if (input.secretsSvc.collectUndeliveredEnvBindings) {
+    const deliveredEnvKeys = Object.keys(parseObject(resolvedConfig.env));
+    const undelivered: MissingRuntimeBinding[] = [];
+    for (const consumer of [
+      input.agentId ? { consumerType: "agent" as const, consumerId: input.agentId } : null,
+      input.projectId ? { consumerType: "project" as const, consumerId: input.projectId } : null,
+      input.environmentId ? { consumerType: "environment" as const, consumerId: input.environmentId } : null,
+      input.routineId ? { consumerType: "routine" as const, consumerId: input.routineId } : null,
+    ]) {
+      if (!consumer) continue;
+      undelivered.push(
+        ...(await input.secretsSvc.collectUndeliveredEnvBindings(
+          input.companyId,
+          consumer,
+          deliveredEnvKeys,
+        )),
+      );
+    }
+    if (undelivered.length > 0) {
+      const detail = undelivered.map(formatUndeliveredBindingForOperator).join("; ");
+      throw new ConfigurationIncompleteFailure(`configuration incomplete: ${detail}`, {
+        configurationIncomplete: {
+          reason: "secret_binding_not_delivered",
+          companyId: input.companyId,
+          agentId: input.agentId ?? null,
+          issueId: input.issueId ?? null,
+          projectId: input.projectId ?? null,
+          routineId: input.routineId ?? null,
+          missingBindings: undelivered,
+        },
+      });
     }
   }
   // Pre-dispatch credential gate for codex_local: a managed Codex home with no

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -689,6 +689,7 @@ type RuntimeSecretResolution = {
 
 type SecretResolutionErrorCode =
   | "binding_missing"
+  | "binding_not_delivered"
   | "secret_deleted"
   | "secret_inactive"
   | "secret_scope_invalid"
@@ -5114,6 +5115,66 @@ export function secretService(db: Db) {
       }
 
       return [...missingSecretBindings, ...missingUserSecretBindings];
+    },
+
+    /**
+     * The inverse of {@link collectMissingRuntimeBindings}. That one walks the
+     * config and asks "is this ref bound?"; this one walks the *bindings* and
+     * asks "did this grant actually reach the run?".
+     *
+     * A grant is not proof of delivery. A binding row can exist while the
+     * matching `env.<KEY>` entry has been dropped from the adapter config, and
+     * nothing on the config-walking side can see that — the run dispatches with
+     * the credential silently absent and dies later inside the agent with an
+     * opaque provider error ("API key is missing"), which reads as a runtime
+     * fault rather than the configuration fault it is.
+     *
+     * `deliveredEnvKeys` is the key set of the fully resolved run env, so a
+     * plain (non-secret) value at the same key still counts as delivered.
+     */
+    collectUndeliveredEnvBindings: async (
+      companyId: string,
+      context: Pick<SecretBindingContext, "consumerType" | "consumerId">,
+      deliveredEnvKeys: Iterable<string>,
+    ): Promise<MissingRuntimeBinding[]> => {
+      const consumerType = missingRuntimeConsumerType(context.consumerType);
+      const rows = await db
+        .select()
+        .from(companySecretBindings)
+        .where(and(
+          eq(companySecretBindings.companyId, companyId),
+          eq(companySecretBindings.targetType, consumerType),
+          eq(companySecretBindings.targetId, context.consumerId),
+          eq(companySecretBindings.required, true),
+          like(companySecretBindings.configPath, "env.%"),
+        ));
+      if (rows.length === 0) return [];
+
+      const delivered = new Set(deliveredEnvKeys);
+      const undelivered = rows.filter((row) => {
+        const envKey = row.configPath.slice("env.".length);
+        return ENV_KEY_RE.test(envKey) && !delivered.has(envKey);
+      });
+      if (undelivered.length === 0) return [];
+
+      const secretRows = await Promise.all(
+        [...new Set(undelivered.map((row) => row.secretId))].map(async (secretId) => [
+          secretId,
+          await getById(secretId).catch(() => null),
+        ] as const),
+      );
+      const secretsById = new Map(secretRows);
+
+      return undelivered.map((row) => ({
+        consumerType,
+        consumerId: context.consumerId,
+        configPath: row.configPath,
+        envKey: row.configPath.slice("env.".length),
+        bindingType: "secret_ref" as const,
+        secretId: row.secretId,
+        secretName: secretsById.get(row.secretId)?.name ?? null,
+        errorCode: "binding_not_delivered" as const,
+      }));
     },
 
     collectMissingAdapterConfigRuntimeBindings: async (

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -5131,11 +5131,19 @@ export function secretService(db: Db) {
      *
      * `deliveredEnvKeys` is the key set of the fully resolved run env, so a
      * plain (non-secret) value at the same key still counts as delivered.
+     *
+     * `allowedBindingIds` carries the low-trust boundary. Delivery can only be
+     * required of a credential the run is permitted to receive, so a binding
+     * outside the boundary is not a finding — that run is *forbidden* to hold
+     * it, and resolution would reject it as `binding_not_allowed` if the config
+     * still declared it. Omit it (or pass null) outside low trust, where every
+     * required binding is in scope.
      */
     collectUndeliveredEnvBindings: async (
       companyId: string,
       context: Pick<SecretBindingContext, "consumerType" | "consumerId">,
       deliveredEnvKeys: Iterable<string>,
+      options?: { allowedBindingIds?: string[] | null },
     ): Promise<MissingRuntimeBinding[]> => {
       const consumerType = missingRuntimeConsumerType(context.consumerType);
       const rows = await db
@@ -5150,8 +5158,12 @@ export function secretService(db: Db) {
         ));
       if (rows.length === 0) return [];
 
+      const allowedBindingIds = Array.isArray(options?.allowedBindingIds)
+        ? new Set(options.allowedBindingIds)
+        : null;
       const delivered = new Set(deliveredEnvKeys);
       const undelivered = rows.filter((row) => {
+        if (allowedBindingIds && !allowedBindingIds.has(row.id)) return false;
         const envKey = row.configPath.slice("env.".length);
         return ENV_KEY_RE.test(envKey) && !delivered.has(envKey);
       });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The secrets subsystem gives an agent a credential in one of two classes. An `env.<KEY>` binding is injected into the run environment. An `access.<ALIAS>` binding is API-only and is read through `POST /api/agents/me/secrets/:key/value`
> - The heartbeat resolves those bindings into the adapter config before it dispatches a run. A pre-dispatch check walks that config and fails the run when a declared `secret_ref` has no binding row
> - That check cannot see the opposite drift. A binding row can exist while its `env.<KEY>` entry is gone from the config. Nothing looks at the bindings and asks whether each one reached the run
> - The run then starts without the credential. It fails later inside the agent with a provider error such as "OpenAI API key is missing", and Paperclip records it as `adapter_failed`. The operator is pointed at the agent runtime, but the fault is in configuration
> - This pull request adds the inverse walk. It reads the agent's declared bindings, compares them against the keys in the resolved run environment, and fails before dispatch when a required key did not arrive
> - The benefit is that a missing credential is named as a configuration problem, at the moment it can still be fixed, instead of becoming an opaque runtime failure

## Linked Issues or Issue Description

No existing public issue covers this. Description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

An agent held a secret binding and still failed at run time. The run stopped with an opaque provider error and Paperclip recorded `adapter_failed`:

```
{"type":"error","error":{"name":"ProviderAuthError","data":{"providerID":"openrouter",
 "message":"OpenRouter API key is missing. Pass it using the 'apiKey' parameter or the
 OPENROUTER_API_KEY environment variable."}}}
```

The credential was never in the run environment. Paperclip dispatched the run anyway, because no check compares the declared bindings against the environment the run receives. A grant is not proof of delivery.

**Expected behavior**

Paperclip must fail the run before dispatch when a required `env.*` binding does not reach the run environment. The failure must name the environment key and the configuration path to restore. The failure must not contain a secret value.

**Steps to reproduce**

1. Give an agent a company secret at `env.OPENAI_API_KEY`. A binding row is created.
2. Remove the `OPENAI_API_KEY` entry from that agent's `adapterConfig.env` without a sync that also removes the binding row.
3. Start a run for that agent.
4. The run dispatches. `OPENAI_API_KEY` is absent from the run environment. The run fails inside the agent with a provider authentication error, not with a configuration error.

**Paperclip version or commit**

`master` at `a7e689b3c`.

**Deployment mode**

Self-hosted, authenticated mode.

**Agent adapter(s) involved**

Not adapter-specific. The gate is in the shared heartbeat dispatch path and applies to every adapter.

**Database mode**

Embedded PostgreSQL.

Related open work on the same subsystem, different function: #11489 projects agent API grants under their access alias in `listAgentSecretAccess`. That pull request corrects which grants an agent can address. This pull request checks whether an `env.*` grant reached the run at all. They do not overlap.

## What Changed

- Add `secretService.collectUndeliveredEnvBindings`. It reads the required `env.*` bindings for one consumer, compares each key against the key set of the resolved run environment, and returns a `MissingRuntimeBinding` for each key that did not arrive.
- Add the `binding_not_delivered` secret resolution error code.
- Run the new check in `resolveExecutionRunAdapterConfig` after all environment resolution and before dispatch. It covers all four consumer scopes: agent, project, environment, and routine.
- Raise `ConfigurationIncompleteFailure` with reason `secret_binding_not_delivered` when the check finds anything. The message names the environment key and the configuration path to restore.
- Exempt `access.<ALIAS>` grants. They are API-only by design and are never injected as environment variables.
- Exempt `required: false` bindings. A run is allowed to start without them.
- Make the new method optional on the heartbeat's secret resolver type, so existing partial test doubles still compile. A double that omits it skips the gate. It does not silently pass it.
- Add `heartbeat-secret-delivery-gate.test.ts` and `secrets-service-undelivered-env-bindings.test.ts`.

## Verification

- `pnpm --filter @paperclipai/server typecheck` passes.
- `npx vitest run src/__tests__/heartbeat-secret-delivery-gate.test.ts` passes, 5 tests.
- I disabled the gate and ran the same file again. 4 of the 5 tests failed. The tests are not vacuous.
- `npx vitest run src/__tests__/heartbeat-project-env.test.ts src/__tests__/secrets-service.test.ts src/__tests__/environment-service.test.ts src/__tests__/heartbeat-secret-delivery-gate.test.ts` passes, 40 tests.
- `node scripts/check-forbidden-tokens.mjs` passes.
- `secrets-service-undelivered-env-bindings.test.ts` needs embedded PostgreSQL. That harness does not start on my host, and every pre-existing embedded-PostgreSQL suite skips there in the same way. CI runs it.
- Because of that skip, I also ran the new query read-only against a live instance with 14 agents and 19 secrets. It returned no findings for any agent, so it does not produce false positives on healthy data. When I gave it a run environment with the granted keys removed, it returned exactly the four keys that agent holds, with the correct configuration paths, and no secret value in the output.

## Risks

Low risk. The gate only adds a failure where a run would otherwise start without a credential it declares, so any run it stops was already going to fail — later, and with a less useful error.

The one behavioral shift to note: a run that today starts and fails inside the agent will now fail earlier, as `configuration_incomplete` routed to a human owner rather than `adapter_failed`. This is the intent of the change.

Two exemptions keep the gate from firing on healthy configurations: `access.<ALIAS>` grants and `required: false` bindings. I confirmed on live data that the gate reports nothing across a whole company today.

The low-trust path is unaffected. A binding outside a low-trust boundary already raises `binding_not_allowed` during resolution, which happens before this gate runs.

No migration. No schema change. No API change.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing documentation describes this dispatch-time check; the behavior is explained in code comments at both call sites
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending on this push
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending first review
- [x] I will address all Greptile and reviewer comments before requesting merge
