### PR TITLE
fix(shared): retry lock owner renames the platform refuses

### DIFF
--- a/packages/shared/src/worktree-port-registry.test.ts
+++ b/packages/shared/src/worktree-port-registry.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   withWorktreePortRegistryLock,
   withWorktreePortRegistryLockSync,
@@ -143,5 +143,29 @@ describe("worktree port registry lock", () => {
     });
 
     expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("survives a rename the platform briefly refuses", () => {
+    // Windows returns EPERM when renaming onto a file another handle has open,
+    // where POSIX just replaces it. The heartbeat worker reads owner.json on an
+    // interval, so the parent's rewrite failed outright on Windows and never on
+    // Linux, which kept it invisible in CI. Acquisition must ride that out.
+    const homeDir = makeTemporaryRoot();
+    const realRename = fs.renameSync.bind(fs);
+    let refusalsLeft = 2;
+    const spy = vi.spyOn(fs, "renameSync").mockImplementation(((from: fs.PathLike, to: fs.PathLike) => {
+      if (refusalsLeft > 0 && String(to).endsWith("owner.json")) {
+        refusalsLeft -= 1;
+        throw Object.assign(new Error("EPERM: operation not permitted, rename"), { code: "EPERM" });
+      }
+      return realRename(from, to);
+    }) as typeof fs.renameSync);
+
+    try {
+      expect(withWorktreePortRegistryLockSync(homeDir, () => "held")).toBe("held");
+      expect(refusalsLeft).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/shared/src/worktree-port-registry.ts
+++ b/packages/shared/src/worktree-port-registry.ts
@@ -18,6 +18,8 @@ const WORKTREE_PORT_REGISTRY_LOCK_STALE_MS = 5_000;
 const WORKTREE_PORT_REGISTRY_LOCK_TIMEOUT_MS = 10_000;
 const WORKTREE_PORT_REGISTRY_LOCK_HEARTBEAT_MS = 1_000;
 const WORKTREE_PORT_REGISTRY_LOCK_PROBE_TIMEOUT_MS = 500;
+const WORKTREE_PORT_REGISTRY_RENAME_TIMEOUT_MS = 2_000;
+const WORKTREE_PORT_REGISTRY_RENAME_RETRY_MS = 10;
 const sleepSyncBuffer = new Int32Array(new SharedArrayBuffer(4));
 
 type RegistryLockOwner = {
@@ -95,9 +97,12 @@ server.listen(0, "127.0.0.1", () => {
     return;
   }
   Atomics.store(control, 2, address.port);
+  // Take the first ownership reading before releasing the parent. The parent
+  // rewrites owner.json as soon as it wakes, and on Windows renaming onto a
+  // file this worker still has open fails with EPERM.
+  touchOwnedLock();
   Atomics.store(control, 0, 1);
   Atomics.notify(control, 0);
-  touchOwnedLock();
   timer = setInterval(() => {
     if (Atomics.load(control, 1) !== 0 || touchOwnedLock() === "lost") finish();
   }, workerData.heartbeatMs);
@@ -160,6 +165,31 @@ function readRegistryLockOwner(lockPath: string): RegistryLockOwner | null {
   return null;
 }
 
+/**
+ * Replace `to` with `from`, tolerating the destination being briefly held open.
+ *
+ * POSIX renames over an open destination without complaint. Windows returns
+ * EPERM, EACCES or EBUSY instead, and several things here open these files for
+ * short reads: the heartbeat worker checks ownership on an interval, and virus
+ * scanners and the search indexer both touch newly created files. Retrying for
+ * a bounded window turns a hard failure back into the atomic replace the rest
+ * of this module assumes it has.
+ */
+function renameWithRetrySync(from: string, to: string): void {
+  const deadline = Date.now() + WORKTREE_PORT_REGISTRY_RENAME_TIMEOUT_MS;
+  for (;;) {
+    try {
+      fs.renameSync(from, to);
+      return;
+    } catch (error) {
+      const code = error instanceof Error && "code" in error ? error.code : null;
+      if (code !== "EPERM" && code !== "EACCES" && code !== "EBUSY") throw error;
+      if (Date.now() >= deadline) throw error;
+      Atomics.wait(sleepSyncBuffer, 0, 0, WORKTREE_PORT_REGISTRY_RENAME_RETRY_MS);
+    }
+  }
+}
+
 function writeRegistryLockOwner(lockPath: string, owner: RegistryLockOwner): void {
   const contents = `${JSON.stringify(owner)}\n`;
   for (const ownerFile of [
@@ -169,7 +199,7 @@ function writeRegistryLockOwner(lockPath: string, owner: RegistryLockOwner): voi
     const ownerPath = path.join(lockPath, ownerFile);
     const temporaryPath = `${ownerPath}.${owner.token}.tmp`;
     fs.writeFileSync(temporaryPath, contents, { mode: 0o600 });
-    fs.renameSync(temporaryPath, ownerPath);
+    renameWithRetrySync(temporaryPath, ownerPath);
   }
 }
 
@@ -407,5 +437,5 @@ export function writeWorktreePortRegistry(homeDir: string, configPaths: Iterable
   };
   const temporaryPath = `${registryPath}.${process.pid}.tmp`;
   fs.writeFileSync(temporaryPath, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
-  fs.renameSync(temporaryPath, registryPath);
+  renameWithRetrySync(temporaryPath, registryPath);
 }

--- a/packages/shared/src/worktree-port-registry.ts
+++ b/packages/shared/src/worktree-port-registry.ts
@@ -20,6 +20,16 @@ const WORKTREE_PORT_REGISTRY_LOCK_HEARTBEAT_MS = 1_000;
 const WORKTREE_PORT_REGISTRY_LOCK_PROBE_TIMEOUT_MS = 500;
 const WORKTREE_PORT_REGISTRY_RENAME_TIMEOUT_MS = 2_000;
 const WORKTREE_PORT_REGISTRY_RENAME_RETRY_MS = 10;
+/**
+ * How long the parent waits for the heartbeat worker to report ready.
+ *
+ * The worker takes its first ownership reading before signalling, so this has to
+ * cover a `readFileSync` and a `utimesSync` against the lock directory, not just
+ * worker startup. On a network-mounted home directory, or while a virus scanner
+ * holds the freshly written owner file, that read can take seconds; too tight a
+ * budget here fails lock acquisition outright rather than waiting it out.
+ */
+const WORKTREE_PORT_REGISTRY_LOCK_START_TIMEOUT_MS = 8_000;
 const sleepSyncBuffer = new Int32Array(new SharedArrayBuffer(4));
 
 type RegistryLockOwner = {
@@ -175,8 +185,11 @@ function readRegistryLockOwner(lockPath: string): RegistryLockOwner | null {
  * a bounded window turns a hard failure back into the atomic replace the rest
  * of this module assumes it has.
  */
-function renameWithRetrySync(from: string, to: string): void {
-  const deadline = Date.now() + WORKTREE_PORT_REGISTRY_RENAME_TIMEOUT_MS;
+function renameWithRetrySync(
+  from: string,
+  to: string,
+  deadline = Date.now() + WORKTREE_PORT_REGISTRY_RENAME_TIMEOUT_MS,
+): void {
   for (;;) {
     try {
       fs.renameSync(from, to);
@@ -192,6 +205,11 @@ function renameWithRetrySync(from: string, to: string): void {
 
 function writeRegistryLockOwner(lockPath: string, owner: RegistryLockOwner): void {
   const contents = `${JSON.stringify(owner)}\n`;
+  // One deadline for the whole write, not one per file. Both owner records are
+  // rewritten on every acquisition, so a per-file budget would let a single
+  // write stall for twice the retry window and eat a fifth of the caller's
+  // WORKTREE_PORT_REGISTRY_LOCK_TIMEOUT_MS before the lock is even held.
+  const deadline = Date.now() + WORKTREE_PORT_REGISTRY_RENAME_TIMEOUT_MS;
   for (const ownerFile of [
     WORKTREE_PORT_REGISTRY_LOCK_OWNER_FILE,
     WORKTREE_PORT_REGISTRY_LOCK_OWNER_BACKUP_FILE,
@@ -199,7 +217,7 @@ function writeRegistryLockOwner(lockPath: string, owner: RegistryLockOwner): voi
     const ownerPath = path.join(lockPath, ownerFile);
     const temporaryPath = `${ownerPath}.${owner.token}.tmp`;
     fs.writeFileSync(temporaryPath, contents, { mode: 0o600 });
-    renameWithRetrySync(temporaryPath, ownerPath);
+    renameWithRetrySync(temporaryPath, ownerPath, deadline);
   }
 }
 
@@ -304,7 +322,7 @@ function startRegistryLockHeartbeat(lockPath: string, token: string): RegistryLo
       token,
     },
   });
-  Atomics.wait(control, 0, 0, 2_000);
+  Atomics.wait(control, 0, 0, WORKTREE_PORT_REGISTRY_LOCK_START_TIMEOUT_MS);
   if (Atomics.load(control, 0) !== 1) {
     void worker.terminate();
     throw new Error(`Failed to start worktree port reservation lock heartbeat at ${lockPath}`);


### PR DESCRIPTION
`paperclipai worktree init` fails on every attempt on Windows:

```
EPERM: operation not permitted, rename
  ...\.worktree-port-reservations.lock\owner.json.<pid>-<uuid>.tmp
  -> ...\.worktree-port-reservations.lock\owner.json
```

### Cause

`acquireRegistryLock` does three things in order:

1. `writeRegistryLockOwner` creates `owner.json` in the fresh lock directory
2. `startRegistryLockHeartbeat` spawns the worker
3. `writeRegistryLockOwner` rewrites `owner.json` with the worker's probe port

The worker signals ready (`Atomics.store` / `Atomics.notify`) **before** taking its first ownership reading, and `touchOwnedLock` opens `owner.json` with `readFileSync`. So the parent's `Atomics.wait` returns and step 3 renames onto `owner.json` while the worker still has it open.

POSIX replaces an open destination silently, so this is invisible on Linux and macOS -- including in CI. Windows returns `EPERM` and the command dies. Step 1 always succeeds because the directory is fresh and nothing is reading yet; it is the second rename that fails.

### Fix

Two parts:

- The worker completes its first `touchOwnedLock()` before releasing the parent, which closes the deterministic window rather than papering over it.
- Renames of the owner files and of the registry file retry for a bounded window (2s, 10ms apart) on `EPERM`, `EACCES` and `EBUSY`. That covers the heartbeat's ongoing interval reads, and the virus scanners and search indexers that routinely hold newly created files open on Windows.

The reorder alone fixes the reported failure; the retry is defence in depth for the cases that remain genuinely racy.

### What I ruled out

Diagnosis was narrowed by testing rather than assumption:

- **Not permissions or antivirus.** Creating that exact directory and performing the identical `writeFileSync` + `renameSync` from both Node and PowerShell succeeds.
- **Not the `mode: 0o600`.** Same result without it.
- **Not a stale lock.** The directory does not exist before the run and is removed on failure; `owner.json` is never a leftover.
- **Not port selection.** `--server-port`, `--db-port`, `--instance` and `--no-seed` fail identically, because the lock is taken before ports are chosen.

### Testing

- New regression test drives the public lock API with `renameSync` refusing twice. **Verified it fails with the plain rename restored** (`Error: EPERM`), and that no other test in the file fails.
- `packages/shared` suite: 6 passed. `@paperclipai/shared` typecheck clean.
- End to end: `paperclipai worktree init --instance launcher --server-port 3200 --db-port 54400` now completes and reports `Worktree ready`, after four consecutive failures before the change.

Verified on Windows 11. The reordering is platform-neutral and the retry only engages on error codes POSIX does not produce here, but I have not run this on macOS or Linux.

Likely relevant to #11913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
