### PR TITLE
fix: allow child agents to name blocked parent assignee as unblock owner

### DIFF
--- a/server/src/__tests__/routable-blocked.test.ts
+++ b/server/src/__tests__/routable-blocked.test.ts
@@ -1,10 +1,44 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  agentUnblockOwnerDeniedReason,
   deliverAgentUnblockNotification,
+  resolveRequestedUnblockDescriptor,
   ROUTABLE_BLOCKED_ROLLOUT_AT,
 } from "../services/routable-blocked.js";
 
 const agentId = "00000000-0000-4000-8000-000000000001";
+const parentAgentId = "00000000-0000-4000-8000-000000000003";
+
+describe("unblock descriptor helpers", () => {
+  it("reads unblockDescriptor from either update fields or request body", () => {
+    const descriptor = { owner: { agentId }, action: "Review" } as const;
+    expect(resolveRequestedUnblockDescriptor({}, { unblockDescriptor: descriptor })).toEqual(descriptor);
+    expect(resolveRequestedUnblockDescriptor({ unblockDescriptor: descriptor }, {})).toEqual(descriptor);
+    expect(resolveRequestedUnblockDescriptor({}, {})).toBeNull();
+  });
+
+  it("allows an assigned child agent to name the blocked parent assignee", () => {
+    expect(agentUnblockOwnerDeniedReason({
+      actorType: "agent",
+      actorAgentId: agentId,
+      issueAssigneeAgentId: agentId,
+      owner: { agentId: parentAgentId },
+      parentAssigneeAgentId: parentAgentId,
+      parentBlockedByChild: true,
+    })).toBeNull();
+  });
+
+  it("rejects naming the parent assignee without a parent blocker edge", () => {
+    expect(agentUnblockOwnerDeniedReason({
+      actorType: "agent",
+      actorAgentId: agentId,
+      issueAssigneeAgentId: agentId,
+      owner: { agentId: parentAgentId },
+      parentAssigneeAgentId: parentAgentId,
+      parentBlockedByChild: false,
+    })).toBe("Agents may only name themselves as an unblock owner");
+  });
+});
 
 function blockedIssue(input: {
   transitionAt?: Date | null;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -233,7 +233,11 @@ import {
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
-import { deliverAgentUnblockNotification } from "../services/routable-blocked.js";
+import {
+  agentUnblockOwnerDeniedReason,
+  deliverAgentUnblockNotification,
+  resolveRequestedUnblockDescriptor,
+} from "../services/routable-blocked.js";
 import {
   assertIssueReviewVerdictActorAllowed,
   isIssueReviewVerdictInteraction,
@@ -9688,24 +9692,18 @@ export function issueRoutes(
     Object.assign(updateFields, transition.patch);
 
     const nextStatus = updateFields.status ?? existing.status;
-    if (updateFields.unblockDescriptor && nextStatus !== "blocked") {
+    const descriptor = resolveRequestedUnblockDescriptor(updateFields, req.body);
+    if (descriptor && nextStatus !== "blocked") {
       throw unprocessable("unblockDescriptor requires blocked status");
     }
-    const descriptor = updateFields.unblockDescriptor ?? null;
-    if (descriptor && typeof descriptor === "object") {
+    if (descriptor) {
       const owner = descriptor.owner;
-      if (req.actor.type === "agent" && (owner === "board" || "userId" in owner)) {
-        throw forbidden("Agents may only name themselves as an unblock owner");
-      }
       if (owner !== "board" && "agentId" in owner) {
         const target = await db.select({ id: agents.id }).from(agents).where(and(
           eq(agents.id, owner.agentId),
           eq(agents.companyId, existing.companyId),
         )).limit(1).then((rows) => rows[0] ?? null);
         if (!target) throw unprocessable("Unblock owner agent must belong to the issue company");
-        if (req.actor.type === "agent" && req.actor.agentId !== owner.agentId) {
-          throw forbidden("Agents may only name themselves as an unblock owner");
-        }
       } else if (owner !== "board" && "userId" in owner) {
         const member = await db.select({ id: companyMemberships.id }).from(companyMemberships).where(and(
           eq(companyMemberships.companyId, existing.companyId),
@@ -9715,6 +9713,46 @@ export function issueRoutes(
         )).limit(1).then((rows) => rows[0] ?? null);
         if (!member) throw unprocessable("Unblock owner user must be an active company member");
       }
+
+      let parentAssigneeAgentId: string | null = null;
+      let parentBlockedByChild = false;
+      if (
+        req.actor.type === "agent" &&
+        existing.parentId &&
+        "agentId" in owner &&
+        req.actor.agentId !== owner.agentId
+      ) {
+        const parent = await db
+          .select({ assigneeAgentId: issueRows.assigneeAgentId })
+          .from(issueRows)
+          .where(and(eq(issueRows.id, existing.parentId), eq(issueRows.companyId, existing.companyId)))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        parentAssigneeAgentId = parent?.assigneeAgentId ?? null;
+        if (parentAssigneeAgentId) {
+          parentBlockedByChild = await db
+            .select({ id: issueRelations.id })
+            .from(issueRelations)
+            .where(and(
+              eq(issueRelations.companyId, existing.companyId),
+              eq(issueRelations.issueId, existing.id),
+              eq(issueRelations.relatedIssueId, existing.parentId),
+              eq(issueRelations.type, "blocks"),
+            ))
+            .limit(1)
+            .then((rows) => rows.length > 0);
+        }
+      }
+
+      const deniedReason = agentUnblockOwnerDeniedReason({
+        actorType: req.actor.type,
+        actorAgentId: req.actor.agentId,
+        issueAssigneeAgentId: existing.assigneeAgentId,
+        owner,
+        parentAssigneeAgentId,
+        parentBlockedByChild,
+      });
+      if (deniedReason) throw forbidden(deniedReason);
     }
     const enteringBlocked = existing.status !== "blocked" && updateFields.status === "blocked";
     if (enteringBlocked) {

--- a/server/src/services/routable-blocked.ts
+++ b/server/src/services/routable-blocked.ts
@@ -1,6 +1,41 @@
-import type { IssueUnblockDescriptor } from "@paperclipai/shared";
+import type { IssueUnblockDescriptor, IssueUnblockOwner } from "@paperclipai/shared";
 
 export const ROUTABLE_BLOCKED_ROLLOUT_AT = new Date("2026-07-23T18:13:03.000Z");
+
+export function resolveRequestedUnblockDescriptor(
+  updateFields: { unblockDescriptor?: IssueUnblockDescriptor | null | undefined },
+  body: { unblockDescriptor?: IssueUnblockDescriptor | null | undefined },
+): IssueUnblockDescriptor | null {
+  const descriptor = updateFields.unblockDescriptor ?? body.unblockDescriptor ?? null;
+  return descriptor && typeof descriptor === "object" ? descriptor : null;
+}
+
+export function agentUnblockOwnerDeniedReason(input: {
+  actorType: string;
+  actorAgentId?: string | null;
+  issueAssigneeAgentId?: string | null;
+  owner: IssueUnblockOwner;
+  parentAssigneeAgentId?: string | null;
+  parentBlockedByChild?: boolean;
+}): string | null {
+  if (input.actorType !== "agent") return null;
+  if (input.owner === "board" || "userId" in input.owner) {
+    return "Agents may only name themselves as an unblock owner";
+  }
+  if ("agentId" in input.owner) {
+    if (input.actorAgentId === input.owner.agentId) return null;
+    const mayNameParentAssignee = Boolean(
+      input.issueAssigneeAgentId &&
+      input.actorAgentId === input.issueAssigneeAgentId &&
+      input.parentAssigneeAgentId &&
+      input.owner.agentId === input.parentAssigneeAgentId &&
+      input.parentBlockedByChild,
+    );
+    if (mayNameParentAssignee) return null;
+    return "Agents may only name themselves as an unblock owner";
+  }
+  return null;
+}
 
 type RoutableBlockedIssue = {
   id: string;


### PR DESCRIPTION
## Thinking Path

- Paperclip structured `blocked` status requires an `unblockDescriptor` naming who can clear the blocker.
- Agent-authored descriptors currently allow only self-ownership, which breaks parent/child delegation: a child executor must hand a blocker back to the parent issue’s assignee (the leader) without board intervention.
- Parent/child work already uses issue hierarchy plus optional `blocks` edges; this change authorizes only that narrow case.
- Atomic `status=blocked` + `unblockDescriptor` PATCHes must validate against the request body, not only parsed update fields, or the transition is rejected inconsistently.
- Related but distinct from reporting-line manager routing (#10366): this path keys off parent issue assignee + child `blocks` parent edge, not `reportsTo` ancestry.

## What Changed

- Add `resolveRequestedUnblockDescriptor` and `agentUnblockOwnerDeniedReason` in `routable-blocked.ts`.
- Allow an assigned child agent to name the parent issue’s assignee as unblock owner when the child issue `blocks` its parent.
- Preserve existing restrictions: agents cannot name board/users/arbitrary agents.
- Read `unblockDescriptor` from either update fields or request body during PATCH validation.
- Unit tests for descriptor resolution, allowed parent-assignee case, and rejection without a parent blocker edge.

## Verification

- Exercised in Hive production downstream on `v2026.817.0` (child blocked handoff with parent leader as unblock owner; previously 403).
- Targeted unit coverage in `server/src/__tests__/routable-blocked.test.ts`.

## Risks

- Authorization is intentionally narrow: requires child assignee === actor, parent assignee === named owner, and an existing `blocks` relation child → parent.
- Does not change assignment, wake delivery, or reporting-line manager logic (#10366).

## Related

- Complements #10112 / #10418 structured-blocker work.
- Orthogonal to #10366 (manager chain via `reportsTo`).


Made with [Cursor](https://cursor.com)