### PR TITLE
fix(acpx): attribute cost events to the model the session ran, not the model it requested

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1068,6 +1068,84 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(statusLine?.text).toContain('"cost"');
   });
 
+  it.each([
+    {
+      name: "attributes the run to the model the ACP session reports when no model is configured",
+      currentModelId: "claude-fable-5[1m]",
+      configModel: undefined as string | undefined,
+      expectedModel: "claude-fable-5[1m]" as string | null,
+      expectedSource: "session",
+    },
+    {
+      name: "prefers the session model over a configured model that was not honored",
+      currentModelId: "claude-sonnet-4-6",
+      configModel: "claude-sonnet-5" as string | undefined,
+      expectedModel: "claude-sonnet-4-6" as string | null,
+      expectedSource: "session",
+    },
+    {
+      name: "falls back to the configured model when the session only offers the picker placeholder",
+      currentModelId: "default",
+      configModel: "claude-opus-5" as string | undefined,
+      expectedModel: "claude-opus-5" as string | null,
+      expectedSource: "requested",
+    },
+    {
+      name: "reports no model rather than the placeholder when nothing resolves",
+      currentModelId: "default",
+      configModel: undefined as string | undefined,
+      expectedModel: null as string | null,
+      expectedSource: "unknown",
+    },
+  ])("$name", async ({ currentModelId, configModel, expectedModel, expectedSource }) => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const execute = createAcpxEngineExecutor({
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        getStatus: async () => ({
+          models: { currentModelId, availableModelIds: ["default", currentModelId] },
+        }),
+        // A configured model reaches a non-claude/codex agent through
+        // set_config_option, so the runtime must advertise the control.
+        setConfigOption: async () => {},
+        startTurn: () => ({
+          events: (async function* () {
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const result = await execute({
+      runId: "run-model-attribution",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "custom",
+        agentCommand: "node ./fake-acp.js",
+        stateDir,
+        ...(configModel ? { model: configModel } : {}),
+      },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.model).toBe(expectedModel);
+    expect((result.resultJson as Record<string, unknown>)?.modelSource).toBe(expectedSource);
+    // The request stays recorded separately so a request/actual mismatch is auditable.
+    expect((result.resultJson as Record<string, unknown>)?.requestedModel).toBe(configModel ?? null);
+  });
+
   it("falls back to usage_update events when the runtime lacks getStatus", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -84,6 +84,7 @@ import {
   DEFAULT_ACP_ENGINE_TIMEOUT_SEC,
   DEFAULT_ACP_ENGINE_WARM_HANDLE_IDLE_MS,
 } from "./constants.js";
+import { resolveAcpxEffectiveModel } from "./model-attribution.js";
 import type {
   AcpRunContext,
   AcquiredRunResources,
@@ -3885,6 +3886,11 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
       // scoped hoisted local, so the settlement `endSession` step can cancel it.
       let runPrompt = "";
       let preTurnStatus: AcpRuntimeStatus | null = null;
+      // The model this run is billed against, resolved from the session rather
+      // than echoed from the request so runs that leave `config.model` unset are
+      // still attributable. Seeded with the request so a failure before the
+      // pre-turn snapshot still reports what it can.
+      let effectiveModel = resolveAcpxEffectiveModel({ requestedModel: prepared.requestedModel });
       // Phase-timing markers for the prepare_turn and turn phases. The prepare
       // phase covers the prompt build and the pre-turn usage snapshot; the turn
       // phase covers the started turn and the event relay.
@@ -3954,6 +3960,12 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         // Snapshot pre-turn usage so cumulative agent-reported cost can be
         // attributed to this run alone.
         preTurnStatus = await readRuntimeStatus(runtime, sessionHandle);
+        // The same snapshot carries the session's advertised model state, so a
+        // turn that fails before the post-turn read still attributes correctly.
+        effectiveModel = resolveAcpxEffectiveModel({
+          preStatus: preTurnStatus,
+          requestedModel: prepared.requestedModel,
+        });
         // The prepare phase (prompt build + usage snapshot) finished; the turn
         // phase starts next.
         await emitPhase("prepare_turn", preparePhaseStart, "ok");
@@ -4005,6 +4017,13 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         const timedOut = input.timedOut;
         // Read usage before the settlement can discard runtime state.
         const postTurnStatus = await readRuntimeStatus(runtime, sessionHandle);
+        // Re-resolve against the post-turn snapshot: a mid-run model switch
+        // lands here, and this is the model the completed turn actually ran on.
+        effectiveModel = resolveAcpxEffectiveModel({
+          postStatus: postTurnStatus,
+          preStatus: preTurnStatus,
+          requestedModel: prepared.requestedModel,
+        });
         const turnUsage = summarizeAcpxTurnUsage({
           preStatus: preTurnStatus,
           postStatus: postTurnStatus,
@@ -4059,7 +4078,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           sessionDisplayId: sessionHandle.agentSessionId ?? sessionHandle.backendSessionId ?? sessionHandle.runtimeSessionName,
           ...billingFields,
           ...referencedProjectStagingFailuresField,
-          model: prepared.requestedModel || null,
+          model: effectiveModel.model,
           ...(turnUsage.usage ? { usage: turnUsage.usage, usageBasis: "per_run" as const } : {}),
           costUsd: turnUsage.costUsd,
           resultJson: {
@@ -4067,6 +4086,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             stopReason: terminalStopReason,
             permissionMode: prepared.permissionMode,
             mode: prepared.mode,
+            modelSource: effectiveModel.source,
             requestedModel: prepared.requestedModel || null,
             requestedThinkingEffort: prepared.requestedThinkingEffort || null,
             fastMode: prepared.fastMode,
@@ -4169,9 +4189,9 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           errorMeta: emitted?.classified.errorMeta,
           ...billingFields,
           ...referencedProjectStagingFailuresField,
-          model: prepared.requestedModel || null,
+          model: effectiveModel.model,
           clearSession: clearSession || timedOut,
-          resultJson: { phase },
+          resultJson: { phase, modelSource: effectiveModel.source },
           summary: message,
         };
         // Return a typed failed completion so the coordinator settles for a cause

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -3890,7 +3890,10 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
       // than echoed from the request so runs that leave `config.model` unset are
       // still attributable. Seeded with the request so a failure before the
       // pre-turn snapshot still reports what it can.
-      let effectiveModel = resolveAcpxEffectiveModel({ requestedModel: prepared.requestedModel });
+      let effectiveModel = resolveAcpxEffectiveModel({
+        requestedModel: prepared.requestedModel,
+        acpxAgent: prepared.acpxAgent,
+      });
       // Phase-timing markers for the prepare_turn and turn phases. The prepare
       // phase covers the prompt build and the pre-turn usage snapshot; the turn
       // phase covers the started turn and the event relay.
@@ -3965,6 +3968,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         effectiveModel = resolveAcpxEffectiveModel({
           preStatus: preTurnStatus,
           requestedModel: prepared.requestedModel,
+          acpxAgent: prepared.acpxAgent,
         });
         // The prepare phase (prompt build + usage snapshot) finished; the turn
         // phase starts next.
@@ -4023,6 +4027,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           postStatus: postTurnStatus,
           preStatus: preTurnStatus,
           requestedModel: prepared.requestedModel,
+          acpxAgent: prepared.acpxAgent,
         });
         const turnUsage = summarizeAcpxTurnUsage({
           preStatus: preTurnStatus,

--- a/packages/adapter-utils/src/acpx-engine/model-attribution.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/model-attribution.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { AcpRuntimeStatus } from "acpx/runtime";
 
-import { readAcpxSessionModelId, resolveAcpxEffectiveModel } from "./model-attribution.js";
+import {
+  readAcpxSessionModelId,
+  resolveAcpxEffectiveModel,
+  resolveClaudeAcpModelId,
+} from "./model-attribution.js";
 
 function statusWithModel(currentModelId: string | undefined): AcpRuntimeStatus {
   return {
@@ -11,6 +15,50 @@ function statusWithModel(currentModelId: string | undefined): AcpRuntimeStatus {
     },
   } as AcpRuntimeStatus;
 }
+
+function claudeStatus(currentModelId: string): AcpRuntimeStatus {
+  return {
+    models: { currentModelId, availableModelIds: ["default", "opus[1m]", "sonnet", "haiku"] },
+    details: {
+      configOptions: [
+        {
+          id: "model",
+          type: "select",
+          currentValue: currentModelId,
+          options: [
+            {
+              value: "default",
+              name: "Default (recommended)",
+              description: "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+            },
+            {
+              value: "opus[1m]",
+              name: "Opus",
+              description: "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+            },
+            { value: "sonnet", name: "Sonnet", description: "Sonnet 5 · Efficient for routine tasks" },
+            { value: "haiku", name: "Haiku", description: "Haiku 4.5 · Fastest for quick answers" },
+          ],
+        },
+      ],
+    },
+  } as AcpRuntimeStatus;
+}
+
+describe("resolveClaudeAcpModelId", () => {
+  it.each([
+    ["default", "claude-opus-4-8[1m]"],
+    ["opus[1m]", "claude-opus-4-8[1m]"],
+    ["sonnet", "claude-sonnet-5"],
+    ["haiku", "claude-haiku-4-5"],
+  ])("canonicalizes the Claude ACP picker value %s", (selected, expected) => {
+    expect(resolveClaudeAcpModelId(claudeStatus(selected), selected)).toBe(expected);
+  });
+
+  it("does not guess when the ACP server omits resolved family/version metadata", () => {
+    expect(resolveClaudeAcpModelId(statusWithModel("sonnet"), "sonnet")).toBeNull();
+  });
+});
 
 describe("readAcpxSessionModelId", () => {
   it("returns the concrete model id the session reports", () => {
@@ -37,6 +85,14 @@ describe("readAcpxSessionModelId", () => {
   it("returns null when currentModelId is not a string", () => {
     const status = { models: { currentModelId: 42, availableModelIds: [] } } as unknown as AcpRuntimeStatus;
     expect(readAcpxSessionModelId(status)).toBeNull();
+  });
+
+  it("resolves Claude's default picker to its canonical model from config metadata", () => {
+    expect(readAcpxSessionModelId(claudeStatus("default"), "claude")).toBe("claude-opus-4-8[1m]");
+  });
+
+  it("canonicalizes Claude's semantic aliases from config metadata", () => {
+    expect(readAcpxSessionModelId(claudeStatus("sonnet"), "claude")).toBe("claude-sonnet-5");
   });
 });
 
@@ -68,6 +124,12 @@ describe("resolveAcpxEffectiveModel", () => {
         preStatus: statusWithModel("claude-fable-5[1m]"),
       }),
     ).toEqual({ model: "claude-fable-5[1m]", source: "session" });
+  });
+
+  it("attributes an unconfigured Claude run to the concrete default advertised by its ACP server", () => {
+    expect(
+      resolveAcpxEffectiveModel({ postStatus: claudeStatus("default"), acpxAgent: "claude" }),
+    ).toEqual({ model: "claude-opus-4-8[1m]", source: "session" });
   });
 
   it("falls back to the requested model when no session model state exists", () => {

--- a/packages/adapter-utils/src/acpx-engine/model-attribution.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/model-attribution.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { AcpRuntimeStatus } from "acpx/runtime";
+
+import { readAcpxSessionModelId, resolveAcpxEffectiveModel } from "./model-attribution.js";
+
+function statusWithModel(currentModelId: string | undefined): AcpRuntimeStatus {
+  return {
+    models: {
+      currentModelId,
+      availableModelIds: ["default", "opus[1m]", "claude-fable-5[1m]", "sonnet", "haiku"],
+    },
+  } as AcpRuntimeStatus;
+}
+
+describe("readAcpxSessionModelId", () => {
+  it("returns the concrete model id the session reports", () => {
+    expect(readAcpxSessionModelId(statusWithModel("claude-fable-5[1m]"))).toBe("claude-fable-5[1m]");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(readAcpxSessionModelId(statusWithModel("  claude-sonnet-4-6 "))).toBe("claude-sonnet-4-6");
+  });
+
+  it.each(["default", "Default", "DEFAULT", "auto", "unknown", "", "   "])(
+    "rejects the placeholder id %j so it is never recorded as a model",
+    (placeholder) => {
+      expect(readAcpxSessionModelId(statusWithModel(placeholder))).toBeNull();
+    },
+  );
+
+  it("returns null when the session advertises no model state", () => {
+    expect(readAcpxSessionModelId({} as AcpRuntimeStatus)).toBeNull();
+    expect(readAcpxSessionModelId(null)).toBeNull();
+    expect(readAcpxSessionModelId(undefined)).toBeNull();
+  });
+
+  it("returns null when currentModelId is not a string", () => {
+    const status = { models: { currentModelId: 42, availableModelIds: [] } } as unknown as AcpRuntimeStatus;
+    expect(readAcpxSessionModelId(status)).toBeNull();
+  });
+});
+
+describe("resolveAcpxEffectiveModel", () => {
+  it("prefers the post-turn session model over the request", () => {
+    expect(
+      resolveAcpxEffectiveModel({
+        postStatus: statusWithModel("opus[1m]"),
+        preStatus: statusWithModel("sonnet"),
+        requestedModel: "claude-sonnet-5",
+      }),
+    ).toEqual({ model: "opus[1m]", source: "session" });
+  });
+
+  it("falls back to the pre-turn session model when the post-turn read fails", () => {
+    expect(
+      resolveAcpxEffectiveModel({
+        postStatus: null,
+        preStatus: statusWithModel("claude-sonnet-4-6"),
+        requestedModel: "claude-sonnet-5",
+      }),
+    ).toEqual({ model: "claude-sonnet-4-6", source: "session" });
+  });
+
+  it("skips a placeholder post-turn model in favour of a concrete pre-turn one", () => {
+    expect(
+      resolveAcpxEffectiveModel({
+        postStatus: statusWithModel("default"),
+        preStatus: statusWithModel("claude-fable-5[1m]"),
+      }),
+    ).toEqual({ model: "claude-fable-5[1m]", source: "session" });
+  });
+
+  it("falls back to the requested model when no session model state exists", () => {
+    expect(
+      resolveAcpxEffectiveModel({
+        postStatus: statusWithModel("default"),
+        preStatus: statusWithModel(""),
+        requestedModel: "claude-opus-5",
+      }),
+    ).toEqual({ model: "claude-opus-5", source: "requested" });
+  });
+
+  it("reports unknown rather than a placeholder when neither source resolves", () => {
+    expect(
+      resolveAcpxEffectiveModel({
+        postStatus: statusWithModel("default"),
+        preStatus: null,
+        requestedModel: "",
+      }),
+    ).toEqual({ model: null, source: "unknown" });
+  });
+
+  it("treats a whitespace-only requested model as absent", () => {
+    expect(resolveAcpxEffectiveModel({ requestedModel: "   " })).toEqual({
+      model: null,
+      source: "unknown",
+    });
+  });
+
+  it("recovers attribution for the unset-config case that produced model='unknown'", () => {
+    // Agents that leave `adapterConfig.model` unset let the ACP server pick. The
+    // engine used to report only the (empty) request, so every cost event they
+    // produced was recorded as `unknown` even though the session knew the model.
+    const beforeFix = { model: "", source: "unknown" };
+    const afterFix = resolveAcpxEffectiveModel({
+      postStatus: statusWithModel("claude-fable-5[1m]"),
+      requestedModel: "",
+    });
+    expect(beforeFix.model || null).toBeNull();
+    expect(afterFix).toEqual({ model: "claude-fable-5[1m]", source: "session" });
+  });
+});

--- a/packages/adapter-utils/src/acpx-engine/model-attribution.ts
+++ b/packages/adapter-utils/src/acpx-engine/model-attribution.ts
@@ -1,0 +1,64 @@
+import type { AcpRuntimeStatus } from "acpx/runtime";
+
+import { isPlaceholderModelId } from "../model-identity.js";
+
+export type AcpxModelSource = "session" | "requested" | "unknown";
+
+export interface AcpxEffectiveModel {
+  /** The model to attribute the run to, or null when it cannot be determined. */
+  model: string | null;
+  /** Where `model` came from, so downstream cost auditing can tell resolved attribution from an echo of the request. */
+  source: AcpxModelSource;
+}
+
+/**
+ * Read the concrete model id the ACP session reports it is running, or null
+ * when the session only offers a placeholder. `AcpRuntimeStatus.models` is
+ * sourced from the persisted session record's advertised model state, which the
+ * ACP server populates from `session/new` and `set_config_option` responses —
+ * so it reflects the model actually in effect rather than the one requested.
+ *
+ * `claude-agent-acp` advertises `default` as the first entry of its model list
+ * and reports it back as `currentModelId` whenever no concrete model was
+ * selected; the runtime also normalizes a missing id to the empty string.
+ * Neither identifies the model a turn ran on, so neither is returned here.
+ */
+export function readAcpxSessionModelId(status: AcpRuntimeStatus | null | undefined): string | null {
+  const currentModelId = status?.models?.currentModelId;
+  if (isPlaceholderModelId(currentModelId)) return null;
+  return (currentModelId as string).trim();
+}
+
+/**
+ * Resolve which model a run should be billed against.
+ *
+ * The ACP engine used to report `config.model` verbatim, which is the model the
+ * run *asked for*, not the one it *got*. Agents that leave `adapterConfig.model`
+ * unset — a supported configuration that lets the ACP server pick its own
+ * default — therefore reported no model at all, and every cost event they
+ * produced was recorded as `unknown`. Reading the session's own current model
+ * back recovers attribution for those runs.
+ *
+ * Preference order:
+ *  1. the post-turn session model — what the turn actually ran on;
+ *  2. the pre-turn session model — the session's state before the turn, used
+ *     when the post-turn read fails (the runtime can be torn down first);
+ *  3. the requested model — a correct answer whenever the request was honored,
+ *     and the only signal available when the session advertises no model state;
+ *  4. null — the run genuinely ran on an unidentified model. The caller records
+ *     that as `unknown` rather than guessing.
+ */
+export function resolveAcpxEffectiveModel(input: {
+  postStatus?: AcpRuntimeStatus | null;
+  preStatus?: AcpRuntimeStatus | null;
+  requestedModel?: string | null;
+}): AcpxEffectiveModel {
+  const sessionModel =
+    readAcpxSessionModelId(input.postStatus) ?? readAcpxSessionModelId(input.preStatus);
+  if (sessionModel) return { model: sessionModel, source: "session" };
+
+  const requested = typeof input.requestedModel === "string" ? input.requestedModel.trim() : "";
+  if (requested) return { model: requested, source: "requested" };
+
+  return { model: null, source: "unknown" };
+}

--- a/packages/adapter-utils/src/acpx-engine/model-attribution.ts
+++ b/packages/adapter-utils/src/acpx-engine/model-attribution.ts
@@ -11,6 +11,66 @@ export interface AcpxEffectiveModel {
   source: AcpxModelSource;
 }
 
+interface AcpxSelectOption {
+  value?: unknown;
+  name?: unknown;
+  description?: unknown;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readClaudeModelFamily(value: string): string | null {
+  const match = value.match(/\b(opus|sonnet|haiku|fable|mythos)\b/i);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function readClaudeModelVersion(value: string): string | null {
+  const match = value.match(/\b(?:opus|sonnet|haiku|fable|mythos)\s+(\d+(?:\.\d+)*)\b/i);
+  return match?.[1]?.replaceAll(".", "-") ?? null;
+}
+
+/**
+ * Resolve a Claude ACP picker value to the concrete model described by the
+ * server's model config option. Claude's ACP server intentionally exposes
+ * semantic values such as `default`, `sonnet`, and `opus[1m]`; their option
+ * metadata carries the resolved family/version (for example "Opus 4.8 with 1M
+ * context"). Reading that metadata avoids a hard-coded alias table that would
+ * silently go stale the next time Claude's default advances.
+ */
+export function resolveClaudeAcpModelId(
+  status: AcpRuntimeStatus | null | undefined,
+  selectedModelId: string,
+): string | null {
+  const details = asRecord(status?.details);
+  const configOptions = details?.configOptions;
+  if (!Array.isArray(configOptions)) return null;
+
+  const modelOption = configOptions
+    .map(asRecord)
+    .find((option) => option?.id === "model");
+  if (!modelOption || !Array.isArray(modelOption.options)) return null;
+
+  const selected = modelOption.options
+    .map(asRecord)
+    .find((option): option is Record<string, unknown> => option?.value === selectedModelId);
+  if (!selected) return null;
+
+  const option = selected as AcpxSelectOption;
+  const text = [option.name, option.description]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+  const family = readClaudeModelFamily(text);
+  const version = readClaudeModelVersion(text);
+  if (!family || !version) return null;
+
+  const contextSuffix = /\b1m\b/i.test(`${selectedModelId} ${text}`) ? "[1m]" : "";
+  return `claude-${family}-${version}${contextSuffix}`;
+}
+
 /**
  * Read the concrete model id the ACP session reports it is running, or null
  * when the session only offers a placeholder. `AcpRuntimeStatus.models` is
@@ -23,10 +83,19 @@ export interface AcpxEffectiveModel {
  * selected; the runtime also normalizes a missing id to the empty string.
  * Neither identifies the model a turn ran on, so neither is returned here.
  */
-export function readAcpxSessionModelId(status: AcpRuntimeStatus | null | undefined): string | null {
+export function readAcpxSessionModelId(
+  status: AcpRuntimeStatus | null | undefined,
+  acpxAgent?: string,
+): string | null {
   const currentModelId = status?.models?.currentModelId;
-  if (isPlaceholderModelId(currentModelId)) return null;
-  return (currentModelId as string).trim();
+  if (typeof currentModelId !== "string" || !currentModelId.trim()) return null;
+  const trimmed = currentModelId.trim();
+  if (acpxAgent === "claude") {
+    const resolved = resolveClaudeAcpModelId(status, trimmed);
+    if (resolved) return resolved;
+  }
+  if (isPlaceholderModelId(trimmed)) return null;
+  return trimmed;
 }
 
 /**
@@ -52,9 +121,11 @@ export function resolveAcpxEffectiveModel(input: {
   postStatus?: AcpRuntimeStatus | null;
   preStatus?: AcpRuntimeStatus | null;
   requestedModel?: string | null;
+  acpxAgent?: string;
 }): AcpxEffectiveModel {
   const sessionModel =
-    readAcpxSessionModelId(input.postStatus) ?? readAcpxSessionModelId(input.preStatus);
+    readAcpxSessionModelId(input.postStatus, input.acpxAgent) ??
+    readAcpxSessionModelId(input.preStatus, input.acpxAgent);
   if (sessionModel) return { model: sessionModel, source: "session" };
 
   const requested = typeof input.requestedModel === "string" ? input.requestedModel.trim() : "";

--- a/packages/adapter-utils/src/model-identity.test.ts
+++ b/packages/adapter-utils/src/model-identity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlaceholderModelId, normalizeRecordedModelId, UNKNOWN_MODEL_ID } from "./model-identity.js";
+
+describe("isPlaceholderModelId", () => {
+  it.each(["default", "Default", " AUTO ", "none", "unknown", "", "   "])(
+    "treats %j as a selection policy, not a model",
+    (value) => {
+      expect(isPlaceholderModelId(value)).toBe(true);
+    },
+  );
+
+  it.each([null, undefined])("treats %j as unattributed", (value) => {
+    expect(isPlaceholderModelId(value)).toBe(true);
+  });
+
+  it.each(["claude-sonnet-5", "claude-fable-5[1m]", "opus[1m]", "gpt-5.6-sol", "sonnet", "haiku"])(
+    "accepts the real model id %j",
+    (value) => {
+      expect(isPlaceholderModelId(value)).toBe(false);
+    },
+  );
+});
+
+describe("normalizeRecordedModelId", () => {
+  it("passes a real model id through, trimmed", () => {
+    expect(normalizeRecordedModelId("  claude-opus-5 ")).toBe("claude-opus-5");
+  });
+
+  it.each(["default", "auto", "none", "", null, undefined])(
+    "records %j as unknown so the attribution gap stays visible",
+    (value) => {
+      expect(normalizeRecordedModelId(value)).toBe(UNKNOWN_MODEL_ID);
+    },
+  );
+
+  it("never returns an empty string, so the not-null model column always has a value", () => {
+    for (const value of ["", "   ", null, undefined, "default"]) {
+      expect(normalizeRecordedModelId(value).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/adapter-utils/src/model-identity.ts
+++ b/packages/adapter-utils/src/model-identity.ts
@@ -1,0 +1,34 @@
+/**
+ * The value recorded on a cost event when the model a run used could not be
+ * determined. Callers should prefer a real model id; this exists so the ledger
+ * distinguishes "not attributed" from a plausible-looking wrong answer.
+ */
+export const UNKNOWN_MODEL_ID = "unknown";
+
+/**
+ * Model ids that identify a *selection policy* rather than a model. Agent model
+ * pickers advertise these (ACP's `default`, "auto" routing modes), and an
+ * adapter that echoes one back would put a string into the cost ledger that
+ * looks like a model but cannot be priced, compared, or audited — which is
+ * strictly worse than recording nothing, because it hides the gap.
+ */
+const PLACEHOLDER_MODEL_IDS = new Set(["default", "auto", "none", "unknown"]);
+
+/** True when the id names a selection policy instead of a model. */
+export function isPlaceholderModelId(model: string | null | undefined): boolean {
+  if (typeof model !== "string") return true;
+  const trimmed = model.trim();
+  return !trimmed || PLACEHOLDER_MODEL_IDS.has(trimmed.toLowerCase());
+}
+
+/**
+ * Normalize an adapter-reported model id for the cost ledger.
+ *
+ * Every adapter result reaching the ledger goes through here so no adapter —
+ * present or future — can record a picker placeholder as a model. A run whose
+ * model cannot be identified is recorded as `unknown`, which the model-attribution
+ * audit can find and act on; a run recorded as `default` would be invisible.
+ */
+export function normalizeRecordedModelId(model: string | null | undefined): string {
+  return isPlaceholderModelId(model) ? UNKNOWN_MODEL_ID : (model as string).trim();
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -288,6 +288,7 @@ import {
   UNMANAGED_BACKGROUND_TASK_STOP_REASON,
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
+import { normalizeRecordedModelId } from "@paperclipai/adapter-utils/model-identity";
 import { extractSkillMentionIds, isUuidLike } from "@paperclipai/shared";
 import { evaluateCodexCredentialReadiness } from "@paperclipai/adapter-codex-local/server";
 import { environmentService } from "./environments.js";
@@ -13971,7 +13972,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         biller,
         billingType,
         costStatus,
-        model: result.model ?? "unknown",
+        // Normalize rather than `?? "unknown"`: an adapter that echoes a model
+        // picker's placeholder id would otherwise write a string into the ledger
+        // that looks like a model but cannot be priced or audited.
+        model: normalizeRecordedModelId(result.model),
         inputTokens,
         cachedInputTokens,
         outputTokens,
@@ -16401,7 +16405,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               configFreshness: configFreshnessResultMetadata,
               provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
               biller: resolveLedgerBiller(adapterResult),
-              model: readNonEmptyString(adapterResult.model) ?? "unknown",
+              model: normalizeRecordedModelId(adapterResult.model),
               ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
               ...(cacheAdjustedCostUsd != null ? { cacheAdjustedCostUsd } : {}),
               costStatus: resolveLedgerCostStatus({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip meters agent spend. Each finished run writes one `cost_events` row with the model that ran.
> - The shared ACPX engine reported the model from `config.model`. That is the model a run asks for, not the model it gets.
> - `adapterConfig.model` is optional. When it is not set, the ACP server selects its own model. Those runs reported no model, and the ledger recorded them as `unknown`.
> - ACP is the default engine, so this applies to almost all runs. The Claude CLI lane is correct, because it reads the model back off the stream.
> - This pull request reads the model back from the ACP session, and rejects model-picker placeholder ids at the ledger write site.
> - The benefit is that spend reports, budgets, and model audits show the model that ran.

## Linked Issues or Issue Description

No open issue covers this. The problem follows the bug report template.

Related: Refs #8810 (a different defect on the same `adapterConfig.model` path).

**What happened?**

Agents that do not set `adapterConfig.model` record every cost event with `model = "unknown"`. On one 30-day sample this was 7 agent rows across 4 companies. The correlation is exact: every agent with an unset model recorded `unknown`, and every agent with a model recorded that model.

The cause is in the shared ACPX engine. `packages/adapter-utils/src/acpx-engine/execute.ts` builds each result with `model: prepared.requestedModel || null`, and `prepared.requestedModel` is `asString(config.model, "").trim()`. So the engine reports the request. When the request is empty, it reports nothing, and `server/src/services/heartbeat.ts` writes `"unknown"`.

The Claude CLI lane does not have this defect. `packages/adapters/claude-local/src/server/execute.ts` resolves `parsedStream.model || parsed.model || config.model`, so it reports the model the run used. ACP is the default engine, so the broken lane is the one that runs almost everything.

**Expected behavior**

A run that leaves the model unset is still attributed to the model the ACP session ran.

**Steps to reproduce**

1. Configure a `claude_local` agent and leave `adapterConfig.model` unset. The engine defaults to ACP.
2. Run one heartbeat.
3. Read the `cost_events` row for the run. Before this change `model` is `unknown`.
4. Read the ACP session record for the same session. `acpx.current_model_id` holds the model, for example `claude-fable-5[1m]`.

**Paperclip version or commit**

Branched from `master` at 3ff636bc4.

**Agent adapter(s) involved**

Claude Code, Codex. The defect is in the shared ACPX engine, so it applies to every adapter that uses the ACP lane.

## What Changed

- Add `packages/adapter-utils/src/acpx-engine/model-attribution.ts`. `resolveAcpxEffectiveModel()` prefers the post-turn session model, then the pre-turn session model, then the requested model, then none.
- Read the model from `AcpRuntimeStatus.models.currentModelId`. The ACPX runtime fills this from the advertised model state of the session record. The engine already reads this status before and after each turn for usage accounting, so the change adds no new calls to the runtime.
- Use the resolved model for the two ACPX results that a session produced. Results that fail before a session exists keep the requested model, because no better value exists yet.
- Record `resultJson.modelSource` (`session`, `requested`, or `unknown`). An audit can then tell a resolved model from an echo of the request.
- Add `packages/adapter-utils/src/model-identity.ts`. `normalizeRecordedModelId()` rejects model ids that name a selection policy instead of a model.
- Use that guard at the `cost_events` write site in `server/src/services/heartbeat.ts`, in place of `?? "unknown"`.

**Why the placeholder guard is necessary.** `claude-agent-acp` advertises `default` in its model list and reports `default` as `currentModelId` when no model was selected. A session record from a live install shows `available_models: ["default", "opus[1m]", "claude-fable-5[1m]", "sonnet", "haiku"]`. A naive read-back would write `default` into the ledger. That string looks like a model but cannot be priced, compared, or audited, so it hides the gap that `unknown` makes visible.

**Category safeguard.** The ledger guard rejects generic placeholders for every adapter. Claude ACP attribution additionally resolves picker aliases from the live model option metadata, so a default change does not require a hard-coded alias-table update.

**Post-deploy follow-up.** Production sampling showed that ACP session state can expose `default`, `sonnet`, and `opus[1m]`. The resolver now reads the selected option metadata (for example, `Opus 4.8 with 1M context` or `Sonnet 5`) to emit canonical ids such as `claude-opus-4-8[1m]` and `claude-sonnet-5`. This resolves both remaining failure modes: `default` no longer becomes `unknown`, and semantic picker aliases no longer split model groupings. Missing family/version metadata still fails closed to `unknown` rather than guessing.

## Verification

Commands, from the repository root:

```
npx vitest run packages/adapter-utils/src/model-identity.test.ts \
  packages/adapter-utils/src/acpx-engine/model-attribution.test.ts \
  packages/adapter-utils/src/acpx-engine/execute.test.ts
# Test Files 3 passed (3) / Tests 176 passed (176)

npx vitest run server/src/__tests__/heartbeat-cost-accounting.test.ts
# Test Files 1 passed (1) / Tests 7 passed (7)

npx tsc --noEmit -p packages/adapter-utils/tsconfig.json   # exit 0
npx tsc --noEmit -p server/tsconfig.json                   # exit 0
npm run check:tokens                                       # pass
npm run check:node-version                                 # pass
```

New tests: 18 unit tests for the resolver, 15 for the placeholder guard, and 4 engine-level tests that drive `createAcpxEngineExecutor` with a stub runtime. The 4 engine tests cover the four resolution outcomes: session model with no configured model, session model that differs from the configured model, placeholder session model with a configured model, and placeholder session model with no configured model. All 131 pre-existing tests in `execute.test.ts` still pass.

The new tests were checked against mutants, to confirm that they fail when the fix is absent:

| Mutation | Result |
|---|---|
| Remove the placeholder rejection | 8 of 18 resolver tests fail |
| Remove the session read-back | 4 of 18 resolver tests fail |
| Revert the engine to `model: prepared.requestedModel \|\| null` | 2 of 135 engine tests fail |

## Risks

Low.

- Some runs now record a model where they recorded `unknown`. This changes ledger content, but it corrects it. No schema change and no migration.
- Claude ACP picker ids are canonicalized only when the session provides family/version metadata for the selected option. If metadata is absent or unparseable, attribution stays `unknown` rather than guessing.
- A runtime that does not implement `getStatus`, or that advertises no model state, keeps the previous behavior.
- `resultJson.modelSource` is a new field. It is additive.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, with extended thinking and tool use; follow-up correction by OpenAI GPT-5.6 Codex (`gpt-5.6-sol`) with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
