### PR TITLE
Require reasons for interaction cancellation

### DIFF
--- a/cli/src/__tests__/issue-subresources.test.ts
+++ b/cli/src/__tests__/issue-subresources.test.ts
@@ -220,6 +220,17 @@ describe("issue subresource commands", () => {
     expect(JSON.parse(String(fetchMock.mock.calls[4]?.[1]?.body))).toEqual({
       selectedOptionIds: ["file-a", "file-b"],
     });
+    expect(JSON.parse(String(fetchMock.mock.calls[6]?.[1]?.body))).toEqual({
+      reason: "stale",
+    });
+  });
+
+  it("requires --reason for interaction:cancel", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(run(["issue", "interaction:cancel", ISSUE_ID, INTERACTION_ID])).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("forwards the agent run-id header and inferred content-type on attachment:upload", async () => {

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -762,29 +762,43 @@ export function registerIssueCommands(program: Command): void {
       }),
   );
 
-  for (const [name, action, schema, description] of [
-    ["interaction:reject", "reject", rejectIssueThreadInteractionSchema, "Reject an issue thread interaction"],
-    ["interaction:cancel", "cancel", cancelIssueThreadInteractionSchema, "Cancel an issue thread interaction"],
-  ] as const) {
-    addCommonClientOptions(
-      issue
-        .command(name)
-        .description(description)
-        .argument("<issueId>", "Issue ID")
-        .argument("<interactionId>", "Interaction ID")
-        .option("--reason <text>", "Reason")
-        .action(async (issueId: string, interactionId: string, opts: InteractionReasonOptions) => {
-          try {
-            const ctx = resolveCommandContext(opts);
-            const payload = schema.parse({ reason: opts.reason });
-            const interaction = await ctx.api.post(`${apiPath`/api/issues/${issueId}/interactions/${interactionId}`}/${action}`, payload);
-            printOutput(interaction, { json: ctx.json });
-          } catch (err) {
-            handleCommandError(err);
-          }
-        }),
-    );
-  }
+  addCommonClientOptions(
+    issue
+      .command("interaction:reject")
+      .description("Reject an issue thread interaction")
+      .argument("<issueId>", "Issue ID")
+      .argument("<interactionId>", "Interaction ID")
+      .option("--reason <text>", "Reason")
+      .action(async (issueId: string, interactionId: string, opts: InteractionReasonOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = rejectIssueThreadInteractionSchema.parse({ reason: opts.reason });
+          const interaction = await ctx.api.post(apiPath`/api/issues/${issueId}/interactions/${interactionId}/reject`, payload);
+          printOutput(interaction, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+
+  addCommonClientOptions(
+    issue
+      .command("interaction:cancel")
+      .description("Cancel an issue thread interaction")
+      .argument("<issueId>", "Issue ID")
+      .argument("<interactionId>", "Interaction ID")
+      .requiredOption("--reason <text>", "Cancellation reason")
+      .action(async (issueId: string, interactionId: string, opts: InteractionReasonOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = cancelIssueThreadInteractionSchema.parse({ reason: opts.reason });
+          const interaction = await ctx.api.post(apiPath`/api/issues/${issueId}/interactions/${interactionId}/cancel`, payload);
+          printOutput(interaction, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
 
   addCommonClientOptions(
     issue

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -392,7 +392,7 @@ npx paperclipai issue interaction:create <issue-id> --payload-json '{"kind":"req
 npx paperclipai issue interaction:accept <issue-id> <interaction-id> [--selected-client-keys key1,key2]
 npx paperclipai issue interaction:reject <issue-id> <interaction-id> [--reason "..."]
 npx paperclipai issue interaction:respond <issue-id> <interaction-id> --answers-json '[{"questionId":"q1","optionIds":["yes"]}]'
-npx paperclipai issue interaction:cancel <issue-id> <interaction-id> [--reason "..."]
+npx paperclipai issue interaction:cancel <issue-id> <interaction-id> --reason "..."
 ```
 
 ```sh

--- a/packages/shared/src/issue-thread-interactions.test.ts
+++ b/packages/shared/src/issue-thread-interactions.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   acceptIssueThreadInteractionSchema,
   askUserQuestionsResultSchema,
+  cancelIssueThreadInteractionSchema,
   createIssueThreadInteractionSchema,
   requestConfirmationPayloadSchema,
   requestConfirmationResultSchema,
@@ -16,6 +17,15 @@ import {
 } from "./validators/issue.js";
 
 describe("issue thread interaction schemas", () => {
+  it("requires a strict, non-empty cancellation reason", () => {
+    expect(cancelIssueThreadInteractionSchema.parse({ reason: "  Superseded  " })).toEqual({
+      reason: "Superseded",
+    });
+    expect(cancelIssueThreadInteractionSchema.safeParse({}).success).toBe(false);
+    expect(cancelIssueThreadInteractionSchema.safeParse({ reason: "   " }).success).toBe(false);
+    expect(cancelIssueThreadInteractionSchema.safeParse({ cancellationReason: "Superseded" }).success).toBe(false);
+  });
+
   it("defines canonical resolver policies and normalizes compatibility aliases", () => {
     expect(ISSUE_THREAD_INTERACTION_CANONICAL_RESOLVER_POLICIES).toEqual([
       "anyone",

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -1394,8 +1394,8 @@ export const rejectIssueThreadInteractionSchema = z.object({
 export type RejectIssueThreadInteraction = z.infer<typeof rejectIssueThreadInteractionSchema>;
 
 export const cancelIssueThreadInteractionSchema = z.object({
-  reason: z.string().trim().max(4000).optional(),
-});
+  reason: z.string().trim().min(1).max(4000),
+}).strict();
 export type CancelIssueThreadInteraction = z.infer<typeof cancelIssueThreadInteractionSchema>;
 
 export const withdrawIssueThreadInteractionSchema = z.object({

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../errors.js";
 
 const ASSIGNEE_AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const UNRELATED_AGENT_ID = "33333333-3333-4333-8333-333333333333";
@@ -506,7 +507,7 @@ describe.sequential("issue thread interaction routes", () => {
         version: 1,
         answers: [],
         cancelled: true,
-        cancellationReason: null,
+        cancellationReason: "No longer needed",
         summaryMarkdown: null,
       },
       createdAt: "2026-04-20T12:00:00.000Z",
@@ -941,14 +942,14 @@ describe.sequential("issue thread interaction routes", () => {
 
     const res = await request(app)
       .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
-      .send({});
+      .send({ reason: "No longer needed" });
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("cancelled");
     expect(mockInteractionService.cancelQuestions).toHaveBeenCalledWith(
       expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
       "interaction-2",
-      {},
+      { reason: "No longer needed" },
       expect.objectContaining({ userId: "local-board" }),
     );
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
@@ -968,7 +969,62 @@ describe.sequential("issue thread interaction routes", () => {
       expect.anything(),
       expect.objectContaining({
         action: "issue.thread_interaction_cancelled",
+        details: expect.objectContaining({ cancellationReason: "No longer needed" }),
       }),
+    );
+  });
+
+  it.each([
+    ["a missing reason", {}],
+    ["the result-only cancellationReason field", { cancellationReason: "No longer needed" }],
+    ["a blank reason", { reason: "   " }],
+  ])("rejects cancellation with %s", async (_label, body) => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+    expect(mockInteractionService.cancelQuestions).not.toHaveBeenCalled();
+  });
+
+  it("returns winner attribution when cancellation loses an exact-once race", async () => {
+    mockInteractionService.cancelQuestions.mockRejectedValueOnce(new HttpError(
+      409,
+      "Interaction has already been resolved",
+      {
+        code: "interaction_already_resolved",
+        interactionStatus: "cancelled",
+        resolvedAt: "2026-04-20T12:01:00.000Z",
+        resolvedByAgentId: null,
+        resolvedByRunId: null,
+        resolvedByUserId: "winning-board-user",
+      },
+    ));
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send({ reason: "Losing cancellation" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Interaction has already been resolved",
+      code: "interaction_already_resolved",
+      details: {
+        code: "interaction_already_resolved",
+        interactionStatus: "cancelled",
+        resolvedAt: "2026-04-20T12:01:00.000Z",
+        resolvedByAgentId: null,
+        resolvedByRunId: null,
+        resolvedByUserId: "winning-board-user",
+      },
+    });
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.thread_interaction_cancelled" }),
     );
   });
 

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -1,7 +1,6 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { HttpError } from "../errors.js";
 
 const ASSIGNEE_AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const UNRELATED_AGENT_ID = "33333333-3333-4333-8333-333333333333";
@@ -991,6 +990,9 @@ describe.sequential("issue thread interaction routes", () => {
   });
 
   it("returns winner attribution when cancellation loses an exact-once race", async () => {
+    // `beforeEach` resets the module graph, so import HttpError in the same graph
+    // that createApp (and therefore errorHandler) will use for this request.
+    const { HttpError } = await import("../errors.js");
     mockInteractionService.cancelQuestions.mockRejectedValueOnce(new HttpError(
       409,
       "Interaction has already been resolved",

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -822,6 +822,64 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     }, {
       userId: "local-board",
     })).rejects.toThrow("Interaction has already been resolved");
+
+    const racingInteraction = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope-race",
+          prompt: "Choose the replacement scope",
+          selectionMode: "single",
+          options: [{ id: "phase-3", label: "Phase 3" }],
+        }],
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const race = await Promise.allSettled([
+      interactionsSvc.cancelQuestions({ id: issueId, companyId }, racingInteraction.id, {
+        reason: "First concurrent cancellation",
+      }, {
+        userId: "board-user-one",
+      }),
+      interactionsSvc.cancelQuestions({ id: issueId, companyId }, racingInteraction.id, {
+        reason: "Second concurrent cancellation",
+      }, {
+        userId: "board-user-two",
+      }),
+    ]);
+    const winnerResult = race.find((result) => result.status === "fulfilled");
+    const loserResult = race.find((result) => result.status === "rejected");
+
+    expect(race.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(race.filter((result) => result.status === "rejected")).toHaveLength(1);
+    if (winnerResult?.status !== "fulfilled" || loserResult?.status !== "rejected") {
+      throw new Error("Expected exactly one winning interaction cancellation");
+    }
+
+    const winner = winnerResult.value;
+    expect(winner).toMatchObject({
+      status: "cancelled",
+      result: {
+        cancellationReason: expect.stringMatching(/concurrent cancellation$/),
+      },
+    });
+    expect(loserResult.reason).toMatchObject({
+      status: 409,
+      details: {
+        code: "interaction_already_resolved",
+        interactionStatus: "cancelled",
+        resolvedAt: expect.any(Date),
+        resolvedByAgentId: null,
+        resolvedByRunId: null,
+        resolvedByUserId: winner.resolvedByUserId,
+      },
+    });
   });
 
   it("persists cancelled ask_user_questions interactions without answer data", async () => {
@@ -891,6 +949,25 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       cancelled: true,
       cancellationReason: "Not needed anymore",
       summaryMarkdown: null,
+    });
+
+    await expect(interactionsSvc.cancelQuestions({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      reason: "Second cancellation",
+    }, {
+      userId: "another-board-user",
+    })).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "interaction_already_resolved",
+        interactionStatus: "cancelled",
+        resolvedAt: expect.any(Date),
+        resolvedByAgentId: null,
+        resolvedByRunId: null,
+        resolvedByUserId: "local-board",
+      },
     });
 
     await expect(interactionsSvc.answerQuestions({

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -561,7 +561,26 @@ function interactionAlreadyResolvedError() {
   );
 }
 
-function interactionTerminalError(row: { status: string; result?: unknown }) {
+type TerminalInteractionSnapshot = {
+  status: string;
+  result?: unknown;
+  resolvedByAgentId?: string | null;
+  resolvedByRunId?: string | null;
+  resolvedByUserId?: string | null;
+  resolvedAt?: Date | string | null;
+};
+
+function terminalInteractionDetails(row: TerminalInteractionSnapshot) {
+  return {
+    interactionStatus: row.status,
+    resolvedAt: row.resolvedAt ?? null,
+    resolvedByAgentId: row.resolvedByAgentId ?? null,
+    resolvedByRunId: row.resolvedByRunId ?? null,
+    resolvedByUserId: row.resolvedByUserId ?? null,
+  };
+}
+
+function interactionTerminalError(row: TerminalInteractionSnapshot) {
   const result = row.result && typeof row.result === "object" && !Array.isArray(row.result)
     ? row.result as unknown as Record<string, unknown>
     : null;
@@ -570,6 +589,7 @@ function interactionTerminalError(row: { status: string; result?: unknown }) {
       409,
       "interaction_stale_target",
       "Interaction target is stale",
+      terminalInteractionDetails(row),
     );
   }
   if (result?.outcome === "superseded_by_comment" || result?.outcome === "superseded_by_newer_request") {
@@ -577,6 +597,7 @@ function interactionTerminalError(row: { status: string; result?: unknown }) {
       409,
       "interaction_superseded",
       "Interaction has been superseded",
+      terminalInteractionDetails(row),
     );
   }
   if (result?.outcome === "issue_closed") return interactionIssueClosedError();
@@ -584,6 +605,7 @@ function interactionTerminalError(row: { status: string; result?: unknown }) {
     409,
     "interaction_already_resolved",
     "Interaction has already been resolved",
+    terminalInteractionDetails(row),
   );
 }
 
@@ -3393,7 +3415,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         throw interactionTerminalError(current);
       }
 
-      const reason = data.reason?.trim() || null;
+      const reason = data.reason.trim();
       const [updated] = await db
         .update(issueThreadInteractions)
         .set({
@@ -3418,6 +3440,12 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         .returning();
 
       if (!updated) {
+        const winner = await db
+          .select()
+          .from(issueThreadInteractions)
+          .where(eq(issueThreadInteractions.id, interactionId))
+          .then((rows) => rows[0] ?? null);
+        if (winner) throw interactionTerminalError(winner);
         throw interactionAlreadyResolvedError();
       }
 

--- a/ui/src/api/issues.test.ts
+++ b/ui/src/api/issues.test.ts
@@ -124,4 +124,17 @@ describe("issuesApi.list", () => {
       },
     );
   });
+
+  it("posts the required interaction cancellation reason", async () => {
+    await issuesApi.cancelInteraction(
+      "issue-1",
+      "interaction-1",
+      "Superseded by a newer question",
+    );
+
+    expect(mockApi.post).toHaveBeenCalledWith(
+      "/issues/issue-1/interactions/interaction-1/cancel",
+      { reason: "Superseded by a newer question" },
+    );
+  });
 });

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -251,8 +251,8 @@ export const issuesApi = {
     api.post<IssueThreadInteraction>(`/issues/${id}/interactions/${interactionId}/accept`, data ?? {}),
   rejectInteraction: (id: string, interactionId: string, reason?: string) =>
     api.post<IssueThreadInteraction>(`/issues/${id}/interactions/${interactionId}/reject`, reason ? { reason } : {}),
-  cancelInteraction: (id: string, interactionId: string, reason?: string) =>
-    api.post<IssueThreadInteraction>(`/issues/${id}/interactions/${interactionId}/cancel`, reason ? { reason } : {}),
+  cancelInteraction: (id: string, interactionId: string, reason: string) =>
+    api.post<IssueThreadInteraction>(`/issues/${id}/interactions/${interactionId}/cancel`, { reason }),
   respondToInteraction: (
     id: string,
     interactionId: string,

--- a/ui/src/components/AttentionInteractionResolver.tsx
+++ b/ui/src/components/AttentionInteractionResolver.tsx
@@ -110,8 +110,8 @@ export function AttentionInteractionResolver({
   });
 
   const cancelMutation = useMutation({
-    mutationFn: (input: { interactionId: string }) =>
-      issuesApi.cancelInteraction(issueId, input.interactionId),
+    mutationFn: (input: { interactionId: string; reason: string }) =>
+      issuesApi.cancelInteraction(issueId, input.interactionId, input.reason),
     onSuccess: invalidate,
   });
 
@@ -154,8 +154,8 @@ export function AttentionInteractionResolver({
       onSubmitInteractionAnswers={(target: AskUserQuestionsInteraction, answers) =>
         respondMutation.mutateAsync({ interactionId: target.id, answers }).then(() => undefined)
       }
-      onCancelInteraction={(target: AskUserQuestionsInteraction) =>
-        cancelMutation.mutateAsync({ interactionId: target.id }).then(() => undefined)
+      onCancelInteraction={(target: AskUserQuestionsInteraction, reason) =>
+        cancelMutation.mutateAsync({ interactionId: target.id, reason }).then(() => undefined)
       }
       onSubmitInteractionVerdicts={(target: RequestItemVerdictsInteraction, verdicts) =>
         verdictsMutation.mutateAsync({ interactionId: target.id, verdicts }).then(() => undefined)

--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -2724,11 +2724,33 @@ describe("IssueChatThread", () => {
       cancelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
+    const textarea = container.querySelector(
+      'textarea[aria-label="Cancellation reason"]',
+    ) as HTMLTextAreaElement | null;
+    expect(textarea).toBeTruthy();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, "Superseded by a newer question");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const confirmButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Confirm cancellation"),
+    );
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
     expect(onCancelInteraction).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "interaction-question-1",
         kind: "ask_user_questions",
       }),
+      "Superseded by a newer question",
     );
 
     act(() => {

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -232,6 +232,7 @@ interface IssueChatMessageContext {
   ) => Promise<void> | void;
   onCancelInteraction?: (
     interaction: AskUserQuestionsInteraction,
+    reason: string,
   ) => Promise<void> | void;
   onSubmitInteractionVerdicts?: (
     interaction: RequestItemVerdictsInteraction,
@@ -557,6 +558,7 @@ interface IssueChatThreadProps {
   ) => Promise<void> | void;
   onCancelInteraction?: (
     interaction: AskUserQuestionsInteraction,
+    reason: string,
   ) => Promise<void> | void;
   onSubmitInteractionVerdicts?: (
     interaction: RequestItemVerdictsInteraction,

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -314,6 +314,51 @@ describe("IssueThreadInteractionCard", () => {
     expect(withHandler.textContent).toContain("Cancel question");
   });
 
+  it("requires and submits an audit reason before cancelling a question", async () => {
+    const onCancelInteraction = vi.fn(async () => undefined);
+    const host = renderCard({
+      interaction: pendingAskUserQuestionsInteraction,
+      onCancelInteraction,
+      onSubmitInteractionAnswers: vi.fn(),
+    });
+
+    const cancelButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Cancel question"),
+    );
+    await act(async () => {
+      cancelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const textarea = host.querySelector(
+      'textarea[aria-label="Cancellation reason"]',
+    ) as HTMLTextAreaElement | null;
+    const confirmButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Confirm cancellation"),
+    ) as HTMLButtonElement | undefined;
+    expect(textarea).toBeTruthy();
+    expect(confirmButton?.disabled).toBe(true);
+    expect(onCancelInteraction).not.toHaveBeenCalled();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, "  Superseded by the revised request  ");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(confirmButton?.disabled).toBe(false);
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onCancelInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "ask_user_questions" }),
+      "Superseded by the revised request",
+    );
+  });
+
   it("renders expired question interactions as resolved and non-actionable", () => {
     const host = renderCard({
       interaction: commentExpiredAskUserQuestionsInteraction,

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -112,6 +112,7 @@ interface IssueThreadInteractionCardProps {
   ) => Promise<void> | void;
   onCancelInteraction?: (
     interaction: AskUserQuestionsInteraction,
+    reason: string,
   ) => Promise<void> | void;
   /** Render confirmation CTAs with the primary action rightmost (task-chat grammar). */
   primaryActionOnRight?: boolean;
@@ -993,6 +994,7 @@ function AskUserQuestionsCard({
   ) => Promise<void> | void;
   onCancelInteraction?: (
     interaction: AskUserQuestionsInteraction,
+    reason: string,
   ) => Promise<void> | void;
   externalReferences?: MarkdownExternalReferenceMap;
 }) {
@@ -1020,6 +1022,8 @@ function AskUserQuestionsCard({
   );
   const [working, setWorking] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [showCancelReason, setShowCancelReason] = useState(false);
+  const [cancelReason, setCancelReason] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
   const resolutionErrorMessage = useResolutionErrorMessage();
 
@@ -1120,11 +1124,12 @@ function AskUserQuestionsCard({
   }
 
   async function handleCancel() {
-    if (!onCancelInteraction) return;
+    const reason = cancelReason.trim();
+    if (!onCancelInteraction || !reason) return;
     setCancelling(true);
     setActionError(null);
     try {
-      await onCancelInteraction(interaction);
+      await onCancelInteraction(interaction, reason);
     } catch (error) {
       setActionError(resolutionErrorMessage(error));
     } finally {
@@ -1264,16 +1269,46 @@ function AskUserQuestionsCard({
             );
           })}
 
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border/70 bg-background/75 p-4">
-            <div className="text-sm text-muted-foreground">
-              Submit once after you finish the full form.
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              {onCancelInteraction ? (
+          {showCancelReason && onCancelInteraction ? (
+            <div className="space-y-3 rounded-2xl border border-border/70 bg-background/75 p-4">
+              <div>
+                <label
+                  htmlFor={`${interaction.id}-cancellation-reason`}
+                  className="text-sm font-semibold text-foreground"
+                >
+                  Cancellation reason
+                </label>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  This reason is retained with the interaction for the audit trail.
+                </p>
+              </div>
+              <Textarea
+                id={`${interaction.id}-cancellation-reason`}
+                aria-label="Cancellation reason"
+                value={cancelReason}
+                onChange={(event) => setCancelReason(event.target.value)}
+                placeholder="Explain why this question is no longer needed"
+                className="min-h-24 bg-background text-sm"
+                maxLength={4000}
+                autoFocus
+              />
+              <div className="flex flex-wrap justify-end gap-2">
                 <Button
                   size="sm"
-                  variant="outline"
-                  disabled={working || cancelling}
+                  variant="ghost"
+                  disabled={cancelling}
+                  onClick={() => {
+                    setShowCancelReason(false);
+                    setCancelReason("");
+                    setActionError(null);
+                  }}
+                >
+                  Keep question
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={!cancelReason.trim() || cancelling}
                   onClick={() => void handleCancel()}
                 >
                   {cancelling ? (
@@ -1282,13 +1317,34 @@ function AskUserQuestionsCard({
                       Cancelling...
                     </>
                   ) : (
-                    "Cancel question"
+                    "Confirm cancellation"
                   )}
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border/70 bg-background/75 p-4">
+            <div className="text-sm text-muted-foreground">
+              Submit once after you finish the full form.
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {onCancelInteraction && !showCancelReason ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={working || cancelling}
+                  onClick={() => {
+                    setActionError(null);
+                    setShowCancelReason(true);
+                  }}
+                >
+                  Cancel question
                   </Button>
                 ) : null}
               <Button
                 size="sm"
-                disabled={!onSubmitInteractionAnswers || !canSubmit || working || cancelling}
+                disabled={!onSubmitInteractionAnswers || !canSubmit || working || cancelling || showCancelReason}
                 onClick={() => void handleSubmit()}
               >
                 {working ? (

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1040,7 +1040,7 @@ type IssueDetailChatTabProps = {
     interaction: IssueThreadInteraction,
     answers: AskUserQuestionsAnswer[],
   ) => Promise<void>;
-  onCancelInteraction: (interaction: AskUserQuestionsInteraction) => Promise<void>;
+  onCancelInteraction: (interaction: AskUserQuestionsInteraction, reason: string) => Promise<void>;
   onSubmitInteractionVerdicts: (
     interaction: RequestItemVerdictsInteraction,
     verdicts: { id: string; verdict: RequestItemVerdictValue; reason?: string }[],
@@ -2958,8 +2958,8 @@ export function IssueDetail() {
   });
 
   const cancelInteraction = useMutation({
-    mutationFn: ({ interaction }: { interaction: AskUserQuestionsInteraction }) =>
-      issuesApi.cancelInteraction(issueId!, interaction.id),
+    mutationFn: ({ interaction, reason }: { interaction: AskUserQuestionsInteraction; reason: string }) =>
+      issuesApi.cancelInteraction(issueId!, interaction.id, reason),
     onSuccess: (interaction) => {
       upsertInteractionInCache(interaction);
       invalidateIssueDetail();
@@ -4050,8 +4050,8 @@ export function IssueDetail() {
   ) => {
     await answerInteraction.mutateAsync({ interaction, answers });
   }, [answerInteraction]);
-  const handleCancelInteraction = useCallback(async (interaction: AskUserQuestionsInteraction) => {
-    await cancelInteraction.mutateAsync({ interaction });
+  const handleCancelInteraction = useCallback(async (interaction: AskUserQuestionsInteraction, reason: string) => {
+    await cancelInteraction.mutateAsync({ interaction, reason });
   }, [cancelInteraction]);
   const handleSubmitInteractionVerdicts = useCallback(async (
     interaction: RequestItemVerdictsInteraction,

--- a/ui/src/pages/Pipelines.tsx
+++ b/ui/src/pages/Pipelines.tsx
@@ -2454,9 +2454,9 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
     await invalidateConversation();
   }, [conversationIssueId, invalidateConversation]);
 
-  const handleCancelConversationInteraction = useCallback(async (interaction: AskUserQuestionsInteraction) => {
+  const handleCancelConversationInteraction = useCallback(async (interaction: AskUserQuestionsInteraction, reason: string) => {
     if (!conversationIssueId) return;
-    await issuesApi.cancelInteraction(conversationIssueId, interaction.id);
+    await issuesApi.cancelInteraction(conversationIssueId, interaction.id, reason);
     await invalidateConversation();
   }, [conversationIssueId, invalidateConversation]);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue thread interactions let agents request structured input from people.
> - A cancellation reason is audit data and must survive a successful request.
> - The old optional, non-strict schema removed unknown fields and could return HTTP 200 with a null stored reason.
> - This pull request requires the public `reason` key, collects it in the UI, and preserves it as `result.cancellationReason`.
> - It also keeps the exact-once update and identifies the winning resolver when a concurrent cancellation loses.
> - The benefit is a complete cancellation audit trail with explicit failure at the request boundary.

## Linked Issues or Issue Description

**What happened?**

The cancel endpoint accepted an optional `reason` and silently removed unknown fields. Sending `{"cancellationReason":"stale"}` returned HTTP 200 but stored `result.cancellationReason: null`. A losing concurrent cancel returned 409 without identifying the winner.

**Expected behavior**

Every cancel must include a non-empty `reason`. Unknown fields must fail validation. A losing cancel must identify the winning resolver without writing a second result.

**Steps to reproduce**

1. Create a pending `ask_user_questions` interaction.
2. Cancel it with `{"cancellationReason":"stale"}`.
3. Observe HTTP 200 and a null stored reason.
4. Send two valid cancels concurrently and inspect the losing 409.

**Paperclip version or commit**

Observed on a self-hosted deployment. Based on upstream `dc5b07070`.

**Deployment mode**

Self-hosted local server.

No exact duplicate or closely related public pull request was found in the preflight GitHub search.

## What Changed

- Require a trimmed `reason` with a 4,000-character limit.
- Reject unknown cancel fields.
- Persist the reason in the result and activity.
- Add winner status, time, agent, run, and user IDs to terminal 409 details.
- Collect the required reason in the shared question card and propagate it through every UI surface.
- Require CLI `--reason` and update its documentation.
- Add schema, CLI, route, persistence, concurrency, and UI tests.

## Verification

- Targeted shared and CLI Vitest suites: 29 tests passed.
- `git diff --check`: passed.
- Server and UI suites did not produce a valid local result. The Windows pnpm tree first exceeded module-resolution path limits; after dependency refresh, Vitest failed before collection because its package map lacked `#module-evaluator`. CI is the remaining repository-test verification path.
- Current-head CI passed build, typecheck, canary, all general and serialized server suites, workspace tests, e2e, policy, and security checks.
- Greptile completed at 5/5 with no blocking findings.
- No live interaction was cancelled for testing.

## Risks

- Cancel requests without a non-empty `reason` now return 400.
- Cancel requests with unknown fields now return 400.
- Valid callers keep the existing stored result shape.
- No migration is required. Roll back by reverting the implementation commit.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, with agentic tool use and code execution.
- The runtime did not expose its context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge