### PR TITLE
fix(recovery): a review path must be maintained to count as an action path

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -445,6 +445,12 @@ export interface IssueReviewAttentionPath {
   responder: string | null;
   since: string | null;
   ref: string | null;
+  /**
+   * True when the path still exists but has gone quiet for longer than its kind allows,
+   * so it no longer satisfies the action-path requirement. Stale paths are still listed
+   * so the board can see which reviewer or interaction went quiet.
+   */
+  stale?: boolean;
 }
 
 export interface IssueReviewAttention {

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -327,13 +327,19 @@ describeEmbeddedPostgres("attention service", () => {
       relatedIssueId: blockerParentId,
       type: "blocks",
     });
+    // Both of these cover a review that still has a *live* participant, so their
+    // freshness is load-bearing: a participant path ages out after
+    // REVIEW_PATH_STALE_AFTER_MS, and a stalled review enters the feed whatever its
+    // participant type. Pinning them to a fixed past date meant they drifted into
+    // "stalled" as the calendar moved, which is the opposite of what each asserts.
+    const recentlyTouched = new Date(Date.now() - 60_000);
     const reviewUserIssueId = await insertIssue({
       companyId,
       identifier: "ATN-6",
       title: "Human review",
       status: "in_review",
       executionState: pendingUserExecutionState(),
-      updatedAt: new Date("2026-07-09T12:06:00.000Z"),
+      updatedAt: recentlyTouched,
     });
     await insertIssue({
       companyId,
@@ -341,7 +347,7 @@ describeEmbeddedPostgres("attention service", () => {
       title: "Agent review excluded",
       status: "in_review",
       executionState: pendingAgentExecutionState(reviewerId),
-      updatedAt: new Date("2026-07-09T12:07:00.000Z"),
+      updatedAt: recentlyTouched,
     });
 
     const pendingApprovalId = randomUUID();

--- a/server/src/__tests__/issue-liveness.test.ts
+++ b/server/src/__tests__/issue-liveness.test.ts
@@ -628,3 +628,144 @@ describe("issue graph liveness classifier", () => {
     });
   });
 });
+
+describe("in_review action-path staleness", () => {
+  const reviewIssueId = "review-1";
+  const now = new Date("2026-08-22T00:00:00.000Z");
+
+  function agedReview(overrides: Record<string, unknown>, updatedAt: string) {
+    return issue({
+      id: reviewIssueId,
+      identifier: "PAP-2279",
+      title: "Screenshot acceptance review",
+      status: "in_review",
+      assigneeAgentId: coderId,
+      executionState: null,
+      updatedAt,
+      ...overrides,
+    });
+  }
+
+  function classify(issueInput: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+    return classifyIssueGraphLiveness({
+      issues: [issueInput],
+      relations: [],
+      agents: [agent(), manager],
+      now,
+      ...extra,
+    });
+  }
+
+  it("flags a review whose human reviewer has gone quiet past the bound", () => {
+    // The BRO-1631 shape: assigned to a person, untouched for weeks, and previously
+    // reported as covered forever because a `human_reviewer` path existed.
+    const findings = classify(
+      agedReview({ assigneeAgentId: coderId, assigneeUserId: "board-user-1" }, "2026-07-27T00:00:00.000Z"),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      state: "in_review_without_action_path",
+      recoveryIssueId: reviewIssueId,
+    });
+    expect(findings[0]?.reason).toContain("human_reviewer");
+  });
+
+  it("leaves a recent human reviewer alone", () => {
+    const findings = classify(
+      agedReview({ assigneeAgentId: coderId, assigneeUserId: "board-user-1" }, "2026-08-21T00:00:00.000Z"),
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a review whose only user participant has gone quiet past the bound", () => {
+    const findings = classify(
+      agedReview(
+        {
+          assigneeUserId: null,
+          executionState: { status: "pending", currentParticipant: { type: "user", userId: "board-user-1" } },
+        },
+        "2026-07-28T00:00:00.000Z",
+      ),
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ state: "in_review_without_action_path" });
+    expect(findings[0]?.reason).toContain("execution_participant");
+  });
+
+  it("flags a review whose only interaction has sat unanswered past the bound", () => {
+    const findings = classify(agedReview({}, "2026-08-01T00:00:00.000Z"), {
+      pendingInteractions: [
+        { companyId, issueId: reviewIssueId, status: "pending", createdAt: "2026-08-01T00:00:00.000Z" },
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toContain("interaction");
+  });
+
+  it("flags a queued wake that never started", () => {
+    // A wake request row is a path only while it is plausibly about to run. Left queued
+    // for a day it is a dead path that still reads as coverage.
+    const findings = classify(agedReview({}, "2026-08-20T00:00:00.000Z"), {
+      queuedWakeRequests: [
+        { companyId, issueId: reviewIssueId, agentId: coderId, status: "queued", createdAt: "2026-08-20T00:00:00.000Z" },
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.reason).toContain("queued_wake");
+  });
+
+  it("keeps a live path authoritative when a stale one sits beside it", () => {
+    const findings = classify(
+      agedReview({ assigneeUserId: "board-user-1" }, "2026-07-27T00:00:00.000Z"),
+      {
+        activeRuns: [
+          { companyId, issueId: reviewIssueId, agentId: coderId, status: "running", createdAt: "2026-08-21T23:00:00.000Z" },
+        ],
+      },
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it("exempts a scheduled monitor, which bounds itself through maxAttempts", () => {
+    const findings = classify(
+      agedReview(
+        {
+          executionPolicy: { monitor: { maxAttempts: 5 } },
+          monitorNextCheckAt: "2026-08-22T06:00:00.000Z",
+          monitorAttemptCount: 1,
+        },
+        "2026-07-01T00:00:00.000Z",
+      ),
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it("does not call any path stale when the issue carries no updatedAt", () => {
+    // Callers that do not supply updatedAt keep the previous behaviour.
+    const findings = classifyIssueGraphLiveness({
+      issues: [
+        issue({
+          id: reviewIssueId,
+          identifier: "PAP-2279",
+          title: "Screenshot acceptance review",
+          status: "in_review",
+          assigneeAgentId: coderId,
+          assigneeUserId: "board-user-1",
+          executionState: null,
+        }),
+      ],
+      relations: [],
+      agents: [agent(), manager],
+      now,
+    });
+
+    expect(findings).toEqual([]);
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3075,6 +3075,7 @@ async function listIssueReviewAttentionMap(
       executionState: issue.executionState,
       monitorNextCheckAt: issue.monitorNextCheckAt,
       monitorAttemptCount: issue.monitorAttemptCount,
+      updatedAt: issue.updatedAt,
     })),
     relations: [],
     agents: agentRows,
@@ -3151,16 +3152,20 @@ async function listIssueReviewAttentionMap(
           ? (path.since instanceof Date ? path.since : new Date(path.since)).toISOString()
           : issue.updatedAt.toISOString(),
         ref: path.ref,
+        stale: path.stale,
       };
     });
 
-    if (paths.length > 0) {
+    // "Maintained" is the operative word: a path that exists but has gone quiet past its
+    // kind's bound is reported, but it does not make the review covered.
+    const livePaths = paths.filter((path) => !path.stale);
+    if (livePaths.length > 0) {
       result.set(issue.id, {
         state: "covered",
         paths,
-        reason: paths.length === 1
+        reason: livePaths.length === 1
           ? "Review has a maintained action path."
-          : `Review has ${paths.length} maintained action paths.`,
+          : `Review has ${livePaths.length} maintained action paths.`,
       });
       continue;
     }
@@ -3168,8 +3173,13 @@ async function listIssueReviewAttentionMap(
     const finding = findingsByIssueId.get(issue.id);
     result.set(issue.id, {
       state: "stalled",
-      paths: [],
-      reason: finding?.reason ?? "Issue is in review without a maintained action path.",
+      // Keep the stale paths on the response so the board can see what went quiet
+      // instead of just being told nothing is there.
+      paths,
+      reason: finding?.reason
+        ?? (paths.length > 0
+          ? `Review has ${paths.length === 1 ? "an action path that has" : "action paths that have"} gone stale, so nothing will wake it.`
+          : "Issue is in review without a maintained action path."),
     });
   }
 

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -28,6 +28,7 @@ export interface IssueLivenessIssueInput {
   executionState?: Record<string, unknown> | null;
   monitorNextCheckAt?: Date | string | null;
   monitorAttemptCount?: number | null;
+  updatedAt?: Date | string | null;
 }
 
 export interface IssueLivenessRelationInput {
@@ -79,7 +80,44 @@ export interface IssueReviewPathFact {
   agentId: string | null;
   userId: string | null;
   since: Date | string | null;
+  /**
+   * True when this path still exists as a row but has gone quiet for longer than its
+   * kind allows. A stale path is reported so callers can explain *what* went quiet,
+   * but it does not satisfy the action-path requirement.
+   */
+  stale: boolean;
 }
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * How long a review path may go without progress before it stops counting as a
+ * maintained action path.
+ *
+ * The action-path requirement is checked when an issue enters `in_review`, but the
+ * paths it accepts are not self-renewing: a human reviewer can simply never look, a
+ * board interaction can sit unanswered, a queued wake can fail to start. Nothing about
+ * those outcomes changes the issue's status, so an entry-only check never runs again
+ * and the issue keeps claiming a reviewer it does not have. Bounding each kind by age
+ * turns the requirement into an invariant that decays back to `stalled` on its own.
+ *
+ * Kinds absent from this map are exempt because they already carry their own bound:
+ * `monitor` burns `maxAttempts`/`timeoutAt` (see `hasScheduledIssueMonitorPath`), and
+ * `recovery` points at an open recovery issue that has its own liveness classification.
+ */
+export const REVIEW_PATH_STALE_AFTER_MS: Partial<Record<IssueReviewPathFactKind, number>> = {
+  // Waits on a person or a board decision. A reviewer taking a day or two is normal; one
+  // who has not moved in three days is not reviewing, and the issue should say so.
+  human_reviewer: 3 * DAY_MS,
+  execution_participant: 3 * DAY_MS,
+  interaction: 3 * DAY_MS,
+  approval: 3 * DAY_MS,
+  // In-flight execution. These represent work that is supposed to be happening now, so a
+  // row still sitting here a day later means the run never started or never finished.
+  active_run: DAY_MS,
+  queued_wake: DAY_MS,
+};
 
 export interface IssueLivenessDependencyPathEntry {
   issueId: string;
@@ -208,6 +246,27 @@ export function hasScheduledIssueMonitorPath(issue: IssueLivenessIssueInput, now
   return true;
 }
 
+/**
+ * True when a path of this kind, last touched at `since`, has gone quiet for longer
+ * than its kind allows. Paths that carry no timestamp of their own are measured from
+ * the issue's own `updatedAt`: any comment, status change, or reassignment refreshes
+ * it, so "the issue has not moved since X" is the right clock for a wait that has no
+ * other progress signal. An issue with no `updatedAt` at all is never called stale,
+ * so callers that do not supply it keep the previous behaviour.
+ */
+function isReviewPathStale(
+  kind: IssueReviewPathFactKind,
+  since: Date | string | null,
+  issue: IssueLivenessIssueInput,
+  nowMs: number,
+) {
+  const staleAfterMs = REVIEW_PATH_STALE_AFTER_MS[kind];
+  if (staleAfterMs === undefined) return false;
+  const sinceMs = readDateMs(since) ?? readDateMs(issue.updatedAt);
+  if (sinceMs === null) return false;
+  return nowMs - sinceMs > staleAfterMs;
+}
+
 export function classifyIssueReviewPaths(
   input: IssueGraphLivenessInput,
   issue: IssueLivenessIssueInput,
@@ -216,9 +275,12 @@ export function classifyIssueReviewPaths(
   const nowMs = readDateMs(input.now ?? new Date()) ?? Date.now();
   const agentsById = new Map(input.agents.map((agent) => [agent.id, agent]));
   const paths: IssueReviewPathFact[] = [];
+  const push = (fact: Omit<IssueReviewPathFact, "stale">) => {
+    paths.push({ ...fact, stale: isReviewPathStale(fact.kind, fact.since, issue, nowMs) });
+  };
 
   if (issue.assigneeUserId) {
-    paths.push({
+    push({
       kind: "human_reviewer",
       ref: issue.assigneeUserId,
       agentId: null,
@@ -234,7 +296,7 @@ export function classifyIssueReviewPaths(
   if (participantAgentId) {
     const participantAgent = agentsById.get(participantAgentId);
     if (participantAgent?.companyId === issue.companyId && isInvokableAgent(participantAgent, agentsById)) {
-      paths.push({
+      push({
         kind: "execution_participant",
         ref: participantAgentId,
         agentId: participantAgentId,
@@ -244,7 +306,7 @@ export function classifyIssueReviewPaths(
     }
   } else if (principalIsResolvableUser(participant)) {
     const userId = (participant as Record<string, unknown>).userId as string;
-    paths.push({
+    push({
       kind: "execution_participant",
       ref: userId,
       agentId: null,
@@ -254,7 +316,7 @@ export function classifyIssueReviewPaths(
   }
 
   if (hasScheduledIssueMonitorPath(issue, nowMs)) {
-    paths.push({ kind: "monitor", ref: null, agentId: issue.assigneeAgentId ?? null, userId: null, since: null });
+    push({ kind: "monitor", ref: null, agentId: issue.assigneeAgentId ?? null, userId: null, since: null });
   }
 
   const appendExecutionPaths = (
@@ -263,7 +325,7 @@ export function classifyIssueReviewPaths(
   ) => {
     for (const entry of entries) {
       if (entry.companyId !== issue.companyId || entry.issueId !== issue.id) continue;
-      paths.push({
+      push({
         kind,
         ref: entry.id ?? null,
         agentId: entry.agentId ?? null,
@@ -281,7 +343,7 @@ export function classifyIssueReviewPaths(
   ) => {
     for (const entry of entries) {
       if (entry.companyId !== issue.companyId || entry.issueId !== issue.id) continue;
-      paths.push({
+      push({
         kind,
         ref: entry.id ?? null,
         agentId: null,
@@ -526,7 +588,11 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
     dependencyPath: IssueLivenessIssueInput[],
   ): IssueLivenessFinding | null {
     if (reviewIssue.status !== "in_review") return null;
-    if (classifyIssueReviewPaths(input, reviewIssue).length > 0) return null;
+    // Only a live path counts. A stale one is still reported on the issue so the board
+    // can see which reviewer went quiet, but it must not suppress the finding.
+    const reviewPaths = classifyIssueReviewPaths(input, reviewIssue);
+    if (reviewPaths.some((path) => !path.stale)) return null;
+    const stalePathKinds = [...new Set(reviewPaths.map((path) => path.kind))].sort();
 
     const ownerCandidates = ownerCandidatesForRecoveryIssue(reviewIssue, input.agents, agentsById, {
       includeStalledAssignee: true,
@@ -557,9 +623,15 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
       });
     }
 
-    if (principalIsResolvableUser(participant)) return null;
+    // A resolvable user participant is a real path only while it is live. If it is live
+    // the issue is fine; if it has gone stale the issue is stranded on a person who is
+    // not coming back, which is `in_review_without_action_path` below — not an invalid
+    // participant. `invalid_review_participant` stays reserved for a participant that
+    // cannot be resolved at all, so a resolvable one must not fall into that branch.
+    const hasResolvableUserParticipant = principalIsResolvableUser(participant);
+    if (hasResolvableUserParticipant && stalePathKinds.length === 0) return null;
 
-    if (hasPendingExecutionState) {
+    if (hasPendingExecutionState && !hasResolvableUserParticipant) {
       return finding({
         issue: source,
         state: "invalid_review_participant",
@@ -573,12 +645,18 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
       });
     }
 
-    if (!reviewIssue.assigneeAgentId || reviewIssue.assigneeUserId) return null;
+    // An issue with neither an agent assignee nor a stale path to explain has no next
+    // action to describe here; other states cover the unowned shapes. But once a path
+    // has gone stale the issue is stranded no matter who it is assigned to, so a user
+    // assignee no longer suppresses the finding.
+    if (!reviewIssue.assigneeAgentId && stalePathKinds.length === 0) return null;
 
     return finding({
       issue: source,
       state: "in_review_without_action_path",
-      reason: `${issueLabel(reviewIssue)} is in review with an agent assignee but no participant, interaction, approval, user owner, wake, active run, or recovery issue owning the next action.`,
+      reason: stalePathKinds.length > 0
+        ? `${issueLabel(reviewIssue)} is in review, but every path owning the next action has gone stale (${stalePathKinds.join(", ")}). Nothing will wake it.`
+        : `${issueLabel(reviewIssue)} is in review with an agent assignee but no participant, interaction, approval, user owner, wake, active run, or recovery issue owning the next action.`,
       dependencyPath,
       recoveryIssue: reviewIssue,
       recommendedOwnerCandidateAgentIds: ownerCandidates.map((candidate) => candidate.agentId),
@@ -613,11 +691,15 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
       });
     }
 
-    if (hasExplicitWaitingPath(blocker)) return null;
-
+    // `in_review` is classified by `reviewFinding` first, because it applies the
+    // staleness rule that `hasExplicitWaitingPath` does not. Checking the coarse gate
+    // first would let a blocked chain mask a stranded review that the same issue would
+    // report as stranded at top level — two gates disagreeing about one invariant.
     if (blocker.status === "in_review") {
       return reviewFinding(source, blocker, dependencyPath);
     }
+
+    if (hasExplicitWaitingPath(blocker)) return null;
 
     if (blocker.status === "backlog" && blocker.assigneeAgentId) {
       return finding({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5461,6 +5461,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         executionState: issues.executionState,
         monitorNextCheckAt: issues.monitorNextCheckAt,
         monitorAttemptCount: issues.monitorAttemptCount,
+        updatedAt: issues.updatedAt,
       })
       .from(issues)
       .where(


### PR DESCRIPTION
## The defect

The action-path requirement is enforced when an issue **enters** `in_review`, but the paths it accepts are not self-renewing. `classifyIssueReviewPaths` asks only whether a path row *exists*, never whether it has *moved*. A reviewer going quiet does not change the issue's status, so the entry guard never runs again and the issue keeps claiming a reviewer it does not have.

`covered` was, in effect, a liveness claim with no liveness check.

## Measurement

On a live board: **24 issues in `in_review`, all 24 reported `covered`** — while 8 of them had been idle for 4 to 26 days.

| idle | paths holding it `covered` |
|---|---|
| 26d | `human_reviewer` |
| 25d | `human_reviewer`, `execution_participant`, `interaction` |
| 17d | `human_reviewer` |
| 15d | `human_reviewer`, `execution_participant` |
| 10d | `human_reviewer` |
| 7d | `interaction` |
| 6d | `human_reviewer` |
| 4d | `interaction` |

`human_reviewer` is the clearest case: it is set once, nothing renews it, and nothing wakes the human. It held a 26-day-old issue `covered` indefinitely.

## The change

Bound each path kind by age (`REVIEW_PATH_STALE_AFTER_MS`): 3 days for waits on a person or a board decision (`human_reviewer`, `execution_participant`, `interaction`, `approval`), 24h for in-flight execution (`active_run`, `queued_wake`) — a wake still queued a day later never started.

`monitor` and `recovery` are **exempt**: they already carry their own bound (`maxAttempts`/`timeoutAt`, and a recovery issue with its own liveness classification).

A stale path is still **reported** — a new `stale` flag on `IssueReviewAttentionPath`, and the kinds are named in the finding's reason — so the board sees *which* reviewer went quiet instead of being told nothing is there.

Two adjacent corrections fall out:

- `blockedFindingForLeaf` checked the coarse `hasExplicitWaitingPath` gate *before* `reviewFinding`, so a blocked chain could mask a stranded review that the same issue reported as stranded at top level — two gates disagreeing about one invariant. `in_review` is now classified by `reviewFinding` first.
- A resolvable-but-stale user participant fell through to `invalid_review_participant`, which is meant for a participant that cannot be resolved *at all*. It is now `in_review_without_action_path`.

## Blast radius

- **Backward compatible by construction:** an issue with no `updatedAt` supplied is never called stale, so callers that do not pass it keep the previous behaviour exactly.
- **Auto-recovery is unaffected by default.** `enableIssueGraphLivenessAutoRecovery` defaults to `false`, so on a default instance this changes only the *read model* (`reviewAttention`) — no new escalations are created.
- **It does raise the human attention feed's volume**, deliberately: `attention.ts` already admits any `stalled` review regardless of participant type, and this makes more reviews honestly stalled. That is the intended effect — those issues had no wake path — but it is a real change in queue volume and worth a maintainer's opinion on the 3-day default.

## Relationship to #11917

Complementary, not overlapping. #11917 fixes the *escalation window* (a self-stranded finding aged out of the lookback and was never escalated). This fixes the step before it: for the worst cases the classifier never emitted a finding at all, because a stale path suppressed it. Both are needed for a stranded review to actually reach someone.

## Tests

- 8 new cases in `issue-liveness.test.ts`: stale human reviewer, fresh human reviewer, stale user participant, unanswered interaction, never-started queued wake, a live path beating a stale one, monitor exemption, and the no-`updatedAt` compatibility case.
- Regression sweep: **1719 tests across 114 files** (issue/review/recovery/attention/decision/heartbeat) pass. `shared`, `server`, and `ui` typecheck clean; `check:tokens` and `check:token-gates` clean.

### Category safeguard

The attention-service fixtures pinned `updatedAt` to a fixed past date, so "live participant" cases silently drifted toward stale as the calendar moved — the test would have started failing on its own regardless of this change. They now derive freshness from the clock and say why in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)