### PR TITLE
fix(recovery,interactions): age out stale pending request_confirmation coverage + cap retry re-arm

### DIFF
--- a/server/src/__tests__/issue-liveness.test.ts
+++ b/server/src/__tests__/issue-liveness.test.ts
@@ -538,6 +538,93 @@ describe("issue graph liveness classifier", () => {
     }
   });
 
+  it("counts a fresh agent-addressed pending interaction as review coverage, but not once it goes stale (AGE-906)", () => {
+    const reviewIssueId = "review-1";
+    const reviewIssue = issue({
+      id: reviewIssueId,
+      identifier: "PAP-2279",
+      title: "Screenshot acceptance review",
+      status: "in_review",
+      assigneeAgentId: coderId,
+      executionState: null,
+    });
+    const now = new Date("2024-06-01T12:00:00.000Z");
+    const freshCreatedAt = new Date(now.getTime() - 30 * 60 * 1000).toISOString();
+    const staleCreatedAt = new Date(now.getTime() - 5 * 60 * 60 * 1000).toISOString();
+
+    const freshFindings = classifyIssueGraphLiveness({
+      issues: [reviewIssue],
+      relations: [],
+      agents: [agent(), manager],
+      pendingInteractions: [{
+        companyId,
+        issueId: reviewIssueId,
+        status: "pending",
+        createdAt: freshCreatedAt,
+        addresseeAgentId: coderId,
+        resolverPolicy: "anyone",
+      }],
+      now,
+    });
+    expect(freshFindings).toEqual([]);
+
+    const staleFindings = classifyIssueGraphLiveness({
+      issues: [reviewIssue],
+      relations: [],
+      agents: [agent(), manager],
+      pendingInteractions: [{
+        companyId,
+        issueId: reviewIssueId,
+        status: "pending",
+        createdAt: staleCreatedAt,
+        addresseeAgentId: coderId,
+        resolverPolicy: "anyone",
+      }],
+      now,
+    });
+    expect(staleFindings).toHaveLength(1);
+    expect(staleFindings[0]).toMatchObject({
+      issueId: reviewIssueId,
+      state: "in_review_without_action_path",
+    });
+
+    // A stale board_only (human_only) card is exempt from the staleness gate
+    // and keeps counting as coverage indefinitely.
+    const staleHumanOnlyFindings = classifyIssueGraphLiveness({
+      issues: [reviewIssue],
+      relations: [],
+      agents: [agent(), manager],
+      pendingInteractions: [{
+        companyId,
+        issueId: reviewIssueId,
+        status: "pending",
+        createdAt: staleCreatedAt,
+        addresseeAgentId: coderId,
+        resolverPolicy: "human_only",
+      }],
+      now,
+    });
+    expect(staleHumanOnlyFindings).toEqual([]);
+
+    // A stale card with no addressee (not agent-specific) also keeps counting
+    // as coverage; the staleness gate only targets agent-addressed cards.
+    const staleUnaddressedFindings = classifyIssueGraphLiveness({
+      issues: [reviewIssue],
+      relations: [],
+      agents: [agent(), manager],
+      pendingInteractions: [{
+        companyId,
+        issueId: reviewIssueId,
+        status: "pending",
+        createdAt: staleCreatedAt,
+        addresseeAgentId: null,
+        resolverPolicy: "anyone",
+      }],
+      now,
+    });
+    expect(staleUnaddressedFindings).toEqual([]);
+  });
+
   it("does not treat a participant retained after changes are requested as an active review path", () => {
     const reviewIssueId = "review-1";
 

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -426,6 +426,97 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     });
   });
 
+  it("widens resolver policy instead of silently re-arming a repeat idempotency-lineage confirmation to the same non-responding agent (AGE-906)", async () => {
+    const { companyId, issueId, goalId } = await seedConfirmationIssue("Repeat re-issuance widens coverage");
+    const creatorAgentId = randomUUID();
+    const addresseeAgentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const otherRunId = randomUUID();
+    await db.insert(agents).values([
+      { id: creatorAgentId, companyId, name: "Creator", role: "engineer", status: "active" },
+      { id: addresseeAgentId, companyId, name: "Non-responding addressee", role: "engineer", status: "active" },
+      { id: otherAgentId, companyId, name: "Other agent", role: "engineer", status: "active" },
+    ]);
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId,
+      agentId: otherAgentId,
+      invocationSource: "manual",
+      status: "running",
+      startedAt: new Date("2026-07-25T12:00:00.000Z"),
+    });
+
+    const basePayload = {
+      version: 1 as const,
+      prompt: "Ready to merge PR #5?",
+    };
+
+    const first = await interactionsSvc.create(
+      { id: issueId, companyId },
+      {
+        kind: "request_confirmation" as const,
+        addresseeAgentId,
+        continuationPolicy: "wake_assignee" as const,
+        idempotencyKey: `confirmation:${issueId}:pr:5`,
+        payload: basePayload,
+      },
+      { agentId: creatorAgentId },
+    );
+    expect(first).toMatchObject({
+      addresseeAgentId,
+      requestedResolverPolicy: "anyone",
+      effectiveResolverPolicy: "anyone",
+    });
+
+    // The addressee never resolves it. A rebase re-issues the confirmation
+    // under a new idempotency key in the same lineage (`...:pr:6`), still
+    // addressed to the same agent. This must not just re-arm an identical
+    // agent-locked card — it must widen the audience so someone else (or a
+    // human) can act.
+    const second = await interactionsSvc.create(
+      { id: issueId, companyId },
+      {
+        kind: "request_confirmation" as const,
+        addresseeAgentId,
+        continuationPolicy: "wake_assignee" as const,
+        idempotencyKey: `confirmation:${issueId}:pr:6`,
+        payload: basePayload,
+      },
+      { agentId: creatorAgentId },
+    );
+    expect(second.addresseeAgentId).toBeNull();
+    expect(second).toMatchObject({
+      requestedResolverPolicy: "anyone",
+      effectiveResolverPolicy: "anyone",
+    });
+
+    // With the addressee lock dropped, an unrelated agent can now resolve it.
+    const accepted = await interactionsSvc.acceptInteraction(
+      { id: issueId, companyId, projectId: null, goalId },
+      second.id,
+      {},
+      { agentId: otherAgentId, runId: otherRunId },
+    );
+    expect(accepted.interaction.status).toBe("accepted");
+    expect(accepted.interaction.resolvedByAgentId).toBe(otherAgentId);
+
+    // A fresh, unrelated idempotency key addressed to the same agent is a
+    // brand-new request, not a repeat re-issuance, and keeps the addressee
+    // lock as normal.
+    const unrelated = await interactionsSvc.create(
+      { id: issueId, companyId },
+      {
+        kind: "request_confirmation" as const,
+        addresseeAgentId,
+        continuationPolicy: "wake_assignee" as const,
+        idempotencyKey: `confirmation:${issueId}:plan:1`,
+        payload: { version: 1 as const, prompt: "Approve the plan?" },
+      },
+      { agentId: creatorAgentId },
+    );
+    expect(unrelated.addresseeAgentId).toBe(addresseeAgentId);
+  });
+
   it("accepts suggested tasks by creating a rooted issue tree under the current issue", async () => {
     const companyId = randomUUID();
     const goalId = randomUUID();

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -432,6 +432,25 @@ function isEquivalentCreateRequest(
 }
 
 /**
+ * Derive the "lineage" grouping of an idempotency key by dropping its last
+ * `:`-delimited segment, e.g. `confirmation:{issueId}:pr:5` and
+ * `confirmation:{issueId}:pr:6` both belong to lineage
+ * `confirmation:{issueId}:pr`. Keys need at least three segments (a real
+ * prefix, an identifying middle portion, and a trailing
+ * variant/version) to participate in the AGE-906 re-issuance-escalation
+ * check below — this avoids treating two-segment keys that merely share a
+ * common human-chosen first segment (e.g. two unrelated
+ * `addressed:second` / `addressed:board-only` idempotency keys picked for
+ * unrelated test cases) as the same logical request lineage.
+ */
+function deriveIssueThreadInteractionIdempotencyLineage(key: string | null | undefined): string | null {
+  if (!key) return null;
+  const segments = key.split(":");
+  if (segments.length < 3) return null;
+  return segments.slice(0, -1).join(":");
+}
+
+/**
  * Parse a stored interaction `result` blob tolerantly. Rows persisted by older
  * builds can carry a `result` shape that predates the current schema — e.g. a
  * legacy `outcome` value ("withdrawn_by_creator") no longer in the enum.
@@ -1487,6 +1506,38 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       .then((rows) => rows[0] ?? null);
   }
 
+  /**
+   * AGE-906: find a still-pending interaction that shares idempotency lineage
+   * with `idempotencyKey` (same purpose, e.g. a re-issued
+   * `confirmation:{issueId}:pr:{n}` after a rebase), addressed to the same
+   * agent, but under a *different* exact idempotency key. Re-issuing to a
+   * non-responding addressee over and over would otherwise silently re-arm
+   * an identical pending card each time forever — never escalating. This
+   * only reports the fact; callers decide whether/how to widen coverage.
+   */
+  async function findStaleIdempotencyLineageInteraction(args: {
+    issueId: string;
+    companyId: string;
+    idempotencyKey: string;
+    addresseeAgentId: string;
+  }) {
+    const lineage = deriveIssueThreadInteractionIdempotencyLineage(args.idempotencyKey);
+    if (!lineage) return null;
+    const candidates = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(and(
+        eq(issueThreadInteractions.companyId, args.companyId),
+        eq(issueThreadInteractions.issueId, args.issueId),
+        eq(issueThreadInteractions.status, "pending"),
+        eq(issueThreadInteractions.addresseeAgentId, args.addresseeAgentId),
+        isNotNull(issueThreadInteractions.idempotencyKey),
+        ne(issueThreadInteractions.idempotencyKey, args.idempotencyKey),
+      ));
+    return candidates.find((row) =>
+      deriveIssueThreadInteractionIdempotencyLineage(row.idempotencyKey) === lineage) ?? null;
+  }
+
   async function getForIssue(issue: { id: string; companyId: string }, interactionId: string) {
     const current = await db
       .select()
@@ -2326,6 +2377,40 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         }
       }
 
+      // AGE-906: a *different* idempotency key sharing lineage with an
+      // existing pending card addressed to the same agent means this is a
+      // repeat re-issuance to a still-non-responding addressee (e.g. a PR
+      // confirmation re-created after a rebase). Re-arming an identical
+      // agent-locked card again would silently repeat forever; widen the
+      // resolver audience instead so any agent (or a human) can unblock the
+      // issue, and drop the addressee lock that would otherwise keep
+      // excluding everyone else from resolving it. This never auto-approves
+      // or auto-rejects the card — it only widens who may act on it.
+      let insertPolicy = policy;
+      let insertAddresseeAgentId = normalizedData.addresseeAgentId ?? null;
+      // Never override an explicit, already-restrictive request for this
+      // specific card (e.g. an explicit human_only/board_only ask) — widening
+      // is only for silently re-arming an identical agent-locked default, not
+      // for second-guessing an explicit stricter request.
+      if (normalizedData.idempotencyKey && insertAddresseeAgentId && policy.requestedResolverPolicy !== "human_only") {
+        const staleLineageMatch = await findStaleIdempotencyLineageInteraction({
+          issueId: issue.id,
+          companyId: issue.companyId,
+          idempotencyKey: normalizedData.idempotencyKey,
+          addresseeAgentId: insertAddresseeAgentId,
+        });
+        if (staleLineageMatch) {
+          insertAddresseeAgentId = null;
+          insertPolicy = resolveInteractionPolicy({
+            kind: data.kind,
+            requested: "anyone",
+            governance,
+            hasToolAction: false,
+            hasSecretProposal: false,
+          });
+        }
+      }
+
       if (data.sourceCommentId) {
         const sourceComment = await db
           .select({
@@ -2396,17 +2481,17 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
               kind: data.kind,
               status: "pending",
               continuationPolicy: data.continuationPolicy,
-              requestedResolverPolicy: policy.requestedResolverPolicy,
-              effectiveResolverPolicy: policy.effectiveResolverPolicy,
-              resolverPolicyProvenance: policy.resolverPolicyProvenance,
-              effectiveResolverPolicySource: policy.effectiveResolverPolicySource,
+              requestedResolverPolicy: insertPolicy.requestedResolverPolicy,
+              effectiveResolverPolicy: insertPolicy.effectiveResolverPolicy,
+              resolverPolicyProvenance: insertPolicy.resolverPolicyProvenance,
+              effectiveResolverPolicySource: insertPolicy.effectiveResolverPolicySource,
               idempotencyKey: data.idempotencyKey ?? null,
               sourceCommentId: data.sourceCommentId ?? null,
               sourceRunId: data.sourceRunId ?? null,
               title: data.title ?? null,
               summary: data.summary ?? null,
               createdByAgentId: actor.agentId ?? null,
-              addresseeAgentId: data.addresseeAgentId ?? null,
+              addresseeAgentId: insertAddresseeAgentId,
               createdByUserId: actor.userId ?? null,
               payload: data.payload,
             })

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -61,6 +61,17 @@ export interface IssueLivenessWaitingPathInput {
   issueId: string;
   status: string;
   createdAt?: Date | string | null;
+  /**
+   * Only populated for `pendingInteractions` entries. When set alongside a
+   * non-"human_only" `resolverPolicy`, the card is agent-addressed and its
+   * usefulness as "someone is on this" coverage decays with age (AGE-906):
+   * an agent that never wakes to act on it leaves the issue stuck forever
+   * with `classifyIssueReviewPaths` reporting a live review path that in
+   * fact isn't. `approval`/`recovery` entries never set these fields and are
+   * unaffected.
+   */
+  addresseeAgentId?: string | null;
+  resolverPolicy?: string | null;
 }
 
 export type IssueReviewPathFactKind =
@@ -191,6 +202,31 @@ function monitorFromIssue(issue: IssueLivenessIssueInput) {
   return { policyMonitor, stateMonitor };
 }
 
+/**
+ * How long a pending, agent-addressed issue-thread interaction still counts
+ * as "someone is on this" review coverage (AGE-906). `human_only`
+ * ("board_only") cards are never addressed to a possibly-non-responding
+ * agent, so they are exempt from this window and always count. Sized like
+ * the other multi-hour recovery windows in this service (see
+ * ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS in ./service.ts).
+ */
+export const PENDING_AGENT_INTERACTION_COVERAGE_STALE_AFTER_MS = 4 * 60 * 60 * 1000;
+
+const CANONICAL_HUMAN_ONLY_RESOLVER_POLICIES = new Set(["human_only", "board_only"]);
+
+function isAgentAddressedInteractionStale(
+  entry: IssueLivenessWaitingPathInput,
+  nowMs: number,
+): boolean {
+  if (!entry.addresseeAgentId) return false;
+  if (entry.resolverPolicy != null && CANONICAL_HUMAN_ONLY_RESOLVER_POLICIES.has(entry.resolverPolicy)) return false;
+  const createdAtMs = readDateMs(entry.createdAt);
+  // No createdAt on an agent-addressed row is unexpected; fail safe by
+  // treating it as stale rather than granting indefinite coverage.
+  if (createdAtMs === null) return true;
+  return nowMs - createdAtMs > PENDING_AGENT_INTERACTION_COVERAGE_STALE_AFTER_MS;
+}
+
 export function hasScheduledIssueMonitorPath(issue: IssueLivenessIssueInput, now: Date | string | number) {
   const nowMs = typeof now === "number" ? now : readDateMs(now) ?? Date.now();
   const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
@@ -281,6 +317,7 @@ export function classifyIssueReviewPaths(
   ) => {
     for (const entry of entries) {
       if (entry.companyId !== issue.companyId || entry.issueId !== issue.id) continue;
+      if (kind === "interaction" && isAgentAddressedInteractionStale(entry, nowMs)) continue;
       paths.push({
         kind,
         ref: entry.id ?? null,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5541,6 +5541,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           companyId: issueThreadInteractions.companyId,
           issueId: issueThreadInteractions.issueId,
           status: issueThreadInteractions.status,
+          createdAt: issueThreadInteractions.createdAt,
+          addresseeAgentId: issueThreadInteractions.addresseeAgentId,
+          resolverPolicy: issueThreadInteractions.effectiveResolverPolicy,
         })
         .from(issueThreadInteractions)
         .where(eq(issueThreadInteractions.status, "pending")),


### PR DESCRIPTION
## ⚠️ Needs human merge

This PR was opened by an automated agent against the upstream `paperclipai/paperclip` repo (same flow as #11768). It cannot be merged by the agent — a human maintainer needs to review and merge it.

Fixes upstream issue: https://github.com/paperclipai/paperclip/issues/11902

## Root cause

`server/src/services/recovery/issue-graph-liveness.ts`'s `classifyIssueReviewPaths`/`appendWaitingPaths` counted **any** row in `pendingInteractions` as permanent review coverage, with no age check. The caller `collectIssueGraphLivenessFindings` in `server/src/services/recovery/service.ts` didn't even select `createdAt`, `addresseeAgentId`, or `resolverPolicy` for pending interactions. `issue_thread_interactions` has no `expiresAt`; a card only leaves `pending` via a later comment, a newer same-kind interaction, or issue closure.

Net effect: an agent-addressed `request_confirmation`/etc. card whose addressee never wakes could mask a stuck `in_review` issue forever — the liveness classifier always saw "coverage exists" and never escalated to `in_review_without_action_path`.

## Changes

1. **`server/src/services/recovery/service.ts`** — `collectIssueGraphLivenessFindings`'s pending-interaction query now also selects `createdAt`, `addresseeAgentId`, and the effective `resolverPolicy`.
2. **`server/src/services/recovery/issue-graph-liveness.ts`** — `IssueLivenessWaitingPathInput` gained the same fields. In `appendWaitingPaths` (used only by `classifyIssueReviewPaths`), an `"interaction"` entry with a non-null `addresseeAgentId` and a `resolverPolicy` other than `human_only`/`board_only` now only counts as coverage while younger than the new `PENDING_AGENT_INTERACTION_COVERAGE_STALE_AFTER_MS` (4h, consistent with this file's other multi-hour recovery windows, e.g. `ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS`). Once stale it's simply dropped from the waiting-path list, letting the existing `in_review_without_action_path`/stalled escalation fire on its own. `human_only` ("board_only") cards and cards with no addressee are exempt and always count, matching current behavior — this scopes the fix to exactly the case in the root-cause analysis.
3. **`server/src/services/issue-thread-interactions.ts`** — `create()` now detects when a new idempotency key shares "lineage" with an existing pending card addressed to the same agent (e.g. `confirmation:{issueId}:pr:5` -> `confirmation:{issueId}:pr:6` after a rebase, same addressee, still pending). Instead of silently re-arming an identical agent-locked card forever, the new card's resolver policy is widened to `anyone` and the addressee lock is dropped, so any agent (or a human) can act. An explicit `human_only`/`board_only` request on the *new* card is never overridden — this only widens a would-be default re-arm, never a deliberately restrictive ask.

**No auto-approve/auto-reject anywhere** — staleness only removes a dead card from "coverage"; widening only changes *who* may resolve a card, never resolves it. "Wake the assignee, don't decide for them" is preserved.

## Tests

- `server/src/__tests__/issue-liveness.test.ts`: a fresh agent-addressed pending interaction still counts as review coverage; once older than the staleness window, `classifyIssueGraphLiveness` reports `in_review_without_action_path`. Also covers that stale `human_only` and stale unaddressed cards remain exempt (no regression).
- `server/src/__tests__/issue-thread-interactions-service.test.ts`: repeat re-issuance of the same confirmation lineage to the same non-responding addressee widens the resolver policy (and drops the addressee lock) so another agent can accept it; a genuinely unrelated idempotency key keeps the normal addressee lock.
- Full existing suites for both touched files stay green: `issue-liveness.test.ts`, `issue-thread-interactions-service.test.ts`, `issue-thread-interactions.test.ts`, `issue-thread-interactions-telemetry.test.ts`, `recovery-classifiers.test.ts` -- 102/102 passing.
- `tsc --noEmit` clean on `server`.
