### PR TITLE
fix(tool-gateway): keep MCP connections callable after one timed-out tools/call

### DIFF
--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -2923,6 +2923,52 @@ rl.on("line", (line) => {
     });
   }
 
+  it("keeps a remote MCP connection callable after one tools/call timeout", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const fake = await startFakeRemoteMcpServer(() => ({
+      delayMs: 75,
+      body: { jsonrpc: "2.0", id: "slow", result: { content: [{ type: "text", text: "late" }] } },
+    }));
+    try {
+      const remoteTool = await createRemoteMcpTool(db, company.id, {
+        applicationKey: "timeout-keeps-connection",
+        toolName: "kv_set",
+        url: fake.url,
+      });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.connectionId === remoteTool.connection.id);
+      expect(connectedTool).toBeTruthy();
+
+      await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha", value: "one" },
+        timeoutMs: 10,
+      }).then(
+        () => {
+          throw new Error("Expected remote MCP call to time out");
+        },
+        (error) => expectGatewayError(error, 504, "tool_timeout"),
+      );
+
+      const [connection] = await db
+        .select()
+        .from(toolConnections)
+        .where(eq(toolConnections.id, remoteTool.connection.id));
+      expect(connection?.healthStatus).toBe("ok");
+      const stillListed = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.connectionId === remoteTool.connection.id);
+      expect(stillListed).toBeTruthy();
+    } finally {
+      await fake.close();
+    }
+  });
+
   it("persists hashed sessions and accepts them across gateway service instances", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -3129,7 +3129,7 @@ export function createToolGatewayService(
       }
       if (payloadRecord.error !== undefined) {
         const errorRecord = asRecord(payloadRecord.error);
-        await markRemoteConnectionHealth(connection, "error", "Remote MCP server returned a JSON-RPC error.");
+        // WHY: one tools/call JSON-RPC error is an invocation result, not a dead transport.
         throw new ToolGatewayHttpError(502, "Remote MCP server returned an error", "remote_mcp_error", {
           code: typeof errorRecord?.code === "number" ? errorRecord.code : null,
           connectionId: connection.id,
@@ -3155,7 +3155,7 @@ export function createToolGatewayService(
         });
       }
       if (error instanceof Error && error.name === "AbortError") {
-        await markRemoteConnectionHealth(connection, "error", "Remote MCP tool call timed out.");
+        // WHY: one slow tools/call is not a dead MCP server; healthStatus=error hides every tool.
         throw new ToolGatewayHttpError(504, "Remote MCP tool call timed out", "tool_timeout", {
           connectionId: connection.id,
           catalogEntryId: entry.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents call company MCP servers through the connected-tool gateway
> - The gateway records one tools/call timeout or JSON-RPC error as connection `healthStatus=error`
> - Listing then admits only `ok` and `healthy` connections, so every tool on that server disappears
> - Recovery then needs a separate board health-check instead of a retry of the same tool
> - This pull request records the failed invocation and leaves the connection callable
> - The benefit is that one slow or failed operation does not hide the rest of the catalog

## Linked Issues or Issue Description

Refs #10147 (first comment: do not flip connection-wide health on one operation timeout).
This change does not make named MCP gateways honor `timeoutMs`. That remaining gap stays on #10147.

Related open PR search (2026-08-21): no in-flight PR for this latch. Nearby MCP HTTP work: #9750 (initialize handshake; different problem).

**What happened?**
One remote `tools/call` that hits the default 10s `tool_timeout` (or a JSON-RPC error) marks the whole MCP connection unhealthy. Later calls return `tool_not_found` for every tool on that connection.

**Expected behavior**
The timed-out call still fails with `tool_timeout` / `remote_mcp_error`. The connection stays listed. A later call or health-check can still reach the same server.

**Steps to reproduce**
1. Connect a remote HTTP MCP server with more than one catalog tool.
2. Invoke one tool that exceeds the gateway timeout.
3. List tools for the same session.
4. Observe that all tools from that connection are gone until a board health-check.

**Paperclip version or commit**
`v2026.817.0` / `213dabab4` (`master` as of this branch base).

**Deployment mode**
Self-hosted server / Docker.

**Agent adapter(s) involved**
Not adapter-specific (core bug).

## What Changed

- Do not call `markRemoteConnectionHealth(..., "error")` on `AbortError` (operation timeout).
- Do not call it on a JSON-RPC error payload from a completed HTTP 200 `tools/call`.
- Keep existing health=error on transport failures (HTTP error, invalid JSON, fetch failure).
- Add a regression test that a timed-out call leaves `healthStatus=ok` and the connection still listed.

## Verification

- Added `keeps a remote MCP connection callable after one tools/call timeout` in `server/src/__tests__/tool-gateway.test.ts`.
- Existing remote MCP timeout case still expects HTTP 504 / `tool_timeout`.
- CI: `pnpm test` / the server tool-gateway vitest file.

## Risks

- A truly dead MCP server may stay `ok` until a later transport failure. Operators can still run a board health-check. That is the intended trade: one slow call must not hide the catalog.

## Model Used

- Provider: Cursor (Grok)
- Model: Cursor Grok 4.6
- Tool use: yes (repository edit, tests, GitHub)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)