### PR TITLE
fix(recovery): escalate a self-stranded issue that is older than the lookback

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -906,6 +906,24 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(escalations).toHaveLength(1);
   });
 
+  it("previews a self-stranded in_review issue that is older than the lookback window", async () => {
+    // The preview exists so an operator can size the batch before it runs. It must
+    // apply the same exemption as reconciliation, or it hides exactly the findings
+    // that the next reconciliation is about to escalate.
+    await enableAutoRecovery();
+    await seedSelfStrandedReviewIssue({ idleHours: 25 });
+    const heartbeat = heartbeatService(db);
+
+    const preview = await heartbeat.buildIssueGraphLivenessAutoRecoveryPreview();
+
+    expect(preview.skippedOutsideLookback).toBe(0);
+    expect(preview.items).toHaveLength(1);
+    expect(preview.items[0]).toMatchObject({ state: "in_review_without_action_path" });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+    expect(result.escalationsCreated).toBe(preview.items.length);
+  });
+
   it("does not create recovery issues outside the configured lookback window", async () => {
     await enableAutoRecovery();
     const { companyId } = await seedBlockedChain({ outsideLookback: true });

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -843,6 +843,69 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     });
   });
 
+  async function seedSelfStrandedReviewIssue(opts: { idleHours: number }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `S${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: false } },
+      permissions: {},
+    });
+
+    const timestamp = new Date(Date.now() - opts.idleHours * 60 * 60 * 1000);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "In review with no reviewer",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  it("escalates a self-stranded in_review issue even when it is older than the lookback window", async () => {
+    // An issue stranded on its own state has a dependency path of just itself, so the
+    // lookback compares its updatedAt against itself. A stranded issue stops being
+    // updated because it is stranded, so it ages out of every window and would never
+    // be escalated. 25 hours is outside the 24 hour default.
+    await enableAutoRecovery();
+    const { companyId } = await seedSelfStrandedReviewIssue({ idleHours: 25 });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.findings).toBe(1);
+    expect(result.skippedOutsideLookback).toBe(0);
+    expect(result.escalationsCreated).toBe(1);
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(1);
+  });
+
   it("does not create recovery issues outside the configured lookback window", async () => {
     await enableAutoRecovery();
     const { companyId } = await seedBlockedChain({ outsideLookback: true });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5982,7 +5982,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         finding,
         updatedAtByIssueKey,
       );
-      if (!latestDependencyUpdatedAt || latestDependencyUpdatedAt < cutoff) {
+      if (!latestDependencyUpdatedAt) {
+        skippedOutsideLookback += 1;
+        continue;
+      }
+      // Mirror the reconciliation exemption for self-referential findings. The preview
+      // exists so an operator can size the next batch before it runs, so it has to
+      // apply the same rule. If it kept the unconditional lookback it would hide the
+      // findings the next reconciliation is about to escalate.
+      if (!isSelfReferentialLivenessFinding(finding) && latestDependencyUpdatedAt < cutoff) {
         skippedOutsideLookback += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5932,6 +5932,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     firstTimestamp!);
   }
 
+  /**
+   * True when a finding's dependency path is just the recovery issue itself.
+   *
+   * `reviewFinding(issue, issue, [issue])` produces these for an issue that is
+   * stranded on its own state rather than behind another issue. The lookback then
+   * compares the issue's `updatedAt` against itself, which cannot answer "has
+   * anything changed": a stranded issue stops being updated precisely because it is
+   * stranded, so it ages out of every window and is never escalated. Exclude these
+   * from the lookback. Findings that depend on a real blocker keep it, because there
+   * the blocker's `updatedAt` is a genuine signal that something moved.
+   */
+  function isSelfReferentialLivenessFinding(finding: IssueLivenessFinding) {
+    const dependencyIssueIds = [...new Set(finding.dependencyPath.map((entry) => entry.issueId))];
+    return dependencyIssueIds.length <= 1
+      && (dependencyIssueIds.length === 0 || dependencyIssueIds[0] === finding.recoveryIssueId);
+  }
+
   function isLivenessFindingInsideAutoRecoveryLookback(
     finding: IssueLivenessFinding,
     cutoff: Date,
@@ -6603,7 +6620,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     for (const finding of findings) {
-      if (!isLivenessFindingInsideAutoRecoveryLookback(finding, cutoff, updatedAtByIssueKey)) {
+      if (
+        !isSelfReferentialLivenessFinding(finding)
+        && !isLivenessFindingInsideAutoRecoveryLookback(finding, cutoff, updatedAtByIssueKey)
+      ) {
         result.skippedOutsideLookback += 1;
         result.skipped += 1;
         continue;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A recovery pass looks for issues that can no longer make progress and escalates them
> - One finding, `in_review_without_action_path`, marks an issue that is in review with an agent assignee and no reviewer, interaction, approval, monitor, or active run
> - The pass only escalates a finding inside a lookback window, and it measures that window from the dependency path
> - For this finding the dependency path is the issue itself, so the window is measured against the issue that is already stuck
> - This pull request excludes self-referential findings from the lookback
> - The benefit is that an issue stranded for weeks is escalated instead of being skipped for being quiet

## Linked Issues or Issue Description

**What happened**

On a self-hosted instance, 16 of 35 issues in `in_review` had no wake path at all. No monitor, no pending interaction, no human assignee, no execution participant. Nothing could resume them. The oldest had been idle for 27 days.

The recovery pass was enabled and running on its normal schedule the whole time. It detected every one of them. It escalated none of them.

**Expected behavior**

A finding that reports an issue cannot make progress should produce one escalation, whatever the age of the issue.

**Steps to reproduce**

1. Create an issue with an agent assignee and no user assignee.
2. Move it to `in_review` with no monitor, no pending interaction and no approval.
3. Leave it for more than `issueGraphLivenessAutoRecoveryLookbackHours`, which defaults to 24.
4. Run `reconcileIssueGraphLiveness`.
5. `findings` is 1. `escalationsCreated` is 0. `skippedOutsideLookback` is 1.

**Cause**

`reviewFinding(issue, issue, [issue])` builds the finding with a dependency path of one entry, the issue itself.

`latestDependencyUpdatedAtForLivenessFinding` reads the newest `updatedAt` across the dependency path. For this finding that is the issue's own `updatedAt`.

`isLivenessFindingInsideAutoRecoveryLookback` then asks whether the issue changed recently. But a stranded issue stops changing **because** it is stranded. The condition that creates the fault is the same condition that hides it. The window can only ever catch an issue in the first 24 hours after it strands, and nothing wakes it in that time to keep it inside the window.

The lookback is correct for a finding that depends on a real blocker. There the blocker's `updatedAt` shows that something moved. It is not meaningful when the path is the issue itself.

**Paperclip version**

Reproduced against `master` at the base commit of this branch.

**Deployment mode**

Self-hosted, single instance, PostgreSQL.

**Related pull requests**

I searched for existing work on this pass. I read #10695, #11126 and #9740; none of them changes how the lookback is measured. This branch is independent of my other open pull requests, #11895, #11896 and #11897.

## What Changed

- Add `isSelfReferentialLivenessFinding`. It is true when the dependency path holds no issue other than the recovery issue.
- Skip the lookback for such a finding, so it is escalated once whatever its age.
- Keep the lookback for every finding that has a real dependency. Behaviour there is unchanged.
- Add a test that seeds a self-stranded `in_review` issue 25 hours old and asserts it is escalated.

Re-escalation stays bounded by the existing cooldown and by the existing-escalation check, so this does not create repeat escalations.

## Verification

Run on Node 24.11.0 with pnpm 9.15.4.

- The new test fails without the change: `expected 1 to be +0`, because `skippedOutsideLookback` is 1 and `escalationsCreated` is 0. It passes with the change.
- `pnpm exec vitest run server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts` — 25 tests passed. This includes the existing test `does not create recovery issues outside the configured lookback window`, which is unchanged and still passes, because it seeds a blocked chain and is not self-referential.
- `heartbeat-issue-liveness-escalation`, `issue-review-attention` and `attention-service` together — 3 files, 53 tests passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/shared typecheck` passed.
- `pnpm --filter @paperclipai/db check:migrations` passed.
- `node scripts/check-node-version-policy.mjs` passed.
- `pnpm install --frozen-lockfile` exits 0.

## Risks

This makes the pass escalate findings it used to skip. On an instance with a backlog of long-stranded issues, the first run after this change creates one escalation for each. That is the intent, but it can be a large first batch. Operators who want to see the size first can call the preview endpoint before deploying.

The change is narrow. A finding with any dependency other than the issue itself keeps the current behaviour exactly, so blocked-chain recovery is untouched.

There is no migration and no API change.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context window, extended thinking enabled, with tool use for repository search, edits, test runs and git operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
