### PR TITLE
fix(environments): record why a lease and its wakeup left the waiting state

### DIFF
--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -466,6 +466,60 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(rows[0]?.status).toBe("released");
   });
 
+  it("persists the run's failure reason on a failed local lease release", async () => {
+    const { companyId, environment, runId } = await seedEnvironment();
+
+    const acquired = await runtime.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    const released = await runtime.releaseRunLeases(
+      runId,
+      "failed",
+      undefined,
+      "adapter exited with code 137",
+    );
+
+    expect(released).toHaveLength(1);
+    expect(released[0]?.lease.failureReason).toBe("adapter exited with code 137");
+
+    // The row itself must carry the reason. A value that lives only in the
+    // activity log is exactly the leak this guards against.
+    const rows = await db
+      .select()
+      .from(environmentLeases)
+      .where(eq(environmentLeases.id, acquired.lease.id));
+    expect(rows[0]?.status).toBe("failed");
+    expect(rows[0]?.failureReason).toBe("adapter exited with code 137");
+    expect(rows[0]?.cleanupStatus).toBe("success");
+  });
+
+  it("invents no failure reason when a local lease is released cleanly", async () => {
+    const { companyId, environment, runId } = await seedEnvironment();
+
+    const acquired = await runtime.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    await runtime.releaseRunLeases(runId);
+
+    const rows = await db
+      .select()
+      .from(environmentLeases)
+      .where(eq(environmentLeases.id, acquired.lease.id));
+    expect(rows[0]?.status).toBe("released");
+    expect(rows[0]?.failureReason).toBeNull();
+    expect(rows[0]?.cleanupStatus).toBe("success");
+  });
+
   it("allows projectless runs through the runtime seam", async () => {
     const { companyId, environment, runId } = await seedEnvironment();
 

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -6371,6 +6371,103 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       }),
     });
     expect(released[0]?.lease.status).toBe("released");
+
+    // A clean release invents no reason, but cleanup is still recorded: the
+    // teardown RPC above returned, so the provider resource is genuinely gone.
+    // Leaving `cleanup_status` null would read as cleanup that never ran.
+    const cleanRows = await db
+      .select()
+      .from(environmentLeases)
+      .where(eq(environmentLeases.id, acquired.lease.id));
+    expect(cleanRows[0]?.failureReason).toBeNull();
+    expect(cleanRows[0]?.cleanupStatus).toBe("success");
+  });
+
+  it("persists the run's failure reason on a failed plugin environment lease release", async () => {
+    const pluginId = randomUUID();
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return { providerLeaseId: "plugin-lease-failed", metadata: {} };
+        }
+        return undefined;
+      }),
+      getWorker: vi.fn(() => ({ supportedMethods: ["environmentResumeLease", "environmentReleaseLease", "environmentDestroyLease"] })),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, {
+      pluginWorkerManager: workerManager,
+    });
+    const { companyId, environment, runId } = await seedEnvironment({
+      driver: "plugin",
+      name: "Plugin Fake plugin",
+      config: {
+        pluginKey: "acme.environments",
+        driverKey: "fake-plugin",
+        driverConfig: {
+          template: "base",
+        },
+      },
+    });
+
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.environments",
+      packageName: "@acme/paperclip-environments",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.environments",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Acme Environments",
+        description: "Test plugin environment driver",
+        author: "Acme",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "fake-plugin",
+            displayName: "Fake plugin",
+            configSchema: { type: "object" },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    const released = await runtimeWithPlugin.releaseRunLeases(
+      runId,
+      "failed",
+      undefined,
+      "adapter exited with code 137",
+    );
+
+    expect(released).toHaveLength(1);
+
+    // The row must carry the reason the run computed. The plugin driver used to
+    // call `releaseLease(id, status)` with no options, so a plugin-backed run
+    // failure was undiagnosable the moment its log rotated away -- the same leak
+    // already closed for the local, ssh, and sandbox drivers.
+    const rows = await db
+      .select()
+      .from(environmentLeases)
+      .where(eq(environmentLeases.id, acquired.lease.id));
+    expect(rows[0]?.status).toBe("failed");
+    expect(rows[0]?.failureReason).toBe("adapter exited with code 137");
+    expect(rows[0]?.cleanupStatus).toBe("success");
   });
 
   async function seedPluginDriverEnvironment(pluginId: string) {

--- a/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
+++ b/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  agentWakeupRequests,
   agents,
   companies,
   createDb,
@@ -43,6 +44,7 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -51,11 +53,12 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
     await tempDb?.cleanup();
   });
 
-  async function seed(input: { issueStatus: string; runStatus: string }) {
+  async function seed(input: { issueStatus: string; runStatus: string; wakeupStatus?: string }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const issueId = randomUUID();
     const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
 
     await db.insert(companies).values({
       id: companyId,
@@ -82,6 +85,15 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       priority: "high",
       assigneeAgentId: agentId,
     });
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "manual",
+      status: input.wakeupStatus ?? "claimed",
+      runId,
+      claimedAt: new Date(),
+    });
     await db.insert(heartbeatRuns).values({
       id: runId,
       companyId,
@@ -90,6 +102,7 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       invocationSource: "manual",
       startedAt: new Date(),
       contextSnapshot: { issueId },
+      wakeupRequestId,
     });
 
     const run = await db
@@ -98,7 +111,15 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0]!);
 
-    return { companyId, agentId, issueId, runId, run };
+    return { companyId, agentId, issueId, runId, wakeupRequestId, run };
+  }
+
+  async function readWakeup(wakeupRequestId: string) {
+    return await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0]!);
   }
 
   it("forces a still-running run to succeeded when the issue already reached done", async () => {
@@ -208,5 +229,50 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       .where(eq(heartbeatRunEvents.runId, runId))
       .then((rows) => rows.length);
     expect(eventCount).toBe(0);
+  });
+
+  it("closes the claimed wakeup as completed when the run terminalizes to succeeded", async () => {
+    const { wakeupRequestId, run } = await seed({ issueStatus: "done", runStatus: "running" });
+
+    await heartbeatService(db).terminalizeRunOnLeaseRelease(run);
+
+    const wakeup = await readWakeup(wakeupRequestId);
+    expect(wakeup.status).toBe("completed");
+    expect(wakeup.finishedAt).not.toBeNull();
+    // A run that reached its goal did not error, so the wakeup must not carry
+    // one -- every other completed row in the table has a null error.
+    expect(wakeup.error).toBeNull();
+  });
+
+  it("closes the claimed wakeup as cancelled when the run is cut short", async () => {
+    const { wakeupRequestId, run } = await seed({ issueStatus: "in_progress", runStatus: "running" });
+
+    await heartbeatService(db).terminalizeRunOnLeaseRelease(run);
+
+    const wakeup = await readWakeup(wakeupRequestId);
+    expect(wakeup.status).toBe("cancelled");
+    expect(wakeup.finishedAt).not.toBeNull();
+    expect(wakeup.error).toContain("lease release");
+  });
+
+  it("leaves a wakeup another path already closed untouched", async () => {
+    // The teardown is a safety net, not an authority. When an explicit branch
+    // already recorded the real outcome, overwriting it with the generic one
+    // would lose information.
+    const { wakeupRequestId, run } = await seed({
+      issueStatus: "in_progress",
+      runStatus: "running",
+      wakeupStatus: "failed",
+    });
+    await db
+      .update(agentWakeupRequests)
+      .set({ finishedAt: new Date(), error: "adapter crashed" })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+
+    await heartbeatService(db).terminalizeRunOnLeaseRelease(run);
+
+    const wakeup = await readWakeup(wakeupRequestId);
+    expect(wakeup.status).toBe("failed");
+    expect(wakeup.error).toBe("adapter crashed");
   });
 });

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -588,6 +588,11 @@ export function environmentRunOrchestrator(
         input.heartbeatRunId,
         status,
         (leaseId, error) => result.errors.push({ leaseId, error }),
+        // Persist the reason on the lease row, not just in the activity log
+        // below. The heartbeat already derived it from the run's own error, and
+        // a lease that ends `failed` with no recorded reason is undiagnosable
+        // once the run's own log has rotated away.
+        input.failureReason,
       );
     } catch (err) {
       result.errors.push({ leaseId: "*", error: err });

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -3010,7 +3010,23 @@ function createPluginEnvironmentDriver(
         providerLeaseId: input.lease.providerLeaseId,
         leaseMetadata: input.lease.metadata ?? undefined,
       });
-      return await environmentsSvc.releaseLease(input.lease.id, input.status);
+      // Reached only once the plugin teardown above returned, so the provider
+      // resource is gone and cleanup is genuinely complete.
+      //
+      // A throwing teardown keeps its current behavior on purpose: the error
+      // propagates to `releaseRunLeases`, which reports it through
+      // `onLeaseReleaseError` and leaves the row `active`. Do not route that
+      // case to `pending_cleanup` the way the plugin-backed *sandbox* path
+      // does -- this driver implements no `retryPendingSandboxTeardown`, so the
+      // cleanup sweep can only throw on such a row, stranding it permanently.
+      return await environmentsSvc.releaseLease(input.lease.id, input.status, {
+        // Prefer the caller's concrete reason; fall back to the generic class
+        // only when the run supplied nothing, matching the sibling
+        // plugin-backed sandbox release.
+        failureReason:
+          input.status === "failed" ? input.failureReason ?? "adapter_or_run_failure" : undefined,
+        cleanupStatus: "success",
+      });
     },
 
     async resumeRunLease(input) {

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -5,6 +5,7 @@ import { companySecrets, companySecretVersions, environmentLeases } from "@paper
 import type {
   Environment,
   EnvironmentLease,
+  EnvironmentLeaseCleanupStatus,
   EnvironmentLeaseStatus,
   ExecutionWorkspace,
   InstanceExperimentalSettings,
@@ -448,6 +449,13 @@ export interface EnvironmentDriverReleaseInput {
   environment: Environment;
   lease: EnvironmentLease;
   status: Extract<EnvironmentLeaseStatus, "released" | "expired" | "failed">;
+  /**
+   * Why the run that held this lease ended, when it ended badly. The heartbeat
+   * already computes this from the run's own error, so drivers persist it on
+   * the lease instead of letting the release drop it. Absent for a clean
+   * release; a driver must not invent one from the status alone.
+   */
+  failureReason?: string;
 }
 
 function resolvePluginSandboxRpcTimeoutMs(config: Record<string, unknown>): number | undefined {
@@ -980,7 +988,7 @@ function createLocalEnvironmentDriver(db: Db): EnvironmentRuntimeDriver {
     },
 
     async releaseRunLease(input) {
-      return await environmentsSvc.releaseLease(input.lease.id, input.status);
+      return await environmentsSvc.releaseLease(input.lease.id, input.status, inProcessTeardownRelease(input));
     },
 
     async realizeWorkspace(input) {
@@ -997,6 +1005,24 @@ function createLocalEnvironmentDriver(db: Db): EnvironmentRuntimeDriver {
         },
       };
     },
+  };
+}
+
+/**
+ * Release options for the drivers that hold no provider-side resource (local,
+ * ssh). There is nothing to tear down, so cleanup is complete the moment the
+ * row flips — `success`, not a permanently-`pending` value that reads as
+ * unfinished work. The failure reason is whatever the heartbeat computed from
+ * the run's own error; these drivers never synthesize one, so a lease with a
+ * null reason means the caller genuinely had none.
+ */
+function inProcessTeardownRelease(input: EnvironmentDriverReleaseInput): {
+  failureReason?: string;
+  cleanupStatus: EnvironmentLeaseCleanupStatus;
+} {
+  return {
+    ...(input.failureReason ? { failureReason: input.failureReason } : {}),
+    cleanupStatus: "success",
   };
 }
 
@@ -1040,7 +1066,7 @@ function createSshEnvironmentDriver(db: Db): EnvironmentRuntimeDriver {
     },
 
     async releaseRunLease(input) {
-      return await environmentsSvc.releaseLease(input.lease.id, input.status);
+      return await environmentsSvc.releaseLease(input.lease.id, input.status, inProcessTeardownRelease(input));
     },
 
     async realizeWorkspace(input) {
@@ -2153,7 +2179,10 @@ function createSandboxEnvironmentDriver(
         ? "retained" as const
         : input.status;
       return await environmentsSvc.releaseLease(input.lease.id, releaseStatus, {
-        failureReason: input.status === "failed" ? "adapter_or_run_failure" : undefined,
+        // Prefer the caller's concrete reason; fall back to the generic class
+        // only when the run supplied nothing.
+        failureReason:
+          input.status === "failed" ? input.failureReason ?? "adapter_or_run_failure" : undefined,
         cleanupStatus,
       });
     },
@@ -2658,9 +2687,9 @@ function createSandboxEnvironmentDriver(
         : input.status;
     const failureReason =
       input.status === "failed"
-        ? "adapter_or_run_failure"
+        ? input.failureReason ?? "adapter_or_run_failure"
         : cleanupStatus === "failed"
-          ? "release_cleanup_failed"
+          ? input.failureReason ?? "release_cleanup_failed"
           : undefined;
     return await environmentsSvc.releaseLease(input.lease.id, releaseStatus, {
       failureReason,
@@ -3242,6 +3271,7 @@ export function environmentRuntimeService(
       heartbeatRunId: string,
       status: Extract<EnvironmentLeaseStatus, "released" | "expired" | "failed"> = "released",
       onLeaseReleaseError?: (leaseId: string, error: unknown) => void,
+      failureReason?: string,
     ): Promise<EnvironmentRuntimeLeaseRecord[]> {
       const leaseRows = await db
         .select()
@@ -3275,8 +3305,11 @@ export function environmentRuntimeService(
                 environment,
                 lease: leaseSnapshot,
                 status,
+                ...(failureReason ? { failureReason } : {}),
               })
-            : await environmentsSvc.releaseLease(leaseRow.id, status);
+            : await environmentsSvc.releaseLease(leaseRow.id, status, {
+                ...(failureReason ? { failureReason } : {}),
+              });
           if (!lease) continue;
 
           released.push({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -357,6 +357,12 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+/**
+ * Wakeup request statuses that are still awaiting an outcome. Every other
+ * status is terminal, so a row in one of these has not yet recorded how it
+ * left the waiting state.
+ */
+const OPEN_WAKEUP_REQUEST_STATUSES = ["queued", "deferred_issue_execution", "claimed"] as const;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -9099,6 +9105,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return write.run ?? run;
     }
 
+    // The run row is terminal now, so its wakeup must be too. This teardown is
+    // the one terminal path that never went through an explicit
+    // success/failure branch, so without this the wakeup row is stranded at
+    // "claimed" forever -- a waiting state with no recorded exit. Mirror the
+    // mapping the explicit branches use: a succeeded run completes its wakeup,
+    // and anything cut short cancels it.
+    await closeWakeupOnTerminalRun(
+      run.wakeupRequestId,
+      terminalStatus === "succeeded" ? "completed" : "cancelled",
+      terminalStatus === "succeeded" ? null : message,
+    ).catch((wakeupErr) => {
+      logger.warn(
+        { err: wakeupErr, runId: run.id, wakeupRequestId: run.wakeupRequestId },
+        "failed to close wakeup request on lease-release terminalization",
+      );
+    });
+
     const terminalRun = write.run;
     if (terminalRun) {
       await appendRunEvent(terminalRun, await nextRunEventSeq(terminalRun.id), {
@@ -9170,6 +9193,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .update(agentWakeupRequests)
       .set({ status, ...patch, updatedAt: new Date() })
       .where(eq(agentWakeupRequests.id, wakeupRequestId));
+  }
+
+  /**
+   * Close a wakeup that is still open, without disturbing one that another path
+   * already finished. Used by the teardown safety net, which can run after an
+   * explicit branch has already recorded the real outcome -- the status
+   * predicate makes it a no-op in that case rather than overwriting a precise
+   * status with a generic one.
+   */
+  async function closeWakeupOnTerminalRun(
+    wakeupRequestId: string | null | undefined,
+    status: "completed" | "cancelled",
+    error: string | null,
+  ) {
+    if (!wakeupRequestId) return;
+    await db
+      .update(agentWakeupRequests)
+      .set({ status, finishedAt: new Date(), ...(error ? { error } : {}), updatedAt: new Date() })
+      .where(
+        and(
+          eq(agentWakeupRequests.id, wakeupRequestId),
+          inArray(agentWakeupRequests.status, [...OPEN_WAKEUP_REQUEST_STATUSES]),
+        ),
+      );
   }
 
   async function addContinuationExhaustedCommentOnce(input: {
@@ -9488,7 +9535,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             and(
               eq(agentWakeupRequests.companyId, issue.companyId),
               eq(agentWakeupRequests.agentId, run.agentId),
-              inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"]),
+              inArray(agentWakeupRequests.status, [...OPEN_WAKEUP_REQUEST_STATUSES]),
               sql`(
                 ${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}
                 or ${agentWakeupRequests.payload} ->> 'taskId' = ${issue.id}

--- a/server/src/services/runtime-exposure/loopback-listener.test.ts
+++ b/server/src/services/runtime-exposure/loopback-listener.test.ts
@@ -1,14 +1,13 @@
 import net from "node:net";
 import { describe, expect, it } from "vitest";
 
-import { RUNTIME_EXPOSURE_APP_PORT_MIN, deriveViteHmrPort } from "@paperclipai/shared";
-
 import {
   diagnoseRuntimeListenerBinds,
   formatProcAddressHex,
   listenerBindFactsForPort,
   parseProcNetListeners,
 } from "./loopback-listener.js";
+import { allocateExposurePortPair, type ExposurePortPair } from "./port-pair.js";
 
 // Real header and row shape, copied from a live /proc/net/tcp{,6} on the host
 // that produced the PAP-17256 failures. Port 42003 is A40B; 52003 is CB23.
@@ -129,8 +128,77 @@ describe("listenerBindFactsForPort", () => {
 });
 
 describe("diagnoseRuntimeListenerBinds against live listeners", () => {
-  const appPort = RUNTIME_EXPOSURE_APP_PORT_MIN + 900;
-  const hmrPort = deriveViteHmrPort(appPort);
+  /**
+   * These tests bind real sockets, so they need real free ports -- and a fixed
+   * pair cannot be assumed free. The suite previously pinned
+   * `RUNTIME_EXPOSURE_APP_PORT_MIN + 900`, whose HMR companion is 52900. Both
+   * that port and the whole 42000-42999 app range sit inside Linux's default
+   * ephemeral range (32768-60999), so any outbound connection on a shared CI
+   * runner can transiently own them. The suite then failed EADDRINUSE on a port
+   * it never chose, on a run whose diff touched no networking.
+   *
+   * Ask the production allocator for a pair that probes free instead. That
+   * shrinks the race from the whole suite duration to the gap between probe and
+   * bind, and keeps the test on the same port policy the runtime uses. The gap
+   * is not zero -- an ephemeral port can still be taken inside it -- so a lost
+   * race retries on a different pair rather than failing the run.
+   */
+  const PORT_PAIR_ATTEMPTS = 5;
+
+  function isAddressInUse(error: unknown): boolean {
+    return (error as NodeJS.ErrnoException | null)?.code === "EADDRINUSE";
+  }
+
+  async function bindsOn(port: number, host: string | undefined): Promise<boolean> {
+    return await new Promise<boolean>((resolve) => {
+      const probe = net.createServer();
+      probe.once("error", () => resolve(false));
+      if (host === undefined) probe.listen(port, () => probe.close(() => resolve(true)));
+      else probe.listen(port, host, () => probe.close(() => resolve(true)));
+    });
+  }
+
+  /**
+   * True only when the port is free on BOTH the wildcard and IPv4 loopback.
+   * Neither probe alone is sufficient: these tests bind the app port on
+   * 127.0.0.1 and the HMR companion on the wildcard, and the two binds fail on
+   * different holders. A hostless listen is dual-stack IPv6, so it can succeed
+   * while a v4-loopback-only holder still owns 127.0.0.1 -- checking only the
+   * wildcard would hand out a port the app-port bind then rejects.
+   */
+  async function isPortBindable(port: number): Promise<boolean> {
+    return (await bindsOn(port, undefined)) && (await bindsOn(port, "127.0.0.1"));
+  }
+
+  /**
+   * Run `body` against an app/HMR port pair that probed free. A pair lost to an
+   * ephemeral bind between probe and listen is retired for this call, so a retry
+   * moves to a different pair rather than re-picking the one that just lost.
+   */
+  async function withFreePortPair(
+    body: (pair: ExposurePortPair) => Promise<void>,
+  ): Promise<void> {
+    const retired = new Set<number>();
+    let lastError: unknown;
+    for (let attempt = 0; attempt < PORT_PAIR_ATTEMPTS; attempt += 1) {
+      const pair = await allocateExposurePortPair({
+        isPortAvailable: isPortBindable,
+        reserved: retired,
+      });
+      try {
+        await body(pair);
+        return;
+      } catch (error) {
+        // Only a lost port race retries. An assertion failure is the real
+        // verdict and must surface on the first attempt.
+        if (!isAddressInUse(error)) throw error;
+        lastError = error;
+        retired.add(pair.appPort);
+        retired.add(pair.hmrPort);
+      }
+    }
+    throw lastError;
+  }
 
   async function withListener<T>(
     port: number,
@@ -151,32 +219,40 @@ describe("diagnoseRuntimeListenerBinds against live listeners", () => {
   }
 
   it("stays silent for a real loopback listener", async () => {
-    await withListener(appPort, "127.0.0.1", async () => {
-      expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+    await withFreePortPair(async ({ appPort }) => {
+      await withListener(appPort, "127.0.0.1", async () => {
+        expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+      });
     });
   });
 
   it("names the port and the wildcard address for a real 0.0.0.0 listener", async () => {
-    await withListener(appPort, undefined, async () => {
-      const diagnosis = await diagnoseRuntimeListenerBinds([appPort]);
-      expect(diagnosis).toContain(`port ${appPort}`);
-      // Node's hostless listen is dual-stack, so /proc shows :: and/or 0.0.0.0.
-      expect(diagnosis).toMatch(/0\.0\.0\.0|::/);
-      expect(diagnosis).toContain("--bind loopback");
+    await withFreePortPair(async ({ appPort }) => {
+      await withListener(appPort, undefined, async () => {
+        const diagnosis = await diagnoseRuntimeListenerBinds([appPort]);
+        expect(diagnosis).toContain(`port ${appPort}`);
+        // Node's hostless listen is dual-stack, so /proc shows :: and/or 0.0.0.0.
+        expect(diagnosis).toMatch(/0\.0\.0\.0|::/);
+        expect(diagnosis).toContain("--bind loopback");
+      });
     });
   });
 
   it("catches the HMR companion port too, not just the app port", async () => {
-    await withListener(appPort, "127.0.0.1", async () => {
-      await withListener(hmrPort, undefined, async () => {
-        const diagnosis = await diagnoseRuntimeListenerBinds([appPort, hmrPort]);
-        expect(diagnosis).toContain(`port ${hmrPort}`);
-        expect(diagnosis).not.toContain(`port ${appPort} is bound`);
+    await withFreePortPair(async ({ appPort, hmrPort }) => {
+      await withListener(appPort, "127.0.0.1", async () => {
+        await withListener(hmrPort, undefined, async () => {
+          const diagnosis = await diagnoseRuntimeListenerBinds([appPort, hmrPort]);
+          expect(diagnosis).toContain(`port ${hmrPort}`);
+          expect(diagnosis).not.toContain(`port ${appPort} is bound`);
+        });
       });
     });
   });
 
   it("stays silent for a port with no listener, leaving the verdict to the broker", async () => {
-    expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+    await withFreePortPair(async ({ appPort }) => {
+      expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The environments subsystem gives each heartbeat run a lease, and the heartbeat subsystem gives each run a wakeup request
> - Both rows enter a waiting state, but neither always records how it left that state: `environment_leases.failure_reason` and `cleanup_status` stay null, and a wakeup request can stay at `claimed` after its run ends
> - A state with no recorded exit cannot be swept, counted, or diagnosed. When a lease ends `failed` with no reason, the cause is lost as soon as the run log rotates away
> - This pull request writes the exit condition at each of the three points that currently drop it
> - The benefit is that lease failures become diagnosable, and no wakeup row stays open after its run is terminal

## Linked Issues or Issue Description

No public issue exists for this. The problem follows the bug report template.

**What happened?**

On a deployment that uses the `local` environment driver, `environment_leases.failure_reason` is null on every row, including rows with status `failed`. `cleanup_status` is null on every row. Separately, `agent_wakeup_requests` rows stay at status `claimed` with a null `finished_at` after their `heartbeat_runs` row has reached a terminal status and carries a `finished_at`.

The lease reason is computed but discarded. The heartbeat derives it from the run's own error and passes it to `releaseForRun` as `input.failureReason`. That value reaches only the activity log entry. It is dropped before the database write at three points:

1. `environment-run-orchestrator.ts` does not forward `input.failureReason` into `environmentRuntime.releaseRunLeases(...)`.
2. `EnvironmentDriverReleaseInput` has no field to carry a reason.
3. The `local` and `ssh` drivers call `environmentsSvc.releaseLease(id, status)` with no options argument, so they cannot write one.

The sandbox and plugin drivers do pass `{ failureReason, cleanupStatus }`, so a deployment that uses only the `local` driver never writes either column.

For the wakeup, `terminalizeRunOnLeaseRelease` exists to make sure a run that releases its lease has a terminal run row. It writes the run row but does not touch `agent_wakeup_requests`. A run that reaches teardown without passing an explicit success or failure branch therefore leaves its wakeup open permanently.

**Expected behavior**

A lease that ends `failed` records why. A lease released by a driver that holds no provider resource records that its cleanup is complete. A run that reaches a terminal status leaves no open wakeup row.

**Steps to reproduce**

1. Run Paperclip with an environment that uses the `local` driver.
2. Let a heartbeat run fail.
3. Read the `environment_leases` row for that run. `status` is `failed`. `failure_reason` and `cleanup_status` are both null.
4. Read the `agent_wakeup_requests` row whose `run_id` is that run. After a teardown that goes through `terminalizeRunOnLeaseRelease`, `status` stays `claimed` and `finished_at` stays null, while the run row is terminal.

**Paperclip version or commit**

`master`, at commit 3ff636bc4.

**Deployment mode**

Self-hosted, single instance.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Database mode**

PostgreSQL.

## What Changed

- Added an optional `failureReason` field to `EnvironmentDriverReleaseInput`.
- `releaseRunLeases` now takes a `failureReason` and forwards it to the driver, and to the direct release used when no driver matches.
- `environment-run-orchestrator.releaseForRun` now forwards its `failureReason` into `releaseRunLeases`. Before this change the value went only to the activity log.
- The `local` and `ssh` drivers now pass release options. They record the caller's `failureReason` and set `cleanupStatus` to `success`, because these drivers hold no provider resource to tear down.
- The sandbox drivers, and the plugin-backed sandbox release path, now prefer the caller's concrete reason. They keep `adapter_or_run_failure` as a fallback for when the caller gives none.
- The `plugin` environment driver does the same. It was a fourth release site still calling `releaseLease(id, status)` with no options object, so a plugin-backed run that ended `failed` wrote a null `failure_reason` and a null `cleanup_status`. It now records both. This is a different path from the plugin-backed *sandbox* release, which already persisted them; only environments whose driver is `plugin` were affected.
- `terminalizeRunOnLeaseRelease` now closes the run's wakeup request. A succeeded run sets `completed`. A run that was cut short sets `cancelled`. This is the same mapping the explicit branches already use.
- The wakeup write is guarded on the open statuses, so this safety net cannot overwrite an outcome that another path already recorded.
- Replaced one inline list of open wakeup statuses with a named constant.

## Verification

```
cd server
pnpm typecheck
pnpm vitest run src/__tests__/environment-runtime.test.ts \
  src/__tests__/heartbeat-run-lease-release-terminalization.test.ts \
  src/__tests__/heartbeat-run-terminalize-before-release.test.ts \
  src/__tests__/environment-service.test.ts \
  src/__tests__/heartbeat-pending-cleanup-sweep.test.ts
```

All pass. Typecheck is clean.

Six tests are new:

- A failed local lease release writes the caller's reason to the row, and sets `cleanupStatus` to `success`.
- A clean local lease release invents no reason. `failure_reason` stays null.
- A failed `plugin` environment lease release writes the caller's reason and `cleanupStatus` `success`, and a clean one invents no reason.
- A run that terminalizes to `succeeded` closes its wakeup as `completed`, with a null error.
- A run that is cut short closes its wakeup as `cancelled`, with the teardown message.
- A wakeup that another path already closed keeps its own status and error.

Each new test was mutation-tested. Removing the `failureReason` forward fails the first test. Removing the wakeup close fails the run-terminalization tests. Removing the open-status guard fails the no-clobber test. For the plugin driver: restoring the bare `releaseLease(id, status)` call fails on both a null reason and a null cleanup status, and dropping the `status === "failed"` guard fails the assertion that a clean release invents no reason.

## Risks

Low risk. The change is additive at every point.

- The new `failureReason` parameter is optional and last, so existing calls behave as before.
- No column that holds a value today is overwritten. `failure_reason` is written only where it was null.
- `cleanupStatus` becomes `success` for `local` and `ssh` releases where it was null. Code that treats null as "not yet cleaned up" now sees a correct terminal value. No existing reader depends on that null, because no row has ever held a non-null value on these drivers.
- The wakeup write is guarded on the open statuses, so it cannot change a row that another path already closed.
- No schema migration. All columns already exist.

One case is deliberately left as it is. When the `plugin` driver's `environmentReleaseLease` RPC throws, the error still propagates to `releaseRunLeases`, which reports it through `onLeaseReleaseError` and leaves the row `active`. The plugin-backed sandbox path handles the same case by routing the row to `pending_cleanup` for the sweep to retry, but that route is not open here: the sweep dispatches through `retryPendingSandboxTeardown`, which throws for any driver that does not implement it, and the `plugin` driver does not. Routing failed plugin releases there would move those rows from leaked to permanently stuck in a sweep that can only throw on them. Giving the driver a teardown-retry path is a real gap, and a wider change than this fix should carry.

## One unrelated commit rides here

`test(runtime-exposure): allocate real free ports instead of pinning one` touches no lease code. It is on this branch because the branch could not go green without it and rerunning a failed job on this repo needs admin rights.

`diagnoseRuntimeListenerBinds against live listeners` pinned `RUNTIME_EXPOSURE_APP_PORT_MIN + 900`, whose HMR companion is 52900. That port, and the entire 42000-42999 app range, sit inside Linux's default ephemeral range (32768-60999), so any outbound connection on a shared runner can transiently own them. Job `server (1/5)` failed `EADDRINUSE: :::52900` on a diff that touches no networking. The test now asks the production allocator for a pair that probes free, retiring a pair lost between probe and bind and retrying on another; only `EADDRINUSE` retries, so an assertion failure still surfaces on the first attempt.

The availability probe checks both the wildcard and 127.0.0.1. That was not obvious and was not assumed: a scratch harness holding `127.0.0.1:42000` was reported *bindable* by a wildcard-only probe, because a hostless listen is dual-stack IPv6 and does not collide with a v4-loopback-only holder. The same harness confirmed the allocator skips a pair whose app port is held, skips a pair whose HMR companion is held while the app port is free, and honors the retired set.

Happy to split this into its own PR if you would rather review it separately.

## Category safeguard

The root cause of this class is that these status columns are plain `text` with no constraint, while their permitted values live only in a TypeScript union. A wrong value is accepted silently and then read by nothing. This affects `agent_wakeup_requests.status`, `environment_leases.status`, `environment_leases.cleanup_status`, and `issue_tree_holds.status` at least.

The class-level fix is a check that every status column accepts only the values in its declared union, either as a database `CHECK` constraint or as a test that reads the distinct values per column and compares them to the shared constant. That is a broader change than this bug fix, so it is not included here. I am happy to open it as a follow-up if maintainers want it.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


