### PR TITLE
fix(workspaces): let the terminal reaper archive shared workspace sessions

### DIFF
--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -43,6 +43,7 @@ import {
   startRuntimeServicesForWorkspaceControl,
   stopRuntimeServicesForExecutionWorkspace,
 } from "../services/workspace-runtime.ts";
+import * as workspaceRuntime from "../services/workspace-runtime.ts";
 import { workspaceGitOperationScheduler } from "../services/workspace-git-operation-scheduler.ts";
 
 const execFileAsync = promisify(execFile);
@@ -1934,6 +1935,189 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "This shared workspace session points at project workspace infrastructure. Archiving it only removes the session record.",
     ]));
   });
+
+  // Seeds the shape this deployment actually runs: a shared session pointing at a
+  // project checkout it does not own, with no branch and no base ref, and a dirty
+  // working tree owned by whatever else is using that checkout.
+  async function seedSharedSessionOnTerminalIssue(options: { issueStatus?: "done" | "todo" } = {}) {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const sharedCheckout = await createTempRepo();
+    tempDirs.add(sharedCheckout);
+    // Dirt that belongs to other work in the shared checkout, not to this session.
+    await fs.writeFile(path.join(sharedCheckout, "someone-elses-wip.txt"), "wip\n", "utf8");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `P${companyId.slice(0, 8).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared sessions",
+      status: "in_progress",
+      executionWorkspacePolicy: { enabled: true },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      isPrimary: true,
+      cwd: sharedCheckout,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Shared session",
+      status: "active",
+      providerType: "local_fs",
+      cwd: sharedCheckout,
+      // The defining shape: no branch of its own, no base ref to compare against.
+      branchName: null,
+      baseRef: null,
+    });
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      projectId,
+      title: "Shared session source issue",
+      status: options.issueStatus ?? "done",
+      priority: "medium",
+      executionWorkspaceId,
+    });
+    await db
+      .update(executionWorkspaces)
+      .set({ sourceIssueId })
+      .where(eq(executionWorkspaces.id, executionWorkspaceId));
+
+    return { companyId, projectId, projectWorkspaceId, executionWorkspaceId, sourceIssueId, sharedCheckout };
+  }
+
+  it("archives a shared session on a terminal issue even though it can never satisfy the delivery gate", async () => {
+    const seeded = await seedSharedSessionOnTerminalIssue();
+
+    const sweep = await svc.sweepTerminalWorkspaces();
+
+    const row = await db
+      .select({
+        status: executionWorkspaces.status,
+        closedAt: executionWorkspaces.closedAt,
+        cleanupEligibleAt: executionWorkspaces.cleanupEligibleAt,
+        cleanupReason: executionWorkspaces.cleanupReason,
+      })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]);
+
+    expect(sweep.archived).toBe(1);
+    expect(sweep.archivedSharedSession).toBe(1);
+    expect(sweep.skippedUndelivered).toBe(0);
+    expect(row).toMatchObject({
+      status: "archived",
+      cleanupReason: "issue_terminal_shared_session",
+    });
+    expect(row?.closedAt).toBeInstanceOf(Date);
+    expect(row?.cleanupEligibleAt).toBeInstanceOf(Date);
+  }, 20_000);
+
+  it("leaves the shared checkout on disk when it archives a shared session", async () => {
+    const seeded = await seedSharedSessionOnTerminalIssue();
+
+    const sweep = await svc.sweepTerminalWorkspaces();
+
+    // The directory is the project checkout. Archiving the session record must not
+    // reclaim it, and "cleaned" must still be true -- measuring cleanliness by the
+    // path being gone would park every shared session in cleanup_failed forever.
+    await expect(fs.stat(seeded.sharedCheckout)).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(seeded.sharedCheckout, "someone-elses-wip.txt")),
+    ).resolves.toBeTruthy();
+    expect(sweep.cleanupFailed).toBe(0);
+    expect(sweep.archived).toBe(1);
+
+    const status = await db
+      .select({ status: executionWorkspaces.status })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]?.status);
+    expect(status).toBe("archived");
+  }, 20_000);
+
+  it("does not scope a shared session's service teardown by the shared checkout path", async () => {
+    const seeded = await seedSharedSessionOnTerminalIssue();
+    const teardownCalls: Array<{ executionWorkspaceId: string; workspaceCwd?: string | null }> = [];
+    const teardownSpy = vi
+      .spyOn(workspaceRuntime, "stopRuntimeServicesForExecutionWorkspace")
+      .mockImplementation(async (input) => {
+        teardownCalls.push({
+          executionWorkspaceId: input.executionWorkspaceId,
+          workspaceCwd: input.workspaceCwd,
+        });
+      });
+
+    try {
+      await svc.sweepTerminalWorkspaces();
+    } finally {
+      teardownSpy.mockRestore();
+    }
+
+    // stopRuntimeServicesForExecutionWorkspace matches live service records by cwd
+    // prefix as well as by workspace id. A shared session's cwd is the project
+    // checkout every sibling session also points at, so passing it would kill a
+    // live neighbour's dev server as a side effect of archiving this session.
+    expect(teardownCalls).toEqual([
+      { executionWorkspaceId: seeded.executionWorkspaceId, workspaceCwd: null },
+    ]);
+  }, 20_000);
+
+  it("refuses to delete a shared session's directory even when it is flagged runtime-created", async () => {
+    const seeded = await seedSharedSessionOnTerminalIssue();
+    // Detach the project workspace and flag the row runtime-created. This is the
+    // one combination that reaches the local_fs removal branch: createdByRuntime
+    // opens it, and with no projectWorkspaceId the containsProjectWorkspace guard
+    // resolves to false and stops guarding. No shared row carries this flag today,
+    // but nothing in the schema prevents one, and the directory underneath is a
+    // real checkout shared by every other session for that project.
+    await db
+      .update(executionWorkspaces)
+      .set({ projectWorkspaceId: null, metadata: { createdByRuntime: true } })
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId));
+
+    await svc.sweepTerminalWorkspaces();
+
+    await expect(fs.stat(seeded.sharedCheckout)).resolves.toBeTruthy();
+    await expect(
+      fs.stat(path.join(seeded.sharedCheckout, "someone-elses-wip.txt")),
+    ).resolves.toBeTruthy();
+  }, 20_000);
+
+  it("still skips a shared session whose issue is not terminal", async () => {
+    const seeded = await seedSharedSessionOnTerminalIssue({ issueStatus: "todo" });
+
+    const sweep = await svc.sweepTerminalWorkspaces();
+
+    expect(sweep.archived).toBe(0);
+    expect(sweep.archivedSharedSession).toBe(0);
+    expect(sweep.skippedNonTerminalTree).toBe(1);
+
+    const status = await db
+      .select({ status: executionWorkspaces.status })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, seeded.executionWorkspaceId))
+      .then((rows) => rows[0]?.status);
+    expect(status).toBe("active");
+  }, 20_000);
 
   it("clears matching environment selections transactionally without touching other workspaces", async () => {
     const companyId = randomUUID();

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -89,6 +89,11 @@ function issueTerminalTimestamp(issue: {
 const WORKSPACE_BRANCH_INCOHERENCE_REASON = "git_worktree_branch_incoherence";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 export const ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON = "issue_terminal";
+// A shared session is archived on issue terminality alone, without the delivery
+// gates, because it owns no branch or directory to have undelivered work in.
+// Recording that separately keeps the two archive routes distinguishable after
+// the fact instead of collapsing them into one indistinguishable reason.
+export const ISSUE_TERMINAL_SHARED_SESSION_CLEANUP_REASON = "issue_terminal_shared_session";
 
 // The reopen-failure reason kept on the row when a rebuild does not finish. The
 // value is sanitized: it never contains a repository URL, a host path, or git
@@ -1351,10 +1356,11 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       .limit(100);
   }
 
-  async function assessDelivery(
-    workspace: ExecutionWorkspaceRow,
-    git: ExecutionWorkspaceCloseGitReadiness | null,
-  ) {
+  // The issue-tree half of the assessment: which issues this workspace serves,
+  // whether they are all terminal, and when the last of them became terminal.
+  // It reads no git state, so it is the whole assessment for a workspace that
+  // owns no git state of its own.
+  async function assessIssueTreeTerminality(workspace: ExecutionWorkspaceRow) {
     const issueTree = await listWorkspaceIssueTree(workspace);
     const sourceIssue = issueTree.find((issue) => issue.id === workspace.sourceIssueId) ?? null;
     const sourceIssueTerminal = Boolean(sourceIssue && TERMINAL_ISSUE_STATUSES.has(sourceIssue.status));
@@ -1370,6 +1376,15 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         cooldownAnchor = terminalAt;
       }
     }
+    return { sourceIssueTerminal, subtreeTerminal, cooldownAnchor };
+  }
+
+  async function assessDelivery(
+    workspace: ExecutionWorkspaceRow,
+    git: ExecutionWorkspaceCloseGitReadiness | null,
+  ) {
+    const { sourceIssueTerminal, subtreeTerminal, cooldownAnchor } =
+      await assessIssueTreeTerminality(workspace);
     let mergedPullRequest = false;
     let pullRequestStateUnknown = false;
     const workspaceHeadSha = git?.repoRoot && git.workspacePath
@@ -1708,10 +1723,18 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
       await assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
       await opts.beforeTerminalWorkspaceCleanup?.(workspace);
       await assertTerminalCleanupGitStateUnchanged(workspace, expectedHeadSha);
+      // Scope the service teardown to what this row owns. stopRuntimeServices
+      // matches by cwd prefix as well as by workspace id, and a shared session's
+      // cwd is the project checkout that every other session for that project also
+      // points at -- 526 unclosed rows share a single directory on this deployment.
+      // Passing that cwd would stop a live neighbour's dev server as a side effect
+      // of archiving an unrelated terminal session. A shared session owns only the
+      // services bound to its own id; services it merely inherits from the project
+      // workspace are scoped to the project workspace and must outlive it.
       await stopRuntimeServicesForExecutionWorkspace({
         db,
         executionWorkspaceId: workspace.id,
-        workspaceCwd: workspace.cwd,
+        workspaceCwd: workspace.mode === "shared_workspace" ? null : workspace.cwd,
       });
       const cleanup = await cleanupExecutionWorkspaceArtifacts({
         workspace,
@@ -2509,6 +2532,7 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           checked: 0,
           eligible: 0,
           archived: 0,
+          archivedSharedSession: 0,
           cleanupFailed: 0,
           skippedActiveRun: 0,
           skippedNonTerminalTree: 0,
@@ -2573,6 +2597,10 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
         checked: candidates.length,
         eligible: 0,
         archived: 0,
+        // Of `archived`, how many were shared sessions. The two routes reach the
+        // archive on different evidence, so one counter cannot show whether the
+        // delivery-gated route still works once the shared route starts firing.
+        archivedSharedSession: 0,
         cleanupFailed: 0,
         skippedActiveRun: 0,
         skippedNonTerminalTree: 0,
@@ -2585,12 +2613,48 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
 
       for (const workspace of candidates) {
         const executionWorkspace = toExecutionWorkspace(workspace);
-        const { git, statusInspectionSucceeded } = await inspectGitCloseReadiness(executionWorkspace);
+        // A shared_workspace row is a session record pointing at project workspace
+        // infrastructure it does not own: no per-issue branch, no per-issue
+        // directory, no exclusive claim on the checkout. The interactive close path
+        // already says so in as many words -- "Archiving it only removes the session
+        // record" -- and treats an open linked issue as a warning there rather than
+        // a blocker.
+        //
+        // The git gates below ask a different model's question: would archiving
+        // destroy unmerged work in a worktree this row owns? For a shared session
+        // that is not just false, it is unanswerable. branch_name and base_ref are
+        // null, so isMergedIntoBase never resolves and no merged PR can match the
+        // branch; deliveryState is therefore pinned at "unknown" and fails the merge
+        // check on every sweep. The dirty check reads a tree whose dirt belongs to
+        // whatever else is using that checkout. So a shared session is rejected
+        // forever, by a gate that can only ever reject it.
+        //
+        // That is why this reaper has archived zero rows: shared_workspace is
+        // 2,616 of the 2,626 rows this deployment has ever created.
+        const sharedSession = workspace.mode === "shared_workspace";
+        // Skip the git inspection entirely for a shared session rather than running
+        // it and discarding the answer. `git status --porcelain -uall` over a large
+        // shared checkout is the expensive part of a sweep tick, and assessDelivery
+        // would additionally resolve pull request state over the network for a
+        // comparison that cannot match.
+        const { git, statusInspectionSucceeded } = sharedSession
+          ? { git: null, statusInspectionSucceeded: true }
+          : await inspectGitCloseReadiness(executionWorkspace);
         if (!statusInspectionSucceeded) {
           result.skippedUndelivered += 1;
           continue;
         }
-        const assessment = await assessDelivery(workspace, git);
+        const assessment = sharedSession
+          ? {
+            ...await assessIssueTreeTerminality(workspace),
+            // Not "unknown" -- these are not applicable to a session record. A
+            // shared session has no delivery to assess and no tree of its own to
+            // be dirty, and the archive below reads neither.
+            deliveryState: null,
+            workspaceDirty: false,
+            workspaceHeadSha: null,
+          }
+          : await assessDelivery(workspace, git);
         const reopenPending = metadataHasReopenPendingConsumption(
           workspace.metadata as Record<string, unknown> | null,
         );
@@ -2610,16 +2674,22 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           result.skippedNonTerminalTree += 1;
           continue;
         }
-        if (assessment.workspaceDirty) {
-          result.skippedUndelivered += 1;
-          continue;
-        }
-        if (
-          assessment.deliveryState !== "merged_via_pr"
-          && assessment.deliveryState !== "merged_by_ancestry"
-        ) {
-          result.skippedUndelivered += 1;
-          continue;
+        // Delivery gates apply only to a workspace that owns the tree they read.
+        // A shared session skips them for the reasons above; every other gate --
+        // terminal subtree, cooldown, reopen fence, active run, and the full
+        // re-check inside the archive transaction -- still applies to it.
+        if (!sharedSession) {
+          if (assessment.workspaceDirty) {
+            result.skippedUndelivered += 1;
+            continue;
+          }
+          if (
+            assessment.deliveryState !== "merged_via_pr"
+            && assessment.deliveryState !== "merged_by_ancestry"
+          ) {
+            result.skippedUndelivered += 1;
+            continue;
+          }
         }
         // Hold the archive during the cooldown window. The anchor is the most
         // recent terminal timestamp across the issue tree. A person can reopen
@@ -2718,7 +2788,9 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
               status: "archived",
               closedAt,
               cleanupEligibleAt: workspace.cleanupEligibleAt ?? closedAt,
-              cleanupReason: ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON,
+              cleanupReason: sharedSession
+                ? ISSUE_TERMINAL_SHARED_SESSION_CLEANUP_REASON
+                : ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON,
               metadata: archivedMetadata,
               updatedAt: closedAt,
             })
@@ -2810,8 +2882,9 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           details: {
             sourceIssueId: archived.sourceIssueId,
             deliveryState: assessment.deliveryState,
+            sharedSession,
             cleanupEligibleAt: archived.cleanupEligibleAt?.toISOString() ?? null,
-            cleanupReason: ISSUE_TERMINAL_WORKSPACE_CLEANUP_REASON,
+            cleanupReason: archived.cleanupReason,
           },
         });
 
@@ -2822,7 +2895,10 @@ export function executionWorkspaceService(db: Db, opts: ExecutionWorkspaceServic
           const cleanup = await cleanupTerminalWorkspace(archived, assessment.workspaceHeadSha, capturedGeneration);
           if (cleanup.skippedReopened) result.skippedReopened += 1;
           else if (!cleanup.cleaned) result.cleanupFailed += 1;
-          else result.archived += 1;
+          else {
+            result.archived += 1;
+            if (sharedSession) result.archivedSharedSession += 1;
+          }
         } catch (error) {
           result.cleanupFailed += 1;
           const failure = error instanceof Error ? error.message : String(error);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -4014,6 +4014,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     projectId: string | null;
     projectWorkspaceId: string | null;
     sourceIssueId: string | null;
+    mode?: string | null;
     metadata?: Record<string, unknown> | null;
   };
   projectWorkspace?: {
@@ -4031,6 +4032,11 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
 }) {
   const warnings: string[] = [];
   const workspacePath = input.workspace.providerRef ?? input.workspace.cwd;
+  // Does this row own the directory it points at, or merely reference one? A
+  // shared_workspace session is a session record over a project checkout that
+  // many sessions share. It owns nothing on disk, which decides both whether
+  // cleanup may remove the path and whether cleanup is complete without doing so.
+  const ownsItsDirectory = input.workspace.mode !== "shared_workspace";
   const repoRoot = input.workspace.providerType === "git_worktree" && workspacePath
     ? await resolveGitRepoRootForWorkspaceCleanup(
       workspacePath,
@@ -4192,7 +4198,19 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
           projectWorkspaceCwd.startsWith(`${resolvedWorkspacePath}${path.sep}`)
         )
       : false;
-    if (containsProjectWorkspace) {
+    // Deleting a shared session's directory destroys the project checkout and
+    // every sibling session's work along with it.
+    //
+    // The createdByRuntime flag above happens to be false on every shared row
+    // today, so this branch is currently unreachable for them -- but that is a
+    // property of the data, not an invariant, and the containsProjectWorkspace
+    // guard below cannot stand in for it: it resolves to false whenever
+    // projectWorkspaceId is null, which is the case for a large share of these
+    // rows. Make the mode itself decide, so ownership is checked rather than
+    // inferred from a flag that something else sets.
+    if (!ownsItsDirectory) {
+      warnings.push(`Refusing to remove path "${workspacePath}" because a shared workspace session does not own its directory.`);
+    } else if (containsProjectWorkspace) {
       warnings.push(`Refusing to remove path "${workspacePath}" because it contains the project workspace.`);
     } else {
       await input.assertSafeToCleanup?.();
@@ -4216,7 +4234,12 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   }
 
+  // "Cleaned" means this row's disk resources are reclaimed. A shared session has
+  // none, so it is clean the moment it closes. Measuring it by whether the path is
+  // gone would mark every shared session cleanup_failed forever, because the path
+  // is the project checkout and it is supposed to still be there.
   const cleaned =
+    !ownsItsDirectory ||
     !workspacePath ||
     !(await directoryExists(workspacePath));
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - When an issue reaches a terminal state, the execution workspace it ran in is reclaimed by a reaper that sweeps every 30 seconds
> - That reaper has a keyset cursor, a lifecycle lock, a generation fence and a cooldown, and it has archived zero rows for the entire lifetime of the table
> - Every candidate is rejected by a delivery gate written for one-worktree-per-issue, applied to rows that are session records over a shared checkout
> - This pull request skips the gates that cannot apply to a session record, and scopes the resulting cleanup to what such a row actually owns
> - The benefit is that workspace rows stop accumulating without any exit condition, which is what the reaper was built to prevent

## Linked Issues or Issue Description

No public issue exists for this. The problem follows the bug report template.

Related in-flight work, not duplicated here: #11832 makes the archive path's issue-link clearing unconditional. It touches the adjacent `cleanup.cleaned && mode === "shared_workspace"` line and moves in the same direction as this change; expect a small textual conflict there and no semantic one.

**What happened?**

`sweepTerminalWorkspaces` archives a candidate only when its delivery state is `merged_via_pr` or `merged_by_ancestry`:

```ts
if (
  assessment.deliveryState !== "merged_via_pr"
  && assessment.deliveryState !== "merged_by_ancestry"
) {
  result.skippedUndelivered += 1;
  continue;
}
```

A `shared_workspace` row cannot reach either value:

- `merged_by_ancestry` requires `isMergedIntoBase === true`, which `inspectGitCloseReadiness` computes only `if (repoRoot && baseRef)`. A shared session has no `base_ref`, so it stays `null`.
- `merged_via_pr` requires a merged pull request with `details.headRef === workspace.branchName`. A shared session has no `branch_name`, so no reference matches.

With both false and `pullRequestStateUnknown` false, `deriveExecutionWorkspaceDeliveryState` returns `"unknown"`, which fails the check above. The dirty check rejects most of them even earlier, reading a working tree whose contents belong to whatever else is using that checkout.

Both gates ask the same question: would archiving destroy unmerged work in a worktree this row owns? For a session record over a shared checkout that is not merely false, it is unanswerable — and answering "no, therefore skip" means the row is rejected on every sweep, forever.

The interactive close path already encodes the correct semantics for these rows, in `getCloseReadiness`:

```ts
warnings.push("This shared workspace session points at project workspace infrastructure. Archiving it only removes the session record.");
```

and there an open linked issue is a warning rather than a blocking reason. The reaper never received the same treatment.

**Expected behavior**

A shared workspace session whose issue tree is terminal is archived, and archiving it removes the session record without touching the checkout it points at.

**Steps to reproduce**

1. Create a `shared_workspace` execution workspace with `branch_name` and `base_ref` null, pointing at a project checkout.
2. Move its source issue to `done`.
3. Run `sweepTerminalWorkspaces`.
4. The row is counted in `skippedUndelivered` and stays `active`. It will be counted there on every subsequent sweep.

## What Changed

- The delivery gates (`workspaceDirty`, `deliveryState`) are skipped for a shared session. Every other guard still applies: terminal subtree, cooldown, reopen fence, active-run check, and the full re-check inside the archive transaction.
- The git inspection is skipped for a shared session rather than run and discarded. `git status --porcelain -uall` over a large shared checkout is the expensive part of a sweep tick, and `assessDelivery` would additionally resolve pull request state over the network for a comparison that cannot match.
- Runtime-service teardown is scoped to the workspace id for a shared session. `stopRuntimeServicesForExecutionWorkspace` matches live records by cwd prefix as well as by id, and a shared session's cwd is the checkout every sibling session also points at.
- A row that owns no directory counts as cleaned. `cleaned` is computed as "the path is gone"; for a shared session the path is the project checkout and is supposed to remain.
- `cleanupExecutionWorkspaceArtifacts` refuses to remove a shared session's directory regardless of the `createdByRuntime` flag.
- Shared-session archives are recorded under their own `cleanup_reason` and an `archivedSharedSession` counter.

## Verification

Typecheck clean across all workspace packages.

`execution-workspaces-service` 71/71, including 5 new tests. Adjacent suites re-run and green: `execution-workspace-reopen`, `execution-workspaces-routes`, `workspace-reaper-cooldown-config`, `execution-workspace-policy`.

`workspace-instance-cleanup` has one failing test, `stops embedded Postgres before deleting the instance root`. It fails identically on the pristine base commit with this branch stashed, so it is pre-existing and unrelated.

Every new test was mutation-tested — each safeguard was removed in turn and the intended test confirmed to fail:

| Mutation | Test that caught it |
|---|---|
| re-apply the delivery gates to shared sessions | all three archive tests (nothing archives) |
| drop the ownership term from `cleaned` | archive test + on-disk test (rows land in `cleanup_failed`, `archived` stays 0) |
| pass the shared cwd to service teardown again | teardown-scoping test, alone |
| let shared sessions bypass the terminal-issue gate | non-terminal skip test, alone |
| remove the shared-session deletion guard | deletion-guard test — the sweep deletes the checkout |

The third and fifth are the ones worth noting. Without the cwd scoping, archiving a terminal session stops a live neighbour's runtime service; without the deletion guard, the sweep removes a real project checkout.

## Risks

The blast radius is 2,616 of 2,626 rows on the deployment this was diagnosed against, since `shared_workspace` is effectively the only mode in use there. Those rows will archive in batches of 50 per sweep once this ships.

What that archiving does is bounded to the row: status, `closed_at`, `cleanup_eligible_at`, `cleanup_reason`, and the issue-link detach that already existed. Nothing on disk is removed for these rows — that is asserted by two of the new tests, one of which drives the only code path that could have deleted anything.

The reverse risk was the one that needed guarding, and both halves are now covered by tests rather than by luck: the cwd-prefix teardown reaching a live sibling, and the `createdByRuntime` flag being the only thing standing between a shared row and `fs.rm` on a developer's checkout.

Isolated workspaces are unaffected: every changed branch is behind `mode === "shared_workspace"`, and the existing delivery-gated tests still pass unchanged.

## Category safeguard

The class here is a policy written for one resource model and applied to rows of another, where the mismatch shows up as a permanently-skipped candidate rather than an error.

Implemented in this PR: the `archivedSharedSession` counter splits the archive total by route, so the two paths cannot silently collapse into one number again. A reaper archiving nothing already had a log line — that was the subject of #11971 — but a reaper archiving only one of two classes did not, and could not, because a single counter cannot express it.

Deferred as a follow-on rather than done here: a startup assertion that every distinct `execution_workspaces.mode` is reachable by at least one archive route, so a mode added later that no route can archive fails loudly instead of accumulating rows for months. That needs a mode registry that does not exist yet, which is more than this fix should carry.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
