### PR TITLE
fix(dev-runner): respect an explicit PAPERCLIP_UI_DEV_MIDDLEWARE override

### DIFF
--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -145,7 +145,10 @@ if (bindMode === "custom" && !bindHost) {
 
 const env: NodeJS.ProcessEnv = {
   ...process.env,
-  PAPERCLIP_UI_DEV_MIDDLEWARE: "true",
+  // Defaults to Vite dev middleware for local `pnpm dev` sessions, but
+  // respects an explicit override (e.g. a launchd-run production instance
+  // that wants to serve a built ui/dist bundle instead).
+  PAPERCLIP_UI_DEV_MIDDLEWARE: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true",
 };
 
 if (mode === "dev") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip's server is started through `scripts/dev-runner.ts`, which is the
>   only supported entrypoint for running the app from a checkout.
> - `dev-runner.ts` builds the child process environment and sets
>   `PAPERCLIP_UI_DEV_MIDDLEWARE: "true"` unconditionally.
> - The server reads that variable to decide between Vite dev middleware and
>   serving a pre-built `ui/dist` bundle.
> - An operator running the server as a long-lived background service wants the
>   built bundle: dev middleware recompiles on demand, holds a Vite server open,
>   and is slower and less predictable for an always-on instance.
> - Setting `PAPERCLIP_UI_DEV_MIDDLEWARE=false` in the service environment looks
>   like it should work, and there is no error or warning when it does not.
> - Because the value is hardcoded rather than defaulted, the operator's setting
>   is silently overwritten and the instance keeps running dev middleware.
> - Making the assignment a default instead of an override fixes that while
>   leaving `pnpm dev` behavior byte-for-byte identical.

## Linked Issues or Issue Description

No public GitHub issue exists for this behavior.

Duplicate PR search: searched open PRs in `paperclipai/paperclip` for
"dev-runner", "PAPERCLIP_UI_DEV_MIDDLEWARE", and "dev middleware"; nothing
matched.

### What happened?

`scripts/dev-runner.ts` sets `PAPERCLIP_UI_DEV_MIDDLEWARE: "true"` on the child
server process unconditionally, so an explicit value in the parent environment
is discarded without any diagnostic.

### Expected behavior

An explicitly-set `PAPERCLIP_UI_DEV_MIDDLEWARE` should reach the server process.
When it is unset, the current default of `"true"` should still apply.

### Steps to reproduce

1. `PAPERCLIP_UI_DEV_MIDDLEWARE=false pnpm dev`
2. Observe that the server still starts Vite dev middleware rather than serving
   the built `ui/dist` bundle.

### Paperclip version or commit

Branched from current `master`.

### Deployment mode

Local development, and a self-hosted instance run as a background service.

## What Changed

- `scripts/dev-runner.ts`: `PAPERCLIP_UI_DEV_MIDDLEWARE` now falls back to
  `"true"` via `process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true"` instead of
  being assigned unconditionally.

One line of behavior change; no new configuration surface, no new flags.

## Verification

- `PAPERCLIP_UI_DEV_MIDDLEWARE=false pnpm dev` now serves the built `ui/dist`
  bundle; the same command on `master` serves Vite dev middleware.
- `pnpm dev` with the variable unset is unchanged — the fallback still yields
  `"true"`.
- This patch has been running continuously on a self-hosted instance since
  2026-08-21 with no regression to local `pnpm dev` workflows.

## Risks

- Low. The only behavior that changes is for someone who has explicitly set
  `PAPERCLIP_UI_DEV_MIDDLEWARE`, which today does nothing — so the change can
  only affect setups that are already not getting what they asked for.
- An operator who sets the variable to `false` without a built `ui/dist` present
  will get no UI. That is the same failure mode as any other stale-build case
  and is self-evident on first page load.

## Model Used

Claude Opus 5, via the ACPX-backed Claude local adapter. Tool use was local
shell inspection and the GitHub CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — `scripts/dev-runner.ts` has no existing test harness; adding one for a one-line env default seemed disproportionate, happy to add if maintainers prefer
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
