### PR TITLE
fix(agents): list running live-runs before queued ones

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -5017,7 +5017,10 @@ export function agentRoutes(
           inArray(heartbeatRuns.status, ["queued", "running"]),
         ),
       )
-      .orderBy(desc(heartbeatRuns.createdAt));
+      // Running runs must never be crowded out of a size-limited page by a
+      // backlog of newer queued ones — a caller asking for "live runs" wants
+      // to see what's actually cooking before what's merely waiting.
+      .orderBy(sql`CASE WHEN ${heartbeatRuns.status} = 'running' THEN 0 ELSE 1 END`, desc(heartbeatRuns.createdAt));
 
     const liveRuns = await liveRunsQuery.limit(limit);
     const targetRunCount = Math.min(minCount, limit);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators watch agent activity through the company live-runs endpoint, which feeds the dashboard, the sidebar, the Agents page and the issue pages
> - The endpoint orders queued and running runs by creation time, newest first, and then cuts the list to a limit
> - A backlog of queued runs is normal, and queued runs are usually newer than the runs that are running now
> - So the queued backlog pushes the running runs out of the list, and the dashboard shows queued runs instead of the agents that work now
> - This pull request orders running runs before queued runs, before the limit applies
> - The benefit is that each caller of the endpoint always sees the running runs first

## Linked Issues or Issue Description

No issue exists for this bug. The description below follows the bug report template.

**What happened?**

`GET /api/companies/:companyId/live-runs` (`server/src/routes/agents.ts`) selects runs with status `queued` or `running`. It orders them by `createdAt` desc and then applies `limit`. The limit is 50 at most, and 50 is the default. All first-party callers use the default limit.

The dashboard panel (`ui/src/components/ActiveAgentsPanel.tsx`) keeps only the first 4 rows on the client. When a company has 4 or more queued runs that are newer than its running runs, the dashboard shows only queued runs. The running runs do not show. With 50 or more newer queued runs, the running runs are not in the response at all, so the sidebar and the Agents page also count them as not running.

Production evidence (anonymised): one company had 41 queued runs and 4 running runs at the same time. A queued backlog of this size is normal: each issue gets one run, and the runs wait behind `maxConcurrentRuns = 1`. Thus the correct fix is the order of the list, not a change to the scheduler.

**Expected behavior**

The endpoint returns running runs first. The queued runs follow. Each group stays newest first.

**Steps to reproduce**

1. Use a company with one agent that has `maxConcurrentRuns = 1`.
2. Start one run for the agent, so that the run is `running`.
3. Queue 4 or more new runs for the agent, for example by assigning 4 issues to it.
4. Open the dashboard. The "Agents" panel shows the 4 newest queued runs. The running run does not show.

**Paperclip version or commit**

`master` at `352153b5e`.

**Deployment mode**

Any. The ordering is in the server route.

Related: #4945 (live-runs `minCount` default), #8271 (task status shows `Queued`, not only `Live`), #4379 (queued-run count on System Health), #11394 (finished runs shown as live on the dashboard). These touch the same endpoint or panel. None of them changes the order of running and queued runs.

## What Changed

- `server/src/routes/agents.ts`: order the live-runs query by `CASE WHEN status = 'running' THEN 0 ELSE 1 END`, then by `createdAt` desc. The limit, the `minCount` fill of recent finished runs, and the response shape do not change.
- `server/src/__tests__/agent-live-runs-ordering-routes.test.ts` (new): an embedded Postgres route test. It seeds 2 running runs and 55 newer queued runs for one company. It calls the route with the default limit. It asserts that the page has 50 rows, that the first 2 rows are the running runs (newest first), and that the next 48 rows are the newest queued runs (newest first).

I chose a route test on a real database instead of an `orderBy` capture in `agent-live-run-routes.test.ts`. The capture would check only the SQL text. The real database checks the result that the dashboard gets, with the limit applied.

## Verification

- `cd server && npx vitest run src/__tests__/agent-live-runs-ordering-routes.test.ts src/__tests__/agent-live-run-routes.test.ts` — 61 passed (1 new, 60 existing).
- Without the fix in `agents.ts`, the new test fails: the first 2 rows are queued runs.
- `pnpm typecheck` — passed (35 workspace projects).

## Risks

- Low risk. The change affects only the order of rows in one read-only endpoint.
- Behavior change: a caller that expects strict `createdAt` order across both statuses now gets running runs first. No first-party caller depends on strict `createdAt` order across statuses.
- No migration and no API schema change. The query uses the existing filter on `company_id` and `status`, so the cost does not change in a meaningful way.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Opus 5 (claude-opus-5), 1M context window, via Claude Code with tool use (code editing, shell, test execution)
- The first commit (the route change) was drafted with Claude Sonnet 5, via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
