### PR TITLE
fix(codex-local): approve managed MCP tools under exec never-mode

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -878,6 +878,7 @@ describe("evaluateCodexCredentialReadiness", () => {
       const zero = await fs.readFile(path.join(zeroHome, "config.toml"), "utf8");
       expect(alpha).toContain('[mcp_servers."alpha"]');
       expect(alpha).toContain('Authorization = "Bearer alpha-token"');
+      expect(alpha).toContain('default_tools_approval_mode = "approve"');
       expect(zero).not.toContain("mcp_servers.");
       expect(zero).not.toContain("stale-token");
       expect(alphaHome).not.toBe(zeroHome);

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -294,6 +294,8 @@ function buildManagedMcpBlock(input: {
       `[mcp_servers.${tomlString(managedName)}]`,
       `url = ${tomlString(url)}`,
       `headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
+      // Codex exec uses approval=never; unnamed MCP tools are otherwise auto-cancelled.
+      `default_tools_approval_mode = ${tomlString("approve")}`,
     );
   });
   lines.push(MANAGED_MCP_BLOCK_END);


### PR DESCRIPTION
## Summary
Codex CLI unattended runs (`approval: never` / bypass) auto-cancel MCP tools that have no `default_tools_approval_mode`. Paperclip already writes governed gateways into `config.toml`, including `search_tools` / `run_tool`, so heartbeats see an empty callable inventory (`user cancelled MCP tool call`) and fall back to shell.

This sets `default_tools_approval_mode = "approve"` on every Paperclip-managed MCP server block. It does not change gateway policy; it only matches Codex's unattended approval contract so the tools Paperclip injected are actually callable.

## Test plan
- [x] Adapter unit test asserts the managed block contains `default_tools_approval_mode = "approve"`
- [ ] `codex exec` heartbeat with a governed gateway can call `search_tools` / `run_tool` without `user cancelled MCP tool call`


Made with [Cursor](https://cursor.com)