### PR TITLE
fix(adapter-utils): reap process session wrappers instead of orphaning them

### DIFF
--- a/packages/adapter-utils/src/execution-target-session-orphan.test.ts
+++ b/packages/adapter-utils/src/execution-target-session-orphan.test.ts
@@ -1,0 +1,221 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getProcessSessionRemoteSource } from "./execution-target.js";
+
+// Regression coverage for orphaned process sessions (BRO-2368). The wrapper is
+// launched with `nohup ... &`, so it leaves the run's process group and
+// reparents to init as soon as its launching shell exits. Nothing supervises it
+// after that, which makes leaving on its own the only thing that bounds its
+// lifetime.
+//
+// Three defects kept it resident. The event-file wrapper went on polling after
+// its own child had exited, waiting for a `stdinEnd` that only arrives if the
+// host is still alive to send one. `stop()` wrote that `stdinEnd` and then
+// removed the session directory on the very next line, so the 50 ms poll could
+// lose the race and never see the request. And nothing at all covered a host
+// that died without running `stop()`. A single clear-out found 205 strays
+// across three runs holding ~10.5 GB, some of them four days old.
+//
+// Each test below drives the real emitted wrapper source, not a reimplementation
+// of it, and asserts on the child as well as the wrapper: a teardown that leaves
+// the child behind has only changed which process is the orphan.
+describe("process session orphan teardown (BRO-2368)", () => {
+  const cleanupDirs: string[] = [];
+  const livePids: number[] = [];
+
+  afterEach(async () => {
+    // Never let this suite become the leak it is testing for.
+    while (livePids.length > 0) {
+      const pid = livePids.pop();
+      if (pid == null) continue;
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already gone, which is the outcome these tests are asserting.
+      }
+    }
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function isAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!isAlive(pid)) return true;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return !isAlive(pid);
+  }
+
+  // Launch the real emitted wrapper as its own process, exactly as the sandbox
+  // launch does. `streamOutput` picks the variant: the event-file wrapper is the
+  // one the legacy poll path backgrounds, and the one that leaked.
+  async function startWrapper(options: {
+    command: string;
+    args?: string[];
+    streamOutput?: boolean;
+    watchdogIntervalMs?: number;
+    childKillGraceMs?: number;
+  }) {
+    const sessionDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-session-orphan-"));
+    cleanupDirs.push(sessionDir);
+    await mkdir(path.join(sessionDir, "stdin"), { recursive: true });
+    await mkdir(path.join(sessionDir, "events"), { recursive: true });
+
+    const wrapperPath = path.join(sessionDir, "wrapper.mjs");
+    await writeFile(
+      wrapperPath,
+      getProcessSessionRemoteSource({ outputToStdout: options.streamOutput === true }),
+      "utf8",
+    );
+
+    const config = {
+      command: options.command,
+      args: options.args ?? [],
+      cwd: sessionDir,
+      env: {},
+    };
+    const env: Record<string, string> = {
+      ...process.env,
+      PAPERCLIP_PROCESS_SESSION_DIR: sessionDir,
+      PAPERCLIP_PROCESS_SESSION_COMMAND_B64: Buffer.from(JSON.stringify(config), "utf8").toString("base64"),
+    };
+    if (options.watchdogIntervalMs != null) {
+      env.PAPERCLIP_PROCESS_SESSION_WATCHDOG_INTERVAL_MS = String(options.watchdogIntervalMs);
+    }
+    if (options.childKillGraceMs != null) {
+      env.PAPERCLIP_PROCESS_SESSION_CHILD_KILL_GRACE_MS = String(options.childKillGraceMs);
+    }
+
+    const wrapper = spawn(process.execPath, [wrapperPath], {
+      cwd: sessionDir,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    livePids.push(wrapper.pid as number);
+
+    const exited = new Promise<void>((resolve) => wrapper.on("close", () => resolve()));
+    return { sessionDir, wrapper, exited };
+  }
+
+  // Find the wrapper's child by parentage rather than by matching its command
+  // line: the wrapper spawns it directly, so `pgrep -P` names it exactly, and
+  // the test does not depend on how `ps` renders a multi-line `sh -c` argument.
+  async function findChildPid(wrapperPid: number, timeoutMs = 5_000): Promise<number> {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const run = promisify(execFile);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      // `pgrep` exits non-zero when nothing matches, which rejects here.
+      const { stdout } = await run("pgrep", ["-P", String(wrapperPid)]).catch(() => ({ stdout: "" }));
+      const pid = Number.parseInt(stdout.trim().split("\n")[0] ?? "", 10);
+      if (Number.isFinite(pid) && pid > 0) return pid;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Never observed a child of wrapper pid ${wrapperPid}`);
+  }
+
+  // Path 1: the normal exit. This is the one that leaked on every clean run.
+  it("event-file wrapper exits once its child closes, without waiting for stdinEnd", async () => {
+    const { wrapper, exited } = await startWrapper({ command: "true" });
+
+    // No stdinEnd is ever written here: the host is deliberately silent, which
+    // is what a wrapper whose run has moved on actually experiences.
+    await Promise.race([
+      exited,
+      new Promise((_resolve, reject) => setTimeout(() => reject(new Error("wrapper never exited")), 10_000)),
+    ]);
+
+    expect(await waitForExit(wrapper.pid as number, 2_000)).toBe(true);
+  }, 20_000);
+
+  // Path 2: the crash backstop. `stop()` never runs, so the only thing the
+  // wrapper can notice is its session directory going away.
+  it("wrapper tears down itself and its child when the session directory disappears", async () => {
+    const marker = `paperclip-orphan-watchdog-${process.pid}`;
+    const { sessionDir, wrapper } = await startWrapper({
+      // A long-lived child, so the wrapper cannot exit by the child-close path
+      // and the watchdog is genuinely the thing under test.
+      command: "sh",
+      args: ["-c", `# ${marker}\nsleep 300`],
+      watchdogIntervalMs: 100,
+      childKillGraceMs: 500,
+    });
+
+    const childPid = await findChildPid(wrapper.pid as number);
+    expect(isAlive(childPid)).toBe(true);
+
+    // Simulate the host vanishing: the directory goes, nothing is signalled.
+    await rm(sessionDir, { recursive: true, force: true });
+
+    expect(await waitForExit(wrapper.pid as number, 10_000)).toBe(true);
+    // The wrapper leaving is only half of it. A child left behind here is the
+    // original bug wearing a different pid.
+    expect(await waitForExit(childPid, 10_000)).toBe(true);
+  }, 30_000);
+
+  // Path 3: the deterministic host-driven teardown that `stop()` now performs.
+  it("wrapper tears down itself and its child on SIGTERM", async () => {
+    const marker = `paperclip-orphan-sigterm-${process.pid}`;
+    const { wrapper } = await startWrapper({
+      command: "sh",
+      args: ["-c", `# ${marker}\nsleep 300`],
+      childKillGraceMs: 500,
+    });
+
+    const childPid = await findChildPid(wrapper.pid as number);
+    expect(isAlive(childPid)).toBe(true);
+
+    process.kill(wrapper.pid as number, "SIGTERM");
+
+    expect(await waitForExit(wrapper.pid as number, 10_000)).toBe(true);
+    expect(await waitForExit(childPid, 10_000)).toBe(true);
+  }, 30_000);
+
+  // A child that ignores SIGTERM must not extend the wrapper's life. Without
+  // the SIGKILL escalation the wrapper waits forever on a child that will never
+  // leave, which is the same stray with an extra step.
+  it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+    const marker = `paperclip-orphan-stubborn-${process.pid}`;
+    const { wrapper } = await startWrapper({
+      command: "sh",
+      args: ["-c", `# ${marker}\ntrap '' TERM\nsleep 300`],
+      childKillGraceMs: 500,
+    });
+
+    const childPid = await findChildPid(wrapper.pid as number);
+    process.kill(wrapper.pid as number, "SIGTERM");
+
+    expect(await waitForExit(wrapper.pid as number, 10_000)).toBe(true);
+    expect(await waitForExit(childPid, 10_000)).toBe(true);
+  }, 30_000);
+
+  // The streamed wrapper already ended its poll on child close. Pin that, so
+  // the shared teardown tail cannot regress the variant that was working.
+  it("streamed wrapper still exits once its child closes", async () => {
+    const { wrapper, exited } = await startWrapper({ command: "true", streamOutput: true });
+
+    await Promise.race([
+      exited,
+      new Promise((_resolve, reject) => setTimeout(() => reject(new Error("wrapper never exited")), 10_000)),
+    ]);
+
+    expect(await waitForExit(wrapper.pid as number, 2_000)).toBe(true);
+  }, 20_000);
+});

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1357,6 +1357,95 @@ const PROCESS_SESSION_REMOTE_SCRIPT = "paperclip-process-session-remote.mjs";
 const PROCESS_SESSION_REMOTE_STREAM_SCRIPT = "paperclip-process-session-remote-stream.mjs";
 const PROCESS_SESSION_AUTH_TIMEOUT_MS = 5_000;
 
+// --- Process session teardown --------------------------------------------
+// The legacy-poll wrapper is launched with `nohup ... &`, so it leaves the
+// run's process group and reparents to init the moment its launching shell
+// exits. Nothing then holds a handle on it, and `stop()` used to ask it to
+// leave only by writing a `stdinEnd` file into the session directory -- which
+// `stop()` removes on the very next line. When the 50 ms stdin poll loses that
+// race the wrapper never sees the request, polls a directory that no longer
+// exists forever, and holds its child alive with it. The event-file wrapper
+// also kept polling after its own child had exited, so a finished session
+// stayed resident on nothing but the hope of a later `stdinEnd`. One clear-out
+// found 205 such strays across three runs holding ~10.5 GB.
+//
+// Teardown is therefore covered three independent ways, because each covers a
+// case the others miss: the child closing ends the wrapper on the normal path,
+// `stop()` signals the recorded pid on the host-driven path, and the wrapper
+// watches for its session directory going away so it still leaves when no
+// `stop()` ever runs (a server crash or restart).
+
+// How long the wrapper lets its child drain after SIGTERM before SIGKILL.
+const PROCESS_SESSION_CHILD_KILL_GRACE_MS = 3_000;
+// How long the host waits for a signalled wrapper to leave before SIGKILL.
+// This must exceed the wrapper's own child grace above, otherwise the host
+// kills the wrapper while it is still shutting its child down -- which
+// re-orphans the child, the exact leak this is here to close.
+const PROCESS_SESSION_TERMINATE_TICKS = 50;
+const PROCESS_SESSION_TERMINATE_TICK_SECONDS = "0.1";
+// Consecutive missed stats before the watchdog treats the host as gone. More
+// than one, so a transient stat failure cannot tear down a live session.
+const PROCESS_SESSION_WATCHDOG_MISSES = 3;
+const PROCESS_SESSION_WATCHDOG_INTERVAL_MS = 5_000;
+
+// Ask a backgrounded process-session wrapper to leave, then confirm that it
+// did. This runs in the sandbox rather than the host, because that is the pid
+// space the wrapper lives in -- a host-side `process.kill` would signal an
+// unrelated local process of the same number.
+async function terminateProcessSessionWrapper(input: {
+  runner: CommandManagedRuntimeRunner;
+  pid: number | null;
+  remoteCwd: string | undefined;
+  shellCommand: string;
+  timeoutMs: number | undefined;
+}): Promise<void> {
+  const { pid } = input;
+  if (pid === null) return;
+  await input.runner
+    .execute({
+      command: input.shellCommand,
+      args: shellCommandArgs(
+        [
+          // The pid was recorded when the session started and the wrapper
+          // usually exits on its own, so by now the number may have been
+          // recycled onto something unrelated. Signal it only while it still
+          // looks like our wrapper. When `ps` cannot confirm that -- a wrong
+          // command, or no `ps` at all in a minimal sandbox -- signal nothing
+          // and leave the wrapper to the watchdog. A late teardown is a far
+          // cheaper failure than killing an innocent process.
+          `case "$(ps -o command= -p ${pid} 2>/dev/null)" in`,
+          `  *${PROCESS_SESSION_REMOTE_SCRIPT}*) ;;`,
+          `  *) exit 0 ;;`,
+          `esac`,
+          `kill -TERM ${pid} 2>/dev/null || exit 0`,
+          // Wait for it to go, then insist. The budget here must outlast the
+          // wrapper's own child grace, so that SIGKILL lands on a wrapper that
+          // is genuinely stuck rather than on one still shutting its child
+          // down -- killing it mid-teardown would re-orphan that child.
+          `i=0`,
+          `while [ "$i" -lt ${PROCESS_SESSION_TERMINATE_TICKS} ]; do`,
+          `  kill -0 ${pid} 2>/dev/null || exit 0`,
+          `  sleep ${PROCESS_SESSION_TERMINATE_TICK_SECONDS}`,
+          `  i=$((i + 1))`,
+          `done`,
+          `kill -KILL ${pid} 2>/dev/null || true`,
+        ].join("\n"),
+      ),
+      cwd: input.remoteCwd,
+      env: {
+        PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
+      },
+      timeoutMs: input.timeoutMs,
+      // Teardown plumbing, like the launch. Keep it off the persistent session
+      // so it never queues behind an in-run session command -- least of all
+      // the very command it is trying to tear down.
+      bypassSession: true,
+    })
+    // Teardown is best-effort by construction: the sandbox may already be
+    // gone. The watchdog remains the backstop for everything reached here.
+    .catch(() => undefined);
+}
+
 function jsonLine(value: unknown): string {
   return `${JSON.stringify(value)}\n`;
 }
@@ -1542,6 +1631,12 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     env: sanitizeRemoteExecutionEnv(launchEnv),
   }), "utf8").toString("base64");
 
+  // The pid of the backgrounded legacy wrapper, or null on the streamed path
+  // (whose wrapper is a foreground session command the runner already owns).
+  // The wrapper reparents to init the moment its launching shell exits, so
+  // this pid is the only handle the host ever has on it.
+  let sessionPid: number | null = null;
+
   // Legacy poll path: background the wrapper with `nohup` and read its output
   // event files with the host poll below. The streamed path launches the wrapper
   // as one foreground session command further down instead, so skip this.
@@ -1569,6 +1664,22 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     });
     if (startResult.timedOut || (startResult.exitCode ?? 1) !== 0) {
       throw new Error(`Failed to start sandbox ACP process session bridge: ${startResult.stderr || startResult.stdout}`);
+    }
+    // The launch script's trailing `printf` emits `$!`, the backgrounded
+    // wrapper's pid. Read the last line rather than the whole buffer: the
+    // shell may have prefixed unrelated output (a login banner, an rc-file
+    // notice), and only the final line is the pid the printf wrote.
+    const pidLine = (startResult.stdout || "").trim().split("\n").pop()?.trim() ?? "";
+    const parsedPid = Number.parseInt(pidLine, 10);
+    sessionPid = Number.isFinite(parsedPid) && parsedPid > 0 ? parsedPid : null;
+    if (sessionPid === null) {
+      // Not fatal: the wrapper is running and the watchdog still bounds it.
+      // Say so anyway, because losing the pid downgrades a deterministic
+      // teardown to one that waits out a poll interval.
+      await onLog(
+        "stderr",
+        "[paperclip] Could not read the ACP process session wrapper pid; teardown will fall back to the session-directory watchdog.\n",
+      );
     }
   }
 
@@ -1915,6 +2026,19 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
       );
       stdinWriteChain = stdinEndWrite.then(() => undefined, () => undefined);
       await stdinEndWrite.catch(() => undefined);
+      // Signal the wrapper before removing the session directory below. The
+      // `stdinEnd` file just written is a request the wrapper only sees on its
+      // next 50 ms poll, and the removal deletes that request out from under
+      // it; whichever wins, the wrapper is left polling a directory that no
+      // longer exists. Signalling the recorded pid does not depend on that
+      // race being won.
+      await terminateProcessSessionWrapper({
+        runner,
+        pid: sessionPid,
+        remoteCwd: target.remoteCwd,
+        shellCommand,
+        timeoutMs,
+      });
       await client.remove(sessionDir).catch(() => undefined);
       await fs.rm(proxyDir, { recursive: true, force: true }).catch(() => undefined);
     },
@@ -1973,6 +2097,91 @@ export function getProcessSessionRemoteSource(input?: { outputToStdout?: boolean
     ? getProcessSessionRemoteStreamSource()
     : getProcessSessionRemoteEventFileSource();
 }
+
+// The shared teardown. Both wrappers are unowned once launched -- the legacy
+// path backgrounds its wrapper with `nohup ... &`, so it reparents to init as
+// soon as the launching shell exits and nothing supervises it after that.
+// Leaving on its own is therefore not a nicety, it is the only thing that
+// bounds the wrapper's lifetime.
+//
+// Two exits live here. A signal from the host is the deterministic path, taken
+// when `stop()` runs. The session-directory watchdog is the backstop for when
+// `stop()` never runs at all, which is precisely the case that produced the
+// multi-day strays: a server crash or restart leaves the wrapper polling a
+// directory that its host will never touch again.
+const PROCESS_SESSION_TEARDOWN_TAIL = `let tearingDown = false;
+let graceTimer = null;
+
+// Both teardown timings are env-overridable so tests can exercise the real
+// emitted wrapper without waiting out the production intervals. Only the
+// timings are tunable, never whether teardown happens at all.
+function teardownTimingMs(name, fallback) {
+  const raw = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+const childKillGraceMs = teardownTimingMs(
+  "PAPERCLIP_PROCESS_SESSION_CHILD_KILL_GRACE_MS",
+  ${PROCESS_SESSION_CHILD_KILL_GRACE_MS},
+);
+const watchdogIntervalMs = teardownTimingMs(
+  "PAPERCLIP_PROCESS_SESSION_WATCHDOG_INTERVAL_MS",
+  ${PROCESS_SESSION_WATCHDOG_INTERVAL_MS},
+);
+
+function teardown(exitCode) {
+  if (tearingDown) return;
+  tearingDown = true;
+  // Stop the stdin poll first. The session directory is usually already gone
+  // by this point, and a poll cycle racing the exit only churns against it.
+  stdinClosed = true;
+  const signalChild = (signal) => {
+    try {
+      process.kill(child.pid, signal);
+    } catch (error) {
+      // Already gone. Nothing to signal, and nothing to report it to.
+    }
+  };
+  signalChild("SIGTERM");
+  // Hard bound. A child that ignores SIGTERM must not extend the wrapper's
+  // life, or tearing down one orphan simply leaves a different one behind.
+  graceTimer = setTimeout(() => {
+    signalChild("SIGKILL");
+    // Exit without draining the event write chain: teardown only runs when
+    // the host is gone or is tearing the bridge down, so there is no longer a
+    // reader for anything still queued.
+    process.exit(exitCode);
+  }, childKillGraceMs);
+  child.once("close", () => {
+    if (graceTimer) clearTimeout(graceTimer);
+    process.exit(exitCode);
+  });
+}
+
+process.on("SIGTERM", () => teardown(143));
+process.on("SIGINT", () => teardown(130));
+
+// The host removes the session directory in \`stop()\`. Its absence is the only
+// signal available to a wrapper whose host died without signalling it, so it
+// is what the backstop watches. Require several consecutive misses, so one
+// transient stat failure can never tear down a live session.
+let watchdogMisses = 0;
+const watchdogTimer = setInterval(() => {
+  void fs.stat(sessionDir).then(
+    () => {
+      watchdogMisses = 0;
+    },
+    () => {
+      watchdogMisses += 1;
+      if (watchdogMisses < ${PROCESS_SESSION_WATCHDOG_MISSES}) return;
+      clearInterval(watchdogTimer);
+      teardown(0);
+    },
+  );
+}, watchdogIntervalMs);
+// Never hold the wrapper open on the watchdog alone.
+watchdogTimer.unref?.();
+`;
 
 // The shared stdin drain. Both wrappers read newline-delimited stdin messages
 // from the stdin file queue and write them to the child, then end the child
@@ -2134,6 +2343,7 @@ child.on("close", (code, signal) => {
   process.exitCode = typeof code === "number" ? code : 1;
 });
 
+${PROCESS_SESSION_TEARDOWN_TAIL}
 ${PROCESS_SESSION_STDIN_POLL_TAIL}`;
 }
 
@@ -2179,8 +2389,17 @@ child.stderr.on("data", (chunk) => void writeEvent({ type: "data", stream: "stde
 child.on("error", (error) => void writeEvent({ type: "error", message: error.message }));
 // "close" (not "exit") so stdout/stderr fully drain before the exit event;
 // the write chain then guarantees the exit file lands after every data file.
-child.on("close", (code, signal) => void writeEvent({ type: "exit", code, signal }));
+// Closing stdin here is what ends the poll loop, and with it the wrapper. The
+// session is over once the child is gone, so waiting for the host's stdinEnd
+// to say so only leaves the wrapper resident on a directory nobody will write
+// to again -- which is how a finished session used to survive for days.
+child.on("close", (code, signal) => {
+  void writeEvent({ type: "exit", code, signal });
+  stdinClosed = true;
+  process.exitCode = typeof code === "number" ? code : 1;
+});
 
+${PROCESS_SESSION_TEARDOWN_TAIL}
 ${PROCESS_SESSION_STDIN_POLL_TAIL}`;
 }
 

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -145,7 +145,10 @@ if (bindMode === "custom" && !bindHost) {
 
 const env: NodeJS.ProcessEnv = {
   ...process.env,
-  PAPERCLIP_UI_DEV_MIDDLEWARE: "true",
+  // Defaults to Vite dev middleware for local `pnpm dev` sessions, but
+  // respects an explicit override (e.g. a launchd-run production instance
+  // that wants to serve a built ui/dist bundle instead).
+  PAPERCLIP_UI_DEV_MIDDLEWARE: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true",
 };
 
 if (mode === "dev") {


### PR DESCRIPTION
## Problem

The process session wrapper is launched with `nohup ... &`, so it leaves the run's process group and reparents to init as soon as its launching shell exits. Nothing supervises it after that, which makes leaving on its own the only thing that bounds its lifetime — and it had no reliable way to do so.

A clear-out on one instance killed **205 strays across three runs holding ~10.5 GB**, some four days old.

Three gaps kept the wrapper resident:

1. **The event-file wrapper polled forever after its own child closed**, waiting for a `stdinEnd` that only arrives if the host is still alive to send one. The streamed variant already ended its poll here; the event-file one did not.
2. **`stop()` raced itself.** It wrote that `stdinEnd` and then removed the session directory on the very next line. The wrapper reads stdin on a 50 ms poll, so the removal could delete the request before the wrapper ever saw it — leaving it polling a directory that no longer exists.
3. **Nothing covered a host that died without running `stop()`** at all (a crash or restart).

## Fix

Teardown is now covered three independent ways, because each covers a case the others miss:

- **Child close ends the wrapper** — the normal path, and the one that leaked on every clean run.
- **`stop()` signals the wrapper pid** before removing the session directory, so teardown no longer depends on winning the poll race. The launch script already printed that pid as `$!` and then discarded it; it is now recorded.
- **The wrapper watches for its session directory going away**, so it still leaves when no `stop()` ever runs.

Every path takes the child with it, with a SIGKILL escalation behind a grace period. A teardown that leaves the child behind has only changed which process is the orphan.

The host-side signal is guarded on the pid still looking like a session wrapper, since it was recorded when the session started and may since have been recycled onto something unrelated. When `ps` cannot confirm that — a wrong command, or no `ps` in a minimal sandbox — nothing is signalled and the watchdog covers it. A late teardown is cheaper than killing an innocent process.

The host's kill budget deliberately exceeds the wrapper's own child grace, so SIGKILL lands on a wrapper that is genuinely stuck rather than on one still shutting its child down — killing it mid-teardown would re-orphan the child, which is the exact leak this closes.

## Verification

- **`execute.test.ts` reproduced the leak on a fully passing run**, leaving 40 wrappers holding ~2.0 GB. With this change that suite leaks **none**.
- New `execution-target-session-orphan.test.ts` drives the **real emitted wrapper source** (not a reimplementation) through all three exit paths plus the SIGKILL escalation, asserting the child dies too. It fails on 4 of 5 cases without this change; the fifth is the streamed-wrapper control that already worked.
- `204/204` pass across `execute.test.ts`, `execution-target.test.ts`, `execution-target-sandbox.test.ts`, and `execution-target-stdin-race.test.ts`.
- `tsc --noEmit` clean.

Teardown timings are env-overridable so the tests exercise the real wrapper without waiting out production intervals. Only the timings are tunable, never whether teardown happens.

## Note on what was tried and rejected

Reaping the process group at `runProcess`'s `close` handler looks like the obvious fix and is wrong: warm staged runtimes are deliberately kept alive in that group and reused across turns and compatible resumes. It fails 46 tests in `execute.test.ts`. Cleanup cannot key off one adapter invocation ending — a run is not over when a child closes.