### PR TITLE
fix(workspaces): honor the resolved execution workspace mode on the reuse path

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -7,8 +7,10 @@ import {
   buildExecutionWorkspaceAdapterConfig,
   defaultIssueExecutionWorkspaceSettingsForProject,
   gateProjectExecutionWorkspacePolicy,
+  isExecutionWorkspaceIsolationDrift,
   isUnrunnableWorktreeCombo,
   issueExecutionWorkspaceModeForPersistedWorkspace,
+  issueExecutionWorkspaceModeForPersistence,
   parseIssueExecutionWorkspaceSettings,
   parseProjectExecutionWorkspacePolicy,
   ManagedSandboxUnavailableError,
@@ -44,6 +46,90 @@ describe("execution workspace policy helpers", () => {
         legacyUseProjectWorkspace: false,
       }),
     ).toBe("isolated_workspace");
+  });
+
+  it("lets a project forbid per-issue mode overrides with allowIssueOverride: false", () => {
+    // The mode an inherited run wrote into the issue must not outrank a project that
+    // declared its default mandatory — this is the escape hatch for issues already
+    // carrying a manufactured `shared_workspace` pin.
+    expect(
+      resolveExecutionWorkspaceMode({
+        projectPolicy: { enabled: true, defaultMode: "isolated_workspace", allowIssueOverride: false },
+        issueSettings: { mode: "shared_workspace" },
+        legacyUseProjectWorkspace: null,
+      }),
+    ).toBe("isolated_workspace");
+    expect(
+      resolveExecutionWorkspaceMode({
+        projectPolicy: { enabled: true, defaultMode: "isolated_workspace", allowIssueOverride: true },
+        issueSettings: { mode: "shared_workspace" },
+        legacyUseProjectWorkspace: null,
+      }),
+    ).toBe("shared_workspace");
+    // Absent keeps the historical issue-wins precedence.
+    expect(
+      resolveExecutionWorkspaceMode({
+        projectPolicy: { enabled: true, defaultMode: "isolated_workspace" },
+        issueSettings: { mode: "shared_workspace" },
+        legacyUseProjectWorkspace: null,
+      }),
+    ).toBe("shared_workspace");
+  });
+
+  it("ignores allowIssueOverride on a disabled project policy", () => {
+    expect(
+      resolveExecutionWorkspaceMode({
+        projectPolicy: { enabled: false, defaultMode: "isolated_workspace", allowIssueOverride: false },
+        issueSettings: { mode: "isolated_workspace" },
+        legacyUseProjectWorkspace: null,
+      }),
+    ).toBe("isolated_workspace");
+  });
+
+  it("records a realized mode on the issue only when the issue chose one itself", () => {
+    // An inheriting issue must stay on `inherit`; writing the realized mode here is what
+    // manufactured the `shared_workspace` pins that made the project default unreachable.
+    for (const priorIssueMode of ["inherit", "reuse_existing", null, undefined] as const) {
+      expect(
+        issueExecutionWorkspaceModeForPersistence({
+          priorIssueMode,
+          persistedWorkspaceMode: "shared_workspace",
+        }),
+      ).toBe("inherit");
+    }
+    // An issue that did choose a mode keeps an explicit one, refreshed to what actually
+    // got realized — so a pinned issue heals to `isolated_workspace` after one run.
+    expect(
+      issueExecutionWorkspaceModeForPersistence({
+        priorIssueMode: "shared_workspace",
+        persistedWorkspaceMode: "isolated_workspace",
+      }),
+    ).toBe("isolated_workspace");
+    expect(
+      issueExecutionWorkspaceModeForPersistence({
+        priorIssueMode: "isolated_workspace",
+        persistedWorkspaceMode: "adapter_managed",
+      }),
+    ).toBe("agent_default");
+  });
+
+  it("detects isolation drift only when the bound workspace cannot be the issue's own tree", () => {
+    for (const existingWorkspaceMode of ["shared_workspace", "adapter_managed", null, undefined]) {
+      expect(
+        isExecutionWorkspaceIsolationDrift({ resolvedMode: "isolated_workspace", existingWorkspaceMode }),
+      ).toBe(true);
+    }
+    for (const existingWorkspaceMode of ["isolated_workspace", "operator_branch", "cloud_sandbox"]) {
+      expect(
+        isExecutionWorkspaceIsolationDrift({ resolvedMode: "operator_branch", existingWorkspaceMode }),
+      ).toBe(false);
+    }
+    // Modes that never promise a private tree cannot drift into one.
+    for (const resolvedMode of ["shared_workspace", "agent_default"] as const) {
+      expect(
+        isExecutionWorkspaceIsolationDrift({ resolvedMode, existingWorkspaceMode: "shared_workspace" }),
+      ).toBe(false);
+    }
   });
 
   it("resolves shared-workspace concurrency from issue override, project policy, then auto", () => {

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -6,9 +6,8 @@ import {
 import {
   buildExecutionWorkspaceAdapterConfig,
   defaultIssueExecutionWorkspaceSettingsForProject,
-  executionWorkspaceModeForReuse,
   gateProjectExecutionWorkspacePolicy,
-  isExecutionWorkspaceIsolationDrift,
+  isExecutionWorkspaceModeDrift,
   isUnrunnableWorktreeCombo,
   issueExecutionWorkspaceModeForPersistedWorkspace,
   issueExecutionWorkspaceModeForPersistence,
@@ -114,73 +113,57 @@ describe("execution workspace policy helpers", () => {
     ).toBe("agent_default");
   });
 
-  it("detects isolation drift only when the bound workspace cannot be the issue's own tree", () => {
+  it("detects mode drift whenever the bound workspace was not realized as the resolved mode", () => {
     for (const existingWorkspaceMode of ["shared_workspace", "adapter_managed", null, undefined]) {
       expect(
-        isExecutionWorkspaceIsolationDrift({ resolvedMode: "isolated_workspace", existingWorkspaceMode }),
+        isExecutionWorkspaceModeDrift({ resolvedMode: "isolated_workspace", existingWorkspaceMode }),
       ).toBe(true);
     }
-    for (const existingWorkspaceMode of ["isolated_workspace", "operator_branch", "cloud_sandbox"]) {
-      expect(
-        isExecutionWorkspaceIsolationDrift({ resolvedMode: "operator_branch", existingWorkspaceMode }),
-      ).toBe(false);
-    }
-    // Modes that never promise a private tree cannot drift into one.
-    for (const resolvedMode of ["shared_workspace", "agent_default"] as const) {
-      expect(
-        isExecutionWorkspaceIsolationDrift({ resolvedMode, existingWorkspaceMode: "shared_workspace" }),
-      ).toBe(false);
-    }
-  });
-
-  it("relabels a reused workspace between the two private modes and nowhere else", () => {
-    // isolated_workspace and operator_branch resolve the same strategy from the same config
-    // (resolveEffectiveWorkspaceStrategyType never branches on which of the two it is), so a
-    // tree realized as one honors the other — only the recorded label goes stale, and the
-    // reuse path is the only writer that can refresh it.
     expect(
-      executionWorkspaceModeForReuse({
+      isExecutionWorkspaceModeDrift({
         resolvedMode: "operator_branch",
-        existingWorkspaceMode: "isolated_workspace",
-      }),
-    ).toBe("operator_branch");
-    expect(
-      executionWorkspaceModeForReuse({
-        resolvedMode: "isolated_workspace",
-        existingWorkspaceMode: "operator_branch",
-      }),
-    ).toBe("isolated_workspace");
-    // Nothing to rewrite when the label already matches.
-    for (const mode of ["isolated_workspace", "operator_branch"] as const) {
-      expect(
-        executionWorkspaceModeForReuse({ resolvedMode: mode, existingWorkspaceMode: mode }),
-      ).toBeNull();
-    }
-    // A resolved mode that promises no private tree must not relabel a private one down to
-    // shared — that is the same DB lie pointing the other way.
-    for (const resolvedMode of ["shared_workspace", "agent_default"] as const) {
-      expect(
-        executionWorkspaceModeForReuse({ resolvedMode, existingWorkspaceMode: "isolated_workspace" }),
-      ).toBeNull();
-    }
-    // Shared -> private never reaches this helper (reuse is refused first), and must not
-    // relabel even if it did.
-    for (const existingWorkspaceMode of ["shared_workspace", "adapter_managed", null, undefined]) {
-      expect(
-        executionWorkspaceModeForReuse({ resolvedMode: "isolated_workspace", existingWorkspaceMode }),
-      ).toBeNull();
-    }
-  });
-
-  it("keeps reuse allowed across the two private modes rather than rebuilding the tree", () => {
-    // The relabel above is only safe because drift detection deliberately treats both private
-    // modes as one class. If this ever resolves to true, the relabel must become a recreate.
-    expect(
-      isExecutionWorkspaceIsolationDrift({
-        resolvedMode: "isolated_workspace",
         existingWorkspaceMode: "operator_branch",
       }),
     ).toBe(false);
+    // Modes that never promise a private tree keep the historical reuse behaviour.
+    for (const resolvedMode of ["shared_workspace", "agent_default"] as const) {
+      expect(
+        isExecutionWorkspaceModeDrift({ resolvedMode, existingWorkspaceMode: "shared_workspace" }),
+      ).toBe(false);
+      expect(
+        isExecutionWorkspaceModeDrift({ resolvedMode, existingWorkspaceMode: "isolated_workspace" }),
+      ).toBe(false);
+    }
+  });
+
+  it("treats a change between the two private modes as drift, not a reusable tree", () => {
+    // `mode` is replacement-class in heartbeat's WORKSPACE_REPLACEMENT_CONFIG_CATEGORIES, so
+    // config freshness already calls any mode change a `replace`. Reuse has to agree: if it
+    // restored the tree instead, shouldPersistLatestWorkspaceConfigMetadata would withhold the
+    // fresh fingerprint and the workspace would re-drift on every subsequent run forever.
+    expect(
+      isExecutionWorkspaceModeDrift({
+        resolvedMode: "isolated_workspace",
+        existingWorkspaceMode: "operator_branch",
+      }),
+    ).toBe(true);
+    expect(
+      isExecutionWorkspaceModeDrift({
+        resolvedMode: "operator_branch",
+        existingWorkspaceMode: "isolated_workspace",
+      }),
+    ).toBe(true);
+    // A cloud sandbox is private but is still not the mode that was resolved.
+    expect(
+      isExecutionWorkspaceModeDrift({
+        resolvedMode: "isolated_workspace",
+        existingWorkspaceMode: "cloud_sandbox",
+      }),
+    ).toBe(true);
+    // Same mode is the one reusable case.
+    for (const mode of ["isolated_workspace", "operator_branch"] as const) {
+      expect(isExecutionWorkspaceModeDrift({ resolvedMode: mode, existingWorkspaceMode: mode })).toBe(false);
+    }
   });
 
   it("resolves shared-workspace concurrency from issue override, project policy, then auto", () => {

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   buildExecutionWorkspaceAdapterConfig,
   defaultIssueExecutionWorkspaceSettingsForProject,
+  executionWorkspaceModeForReuse,
   gateProjectExecutionWorkspacePolicy,
   isExecutionWorkspaceIsolationDrift,
   isUnrunnableWorktreeCombo,
@@ -130,6 +131,56 @@ describe("execution workspace policy helpers", () => {
         isExecutionWorkspaceIsolationDrift({ resolvedMode, existingWorkspaceMode: "shared_workspace" }),
       ).toBe(false);
     }
+  });
+
+  it("relabels a reused workspace between the two private modes and nowhere else", () => {
+    // isolated_workspace and operator_branch resolve the same strategy from the same config
+    // (resolveEffectiveWorkspaceStrategyType never branches on which of the two it is), so a
+    // tree realized as one honors the other — only the recorded label goes stale, and the
+    // reuse path is the only writer that can refresh it.
+    expect(
+      executionWorkspaceModeForReuse({
+        resolvedMode: "operator_branch",
+        existingWorkspaceMode: "isolated_workspace",
+      }),
+    ).toBe("operator_branch");
+    expect(
+      executionWorkspaceModeForReuse({
+        resolvedMode: "isolated_workspace",
+        existingWorkspaceMode: "operator_branch",
+      }),
+    ).toBe("isolated_workspace");
+    // Nothing to rewrite when the label already matches.
+    for (const mode of ["isolated_workspace", "operator_branch"] as const) {
+      expect(
+        executionWorkspaceModeForReuse({ resolvedMode: mode, existingWorkspaceMode: mode }),
+      ).toBeNull();
+    }
+    // A resolved mode that promises no private tree must not relabel a private one down to
+    // shared — that is the same DB lie pointing the other way.
+    for (const resolvedMode of ["shared_workspace", "agent_default"] as const) {
+      expect(
+        executionWorkspaceModeForReuse({ resolvedMode, existingWorkspaceMode: "isolated_workspace" }),
+      ).toBeNull();
+    }
+    // Shared -> private never reaches this helper (reuse is refused first), and must not
+    // relabel even if it did.
+    for (const existingWorkspaceMode of ["shared_workspace", "adapter_managed", null, undefined]) {
+      expect(
+        executionWorkspaceModeForReuse({ resolvedMode: "isolated_workspace", existingWorkspaceMode }),
+      ).toBeNull();
+    }
+  });
+
+  it("keeps reuse allowed across the two private modes rather than rebuilding the tree", () => {
+    // The relabel above is only safe because drift detection deliberately treats both private
+    // modes as one class. If this ever resolves to true, the relabel must become a recreate.
+    expect(
+      isExecutionWorkspaceIsolationDrift({
+        resolvedMode: "isolated_workspace",
+        existingWorkspaceMode: "operator_branch",
+      }),
+    ).toBe(false);
   });
 
   it("resolves shared-workspace concurrency from issue override, project policy, then auto", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
+import { executionWorkspaceModeForReuse } from "../services/execution-workspace-policy.ts";
 import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
@@ -1840,6 +1841,29 @@ describe("effective run execution workspace config freshness", () => {
       requestedShouldReuseExisting: true,
       existingExecutionWorkspaceAvailable: true,
     });
+  });
+
+  it("reuses the private tree across an isolated_workspace -> operator_branch flip, relabelled", () => {
+    // Both private modes realize through the same strategy, so rebuilding the tree on a flip
+    // would cost a worktree for nothing. Reuse stands; the stale label is what gets fixed, and
+    // it is fixed on the reuse path because the create arm is the only other writer of `mode`.
+    expect(resolveExecutionWorkspaceReuseRequestForIssue({
+      issueExecutionWorkspaceId: "workspace-private",
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspaceStatus: "active",
+      resolvedExecutionWorkspaceMode: "operator_branch",
+      existingExecutionWorkspaceMode: "isolated_workspace",
+    })).toEqual({
+      requestedExecutionWorkspaceId: "workspace-private",
+      requestedShouldReuseExisting: true,
+      existingExecutionWorkspaceAvailable: true,
+    });
+    expect(
+      executionWorkspaceModeForReuse({
+        resolvedMode: "operator_branch",
+        existingWorkspaceMode: "isolated_workspace",
+      }),
+    ).toBe("operator_branch");
   });
 
   it("keeps reusing a shared workspace when the resolved mode is still shared", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
-import { executionWorkspaceModeForReuse } from "../services/execution-workspace-policy.ts";
 import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
@@ -1843,10 +1842,13 @@ describe("effective run execution workspace config freshness", () => {
     });
   });
 
-  it("reuses the private tree across an isolated_workspace -> operator_branch flip, relabelled", () => {
-    // Both private modes realize through the same strategy, so rebuilding the tree on a flip
-    // would cost a worktree for nothing. Reuse stands; the stale label is what gets fixed, and
-    // it is fixed on the reuse path because the create arm is the only other writer of `mode`.
+  it("refuses reuse across an isolated_workspace -> operator_branch flip", () => {
+    // `mode` is replacement-class, so config freshness already classifies this flip as a
+    // `replace`. resolveExecutionWorkspaceReuseProvisioningPolicy takes
+    // shouldRestoreExistingWorkspace straight from the reuse request and never consults that
+    // action, so if reuse said "restore" the run would keep the tree realized under the old
+    // mode while replacementClassDrift withheld the fresh fingerprint — re-drifting forever.
+    // Refusing keeps the two decisions in agreement.
     expect(resolveExecutionWorkspaceReuseRequestForIssue({
       issueExecutionWorkspaceId: "workspace-private",
       issueExecutionWorkspacePreference: "reuse_existing",
@@ -1855,15 +1857,40 @@ describe("effective run execution workspace config freshness", () => {
       existingExecutionWorkspaceMode: "isolated_workspace",
     })).toEqual({
       requestedExecutionWorkspaceId: "workspace-private",
-      requestedShouldReuseExisting: true,
-      existingExecutionWorkspaceAvailable: true,
+      requestedShouldReuseExisting: false,
+      existingExecutionWorkspaceAvailable: false,
     });
-    expect(
-      executionWorkspaceModeForReuse({
-        resolvedMode: "operator_branch",
-        existingWorkspaceMode: "isolated_workspace",
-      }),
-    ).toBe("operator_branch");
+  });
+
+  it("keeps the reuse decision agreeing with a replacement-class freshness decision", () => {
+    // The invariant the flip above protects: whenever reuse is granted, provisioning restores
+    // unconditionally, so a granted reuse must never coexist with a `replace` freshness action
+    // on the mode category.
+    const reuseRequest = resolveExecutionWorkspaceReuseRequestForIssue({
+      issueExecutionWorkspaceId: "workspace-private",
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspaceStatus: "active",
+      resolvedExecutionWorkspaceMode: "isolated_workspace",
+      existingExecutionWorkspaceMode: "operator_branch",
+    });
+    const policy = resolveExecutionWorkspaceReuseProvisioningPolicy({
+      requestedShouldReuseExisting: reuseRequest.requestedShouldReuseExisting,
+      workspaceConfigFreshness: {
+        action: "replace",
+        shouldReuseExisting: false,
+        shouldRefreshConfigSnapshot: false,
+        reasons: ["execution workspace configuration changed: mode"],
+        changedCategories: ["mode"],
+        storedFingerprint: "old",
+        inferredFingerprint: null,
+        nextFingerprint: "new",
+        storedFingerprintPresent: true,
+      },
+    });
+    expect(policy.shouldRestoreExistingWorkspace).toBe(false);
+    // With reuse refused there is no replacement-class drift to suppress persistence, so the
+    // create path records metadata that matches the mode it realized.
+    expect(policy.shouldPersistLatestWorkspaceConfigMetadata).toBe(true);
   });
 
   it("keeps reusing a shared workspace when the resolved mode is still shared", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1783,6 +1783,79 @@ describe("effective run execution workspace config freshness", () => {
     });
   });
 
+  it("refuses to reuse a shared workspace once the resolved mode is isolated_workspace", async () => {
+    // The regression this covers: `resolveExecutionWorkspaceMode` resolves
+    // `isolated_workspace` for an issue whose inherited binding points at a shared tree,
+    // the reuse branch restores that tree anyway (only the create path ever records a
+    // mode), and the resolved mode is discarded on every run. Refusing reuse routes the
+    // run through the create path, which realizes and persists the isolated workspace —
+    // self-healing the binding with no data migration.
+    const reuseRequest = resolveExecutionWorkspaceReuseRequestForIssue({
+      issueExecutionWorkspaceId: "workspace-shared",
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspaceStatus: "active",
+      resolvedExecutionWorkspaceMode: "isolated_workspace",
+      existingExecutionWorkspaceMode: "shared_workspace",
+    });
+
+    expect(reuseRequest).toEqual({
+      requestedExecutionWorkspaceId: "workspace-shared",
+      requestedShouldReuseExisting: false,
+      existingExecutionWorkspaceAvailable: false,
+    });
+
+    const metadata = buildWorkspaceConfigMetadata();
+    const decision = resolveExecutionWorkspaceConfigFreshness({
+      hasExistingWorkspace: reuseRequest.existingExecutionWorkspaceAvailable,
+      existingWorkspaceMetadata: null,
+      nextMetadata: metadata,
+    });
+    const realizeWorkspace = vi.fn(async () => ({ id: "isolated-workspace", warnings: [] }));
+    const restoreExistingWorkspace = vi.fn(async () => ({ id: "workspace-shared", warnings: [] }));
+
+    const result = await provisionExecutionWorkspaceForFreshnessDecision({
+      requestedShouldReuseExisting: reuseRequest.requestedShouldReuseExisting,
+      existingExecutionWorkspaceId: reuseRequest.requestedExecutionWorkspaceId,
+      issueRef: { id: "issue-1", identifier: "PAP-42" },
+      runId: "run-1",
+      workspaceConfigFreshness: decision,
+      restoreExistingWorkspace,
+      realizeWorkspace,
+    });
+
+    expect(result.executionWorkspace).toEqual({ id: "isolated-workspace", warnings: [] });
+    expect(result.reusedExecutionWorkspace).toBeNull();
+    expect(restoreExistingWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("keeps reusing a workspace that already provides the resolved isolated tree", () => {
+    expect(resolveExecutionWorkspaceReuseRequestForIssue({
+      issueExecutionWorkspaceId: "workspace-isolated",
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspaceStatus: "active",
+      resolvedExecutionWorkspaceMode: "isolated_workspace",
+      existingExecutionWorkspaceMode: "isolated_workspace",
+    })).toEqual({
+      requestedExecutionWorkspaceId: "workspace-isolated",
+      requestedShouldReuseExisting: true,
+      existingExecutionWorkspaceAvailable: true,
+    });
+  });
+
+  it("keeps reusing a shared workspace when the resolved mode is still shared", () => {
+    expect(resolveExecutionWorkspaceReuseRequestForIssue({
+      issueExecutionWorkspaceId: "workspace-shared",
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspaceStatus: "active",
+      resolvedExecutionWorkspaceMode: "shared_workspace",
+      existingExecutionWorkspaceMode: "shared_workspace",
+    })).toEqual({
+      requestedExecutionWorkspaceId: "workspace-shared",
+      requestedShouldReuseExisting: true,
+      existingExecutionWorkspaceAvailable: true,
+    });
+  });
+
   it("fails loudly when explicit reuse restore returns no workspace", async () => {
     const metadata = buildWorkspaceConfigMetadata();
     const decision = resolveExecutionWorkspaceConfigFreshness({

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -351,56 +351,30 @@ export function issueExecutionWorkspaceModeForPersistence(input: {
 }
 
 /**
- * Whether a persisted execution workspace gives its issue a tree no other issue runs in.
- * `shared_workspace` and `adapter_managed` (the agent's own home cwd) are shared by
- * construction, and an unrecorded mode cannot be proven private — only a worktree, an
- * operator branch, or a per-run cloud sandbox is genuinely the issue's own.
+ * True when the freshly resolved mode promises the issue a tree of its own and the workspace
+ * it is bound to was not realized as that same mode. Reusing such a binding would run the
+ * issue in a tree realized under a different mode while every downstream record claims the
+ * resolved one, so the reuse path refuses and the create path realizes what was resolved.
+ *
+ * The comparison is exact rather than "is it private enough", because `mode` is a member of
+ * `WORKSPACE_REPLACEMENT_CONFIG_CATEGORIES` in heartbeat.ts: the config-freshness machinery
+ * already classifies *any* mode change as replacement-class. Accepting reuse across two
+ * private modes would contradict that — the freshness decision says `replace` while
+ * provisioning restores, and `shouldPersistLatestWorkspaceConfigMetadata` then withholds the
+ * fresh fingerprint, so the workspace re-drifts on every subsequent run forever. Refusing
+ * here keeps the two decisions saying the same thing, and the create path persists metadata
+ * that matches the mode it actually realized.
+ *
+ * Modes that do not promise a private tree keep the historical reuse behaviour.
  */
-function persistedExecutionWorkspaceIsolatesTree(mode: string | null | undefined): boolean {
-  return mode === "isolated_workspace" || mode === "operator_branch" || mode === "cloud_sandbox";
-}
-
-/**
- * True when the freshly resolved mode promises the issue a tree of its own but the workspace
- * it is bound to is a shared one. Reusing that binding would run the issue in the shared tree
- * while every downstream record claims it is isolated, so the reuse path refuses and the
- * create path realizes the mode that was actually resolved.
- */
-export function isExecutionWorkspaceIsolationDrift(input: {
+export function isExecutionWorkspaceModeDrift(input: {
   resolvedMode: ParsedExecutionWorkspaceMode;
   existingWorkspaceMode: string | null | undefined;
 }): boolean {
   if (input.resolvedMode !== "isolated_workspace" && input.resolvedMode !== "operator_branch") {
     return false;
   }
-  return !persistedExecutionWorkspaceIsolatesTree(input.existingWorkspaceMode);
-}
-
-/**
- * The mode to record on an execution workspace the reuse path restores, or `null` to leave
- * the recorded mode alone.
- *
- * The reuse path never wrote a mode at all, so a restored workspace kept the label of
- * whichever mode first created it. `isExecutionWorkspaceIsolationDrift` already refuses
- * reuse when the resolved mode wants a private tree and the bound workspace is a shared
- * one, so the relabel left to do is between the two private modes: `isolated_workspace`
- * and `operator_branch` resolve the same strategy from the same config
- * (`resolveEffectiveWorkspaceStrategyType` never branches on which of the two it is), so
- * the restored tree honors either and only the label is stale.
- *
- * A resolved mode that does not promise a private tree keeps the recorded mode: rewriting
- * a physically private worktree to `shared_workspace` would be the same DB lie this fix
- * exists to prevent, just pointing the other way.
- */
-export function executionWorkspaceModeForReuse(input: {
-  resolvedMode: ParsedExecutionWorkspaceMode;
-  existingWorkspaceMode: string | null | undefined;
-}): "isolated_workspace" | "operator_branch" | null {
-  if (input.resolvedMode !== "isolated_workspace" && input.resolvedMode !== "operator_branch") {
-    return null;
-  }
-  if (!persistedExecutionWorkspaceIsolatesTree(input.existingWorkspaceMode)) return null;
-  return input.existingWorkspaceMode === input.resolvedMode ? null : input.resolvedMode;
+  return input.existingWorkspaceMode !== input.resolvedMode;
 }
 
 export function resolveExecutionWorkspaceMode(input: {

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -327,13 +327,69 @@ export function issueExecutionWorkspaceModeForPersistedWorkspace(
   return "shared_workspace";
 }
 
+/**
+ * The mode to record on an issue after a run realizes a workspace for it.
+ *
+ * Recording the realized mode unconditionally is what pinned inherited issues to a shared
+ * tree: an issue that never chose a mode got an explicit `shared_workspace` written into its
+ * settings on its first run, and an explicit issue mode outranks the project default from
+ * then on — so changing the project default could never reach it again. Only issues that
+ * actually chose a mode keep an explicit one; inheriting issues stay on `inherit` so the
+ * project default keeps applying. Workspace continuity is carried by the issue's
+ * `executionWorkspaceId` + `reuse_existing` preference, not by this field.
+ */
+export function issueExecutionWorkspaceModeForPersistence(input: {
+  priorIssueMode: IssueExecutionWorkspaceSettings["mode"] | null | undefined;
+  persistedWorkspaceMode: string | null | undefined;
+}): IssueExecutionWorkspaceSettings["mode"] {
+  const priorIssueMode = input.priorIssueMode;
+  const issueChoseItsOwnMode =
+    Boolean(priorIssueMode) && priorIssueMode !== "inherit" && priorIssueMode !== "reuse_existing";
+  return issueChoseItsOwnMode
+    ? issueExecutionWorkspaceModeForPersistedWorkspace(input.persistedWorkspaceMode)
+    : "inherit";
+}
+
+/**
+ * Whether a persisted execution workspace gives its issue a tree no other issue runs in.
+ * `shared_workspace` and `adapter_managed` (the agent's own home cwd) are shared by
+ * construction, and an unrecorded mode cannot be proven private — only a worktree, an
+ * operator branch, or a per-run cloud sandbox is genuinely the issue's own.
+ */
+export function persistedExecutionWorkspaceIsolatesTree(mode: string | null | undefined): boolean {
+  return mode === "isolated_workspace" || mode === "operator_branch" || mode === "cloud_sandbox";
+}
+
+/**
+ * True when the freshly resolved mode promises the issue a tree of its own but the workspace
+ * it is bound to is a shared one. Reusing that binding would run the issue in the shared tree
+ * while every downstream record claims it is isolated, so the reuse path refuses and the
+ * create path realizes the mode that was actually resolved.
+ */
+export function isExecutionWorkspaceIsolationDrift(input: {
+  resolvedMode: ParsedExecutionWorkspaceMode;
+  existingWorkspaceMode: string | null | undefined;
+}): boolean {
+  if (input.resolvedMode !== "isolated_workspace" && input.resolvedMode !== "operator_branch") {
+    return false;
+  }
+  return !persistedExecutionWorkspaceIsolatesTree(input.existingWorkspaceMode);
+}
+
 export function resolveExecutionWorkspaceMode(input: {
   projectPolicy: ProjectExecutionWorkspacePolicy | null;
   issueSettings: IssueExecutionWorkspaceSettings | null;
   legacyUseProjectWorkspace: boolean | null;
 }): ParsedExecutionWorkspaceMode {
   const issueMode = input.issueSettings?.mode;
-  if (issueMode && issueMode !== "inherit" && issueMode !== "reuse_existing") {
+  // `allowIssueOverride: false` is the project declaring its default mode mandatory. It was
+  // parsed, persisted, and round-tripped by the settings UI while no resolver read it, so a
+  // per-issue mode outranked the project default even when the project had forbidden exactly
+  // that. Absent (or `true`) keeps the historical issue-wins precedence.
+  const issueOverrideAllowed = input.projectPolicy?.enabled
+    ? input.projectPolicy.allowIssueOverride !== false
+    : true;
+  if (issueOverrideAllowed && issueMode && issueMode !== "inherit" && issueMode !== "reuse_existing") {
     return issueMode;
   }
   if (input.projectPolicy?.enabled) {

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -376,6 +376,33 @@ export function isExecutionWorkspaceIsolationDrift(input: {
   return !persistedExecutionWorkspaceIsolatesTree(input.existingWorkspaceMode);
 }
 
+/**
+ * The mode to record on an execution workspace the reuse path restores, or `null` to leave
+ * the recorded mode alone.
+ *
+ * The reuse path never wrote a mode at all, so a restored workspace kept the label of
+ * whichever mode first created it. `isExecutionWorkspaceIsolationDrift` already refuses
+ * reuse when the resolved mode wants a private tree and the bound workspace is a shared
+ * one, so the relabel left to do is between the two private modes: `isolated_workspace`
+ * and `operator_branch` resolve the same strategy from the same config
+ * (`resolveEffectiveWorkspaceStrategyType` never branches on which of the two it is), so
+ * the restored tree honors either and only the label is stale.
+ *
+ * A resolved mode that does not promise a private tree keeps the recorded mode: rewriting
+ * a physically private worktree to `shared_workspace` would be the same DB lie this fix
+ * exists to prevent, just pointing the other way.
+ */
+export function executionWorkspaceModeForReuse(input: {
+  resolvedMode: ParsedExecutionWorkspaceMode;
+  existingWorkspaceMode: string | null | undefined;
+}): "isolated_workspace" | "operator_branch" | null {
+  if (input.resolvedMode !== "isolated_workspace" && input.resolvedMode !== "operator_branch") {
+    return null;
+  }
+  if (!persistedExecutionWorkspaceIsolatesTree(input.existingWorkspaceMode)) return null;
+  return input.existingWorkspaceMode === input.resolvedMode ? null : input.resolvedMode;
+}
+
 export function resolveExecutionWorkspaceMode(input: {
   projectPolicy: ProjectExecutionWorkspacePolicy | null;
   issueSettings: IssueExecutionWorkspaceSettings | null;

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -356,7 +356,7 @@ export function issueExecutionWorkspaceModeForPersistence(input: {
  * construction, and an unrecorded mode cannot be proven private — only a worktree, an
  * operator branch, or a per-run cloud sandbox is genuinely the issue's own.
  */
-export function persistedExecutionWorkspaceIsolatesTree(mode: string | null | undefined): boolean {
+function persistedExecutionWorkspaceIsolatesTree(mode: string | null | undefined): boolean {
   return mode === "isolated_workspace" || mode === "operator_branch" || mode === "cloud_sandbox";
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -196,6 +196,8 @@ import {
   buildExecutionWorkspaceAdapterConfig,
   gateProjectExecutionWorkspacePolicy,
   issueExecutionWorkspaceModeForPersistedWorkspace,
+  issueExecutionWorkspaceModeForPersistence,
+  isExecutionWorkspaceIsolationDrift,
   isUnrunnableWorktreeCombo,
   parseIssueExecutionWorkspaceSettings,
   parseProjectExecutionWorkspacePolicy,
@@ -207,6 +209,7 @@ import {
   WORKSPACE_WORKTREE_REQUIRES_PROJECT_CODE,
   WORKSPACE_WORKTREE_REQUIRES_PROJECT_MESSAGE,
   WORKSPACE_WORKTREE_REQUIRES_PROJECT_REMEDIATION,
+  type ParsedExecutionWorkspaceMode,
 } from "./execution-workspace-policy.js";
 import {
   instanceSettingsService,
@@ -4463,6 +4466,8 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
   existingExecutionWorkspaceStatus?: string | null;
   requestedExistingBranch?: string | null;
   existingExecutionWorkspaceBranchName?: string | null;
+  resolvedExecutionWorkspaceMode?: ParsedExecutionWorkspaceMode | null;
+  existingExecutionWorkspaceMode?: string | null;
 }): ExecutionWorkspaceReuseRequestForIssue {
   const requestedExecutionWorkspaceId = readNonEmptyString(input.issueExecutionWorkspaceId);
   // An explicitly pinned existing branch outranks an inherited reuse_existing
@@ -4473,10 +4478,22 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
   const existingWorkspaceMatchesRequestedBranch =
     requestedExistingBranch === null ||
     readNonEmptyString(input.existingExecutionWorkspaceBranchName) === requestedExistingBranch;
+  // A resolved mode that demands the issue's own tree outranks the reuse binding for the
+  // same reason: only the create path ever records a mode, so restoring a shared workspace
+  // would keep the run in the shared tree and silently discard the resolved mode on every
+  // run. Refusing here lets the create path realize it, which self-heals the binding without
+  // a data migration. Callers that do not resolve a mode keep the historical behaviour.
+  const isolationDrift =
+    input.resolvedExecutionWorkspaceMode != null &&
+    isExecutionWorkspaceIsolationDrift({
+      resolvedMode: input.resolvedExecutionWorkspaceMode,
+      existingWorkspaceMode: input.existingExecutionWorkspaceMode,
+    });
   const requestedShouldReuseExisting =
     input.issueExecutionWorkspacePreference === "reuse_existing" &&
     requestedExecutionWorkspaceId !== null &&
-    existingWorkspaceMatchesRequestedBranch;
+    existingWorkspaceMatchesRequestedBranch &&
+    !isolationDrift;
 
   return {
     requestedExecutionWorkspaceId,
@@ -14509,6 +14526,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingExecutionWorkspaceStatus: existingExecutionWorkspace?.status ?? null,
       requestedExistingBranch: issueExecutionWorkspaceSettings?.workspaceStrategy?.existingBranch ?? null,
       existingExecutionWorkspaceBranchName: existingExecutionWorkspace?.branchName ?? null,
+      resolvedExecutionWorkspaceMode: requestedExecutionWorkspaceMode,
+      existingExecutionWorkspaceMode: existingExecutionWorkspace?.mode ?? null,
     });
     const requestedShouldReuseExisting = workspaceReuseRequest.requestedShouldReuseExisting;
     const reusableExistingExecutionWorkspace = workspaceReuseRequest.existingExecutionWorkspaceAvailable
@@ -15271,7 +15290,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     }
     if (issueId && persistedExecutionWorkspace) {
-      const nextIssueWorkspaceMode = issueExecutionWorkspaceModeForPersistedWorkspace(persistedExecutionWorkspace.mode);
+      const nextIssueWorkspaceMode = issueExecutionWorkspaceModeForPersistence({
+        priorIssueMode: issueExecutionWorkspaceSettings?.mode ?? null,
+        persistedWorkspaceMode: persistedExecutionWorkspace.mode,
+      });
       const shouldSwitchIssueToExistingWorkspace =
         issueRef?.executionWorkspacePreference === "reuse_existing" ||
         requestedExecutionWorkspaceMode === "isolated_workspace" ||
@@ -18370,20 +18392,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             legacyUseProjectWorkspace: null,
           });
           const resolvedStrategy = resolveEffectiveWorkspaceStrategyType(resolvedMode, workspaceManagedConfig);
-          const existingExecutionWorkspaceStatus = issue.executionWorkspaceId
+          const existingExecutionWorkspaceRow = issue.executionWorkspaceId
             ? await tx
-              .select({ status: executionWorkspaces.status })
+              .select({ status: executionWorkspaces.status, mode: executionWorkspaces.mode })
               .from(executionWorkspaces)
               .where(and(
                 eq(executionWorkspaces.id, issue.executionWorkspaceId),
                 eq(executionWorkspaces.companyId, issue.companyId),
               ))
-              .then((rows) => rows[0]?.status ?? null)
+              .then((rows) => rows[0] ?? null)
             : null;
           const reuseRequest = resolveExecutionWorkspaceReuseRequestForIssue({
             issueExecutionWorkspaceId: issue.executionWorkspaceId,
             issueExecutionWorkspacePreference: issue.executionWorkspacePreference,
-            existingExecutionWorkspaceStatus,
+            existingExecutionWorkspaceStatus: existingExecutionWorkspaceRow?.status ?? null,
+            resolvedExecutionWorkspaceMode: resolvedMode,
+            existingExecutionWorkspaceMode: existingExecutionWorkspaceRow?.mode ?? null,
           });
           const hasResolvablePriorSessionWorkspace = await resolveHasResolvablePriorSessionWorkspace();
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -194,6 +194,7 @@ import {
 } from "./run-scratch.js";
 import {
   buildExecutionWorkspaceAdapterConfig,
+  executionWorkspaceModeForReuse,
   gateProjectExecutionWorkspacePolicy,
   issueExecutionWorkspaceModeForPersistedWorkspace,
   issueExecutionWorkspaceModeForPersistence,
@@ -15179,9 +15180,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const pendingForwardBranchReconcile = executionWorkspace.pendingForwardBranchReconcile ?? null;
     const branchNameForInitialPersistence =
       pendingForwardBranchReconcile?.recordedBranchName ?? executionWorkspace.branchName;
+    // Only the create arm ever recorded a mode, so a restored workspace kept its original
+    // label even after the resolved mode moved on. Refusing reuse covers the shared -> private
+    // case; this covers the private -> private one, where the tree honors either mode and the
+    // label is the only thing left stale.
+    const reusedExecutionWorkspaceMode = reusableExistingExecutionWorkspace
+      ? executionWorkspaceModeForReuse({
+          resolvedMode: requestedExecutionWorkspaceMode,
+          existingWorkspaceMode: reusableExistingExecutionWorkspace.mode,
+        })
+      : null;
     try {
       persistedExecutionWorkspace = resolvedWorkspaceReusePolicy.shouldRestoreExistingWorkspace && reusableExistingExecutionWorkspace
         ? await executionWorkspacesSvc.update(reusableExistingExecutionWorkspace.id, {
+            ...(reusedExecutionWorkspaceMode ? { mode: reusedExecutionWorkspaceMode } : {}),
             cwd: executionWorkspace.cwd,
             repoUrl: executionWorkspace.repoUrl,
             baseRef: executionWorkspace.repoRef,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -194,11 +194,10 @@ import {
 } from "./run-scratch.js";
 import {
   buildExecutionWorkspaceAdapterConfig,
-  executionWorkspaceModeForReuse,
   gateProjectExecutionWorkspacePolicy,
   issueExecutionWorkspaceModeForPersistedWorkspace,
   issueExecutionWorkspaceModeForPersistence,
-  isExecutionWorkspaceIsolationDrift,
+  isExecutionWorkspaceModeDrift,
   isUnrunnableWorktreeCombo,
   parseIssueExecutionWorkspaceSettings,
   parseProjectExecutionWorkspacePolicy,
@@ -4479,14 +4478,15 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
   const existingWorkspaceMatchesRequestedBranch =
     requestedExistingBranch === null ||
     readNonEmptyString(input.existingExecutionWorkspaceBranchName) === requestedExistingBranch;
-  // A resolved mode that demands the issue's own tree outranks the reuse binding for the
-  // same reason: only the create path ever records a mode, so restoring a shared workspace
-  // would keep the run in the shared tree and silently discard the resolved mode on every
-  // run. Refusing here lets the create path realize it, which self-heals the binding without
-  // a data migration. Callers that do not resolve a mode keep the historical behaviour.
-  const isolationDrift =
+  // A resolved mode that demands the issue's own tree outranks the reuse binding: only the
+  // create path ever records a mode, so restoring a workspace realized under a different one
+  // would keep the run in that tree and silently discard the resolved mode on every run.
+  // Refusing here lets the create path realize it, which self-heals the binding without a data
+  // migration, and keeps this decision agreeing with the config-freshness one, which already
+  // treats `mode` as replacement-class. Callers that resolve no mode keep historical behaviour.
+  const modeDrift =
     input.resolvedExecutionWorkspaceMode != null &&
-    isExecutionWorkspaceIsolationDrift({
+    isExecutionWorkspaceModeDrift({
       resolvedMode: input.resolvedExecutionWorkspaceMode,
       existingWorkspaceMode: input.existingExecutionWorkspaceMode,
     });
@@ -4494,7 +4494,7 @@ export function resolveExecutionWorkspaceReuseRequestForIssue(input: {
     input.issueExecutionWorkspacePreference === "reuse_existing" &&
     requestedExecutionWorkspaceId !== null &&
     existingWorkspaceMatchesRequestedBranch &&
-    !isolationDrift;
+    !modeDrift;
 
   return {
     requestedExecutionWorkspaceId,
@@ -15180,20 +15180,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const pendingForwardBranchReconcile = executionWorkspace.pendingForwardBranchReconcile ?? null;
     const branchNameForInitialPersistence =
       pendingForwardBranchReconcile?.recordedBranchName ?? executionWorkspace.branchName;
-    // Only the create arm ever recorded a mode, so a restored workspace kept its original
-    // label even after the resolved mode moved on. Refusing reuse covers the shared -> private
-    // case; this covers the private -> private one, where the tree honors either mode and the
-    // label is the only thing left stale.
-    const reusedExecutionWorkspaceMode = reusableExistingExecutionWorkspace
-      ? executionWorkspaceModeForReuse({
-          resolvedMode: requestedExecutionWorkspaceMode,
-          existingWorkspaceMode: reusableExistingExecutionWorkspace.mode,
-        })
-      : null;
     try {
       persistedExecutionWorkspace = resolvedWorkspaceReusePolicy.shouldRestoreExistingWorkspace && reusableExistingExecutionWorkspace
         ? await executionWorkspacesSvc.update(reusableExistingExecutionWorkspace.id, {
-            ...(reusedExecutionWorkspaceMode ? { mode: reusedExecutionWorkspaceMode } : {}),
             cwd: executionWorkspace.cwd,
             repoUrl: executionWorkspace.repoUrl,
             baseRef: executionWorkspace.repoRef,


### PR DESCRIPTION
## Thinking Path

> - Paperclip assigns a workspace to each agent run
> - A project policy can select a shared workspace or a private workspace
> - The server resolves that policy before each run
> - A reused workspace could ignore the resolved mode
> - An inherited issue could also receive a mode that looked like a user override
> - The existing `allowIssueOverride` field did not change server behavior
> - This pull request makes workspace reuse follow the resolved mode
> - The benefit is that a project can change its default mode without a data migration

## Linked Issues or Issue Description

Refs: #11850

No public issue covers this exact defect.

**What happened?**

An issue can have `executionWorkspacePreference: "reuse_existing"` and a bound workspace. The server resolved the current mode, but the reuse path restored the bound workspace without checking its persisted mode. A shared workspace could therefore remain in use after the project selected `isolated_workspace`.

The server also wrote the realized mode back to the issue. This changed an inherited mode into an explicit issue setting. In addition, the server parsed `allowIssueOverride`, but the mode resolver did not use it.

**Expected behavior**

A reused workspace must provide the mode that the server resolved. An inherited issue must continue to inherit the project mode. A project with `allowIssueOverride: false` must make its default mode mandatory.

**Steps to reproduce**

1. Run an issue in a project that uses `shared_workspace`.
2. Bind the issue to that workspace with `reuse_existing`.
3. Change the project default to `isolated_workspace`.
4. Run the issue again.
5. Observe that the old code restores the shared workspace.

**Paperclip version or commit**

The defect was present at commit `417336f8b`.

**Deployment mode**

Local, single instance.

**Agent adapter(s) involved**

This is core server behavior. It is not specific to one adapter.

**Database mode**

Embedded PostgreSQL.

**Relevant logs or output**

The reuse path updated workspace metadata but did not check whether the bound workspace mode matched the resolved private mode.

**Additional context**

Relabeling the existing row is unsafe. The directory can still be a shared tree. The correct fix is to refuse reuse and let the create path make the private workspace.

## What Changed

- `resolveExecutionWorkspaceReuseRequestForIssue` now receives the resolved mode and the bound workspace mode.
- `isExecutionWorkspaceModeDrift` refuses reuse when a resolved private mode does not match the bound workspace mode.
- The create path now replaces the incompatible binding on the next run. No data migration is required.
- Inherited issue settings now stay on `inherit` after workspace persistence.
- `resolveExecutionWorkspaceMode` now applies `allowIssueOverride: false`.

## Verification

- `pnpm exec vitest run server/src/__tests__/execution-workspace-policy.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts` passes: 175 tests.
- `pnpm --filter @paperclipai/server typecheck` passes.
- The focused tests also pass after rebasing the change onto the latest `paperclipai/master`.
- GitHub CI passes on the pull request.
- Greptile reports 5/5 with no blocking finding.

## Risks

- Risk is low and limited to workspace selection.
- A mismatched private-mode binding now creates a new workspace instead of restoring the old one.
- The old shared workspace stays available for other issues.
- A missing workspace mode is treated as a mismatch when the resolved mode is private.
- There is no schema change and no data migration.

## Model Used

- Anthropic Claude Opus 5 (`claude-opus-5`), extended reasoning, tool use, and code execution produced the implementation.
- OpenAI Codex with GPT-5 and GPT-5.4, reasoning, tool use, and code execution verified the final change. The client did not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing public issue or described the issue with the bug template fields
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal issue id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation or confirmed that no documentation change is required
- [x] I have considered and documented the risks
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2 findings, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
