### PR TITLE
fix(heartbeat): run agent-addressed interaction wakes

### DIFF
--- a/doc/plans/2026-08-22-agent-addressed-interaction-wake.md
+++ b/doc/plans/2026-08-22-agent-addressed-interaction-wake.md
@@ -1,0 +1,38 @@
+# Agent-addressed interaction wake authorization
+
+## Problem
+
+Creating a pending issue-thread interaction with a named `addresseeAgentId`
+queues that agent with `wakeReason: interaction_pending`. If the addressee is
+not also the issue assignee (or current review participant), queued-run
+staleness invalidation cancels the run as `issue_assignee_changed`. The named
+agent therefore never receives the interaction that only it is authorized to
+resolve.
+
+## Design
+
+Treat a named pending interaction as a narrow execution authorization, not as
+issue ownership. At claim time, read `interactionId` from the queued run context
+and verify the backing `issue_thread_interactions` row against the database. The
+row must:
+
+- belong to the run's company and issue;
+- still have status `pending`; and
+- name the run's agent as `addresseeAgentId`.
+
+Only a wake satisfying all of those conditions may bypass the non-assignee and
+non-review-participant staleness checks. Context containing only
+`wakeReason: interaction_pending` is insufficient, so forged, stale, resolved,
+cross-company, cross-issue, and wrong-agent wakes remain rejected.
+
+The authorization is also valid while issue dependencies are blocked: the
+addressee must be able to answer the interaction without acquiring the issue's
+execution lock or performing issue implementation work. Existing verified
+comment-based interaction wakes retain their current behavior.
+
+## Verification
+
+Add embedded-Postgres heartbeat tests proving that a valid named addressee run
+executes while wrong-agent, wrong-issue, resolved, and missing-interaction
+contexts are cancelled before adapter execution. Run the focused heartbeat
+suite, server typecheck, and the repository's required PR-ready checks.

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -12,6 +12,8 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueRelations,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
@@ -211,6 +213,27 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       permissions: {},
     });
     return { companyId, agentId };
+  }
+
+  async function seedAgent(companyId: string, name: string) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    return agentId;
   }
 
   async function seedQueuedRun(input: {
@@ -1117,6 +1140,224 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(run?.resultJson).toMatchObject({ stopReason: "issue_assignee_changed" });
     expect(wakeup?.status).toBe("skipped");
     expect(wakeup?.error).toContain("assignee changed");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("runs a pending interaction wake when its named addressee is neither assignee nor review participant", async () => {
+    const { companyId, agentId: assigneeAgentId } = await seedCompanyAndAgent({ agentName: "Assignee" });
+    const addresseeAgentId = await seedAgent(companyId, "Addressee");
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs another agent's confirmation",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId,
+      executionState: {
+        status: "pending",
+        currentStageId: randomUUID(),
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: assigneeAgentId, userId: null },
+        returnAssignee: { type: "agent", agentId: assigneeAgentId, userId: null },
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    });
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      addresseeAgentId,
+      payload: {},
+    });
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId: addresseeAgentId,
+      issueId,
+      wakeReason: "interaction_pending",
+      invocationSource: "automation",
+      contextExtras: { interactionId },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+
+  it("queues and runs a verified addressed interaction wake while issue dependencies are blocked", async () => {
+    const { companyId, agentId: assigneeAgentId } = await seedCompanyAndAgent({ agentName: "Assignee" });
+    const addresseeAgentId = await seedAgent(companyId, "Addressee");
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Unresolved blocker",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked issue needs confirmation",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: blockedIssueId,
+      kind: "request_confirmation",
+      status: "pending",
+      addresseeAgentId,
+      payload: {},
+    });
+
+    const run = await heartbeat.wakeup(addresseeAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "interaction_pending",
+      payload: { issueId: blockedIssueId, interactionId, mutation: "interaction" },
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        interactionId,
+        wakeReason: "interaction_pending",
+      },
+    });
+
+    expect(run).not.toBeNull();
+    await waitForCondition(async () => {
+      const status = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run!.id))
+        .then((rows) => rows[0]?.status ?? null);
+      return status === "succeeded";
+    });
+    expect(countExecuteCallsForRun(run!.id)).toBe(1);
+  });
+
+  it.each([
+    "missing interaction",
+    "resolved interaction",
+    "wrong addressee",
+    "wrong issue",
+    "wrong company",
+  ])("rejects a non-assignee interaction wake with %s", async (invalidCase) => {
+    const { companyId, agentId: assigneeAgentId } = await seedCompanyAndAgent({ agentName: "Assignee" });
+    const addresseeAgentId = await seedAgent(companyId, "Addressee");
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Interaction authorization boundary",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId,
+    });
+
+    const interactionId = randomUUID();
+    if (invalidCase !== "missing interaction") {
+      let interactionCompanyId = companyId;
+      let interactionIssueId = issueId;
+      let interactionAddresseeAgentId = addresseeAgentId;
+      if (invalidCase === "wrong issue") {
+        interactionIssueId = randomUUID();
+        await db.insert(issues).values({
+          id: interactionIssueId,
+          companyId,
+          title: "Different issue",
+          status: "in_progress",
+          priority: "medium",
+          assigneeAgentId,
+        });
+      } else if (invalidCase === "wrong company") {
+        const foreign = await seedCompanyAndAgent({ agentName: "Foreign addressee" });
+        interactionCompanyId = foreign.companyId;
+        interactionAddresseeAgentId = foreign.agentId;
+        interactionIssueId = randomUUID();
+        await db.insert(issues).values({
+          id: interactionIssueId,
+          companyId: foreign.companyId,
+          title: "Foreign issue",
+          status: "in_progress",
+          priority: "medium",
+          assigneeAgentId: foreign.agentId,
+        });
+      } else if (invalidCase === "wrong addressee") {
+        interactionAddresseeAgentId = assigneeAgentId;
+      }
+      await db.insert(issueThreadInteractions).values({
+        id: interactionId,
+        companyId: interactionCompanyId,
+        issueId: interactionIssueId,
+        kind: "request_confirmation",
+        status: invalidCase === "resolved interaction" ? "accepted" : "pending",
+        addresseeAgentId: interactionAddresseeAgentId,
+        payload: {},
+      });
+    }
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId: addresseeAgentId,
+      issueId,
+      wakeReason: "interaction_pending",
+      invocationSource: "automation",
+      contextExtras: { interactionId },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_assignee_changed");
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4229,6 +4229,33 @@ function allowsIssueInteractionWake(
   return Boolean(deriveCommentId(contextSnapshot, null));
 }
 
+async function isVerifiedAddressedInteractionWake(
+  dbOrTx: Pick<Db, "select">,
+  input: {
+    companyId: string;
+    issueId: string;
+    agentId: string;
+    contextSnapshot: Record<string, unknown> | null | undefined;
+  },
+) {
+  const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason);
+  const interactionId = readNonEmptyString(input.contextSnapshot?.interactionId);
+  if (wakeReason !== "interaction_pending" || !interactionId) return false;
+
+  return dbOrTx
+    .select({ id: issueThreadInteractions.id })
+    .from(issueThreadInteractions)
+    .where(and(
+      eq(issueThreadInteractions.id, interactionId),
+      eq(issueThreadInteractions.companyId, input.companyId),
+      eq(issueThreadInteractions.issueId, input.issueId),
+      eq(issueThreadInteractions.status, "pending"),
+      eq(issueThreadInteractions.addresseeAgentId, input.agentId),
+    ))
+    .limit(1)
+    .then((rows) => Boolean(rows[0]));
+}
+
 async function listUnresolvedBlockerSummaries(
   dbOrTx: Pick<Db, "select">,
   companyId: string,
@@ -12654,6 +12681,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const issueId = readNonEmptyString(context.issueId);
     if (issueId) {
+      const addressedInteractionWake = await isVerifiedAddressedInteractionWake(db, {
+        companyId: run.companyId,
+        issueId,
+        agentId: run.agentId,
+        contextSnapshot: context,
+      });
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
       const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(db, {
         companyId: run.companyId,
@@ -12689,13 +12722,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
       const readiness = dependencyReadiness.get(issueId);
       const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
-      if (unresolvedBlockerCount > 0 && !allowsIssueInteractionWake(context)) {
+      if (
+        unresolvedBlockerCount > 0 &&
+        !allowsIssueInteractionWake(context) &&
+        !addressedInteractionWake
+      ) {
         await cancelQueuedRunForBlockedDependencies(run, issueId, readiness?.unresolvedBlockerIssueIds ?? []);
         logger.info({ runId: run.id, issueId, unresolvedBlockerCount }, "claimQueuedRun: cancelled blocked queued run");
         return null;
       }
 
-      const staleness = await evaluateQueuedRunStaleness(run, issueId, context);
+      const staleness = await evaluateQueuedRunStaleness(run, issueId, context, addressedInteractionWake);
       if (staleness.stale) {
         await cancelQueuedRunForStaleIssue(run, issueId, staleness);
         logger.info(
@@ -12853,6 +12890,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     issueId: string,
     context: Record<string, unknown>,
+    addressedInteractionWake = false,
   ): Promise<QueuedRunStaleness> {
     const issue = await db
       .select({
@@ -12939,6 +12977,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (
       issue.assigneeAgentId !== run.agentId &&
       !isInteractionWake &&
+      !addressedInteractionWake &&
       !isCurrentReviewParticipant &&
       !authorizedSourceScopedRecovery &&
       !isNonAssigneeWorkspaceBusyRetry(retryReason, context)
@@ -12995,7 +13034,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (currentParticipant) {
         const participantMatches =
           currentParticipant.type === "agent" && currentParticipant.agentId === run.agentId;
-        if (!participantMatches && !wakeCommentId) {
+        if (!participantMatches && !wakeCommentId && !addressedInteractionWake) {
           return {
             stale: true,
             errorCode: "issue_review_participant_changed",
@@ -18320,7 +18359,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const blockedInteractionWake =
           dependencyReadiness &&
           !dependencyReadiness.isDependencyReady &&
-          allowsIssueInteractionWake(enrichedContextSnapshot);
+          (
+            allowsIssueInteractionWake(enrichedContextSnapshot) ||
+            await isVerifiedAddressedInteractionWake(tx, {
+              companyId: issue.companyId,
+              issueId: issue.id,
+              agentId,
+              contextSnapshot: enrichedContextSnapshot,
+            })
+          );
 
         if (blockedInteractionWake) {
           enrichedContextSnapshot.dependencyBlockedInteraction = true;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue-thread interactions let an agent request a decision from a named agent.
> - The interaction route queues the named agent with `interaction_pending`.
> - The heartbeat stale-run gate still requires the issue assignee or review participant.
> - The gate cancels a valid named-agent run before the adapter starts.
> - This pull request verifies the pending interaction in the database before it grants a narrow claim exception.
> - The benefit is that the named agent can respond without becoming the issue owner.

## Linked Issues or Issue Description

- Fixes: #11932
- Refs #7945
- Refs #11902
- Refs #11390

## What Changed

- Verify a pending addressed interaction against its company, issue, status, and addressee.
- Reuse the verified result at the dependency, assignee, and review-participant gates.
- Add positive and negative embedded-Postgres regression tests.
- Add the authorization design note.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts` passed with 31 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm -r typecheck` passed.
- `pnpm build` passed.
- A red/green check cancelled the valid addressed run with `issue_assignee_changed` when the verifier was temporarily disabled. The test passed after the verifier was restored.
- `pnpm test:run` did not pass locally. It reported failures in unchanged workspace-runtime, runtime-exposure, execution-workspace-control, and company-skills suites. The changed heartbeat suite passed in that run. I stopped the runner after it reported these failures.

## Risks

- Data risk is low. This change has no migration.
- The exception requires an exact pending interaction, company, issue, and addressee match.
- The exception does not change assignment or execution-lock ownership.
- An `interaction_pending` claim adds one indexed interaction lookup.

> I checked `ROADMAP.md`. This fix supports the existing interaction system and does not add a planned core feature.

## Model Used

- OpenAI Codex with GPT-5, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
