### PR TITLE
fix(codex): keep MCP access run-bound

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./codex-home.js";
 
 describe("mergeManagedCodexMcpGateways", () => {
-  it("keeps runtime gateways and appends non-overlapping context gateways", () => {
+  it("uses runtime gateways as the authoritative run-bound surface", () => {
     expect(
       mergeManagedCodexMcpGateways(
         [{ name: "runtime", endpointPath: "/runtime", bearerToken: "runtime-token" }],
@@ -26,10 +26,16 @@ describe("mergeManagedCodexMcpGateways", () => {
           { name: "manual", endpointPath: "/manual", bearerToken: "manual-token" },
         ],
       ),
-    ).toEqual([
-      { name: "runtime", endpointPath: "/runtime", bearerToken: "runtime-token" },
-      { name: "manual", endpointPath: "/manual", bearerToken: "manual-token" },
-    ]);
+    ).toEqual([{ name: "runtime", endpointPath: "/runtime", bearerToken: "runtime-token" }]);
+  });
+
+  it("falls back to context gateways when no runtime surface exists", () => {
+    expect(
+      mergeManagedCodexMcpGateways(
+        [],
+        [{ name: "manual", endpointPath: "/manual", bearerToken: "manual-token" }],
+      ),
+    ).toEqual([{ name: "manual", endpointPath: "/manual", bearerToken: "manual-token" }]);
   });
 });
 

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -37,14 +37,7 @@ export function mergeManagedCodexMcpGateways(
   primary: ManagedCodexMcpGateway[],
   secondary: ManagedCodexMcpGateway[],
 ): ManagedCodexMcpGateway[] {
-  const merged = [...primary];
-  const names = new Set(primary.map((gateway) => gateway.name));
-  for (const gateway of secondary) {
-    if (names.has(gateway.name)) continue;
-    merged.push(gateway);
-    names.add(gateway.name);
-  }
-  return merged;
+  return primary.length > 0 ? primary : secondary;
 }
 
 function nonEmpty(value: string | undefined): string | null {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent runs and their governed tool access.
> - The Codex adapter combines run-bound MCP gateways with optional context gateways.
> - A run-bound gateway list already contains the authoritative access surface for that run.
> - Appending context gateways can add duplicate or unrelated MCP servers.
> - Duplicate servers can make the effective Codex tool surface inconsistent.
> - This pull request uses context gateways only when no run-bound gateways exist.
> - The benefit is one deterministic and auditable MCP surface per Codex run.

## Linked Issues or Issue Description

**What happened?**

The Codex adapter appended context MCP gateways after it received a non-empty run-bound gateway list. This could add duplicate endpoints or gateways from a different execution context.

**Expected behavior**

The adapter must use the run-bound gateway list as the authoritative surface. It may use context gateways only as a compatibility fallback when the run has no gateway list.

**Steps to reproduce**

1. Start a Codex run with one gateway in `runtimeMcp`.
2. Add a different gateway through `paperclipManagedMcp` context.
3. Inspect the generated Codex MCP configuration.
4. Observe that both gateway sets are present before this change.

Paperclip version or commit: `cc42a67e7e9e8eb183097afc8ff4ebfa694fb3e0`

Deployment mode: Self-hosted server

Agent adapter: Codex

## What Changed

- Use the run-bound MCP gateway list when it is non-empty.
- Use context gateways only when the run-bound list is empty.
- Cover the authoritative path and the compatibility fallback with unit tests.

## Verification

- `vitest run packages/adapters/codex-local/src/server/codex-home.test.ts`
- Result: 50 tests passed.
- A self-hosted canary confirmed that the generated Codex configuration contained only the expected run-bound servers.

## Risks

Low risk. A run with an authoritative gateway list no longer receives extra context gateways. Runs without a gateway list keep the existing context fallback.

This bug fix does not add a roadmap feature.

## Model Used

OpenAI Codex, `gpt-5.6-sol`, low reasoning effort, with repository and code execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
