### PR TITLE
Auto-provision the agent JWT secret for local_trusted servers

### DIFF
--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -1,6 +1,13 @@
 import { createHmac } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createLocalAgentJwt, verifyLocalAgentJwt } from "../agent-auth-jwt.js";
+import {
+  createLocalAgentJwt,
+  ensureLocalTrustedAgentJwtSecret,
+  verifyLocalAgentJwt,
+} from "../agent-auth-jwt.js";
 
 describe("agent local JWT", () => {
   const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
@@ -315,5 +322,77 @@ describe("agent local JWT", () => {
       adapter_type: "claude_local",
       run_id: "run-1",
     });
+  });
+});
+
+describe("ensureLocalTrustedAgentJwtSecret", () => {
+  const secretEnv = "PAPERCLIP_AGENT_JWT_SECRET";
+  const betterAuthSecretEnv = "BETTER_AUTH_SECRET";
+  const originalEnv = {
+    secret: process.env[secretEnv],
+    betterAuthSecret: process.env[betterAuthSecretEnv],
+  };
+  let tempDir: string;
+
+  beforeEach(() => {
+    delete process.env[secretEnv];
+    delete process.env[betterAuthSecretEnv];
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "agent-jwt-secret-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalEnv.secret === undefined) delete process.env[secretEnv];
+    else process.env[secretEnv] = originalEnv.secret;
+    if (originalEnv.betterAuthSecret === undefined) delete process.env[betterAuthSecretEnv];
+    else process.env[betterAuthSecretEnv] = originalEnv.betterAuthSecret;
+  });
+
+  it("is a no-op when a secret is already in the environment", () => {
+    process.env[secretEnv] = "already-set";
+    const envFilePath = path.join(tempDir, ".env");
+    const result = ensureLocalTrustedAgentJwtSecret(envFilePath);
+    expect(result.source).toBe("process_env");
+    expect(existsSync(envFilePath)).toBe(false);
+    expect(process.env[secretEnv]).toBe("already-set");
+  });
+
+  it("treats BETTER_AUTH_SECRET as a sufficient signing secret", () => {
+    process.env[betterAuthSecretEnv] = "better-auth-secret";
+    const envFilePath = path.join(tempDir, ".env");
+    const result = ensureLocalTrustedAgentJwtSecret(envFilePath);
+    expect(result.source).toBe("process_env");
+    expect(existsSync(envFilePath)).toBe(false);
+  });
+
+  it("loads an existing env-file secret into the environment", () => {
+    const envFilePath = path.join(tempDir, ".env");
+    writeFileSync(envFilePath, "PAPERCLIP_INSTANCE_ID=default\nPAPERCLIP_AGENT_JWT_SECRET=file-secret\n");
+    const result = ensureLocalTrustedAgentJwtSecret(envFilePath);
+    expect(result.source).toBe("env_file");
+    expect(process.env[secretEnv]).toBe("file-secret");
+  });
+
+  it("generates and persists a secret when none exists, preserving other entries", () => {
+    const envFilePath = path.join(tempDir, ".env");
+    writeFileSync(envFilePath, "PAPERCLIP_INSTANCE_ID=default\n");
+    const result = ensureLocalTrustedAgentJwtSecret(envFilePath);
+    expect(result.source).toBe("generated");
+    const generated = process.env[secretEnv];
+    expect(generated).toMatch(/^[0-9a-f]{64}$/);
+    const contents = readFileSync(envFilePath, "utf8");
+    expect(contents).toContain("PAPERCLIP_INSTANCE_ID=default");
+    expect(contents).toContain(`PAPERCLIP_AGENT_JWT_SECRET=${generated}`);
+    // The generated secret must produce working run tokens end to end.
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+    expect(token).not.toBeNull();
+    expect(verifyLocalAgentJwt(token!)).toMatchObject({ sub: "agent-1" });
+  });
+
+  it("creates the env file when it does not exist yet", () => {
+    const envFilePath = path.join(tempDir, "nested", ".env");
+    const result = ensureLocalTrustedAgentJwtSecret(envFilePath);
+    expect(result.source).toBe("generated");
+    expect(readFileSync(envFilePath, "utf8")).toContain("PAPERCLIP_AGENT_JWT_SECRET=");
   });
 });

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -1,6 +1,10 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { parse as parseEnvFileContents } from "dotenv";
 import { normalizeAgentApiKeyScope, type AgentApiKeyScope } from "@paperclipai/shared";
+import { updateEnvFileContents, writeEnvFileAtomicallyIfChanged } from "@paperclipai/shared/env-file";
 import { resolvePaperclipInstanceId } from "./home-paths.js";
+import { resolvePaperclipEnvPath } from "./paths.js";
 
 interface JwtHeader {
   alg: string;
@@ -117,6 +121,49 @@ function safeCompare(a: string, b: string) {
   const right = Buffer.from(b);
   if (left.length !== right.length) return false;
   return timingSafeEqual(left, right);
+}
+
+export type AgentJwtSecretBootstrap = {
+  source: "process_env" | "env_file" | "generated";
+  envFilePath: string;
+};
+
+/**
+ * Guarantees the local agent JWT secret exists for a local_trusted instance.
+ *
+ * Without a secret, `createLocalAgentJwt` returns null and every heartbeat run
+ * spawns with no PAPERCLIP_API_KEY — the agent's unauthenticated API writes are
+ * then attributed to the implicit local board actor (human-authored chat
+ * bubbles, board-attributed comments). Onboarding via the CLI provisions the
+ * secret, but servers started directly (`pnpm dev`, launchd) previously only
+ * got a startup-banner warning, so a missing secret silently poisoned every
+ * run's attribution. Mirrors `ensureAgentJwtSecret` in cli/src/config/env.ts.
+ */
+export function ensureLocalTrustedAgentJwtSecret(
+  envFilePath = resolvePaperclipEnvPath(),
+): AgentJwtSecretBootstrap {
+  if (process.env.PAPERCLIP_AGENT_JWT_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim()) {
+    return { source: "process_env", envFilePath };
+  }
+
+  const previousContents = existsSync(envFilePath) ? readFileSync(envFilePath, "utf8") : null;
+  const fileSecret = previousContents
+    ? parseEnvFileContents(previousContents).PAPERCLIP_AGENT_JWT_SECRET?.trim()
+    : undefined;
+  if (fileSecret) {
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = fileSecret;
+    return { source: "env_file", envFilePath };
+  }
+
+  const secret = randomBytes(32).toString("hex");
+  const nextContents = updateEnvFileContents(
+    previousContents ?? "",
+    { PAPERCLIP_AGENT_JWT_SECRET: secret },
+    { valueEncoding: "minimal" },
+  );
+  writeEnvFileAtomicallyIfChanged(envFilePath, previousContents, nextContents);
+  process.env.PAPERCLIP_AGENT_JWT_SECRET = secret;
+  return { source: "generated", envFilePath };
 }
 
 export function createLocalAgentJwt(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -85,6 +85,7 @@ import { isLoopbackHost, rewriteLoopbackUrlPort } from "./url-utils.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
+import { ensureLocalTrustedAgentJwtSecret } from "./agent-auth-jwt.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
@@ -595,6 +596,13 @@ export async function startServer(): Promise<StartedServer> {
     | undefined;
   if (config.deploymentMode === "local_trusted") {
     await ensureLocalTrustedBoardPrincipal(db as any);
+    const agentJwtSecretBootstrap = ensureLocalTrustedAgentJwtSecret();
+    if (agentJwtSecretBootstrap.source !== "process_env") {
+      logger.info(
+        { source: agentJwtSecretBootstrap.source, envFilePath: agentJwtSecretBootstrap.envFilePath },
+        "Provisioned PAPERCLIP_AGENT_JWT_SECRET for local_trusted agent runs",
+      );
+    }
   }
   const accessBackfill = await backfillPrincipalAccessCompatibility(db as any);
   if (accessBackfill.agentMembershipsInserted > 0 || accessBackfill.humanGrantsInserted > 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15954,14 +15954,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
-        await appendRunEvent(currentRun, seq++, {
-          eventType: "adapter.auth_token_missing",
-          stream: "system",
-          level: "warn",
-          message:
-            "Agent JWT secret is missing; this run has no PAPERCLIP_API_KEY, so unauthenticated API writes would be attributed to the board instead of the agent.",
-          payload: { adapterType: agent.adapterType },
-        });
+        try {
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "adapter.auth_token_missing",
+            stream: "system",
+            level: "warn",
+            message:
+              "Agent JWT secret is missing; this run has no PAPERCLIP_API_KEY, so unauthenticated API writes would be attributed to the board instead of the agent.",
+            payload: { adapterType: agent.adapterType },
+          });
+        } catch (err) {
+          // The event is purely diagnostic; a persistence failure must not
+          // prevent the adapter from launching.
+          logger.warn(
+            { runId: run.id, err },
+            "failed to persist adapter.auth_token_missing run event",
+          );
+        }
       }
       let adapterFinalizeOutcome: "succeeded" | "failed" | null = null;
       const inspectFinalizeWorkspaceBranch = async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15954,6 +15954,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
+        await appendRunEvent(currentRun, seq++, {
+          eventType: "adapter.auth_token_missing",
+          stream: "system",
+          level: "warn",
+          message:
+            "Agent JWT secret is missing; this run has no PAPERCLIP_API_KEY, so unauthenticated API writes would be attributed to the board instead of the agent.",
+          payload: { adapterType: agent.adapterType },
+        });
       }
       let adapterFinalizeOutcome: "succeeded" | "failed" | null = null;
       const inspectFinalizeWorkspaceBranch = async () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server signs a short-lived JWT for each agent run and injects it as `PAPERCLIP_API_KEY`, so agent API writes are attributed to the agent
> - The signing secret only comes from `PAPERCLIP_AGENT_JWT_SECRET` or `BETTER_AUTH_SECRET`; CLI onboarding writes it, but a server started directly (`pnpm dev`, a supervisor) can run without it
> - Without the secret, every run spawns with no `PAPERCLIP_API_KEY`; in `local_trusted` mode the agent's unauthenticated writes become the implicit local-board human actor, so agent chat messages render as human-authored blue bubbles
> - The only signal was one startup-banner line and a server-log warn; nothing repaired the state, so the misattribution continued on every run
> - This pull request makes `local_trusted` startup provision the secret itself and makes a credential-less run spawn visible in the run log
> - The benefit is that agent writes always authenticate as the agent, so agent messages can no longer be misattributed to the human board

## Linked Issues or Issue Description

**What happened?**
An agent's chat messages appeared as human-authored blue bubbles. The server had no `PAPERCLIP_AGENT_JWT_SECRET` and no `BETTER_AUTH_SECRET`, so `createLocalAgentJwt` returned null and each run spawned without `PAPERCLIP_API_KEY`. The agent's API writes carried no credentials. In `local_trusted` mode, a request without credentials is the implicit local-board human actor, so the writes were stored as human-authored.

**Expected behavior**
Agent messages are always attributed to the agent. A missing signing secret must not silently downgrade attribution; the server should repair the state or fail loudly.

**Steps to reproduce**
1. Configure a `local_trusted` instance whose env file has no `PAPERCLIP_AGENT_JWT_SECRET`, and do not set `BETTER_AUTH_SECRET`.
2. Start the server directly with `pnpm dev` (skip `paperclipai onboard`).
3. Let an agent heartbeat run post an issue comment with `curl` using `$PAPERCLIP_API_KEY`.
4. The variable is empty, the write is unauthenticated, and the comment renders as a human (blue) message.

## What Changed

- `server/src/agent-auth-jwt.ts`: new `ensureLocalTrustedAgentJwtSecret()`. It reuses a secret already in the environment, loads one from the resolved `.paperclip/.env`, or generates a 32-byte secret and persists it there atomically. Mirrors `ensureAgentJwtSecret` in `cli/src/config/env.ts`.
- `server/src/index.ts`: `local_trusted` startup calls the new function, so the secret always exists before the first heartbeat run spawns.
- `server/src/services/heartbeat.ts`: when a JWT-capable adapter spawns without an auth token, the run now records a warn run event in addition to the server-log warn, so the misconfiguration is visible in the run log UI.
- `server/src/__tests__/agent-auth-jwt.test.ts`: five new tests for the bootstrap paths (env no-op, `BETTER_AUTH_SECRET` no-op, env-file load, generate-and-persist with round-trip token verification, env-file creation).

## Verification

- `pnpm vitest run src/__tests__/agent-auth-jwt.test.ts` in `server/` — 22 tests pass.
- `pnpm tsc --noEmit` in `server/` — clean.
- Manual: on an instance with no secret in `.paperclip/.env`, start the server; the file gains `PAPERCLIP_AGENT_JWT_SECRET`, and the next agent run's environment contains a working `PAPERCLIP_API_KEY` (verify with `curl -H "Authorization: Bearer $PAPERCLIP_API_KEY" .../api/agents/me`).

## Risks

- Low risk. The bootstrap only runs in `local_trusted` mode and only when no secret exists anywhere, which is exactly the state that misattributes writes today.
- The env file is written atomically with mode 0600 and other entries are preserved.
- E2E is unaffected: the Playwright config pins its own `PAPERCLIP_AGENT_JWT_SECRET`, so the process-env no-op path applies.
- Worktree provisioning already copies the secret from the source instance env, so shared-secret instances keep one secret; per-instance signing-key derivation still separates forks from the live plane.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), extended thinking, tool use via Claude Code / Claude Agent SDK.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
