### PR TITLE
feat(server): flat monitorStatus field + noWakePath list filter

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -824,6 +824,16 @@ export interface Issue {
   monitorAttemptCount?: number;
   monitorNotes?: string | null;
   monitorScheduledBy?: IssueMonitorScheduledBy | null;
+  /**
+   * Cheap, list-safe monitor liveness projection derived from the flat
+   * `monitor*` columns above (see `deriveFlatMonitorStatus` in the server) —
+   * always present (never omitted) whenever an issue is returned from a list
+   * or single-issue read. Collapses the full `executionState.monitor.status`
+   * enum's `"cleared"` into `"none"`, since both mean "no live wake path".
+   * Do not read `.executionState?.monitor?.status` and default to `"none"`
+   * for the same field — use this field instead (AGE-924).
+   */
+  monitorStatus?: "scheduled" | "triggered" | "none";
   executionWorkspaceId: string | null;
   executionWorkspacePreference: string | null;
   executionWorkspaceSettings: IssueExecutionWorkspaceSettings | null;
@@ -925,6 +935,7 @@ export type CompactIssue = Pick<
   archivedByRunId?: string | null;
   activeRecoveryAction: IssueRecoveryAction | null;
   successfulRunHandoff: SuccessfulRunHandoffState | null;
+  monitorStatus?: "scheduled" | "triggered" | "none";
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ overrides:
 
 patchedDependencies:
   acpx@0.12.0:
-    hash: x3fethhotv43zektyl5prdwf54
+    hash: a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e
     path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
-    hash: 55uhvnotpqyiy37rn3pqpukhei
+    hash: d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800
     path: patches/embedded-postgres@18.1.0-beta.16.patch
 
 importers:
@@ -108,7 +108,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
+        version: 18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -127,7 +127,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
+        version: 0.12.0(patch_hash=a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -365,7 +365,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
+        version: 18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800)
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -839,7 +839,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
+        version: 18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800)
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -1015,6 +1015,9 @@ importers:
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1
+      motion:
+        specifier: ^12.42.2
+        version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       radix-ui:
         specifier: ^1.6.7
         version: 1.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1124,21 +1127,25 @@ packages:
     resolution: {integrity: sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
     resolution: {integrity: sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
     resolution: {integrity: sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
     resolution: {integrity: sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
     resolution: {integrity: sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw==}
@@ -2678,89 +2685,105 @@ packages:
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.3':
     resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.3':
     resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.3':
     resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.3':
     resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
@@ -3105,6 +3128,7 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-runtime@1.2.0':
     resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
@@ -3232,48 +3256,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -3346,41 +3378,49 @@ packages:
     resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
@@ -4805,131 +4845,157 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.5':
     resolution: {integrity: sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.5':
     resolution: {integrity: sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.5':
     resolution: {integrity: sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.5':
     resolution: {integrity: sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.5':
     resolution: {integrity: sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.5':
     resolution: {integrity: sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.5':
     resolution: {integrity: sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.5':
     resolution: {integrity: sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.5':
     resolution: {integrity: sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.5':
     resolution: {integrity: sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.5':
     resolution: {integrity: sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.5':
     resolution: {integrity: sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.5':
     resolution: {integrity: sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -5189,24 +5255,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -6804,6 +6874,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.43.0:
+    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^19.2.8
+      react-dom: ^19.2.8
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -7258,24 +7342,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7630,6 +7718,26 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  motion-dom@12.43.0:
+    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.43.0:
+    resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^19.2.8
+      react-dom: ^19.2.8
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -13557,7 +13665,7 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
+  acpx@0.12.0(patch_hash=a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0
@@ -14377,7 +14485,7 @@ snapshots:
 
   electron-to-chromium@1.5.409: {}
 
-  embedded-postgres@18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei):
+  embedded-postgres@18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800):
     dependencies:
       async-exit-hook: 2.0.1
       pg: 8.18.0
@@ -14779,6 +14887,15 @@ snapshots:
       once: 1.4.0
 
   forwarded@0.2.0: {}
+
+  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 12.43.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   fresh@2.0.0: {}
 
@@ -15964,6 +16081,20 @@ snapshots:
 
   mkdirp@1.0.4:
     optional: true
+
+  motion-dom@12.43.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   mri@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ overrides:
 
 patchedDependencies:
   acpx@0.12.0:
-    hash: a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e
+    hash: x3fethhotv43zektyl5prdwf54
     path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
-    hash: d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800
+    hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
 
 importers:
@@ -108,7 +108,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800)
+        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -127,7 +127,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e)
+        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -365,7 +365,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800)
+        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -839,7 +839,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
-        version: 18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800)
+        version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
       express:
         specifier: ^5.1.0
         version: 5.2.1
@@ -1015,9 +1015,6 @@ importers:
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1
-      motion:
-        specifier: ^12.42.2
-        version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       radix-ui:
         specifier: ^1.6.7
         version: 1.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1127,25 +1124,21 @@ packages:
     resolution: {integrity: sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
     resolution: {integrity: sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
     resolution: {integrity: sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
     resolution: {integrity: sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
     resolution: {integrity: sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw==}
@@ -2685,105 +2678,89 @@ packages:
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.3':
     resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.3':
     resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.3':
     resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.3':
     resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
@@ -3128,7 +3105,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/wasm-runtime@1.2.0':
     resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
@@ -3256,56 +3232,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -3378,49 +3346,41 @@ packages:
     resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
@@ -4845,157 +4805,131 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.5':
     resolution: {integrity: sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.5':
     resolution: {integrity: sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.5':
     resolution: {integrity: sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.5':
     resolution: {integrity: sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.5':
     resolution: {integrity: sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.5':
     resolution: {integrity: sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.5':
     resolution: {integrity: sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.5':
     resolution: {integrity: sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.5':
     resolution: {integrity: sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.5':
     resolution: {integrity: sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.5':
     resolution: {integrity: sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.5':
     resolution: {integrity: sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.5':
     resolution: {integrity: sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -5255,28 +5189,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -6874,20 +6804,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.43.0:
-    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^19.2.8
-      react-dom: ^19.2.8
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -7342,28 +7258,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7718,26 +7630,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  motion-dom@12.43.0:
-    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
-
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
-
-  motion@12.43.0:
-    resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^19.2.8
-      react-dom: ^19.2.8
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -13665,7 +13557,7 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  acpx@0.12.0(patch_hash=a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e):
+  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0
@@ -14485,7 +14377,7 @@ snapshots:
 
   electron-to-chromium@1.5.409: {}
 
-  embedded-postgres@18.1.0-beta.16(patch_hash=d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800):
+  embedded-postgres@18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei):
     dependencies:
       async-exit-hook: 2.0.1
       pg: 8.18.0
@@ -14887,15 +14779,6 @@ snapshots:
       once: 1.4.0
 
   forwarded@0.2.0: {}
-
-  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      motion-dom: 12.43.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   fresh@2.0.0: {}
 
@@ -16081,20 +15964,6 @@ snapshots:
 
   mkdirp@1.0.4:
     optional: true
-
-  motion-dom@12.43.0:
-    dependencies:
-      motion-utils: 12.39.0
-
-  motion-utils@12.39.0: {}
-
-  motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   mri@1.2.0: {}
 

--- a/server/src/__tests__/issue-no-wake-path.test.ts
+++ b/server/src/__tests__/issue-no-wake-path.test.ts
@@ -134,6 +134,20 @@ describe("classifyNoWakePath", () => {
     ).toBeNull();
   });
 
+  it("condition 4's hasActiveRun is documented as covering queued runs and scheduled retries, not just 'running' (regression for AGE-924 PR #11911 Greptile finding)", () => {
+    // The classifier itself only sees the boolean; the broadening lives in
+    // how the caller (issues.ts) computes it via noWakePathLiveExecutionIssueIds,
+    // which folds in queued heartbeat runs, scheduled_retry runs, and queued
+    // wake requests that have not yet stamped issues.executionRunId. This
+    // test pins the classifier's contract: hasActiveRun: true always wins,
+    // regardless of which underlying live-path kind it represents.
+    expect(
+      classifyNoWakePath(
+        issue({ status: "in_progress", assigneeAgentId: "agent-1", assigneeAgentStatus: "running", hasActiveRun: true }),
+      ),
+    ).toBeNull();
+  });
+
   it("a healthy in_review issue with a live monitor is not a no-wake-path issue", () => {
     expect(
       isNoWakePath(

--- a/server/src/__tests__/issue-no-wake-path.test.ts
+++ b/server/src/__tests__/issue-no-wake-path.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { deriveFlatMonitorStatus } from "../services/issue-execution-policy.js";
+import { classifyNoWakePath, isNoWakePath, type NoWakePathIssueInput } from "../services/issue-no-wake-path.js";
+
+/**
+ * AGE-924: `GET /companies/:companyId/issues` used to omit `executionState`
+ * (JSON `null`) with no cheap flat monitor-liveness signal, so any consumer
+ * doing `.executionState?.monitor?.status ?? "none"` silently treated "field
+ * omitted" the same as "no monitor" — a stranding sweep run reported 47 dead
+ * issues when the real number was 9. These are the pure unit tests for the
+ * two building blocks that fix that: the flat `monitorStatus` projection, and
+ * the 4-condition "no wake path" classifier layered on top of it.
+ */
+
+describe("deriveFlatMonitorStatus", () => {
+  it("is 'scheduled' whenever monitorNextCheckAt is set, regardless of trigger history", () => {
+    expect(deriveFlatMonitorStatus({ monitorNextCheckAt: new Date(Date.now() + 60_000) })).toBe("scheduled");
+    expect(
+      deriveFlatMonitorStatus({
+        monitorNextCheckAt: new Date(Date.now() + 60_000),
+        monitorLastTriggeredAt: new Date(),
+        monitorAttemptCount: 3,
+      }),
+    ).toBe("scheduled");
+  });
+
+  it("is 'triggered' once fired with nothing currently scheduled", () => {
+    expect(
+      deriveFlatMonitorStatus({ monitorNextCheckAt: null, monitorLastTriggeredAt: new Date(), monitorAttemptCount: 1 }),
+    ).toBe("triggered");
+    expect(
+      deriveFlatMonitorStatus({ monitorNextCheckAt: null, monitorLastTriggeredAt: null, monitorAttemptCount: 2 }),
+    ).toBe("triggered");
+  });
+
+  it("is 'none' when nothing was ever scheduled or triggered (covers both never-scheduled and cleared-without-triggering)", () => {
+    expect(deriveFlatMonitorStatus({ monitorNextCheckAt: null, monitorLastTriggeredAt: null, monitorAttemptCount: 0 })).toBe("none");
+    expect(deriveFlatMonitorStatus({})).toBe("none");
+  });
+
+  it("never returns undefined/absent — the whole point of AGE-924 is the field is always present", () => {
+    const result = deriveFlatMonitorStatus({});
+    expect(result).not.toBeUndefined();
+    expect(["scheduled", "triggered", "none"]).toContain(result);
+  });
+});
+
+function issue(overrides: Partial<NoWakePathIssueInput>): NoWakePathIssueInput {
+  return {
+    status: "todo",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    blockedByIssueIds: [],
+    monitorStatus: "none",
+    hasActiveRun: false,
+    assigneeAgentStatus: null,
+    ...overrides,
+  };
+}
+
+describe("classifyNoWakePath", () => {
+  it("condition 1: blocked with no unresolved blockers and no live monitor has no wake path", () => {
+    expect(classifyNoWakePath(issue({ status: "blocked", blockedByIssueIds: [] }))).toBe(
+      "blocked_no_blockers_no_monitor",
+    );
+  });
+
+  it("condition 1 does not fire when blocked issue has an unresolved blocker", () => {
+    expect(classifyNoWakePath(issue({ status: "blocked", blockedByIssueIds: ["blocker-1"] }))).toBeNull();
+  });
+
+  it("condition 1 does not fire when blocked issue has a live scheduled monitor", () => {
+    expect(
+      classifyNoWakePath(issue({ status: "blocked", blockedByIssueIds: [], monitorStatus: "scheduled" })),
+    ).toBeNull();
+  });
+
+  it("condition 2: in_review with a spent monitor (none) and no unresolved blocker has no wake path", () => {
+    expect(
+      classifyNoWakePath(issue({ status: "in_review", monitorStatus: "none", blockedByIssueIds: [] })),
+    ).toBe("in_review_spent_monitor_no_blocker");
+  });
+
+  it("condition 2: 'triggered' is treated the same as 'none' — it is a spent state, not a live wait", () => {
+    expect(
+      classifyNoWakePath(issue({ status: "in_review", monitorStatus: "triggered", blockedByIssueIds: [] })),
+    ).toBe("in_review_spent_monitor_no_blocker");
+  });
+
+  it("condition 2 does not fire when the monitor is live scheduled", () => {
+    expect(
+      classifyNoWakePath(issue({ status: "in_review", monitorStatus: "scheduled", blockedByIssueIds: [] })),
+    ).toBeNull();
+  });
+
+  it("condition 2 does not fire when there is an unresolved blocker even with a spent monitor", () => {
+    expect(
+      classifyNoWakePath(issue({ status: "in_review", monitorStatus: "none", blockedByIssueIds: ["blocker-1"] })),
+    ).toBeNull();
+  });
+
+  it("condition 3: todo with no assignee at all has no wake path", () => {
+    expect(classifyNoWakePath(issue({ status: "todo", assigneeAgentId: null, assigneeUserId: null }))).toBe(
+      "todo_unassigned",
+    );
+  });
+
+  it("condition 3 does not fire once an agent or user is assigned", () => {
+    expect(classifyNoWakePath(issue({ status: "todo", assigneeAgentId: "agent-1" }))).toBeNull();
+    expect(classifyNoWakePath(issue({ status: "todo", assigneeUserId: "user-1" }))).toBeNull();
+  });
+
+  it("condition 4: an agent assignee whose own status is 'running' but with no active run bound to this issue is saturated elsewhere", () => {
+    expect(
+      classifyNoWakePath(
+        issue({ status: "in_progress", assigneeAgentId: "agent-1", assigneeAgentStatus: "running", hasActiveRun: false }),
+      ),
+    ).toBe("assignee_saturated");
+  });
+
+  it("condition 4 does not fire when the active run is bound to this same issue", () => {
+    expect(
+      classifyNoWakePath(
+        issue({ status: "in_progress", assigneeAgentId: "agent-1", assigneeAgentStatus: "running", hasActiveRun: true }),
+      ),
+    ).toBeNull();
+  });
+
+  it("condition 4 does not fire when the assignee agent is idle (not running anything)", () => {
+    expect(
+      classifyNoWakePath(
+        issue({ status: "in_progress", assigneeAgentId: "agent-1", assigneeAgentStatus: "idle", hasActiveRun: false }),
+      ),
+    ).toBeNull();
+  });
+
+  it("a healthy in_review issue with a live monitor is not a no-wake-path issue", () => {
+    expect(
+      isNoWakePath(
+        issue({
+          status: "in_review",
+          monitorStatus: "scheduled",
+          assigneeAgentId: "agent-1",
+          assigneeAgentStatus: "running",
+          hasActiveRun: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("done/cancelled issues are never classified as no-wake-path (the question is moot)", () => {
+    expect(classifyNoWakePath(issue({ status: "done" }))).toBeNull();
+    expect(classifyNoWakePath(issue({ status: "cancelled" }))).toBeNull();
+  });
+});

--- a/server/src/__tests__/issues-no-wake-path-route.test.ts
+++ b/server/src/__tests__/issues-no-wake-path-route.test.ts
@@ -2,7 +2,16 @@ import { randomUUID } from "node:crypto";
 import request from "supertest";
 import { isNotNull } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import { agents, companies, companyMemberships, issueRelations, issues, principalPermissionGrants } from "@paperclipai/db";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  companyMemberships,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+  principalPermissionGrants,
+} from "@paperclipai/db";
 import { issueRoutes } from "../routes/issues.js";
 import {
   describeEmbeddedPostgres,
@@ -27,6 +36,8 @@ describeEmbeddedPostgres("issue list monitorStatus + noWakePath (AGE-924)", () =
     // `agents.companyId` both carry FKs, so agents must go after the issues
     // that reference them and before the companies that agents reference.
     resetEach: async (db) => {
+      await db.delete(heartbeatRuns);
+      await db.delete(agentWakeupRequests);
       await db.delete(issues).where(isNotNull(issues.parentId));
       await db.delete(issues);
       await db.delete(agents);
@@ -225,5 +236,76 @@ describeEmbeddedPostgres("issue list monitorStatus + noWakePath (AGE-924)", () =
     await request(routeApp(ctx.db, company.actor, issueRoutes))
       .get(`/api/companies/${company.companyId}/issues?noWakePath=true&attention=blocked`)
       .expect(400);
+  });
+
+  it("does not misclassify a queued run or scheduled retry as assignee saturation (Greptile finding on PR #11911)", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path queued and retry");
+    const companyId = company.companyId;
+    const [runningAgent] = await ctx.db
+      .insert(agents)
+      .values([{ id: randomUUID(), companyId, name: "Busy", status: "running" }])
+      .returning();
+
+    const queuedWakeIssueId = randomUUID();
+    const scheduledRetryIssueId = randomUUID();
+    const queuedRunNotBoundIssueId = randomUUID();
+    await ctx.db.insert(issues).values([
+      // A wake was queued for this issue but has not converted into a run yet
+      // (issues.executionRunId is still null), so `activeRun` alone would
+      // report false — this must still count as a live path.
+      { id: queuedWakeIssueId, companyId, title: "Queued wake, no run yet", status: "in_progress", priority: "medium", assigneeAgentId: runningAgent!.id },
+      // A run is `scheduled_retry` for this issue — a live path, not dead.
+      { id: scheduledRetryIssueId, companyId, title: "Scheduled retry", status: "in_progress", priority: "medium", assigneeAgentId: runningAgent!.id },
+      // A run is `queued` for this issue via contextSnapshot, but
+      // issues.executionRunId was never stamped.
+      { id: queuedRunNotBoundIssueId, companyId, title: "Queued run via contextSnapshot only", status: "in_progress", priority: "medium", assigneeAgentId: runningAgent!.id },
+    ]);
+    await ctx.db.insert(agentWakeupRequests).values({
+      id: randomUUID(),
+      companyId,
+      agentId: runningAgent!.id,
+      source: "issue_watchdog",
+      status: "queued",
+      reason: "issue_wake",
+      payload: { issueId: queuedWakeIssueId },
+    });
+    await ctx.db.insert(heartbeatRuns).values([
+      {
+        id: randomUUID(),
+        companyId,
+        agentId: runningAgent!.id,
+        status: "scheduled_retry",
+        contextSnapshot: { issueId: scheduledRetryIssueId },
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        agentId: runningAgent!.id,
+        status: "queued",
+        contextSnapshot: { issueId: queuedRunNotBoundIssueId },
+      },
+    ]);
+
+    const res = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true`)
+      .expect(200);
+    const ids = new Set((res.body as Array<{ id: string }>).map((row) => row.id));
+
+    expect(ids.has(queuedWakeIssueId)).toBe(false);
+    expect(ids.has(scheduledRetryIssueId)).toBe(false);
+    expect(ids.has(queuedRunNotBoundIssueId)).toBe(false);
+  });
+
+  it("surfaces X-Paperclip-No-Wake-Path-Scan-Truncated when the bounded scan hits its cap", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path truncation");
+    const companyId = company.companyId;
+    await ctx.db.insert(issues).values([
+      { id: randomUUID(), companyId, title: "Todo, unassigned", status: "todo", priority: "medium" },
+    ]);
+
+    const healthyRes = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true`)
+      .expect(200);
+    expect(healthyRes.headers["x-paperclip-no-wake-path-scan-truncated"]).toBeUndefined();
   });
 });

--- a/server/src/__tests__/issues-no-wake-path-route.test.ts
+++ b/server/src/__tests__/issues-no-wake-path-route.test.ts
@@ -1,0 +1,229 @@
+import { randomUUID } from "node:crypto";
+import request from "supertest";
+import { isNotNull } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents, companies, companyMemberships, issueRelations, issues, principalPermissionGrants } from "@paperclipai/db";
+import { issueRoutes } from "../routes/issues.js";
+import {
+  describeEmbeddedPostgres,
+  routeApp,
+  seedCompanyWithBoardAccess,
+  useEmbeddedPostgres,
+} from "./helpers/route-test-harness.js";
+
+/**
+ * AGE-924 regression coverage: `GET /companies/:companyId/issues` used to
+ * silently omit any monitor-liveness signal, so a stranding sweep computing
+ * `.executionState?.monitor?.status ?? "none"` could not tell "no monitor"
+ * apart from "field never sent". These tests pin the fix at the HTTP
+ * boundary: `monitorStatus` is present on every list row, matches the
+ * single-issue read for a live monitor, and the `?noWakePath=true` filter
+ * implements the 4-condition definition end to end.
+ */
+describeEmbeddedPostgres("issue list monitorStatus + noWakePath (AGE-924)", () => {
+  const ctx = useEmbeddedPostgres("paperclip-issues-no-wake-path-", {
+    // Mirrors `resetCompanyIssueFixtures`, but deletes `agents` between the
+    // issues delete and the companies delete: `issues.assigneeAgentId` and
+    // `agents.companyId` both carry FKs, so agents must go after the issues
+    // that reference them and before the companies that agents reference.
+    resetEach: async (db) => {
+      await db.delete(issues).where(isNotNull(issues.parentId));
+      await db.delete(issues);
+      await db.delete(agents);
+      await db.delete(principalPermissionGrants);
+      await db.delete(companyMemberships);
+      await db.delete(companies);
+    },
+  });
+
+  it("monitorStatus is present (never absent) on every list row, and 'scheduled' matches the single-issue read for a live monitor", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "Monitor status presence");
+    const companyId = company.companyId;
+    const [agent] = await ctx.db
+      .insert(agents)
+      .values({ id: randomUUID(), companyId, name: "Reviewer", status: "idle" })
+      .returning();
+
+    const liveMonitorIssueId = randomUUID();
+    const noMonitorIssueId = randomUUID();
+    const triggeredMonitorIssueId = randomUUID();
+    await ctx.db.insert(issues).values([
+      {
+        id: liveMonitorIssueId,
+        companyId,
+        title: "In review with a live monitor",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: agent!.id,
+        monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+      {
+        id: noMonitorIssueId,
+        companyId,
+        title: "In review, never monitored",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: agent!.id,
+      },
+      {
+        id: triggeredMonitorIssueId,
+        companyId,
+        title: "In review, monitor already fired",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: agent!.id,
+        monitorLastTriggeredAt: new Date(),
+        monitorAttemptCount: 1,
+      },
+    ]);
+
+    const listRes = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues`)
+      .expect(200);
+    const byId = new Map((listRes.body as Array<{ id: string; monitorStatus?: string }>).map((row) => [row.id, row]));
+
+    // The field must be present on every row, not absent — this is the core
+    // AGE-924 assertion. `in` (not `?? "none"`) is the whole point: the old
+    // bug was indistinguishable from "none" using `??`.
+    for (const row of listRes.body as Array<Record<string, unknown>>) {
+      expect("monitorStatus" in row).toBe(true);
+    }
+
+    expect(byId.get(liveMonitorIssueId)?.monitorStatus).toBe("scheduled");
+    expect(byId.get(noMonitorIssueId)?.monitorStatus).toBe("none");
+    expect(byId.get(triggeredMonitorIssueId)?.monitorStatus).toBe("triggered");
+
+    // Cross-check against the single-issue read for the live-monitor case,
+    // the exact scenario the operator sweep got wrong (37 of 46 in_review
+    // issues had a live monitor the list route couldn't see).
+    const singleRes = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/issues/${liveMonitorIssueId}`)
+      .expect(200);
+    expect(singleRes.body.monitorStatus).toBe("scheduled");
+    expect(singleRes.body.executionState?.monitor?.status ?? "scheduled").toBe("scheduled");
+  });
+
+  it("compact view also carries monitorStatus", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "Monitor status compact view");
+    const companyId = company.companyId;
+    await ctx.db.insert(issues).values([
+      { id: randomUUID(), companyId, title: "Todo", status: "todo", priority: "medium" },
+    ]);
+    const res = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?view=compact`)
+      .expect(200);
+    for (const row of res.body as Array<Record<string, unknown>>) {
+      expect("monitorStatus" in row).toBe(true);
+      expect(row.monitorStatus).toBe("none");
+    }
+  });
+
+  it("?noWakePath=true implements the 4-condition definition and excludes healthy issues", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path filter");
+    const companyId = company.companyId;
+    const [runningAgent, idleAgent] = await ctx.db
+      .insert(agents)
+      .values([
+        { id: randomUUID(), companyId, name: "Saturated", status: "running" },
+        { id: randomUUID(), companyId, name: "Idle", status: "idle" },
+      ])
+      .returning();
+
+    const blockedNoWakePathId = randomUUID();
+    const blockedHealthyId = randomUUID();
+    const reviewNoWakePathId = randomUUID();
+    const reviewHealthyId = randomUUID();
+    const todoUnassignedId = randomUUID();
+    const todoAssignedId = randomUUID();
+    const saturatedAssigneeId = randomUUID();
+    const healthyRunningAssigneeId = randomUUID();
+    const blockerId = randomUUID();
+
+    await ctx.db.insert(issues).values([
+      { id: blockerId, companyId, title: "Open blocker", status: "in_progress", priority: "medium" },
+      // Condition 1: blocked, no blockers recorded, no monitor.
+      { id: blockedNoWakePathId, companyId, title: "Blocked with no blockers", status: "blocked", priority: "medium" },
+      // Healthy: blocked but has a real open blocker.
+      { id: blockedHealthyId, companyId, title: "Blocked with an open blocker", status: "blocked", priority: "medium" },
+      // Condition 2: in_review, monitor never scheduled, no blocker.
+      {
+        id: reviewNoWakePathId,
+        companyId,
+        title: "In review, no monitor",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: idleAgent!.id,
+      },
+      // Healthy: in_review with a live scheduled monitor.
+      {
+        id: reviewHealthyId,
+        companyId,
+        title: "In review, live monitor",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: idleAgent!.id,
+        monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+      // Condition 3: todo, unassigned.
+      { id: todoUnassignedId, companyId, title: "Todo, unassigned", status: "todo", priority: "medium" },
+      // Healthy: todo but assigned.
+      {
+        id: todoAssignedId,
+        companyId,
+        title: "Todo, assigned",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: idleAgent!.id,
+      },
+      // Condition 4: assignee's agent status is running, but no active run
+      // owns this issue (saturated on some other lane).
+      {
+        id: saturatedAssigneeId,
+        companyId,
+        title: "Assignee running elsewhere",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: runningAgent!.id,
+      },
+      // Healthy: assignee's agent is idle (not claiming to run anything).
+      {
+        id: healthyRunningAssigneeId,
+        companyId,
+        title: "Assignee idle",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: idleAgent!.id,
+      },
+    ]);
+    // `blockedHealthyId` is blocked by the still-open `blockerId` issue.
+    await ctx.db.insert(issueRelations).values({
+      id: randomUUID(),
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedHealthyId,
+      type: "blocks",
+    });
+
+    const res = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true`)
+      .expect(200);
+    const ids = new Set((res.body as Array<{ id: string }>).map((row) => row.id));
+
+    expect(ids.has(blockedNoWakePathId)).toBe(true);
+    expect(ids.has(reviewNoWakePathId)).toBe(true);
+    expect(ids.has(todoUnassignedId)).toBe(true);
+    expect(ids.has(saturatedAssigneeId)).toBe(true);
+
+    expect(ids.has(blockedHealthyId)).toBe(false);
+    expect(ids.has(reviewHealthyId)).toBe(false);
+    expect(ids.has(todoAssignedId)).toBe(false);
+    expect(ids.has(healthyRunningAssigneeId)).toBe(false);
+  });
+
+  it("rejects noWakePath combined with attention=blocked", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path invalid combo");
+    await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${company.companyId}/issues?noWakePath=true&attention=blocked`)
+      .expect(400);
+  });
+});

--- a/server/src/__tests__/issues-no-wake-path-route.test.ts
+++ b/server/src/__tests__/issues-no-wake-path-route.test.ts
@@ -339,4 +339,55 @@ describeEmbeddedPostgres("issue list monitorStatus + noWakePath (AGE-924)", () =
       .expect(200);
     expect(pastEndRes.body).toEqual([]);
   });
+
+  it("a window with more matches than the requested limit exposes X-Paperclip-No-Wake-Path-Next-Offset pointing exactly past the last returned match (Greptile follow-up on PR #11911)", async () => {
+    // Greptile flagged: if a scanned window holds more matches than `limit`,
+    // the surplus must not be silently dropped, and the caller must not have
+    // to guess a fixed jump size (which can both repeat and skip rows). The
+    // response must carry the exact raw-row offset to resume from.
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path surplus matches in one window");
+    const companyId = company.companyId;
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+    const thirdId = randomUUID();
+    await ctx.db.insert(issues).values([
+      { id: firstId, companyId, title: "Todo, unassigned, first", status: "todo", priority: "medium" },
+      { id: secondId, companyId, title: "Todo, unassigned, second", status: "todo", priority: "medium" },
+      { id: thirdId, companyId, title: "Todo, unassigned, third", status: "todo", priority: "medium" },
+    ]);
+
+    const page1 = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true&limit=1`)
+      .expect(200);
+    expect(page1.body).toHaveLength(1);
+    expect(page1.headers["x-paperclip-no-wake-path-scan-truncated"]).toBe("true");
+    const nextOffset = Number(page1.headers["x-paperclip-no-wake-path-next-offset"]);
+    expect(Number.isInteger(nextOffset)).toBe(true);
+    expect(nextOffset).toBeGreaterThan(0);
+
+    // Resuming from the returned cursor must reach the remaining matches,
+    // with no gap and no repeat of the first page's result.
+    const page2 = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true&offset=${nextOffset}`)
+      .expect(200);
+    const page2Ids = (page2.body as Array<{ id: string }>).map((row) => row.id);
+    expect(page2Ids).toHaveLength(2);
+    expect(page2Ids).not.toContain(page1.body[0].id);
+  });
+
+  it("compact view also surfaces the truncation header (Greptile follow-up on PR #11911: compact responses previously dropped it)", async () => {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path compact truncation");
+    const companyId = company.companyId;
+    await ctx.db.insert(issues).values([
+      { id: randomUUID(), companyId, title: "Todo, unassigned, first", status: "todo", priority: "medium" },
+      { id: randomUUID(), companyId, title: "Todo, unassigned, second", status: "todo", priority: "medium" },
+    ]);
+
+    const res = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true&limit=1&view=compact`)
+      .expect(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.headers["x-paperclip-no-wake-path-scan-truncated"]).toBe("true");
+    expect(Number.isInteger(Number(res.headers["x-paperclip-no-wake-path-next-offset"]))).toBe(true);
+  });
 });

--- a/server/src/__tests__/issues-no-wake-path-route.test.ts
+++ b/server/src/__tests__/issues-no-wake-path-route.test.ts
@@ -308,4 +308,35 @@ describeEmbeddedPostgres("issue list monitorStatus + noWakePath (AGE-924)", () =
       .expect(200);
     expect(healthyRes.headers["x-paperclip-no-wake-path-scan-truncated"]).toBeUndefined();
   });
+
+  it("?offset= is the raw-scan continuation cursor for noWakePath, not a match-count skip (Greptile follow-up on PR #11911)", async () => {
+    // When noWakePath is truncated, a caller must advance `offset` by the
+    // scan cap to reach matches a prior window missed — which only works if
+    // `offset` skips raw candidate rows (SQL order), not already-classified
+    // matches. This pins that contract on a small, fast dataset: two
+    // no-wake-path issues exist, ordered by identifier/creation; skipping past
+    // the first one via `offset=1` must still find the second, and skipping
+    // past both must return empty even though matches exist earlier.
+    const company = await seedCompanyWithBoardAccess(ctx.db, "No wake path offset is a scan cursor");
+    const companyId = company.companyId;
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+    await ctx.db.insert(issues).values([
+      { id: firstId, companyId, title: "Todo, unassigned, first", status: "todo", priority: "medium" },
+      { id: secondId, companyId, title: "Todo, unassigned, second", status: "todo", priority: "medium" },
+    ]);
+
+    const fullRes = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true`)
+      .expect(200);
+    const fullIds = (fullRes.body as Array<{ id: string }>).map((row) => row.id);
+    expect(fullIds).toHaveLength(2);
+
+    // Skip past every raw candidate row: no matches remain in this window,
+    // even though two real matches exist starting at offset 0.
+    const pastEndRes = await request(routeApp(ctx.db, company.actor, issueRoutes))
+      .get(`/api/companies/${companyId}/issues?noWakePath=true&offset=2`)
+      .expect(200);
+    expect(pastEndRes.body).toEqual([]);
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2436,6 +2436,7 @@ type IssueListPreparedResponse =
   | {
       kind: "full";
       body: unknown[];
+      noWakePathScanTruncated?: boolean;
     };
 
 type IssueListCacheStatus = "miss" | "hit" | "coalesced" | "stale" | "retry";
@@ -6108,6 +6109,7 @@ export function issueRoutes(
       diagnostics: opts.issueListDiagnostics,
       compute: async () => {
         const rawResult = await svc.list(companyId, listFilters);
+        const noWakePathScanTruncated = Boolean((rawResult as unknown as { noWakePathScanTruncated?: boolean }).noWakePathScanTruncated);
         const result = await actorCanReadCompanyScope(req, companyId)
           ? rawResult
           : await filterIssuesForActor(req, rawResult);
@@ -6162,6 +6164,7 @@ export function issueRoutes(
         }));
         return {
           kind: "full",
+          noWakePathScanTruncated,
           body: result.map((issue) => ({
             ...issue,
             successfulRunHandoff: handoffStates.get(issue.id) ?? null,
@@ -6227,6 +6230,9 @@ export function issueRoutes(
       etagOutcome: "none",
       identicalInFlightCount: coordinated.identicalInFlightCount,
     });
+    if (coordinated.response.noWakePathScanTruncated) {
+      res.setHeader("X-Paperclip-No-Wake-Path-Scan-Truncated", "true");
+    }
     res.json(coordinated.response.body);
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2432,11 +2432,14 @@ type IssueListPreparedResponse =
       body: CompactIssue[];
       etag: string;
       cacheControl: string;
+      noWakePathScanTruncated?: boolean;
+      noWakePathNextOffset?: number;
     }
   | {
       kind: "full";
       body: unknown[];
       noWakePathScanTruncated?: boolean;
+      noWakePathNextOffset?: number;
     };
 
 type IssueListCacheStatus = "miss" | "hit" | "coalesced" | "stale" | "retry";
@@ -6110,6 +6113,7 @@ export function issueRoutes(
       compute: async () => {
         const rawResult = await svc.list(companyId, listFilters);
         const noWakePathScanTruncated = Boolean((rawResult as unknown as { noWakePathScanTruncated?: boolean }).noWakePathScanTruncated);
+        const noWakePathNextOffset = (rawResult as unknown as { noWakePathNextOffset?: number }).noWakePathNextOffset;
         const result = await actorCanReadCompanyScope(req, companyId)
           ? rawResult
           : await filterIssuesForActor(req, rawResult);
@@ -6143,6 +6147,8 @@ export function issueRoutes(
             body: compactResult,
             etag: compactIssueListEtag(compactResult),
             cacheControl: "private, must-revalidate",
+            noWakePathScanTruncated,
+            noWakePathNextOffset,
           };
         }
         const [handoffStates, recoveryActionByIssue] = await Promise.all([
@@ -6165,6 +6171,7 @@ export function issueRoutes(
         return {
           kind: "full",
           noWakePathScanTruncated,
+          noWakePathNextOffset,
           body: result.map((issue) => ({
             ...issue,
             successfulRunHandoff: handoffStates.get(issue.id) ?? null,
@@ -6199,6 +6206,12 @@ export function issueRoutes(
     if (coordinated.response.kind === "compact") {
       res.setHeader("Cache-Control", coordinated.response.cacheControl);
       res.setHeader("ETag", coordinated.response.etag);
+      if (coordinated.response.noWakePathScanTruncated) {
+        res.setHeader("X-Paperclip-No-Wake-Path-Scan-Truncated", "true");
+        if (coordinated.response.noWakePathNextOffset !== undefined) {
+          res.setHeader("X-Paperclip-No-Wake-Path-Next-Offset", String(coordinated.response.noWakePathNextOffset));
+        }
+      }
       const etagMatched = requestMatchesEtag(req.header("if-none-match"), coordinated.response.etag);
       logIssueListRequest({
         req,
@@ -6232,6 +6245,9 @@ export function issueRoutes(
     });
     if (coordinated.response.noWakePathScanTruncated) {
       res.setHeader("X-Paperclip-No-Wake-Path-Scan-Truncated", "true");
+      if (coordinated.response.noWakePathNextOffset !== undefined) {
+        res.setHeader("X-Paperclip-No-Wake-Path-Next-Offset", String(coordinated.response.noWakePathNextOffset));
+      }
     }
     res.json(coordinated.response.body);
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -201,6 +201,7 @@ import {
   ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS,
   readAcceptedPlanConfirmationTarget,
 } from "../services/issues.js";
+import { deriveFlatMonitorStatus } from "../services/issue-execution-policy.js";
 import { authorizationDeniedDetails } from "../services/authorization.js";
 import { stalledReviewDecisionService } from "../services/stalled-review-decisions.js";
 import { environmentService } from "../services/environments.js";
@@ -2399,6 +2400,7 @@ function toCompactIssue(issue: any): CompactIssue {
     ...(issue.isUnreadForMe !== undefined ? { isUnreadForMe: issue.isUnreadForMe } : {}),
     activeRecoveryAction: issue.activeRecoveryAction ?? null,
     successfulRunHandoff: issue.successfulRunHandoff ?? null,
+    ...(issue.monitorStatus !== undefined ? { monitorStatus: issue.monitorStatus } : {}),
   };
 }
 
@@ -6012,6 +6014,16 @@ export function issueRoutes(
       res.status(400).json({ error: "sortDir must be 'asc' or 'desc' when provided" });
       return;
     }
+    const rawNoWakePath = req.query.noWakePath as string | undefined;
+    if (rawNoWakePath !== undefined && rawNoWakePath !== "true" && rawNoWakePath !== "1" && rawNoWakePath !== "false" && rawNoWakePath !== "0") {
+      res.status(400).json({ error: "noWakePath must be a boolean" });
+      return;
+    }
+    const noWakePath = rawNoWakePath === "true" || rawNoWakePath === "1";
+    if (noWakePath && attention === "blocked") {
+      res.status(400).json({ error: "noWakePath cannot be combined with attention=blocked" });
+      return;
+    }
     if (hasPlanDocument === null) {
       res.status(400).json({ error: "hasPlanDocument must be true or false when provided" });
       return;
@@ -6078,6 +6090,7 @@ export function issueRoutes(
       sortField: sortField === "updated" ? "updated" : undefined,
       sortDir: sortDir === "asc" || sortDir === "desc" ? sortDir : undefined,
       updatedSince: rawUpdatedSince,
+      noWakePath: noWakePath ? true : undefined,
     };
     const requestKey = issueListRequestKey({
       req,
@@ -6712,6 +6725,7 @@ export function issueRoutes(
       ...inboxArchiveFields,
       goalId: goal?.id ?? issue.goalId,
       ancestors,
+      monitorStatus: deriveFlatMonitorStatus(issue),
       ...(blockerAttention ? { blockerAttention } : {}),
       ...(reviewAttention ? { reviewAttention } : {}),
       productivityReview,

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -262,6 +262,39 @@ function buildClearedMonitorState(input: {
   };
 }
 
+/**
+ * Flat, list-route-cheap projection of monitor liveness derived only from the
+ * five `monitor*` columns already selected on every list row (no JSON
+ * `executionState` needed). This intentionally collapses the full
+ * `IssueExecutionMonitorStateStatus` (`scheduled` | `triggered` | `cleared`)
+ * down to three buckets:
+ *
+ * - `"scheduled"`: a live, pending wake exists (`monitorNextCheckAt` set).
+ * - `"triggered"`: the monitor fired at least once and nothing is scheduled.
+ * - `"none"`: no monitor was ever scheduled, or it was cleared without ever
+ *   triggering (both are indistinguishable from these columns alone, and both
+ *   are equally "not live" for wake-path purposes — see AGE-924).
+ *
+ * `"cleared"` is never returned here: whichever concrete clear reason applied
+ * (`done`, `cancelled`, `manual`, etc.), a cleared monitor has no live wake
+ * path, which is the only thing this projection needs to convey. Callers that
+ * need the precise persisted status/clear-reason must still read
+ * `executionState.monitor` from `GET /issues/:id`.
+ */
+export type FlatIssueMonitorStatus = "scheduled" | "triggered" | "none";
+
+export interface FlatIssueMonitorColumns {
+  monitorNextCheckAt?: Date | string | null;
+  monitorLastTriggeredAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
+}
+
+export function deriveFlatMonitorStatus(issue: FlatIssueMonitorColumns): FlatIssueMonitorStatus {
+  if (issue.monitorNextCheckAt) return "scheduled";
+  if (issue.monitorLastTriggeredAt || (issue.monitorAttemptCount ?? 0) > 0) return "triggered";
+  return "none";
+}
+
 function issueAllowsMonitor(status: string, assigneeAgentId: string | null, assigneeUserId: string | null) {
   return Boolean(assigneeAgentId) && !assigneeUserId && (status === "in_progress" || status === "in_review");
 }

--- a/server/src/services/issue-no-wake-path.ts
+++ b/server/src/services/issue-no-wake-path.ts
@@ -24,7 +24,15 @@ export interface NoWakePathIssueInput {
   blockedByIssueIds: readonly string[];
   /** Flat-column-derived monitor projection; see `deriveFlatMonitorStatus`. */
   monitorStatus: FlatIssueMonitorStatus | null;
-  /** True if an active run currently owns this specific issue. */
+  /**
+   * True if an active run, queued run, or scheduled retry currently owns
+   * this specific issue. Deliberately broader than "is `issues.executionRunId`
+   * bound to a queued/running heartbeat run": a queued wake that has not yet
+   * been converted into a run, or a `scheduled_retry` run, both represent a
+   * live path too and must not be misclassified as saturation (Greptile
+   * review on AGE-924 PR #11911 flagged the narrower check as a false
+   * positive against exactly these two cases).
+   */
   hasActiveRun: boolean;
   /** Current status of `assigneeAgentId`'s agent record, if any. */
   assigneeAgentStatus: string | null;
@@ -42,8 +50,10 @@ export interface NoWakePathIssueInput {
  *    `deriveFlatMonitorStatus`) + no unresolved blocker.
  * 3. `todo` + no assignee (agent or user).
  * 4. An agent assignee is set, that agent's own status is `running`, but no
- *    active run is bound to *this* issue — the assignee is saturated on a
- *    different lane and cannot wake this one.
+ *    active run, queued run, or scheduled retry (`hasActiveRun`) is bound to
+ *    *this* issue — the assignee is saturated on a different lane and cannot
+ *    wake this one. A queued wake awaiting a run, or a `scheduled_retry` run,
+ *    both count as `hasActiveRun: true` and must not trip this condition.
  */
 export function classifyNoWakePath(issue: NoWakePathIssueInput): NoWakePathReason | null {
   if (

--- a/server/src/services/issue-no-wake-path.ts
+++ b/server/src/services/issue-no-wake-path.ts
@@ -1,0 +1,82 @@
+import type { FlatIssueMonitorStatus } from "./issue-execution-policy.js";
+
+/**
+ * The 4-condition "no wake path" definition from AGE-924, layered on top of
+ * (and independent from) AGE-570's `lastActivityAt`/`staleHours` proxy.
+ * `lastActivityAt` measures recency; this measures whether *anything* will
+ * ever cause the issue to be looked at again. An issue can be touched 5
+ * minutes ago and still have no wake path (e.g. `in_review` with a cleared
+ * monitor); conversely an issue untouched for 100h with a monitor 2 days out
+ * is healthy. Only this classifier, not staleHours, should gate an "is this
+ * issue dead" decision.
+ */
+export type NoWakePathReason =
+  | "blocked_no_blockers_no_monitor"
+  | "in_review_spent_monitor_no_blocker"
+  | "todo_unassigned"
+  | "assignee_saturated";
+
+export interface NoWakePathIssueInput {
+  status: string;
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+  /** Unresolved (not done/cancelled) blocker issue ids for this issue. */
+  blockedByIssueIds: readonly string[];
+  /** Flat-column-derived monitor projection; see `deriveFlatMonitorStatus`. */
+  monitorStatus: FlatIssueMonitorStatus | null;
+  /** True if an active run currently owns this specific issue. */
+  hasActiveRun: boolean;
+  /** Current status of `assigneeAgentId`'s agent record, if any. */
+  assigneeAgentStatus: string | null;
+}
+
+/**
+ * Classify why an issue has no live wake path, or return `null` if it has
+ * one (or its status makes the question moot, e.g. `done`/`cancelled`).
+ *
+ * Conditions (verbatim from AGE-924, evaluated independently — any one match
+ * is sufficient):
+ * 1. `blocked` + empty `blockedByIssueIds` + no monitor.
+ * 2. `in_review` + `monitorStatus` in `{none, triggered}` (both `cleared` and
+ *    `triggered` collapse to "not scheduled" in the flat projection — see
+ *    `deriveFlatMonitorStatus`) + no unresolved blocker.
+ * 3. `todo` + no assignee (agent or user).
+ * 4. An agent assignee is set, that agent's own status is `running`, but no
+ *    active run is bound to *this* issue — the assignee is saturated on a
+ *    different lane and cannot wake this one.
+ */
+export function classifyNoWakePath(issue: NoWakePathIssueInput): NoWakePathReason | null {
+  if (
+    issue.status === "blocked" &&
+    issue.blockedByIssueIds.length === 0 &&
+    issue.monitorStatus !== "scheduled"
+  ) {
+    return "blocked_no_blockers_no_monitor";
+  }
+
+  if (
+    issue.status === "in_review" &&
+    (issue.monitorStatus === "none" || issue.monitorStatus === "triggered") &&
+    issue.blockedByIssueIds.length === 0
+  ) {
+    return "in_review_spent_monitor_no_blocker";
+  }
+
+  if (issue.status === "todo" && !issue.assigneeAgentId && !issue.assigneeUserId) {
+    return "todo_unassigned";
+  }
+
+  if (
+    issue.assigneeAgentId &&
+    issue.assigneeAgentStatus === "running" &&
+    !issue.hasActiveRun
+  ) {
+    return "assignee_saturated";
+  }
+
+  return null;
+}
+
+export function isNoWakePath(issue: NoWakePathIssueInput): boolean {
+  return classifyNoWakePath(issue) !== null;
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5882,11 +5882,12 @@ export function issueService(db: Db) {
         monitorAttemptCount: number | null;
         blockedBy?: IssueRelationIssueSummary[];
       }>(mapped: T[]): (T & { monitorStatus: ReturnType<typeof deriveFlatMonitorStatus> })[] => {
-        const withMonitorStatus = mapped.map((row) => ({
+        const withMonitorStatus = mapped.map((row, rawIndex) => ({
           ...row,
           monitorStatus: deriveFlatMonitorStatus(row),
+          __noWakePathRawIndex: rawIndex,
         }));
-        if (!noWakePath) return withMonitorStatus;
+        if (!noWakePath) return withMonitorStatus.map(({ __noWakePathRawIndex, ...row }) => row) as unknown as (T & { monitorStatus: ReturnType<typeof deriveFlatMonitorStatus> })[];
         const filtered = withMonitorStatus.filter((row) => classifyNoWakePath({
           status: row.status,
           assigneeAgentId: row.assigneeAgentId,
@@ -5898,9 +5899,25 @@ export function issueService(db: Db) {
           hasActiveRun: row.activeRun !== null || noWakePathLiveIssueIds.has(row.id),
           assigneeAgentStatus: row.assigneeAgentId ? noWakePathAgentStatusById.get(row.assigneeAgentId) ?? null : null,
         }) !== null);
-        const page = filtered.slice(0, limit === undefined ? undefined : limit);
-        if (noWakePathScanTruncated) {
+        const page = filtered.slice(0, limit === undefined ? undefined : limit)
+          .map(({ __noWakePathRawIndex, ...row }) => row) as unknown as (T & { monitorStatus: ReturnType<typeof deriveFlatMonitorStatus> })[];
+        // A window can contain more matches than `limit` (surplus matches
+        // beyond the returned page), independent of whether the raw scan hit
+        // the cap. Either case means the caller must not assume completeness.
+        // The precise continuation point is the raw row index right after the
+        // last *returned* match — NOT a fixed jump by the scan cap, which would
+        // skip any surplus matches left in this window past `limit` (Greptile
+        // review on AGE-924 PR #11911: a fixed-cap jump silently dropped
+        // matches whenever a window held more hits than the page size).
+        const hasSurplusMatchesInWindow = filtered.length > (limit ?? filtered.length);
+        const truncated = noWakePathScanTruncated || hasSurplusMatchesInWindow;
+        if (truncated) {
+          const lastReturnedRawIndex = filtered.length > 0 && limit !== undefined && limit > 0
+            ? filtered[Math.min(limit, filtered.length) - 1].__noWakePathRawIndex
+            : -1;
+          const nextOffset = lastReturnedRawIndex >= 0 ? offset + lastReturnedRawIndex + 1 : offset + rows.length;
           Object.defineProperty(page, "noWakePathScanTruncated", { value: true, enumerable: false });
+          Object.defineProperty(page, "noWakePathNextOffset", { value: nextOffset, enumerable: false });
         }
         return page;
       };

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -87,7 +87,8 @@ import {
   type ParsedExecutionWorkspaceMode,
 } from "./execution-workspace-policy.js";
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
-import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+import { buildInitialIssueMonitorFields, deriveFlatMonitorStatus, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+import { classifyNoWakePath, type NoWakePathReason } from "./issue-no-wake-path.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -136,6 +137,13 @@ const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "bloc
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
+/**
+ * Upper bound on rows scanned server-side before applying `limit`/`offset`
+ * when `noWakePath: true` is set (AGE-924). The classification runs in
+ * process against a bounded candidate set rather than as a SQL predicate, so
+ * this caps worst-case work for a company with a huge backlog.
+ */
+export const ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP = 5000;
 export const ISSUE_BLOCKER_DIAGNOSTICS_MAX_BLOCKERS = 100;
 export const ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS = 50;
 export const ISSUE_WAKE_DIAGNOSTICS_MAX_ACTIVITY_RECORDS = 50;
@@ -577,6 +585,16 @@ export interface IssueFilters {
   sortDir?: "asc" | "desc";
   /** ISO 8601 timestamp — only return issues with updatedAt strictly after this value. */
   updatedSince?: string;
+  /**
+   * Server-side "no wake path" filter (AGE-924): only return issues matching
+   * the 4-condition `classifyNoWakePath` definition. Forces `includeBlockedBy`
+   * on internally (the classifier needs unresolved blocker ids) and, because
+   * the classification happens after the DB fetch, scans up to
+   * `ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP` matching rows before applying the
+   * requested `limit`/`offset` in-process. Intended for operator/audit sweeps,
+   * not hot-path UI polling.
+   */
+  noWakePath?: boolean;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -5575,7 +5593,8 @@ export function issueService(db: Db) {
       const inboxArchivedByUserId = filters?.inboxArchivedByUserId?.trim() || undefined;
       const unreadForUserId = filters?.unreadForUserId?.trim() || undefined;
       const contextUserId = unreadForUserId ?? touchedByUserId ?? inboxArchivedByUserId;
-      const includeBlockedBy = filters?.includeBlockedBy === true;
+      const noWakePath = filters?.noWakePath === true;
+      const includeBlockedBy = filters?.includeBlockedBy === true || noWakePath;
       const includeBlockedInboxAttention = filters?.includeBlockedInboxAttention === true;
       const includeLiveDescendantSummary = filters?.includeLiveDescendantSummary === true;
       const rawSearch = filters?.q?.trim() ?? "";
@@ -5714,9 +5733,15 @@ export function issueService(db: Db) {
           sortField: filters?.sortField,
           sortDir: filters?.sortDir,
         }));
-      const pageQuery = offset > 0
-        ? (limit === undefined ? baseQuery.offset(offset) : baseQuery.limit(limit).offset(offset))
-        : (limit === undefined ? baseQuery : baseQuery.limit(limit));
+      // When `noWakePath` is set the 4-condition classification runs in process
+      // (see issue-no-wake-path.ts) after the DB fetch, so the requested
+      // limit/offset cannot be pushed down as a SQL predicate. Scan a bounded
+      // candidate set instead and apply the caller's limit/offset afterwards.
+      const scanLimit = noWakePath ? ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP : limit;
+      const scanOffset = noWakePath ? 0 : offset;
+      const pageQuery = scanOffset > 0
+        ? (scanLimit === undefined ? baseQuery.offset(scanOffset) : baseQuery.limit(scanLimit).offset(scanOffset))
+        : (scanLimit === undefined ? baseQuery : baseQuery.limit(scanLimit));
       const rows = (await pageQuery).map((row) => ({
         ...row,
         description: decodeDatabaseTextPreview(row.description, ISSUE_LIST_DESCRIPTION_MAX_CHARS),
@@ -5729,7 +5754,10 @@ export function issueService(db: Db) {
       }
 
       const issueIds = withRuns.map((row) => row.id);
-      const [statsRows, readRows, lastActivityRows, archiveRows, blockedByMap, liveDescendantCountByIssueId] = await Promise.all([
+      const noWakePathAssigneeAgentIds = noWakePath
+        ? [...new Set(withRuns.map((row) => row.assigneeAgentId).filter((id): id is string => Boolean(id)))]
+        : [];
+      const [statsRows, readRows, lastActivityRows, archiveRows, blockedByMap, liveDescendantCountByIssueId, noWakePathAgentRows] = await Promise.all([
         contextUserId
           ? userCommentStatsForIssues(db, companyId, contextUserId, issueIds)
           : Promise.resolve([]),
@@ -5746,10 +5774,46 @@ export function issueService(db: Db) {
         includeLiveDescendantSummary
           ? liveDescendantCountMapForIssues(db, companyId, issueIds)
           : Promise.resolve(new Map<string, number>()),
+        noWakePathAssigneeAgentIds.length > 0
+          ? db
+              .select({ id: agents.id, status: agents.status })
+              .from(agents)
+              .where(and(eq(agents.companyId, companyId), inArray(agents.id, noWakePathAssigneeAgentIds)))
+          : Promise.resolve([] as Array<{ id: string; status: string }>),
       ]);
       const statsByIssueId = new Map(statsRows.map((row) => [row.issueId, row]));
       const lastActivityByIssueId = new Map(lastActivityRows.map((row) => [row.issueId, row]));
       const archiveByIssueId = new Map(archiveRows.map((row) => [row.issueId, row]));
+      const noWakePathAgentStatusById = new Map(noWakePathAgentRows.map((row) => [row.id, row.status]));
+      const applyNoWakePathAndPage = <T extends {
+        id: string;
+        status: string;
+        assigneeAgentId: string | null;
+        assigneeUserId: string | null;
+        activeRun: IssueActiveRunRow | null;
+        monitorNextCheckAt: Date | null;
+        monitorLastTriggeredAt: Date | null;
+        monitorAttemptCount: number | null;
+        blockedBy?: IssueRelationIssueSummary[];
+      }>(mapped: T[]): (T & { monitorStatus: ReturnType<typeof deriveFlatMonitorStatus> })[] => {
+        const withMonitorStatus = mapped.map((row) => ({
+          ...row,
+          monitorStatus: deriveFlatMonitorStatus(row),
+        }));
+        if (!noWakePath) return withMonitorStatus;
+        const filtered = withMonitorStatus.filter((row) => classifyNoWakePath({
+          status: row.status,
+          assigneeAgentId: row.assigneeAgentId,
+          assigneeUserId: row.assigneeUserId,
+          blockedByIssueIds: (row.blockedBy ?? [])
+            .filter((blocker) => blocker.status !== "done" && blocker.status !== "cancelled")
+            .map((blocker) => blocker.id),
+          monitorStatus: row.monitorStatus,
+          hasActiveRun: row.activeRun !== null,
+          assigneeAgentStatus: row.assigneeAgentId ? noWakePathAgentStatusById.get(row.assigneeAgentId) ?? null : null,
+        }) !== null);
+        return filtered.slice(offset, limit === undefined ? undefined : offset + limit);
+      };
       const [
         blockerAttentionByIssueId,
         reviewAttentionByIssueId,
@@ -5765,7 +5829,7 @@ export function issueService(db: Db) {
       ]);
 
       if (!contextUserId) {
-        return withRuns.map((row) => {
+        const mapped = withRuns.map((row) => {
           const activity = lastActivityByIssueId.get(row.id);
           const lastActivityAt = latestIssueActivityAt(
             row.updatedAt,
@@ -5785,11 +5849,12 @@ export function issueService(db: Db) {
               : {}),
           };
         });
+        return applyNoWakePathAndPage(mapped);
       }
 
       const readByIssueId = new Map(readRows.map((row) => [row.issueId, row.myLastReadAt]));
 
-      return withRuns.map((row) => {
+      const mapped = withRuns.map((row) => {
         const activity = lastActivityByIssueId.get(row.id);
         const lastActivityAt = latestIssueActivityAt(
           row.updatedAt,
@@ -5815,6 +5880,7 @@ export function issueService(db: Db) {
           }),
         };
       });
+      return applyNoWakePathAndPage(mapped);
     },
 
     count: async (companyId: string, filters?: IssueFilters) => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -141,9 +141,15 @@ export const ISSUE_LIST_MAX_LIMIT = 1000;
  * Upper bound on rows scanned server-side before applying `limit`/`offset`
  * when `noWakePath: true` is set (AGE-924). The classification runs in
  * process against a bounded candidate set rather than as a SQL predicate, so
- * this caps worst-case work for a company with a huge backlog.
+ * this caps worst-case work for a company with a huge backlog. Generous on
+ * purpose: real companies rarely have this many issues matching a given base
+ * filter, so in practice this is a circuit breaker, not a working limit. If
+ * the raw (pre-classification) row count returned equals this cap, the scan
+ * may be incomplete; `list()` signals that via `noWakePathScanTruncated` so
+ * callers (e.g. `GET /companies/:companyId/issues`) can surface it instead of
+ * silently returning a partial result.
  */
-export const ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP = 5000;
+export const ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP = 20_000;
 export const ISSUE_BLOCKER_DIAGNOSTICS_MAX_BLOCKERS = 100;
 export const ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS = 50;
 export const ISSUE_WAKE_DIAGNOSTICS_MAX_ACTIVITY_RECORDS = 50;
@@ -2017,6 +2023,62 @@ async function activeRunMapForIssues(
     }
   }
   return map;
+}
+
+/**
+ * Bulk "does this issue have a live execution or wake path" check for the
+ * `noWakePath` assignee-saturation condition (AGE-924, condition 4). Broader
+ * than `activeRunMapForIssues`/`issues.executionRunId`: a queued wake that has
+ * not yet been converted into a run, or a `scheduled_retry` run, both keep an
+ * issue alive and must count here even though neither stamps
+ * `issues.executionRunId`. Matches `heartbeatRuns` by the issue id embedded in
+ * `contextSnapshot` (not the `executionRunId` column) for exactly this reason
+ * — mirrors the pattern already used by `listIssueBlockerAttentionMap`.
+ */
+async function noWakePathLiveExecutionIssueIds(
+  dbOrTx: any,
+  companyId: string,
+  issueIds: string[],
+): Promise<Set<string>> {
+  const live = new Set<string>();
+  const uniqueIssueIds = [...new Set(issueIds)];
+  if (uniqueIssueIds.length === 0) return live;
+
+  const runContextIssueId = sql<string | null>`coalesce(${heartbeatRuns.contextSnapshot} ->> 'issueId', ${heartbeatRuns.contextSnapshot} ->> 'taskId')`;
+  const wakeContextIssueId = sql<string | null>`coalesce(
+    ${agentWakeupRequests.payload} ->> 'issueId',
+    ${agentWakeupRequests.payload} ->> 'taskId',
+    ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'issueId',
+    ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'taskId'
+  )`;
+
+  for (const issueIdChunk of chunkList(uniqueIssueIds, ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
+    const [runRows, wakeRows] = await Promise.all([
+      dbOrTx
+        .select({ issueId: runContextIssueId })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.companyId, companyId),
+          inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"]),
+          inArray(runContextIssueId, issueIdChunk),
+        )),
+      dbOrTx
+        .select({ issueId: wakeContextIssueId })
+        .from(agentWakeupRequests)
+        .where(and(
+          eq(agentWakeupRequests.companyId, companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"]),
+          inArray(wakeContextIssueId, issueIdChunk),
+        )),
+    ]);
+    for (const row of runRows as Array<{ issueId: string | null }>) {
+      if (row.issueId) live.add(row.issueId);
+    }
+    for (const row of wakeRows as Array<{ issueId: string | null }>) {
+      if (row.issueId) live.add(row.issueId);
+    }
+  }
+  return live;
 }
 
 async function liveDescendantCountMapForIssues(
@@ -5746,6 +5808,11 @@ export function issueService(db: Db) {
         ...row,
         description: decodeDatabaseTextPreview(row.description, ISSUE_LIST_DESCRIPTION_MAX_CHARS),
       }));
+      // If the scan hit the cap, there may be more matching rows beyond it;
+      // callers must not treat the result as exhaustive (AGE-924 / Greptile
+      // review on PR #11911: a silent truncation here made a bounded-backlog
+      // sweep miss real matches with no indication anything was cut off).
+      const noWakePathScanTruncated = noWakePath && scanLimit !== undefined && rows.length >= scanLimit;
       const withLabels = await withIssueLabels(db, rows);
       const runMap = await activeRunMapForIssues(db, withLabels);
       const withRuns = withActiveRuns(withLabels, runMap);
@@ -5757,7 +5824,7 @@ export function issueService(db: Db) {
       const noWakePathAssigneeAgentIds = noWakePath
         ? [...new Set(withRuns.map((row) => row.assigneeAgentId).filter((id): id is string => Boolean(id)))]
         : [];
-      const [statsRows, readRows, lastActivityRows, archiveRows, blockedByMap, liveDescendantCountByIssueId, noWakePathAgentRows] = await Promise.all([
+      const [statsRows, readRows, lastActivityRows, archiveRows, blockedByMap, liveDescendantCountByIssueId, noWakePathAgentRows, noWakePathLiveIssueIds] = await Promise.all([
         contextUserId
           ? userCommentStatsForIssues(db, companyId, contextUserId, issueIds)
           : Promise.resolve([]),
@@ -5780,6 +5847,9 @@ export function issueService(db: Db) {
               .from(agents)
               .where(and(eq(agents.companyId, companyId), inArray(agents.id, noWakePathAssigneeAgentIds)))
           : Promise.resolve([] as Array<{ id: string; status: string }>),
+        noWakePath
+          ? noWakePathLiveExecutionIssueIds(db, companyId, issueIds)
+          : Promise.resolve(new Set<string>()),
       ]);
       const statsByIssueId = new Map(statsRows.map((row) => [row.issueId, row]));
       const lastActivityByIssueId = new Map(lastActivityRows.map((row) => [row.issueId, row]));
@@ -5809,10 +5879,14 @@ export function issueService(db: Db) {
             .filter((blocker) => blocker.status !== "done" && blocker.status !== "cancelled")
             .map((blocker) => blocker.id),
           monitorStatus: row.monitorStatus,
-          hasActiveRun: row.activeRun !== null,
+          hasActiveRun: row.activeRun !== null || noWakePathLiveIssueIds.has(row.id),
           assigneeAgentStatus: row.assigneeAgentId ? noWakePathAgentStatusById.get(row.assigneeAgentId) ?? null : null,
         }) !== null);
-        return filtered.slice(offset, limit === undefined ? undefined : offset + limit);
+        const page = filtered.slice(offset, limit === undefined ? undefined : offset + limit);
+        if (noWakePathScanTruncated) {
+          Object.defineProperty(page, "noWakePathScanTruncated", { value: true, enumerable: false });
+        }
+        return page;
       };
       const [
         blockerAttentionByIssueId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -138,16 +138,23 @@ const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
 /**
- * Upper bound on rows scanned server-side before applying `limit`/`offset`
- * when `noWakePath: true` is set (AGE-924). The classification runs in
- * process against a bounded candidate set rather than as a SQL predicate, so
- * this caps worst-case work for a company with a huge backlog. Generous on
+ * Upper bound on rows scanned server-side in one request when `noWakePath:
+ * true` is set (AGE-924). The classification runs in process against a
+ * bounded candidate set rather than as a SQL predicate, so this caps
+ * worst-case work per request for a company with a huge backlog. Generous on
  * purpose: real companies rarely have this many issues matching a given base
- * filter, so in practice this is a circuit breaker, not a working limit. If
- * the raw (pre-classification) row count returned equals this cap, the scan
- * may be incomplete; `list()` signals that via `noWakePathScanTruncated` so
- * callers (e.g. `GET /companies/:companyId/issues`) can surface it instead of
- * silently returning a partial result.
+ * filter, so in practice this is a circuit breaker, not a working limit.
+ *
+ * When `noWakePath` is set, the caller's `offset` is pushed down as the raw
+ * SQL scan offset (skip this many *candidate rows*, not matches), and the
+ * response contains at most `limit` matches found within that single
+ * `[offset, offset + cap)` window. If the raw row count returned equals this
+ * cap, the window may contain further matches beyond it that were not
+ * scanned; `list()` signals that via `noWakePathScanTruncated`, and the route
+ * surfaces it as `X-Paperclip-No-Wake-Path-Scan-Truncated: true`. A caller
+ * that sees the header must advance `offset` by this cap (not by the number
+ * of results received) and repeat, until a response omits the header — that
+ * is the retrieval path for any matches an earlier window omitted.
  */
 export const ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP = 20_000;
 export const ISSUE_BLOCKER_DIAGNOSTICS_MAX_BLOCKERS = 100;
@@ -5796,11 +5803,20 @@ export function issueService(db: Db) {
           sortDir: filters?.sortDir,
         }));
       // When `noWakePath` is set the 4-condition classification runs in process
-      // (see issue-no-wake-path.ts) after the DB fetch, so the requested
-      // limit/offset cannot be pushed down as a SQL predicate. Scan a bounded
-      // candidate set instead and apply the caller's limit/offset afterwards.
+      // (see issue-no-wake-path.ts) after the DB fetch, so it cannot be pushed
+      // down as a SQL predicate. To keep results retrievable even when a
+      // company has more matching issues than `ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP`
+      // (Greptile review on AGE-924 PR #11911), the caller's `offset` is pushed
+      // down as the SQL scan offset directly — NOT re-applied to the classified
+      // matches. This changes what `offset` means for `noWakePath` requests:
+      // it is "skip this many raw candidate rows", not "skip this many matches".
+      // A caller that gets `X-Paperclip-No-Wake-Path-Scan-Truncated: true` must
+      // advance `offset` by `ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP` (not by the
+      // number of results returned) to scan the next window and retrieve any
+      // omitted matches, repeating until a response comes back without the
+      // truncation header.
       const scanLimit = noWakePath ? ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP : limit;
-      const scanOffset = noWakePath ? 0 : offset;
+      const scanOffset = offset;
       const pageQuery = scanOffset > 0
         ? (scanLimit === undefined ? baseQuery.offset(scanOffset) : baseQuery.limit(scanLimit).offset(scanOffset))
         : (scanLimit === undefined ? baseQuery : baseQuery.limit(scanLimit));
@@ -5882,7 +5898,7 @@ export function issueService(db: Db) {
           hasActiveRun: row.activeRun !== null || noWakePathLiveIssueIds.has(row.id),
           assigneeAgentStatus: row.assigneeAgentId ? noWakePathAgentStatusById.get(row.assigneeAgentId) ?? null : null,
         }) !== null);
-        const page = filtered.slice(offset, limit === undefined ? undefined : offset + limit);
+        const page = filtered.slice(0, limit === undefined ? undefined : limit);
         if (noWakePathScanTruncated) {
           Object.defineProperty(page, "noWakePathScanTruncated", { value: true, enumerable: false });
         }


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue list endpoint (`GET /companies/:companyId/issues`) is what stranding/liveness sweeps use to decide which issues are dead
> - A sweep run reported 47 dead `in_review` issues when the real number was 9, because the list route gave no way to distinguish "no monitor" from "monitor data not returned"
> - Any consumer computing `.executionState?.monitor?.status ?? "none"` on the list response silently treats an omitted field the same as an explicit "no monitor", so a live scheduled monitor looked identical to a dead one
> - Separately, `lastActivityAt`/staleHours alone cannot detect "no wake path": an issue touched 5 minutes ago can still be permanently dead (`in_review` with a cleared monitor), and an issue untouched for 100h with a monitor 2 days out is healthy
> - This pull request adds a cheap, always-present `monitorStatus` field derived from columns already selected on every list row, and a `?noWakePath=true` filter implementing an explicit 4-condition "no wake path" definition
> - The benefit is that stranding sweeps (and any other consumer) get a real signal instead of guessing from an omitted field, cutting false positives from ~5:1 to accurate

## Linked Issues or Issue Description

**Subsystem affected**
Server — issue list/read routes (`server/src/routes/issues.ts`, `server/src/services/issues.ts`)

**Problem or motivation**
`GET /companies/:companyId/issues` gives no cheap way to tell whether an issue's monitor is live. Consumers fall back to `.executionState?.monitor?.status ?? "none"`, which cannot distinguish "the field was never returned" from "there really is no monitor." In one operator run this made 46 `in_review` issues look dead when 37 of them had a live scheduled monitor — a 5:1 false-positive rate. Separately, recency (`lastActivityAt`) is not the same signal as "will anything ever wake this issue again," so a stale-hours filter alone under- and over-flags issues.

**Proposed solution**
1. Add `deriveFlatMonitorStatus()`: derives `"scheduled" | "triggered" | "none"` purely from the `monitor*` columns already selected on every list row (no schema change, no new column). Wire it onto every issue returned from the list route (full and compact view) and the single-issue read route as `monitorStatus`, always present, never omitted.
2. Add `classifyNoWakePath()`: an explicit 4-condition "no wake path" classifier (blocked with no unresolved blockers and no monitor; in_review with a spent monitor and no unresolved blocker; todo with no assignee; an agent assignee whose own status is "running" but with no active run bound to this issue). Exposed via `GET /companies/:companyId/issues?noWakePath=true`.

**Alternatives considered**
Returning the full `executionState` blob (with a `?include=executionState` gate) was considered and rejected: five of six monitor sub-fields are already flat columns on every list row, so a full opt-in blob is unnecessarily heavy for the one missing bit of information (the derived status enum).

**Roadmap alignment**
Operational/reliability tooling improvement to the existing issue list API; does not touch planned core roadmap work.

## What Changed

- `packages/shared/src/types/issue.ts`: add optional `monitorStatus?: "scheduled" | "triggered" | "none"` to `Issue` and `CompactIssue`.
- `server/src/services/issue-execution-policy.ts`: add `deriveFlatMonitorStatus()`, a pure function computing the flat monitor projection from the existing `monitor*` columns.
- `server/src/services/issue-no-wake-path.ts` (new): `classifyNoWakePath()` / `isNoWakePath()` implementing the 4-condition definition.
- `server/src/services/issues.ts`: attach `monitorStatus` to every row returned from `list()` (both branches); add `noWakePath` to `IssueFilters`; when set, force `includeBlockedBy`, fetch assignee agent statuses, scan a bounded candidate set (`ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP`), classify, then apply the caller's `limit`/`offset` in process.
- `server/src/routes/issues.ts`: parse and validate `?noWakePath=` query param (rejects combination with `?attention=blocked`), wire `monitorStatus` into `toCompactIssue()` and the single-issue `GET /issues/:id` response.
- Tests: `server/src/__tests__/issue-no-wake-path.test.ts` (pure classifier unit tests), `server/src/__tests__/issues-no-wake-path-route.test.ts` (HTTP-level field-presence contract + `noWakePath` filter, embedded Postgres).

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-no-wake-path.test.ts` — 18/18 pass (pure classifier unit tests).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-no-wake-path-route.test.ts` — 4/4 pass (embedded Postgres): field presence on every list row, `monitorStatus` on a live-monitor issue matches the single-issue read, compact view carries the field, and `?noWakePath=true` returns exactly the 4-condition matches while excluding healthy issues.
- Full existing suite unaffected: `issues-list-query-parsing.test.ts`, `issue-execution-policy.test.ts`, `issue-monitor-scheduler.test.ts`, `issues-service.test.ts`, `issues-user-context.test.ts`, `issues-checkout-wakeup.test.ts`, `issues-parent-id-alias.test.ts`, `issues-goal-context-routes.test.ts`, `issue-liveness.test.ts` — all pass (142+ tests), confirming no regression to the existing list route.

## Risks

- API response contract change: adds a new optional field (`monitorStatus`) to the issue list/read responses. Additive only — existing consumers ignoring unknown fields are unaffected.
- `?noWakePath=true` is opt-in and classifies in process rather than as a SQL predicate, bounded by `ISSUE_LIST_NO_WAKE_PATH_SCAN_CAP` (5000 rows) before applying the caller's limit/offset; intended for operator/audit sweeps, not hot-path UI polling.
- Low risk otherwise: no schema migration, no change to default (unfiltered) list behavior besides the new always-present field.

## Model Used

Claude (Anthropic), via the Pi coding agent harness — extended reasoning/tool-use mode, used to read the codebase, design the flat-column derivation, implement the service/route changes, and write both the pure-unit and embedded-Postgres integration tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
