### PR TITLE
fix(workspaces): the inert-reaper warning was blind to two of its own outcomes

### DIFF
--- a/server/src/__tests__/terminal-workspace-sweep-inert.test.ts
+++ b/server/src/__tests__/terminal-workspace-sweep-inert.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { terminalWorkspaceSweepWasInert } from "../services/execution-workspaces.ts";
+
+/**
+ * The full result shape `sweepTerminalWorkspaces` returns. Every counter is
+ * listed so the "one non-zero outcome at a time" case below covers all of them
+ * rather than the subset someone happened to think of.
+ */
+const EMPTY_SWEEP = {
+  checked: 0,
+  eligible: 0,
+  archived: 0,
+  cleanupFailed: 0,
+  skippedActiveRun: 0,
+  skippedNonTerminalTree: 0,
+  skippedUndelivered: 0,
+  skippedRace: 0,
+  skippedReopened: 0,
+  skippedCooldown: 0,
+  clearedStaleReopenPending: 0,
+};
+
+const NON_ARCHIVING_OUTCOMES = [
+  "skippedActiveRun",
+  "skippedNonTerminalTree",
+  "skippedUndelivered",
+  "skippedRace",
+  "skippedReopened",
+  "skippedCooldown",
+  "clearedStaleReopenPending",
+] as const;
+
+describe("terminalWorkspaceSweepWasInert", () => {
+  it("reports a sweep that found no candidates as not inert", () => {
+    // Nothing to archive is not the same as failing to archive. An idle
+    // instance must not log every ten minutes.
+    expect(terminalWorkspaceSweepWasInert(EMPTY_SWEEP)).toBe(false);
+  });
+
+  it("reports a sweep that archived or cleanup-failed as not inert", () => {
+    expect(terminalWorkspaceSweepWasInert({ ...EMPTY_SWEEP, checked: 5, archived: 1 })).toBe(false);
+    expect(terminalWorkspaceSweepWasInert({ ...EMPTY_SWEEP, checked: 5, cleanupFailed: 1 })).toBe(false);
+  });
+
+  // The regression this predicate exists for. The caller used to sum five named
+  // skip counters and omitted `skippedReopened` and `clearedStaleReopenPending`,
+  // so a reaper skipping every candidate for either reason logged nothing --
+  // permanently silent, which is how an instance reached 2,598 workspaces and
+  // zero archived rows without a single warning.
+  it.each(NON_ARCHIVING_OUTCOMES)("reports a sweep whose only outcome is %s as inert", (outcome) => {
+    expect(terminalWorkspaceSweepWasInert({ ...EMPTY_SWEEP, checked: 3, [outcome]: 3 })).toBe(true);
+  });
+
+  // Guards the shape itself: a new non-archiving outcome added to the sweep
+  // must not need this predicate updated to stay visible.
+  it("reports a sweep with candidates and no recognised outcome at all as inert", () => {
+    expect(terminalWorkspaceSweepWasInert({ ...EMPTY_SWEEP, checked: 3 })).toBe(true);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ import {
   decisionRetentionService,
   externalObjectService,
   executionWorkspaceService,
+  terminalWorkspaceSweepWasInert,
   heartbeatService,
   issueThreadInteractionService,
   issueService,
@@ -1118,14 +1119,11 @@ export async function startServer(): Promise<StartedServer> {
             logger.info(result, "terminal issue workspace reaper changed workspace state");
             return;
           }
-          const skipped =
-            result.skippedActiveRun
-            + result.skippedNonTerminalTree
-            + result.skippedUndelivered
-            + result.skippedRace
-            + result.skippedCooldown;
           const nowMs = Date.now();
-          if (skipped > 0 && nowMs - lastTerminalWorkspaceSkipLogAt >= terminalWorkspaceSkipLogIntervalMs) {
+          if (
+            terminalWorkspaceSweepWasInert(result)
+            && nowMs - lastTerminalWorkspaceSkipLogAt >= terminalWorkspaceSkipLogIntervalMs
+          ) {
             lastTerminalWorkspaceSkipLogAt = nowMs;
             logger.info(result, "terminal issue workspace reaper skipped all candidates");
           }

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -90,6 +90,26 @@ const WORKSPACE_BRANCH_INCOHERENCE_REASON = "git_worktree_branch_incoherence";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 export const ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON = "issue_terminal";
 
+/**
+ * True when a terminal-workspace sweep inspected candidates and changed none of
+ * them — an inert reaper, which is worth a periodic log line.
+ *
+ * Deliberately derived from `checked` rather than from a sum of the individual
+ * skip counters. The caller used to enumerate five of them and omitted
+ * `skippedReopened` and `clearedStaleReopenPending`, so a reaper that skipped
+ * every candidate for either reason produced no log at all — the one instrument
+ * built to detect an inert reaper was blind to two of its own seven outcomes.
+ * A predicate written against `checked` cannot acquire that blind spot when a
+ * new outcome is added.
+ */
+export function terminalWorkspaceSweepWasInert(result: {
+  checked: number;
+  archived: number;
+  cleanupFailed: number;
+}): boolean {
+  return result.checked > 0 && result.archived === 0 && result.cleanupFailed === 0;
+}
+
 // The reopen-failure reason kept on the row when a rebuild does not finish. The
 // value is sanitized: it never contains a repository URL, a host path, or git
 // output.

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -157,7 +157,7 @@ export {
   type MintedEnvironmentCustomImageTerminalSession,
   type ParsedCustomImageSetupSshCommand,
 } from "./environment-custom-image-terminal-sessions.js";
-export { executionWorkspaceService } from "./execution-workspaces.js";
+export { executionWorkspaceService, terminalWorkspaceSweepWasInert } from "./execution-workspaces.js";
 export { workspaceOperationService } from "./workspace-operations.js";
 export {
   workspaceRuntimeLeaseService,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A terminal issue's execution workspace is reclaimed by a reaper that sweeps every 30 seconds
> - A reaper that inspects candidates and archives none is indistinguishable from an idle one, so the scheduler logs a throttled line for exactly that case
> - That log's condition enumerates five of the sweep's seven non-archiving outcomes, so a reaper skipping every candidate for either of the other two is permanently silent
> - This pull request derives the condition from the candidate count instead of from a sum of named counters
> - The benefit is that the one instrument built to detect an inert reaper stops having a blind spot in the case it exists to detect

## Linked Issues or Issue Description

No public issue exists for this. The problem follows the bug report template.

**What happened?**

`sweepTerminalWorkspaces` returns eleven counters. Seven of them describe a candidate that was inspected and not archived: `skippedActiveRun`, `skippedNonTerminalTree`, `skippedUndelivered`, `skippedRace`, `skippedReopened`, `skippedCooldown`, and `clearedStaleReopenPending`.

The scheduler in `server/src/index.ts` summed five:

```ts
const skipped =
  result.skippedActiveRun
  + result.skippedNonTerminalTree
  + result.skippedUndelivered
  + result.skippedRace
  + result.skippedCooldown;
if (skipped > 0 && /* throttle */) { logger.info(result, "terminal issue workspace reaper skipped all candidates"); }
```

`skippedReopened` and `clearedStaleReopenPending` are absent. A sweep whose candidates all land in either of those hits `skipped === 0`, takes neither the archive branch nor the skip branch, and produces no output — on every tick, indefinitely.

The comment directly above that code states the intent: *"Emit a periodic signal when the reaper inspects candidates but archives none, so an inert reaper that skips every candidate is never fully silent."* The implementation does not hold for two of the seven ways a candidate can be skipped.

**Expected behavior**

A sweep that inspects candidates and changes none of them is reported, regardless of which guard the candidates hit.

**Steps to reproduce**

1. Arrange a set of terminal-issue workspaces whose only skip outcome is `skippedReopened` (a reopen-pending flag inside its grace window on every candidate).
2. Let the reaper run.
3. `checked` is non-zero and `archived` is zero, and nothing is logged — not on the first tick, and not on any tick after it.

**Paperclip version or commit**

`master`, at commit cc42a67e7.

**Deployment mode**

Self-hosted, single instance.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Database mode**

PostgreSQL.

## What Changed

- Added `terminalWorkspaceSweepWasInert(result)` to `services/execution-workspaces.ts`, next to the sweep whose shape it reads: `checked > 0 && archived === 0 && cleanupFailed === 0`.
- The scheduler calls it instead of summing counters by name.
- Extracted rather than inlined so the predicate is testable. The scheduler closure around it — timers, throttle state, `trackHeartbeatSchedulerWork` — is not.

The choice of `checked` over "add the two missing names" is the substance of the fix. Enumerating outcomes is what created the blind spot; a longer enumeration is the same bug with a later expiry date. Deriving from the candidate count cannot go stale when an eighth outcome is added.

## Verification

- `server/src/__tests__/terminal-workspace-sweep-inert.test.ts` (new, 10 cases) — passes. No database required; it is a pure predicate.
- `tsc --noEmit -p server/tsconfig.json` — no new errors. Two pre-existing `plugin-worker-manager.ts` errors reproduce identically on the unmodified base commit.

The regression case is driven by `it.each` over all seven non-archiving outcomes, asserted from a literal of the sweep's full result shape. Both previously-missed outcomes are covered by construction rather than by having been thought of.

## Risks

- **More log volume on an instance whose reaper is genuinely inert.** That is the intent. The existing ten-minute throttle is unchanged, so the ceiling is six lines an hour.
- **No behavioural change to the reaper itself.** Only the reporting condition moves; archive, cleanup, and skip logic are untouched.
- **`checked > 0` keeps an idle instance quiet.** A sweep that finds no candidates is not inert, and does not log.

## Category safeguard

Implemented here rather than deferred: the test builds its cases from the sweep's full result shape and iterates every non-archiving outcome, so an outcome added later that this predicate would miss fails the suite instead of going unreported. That is the class-level version of the bug — a hand-maintained enumeration of a growing set — rather than a fix to the two names that happened to be missing.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
