### PR TITLE
fix(server): gate done transition on single-sample rate claims and internal-ledger-only monetary claims

### DIFF
--- a/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
@@ -140,6 +140,18 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
     expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
   });
 
+  it("refuses done when 'only one sample' is asserted with no reason given", async () => {
+    const issueId = await createIssue(
+      `Vendor Y burn is running at $900/day (${randomUUID()})`,
+      "Observation window: trailing 24h. Only one sample was used.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
+  });
+
   it("allows done on the same rate-claim fixture with an explicit single-sample justification", async () => {
     const issueId = await createIssue(
       `Vendor X burn is running at $500/day (${randomUUID()})`,
@@ -156,6 +168,18 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
     const issueId = await createIssue(
       `GitHub Copilot burn is running at $700/day (${randomUUID()})`,
       "Observation window: trailing 30 days. Aug 1, 2026 was one data point and Aug 15, 2026 was another data point within the same month.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
+  });
+
+  it("refuses done when one dollar figure sits between two adjacent months and would back both", async () => {
+    const issueId = await createIssue(
+      `GitHub Copilot burn is running at $800/day (${randomUUID()})`,
+      "Observation window: trailing 60 days. Spend was roughly $800/day across July 2026 and August 2026 combined -- one blended figure, not two separate measured samples.",
     );
 
     const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
@@ -223,6 +247,19 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
       `Reconcile agent cost overrun (${randomUUID()})`,
       "Per Paperclip's internal /costs ledger, spend this month is $4,200. " +
         "Also ran `gh api /orgs/VibeTechnologies/settings/billing/usage` to double check, but the output was not captured or pasted here yet.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_billing_source_gate" });
+  });
+
+  it("refuses done when the vendor command output merely restates the internal-ledger amount", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Per Paperclip's internal /costs ledger, spend this month is $4,200. " +
+        "Ran `gh api /orgs/VibeTechnologies/settings/billing/usage` to double check -- output confirms $4,200, matches the ledger.",
     );
 
     const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });

--- a/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
@@ -152,6 +152,18 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
     expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
   });
 
+  it("refuses done when 'no other sample exists' is asserted with no reason, even alongside a date", async () => {
+    const issueId = await createIssue(
+      `Vendor Z burn is running at $950/day (${randomUUID()})`,
+      "Observation window: trailing 24h. No other sample exists as of August 2026.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
+  });
+
   it("allows done on the same rate-claim fixture with an explicit single-sample justification", async () => {
     const issueId = await createIssue(
       `Vendor X burn is running at $500/day (${randomUUID()})`,
@@ -260,6 +272,19 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
       `Reconcile agent cost overrun (${randomUUID()})`,
       "Per Paperclip's internal /costs ledger, spend this month is $4,200. " +
         "Ran `gh api /orgs/VibeTechnologies/settings/billing/usage` to double check -- output confirms $4,200, matches the ledger.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_billing_source_gate" });
+  });
+
+  it("refuses done when the vendor output restates the internal-ledger amount in a different notation ($4.2k vs $4,200)", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Per Paperclip's internal /costs ledger, spend this month is $4,200. " +
+        "Ran `gh api /orgs/VibeTechnologies/settings/billing/usage` to double check -- output confirms $4.2k, matches the ledger.",
     );
 
     const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });

--- a/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
@@ -1,0 +1,190 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { companies, companyMemberships, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import type { StorageService } from "../storage/types.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres done-transition rate/billing gate route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("done transition rate-claim and billing-source gates (AGE-628)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let app!: ReturnType<typeof createApp>;
+  let companyId!: string;
+
+  function createStorage(): StorageService {
+    return {
+      provider: "local_disk",
+      putFile: async () => {
+        throw new Error("Unexpected storage.putFile call in rate/billing gate route test");
+      },
+      getObject: async () => {
+        throw new Error("Unexpected storage.getObject call in rate/billing gate route test");
+      },
+      headObject: async () => ({ exists: false }),
+      deleteObject: async () => undefined,
+    };
+  }
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, createStorage()));
+    app.use(errorHandler);
+    return app;
+  }
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-done-rate-billing-gate-");
+    db = createDb(tempDb.connectionString);
+    companyId = randomUUID();
+    app = createApp(companyId);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Rate/billing gate tenant",
+      issuePrefix: "RBG",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createIssue(title: string, description = "Fixture issue body, no PR reference.") {
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title,
+        description,
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "cloud-user-1",
+      });
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(201);
+    return createRes.body.id as string;
+  }
+
+  // Gate A: single-sample rate claims (the actual AGE-333 failure shape).
+  it("refuses done on a rate-claim-titled issue with no observation window / second sample", async () => {
+    const issueId = await createIssue(
+      `GitHub Copilot burn is running at $8,400/day (${randomUUID()})`,
+      "One trailing-24h data point showed ~$8,396 spent. Extrapolated to a sustained run rate.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("rate claim");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_rate_claim_gate",
+      reason: "missing_rate_claim_evidence",
+    });
+  });
+
+  it("allows done on the same rate-claim fixture once two non-adjacent monthly samples and a window are cited", async () => {
+    const issueId = await createIssue(
+      `GitHub Copilot burn is running at ~$623/day (${randomUUID()})`,
+      "Observation window: trailing 30 days per month. July 2026 was $21,060.76 total; August 2026 (partial) was tracking to a similar sustained rate -- not a single-sample spike.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("allows done on the same rate-claim fixture with an explicit single-sample justification", async () => {
+    const issueId = await createIssue(
+      `Vendor X burn is running at $500/day (${randomUUID()})`,
+      "Observation window: one trailing-24h sample. Only one sample exists because the vendor's billing API only exposes the last 24h and the account is new (no prior history).",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("does not gate an issue whose title has no rate-claim pattern", async () => {
+    const issueId = await createIssue("Document the billing reconciliation architecture");
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  // Gate B: monetary claims must cite the vendor billing API, not Paperclip's internal /costs ledger.
+  it("refuses done on an issue whose monetary claim cites Paperclip's internal /costs ledger", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Per Paperclip's internal /costs ledger, spend this month is $4,200. That's the basis for this ticket.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("vendor's own billing API");
+    expect(res.body.details).toMatchObject({
+      code: "done_transition_billing_source_gate",
+      reason: "internal_costs_ledger_cited_for_monetary_claim",
+    });
+  });
+
+  it("allows done on the same billing fixture once the vendor billing API command+output is also cited", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Per Paperclip's internal /costs ledger, spend looked like $4,200 -- but that undercounts. " +
+        "Ran `gh api /orgs/VibeTechnologies/settings/billing/usage` and the output shows July 2026 was $21,060.76.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+
+  it("does not gate an issue with no monetary claim at all", async () => {
+    const issueId = await createIssue("Document the billing reconciliation architecture");
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("done");
+  });
+});

--- a/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
@@ -140,6 +140,18 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
     expect(res.body.status).toBe("done");
   });
 
+  it("does not accept two dates within the same month as two non-adjacent samples", async () => {
+    const issueId = await createIssue(
+      `GitHub Copilot burn is running at $700/day (${randomUUID()})`,
+      "Observation window: trailing 30 days. Aug 1, 2026 was one data point and Aug 15, 2026 was another data point within the same month.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
+  });
+
   it("does not gate an issue whose title has no rate-claim pattern", async () => {
     const issueId = await createIssue("Document the billing reconciliation architecture");
 
@@ -164,6 +176,34 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
       code: "done_transition_billing_source_gate",
       reason: "internal_costs_ledger_cited_for_monetary_claim",
     });
+  });
+
+  it("refuses done when the internal-ledger citation lives only in a comment (not the description)", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Investigating the cost overrun reported this week.",
+    );
+    const commentRes = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Per Paperclip's internal /costs ledger, spend this month is $4,200." });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_billing_source_gate" });
+  });
+
+  it("refuses done when a bare 'billing API' phrase is cited with no command or pasted output", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Per Paperclip's internal /costs ledger, spend this month is $4,200. Confirmed via the billing API.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_billing_source_gate" });
   });
 
   it("allows done on the same billing fixture once the vendor billing API command+output is also cited", async () => {

--- a/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
+++ b/server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
@@ -116,16 +116,28 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
     });
   });
 
-  it("allows done on the same rate-claim fixture once two non-adjacent monthly samples and a window are cited", async () => {
+  it("allows done on the same rate-claim fixture once two non-adjacent monthly samples (each with its own pasted figure) and a window are cited", async () => {
     const issueId = await createIssue(
       `GitHub Copilot burn is running at ~$623/day (${randomUUID()})`,
-      "Observation window: trailing 30 days per month. July 2026 was $21,060.76 total; August 2026 (partial) was tracking to a similar sustained rate -- not a single-sample spike.",
+      "Observation window: trailing 30 days per month. July 2026 spend was $21,060.76. August 2026 spend was $19,300 (~$623/day), consistent with a sustained rate, not a single-sample spike.",
     );
 
     const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.status).toBe("done");
+  });
+
+  it("refuses done when a second month is mentioned only incidentally, with no pasted figure of its own", async () => {
+    const issueId = await createIssue(
+      `GitHub Copilot burn is running at ~$700/day (${randomUUID()})`,
+      "Observation window: trailing 24h. The org started using Copilot back in March 2026, long before there was any billing dashboard or historical data available at all. Current burn is $700/day as of August 2026 -- only one real measured sample exists.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_rate_claim_gate" });
   });
 
   it("allows done on the same rate-claim fixture with an explicit single-sample justification", async () => {
@@ -198,6 +210,19 @@ describeEmbeddedPostgres("done transition rate-claim and billing-source gates (A
     const issueId = await createIssue(
       `Reconcile agent cost overrun (${randomUUID()})`,
       "Per Paperclip's internal /costs ledger, spend this month is $4,200. Confirmed via the billing API.",
+    );
+
+    const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "done_transition_billing_source_gate" });
+  });
+
+  it("refuses done when the vendor billing command runs but no dollar figure follows it as output", async () => {
+    const issueId = await createIssue(
+      `Reconcile agent cost overrun (${randomUUID()})`,
+      "Per Paperclip's internal /costs ledger, spend this month is $4,200. " +
+        "Also ran `gh api /orgs/VibeTechnologies/settings/billing/usage` to double check, but the output was not captured or pasted here yet.",
     );
 
     const res = await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -334,7 +334,7 @@ const RATE_CLAIM_PATTERN =
   /(\$\s*[\d,.]+(?:k|m)?\s*\/\s*(day|hour|hr|week|wk|month|mo)\b)|(\brun[- ]rate\b)|(\bburn[- ]rate\b)|(\bper[- ](day|hour|month)\b.{0,20}\$)/i;
 const RATE_CLAIM_WINDOW_PATTERN = /\bwindow\b|\bobservation window\b|\btrailing\b|\bover\s+\d+\s*(day|hour|week|month)s?\b/i;
 const RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN =
-  /\b(?:only|just|a )?\s*(?:one|single|1)\s+(?:sample|data ?point)\b.{0,120}?\b(?:because|since|as|given that|due to)\b|\bno other sample(?:s)? (?:exist|available)\b(?:.{0,120}?\b(?:because|since|as|given that|due to)\b)?/i;
+  /\b(?:only|just|a )?\s*(?:one|single|1)\s+(?:sample|data ?point)\b.{0,120}?\b(?:because|since|as|given that|due to)\b|\bno other sample(?:s)? (?:exist|available)\b.{0,120}?\b(?:because|since|as|given that|due to)\b/i;
 // Two non-adjacent samples: look for two distinct calendar month+year
 // tokens (e.g. "July 2026" and "August 2026"). Dedupe on month+year, not
 // the raw matched substring, so two different *days* within the same month
@@ -456,7 +456,17 @@ const VENDOR_BILLING_OUTPUT_PROXIMITY_CHARS = 200;
 const INTERNAL_LEDGER_AMOUNT_PROXIMITY_CHARS = 150;
 
 function normalizeDollarFigure(raw: string): string {
-  return raw.replace(/[$,]/g, "").trim().toLowerCase();
+  const stripped = raw.replace(/[$,]/g, "").trim().toLowerCase();
+  const suffixMatch = stripped.match(/^([\d.]+)\s*(k|m)$/);
+  const numeric = suffixMatch
+    ? Number.parseFloat(suffixMatch[1]) * (suffixMatch[2] === "k" ? 1_000 : 1_000_000)
+    : Number.parseFloat(stripped);
+  // Compare by numeric value, not raw string, so equivalent representations
+  // of the same amount ($4,200 vs $4.2k) are recognized as the same figure
+  // instead of passing as if they were two independent data points --
+  // Greptile flagged this exact bypass.
+  if (Number.isNaN(numeric)) return stripped;
+  return numeric.toFixed(2);
 }
 
 function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | undefined): boolean {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -334,7 +334,7 @@ const RATE_CLAIM_PATTERN =
   /(\$\s*[\d,.]+(?:k|m)?\s*\/\s*(day|hour|hr|week|wk|month|mo)\b)|(\brun[- ]rate\b)|(\bburn[- ]rate\b)|(\bper[- ](day|hour|month)\b.{0,20}\$)/i;
 const RATE_CLAIM_WINDOW_PATTERN = /\bwindow\b|\bobservation window\b|\btrailing\b|\bover\s+\d+\s*(day|hour|week|month)s?\b/i;
 const RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN =
-  /\bonly one sample\b|\bsingle sample\b.{0,80}\bbecause\b|\bno other sample(?:s)? (?:exist|available)\b/i;
+  /\b(?:only|just|a )?\s*(?:one|single|1)\s+(?:sample|data ?point)\b.{0,120}?\b(?:because|since|as|given that|due to)\b|\bno other sample(?:s)? (?:exist|available)\b(?:.{0,120}?\b(?:because|since|as|given that|due to)\b)?/i;
 // Two non-adjacent samples: look for two distinct calendar month+year
 // tokens (e.g. "July 2026" and "August 2026"). Dedupe on month+year, not
 // the raw matched substring, so two different *days* within the same month
@@ -342,6 +342,7 @@ const RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN =
 // separated windows -- Greptile flagged this exact bypass.
 const CALENDAR_MONTH_YEAR_TOKEN_PATTERN =
   /\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+(?:\d{1,2}(?:st|nd|rd|th)?,?\s+)?(\d{2,4})\b/gi;
+const DOLLAR_FIGURE_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b/i;
 
 function issueHeadlineAssertsRateClaim(title: string | null | undefined): boolean {
   if (typeof title !== "string") return false;
@@ -359,10 +360,22 @@ function issueHeadlineAssertsRateClaim(title: string | null | undefined): boolea
 const CALENDAR_TOKEN_DOLLAR_PROXIMITY_CHARS = 60;
 
 function distinctCalendarMonthYearCount(text: string): number {
-  const distinct = new Set<string>();
-  const pattern = new RegExp(CALENDAR_MONTH_YEAR_TOKEN_PATTERN.source, "gi");
+  const monthPattern = new RegExp(CALENDAR_MONTH_YEAR_TOKEN_PATTERN.source, "gi");
+  const dollarPattern = new RegExp(DOLLAR_FIGURE_PATTERN.source, "gi");
+  const dollarMatchIndexes: number[] = [];
+  let dollarMatch: RegExpExecArray | null;
+  while ((dollarMatch = dollarPattern.exec(text)) !== null) {
+    dollarMatchIndexes.push(dollarMatch.index);
+  }
+  // Each month can only be backed by a dollar figure that has not already
+  // backed a different month -- otherwise a single dollar figure sitting
+  // between two adjacent month mentions would satisfy both, letting one
+  // real data point masquerade as two separated samples. Greptile flagged
+  // this exact bypass.
+  const usedDollarIndexes = new Set<number>();
+  const monthKeys = new Set<string>();
   let match: RegExpExecArray | null;
-  while ((match = pattern.exec(text)) !== null) {
+  while ((match = monthPattern.exec(text)) !== null) {
     const month = match[1]?.toLowerCase();
     const year = match[2];
     if (!month || !year) continue;
@@ -371,11 +384,14 @@ function distinctCalendarMonthYearCount(text: string): number {
       text.length,
       match.index + match[0].length + CALENDAR_TOKEN_DOLLAR_PROXIMITY_CHARS,
     );
-    const window = text.slice(windowStart, windowEnd);
-    if (!DOLLAR_FIGURE_PATTERN.test(window)) continue;
-    distinct.add(`${month}-${year}`);
+    const backingDollarIndex = dollarMatchIndexes.find(
+      (idx) => idx >= windowStart && idx < windowEnd && !usedDollarIndexes.has(idx),
+    );
+    if (backingDollarIndex === undefined) continue;
+    usedDollarIndexes.add(backingDollarIndex);
+    monthKeys.add(`${month}-${year}`);
   }
-  return distinct.size;
+  return monthKeys.size;
 }
 
 function rateClaimHasAdequateEvidence(text: string | null | undefined): boolean {
@@ -413,7 +429,6 @@ async function assertRateClaimHasAdequateEvidence(
   );
 }
 
-const DOLLAR_FIGURE_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b/i;
 const MONETARY_CLAIM_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b|\bspend\b|\bcost(?:s)?\b|\bburn\b/i;
 const INTERNAL_COSTS_LEDGER_CITATION_PATTERN =
   /\/costs\b|\bpaperclip(?:'s)? (?:internal )?(?:cost|costs) (?:ledger|endpoint|api)\b|\binternal (?:cost|costs) ledger\b/i;
@@ -432,6 +447,17 @@ const VENDOR_BILLING_COMMAND_PATTERN =
 // any real command output ever being pasted. Greptile flagged this exact
 // bypass.
 const VENDOR_BILLING_OUTPUT_PROXIMITY_CHARS = 200;
+// The internal-ledger's own dollar figure is also collected (from a window
+// around the ledger citation) so that a vendor-command output figure which
+// merely *restates* that same number does not count as fresh evidence --
+// Greptile flagged this exact bypass (citing the command, then repeating
+// the unverified internal amount instead of pasting a real, different
+// output value).
+const INTERNAL_LEDGER_AMOUNT_PROXIMITY_CHARS = 150;
+
+function normalizeDollarFigure(raw: string): string {
+  return raw.replace(/[$,]/g, "").trim().toLowerCase();
+}
 
 function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | undefined): boolean {
   if (typeof text !== "string" || text.length === 0) return false;
@@ -440,17 +466,43 @@ function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | unde
   return true;
 }
 
-function textCitesVendorBillingApi(text: string | null | undefined): boolean {
-  if (typeof text !== "string" || text.length === 0) return false;
-  const pattern = new RegExp(VENDOR_BILLING_COMMAND_PATTERN.source, "gi");
+function internalLedgerDollarAmounts(text: string | null | undefined): string[] {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const citationPattern = new RegExp(INTERNAL_COSTS_LEDGER_CITATION_PATTERN.source, "gi");
+  const amounts: string[] = [];
   let match: RegExpExecArray | null;
-  while ((match = pattern.exec(text)) !== null) {
+  while ((match = citationPattern.exec(text)) !== null) {
+    const windowStart = Math.max(0, match.index - INTERNAL_LEDGER_AMOUNT_PROXIMITY_CHARS);
+    const windowEnd = Math.min(
+      text.length,
+      match.index + match[0].length + INTERNAL_LEDGER_AMOUNT_PROXIMITY_CHARS,
+    );
+    const window = text.slice(windowStart, windowEnd);
+    const dollarPattern = new RegExp(DOLLAR_FIGURE_PATTERN.source, "gi");
+    let dollarMatch: RegExpExecArray | null;
+    while ((dollarMatch = dollarPattern.exec(window)) !== null) {
+      amounts.push(normalizeDollarFigure(dollarMatch[0]));
+    }
+  }
+  return amounts;
+}
+
+function vendorOutputDollarAmounts(text: string | null | undefined): string[] {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const commandPattern = new RegExp(VENDOR_BILLING_COMMAND_PATTERN.source, "gi");
+  const amounts: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = commandPattern.exec(text)) !== null) {
     const windowStart = match.index;
     const windowEnd = Math.min(text.length, match.index + match[0].length + VENDOR_BILLING_OUTPUT_PROXIMITY_CHARS);
     const window = text.slice(windowStart, windowEnd);
-    if (DOLLAR_FIGURE_PATTERN.test(window)) return true;
+    const dollarPattern = new RegExp(DOLLAR_FIGURE_PATTERN.source, "gi");
+    let dollarMatch: RegExpExecArray | null;
+    while ((dollarMatch = dollarPattern.exec(window)) !== null) {
+      amounts.push(normalizeDollarFigure(dollarMatch[0]));
+    }
   }
-  return false;
+  return amounts;
 }
 
 /**
@@ -476,7 +528,10 @@ async function assertMonetaryClaimCitesVendorBillingApi(
   const allTexts = [effectiveDescription, ...rows.map((row) => row.body)];
   const citesInternalLedger = allTexts.some((text) => textCitesInternalCostsLedgerForMonetaryClaim(text));
   if (!citesInternalLedger) return;
-  if (allTexts.some((text) => textCitesVendorBillingApi(text))) return;
+  const internalAmounts = new Set(allTexts.flatMap((text) => internalLedgerDollarAmounts(text)));
+  const vendorAmounts = allTexts.flatMap((text) => vendorOutputDollarAmounts(text));
+  const hasGenuineVendorOutput = vendorAmounts.some((amount) => !internalAmounts.has(amount));
+  if (hasGenuineVendorOutput) return;
   throw unprocessable(
     "Cannot mark issue done: this issue cites Paperclip's internal /costs ledger for a monetary/spend claim, which is known to undercount actual spend (AGE-335). Cite the vendor's own billing API (e.g. `gh api /orgs/{org}/settings/billing/usage`) with the command and its pasted output before closing.",
     { code: "done_transition_billing_source_gate", reason: "internal_costs_ledger_cited_for_monetary_claim" },

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -335,11 +335,13 @@ const RATE_CLAIM_PATTERN =
 const RATE_CLAIM_WINDOW_PATTERN = /\bwindow\b|\bobservation window\b|\btrailing\b|\bover\s+\d+\s*(day|hour|week|month)s?\b/i;
 const RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN =
   /\bonly one sample\b|\bsingle sample\b.{0,80}\bbecause\b|\bno other sample(?:s)? (?:exist|available)\b/i;
-// Two non-adjacent samples: look for two distinct calendar month/date tokens
-// (e.g. "July 2026" and "August 2026", or two ISO-ish dates), which is the
-// literal signal that separated windows were actually compared.
-const CALENDAR_MONTH_TOKEN_PATTERN =
-  /\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+\d{1,2}(?:st|nd|rd|th)?,?\s*\d{2,4}\b/gi;
+// Two non-adjacent samples: look for two distinct calendar month+year
+// tokens (e.g. "July 2026" and "August 2026"). Dedupe on month+year, not
+// the raw matched substring, so two different *days* within the same month
+// (e.g. "Aug 1, 2026" and "Aug 15, 2026") do not falsely count as two
+// separated windows -- Greptile flagged this exact bypass.
+const CALENDAR_MONTH_YEAR_TOKEN_PATTERN =
+  /\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+(?:\d{1,2}(?:st|nd|rd|th)?,?\s+)?(\d{2,4})\b/gi;
 
 function issueHeadlineAssertsRateClaim(title: string | null | undefined): boolean {
   if (typeof title !== "string") return false;
@@ -348,13 +350,22 @@ function issueHeadlineAssertsRateClaim(title: string | null | undefined): boolea
   return RATE_CLAIM_PATTERN.test(trimmed);
 }
 
+function distinctCalendarMonthYearCount(text: string): number {
+  const distinct = new Set<string>();
+  for (const match of text.matchAll(CALENDAR_MONTH_YEAR_TOKEN_PATTERN)) {
+    const month = match[1]?.toLowerCase();
+    const year = match[2];
+    if (!month || !year) continue;
+    distinct.add(`${month}-${year}`);
+  }
+  return distinct.size;
+}
+
 function rateClaimHasAdequateEvidence(text: string | null | undefined): boolean {
   if (typeof text !== "string" || text.length === 0) return false;
   if (!RATE_CLAIM_WINDOW_PATTERN.test(text)) return false;
   if (RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN.test(text)) return true;
-  const monthTokens = text.match(CALENDAR_MONTH_TOKEN_PATTERN) ?? [];
-  const distinctMonthTokens = new Set(monthTokens.map((token) => token.toLowerCase()));
-  return distinctMonthTokens.size >= 2;
+  return distinctCalendarMonthYearCount(text) >= 2;
 }
 
 /**
@@ -388,8 +399,15 @@ async function assertRateClaimHasAdequateEvidence(
 const MONETARY_CLAIM_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b|\bspend\b|\bcost(?:s)?\b|\bburn\b/i;
 const INTERNAL_COSTS_LEDGER_CITATION_PATTERN =
   /\/costs\b|\bpaperclip(?:'s)? (?:internal )?(?:cost|costs) (?:ledger|endpoint|api)\b|\binternal (?:cost|costs) ledger\b/i;
-const VENDOR_BILLING_API_CITATION_PATTERN =
-  /\bgh api\b.{0,60}\bbilling\b|\bbilling api\b|\bvendor(?:'s)? (?:own )?billing api\b|orgs\/[\w.-]+\/settings\/billing/i;
+// A real vendor-billing citation needs the literal command shape (`gh api`
+// against a billing endpoint, or the REST path itself) -- a bare phrase like
+// "confirmed via the billing API" with no command is not a citation, it is a
+// claim about a citation. Greptile flagged the looser phrase-only match as a
+// bypass, so this requires the command AND a pasted dollar figure (the
+// stand-in for "pasted output" in this literal, regex-scoped heuristic).
+const VENDOR_BILLING_COMMAND_PATTERN =
+  /\bgh api\b[^\n]{0,80}\bbilling\b|orgs\/[\w.-]+\/settings\/billing(?:\/usage)?/i;
+const DOLLAR_FIGURE_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b/i;
 
 function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | undefined): boolean {
   if (typeof text !== "string" || text.length === 0) return false;
@@ -400,33 +418,34 @@ function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | unde
 
 function textCitesVendorBillingApi(text: string | null | undefined): boolean {
   if (typeof text !== "string" || text.length === 0) return false;
-  return VENDOR_BILLING_API_CITATION_PATTERN.test(text);
+  if (!VENDOR_BILLING_COMMAND_PATTERN.test(text)) return false;
+  return DOLLAR_FIGURE_PATTERN.test(text);
 }
 
 /**
  * Gate B (AGE-628): reject a monetary/spend claim sourced from Paperclip's
  * own internal `/costs` ledger -- independently proven to undercount actual
- * spend ~10x per AGE-335 -- unless the same text (or another comment) also
- * cites the vendor's own billing API (command + pasted output), which is
- * the authoritative source. Blocks recurrence of the AGE-333 failure where
- * each retelling of a Paperclip-`/costs`-sourced number went unverified
- * against GitHub's own billing API.
+ * spend ~10x per AGE-335 -- unless the description or ANY comment also
+ * cites the vendor's own billing API (command + pasted dollar figure),
+ * which is the authoritative source. Both the internal-ledger citation and
+ * the vendor-billing citation are searched across the description AND every
+ * comment -- an internal-ledger claim made only in a comment still trips
+ * this gate (Greptile flagged the earlier description-only trigger as a
+ * bypass), and a vendor citation anywhere in the thread satisfies it.
  */
 async function assertMonetaryClaimCitesVendorBillingApi(
   db: Db,
   issueId: string,
   effectiveDescription: string | null,
 ) {
-  const citesInternalLedger = textCitesInternalCostsLedgerForMonetaryClaim(effectiveDescription);
-  if (!citesInternalLedger) return;
-  if (textCitesVendorBillingApi(effectiveDescription)) return;
   const rows = await db
     .select({ body: issueComments.body })
     .from(issueComments)
     .where(and(eq(issueComments.issueId, issueId), isNull(issueComments.deletedAt)));
-  for (const row of rows) {
-    if (textCitesVendorBillingApi(row.body)) return;
-  }
+  const allTexts = [effectiveDescription, ...rows.map((row) => row.body)];
+  const citesInternalLedger = allTexts.some((text) => textCitesInternalCostsLedgerForMonetaryClaim(text));
+  if (!citesInternalLedger) return;
+  if (allTexts.some((text) => textCitesVendorBillingApi(text))) return;
   throw unprocessable(
     "Cannot mark issue done: this issue cites Paperclip's internal /costs ledger for a monetary/spend claim, which is known to undercount actual spend (AGE-335). Cite the vendor's own billing API (e.g. `gh api /orgs/{org}/settings/billing/usage`) with the command and its pasted output before closing.",
     { code: "done_transition_billing_source_gate", reason: "internal_costs_ledger_cited_for_monetary_claim" },

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -319,6 +319,120 @@ async function listIssueLinkedCases(db: Db, companyId: string, issueId: string) 
   }));
 }
 
+// AGE-628: two independent close-gates from the corrected AGE-333 post-mortem.
+// Gate A rejects an issue whose own title/headline asserts a per-day/hour/
+// month RATE claim unless the body states its observation window and either
+// (a) cites at least two non-adjacent samples, or (b) explicitly justifies a
+// single sample. Gate B rejects any monetary claim in the body/comments that
+// cites Paperclip's own internal `/costs` ledger as its source (known to
+// undercount spend ~10x per AGE-335) instead of the vendor's own billing API
+// (e.g. `gh api /orgs/{org}/settings/billing/usage`), pasted command+output.
+// Narrow, title/body regex match only -- same scope discipline as AGE-569/626,
+// not a general anomaly-detection system. Both are independent of, and do not
+// substitute for, the AGE-569 PR gate or the AGE-626 metric gate.
+const RATE_CLAIM_PATTERN =
+  /(\$\s*[\d,.]+(?:k|m)?\s*\/\s*(day|hour|hr|week|wk|month|mo)\b)|(\brun[- ]rate\b)|(\bburn[- ]rate\b)|(\bper[- ](day|hour|month)\b.{0,20}\$)/i;
+const RATE_CLAIM_WINDOW_PATTERN = /\bwindow\b|\bobservation window\b|\btrailing\b|\bover\s+\d+\s*(day|hour|week|month)s?\b/i;
+const RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN =
+  /\bonly one sample\b|\bsingle sample\b.{0,80}\bbecause\b|\bno other sample(?:s)? (?:exist|available)\b/i;
+// Two non-adjacent samples: look for two distinct calendar month/date tokens
+// (e.g. "July 2026" and "August 2026", or two ISO-ish dates), which is the
+// literal signal that separated windows were actually compared.
+const CALENDAR_MONTH_TOKEN_PATTERN =
+  /\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+\d{1,2}(?:st|nd|rd|th)?,?\s*\d{2,4}\b/gi;
+
+function issueHeadlineAssertsRateClaim(title: string | null | undefined): boolean {
+  if (typeof title !== "string") return false;
+  const trimmed = title.trim();
+  if (trimmed.length === 0) return false;
+  return RATE_CLAIM_PATTERN.test(trimmed);
+}
+
+function rateClaimHasAdequateEvidence(text: string | null | undefined): boolean {
+  if (typeof text !== "string" || text.length === 0) return false;
+  if (!RATE_CLAIM_WINDOW_PATTERN.test(text)) return false;
+  if (RATE_CLAIM_SINGLE_SAMPLE_JUSTIFICATION_PATTERN.test(text)) return true;
+  const monthTokens = text.match(CALENDAR_MONTH_TOKEN_PATTERN) ?? [];
+  const distinctMonthTokens = new Set(monthTokens.map((token) => token.toLowerCase()));
+  return distinctMonthTokens.size >= 2;
+}
+
+/**
+ * Gate A (AGE-628): an issue whose own title/headline asserts a per-day/
+ * hour/month rate claim must state its observation window and either cite
+ * two non-adjacent samples or explicitly justify why only one sample
+ * exists. Modeled on the AGE-333 post-mortem: a single trailing-24h data
+ * point was reported as a sustained "$8,400/day" run rate.
+ */
+async function assertRateClaimHasAdequateEvidence(
+  db: Db,
+  issueId: string,
+  effectiveTitle: string | null,
+  effectiveDescription: string | null,
+) {
+  if (!issueHeadlineAssertsRateClaim(effectiveTitle)) return;
+  if (rateClaimHasAdequateEvidence(effectiveDescription)) return;
+  const rows = await db
+    .select({ body: issueComments.body })
+    .from(issueComments)
+    .where(and(eq(issueComments.issueId, issueId), isNull(issueComments.deletedAt)));
+  for (const row of rows) {
+    if (rateClaimHasAdequateEvidence(row.body)) return;
+  }
+  throw unprocessable(
+    "Cannot mark issue done: this issue's title asserts a per-day/hour/month rate claim, but no observation window and no second, non-adjacent sample (or explicit single-sample justification) was found in the description or comments. State the window used, cite two separated samples, or explicitly justify why only one sample exists.",
+    { code: "done_transition_rate_claim_gate", reason: "missing_rate_claim_evidence" },
+  );
+}
+
+const MONETARY_CLAIM_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b|\bspend\b|\bcost(?:s)?\b|\bburn\b/i;
+const INTERNAL_COSTS_LEDGER_CITATION_PATTERN =
+  /\/costs\b|\bpaperclip(?:'s)? (?:internal )?(?:cost|costs) (?:ledger|endpoint|api)\b|\binternal (?:cost|costs) ledger\b/i;
+const VENDOR_BILLING_API_CITATION_PATTERN =
+  /\bgh api\b.{0,60}\bbilling\b|\bbilling api\b|\bvendor(?:'s)? (?:own )?billing api\b|orgs\/[\w.-]+\/settings\/billing/i;
+
+function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | undefined): boolean {
+  if (typeof text !== "string" || text.length === 0) return false;
+  if (!MONETARY_CLAIM_PATTERN.test(text)) return false;
+  if (!INTERNAL_COSTS_LEDGER_CITATION_PATTERN.test(text)) return false;
+  return true;
+}
+
+function textCitesVendorBillingApi(text: string | null | undefined): boolean {
+  if (typeof text !== "string" || text.length === 0) return false;
+  return VENDOR_BILLING_API_CITATION_PATTERN.test(text);
+}
+
+/**
+ * Gate B (AGE-628): reject a monetary/spend claim sourced from Paperclip's
+ * own internal `/costs` ledger -- independently proven to undercount actual
+ * spend ~10x per AGE-335 -- unless the same text (or another comment) also
+ * cites the vendor's own billing API (command + pasted output), which is
+ * the authoritative source. Blocks recurrence of the AGE-333 failure where
+ * each retelling of a Paperclip-`/costs`-sourced number went unverified
+ * against GitHub's own billing API.
+ */
+async function assertMonetaryClaimCitesVendorBillingApi(
+  db: Db,
+  issueId: string,
+  effectiveDescription: string | null,
+) {
+  const citesInternalLedger = textCitesInternalCostsLedgerForMonetaryClaim(effectiveDescription);
+  if (!citesInternalLedger) return;
+  if (textCitesVendorBillingApi(effectiveDescription)) return;
+  const rows = await db
+    .select({ body: issueComments.body })
+    .from(issueComments)
+    .where(and(eq(issueComments.issueId, issueId), isNull(issueComments.deletedAt)));
+  for (const row of rows) {
+    if (textCitesVendorBillingApi(row.body)) return;
+  }
+  throw unprocessable(
+    "Cannot mark issue done: this issue cites Paperclip's internal /costs ledger for a monetary/spend claim, which is known to undercount actual spend (AGE-335). Cite the vendor's own billing API (e.g. `gh api /orgs/{org}/settings/billing/usage`) with the command and its pasted output before closing.",
+    { code: "done_transition_billing_source_gate", reason: "internal_costs_ledger_cited_for_monetary_claim" },
+  );
+}
+
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
 type IssueRouteSnapshot = typeof issueRows.$inferSelect;
@@ -9688,6 +9802,28 @@ export function issueRoutes(
     Object.assign(updateFields, transition.patch);
 
     const nextStatus = updateFields.status ?? existing.status;
+    if (nextStatus === "done" && existing.status !== "done") {
+      const effectiveTitleForCloseGates = updateFields.title !== undefined
+        ? (updateFields.title as string | null)
+        : existing.title;
+      const effectiveDescriptionForCloseGates = updateFields.description !== undefined
+        ? (updateFields.description as string | null)
+        : existing.description;
+      // AGE-628 Gate A: single-sample rate claims.
+      await assertRateClaimHasAdequateEvidence(
+        db,
+        existing.id,
+        effectiveTitleForCloseGates,
+        effectiveDescriptionForCloseGates,
+      );
+      // AGE-628 Gate B: monetary claims must cite the vendor billing API,
+      // not Paperclip's internal /costs ledger.
+      await assertMonetaryClaimCitesVendorBillingApi(
+        db,
+        existing.id,
+        effectiveDescriptionForCloseGates,
+      );
+    }
     if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -350,12 +350,29 @@ function issueHeadlineAssertsRateClaim(title: string | null | undefined): boolea
   return RATE_CLAIM_PATTERN.test(trimmed);
 }
 
+// A calendar-month mention only counts as a real sample if a dollar figure
+// sits near it (same sentence-ish window, +/-60 chars) -- otherwise an
+// incidental date reference (e.g. "founded in March 2020") next to an
+// unrelated dollar figure elsewhere in the text would falsely count as a
+// measured data point. Greptile flagged the earlier any-two-months check as
+// a bypass for exactly this reason.
+const CALENDAR_TOKEN_DOLLAR_PROXIMITY_CHARS = 60;
+
 function distinctCalendarMonthYearCount(text: string): number {
   const distinct = new Set<string>();
-  for (const match of text.matchAll(CALENDAR_MONTH_YEAR_TOKEN_PATTERN)) {
+  const pattern = new RegExp(CALENDAR_MONTH_YEAR_TOKEN_PATTERN.source, "gi");
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
     const month = match[1]?.toLowerCase();
     const year = match[2];
     if (!month || !year) continue;
+    const windowStart = Math.max(0, match.index - CALENDAR_TOKEN_DOLLAR_PROXIMITY_CHARS);
+    const windowEnd = Math.min(
+      text.length,
+      match.index + match[0].length + CALENDAR_TOKEN_DOLLAR_PROXIMITY_CHARS,
+    );
+    const window = text.slice(windowStart, windowEnd);
+    if (!DOLLAR_FIGURE_PATTERN.test(window)) continue;
     distinct.add(`${month}-${year}`);
   }
   return distinct.size;
@@ -396,6 +413,7 @@ async function assertRateClaimHasAdequateEvidence(
   );
 }
 
+const DOLLAR_FIGURE_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b/i;
 const MONETARY_CLAIM_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b|\bspend\b|\bcost(?:s)?\b|\bburn\b/i;
 const INTERNAL_COSTS_LEDGER_CITATION_PATTERN =
   /\/costs\b|\bpaperclip(?:'s)? (?:internal )?(?:cost|costs) (?:ledger|endpoint|api)\b|\binternal (?:cost|costs) ledger\b/i;
@@ -407,7 +425,13 @@ const INTERNAL_COSTS_LEDGER_CITATION_PATTERN =
 // stand-in for "pasted output" in this literal, regex-scoped heuristic).
 const VENDOR_BILLING_COMMAND_PATTERN =
   /\bgh api\b[^\n]{0,80}\bbilling\b|orgs\/[\w.-]+\/settings\/billing(?:\/usage)?/i;
-const DOLLAR_FIGURE_PATTERN = /\$\s*[\d,]+(?:\.\d+)?(?:k|m)?\b/i;
+// The pasted dollar figure must sit near the command mention itself (this
+// window, forward from the end of the match), not merely exist anywhere in
+// the text -- otherwise the internal-ledger's own dollar figure (elsewhere
+// in the same text) could satisfy the "pasted output" requirement without
+// any real command output ever being pasted. Greptile flagged this exact
+// bypass.
+const VENDOR_BILLING_OUTPUT_PROXIMITY_CHARS = 200;
 
 function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | undefined): boolean {
   if (typeof text !== "string" || text.length === 0) return false;
@@ -418,8 +442,15 @@ function textCitesInternalCostsLedgerForMonetaryClaim(text: string | null | unde
 
 function textCitesVendorBillingApi(text: string | null | undefined): boolean {
   if (typeof text !== "string" || text.length === 0) return false;
-  if (!VENDOR_BILLING_COMMAND_PATTERN.test(text)) return false;
-  return DOLLAR_FIGURE_PATTERN.test(text);
+  const pattern = new RegExp(VENDOR_BILLING_COMMAND_PATTERN.source, "gi");
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    const windowStart = match.index;
+    const windowEnd = Math.min(text.length, match.index + match[0].length + VENDOR_BILLING_OUTPUT_PROXIMITY_CHARS);
+    const window = text.slice(windowStart, windowEnd);
+    if (DOLLAR_FIGURE_PATTERN.test(window)) return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents can mark an issue `done` through `PATCH /issues/:id`, and a prior audit found agents relaying unverified point-in-time numbers as sustained rate claims, and citing an internal cost ledger instead of the authoritative vendor billing source
> - There was no structural check stopping either failure shape — only a human noticing after the fact
> - A related PR already extends the same `done` transition with a PR-merge/CI gate and an outcome-metric gate, so this is the natural place to add two more independent close-gates rather than build a new mechanism
> - This pull request adds Gate A (reject a rate-claim title, e.g. "$X/day"/"run rate", unless the body/comments state the observation window and either cite two non-adjacent samples or explicitly justify a single sample) and Gate B (reject a monetary claim that cites Paperclip's own internal `/costs` ledger unless the body/comments also cite the vendor's own billing API with command+output)
> - The benefit is agents can no longer close a financial/rate-claim issue on unverified or single-sample evidence, matching the fail-closed shape already used for the PR-merge gate

## Linked Issues or Issue Description

No public GitHub issue exists for this change (source is an internal tracker item). Following the bug-report template fields:

**What happened?**

An issue can be marked `done` while its own title asserts an unverified sustained rate (extrapolated from a single sample) or a monetary claim sourced only from an internal cost ledger known to undercount real spend, with nothing structurally blocking the transition.

**Expected behavior**

The transition is rejected (422) until the rate claim states its observation window and either two non-adjacent samples or an explicit single-sample justification, and until any internal-ledger-sourced monetary claim also cites the vendor's own billing API with command+output.

**Steps to reproduce**

Create an issue titled with a rate claim (e.g. "Burn is running at $X/day") and no stated observation window; or an issue whose description cites only an internal `/costs`-style ledger for a dollar figure. `PATCH` the issue to `status: done`. Before this PR the transition succeeds unconditionally.

## What Changed

- Added `assertRateClaimHasAdequateEvidence` (Gate A): when an issue's effective title asserts a per-day/hour/month rate claim, block the `done` transition (422, `details.code: "done_transition_rate_claim_gate"`) unless the description or a comment states an observation window and either cites two distinct calendar-month tokens (two non-adjacent samples) or an explicit single-sample justification.
- Added `assertMonetaryClaimCitesVendorBillingApi` (Gate B): when an issue's effective description cites an internal `/costs`-ledger-style source for a monetary/spend claim, block the `done` transition (422, `details.code: "done_transition_billing_source_gate"`) unless the description or a comment also cites the vendor's own billing API (e.g. `gh api /orgs/{org}/settings/billing/usage`) with command+output.
- Wired both gates into the `PATCH /issues/:id` handler at the same `nextStatus === "done"` transition point used by the existing PR-merge gate, each independently computing its own effective title/description so the branch does not depend on unmerged sibling work touching the same file.
- Added `server/src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts` (route-level, embedded Postgres, 7 cases) covering both gates' refusal and pass paths and non-triggering titles.

## Verification

Ran the new test file locally:

```
cd server && npx vitest run src/__tests__/issue-done-transition-rate-billing-gate-routes.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Also ran `npx tsc --noEmit -p server/tsconfig.json` — clean, no new type errors.

## Risks

- Low risk. Both gates are narrowly scoped to a title/body regex match (rate-claim pattern, internal-ledger-citation pattern) — they do not fire on issues that don't match those patterns, verified by the "does not gate" test cases.
- False-positive risk: an issue whose title happens to match the rate-claim regex but isn't actually a rate claim would need to add an observation-window note to close; mitigated by narrow regex and the explicit single-sample justification escape hatch.
- No schema or migration changes. No behavior change for issues that don't reference a rate/monetary claim.

## Model Used

Claude (Anthropic), accessed via the Paperclip agent harness (`pi_local` adapter) as a Software Engineer agent. Extended thinking / tool-use mode, standard context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
