### PR TITLE
fix(acpx): keep projected secrets off the persisted session env

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1269,17 +1269,23 @@ describe("shared ACPX engine runtime behavior", () => {
         "custom-a",
       ),
     ).toBe("node ./fake-acp.js");
+    // GAM-470: a credencial de run viaja em `authCredentials`, que o acpx injeta no
+    // filho e NAO grava no registro da sessao. `sessionOptions.env` e persistido em
+    // disco, entao nao pode mais carrega-la.
+    expect(
+      (second.runtimeOptions[0]!.authCredentials as Record<string, string>).PAPERCLIP_API_KEY,
+    ).toBe("new-key");
     expect(
       (second.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env
         .PAPERCLIP_API_KEY,
-    ).toBe("new-key");
+    ).toBeUndefined();
     await expect(fs.access(path.join(stateDir, "wrappers"))).rejects.toThrow();
   });
 
   it("forwards resolved adapter env through session options without overriding runtime vars", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const { sessionInputs } = await runExecutor(
+    const { sessionInputs, runtimeOptions } = await runExecutor(
       {
         agentCommand: "node ./fake-acp.js",
         stateDir,
@@ -1301,11 +1307,19 @@ describe("shared ACPX engine runtime behavior", () => {
       },
     );
     const env = (sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env;
+    const auth = runtimeOptions[0]!.authCredentials as Record<string, string>;
+    // Configuracao comum continua no lado persistido.
     expect(env.OOGA_BOOGA_123).toBe("plain-value");
-    expect(env.OPENROUTER_API_KEY).toBe("resolved-secret-value");
     expect(env.PAPERCLIP_TASK_ID).toBe("issue-real");
-    expect(env.PAPERCLIP_API_KEY).toBe("runtime-secret-token");
-    expect(env.PAPERCLIP_CLOUD_PROVIDER_TOKEN).toBe("cloud-token");
+    // GAM-470: tudo que casa a heuristica de credencial muda de faixa. O filho recebe
+    // igual (`buildAgentEnvironment` injeta `authCredentials`), mas o registro da
+    // sessao em disco nao vê mais o valor.
+    expect(auth.OPENROUTER_API_KEY).toBe("resolved-secret-value");
+    expect(auth.PAPERCLIP_API_KEY).toBe("runtime-secret-token");
+    expect(auth.PAPERCLIP_CLOUD_PROVIDER_TOKEN).toBe("cloud-token");
+    expect(env.OPENROUTER_API_KEY).toBeUndefined();
+    expect(env.PAPERCLIP_API_KEY).toBeUndefined();
+    expect(env.PAPERCLIP_CLOUD_PROVIDER_TOKEN).toBeUndefined();
   });
 
   it("busts the session fingerprint when resolved adapter env changes but not across wakes", async () => {
@@ -1542,14 +1556,18 @@ describe("shared ACPX engine runtime behavior", () => {
       runExecutor({ agent: "custom", agentCommand: "node ./fake-acp.js" }, { authToken: "first" }),
       runExecutor({ agent: "custom", agentCommand: "node ./fake-acp.js" }, { authToken: "second" }),
     ]);
+    // GAM-470: o isolamento continua sendo por run — mudou so a faixa em que a
+    // credencial viaja, de `sessionOptions.env` (persistido) para `authCredentials`.
+    expect(
+      (first.runtimeOptions[0]!.authCredentials as Record<string, string>).PAPERCLIP_API_KEY,
+    ).toBe("first");
+    expect(
+      (second.runtimeOptions[0]!.authCredentials as Record<string, string>).PAPERCLIP_API_KEY,
+    ).toBe("second");
     expect(
       (first.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env
         .PAPERCLIP_API_KEY,
-    ).toBe("first");
-    expect(
-      (second.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env
-        .PAPERCLIP_API_KEY,
-    ).toBe("second");
+    ).toBeUndefined();
   });
 
   it("enriches acpx.error diagnostics and child stderr when ensureSession rejects", async () => {
@@ -1829,8 +1847,11 @@ describe("shared ACPX engine runtime behavior", () => {
 
   it("passes Paperclip env through ACPX session options instead of process.env", async () => {
     let observedSessionEnv: Record<string, string> | undefined;
+    let observedAuthCredentials: Record<string, string> | undefined;
     const execute = createAcpxEngineExecutor({
-      createRuntime: () => ({
+      createRuntime: (options: { authCredentials?: Record<string, string> }) => ((
+        observedAuthCredentials = options.authCredentials,
+        {
         ensureSession: async (input: { sessionOptions?: { env?: Record<string, string> } }) => {
           observedSessionEnv = input.sessionOptions?.env;
           return { backendSessionId: "backend-session", agentSessionId: "agent-session", runtimeSessionName: "runtime-session" };
@@ -1841,7 +1862,7 @@ describe("shared ACPX engine runtime behavior", () => {
           cancel: async () => {},
         }),
         close: async () => {},
-      }) as never,
+      })) as never,
     });
     const previousApiKey = process.env.PAPERCLIP_API_KEY;
     try {
@@ -1857,7 +1878,10 @@ describe("shared ACPX engine runtime behavior", () => {
         onMeta: async () => {},
       } as never);
       expect(result.exitCode).toBe(0);
-      expect(observedSessionEnv?.PAPERCLIP_API_KEY).toBe("runtime-key");
+      // GAM-470: continua NAO vindo de `process.env` — e agora tambem nao vem por
+      // `sessionOptions.env`, que o acpx grava em disco. Vem por `authCredentials`.
+      expect(observedAuthCredentials?.PAPERCLIP_API_KEY).toBe("runtime-key");
+      expect(observedSessionEnv?.PAPERCLIP_API_KEY).toBeUndefined();
       expect(process.env.PAPERCLIP_API_KEY).toBeUndefined();
     } finally {
       if (previousApiKey === undefined) delete process.env.PAPERCLIP_API_KEY;

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -56,6 +56,7 @@ import {
   removeMaintainerOnlySkillSymlinks,
   rewriteWorkspaceCwdEnvVarsForExecution,
   shapePaperclipWorkspaceEnvForExecution,
+  splitAdapterEnvForPersistence,
   stringifyPaperclipWakePayload,
   type PaperclipSkillEntry,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -387,6 +388,12 @@ interface AcpxPreparedRuntime {
   workspaceRepoUrl: string;
   workspaceRepoRef: string;
   env: Record<string, string>;
+  // `env` menos os segredos: e o unico pedaco que pode ir para `sessionOptions.env`,
+  // porque o acpx persiste esse objeto no registro da sessao (GAM-470).
+  sessionEnv: Record<string, string>;
+  // Os segredos que sairam de `sessionEnv`. Viajam por `authCredentials`, que o acpx
+  // injeta no filho e nao grava em disco.
+  authCredentials: Record<string, string>;
   loggedEnv: Record<string, string>;
   stateDir: string;
   permissionMode: "approve-all" | "approve-reads" | "deny-all";
@@ -2165,6 +2172,8 @@ async function buildRuntime(input: {
     resolvedCommand: agentCommand ?? acpxAgent,
   });
 
+  const { sessionEnv, authCredentials } = splitAdapterEnvForPersistence(env);
+
   return {
     acpxAgent,
     coalescePlaceholderToolUpdates,
@@ -2182,6 +2191,8 @@ async function buildRuntime(input: {
     workspaceRepoUrl,
     workspaceRepoRef,
     env,
+    sessionEnv,
+    authCredentials,
     loggedEnv,
     stateDir,
     permissionMode,
@@ -3532,6 +3543,10 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           // fingerprint / compat key are unaffected — this redirects ONLY the host
           // `spawn()` `chdir`, not the in-sandbox data path.
           spawnCwd: prepared.hostSpawnCwd,
+          // GAM-470: os segredos do charter vao por aqui, nao por `sessionOptions.env`.
+          // O acpx injeta `authCredentials` no ambiente do filho e NAO os grava no
+          // registro da sessao; `sessionOptions.env` e gravado e lido de volta.
+          authCredentials: prepared.authCredentials,
           sessionStore: createRuntimeStore({ stateDir: prepared.stateDir }),
           agentRegistry: prepared.agentRegistry,
           permissionMode: prepared.permissionMode,
@@ -3623,7 +3638,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
                   mode: prepared.mode,
                   cwd: prepared.cwd,
                   resumeSessionId,
-                  sessionOptions: { env: prepared.env },
+                  sessionOptions: { env: prepared.sessionEnv },
                 });
                 ensureSessionMs = now() - ensureSessionStart;
                 return established;
@@ -3654,7 +3669,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
                   agent: prepared.acpxAgent,
                   mode: prepared.mode,
                   cwd: prepared.cwd,
-                  sessionOptions: { env: prepared.env },
+                  sessionOptions: { env: prepared.sessionEnv },
                 });
                 retryEnsureSessionMs = now() - ensureSessionStart;
                 return established;

--- a/packages/adapter-utils/src/server-utils-env.test.ts
+++ b/packages/adapter-utils/src/server-utils-env.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeInheritedPaperclipEnv } from "./server-utils.js";
+import {
+  sanitizeInheritedPaperclipEnv,
+  splitAdapterEnvForPersistence,
+} from "./server-utils.js";
 
 describe("sanitizeInheritedPaperclipEnv", () => {
   it("drops the host-only Paperclip CLI command pointer", () => {
@@ -11,5 +14,64 @@ describe("sanitizeInheritedPaperclipEnv", () => {
       PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
       PATH: "/usr/bin",
     });
+  });
+});
+
+// acpx writes `sessionOptions.env` into the session record on disk and reads it back to
+// rebuild the turn client for the next turn, and its own type doc says "Do not put secrets
+// here; use authCredentials for credentials". Measured on a self-hosted deployment on
+// 2026-08-21: a `SENTRY_AUTH_TOKEN` projected through the agent config showed up in clear
+// text in the transcript, under `acpx > session_options > env`, on every run.
+//
+// Redacting at write time does NOT work: the value has to survive the round trip, or the
+// next turn is handed `***REDACTED***` as a credential. Hence the split — the secret
+// changes lane, not shape.
+describe("splitAdapterEnvForPersistence", () => {
+  it("keeps ordinary configuration persistable and moves every credential to the auth lane", () => {
+    expect(splitAdapterEnvForPersistence({
+      PATH: "/usr/bin",
+      HOME: "/home/paperclip",
+      PAPERCLIP_RUN_SCRATCH_DIR: "/tmp/paperclip-run-1",
+      SENTRY_AUTH_TOKEN: "sentry-secret",
+      PAPERCLIP_API_KEY: "run-jwt",
+      DATABASE_URL: "postgres://user:password@db/paperclip",
+    })).toEqual({
+      sessionEnv: {
+        PATH: "/usr/bin",
+        HOME: "/home/paperclip",
+        PAPERCLIP_RUN_SCRATCH_DIR: "/tmp/paperclip-run-1",
+      },
+      authCredentials: {
+        SENTRY_AUTH_TOKEN: "sentry-secret",
+        PAPERCLIP_API_KEY: "run-jwt",
+        DATABASE_URL: "postgres://user:password@db/paperclip",
+      },
+    });
+  });
+
+  it("never leaves a credential value on the lane that gets written to disk", () => {
+    const { sessionEnv } = splitAdapterEnvForPersistence({
+      PATH: "/usr/bin",
+      SENTRY_AUTH_TOKEN: "sentry-secret",
+      SOME_PASSWORD: "pw",
+      HTTP_AUTHORIZATION: "Bearer abc",
+      SESSION_COOKIE: "sid=1",
+    });
+    expect(Object.values(sessionEnv)).toEqual(["/usr/bin"]);
+  });
+
+  it("splits without losing or duplicating a key", () => {
+    const env = {
+      PATH: "/usr/bin",
+      LANG: "en_US.UTF-8",
+      SENTRY_AUTH_TOKEN: "sentry-secret",
+      PAPERCLIP_API_KEY: "run-jwt",
+    };
+    const { sessionEnv, authCredentials } = splitAdapterEnvForPersistence(env);
+    expect([...Object.keys(sessionEnv), ...Object.keys(authCredentials)].sort())
+      .toEqual(Object.keys(env).sort());
+    for (const [key, value] of Object.entries(env)) {
+      expect(sessionEnv[key] ?? authCredentials[key]).toBe(value);
+    }
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2348,6 +2348,35 @@ export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJ
   return env;
 }
 
+/**
+ * Split an adapter env into the half acpx may persist and the half it may not.
+ *
+ * acpx writes `sessionOptions.env` into the session record on disk and reads it back
+ * to rebuild the turn client on reconnect (`AcpRuntimeManager.createTurnClient` calls
+ * `sessionOptionsFromRecord(record)`), so the value has to survive a round trip — you
+ * cannot redact it on the way out without handing the next turn a redacted credential.
+ * acpx says as much in its own type docs: "persisted with the session record for
+ * reconnects (...) Do not put secrets here; use authCredentials for credentials."
+ *
+ * So anything sensitive travels on the credential lane instead. acpx injects
+ * `authCredentials` into the spawned child (`buildAgentEnvironment`) and never writes
+ * it to the record, which is exactly the split we want: the child still gets the value,
+ * the transcript does not.
+ */
+export function splitAdapterEnvForPersistence(env: Record<string, string>): {
+  sessionEnv: Record<string, string>;
+  authCredentials: Record<string, string>;
+} {
+  const sessionEnv: Record<string, string> = {};
+  const authCredentials: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== "string") continue;
+    if (SENSITIVE_ENV_KEY.test(key) || key === "DATABASE_URL") authCredentials[key] = value;
+    else sessionEnv[key] = value;
+  }
+  return { sessionEnv, authCredentials };
+}
+
 export function defaultPathForPlatform() {
   if (process.platform === "win32") {
     return "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\Wbem";

--- a/patches/acpx@0.12.0.patch
+++ b/patches/acpx@0.12.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/live-checkpoint-ClPCSdrW.js b/dist/live-checkpoint-ClPCSdrW.js
-index 243c9d13bcba520923b63adfddad75cf2d94362d..336a1699b80b9e99416f9da4346ca73ee2ad1626 100644
+index 243c9d1..ac7d09c 100644
 --- a/dist/live-checkpoint-ClPCSdrW.js
 +++ b/dist/live-checkpoint-ClPCSdrW.js
 @@ -1532,7 +1532,7 @@ const ZED_TAG_KEYS = /* @__PURE__ */ new Set([
@@ -20,9 +20,10 @@ index 243c9d13bcba520923b63adfddad75cf2d94362d..336a1699b80b9e99416f9da4346ca73e
  		current: state.current,
  		quote: state.quote,
  		escaping: true,
-@@ -3959,7 +3959,24 @@ var AcpClient = class {
--		this.attachAgentLifecycleObservers(child);
-+		this.attachAgentLifecycleObservers(child);
+@@ -3957,9 +3957,26 @@ var AcpClient = class {
+ 		this.lastAgentExit = void 0;
+ 		this.lastKnownPid = child.pid ?? void 0;
+ 		this.attachAgentLifecycleObservers(child);
 +		if (this.options.onAgentSpawn) {
 +			try {
 +				if (typeof child.pid !== "number" || child.pid <= 0) {
@@ -56,21 +57,22 @@ index 243c9d13bcba520923b63adfddad75cf2d94362d..336a1699b80b9e99416f9da4346ca73e
  	}
  	logAgentLaunch(plan) {
 diff --git a/dist/runtime.d.ts b/dist/runtime.d.ts
-index ccdbe5b032521518022223733049b8b38793473b..3d4e04231e78efeecd8540735b08e1e43547ff2d 100644
+index ccdbe5b..3aae8a3 100644
 --- a/dist/runtime.d.ts
 +++ b/dist/runtime.d.ts
-@@ -266,6 +266,9 @@ type AcpRuntimeOptions = {
+@@ -266,6 +266,10 @@ type AcpRuntimeOptions = {
    timeoutMs?: number;
    probeAgent?: string;
    verbose?: boolean;
 +  onAgentStderr?: (chunk: string) => void;
 +  onAgentSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
 +  spawnCwd?: string;
++  authCredentials?: Record<string, string>;
    onPermissionRequest?: (req: AcpPermissionRequest, ctx: {
      signal: AbortSignal;
    }) => Promise<AcpPermissionDecision | undefined>;
 diff --git a/dist/runtime.js b/dist/runtime.js
-index 6c9cc999e50a11c399c68b3a0f1b7af4bc2317c0..33b5054b2906502d1d4b512bfa259bd2ba5a9f05 100644
+index 6c9cc99..1cfff2e 100644
 --- a/dist/runtime.js
 +++ b/dist/runtime.js
 @@ -744,7 +744,8 @@ var AcpRuntimeManager = class {
@@ -78,13 +80,13 @@ index 6c9cc999e50a11c399c68b3a0f1b7af4bc2317c0..33b5054b2906502d1d4b512bfa259bd2
  	}
  	createClient(options) {
 -		return this.deps.clientFactory?.(options) ?? new AcpClient(options);
-+		const clientOptions = { ...options, onAgentStderr: this.options.onAgentStderr, onAgentSpawn: this.options.onAgentSpawn, spawnCwd: this.options.spawnCwd };
++		const clientOptions = { authCredentials: this.options.authCredentials, ...options, onAgentStderr: this.options.onAgentStderr, onAgentSpawn: this.options.onAgentSpawn, spawnCwd: this.options.spawnCwd };
 +		return this.deps.clientFactory?.(clientOptions) ?? new AcpClient(clientOptions);
  	}
  	async readPendingPersistentClient(record, options) {
  		const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
 diff --git a/dist/session-options-jkYbBxGE.d.ts b/dist/session-options-jkYbBxGE.d.ts
-index 9d37f377fb6a0828e0d2bc5a48754f3aa71509a4..680bc080fc5d6ffd266ed1b27d3d5056add9d980 100644
+index 9d37f37..67e76a6 100644
 --- a/dist/session-options-jkYbBxGE.d.ts
 +++ b/dist/session-options-jkYbBxGE.d.ts
 @@ -84,6 +84,9 @@ type AcpClientOptions = {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Secrets Manager gives each agent only the credentials it needs, projected into the agent environment.
> - The acpx engine passes that whole environment to acpx as `sessionOptions.env`.
> - acpx persists `sessionOptions.env` with the session record on disk and reads it back to rebuild the turn client on reconnect.
> - Every projected credential is therefore written to disk in clear text and stays in the transcript.
> - acpx documents the correct lane on its own type: `authCredentials` is injected into the child and never persisted.
> - This pull request splits the adapter environment so credentials travel on `authCredentials` and only ordinary configuration is persisted.
> - The benefit is that per-agent secret scoping survives all the way to disk, instead of ending at the process boundary.

## Linked Issues or Issue Description

No existing issue found. Searched `authCredentials`, `persisted session env secret`, and `secret transcript session record` in this repository and found no open or closed duplicate. Describing the bug in-PR, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

The acpx engine passes the full adapter environment to acpx as `sessionOptions.env`. acpx persists that object with the session record and reads it back on reconnect. Every credential projected into an agent environment is written to disk in clear text and remains in the session record.

**Expected behavior**

A credential projected into an agent environment must reach the agent process, and must not be written to the persisted session record. Ordinary configuration can still be persisted, because it must survive the reconnect round trip.

**Steps to reproduce**

1. Configure a self-hosted server with an acpx-engine adapter.
2. Project any secret into the agent configuration environment, for example `SENTRY_AUTH_TOKEN`.
3. Start an agent run.
4. Read the session record on disk under the acpx state directory.
5. Observe the secret value in clear text at `acpx > session_options > env`.

**Paperclip version or commit**

Reproduced from `master` at `dc5b070`.

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Every adapter that uses the acpx engine.

## What Changed

- Add `splitAdapterEnvForPersistence` to `server-utils`. It splits an adapter environment in two using the existing `SENSITIVE_ENV_KEY` test, plus `DATABASE_URL`.
- The acpx engine computes the split once in `buildRuntime` and exposes `sessionEnv` and `authCredentials` on the prepared runtime.
- Both `ensureSession` call sites now send `sessionOptions: { env: prepared.sessionEnv }` instead of the full environment.
- The runtime options now carry `authCredentials`, which acpx injects into the spawned child and never writes to the session record.
- Extend `patches/acpx@0.12.0.patch` so `AcpRuntimeManager` forwards `authCredentials` from the runtime options into the client options, which is where `buildAgentEnvironment` consumes it. Without this the option is accepted and then dropped.
- Add tests for the split and for the two `ensureSession` call sites.

Redacting at write time was considered and does not work. `createTurnClient` rebuilds the next turn with `sessionOptionsFromRecord(record)`, so a redacted record hands the agent `***REDACTED***` as a credential. The secret has to change lane, not shape.

## Verification

- `npx vitest run packages/adapter-utils/src/server-utils-env.test.ts packages/adapter-utils/src/acpx-engine/execute.test.ts` — 2 files, 135 tests, all pass on `master` at `dc5b070`.
- `pnpm install` applies the updated acpx patch cleanly; the installed `acpx/dist/runtime.js` contains the forwarding.
- On a self-hosted deployment, a `SENTRY_AUTH_TOKEN` projected through an agent configuration appeared in clear text under `acpx > session_options > env` in every new transcript before the change.

## Risks

Low, with one behavioral note. The split is by environment variable NAME, using the existing `SENSITIVE_ENV_KEY` regular expression. A credential whose name does not match that pattern, for example a service-account JSON in a variable named without `key`, `token`, or `secret`, stays on the persisted lane exactly as it does today. This pull request does not make that case worse, and a test documents the boundary.

The `authCredentials` forwarding in the acpx patch is additive and spreads before `...options`, so an explicit per-call value still wins.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing documentation covers this internal lane
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not yet run at the time of opening
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not yet run at the time of opening
- [x] I will address all Greptile and reviewer comments before requesting merge
