### PR TITLE
fix(issues): preserve requested blocked descriptor semantics

### DIFF
--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -739,6 +739,137 @@ describe("issue execution policy routes", () => {
     expect(mockIssueApprovalService.listApprovalsForIssue).not.toHaveBeenCalled();
   });
 
+  it("atomically persists a blocked status, blocker relation, and unblock descriptor without review", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      createdByUserId: "local-board",
+      identifier: "PAP-1007A",
+      title: "Blockable issue",
+      executionPolicy: null,
+      executionState: null,
+      blockedByIssueIds: [],
+    };
+    const blockerId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let blockedByIssueIds: string[] = [];
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getRelationSummaries.mockImplementation(async () => ({
+      blockedBy: blockedByIssueIds.map((id) => ({ id })),
+      blocks: [],
+    }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      blockedByIssueIds = (patch.blockedByIssueIds as string[] | undefined) ?? blockedByIssueIds;
+      return {
+        ...issue,
+        ...patch,
+        blockedByIssueIds,
+        updatedAt: new Date(),
+      };
+    });
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "blocked",
+        blockedByIssueIds: [blockerId],
+        unblockDescriptor: { owner: "board", action: "Review the blocker" },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "blocked",
+        blockedByIssueIds: [blockerId],
+        unblockDescriptor: { owner: "board", action: "Review the blocker" },
+      }),
+    );
+    expect(res.body).toMatchObject({
+      status: "blocked",
+      blockedByIssueIds: [blockerId],
+      blockedBy: [{ id: blockerId }],
+    });
+  });
+
+  it("drops an unblock descriptor when a pending review rewrites blocked to in_progress", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "review",
+          participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+        },
+      ],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1007B",
+      title: "Review-gated issue",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: "11111111-1111-4111-8111-111111111111",
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: "33333333-3333-4333-8333-333333333333" },
+        returnAssignee: { type: "agent", agentId: "44444444-4444-4444-8444-444444444444" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    let persistedIssue: Record<string, unknown> = issue;
+    mockIssueService.getById.mockImplementation(async () => persistedIssue);
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1", body: "The review found a blocker." });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      persistedIssue = { ...persistedIssue, ...patch, updatedAt: new Date() };
+      return persistedIssue;
+    });
+    mockDb.transaction.mockImplementation(async (callback) =>
+      callback({
+        select: mockDbSelect,
+        insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+      } as any),
+    );
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "blocked",
+        comment: "The review found a blocker.",
+        unblockDescriptor: {
+          owner: { agentId: "33333333-3333-4333-8333-333333333333" },
+          action: "Review the blocker",
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("in_progress");
+    expect(res.body).not.toHaveProperty("unblockDescriptor");
+    expect(mockIssueService.update).toHaveBeenCalledTimes(1);
+    const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch.status).toBe("in_progress");
+    expect(updatePatch).not.toHaveProperty("unblockDescriptor");
+    const readback = await mockIssueService.getById(issue.id);
+    expect(readback).toMatchObject({ status: "in_progress" });
+    expect(readback).not.toHaveProperty("unblockDescriptor");
+    expect(res.body.error).toBeUndefined();
+  });
+
   it("allows a board user to cancel an active agent review task", async () => {
     const policy = normalizeIssueExecutionPolicy({
       stages: [

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -200,7 +200,10 @@ describe("issue execution policy routes", () => {
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
     mockDbSelect.mockImplementation(() => ({ from: mockDbSelectFrom }));
-    mockDbSelectFrom.mockImplementation(() => ({ where: mockDbSelectWhere }));
+    mockDbSelectFrom.mockImplementation(() => ({
+      where: mockDbSelectWhere,
+      innerJoin: () => ({ where: mockDbSelectWhere }),
+    }));
     mockDbSelectWhere.mockImplementation(() => ({
       limit: async () => [{ id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" }],
       for: () => ({

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -202,6 +202,7 @@ describe("issue execution policy routes", () => {
     mockDbSelect.mockImplementation(() => ({ from: mockDbSelectFrom }));
     mockDbSelectFrom.mockImplementation(() => ({ where: mockDbSelectWhere }));
     mockDbSelectWhere.mockImplementation(() => ({
+      limit: async () => [{ id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" }],
       for: () => ({
         then: (onFulfilled: (rows: unknown[]) => unknown, onRejected?: (reason: unknown) => unknown) =>
           Promise.resolve([{

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -985,6 +985,40 @@ describe("issue execution policy transitions", () => {
       expect(result.patch).toEqual({});
     });
 
+    it("rewrites a requested blocked transition while a review stage is pending", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          responsibleUserId: boardUserId,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "blocked",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: "The review found a blocker.",
+      });
+
+      expect(result.patch.status).toBe("in_progress");
+      expect(result.patch.executionState).toMatchObject({
+        status: "changes_requested",
+        currentStageId: reviewStageId,
+      });
+    });
+
     it("coerces a malformed executor in_review patch into the first policy stage", () => {
       const result = applyIssueExecutionPolicyTransition({
         issue: {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9685,11 +9685,15 @@ export function issueRoutes(
         lastDecisionId: decisionId,
       };
     }
+    const requestedStatusForDescriptor = typeof updateFields.status === "string" ? updateFields.status : existing.status;
     Object.assign(updateFields, transition.patch);
 
     const nextStatus = updateFields.status ?? existing.status;
-    if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
+    if (updateFields.unblockDescriptor && requestedStatusForDescriptor !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");
+    }
+    if (requestedStatusForDescriptor === "blocked" && nextStatus !== "blocked") {
+      delete updateFields.unblockDescriptor;
     }
     const descriptor = updateFields.unblockDescriptor ?? null;
     if (descriptor && typeof descriptor === "object") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue route applies execution-policy transitions before it validates an unblock descriptor.
> - A pending review stage may rewrite a requested `blocked` status to `in_progress`.
> - The later validation then sees the rewritten status instead of the caller request.
> - This pull request keeps the caller request for the descriptor check and removes an orphan descriptor when the review stage wins.
> - The benefit is a correct response and no misleading 422 for a valid review-gated transition.

## Linked Issues or Issue Description

**What happened?**

A PATCH request with `status: blocked` and `unblockDescriptor` can receive `422 unblockDescriptor requires blocked status` when the issue has an active execution-policy review stage. The policy transition rewrites the effective status before the descriptor guard runs.

**Expected behavior**

The request should not receive the misleading 422 when the caller requested `blocked`. If the active review stage rewrites the effective status, the response should show that effective status and must not persist `unblockDescriptor` on the non-blocked issue.

**Steps to reproduce**

1. Create an issue with a pending review stage.
2. Send a PATCH request with `status: blocked` and an `unblockDescriptor`.
3. Confirm that the response reflects the review transition and contains no orphan descriptor.

**Paperclip version or commit**

`9137f8c52`

**Deployment mode**

Local dev (`pnpm dev`)

**Installation method**

Built from source (`pnpm dev`)

**Agent adapter(s) involved**

Not adapter-specific (core bug)

**Database mode**

Not database-related

## What Changed

- Capture the caller-requested status before merging the execution-policy transition patch.
- Validate `unblockDescriptor` against the caller request, not the rewritten effective status.
- Drop the descriptor when a requested `blocked` transition is rewritten to a non-blocked status.
- Add unit coverage for the pending-review rewrite.
- Add route coverage for the no-review atomic blocked update and the active-review cleanup path.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-execution-policy.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts`
- Result: 2 files passed; 87 tests passed.
- The pre-fix regression run returned the reported 422.
- The final targeted run passed. It emitted two existing mocked-environment cleanup warnings. The warnings did not fail tests.

## Risks

Low risk. The change is limited to PATCH descriptor validation ordering. It adds no endpoint, schema, or migration. Existing blocked transitions without an active review stage keep their current behavior. The targeted tests cover both paths.

## Model Used

OpenAI Codex provider, `gpt-5.6-luna`. Tool use and local TypeScript/Vitest execution were used. An independent review agent is validating the exact diff and targeted tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes; no documentation change is required for this internal behavior fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green; CI is pending
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups; review is pending
- [ ] I will address all Greptile and reviewer comments before requesting merge
