### PR TITLE
fix(heartbeat): defer routine execution lock contention and guard recovery promotion

### DIFF
--- a/server/src/__tests__/heartbeat-routine-execution-lock-contention.test.ts
+++ b/server/src/__tests__/heartbeat-routine-execution-lock-contention.test.ts
@@ -1,0 +1,338 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+// Regression coverage for routine execution-lock contention. A routine with
+// concurrencyPolicy=always_enqueue can have a later fire's execution issue claimed
+// while a prior fire's execution issue still holds the routine execution lock
+// (execution_run_id set). The null->set lock stamp then collides with the
+// issues_open_routine_execution_uq partial unique index. Before the fix this raised
+// an unhandled 23505 ("Failed query") that killed the run and dropped the digest
+// with no visible error; now the contended run is left queued and retried once the
+// prior lock frees.
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Routine execution-lock contention test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping routine execution-lock contention tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
+describeEmbeddedPostgres("heartbeat routine execution-lock contention", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  const countExecuteCallsForRun = (runId: string) =>
+    mockAdapterExecute.mock.calls.filter(([context]) => context?.runId === runId).length;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-routine-exec-lock-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Routine execution-lock contention test run.",
+      provider: "test",
+      model: "test-model",
+    }));
+    runningProcesses.clear();
+    await heartbeat.drainActiveRunExecutions();
+    await db.execute(sql.raw(`
+      TRUNCATE TABLE
+        "issues",
+        "heartbeat_run_events",
+        "cost_events",
+        "activity_log",
+        "heartbeat_runs",
+        "agent_wakeup_requests",
+        "agent_runtime_state",
+        "agents",
+        "companies"
+      RESTART IDENTITY CASCADE
+    `));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Scheduled Sweeper",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          // Allow a free concurrency slot so claimQueuedRun actually runs for the
+          // contended fire (the lock holder below is a terminal run, so it does not
+          // consume a slot).
+          maxConcurrentRuns: 2,
+        },
+      },
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  // Seeds an open routine-execution issue for a routine identity. When a lock
+  // holder run id is provided the issue holds the routine execution lock.
+  async function seedRoutineExecutionIssue(input: {
+    companyId: string;
+    agentId: string;
+    originId: string;
+    originFingerprint: string;
+    lockHeldByRunId?: string | null;
+  }) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: input.companyId,
+      title: "Scheduled sweep — 3x daily",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: input.agentId,
+      originKind: "routine_execution",
+      originId: input.originId,
+      originFingerprint: input.originFingerprint,
+      executionRunId: input.lockHeldByRunId ?? null,
+      executionAgentNameKey: input.lockHeldByRunId ? "scheduled-sweeper" : null,
+      executionLockedAt: input.lockHeldByRunId ? new Date() : null,
+    });
+    return issueId;
+  }
+
+  async function seedQueuedRun(input: { companyId: string; agentId: string; issueId: string }) {
+    const wakeupRequestId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: input.issueId },
+      status: "queued",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId,
+      contextSnapshot: { issueId: input.issueId, wakeReason: "issue_assigned" },
+    });
+    await db
+      .update(agentWakeupRequests)
+      .set({ runId })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+    return { runId, wakeupRequestId };
+  }
+
+  // Terminal heartbeat run that a stale routine execution lock points at.
+  async function seedLockHolderRun(input: { companyId: string; agentId: string }) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      createdAt: new Date(),
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      contextSnapshot: {},
+    });
+    return runId;
+  }
+
+  it("defers a contended routine-execution fire instead of failing it", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const originId = randomUUID();
+    const originFingerprint = randomUUID();
+
+    // Prior fire's execution issue still holds the routine lock.
+    const holderRunId = await seedLockHolderRun({ companyId, agentId });
+    const priorIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+      lockHeldByRunId: holderRunId,
+    });
+
+    // Next fire's execution issue + its queued run.
+    const nextIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+    });
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId: nextIssueId,
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    // Give any (incorrect) background execution a chance to surface.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const [run] = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    const [nextIssue] = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, nextIssueId));
+    const [priorIssue] = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, priorIssueId));
+    const [wakeup] = await db
+      .select({ status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+
+    // Contended fire is left queued for retry, not failed/cancelled.
+    expect(run?.status).toBe("queued");
+    expect(run?.errorCode).toBeNull();
+    // The lock was not stolen from the prior issue, and the next issue never
+    // acquired it.
+    expect(nextIssue?.executionRunId).toBeNull();
+    expect(priorIssue?.executionRunId).toBe(holderRunId);
+    // No adapter execution happened for the deferred run.
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+    // The wakeup is still pending (queued), not skipped/failed.
+    expect(wakeup?.status).toBe("queued");
+  });
+
+  it("runs the deferred fire once the prior routine lock is released", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const originId = randomUUID();
+    const originFingerprint = randomUUID();
+
+    const holderRunId = await seedLockHolderRun({ companyId, agentId });
+    const priorIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+      lockHeldByRunId: holderRunId,
+    });
+    const nextIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+    });
+    const { runId } = await seedQueuedRun({ companyId, agentId, issueId: nextIssueId });
+
+    // First pass: contended, deferred (stays queued).
+    await heartbeat.resumeQueuedRuns();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const [deferred] = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(deferred?.status).toBe("queued");
+
+    // Prior fire completes and releases the routine lock.
+    await db
+      .update(issues)
+      .set({ status: "done", executionRunId: null, executionAgentNameKey: null, executionLockedAt: null })
+      .where(eq(issues.id, priorIssueId));
+
+    // Second pass: the deferred run now claims the lock and executes.
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const [run] = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      return run?.status === "succeeded";
+    });
+
+    const [run] = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6466,6 +6466,35 @@ function normalizeAgentNameKey(value: string | null | undefined) {
   return normalized.length > 0 ? normalized : null;
 }
 
+// Detects the Postgres unique-violation (23505) raised by the
+// `issues_open_routine_execution_uq` partial unique index, which enforces at most
+// one *locked* (execution_run_id set) open routine-execution issue per routine
+// identity (companyId, originKind, originId, originFingerprint). The error can
+// arrive as the raw pg error or wrapped by Drizzle's query error, so we walk the
+// cause chain. See routines.ts for the sibling detection on the dispatch path.
+function isOpenRoutineExecutionLockConflict(error: unknown): boolean {
+  const constraint = "issues_open_routine_execution_uq";
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth += 1) {
+    // node-postgres surfaces the index on `constraint`; the porsager `postgres`
+    // driver used here surfaces it on `constraint_name`. Match either.
+    const candidate = current as {
+      code?: unknown;
+      constraint?: unknown;
+      constraint_name?: unknown;
+      cause?: unknown;
+    };
+    if (
+      candidate.code === "23505" &&
+      (candidate.constraint === constraint || candidate.constraint_name === constraint)
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
 const defaultSessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     const asObj = parseObject(raw);
@@ -12715,6 +12744,55 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueContext: issueId ? await getIssueExecutionContext(run.companyId, issueId) : null,
       routineEnvContext: { routineId: null, env: null, responsibleUserId: null },
     });
+
+    // Fix A (lazy locking): stamp executionRunId at claim time (not at queue time).
+    // Guard is idempotent — safe if called more than once.
+    //
+    // This runs BEFORE flipping the run to "running" so a routine-execution lock
+    // contention leaves the run cleanly queued for a later tick instead of failing
+    // the fire. The issues_open_routine_execution_uq partial unique index
+    // permits only one *locked* open routine-execution issue per routine identity;
+    // under always_enqueue a later fire can be claimed while a prior fire's
+    // execution issue still holds the lock, and the null->set transition then hits
+    // that index. Previously the unhandled 23505 surfaced as "Failed query" and
+    // killed the run, dropping the digest with no visible error. We now serialize:
+    // leave this run queued and retry once the prior execution issue completes or
+    // the stale-lock backstop sweeper clears the lock.
+    const wakeReason = readNonEmptyString(context.wakeReason);
+    if (issueId && wakeReason !== "source_scoped_recovery_action") {
+      const claimedAgent = await getAgent(run.agentId);
+      try {
+        await db
+          .update(issues)
+          .set({
+            executionRunId: run.id,
+            executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
+            executionLockedAt: claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              // Mention/context runs can touch an issue, but only the current assignee
+              // owns the issue execution lock shown as the active run.
+              eq(issues.assigneeAgentId, run.agentId),
+              or(isNull(issues.executionRunId), eq(issues.executionRunId, run.id)),
+            ),
+          );
+      } catch (error) {
+        if (!isOpenRoutineExecutionLockConflict(error)) throw error;
+        // Another open execution issue for the same routine identity currently
+        // holds the lock. Leave this run queued (do not flip to "running") so a
+        // later tick retries it once the lock frees, instead of failing the fire.
+        logger.info(
+          { runId: run.id, issueId, agentId: run.agentId },
+          "claimQueuedRun: deferred routine execution run; routine lock held by a concurrent execution",
+        );
+        return null;
+      }
+    }
+
     const claimed = await db
       .update(heartbeatRuns)
       .set({
@@ -12746,33 +12824,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     publishRunLifecyclePluginEvent(claimed);
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
-
-    // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedContext = parseObject(claimed.contextSnapshot);
-    const claimedIssueId = readNonEmptyString(claimedContext.issueId);
-    const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
-    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
-      const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, claimedIssueId),
-            eq(issues.companyId, claimed.companyId),
-            // Mention/context runs can touch an issue, but only the current assignee
-            // owns the issue execution lock shown as the active run.
-            eq(issues.assigneeAgentId, claimed.agentId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
-        );
-    }
 
     return claimed;
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { createHash, randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, gte, inArray, isNull, lt, lte, ne, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, gte, inArray, isNotNull, isNull, lt, lte, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -6495,6 +6495,97 @@ function isOpenRoutineExecutionLockConflict(error: unknown): boolean {
   return false;
 }
 
+const ROUTINE_EXECUTION_OPEN_ISSUE_STATUSES = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "in_review",
+  "blocked",
+] as const;
+
+async function routineExecutionLockHeldBySiblingIssue(
+  executor: Pick<Db, "select">,
+  issue: {
+    id: string;
+    companyId: string;
+    originKind: string | null;
+    originId: string | null;
+    originFingerprint: string | null;
+  },
+): Promise<boolean> {
+  if (issue.originKind !== "routine_execution" || !issue.originId || !issue.originFingerprint) {
+    return false;
+  }
+  const holder = await executor
+    .select({ id: issues.id })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, issue.companyId),
+        eq(issues.originKind, "routine_execution"),
+        eq(issues.originId, issue.originId),
+        eq(issues.originFingerprint, issue.originFingerprint),
+        ne(issues.id, issue.id),
+        isNull(issues.hiddenAt),
+        inArray(issues.status, [...ROUTINE_EXECUTION_OPEN_ISSUE_STATUSES]),
+        isNotNull(issues.executionRunId),
+      ),
+    )
+    .limit(1);
+  return holder.length > 0;
+}
+
+async function lockRoutineExecutionIdentityRows(
+  executor: Pick<Db, "execute">,
+  issue: {
+    companyId: string;
+    originKind: string | null;
+    originId: string | null;
+    originFingerprint: string | null;
+  },
+) {
+  if (issue.originKind !== "routine_execution" || !issue.originId || !issue.originFingerprint) {
+    return;
+  }
+  await executor.execute(sql`
+    select id from issues
+    where company_id = ${issue.companyId}
+      and origin_kind = 'routine_execution'
+      and origin_id = ${issue.originId}
+      and origin_fingerprint = ${issue.originFingerprint}
+      and hidden_at is null
+      and status in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')
+    order by id
+    for update
+  `);
+}
+
+async function abortQueuedRunPromotionAfterRoutineLockConflict(
+  executor: Pick<Db, "update">,
+  input: { queuedRunId: string; wakeupRequestId: string; now: Date },
+) {
+  const message = "Another open routine execution issue already holds this lane lock";
+  await executor
+    .update(heartbeatRuns)
+    .set({
+      status: "cancelled",
+      finishedAt: input.now,
+      error: message,
+      errorCode: "routine_execution_lock_contended",
+      updatedAt: input.now,
+    })
+    .where(eq(heartbeatRuns.id, input.queuedRunId));
+  await executor
+    .update(agentWakeupRequests)
+    .set({
+      status: "skipped",
+      finishedAt: input.now,
+      error: message,
+      updatedAt: input.now,
+    })
+    .where(eq(agentWakeupRequests.id, input.wakeupRequestId));
+}
+
 const defaultSessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     const asObj = parseObject(raw);
@@ -10043,7 +10134,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
 
       const issue = await tx
-        .select({ id: issues.id })
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          originKind: issues.originKind,
+          originId: issues.originId,
+          originFingerprint: issues.originFingerprint,
+        })
         .from(issues)
         .where(and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)))
         .then((rows) => rows[0] ?? null);
@@ -10096,6 +10193,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           updatedAt: now,
         })
         .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+      await lockRoutineExecutionIdentityRows(tx, issue);
+      if (await routineExecutionLockHeldBySiblingIssue(tx, issue)) {
+        await abortQueuedRunPromotionAfterRoutineLockConflict(tx, {
+          queuedRunId: queuedRun.id,
+          wakeupRequestId: wakeupRequest.id,
+          now,
+        });
+        return null;
+      }
 
       await tx
         .update(issues)
@@ -17430,6 +17537,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           })
           .where(eq(agentWakeupRequests.id, deferred.id));
 
+        await lockRoutineExecutionIdentityRows(tx, issue);
+        if (await routineExecutionLockHeldBySiblingIssue(tx, issue)) {
+          await abortQueuedRunPromotionAfterRoutineLockConflict(tx, {
+            queuedRunId: newRun.id,
+            wakeupRequestId: deferred.id,
+            now,
+          });
+          return { kind: "released" as const };
+        }
+
         await tx
           .update(issues)
           .set({
@@ -17588,6 +17705,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             updatedAt: now,
           })
           .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+        if (await routineExecutionLockHeldBySiblingIssue(tx, issue)) {
+          await abortQueuedRunPromotionAfterRoutineLockConflict(tx, {
+            queuedRunId: queuedRun.id,
+            wakeupRequestId: wakeupRequest.id,
+            now,
+          });
+          return { kind: "released" as const };
+        }
 
         await tx
           .update(issues)
@@ -17750,6 +17876,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           updatedAt: now,
         })
         .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+      await lockRoutineExecutionIdentityRows(tx, issue);
+      if (await routineExecutionLockHeldBySiblingIssue(tx, issue)) {
+        await abortQueuedRunPromotionAfterRoutineLockConflict(tx, {
+          queuedRunId: queuedRun.id,
+          wakeupRequestId: wakeupRequest.id,
+          now,
+        });
+        return { kind: "released" as const };
+      }
 
       await tx
         .update(issues)


### PR DESCRIPTION
## Thinking Path

> - Paperclip routines create `routine_execution` issues; a partial unique index permits only one *locked* open issue per routine identity.
> - Under `always_enqueue`, a later fire can be claimed while a prior issue still holds `execution_run_id`; stamping the lock then hits `issues_open_routine_execution_uq`.
> - Upstream PR #10823 defers contended claims in `claimQueuedRun` instead of failing the run.
> - Production also saw the same constraint during `releaseIssueExecutionAndPromote` recovery promotion, which aborted periodic recovery loops (Refs #3824).
> - This PR includes the #10823 claim-path fix and adds recovery-path guards: lock sibling rows, pre-check for an existing holder, and cancel orphan queued promotions without aborting the transaction.

## Linked Issues

Refs #3824
Refs #10823

If #10823 merges first, I will rebase the recovery-only commit onto master.

## What Changed

- `claimQueuedRun`: move routine execution lock stamp before flipping to `running`; on `issues_open_routine_execution_uq`, leave the run queued (from #10823).
- `releaseIssueExecutionAndPromote` + missing-comment retry: `lockRoutineExecutionIdentityRows` + sibling pre-check before stamping; cancel orphan queued promotion when a sibling already holds the lane lock.
- Embedded Postgres regression test for contended claim deferral (from #10823).

## Verification

- Cherry-picks verified on private downstream `hive/production` (`de23fbc7c`).
- R2 review loop on recovery paths (transaction-safe pre-check + row locks).
- Upstream contribution prepared via `prepare-upstream-contribution.sh` (hygiene scan clean).

## Risks

Low. Claim-path behavior matches #10823. Recovery-path change only affects duplicate routine lanes with an existing lock holder.

## Model Used

Claude Sonnet (Cursor agent), with independent R2 review pass.

## Checklist

- [x] Thinking Path included
- [x] Model Used included
- [x] Searched duplicates; linked #3824 and #10823
- [x] No internal Hive ticket ids in upstream-facing text
- [x] Branch name is `fix/routine-execution-lock-contention-recovery`
- [ ] Full Paperclip CI green — pending
- [ ] Greptile 5/5 — pending first review

Made with [Cursor](https://cursor.com)