### PR TITLE
fix(issues): notify the unblock owner on every path that leaves an issue blocked

### DIFF
--- a/server/src/__tests__/blocked-owner-notification-routes.test.ts
+++ b/server/src/__tests__/blocked-owner-notification-routes.test.ts
@@ -1,0 +1,248 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// See issue-dependency-wakeups-routes.test.ts: the first test pays the
+// one-time cost of importing the large routes/issues.ts module, which can
+// cross vitest's default 5s timeout on a loaded serial shard.
+vi.setConfig({ testTimeout: 15000 });
+
+const OWNER_AGENT_ID = "00000000-0000-4000-8000-0000000000a1";
+const ISSUE_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+// Must sit after ROUTABLE_BLOCKED_ROLLOUT_AT or the delivery is declined by design.
+const BLOCKED_AT = new Date("2026-08-21T19:19:58.733Z");
+
+const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
+const mockIssueService = vi.hoisted(() => ({
+  getAncestors: vi.fn(async () => []),
+  getById: vi.fn(),
+  getByIdForUpdate: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getComment: vi.fn(async () => null),
+  getCommentCursor: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  update: vi.fn(),
+  getDependencyReadiness: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+  findMentionedAgents: vi.fn(async () => []),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => ({ canUser: vi.fn(), hasPermission: vi.fn() }),
+  agentService: () => ({ getById: vi.fn() }),
+  companySkillService: () => ({ completeTestRunForIssue: vi.fn(async () => null) }),
+  documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+  documentService: () => ({ getIssueDocumentPayload: vi.fn(async () => ({})) }),
+  executionWorkspaceService: () => ({ getById: vi.fn() }),
+  feedbackService: () => ({}),
+  goalService: () => ({ getById: vi.fn(), getDefaultCompanyGoal: vi.fn() }),
+  heartbeatService: () => ({
+    wakeup: mockWakeup,
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  getIssueContinuationSummaryDocument: vi.fn(async () => null),
+  instanceSettingsService: () => ({ get: vi.fn(), listCompanyIds: vi.fn() }),
+  issueApprovalService: () => ({}),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueRecoveryActionService: () => ({
+    getActiveForIssue: vi.fn(async () => null),
+    listActiveForIssues: vi.fn(async () => new Map()),
+  }),
+  issueThreadInteractionService: () => ({
+    listForIssue: vi.fn(async () => []),
+    expirePendingInteractionsForTerminalIssue: vi.fn(async () => []),
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({ getById: vi.fn(), listByIds: vi.fn(async () => []) }),
+  routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+  workProductService: () => ({ listForIssue: vi.fn(async () => []) }),
+}));
+
+/**
+ * `select` resolves to a single row so the route's "unblock owner agent must
+ * belong to this company" lookup succeeds. `update` has to be a real stub
+ * because recording delivery writes blockedOwnerNotifiedAt directly.
+ */
+function createRouteDb() {
+  const rows = [{ id: OWNER_AGENT_ID }];
+  const whereResult = {
+    limit: vi.fn(async () => rows),
+    then: async (resolve: (value: unknown[]) => unknown) => resolve(rows),
+  };
+  const query: Record<string, unknown> = {};
+  query.innerJoin = vi.fn(() => query);
+  query.where = vi.fn(() => whereResult);
+  const updateWhere = vi.fn(async () => undefined);
+  return {
+    db: {
+      select: vi.fn(() => ({ from: vi.fn(() => query) })),
+      update: vi.fn(() => ({ set: vi.fn(() => ({ where: updateWhere })) })),
+      transaction: async (cb: (tx: Record<string, never>) => Promise<unknown>) => cb({}),
+    },
+    updateWhere,
+  };
+}
+
+async function createApp(routeDb: unknown) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(routeDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function issueRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: "company-1",
+    identifier: "PAP-2377",
+    title: "Already blocked, descriptor attached later",
+    description: null,
+    status: "blocked",
+    priority: "medium",
+    parentId: null,
+    assigneeAgentId: "agent-assignee",
+    assigneeUserId: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    executionWorkspaceId: null,
+    labels: [],
+    labelIds: [],
+    unblockDescriptor: null,
+    blockedTransitionAt: BLOCKED_AT,
+    blockedOwnerNotifiedAt: null,
+    ...overrides,
+  };
+}
+
+describe("blocked owner notification in issue routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.clearAllMocks();
+    mockIssueService.getByIdForUpdate.mockImplementation(async () => mockIssueService.getById());
+    mockIssueService.getCommentCursor.mockResolvedValue({
+      totalComments: 0,
+      latestCommentId: null,
+      latestCommentAt: null,
+    });
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: ISSUE_ID,
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+  });
+
+  // BRO-2453 / BRO-2377: the issue was blocked at 14:57 and the descriptor was
+  // attached at 14:59. Notification was wired only to the blocked *transition*,
+  // so the named owner was never woken and the issue sat untouched for a day.
+  it("wakes the owner when a descriptor is attached to an already-blocked issue", async () => {
+    const descriptor = { owner: { agentId: OWNER_AGENT_ID }, action: "Verify the rollout" };
+    mockIssueService.getById.mockResolvedValue(issueRow());
+    mockIssueService.update.mockResolvedValue(issueRow({ unblockDescriptor: descriptor }));
+
+    const { db, updateWhere } = createRouteDb();
+    const res = await request(await createApp(db))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ unblockDescriptor: descriptor });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockWakeup).toHaveBeenCalledWith(
+        OWNER_AGENT_ID,
+        expect.objectContaining({
+          reason: "issue_unblock_requested",
+          payload: { issueId: ISSUE_ID, action: "Verify the rollout" },
+        }),
+      );
+    });
+    // Delivery must be recorded, or the next PATCH re-wakes the same owner.
+    expect(updateWhere).toHaveBeenCalled();
+  });
+
+  // A re-point names a *different* owner, so a prior delivery stamp must not
+  // suppress it. Deduplication is the fingerprinted idempotency key's job.
+  it("wakes the new owner when an already-notified descriptor is re-pointed", async () => {
+    const descriptor = { owner: { agentId: OWNER_AGENT_ID }, action: "Take this over" };
+    mockIssueService.getById.mockResolvedValue(issueRow({
+      unblockDescriptor: { owner: { agentId: "00000000-0000-4000-8000-0000000000b2" }, action: "Old" },
+      blockedOwnerNotifiedAt: new Date("2026-08-21T19:20:00.000Z"),
+    }));
+    mockIssueService.update.mockResolvedValue(issueRow({
+      unblockDescriptor: descriptor,
+      blockedOwnerNotifiedAt: new Date("2026-08-21T19:20:00.000Z"),
+    }));
+
+    const { db } = createRouteDb();
+    const res = await request(await createApp(db))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ unblockDescriptor: descriptor });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockWakeup).toHaveBeenCalledWith(OWNER_AGENT_ID, expect.anything());
+    });
+  });
+
+  it("does not re-wake when the descriptor is unchanged", async () => {
+    const descriptor = { owner: { agentId: OWNER_AGENT_ID }, action: "Verify the rollout" };
+    mockIssueService.getById.mockResolvedValue(issueRow({
+      unblockDescriptor: descriptor,
+      blockedOwnerNotifiedAt: new Date("2026-08-21T19:20:00.000Z"),
+    }));
+    mockIssueService.update.mockResolvedValue(issueRow({
+      unblockDescriptor: descriptor,
+      blockedOwnerNotifiedAt: new Date("2026-08-21T19:20:00.000Z"),
+    }));
+
+    const { db } = createRouteDb();
+    const res = await request(await createApp(db))
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ unblockDescriptor: descriptor });
+
+    expect(res.status).toBe(200);
+    expect(mockWakeup).not.toHaveBeenCalledWith(OWNER_AGENT_ID, expect.objectContaining({
+      reason: "issue_unblock_requested",
+    }));
+  });
+});

--- a/server/src/__tests__/routable-blocked.test.ts
+++ b/server/src/__tests__/routable-blocked.test.ts
@@ -41,7 +41,7 @@ describe("routable blocked notifications", () => {
       reason: "issue_unblock_requested",
       idempotencyKey: `issue-unblock:${issue.id}:${issue.blockedTransitionAt!.toISOString()}:${
         unblockDescriptorFingerprint(issue.unblockDescriptor)
-      }`,
+      }:first`,
       payload: { issueId: issue.id, action: "Review the finding" },
     }));
     expect(markNotified).toHaveBeenCalledWith(now);
@@ -85,8 +85,9 @@ describe("routable blocked notifications", () => {
 
   // BRO-2453: BRO-2377 was already blocked when an agent attached its
   // descriptor. The transition timestamp does not move on a re-point, so the
-  // descriptor itself has to discriminate the key or the wakeup is deduped
-  // against the previous owner's and the new owner is never told.
+  // descriptor itself has to discriminate the key — otherwise two owners'
+  // deliveries are indistinguishable in the wakeup log, and any future dedupe
+  // wired onto this prefix would drop the second one.
   it("gives a re-pointed descriptor a distinct idempotency key on the same transition", async () => {
     const transitionAt = new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() + 1);
     const first = blockedIssue({ transitionAt });
@@ -111,6 +112,40 @@ describe("routable blocked notifications", () => {
     expect(firstKey).toContain(transitionAt.toISOString());
     expect(repointedKey).toContain(transitionAt.toISOString());
     expect(repointedKey).not.toBe(firstKey);
+  });
+
+  // BRO-2453 (Greptile): owner+action+transition are identical on the first and
+  // third delivery of an A -> B -> A re-point, so the descriptor fingerprint
+  // alone rebuilds A's original key. The superseded delivery stamp is the only
+  // thing separating the renewed obligation from the one already sent.
+  it("separates a descriptor re-pointed back to the first owner from its first delivery", async () => {
+    const transitionAt = new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() + 1);
+    const wakeup = vi.fn(async () => undefined);
+    const repoints = [
+      { owner: { agentId }, at: new Date("2026-07-24T00:00:00.000Z") },
+      { owner: { agentId: otherAgentId }, at: new Date("2026-07-24T01:00:00.000Z") },
+      { owner: { agentId }, at: new Date("2026-07-24T02:00:00.000Z") },
+    ];
+
+    // Mirrors the route: the first delivery supersedes nothing, and each
+    // re-point clears the stamp for suppression but carries it into the key.
+    let notifiedAt: Date | null = null;
+    for (const [index, repoint] of repoints.entries()) {
+      const supersedesNotifiedAt = index === 0 ? null : notifiedAt;
+      await deliverAgentUnblockNotification({
+        issue: blockedIssue({ transitionAt, owner: repoint.owner }),
+        supersedesNotifiedAt,
+        wakeup,
+        markNotified: async (at) => { notifiedAt = at; },
+        now: () => repoint.at,
+      });
+    }
+
+    expect(wakeup.mock.calls.map((call) => call[0])).toEqual([agentId, otherAgentId, agentId]);
+    const keys = wakeup.mock.calls.map((call) => (call[1] as { idempotencyKey: string }).idempotencyKey);
+    expect(new Set(keys).size).toBe(3);
+    // The specific collision Greptile flagged: third delivery vs. first.
+    expect(keys[2]).not.toBe(keys[0]);
   });
 
   it("separates keys when only the action text changes", () => {

--- a/server/src/__tests__/routable-blocked.test.ts
+++ b/server/src/__tests__/routable-blocked.test.ts
@@ -2,18 +2,25 @@ import { describe, expect, it, vi } from "vitest";
 import {
   deliverAgentUnblockNotification,
   ROUTABLE_BLOCKED_ROLLOUT_AT,
+  unblockDescriptorFingerprint,
 } from "../services/routable-blocked.js";
 
 const agentId = "00000000-0000-4000-8000-000000000001";
+const otherAgentId = "00000000-0000-4000-8000-000000000003";
 
 function blockedIssue(input: {
   transitionAt?: Date | null;
   notifiedAt?: Date | null;
+  owner?: { agentId: string } | { userId: string } | "board";
+  action?: string;
 } = {}) {
   return {
     id: "00000000-0000-4000-8000-000000000002",
     status: "blocked",
-    unblockDescriptor: { owner: { agentId }, action: "Review the finding" } as const,
+    unblockDescriptor: {
+      owner: input.owner ?? { agentId },
+      action: input.action ?? "Review the finding",
+    },
     blockedTransitionAt: input.transitionAt === undefined
       ? new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() + 1)
       : input.transitionAt,
@@ -32,7 +39,9 @@ describe("routable blocked notifications", () => {
       .resolves.toBe(true);
     expect(wakeup).toHaveBeenCalledWith(agentId, expect.objectContaining({
       reason: "issue_unblock_requested",
-      idempotencyKey: `issue-unblock:${issue.id}:${issue.blockedTransitionAt!.toISOString()}`,
+      idempotencyKey: `issue-unblock:${issue.id}:${issue.blockedTransitionAt!.toISOString()}:${
+        unblockDescriptorFingerprint(issue.unblockDescriptor)
+      }`,
       payload: { issueId: issue.id, action: "Review the finding" },
     }));
     expect(markNotified).toHaveBeenCalledWith(now);
@@ -72,5 +81,43 @@ describe("routable blocked notifications", () => {
     expect(wakeup.mock.calls[0]?.[1]).toMatchObject({
       idempotencyKey: expect.stringContaining(secondTransition.toISOString()),
     });
+  });
+
+  // BRO-2453: BRO-2377 was already blocked when an agent attached its
+  // descriptor. The transition timestamp does not move on a re-point, so the
+  // descriptor itself has to discriminate the key or the wakeup is deduped
+  // against the previous owner's and the new owner is never told.
+  it("gives a re-pointed descriptor a distinct idempotency key on the same transition", async () => {
+    const transitionAt = new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() + 1);
+    const first = blockedIssue({ transitionAt });
+    const repointed = blockedIssue({ transitionAt, owner: { agentId: otherAgentId } });
+
+    const firstWakeup = vi.fn(async () => undefined);
+    const repointedWakeup = vi.fn(async () => undefined);
+    await deliverAgentUnblockNotification({
+      issue: first,
+      wakeup: firstWakeup,
+      markNotified: async () => undefined,
+    });
+    await deliverAgentUnblockNotification({
+      issue: repointed,
+      wakeup: repointedWakeup,
+      markNotified: async () => undefined,
+    });
+
+    expect(repointedWakeup).toHaveBeenCalledWith(otherAgentId, expect.anything());
+    const firstKey = (firstWakeup.mock.calls[0]?.[1] as { idempotencyKey: string }).idempotencyKey;
+    const repointedKey = (repointedWakeup.mock.calls[0]?.[1] as { idempotencyKey: string }).idempotencyKey;
+    expect(firstKey).toContain(transitionAt.toISOString());
+    expect(repointedKey).toContain(transitionAt.toISOString());
+    expect(repointedKey).not.toBe(firstKey);
+  });
+
+  it("separates keys when only the action text changes", () => {
+    const owner = { agentId } as const;
+    expect(unblockDescriptorFingerprint({ owner, action: "Do A" }))
+      .not.toBe(unblockDescriptorFingerprint({ owner, action: "Do B" }));
+    expect(unblockDescriptorFingerprint({ owner, action: "Do A" }))
+      .toBe(unblockDescriptorFingerprint({ owner, action: "Do A" }));
   });
 });

--- a/server/src/__tests__/source-files-are-text.test.ts
+++ b/server/src/__tests__/source-files-are-text.test.ts
@@ -1,0 +1,41 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Category safeguard (BRO-2453).
+ *
+ * A stray NUL byte reached a template-string separator in
+ * services/routable-blocked.ts. The code still ran and every test passed, but
+ * git reclassified the file as binary — so `git diff` showed "Binary files
+ * differ" and the change became invisible to human and automated review alike.
+ * A defect that hides the diff it lives in is worth failing the build over.
+ */
+async function collectTypeScriptFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectTypeScriptFiles(full);
+    return entry.name.endsWith(".ts") || entry.name.endsWith(".tsx") ? [full] : [];
+  }));
+  return files.flat();
+}
+
+describe("server source files stay reviewable text", () => {
+  it("contains no NUL bytes that would make git treat a source file as binary", async () => {
+    const files = await collectTypeScriptFiles(SRC_ROOT);
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const contents = await readFile(file);
+      const index = contents.indexOf(0);
+      if (index !== -1) offenders.push(`${path.relative(SRC_ROOT, file)} (byte ${index})`);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -92,6 +92,7 @@ import {
   type IssueWakeDiagnosticsResponse,
   type IssueRelationIssueSummary,
   type IssueReviewPolicy,
+  type IssueUnblockDescriptor,
   type IssueThreadInteractionCanonicalResolverPolicy,
   type IssueCommentPresentation,
   type IssueWatchdogDiscoveryKind,
@@ -233,7 +234,7 @@ import {
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
-import { deliverAgentUnblockNotification } from "../services/routable-blocked.js";
+import { deliverAgentUnblockNotification, unblockDescriptorFingerprint } from "../services/routable-blocked.js";
 import {
   assertIssueReviewVerdictActorAllowed,
   isIssueReviewVerdictInteraction,
@@ -2816,6 +2817,42 @@ export function issueRoutes(
   });
   const enqueueStalledReviewDecisionWakeup = opts.stalledReviewDecisionEnqueueWakeup ?? heartbeat.wakeup;
   const enqueueRecoveryActionWakeup = opts.recoveryActionEnqueueWakeup ?? heartbeat.wakeup;
+
+  /**
+   * Wake the agent named by an issue's unblockDescriptor and record delivery.
+   *
+   * Every path that can leave an issue blocked with an agent-owned descriptor
+   * has to call this — entering blocked, attaching a descriptor to an issue
+   * that is *already* blocked, and creating an issue directly in blocked. It
+   * used to be wired only to the first, so a descriptor attached seconds after
+   * the transition (or a child born blocked) never notified anyone.
+   *
+   * Returns the persisted notification timestamp, or null when nothing was due
+   * (no descriptor, board/user owner, already notified for this descriptor).
+   */
+  async function notifyBlockedOwner(issue: {
+    id: string;
+    companyId: string;
+    status: string;
+    unblockDescriptor?: IssueUnblockDescriptor | null;
+    blockedTransitionAt?: Date | null;
+    blockedOwnerNotifiedAt?: Date | null;
+  }): Promise<Date | null> {
+    let ownerNotifiedAt: Date | null = null;
+    await deliverAgentUnblockNotification({
+      issue,
+      wakeup: heartbeat.wakeup,
+      markNotified: async (blockedOwnerNotifiedAt) => {
+        ownerNotifiedAt = blockedOwnerNotifiedAt;
+      },
+    });
+    if (!ownerNotifiedAt) return null;
+    await db.update(issueRows).set({ blockedOwnerNotifiedAt: ownerNotifiedAt }).where(and(
+      eq(issueRows.id, issue.id),
+      eq(issueRows.companyId, issue.companyId),
+    ));
+    return ownerNotifiedAt;
+  }
   const feedback = feedbackService(db);
   const companiesSvc = companyService(db);
   let searchSvc = opts.searchService ?? null;
@@ -8711,6 +8748,10 @@ export function issueRoutes(
       },
     });
 
+    // An issue can be born blocked; that owner needs waking exactly as much as
+    // one blocked by a later PATCH.
+    await notifyBlockedOwner(issue);
+
     if (executionPolicy?.monitor) {
       await logActivity(db, {
         companyId,
@@ -8912,6 +8953,10 @@ export function issueRoutes(
           : {}),
       },
     });
+
+    // A child can be born blocked with a descriptor already attached; without
+    // this the named owner is never woken and the child silently strands.
+    await notifyBlockedOwner(issue);
 
     if (executionPolicy?.monitor) {
       await logActivity(db, {
@@ -9135,6 +9180,8 @@ export function issueRoutes(
             : {}),
         },
       });
+
+      await notifyBlockedOwner(issue);
 
       const executionPolicy = normalizeIssueExecutionPolicy(issue.executionPolicy);
       if (executionPolicy?.monitor) {
@@ -9717,6 +9764,15 @@ export function issueRoutes(
       }
     }
     const enteringBlocked = existing.status !== "blocked" && updateFields.status === "blocked";
+    // Attaching or re-pointing a descriptor on an issue that is *already*
+    // blocked is just as much a "someone owes this issue an action" event as
+    // the transition itself, and it was previously silent.
+    const previousDescriptor = (existing.unblockDescriptor ?? null) as IssueUnblockDescriptor | null;
+    const descriptorRepointedWhileBlocked = !enteringBlocked
+      && nextStatus === "blocked"
+      && descriptor !== null
+      && unblockDescriptorFingerprint(descriptor as IssueUnblockDescriptor)
+        !== (previousDescriptor ? unblockDescriptorFingerprint(previousDescriptor) : null);
     if (enteringBlocked) {
       const requestedBlockerIds = Array.isArray(req.body.blockedByIssueIds)
         ? [...new Set(req.body.blockedByIssueIds as string[])]
@@ -10016,21 +10072,17 @@ export function issueRoutes(
     }
     for (const publication of postCommitActivityPublications) publishActivity(publication);
 
-    if (enteringBlocked) {
+    if (enteringBlocked || descriptorRepointedWhileBlocked) {
       const blockedIssue = issue;
-      let ownerNotifiedAt: Date | null = null;
-      await deliverAgentUnblockNotification({
-        issue: blockedIssue,
-        wakeup: heartbeat.wakeup,
-        markNotified: async (blockedOwnerNotifiedAt) => {
-          ownerNotifiedAt = blockedOwnerNotifiedAt;
-        },
-      });
+      // A re-point is a fresh obligation for a different owner, so the prior
+      // delivery stamp must not suppress it; the fingerprint in the wakeup's
+      // idempotency key is what keeps genuine retries deduplicated.
+      const ownerNotifiedAt = await notifyBlockedOwner(
+        descriptorRepointedWhileBlocked
+          ? { ...blockedIssue, blockedOwnerNotifiedAt: null }
+          : blockedIssue,
+      );
       if (ownerNotifiedAt) {
-        await db.update(issueRows).set({ blockedOwnerNotifiedAt: ownerNotifiedAt }).where(and(
-          eq(issueRows.id, blockedIssue.id),
-          eq(issueRows.companyId, blockedIssue.companyId),
-        ));
         issue = { ...blockedIssue, blockedOwnerNotifiedAt: ownerNotifiedAt };
       }
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2817,6 +2817,33 @@ export function issueRoutes(
   });
   const enqueueStalledReviewDecisionWakeup = opts.stalledReviewDecisionEnqueueWakeup ?? heartbeat.wakeup;
   const enqueueRecoveryActionWakeup = opts.recoveryActionEnqueueWakeup ?? heartbeat.wakeup;
+  const feedback = feedbackService(db);
+  const companiesSvc = companyService(db);
+  let searchSvc = opts.searchService ?? null;
+  const getSearchService = () => {
+    searchSvc ??= companySearchService(db);
+    return searchSvc;
+  };
+  const searchRateLimiter = opts.searchRateLimiter ?? defaultCompanySearchRateLimiter;
+  const instanceSettings = instanceSettingsService(db);
+  const agentsSvc = agentService(db);
+  const projectsSvc = projectService(db);
+  const goalsSvc = goalService(db);
+  const issueApprovalsSvc = issueApprovalService(db);
+  const recoveryActionsSvc = issueRecoveryActionService(db);
+  const executionWorkspacesSvc = executionWorkspaceServiceDirect(db);
+  const workProductsSvc = workProductService(db);
+  const documentsSvc = documentService(db);
+  const artifactReviewDocumentsSvc = artifactReviewDocumentService(db, storage);
+  const companySkillsSvc = companySkillService(db);
+  const documentAnnotationsSvc = documentAnnotationService(db);
+  const decisionTrainingSvc = decisionTrainingService(db);
+  const issueReferencesSvc = issueReferenceService(db);
+  const issueThreadInteractionsSvc = issueThreadInteractionService(db);
+  const memoizeIssueRead = createRequestPromiseMemo<Request, Awaited<ReturnType<typeof svc.getById>>>({
+    shouldCache: (issue) => issue !== null,
+  });
+  const memoizeIssueReadDecision = createRequestPromiseMemo<Request, Awaited<ReturnType<typeof decideIssueAccess>>>();
 
   /**
    * Wake the agent named by an issue's unblockDescriptor and record delivery.
@@ -2853,33 +2880,6 @@ export function issueRoutes(
     ));
     return ownerNotifiedAt;
   }
-  const feedback = feedbackService(db);
-  const companiesSvc = companyService(db);
-  let searchSvc = opts.searchService ?? null;
-  const getSearchService = () => {
-    searchSvc ??= companySearchService(db);
-    return searchSvc;
-  };
-  const searchRateLimiter = opts.searchRateLimiter ?? defaultCompanySearchRateLimiter;
-  const instanceSettings = instanceSettingsService(db);
-  const agentsSvc = agentService(db);
-  const projectsSvc = projectService(db);
-  const goalsSvc = goalService(db);
-  const issueApprovalsSvc = issueApprovalService(db);
-  const recoveryActionsSvc = issueRecoveryActionService(db);
-  const executionWorkspacesSvc = executionWorkspaceServiceDirect(db);
-  const workProductsSvc = workProductService(db);
-  const documentsSvc = documentService(db);
-  const artifactReviewDocumentsSvc = artifactReviewDocumentService(db, storage);
-  const companySkillsSvc = companySkillService(db);
-  const documentAnnotationsSvc = documentAnnotationService(db);
-  const decisionTrainingSvc = decisionTrainingService(db);
-  const issueReferencesSvc = issueReferenceService(db);
-  const issueThreadInteractionsSvc = issueThreadInteractionService(db);
-  const memoizeIssueRead = createRequestPromiseMemo<Request, Awaited<ReturnType<typeof svc.getById>>>({
-    shouldCache: (issue) => issue !== null,
-  });
-  const memoizeIssueReadDecision = createRequestPromiseMemo<Request, Awaited<ReturnType<typeof decideIssueAccess>>>();
 
   function getIssueById(req: Request, id: string) {
     if (req.method !== "GET") return svc.getById(id);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2864,10 +2864,11 @@ export function issueRoutes(
     unblockDescriptor?: IssueUnblockDescriptor | null;
     blockedTransitionAt?: Date | null;
     blockedOwnerNotifiedAt?: Date | null;
-  }): Promise<Date | null> {
+  }, supersedesNotifiedAt: Date | null = null): Promise<Date | null> {
     let ownerNotifiedAt: Date | null = null;
     await deliverAgentUnblockNotification({
       issue,
+      supersedesNotifiedAt,
       wakeup: heartbeat.wakeup,
       markNotified: async (blockedOwnerNotifiedAt) => {
         ownerNotifiedAt = blockedOwnerNotifiedAt;
@@ -10075,12 +10076,15 @@ export function issueRoutes(
     if (enteringBlocked || descriptorRepointedWhileBlocked) {
       const blockedIssue = issue;
       // A re-point is a fresh obligation for a different owner, so the prior
-      // delivery stamp must not suppress it; the fingerprint in the wakeup's
-      // idempotency key is what keeps genuine retries deduplicated.
+      // delivery stamp must not suppress it. That stamp is still what makes the
+      // new wakeup's key distinct: `blockedTransitionAt` does not move on a
+      // re-point, so without it a descriptor re-pointed A -> B -> A would
+      // rebuild the key A's first delivery already used.
       const ownerNotifiedAt = await notifyBlockedOwner(
         descriptorRepointedWhileBlocked
           ? { ...blockedIssue, blockedOwnerNotifiedAt: null }
           : blockedIssue,
+        descriptorRepointedWhileBlocked ? (blockedIssue.blockedOwnerNotifiedAt ?? null) : null,
       );
       if (ownerNotifiedAt) {
         issue = { ...blockedIssue, blockedOwnerNotifiedAt: ownerNotifiedAt };

--- a/server/src/services/routable-blocked.ts
+++ b/server/src/services/routable-blocked.ts
@@ -1,6 +1,29 @@
+import { createHash } from "node:crypto";
 import type { IssueUnblockDescriptor } from "@paperclipai/shared";
 
 export const ROUTABLE_BLOCKED_ROLLOUT_AT = new Date("2026-07-23T18:13:03.000Z");
+
+/**
+ * Stable discriminator for "which descriptor was this owner told about".
+ *
+ * The idempotency key has to change when the descriptor changes, otherwise
+ * re-pointing an already-blocked issue at a new owner reuses the previous
+ * key, the wakeup is silently deduplicated, and the new owner is never told.
+ */
+export function unblockDescriptorFingerprint(descriptor: IssueUnblockDescriptor): string {
+  const owner = descriptor.owner;
+  const ownerKey = owner === "board"
+    ? "board"
+    : "agentId" in owner
+      ? `agent:${owner.agentId}`
+      : `user:${owner.userId}`;
+  // JSON.stringify keeps the two fields unambiguously delimited, so an action
+  // text containing the separator cannot forge another owner's key.
+  return createHash("sha256")
+    .update(JSON.stringify([ownerKey, descriptor.action]))
+    .digest("hex")
+    .slice(0, 12);
+}
 
 type RoutableBlockedIssue = {
   id: string;
@@ -45,7 +68,9 @@ export async function deliverAgentUnblockNotification(input: {
     source: "automation",
     triggerDetail: "system",
     reason: "issue_unblock_requested",
-    idempotencyKey: `issue-unblock:${issue.id}:${issue.blockedTransitionAt.toISOString()}`,
+    idempotencyKey: `issue-unblock:${issue.id}:${issue.blockedTransitionAt.toISOString()}:${
+      unblockDescriptorFingerprint(issue.unblockDescriptor)
+    }`,
     payload: { issueId: issue.id, action: issue.unblockDescriptor.action },
     contextSnapshot: { wakeReason: "issue_unblock_requested", issueId: issue.id, taskId: issue.id },
   });

--- a/server/src/services/routable-blocked.ts
+++ b/server/src/services/routable-blocked.ts
@@ -6,9 +6,12 @@ export const ROUTABLE_BLOCKED_ROLLOUT_AT = new Date("2026-07-23T18:13:03.000Z");
 /**
  * Stable discriminator for "which descriptor was this owner told about".
  *
- * The idempotency key has to change when the descriptor changes, otherwise
- * re-pointing an already-blocked issue at a new owner reuses the previous
- * key, the wakeup is silently deduplicated, and the new owner is never told.
+ * What actually suppresses a repeat delivery is the persisted
+ * `blocked_owner_notified_at` stamp, not this key: no unique index and no
+ * caller-side pre-check covers the `issue-unblock:` prefix, so nothing in the
+ * wakeup path collapses two rows that share one key. The key is an identifier
+ * — but it still has to stay collision-free per delivery, so that wiring
+ * dedupe onto it later cannot silently start dropping notifications.
  */
 export function unblockDescriptorFingerprint(descriptor: IssueUnblockDescriptor): string {
   const owner = descriptor.owner;
@@ -54,6 +57,16 @@ export async function deliverAgentUnblockNotification(input: {
     contextSnapshot: { wakeReason: "issue_unblock_requested"; issueId: string; taskId: string };
   }) => Promise<unknown>;
   markNotified: (notifiedAt: Date) => Promise<unknown>;
+  /**
+   * The delivery stamp this one supersedes, when the caller is re-pointing a
+   * descriptor on an issue that is already blocked.
+   *
+   * `blockedTransitionAt` does not move on a re-point, so owner/action alone
+   * cannot separate deliveries within one blocked span: re-pointing A -> B -> A
+   * rebuilds the exact key A's first delivery used. The superseded stamp is the
+   * generation counter that keeps the third key distinct from the first.
+   */
+  supersedesNotifiedAt?: Date | null;
   now?: () => Date;
 }) {
   const { issue } = input;
@@ -68,9 +81,13 @@ export async function deliverAgentUnblockNotification(input: {
     source: "automation",
     triggerDetail: "system",
     reason: "issue_unblock_requested",
-    idempotencyKey: `issue-unblock:${issue.id}:${issue.blockedTransitionAt.toISOString()}:${
-      unblockDescriptorFingerprint(issue.unblockDescriptor)
-    }`,
+    idempotencyKey: [
+      "issue-unblock",
+      issue.id,
+      issue.blockedTransitionAt.toISOString(),
+      unblockDescriptorFingerprint(issue.unblockDescriptor),
+      input.supersedesNotifiedAt ? `after:${input.supersedesNotifiedAt.toISOString()}` : "first",
+    ].join(":"),
     payload: { issueId: issue.id, action: issue.unblockDescriptor.action },
     contextSnapshot: { wakeReason: "issue_unblock_requested", issueId: issue.id, taskId: issue.id },
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issues subsystem lets a blocked issue record an `unblockDescriptor`: the agent who owns the way out, and the action they must do
> - When that descriptor names an agent, the server wakes that agent so the block becomes routable work instead of a dead row
> - That wakeup was wired to one path only: the moment an issue moves into `blocked`. Two other paths reach the same state and stayed silent
> - This pull request calls the same notify step from every path that can leave an issue blocked with an agent-owned descriptor
> - The benefit is that a blocked issue with a named owner always tells that owner, so blocked work stops being invisible to the person who can clear it

## Linked Issues or Issue Description

No public issue exists for this. The problem follows the bug report template.

**What happened?**

A blocked issue can name an agent as its unblock owner. The server is supposed to wake that agent. It only does so when the issue *enters* `blocked` through `PATCH /api/issues/:id`. Two other paths reach the same state and send nothing:

1. **Descriptor attached after the transition.** An issue moves to `blocked` with blockers and no descriptor. A later PATCH adds the descriptor. `enteringBlocked` is already false, so the notify branch is skipped. The owner is never told.
2. **Issue created directly in `blocked`.** The create and child-create handlers never called the notify step at all. An issue born blocked with a descriptor strands immediately.

There is a third, quieter failure. The wakeup idempotency key was `issue-unblock:<issueId>:<blockedTransitionAt>`. Re-pointing a descriptor at a different owner does not move `blockedTransitionAt`, so the new owner's wakeup reuses the previous owner's key and is discarded as a duplicate.

Observed on a live instance: of the blocked issues whose descriptor names an agent, three had a null `blocked_owner_notified_at`. One had been waiting a full day. Two of the three were created directly as blocked children; the third had its descriptor attached about two minutes after the transition.

**Expected behavior**

An issue that is blocked with an agent-owned `unblockDescriptor` wakes that agent, whichever path put it in that state. Re-pointing the descriptor at a different agent wakes the new owner. An unchanged descriptor does not wake anyone again.

**Steps to reproduce**

1. Create an issue and move it to `blocked` with a blocker and no `unblockDescriptor`.
2. Send a second PATCH that sets `unblockDescriptor` to `{ "owner": { "agentId": "<id>" }, "action": "..." }`.
3. Read the issue row. `unblock_descriptor` is set and `blocked_owner_notified_at` is null. No wakeup was queued for that agent.
4. Alternatively, create a child issue with `status: "blocked"` and an `unblockDescriptor` in the same request. The same two columns show the same result.

**Paperclip version or commit**

`master`, at commit cc42a67e7.

**Deployment mode**

Self-hosted, single instance.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

## What Changed

- Added `notifyBlockedOwner` in `routes/issues.ts`. It runs the delivery and writes `blockedOwnerNotifiedAt`. All call sites now use it.
- Called it from the three paths that previously skipped it: issue create, child create (both handlers), and the bulk child-create loop.
- Widened the PATCH condition from "entering blocked" to also include a descriptor that is attached or re-pointed while the issue is already blocked.
- A re-point ignores the earlier delivery stamp, because it is a new obligation for a different owner.
- Added `unblockDescriptorFingerprint` and put it in the wakeup idempotency key, so a re-point no longer collides with the previous owner's key. Genuine retries still deduplicate.
- Added a test that fails if any server source file contains a NUL byte.

## Verification

```
cd server
npx vitest run \
  src/__tests__/routable-blocked.test.ts \
  src/__tests__/blocked-owner-notification-routes.test.ts \
  src/__tests__/source-files-are-text.test.ts \
  src/__tests__/issue-dependency-wakeups-routes.test.ts \
  src/__tests__/attention-service.test.ts
npm run typecheck
```

All pass. The wider issue-route suites also pass (231 tests across
`issue-create-deduplication`, `issue-blocker-diagnostics`,
`issue-agent-mutation-ownership`, `issue-execution-policy`,
`issue-scheduled-retry`, and `issue-comment-reopen`).

Each new test was checked against a deliberately broken build to confirm it
fails when the fix is removed:

- Narrowing the PATCH condition back to `enteringBlocked` fails both new route tests.
- Treating every descriptor as changed fails the "unchanged descriptor" test.
- Removing the fingerprint from the idempotency key fails both unit tests.
- Adding a NUL byte to a source file fails the new text test.

## Risks

- No migration and no schema change. The affected columns already exist.
- Agents can now receive a wakeup from paths that never sent one. This is the intent of the change. The volume is bounded by how many issues are blocked with an agent-owned descriptor, which is a small number in practice.
- The idempotency key format changed. A key is only compared against other keys for the same issue and the same transition timestamp, so an in-flight wakeup queued under the old format is not re-sent. The worst case is one duplicate wakeup for an issue that is blocked across the deploy.
- A descriptor owned by the board or by a user still sends nothing, which is unchanged.

## Category safeguard

A stray NUL byte reached a template-string separator in `routable-blocked.ts`
during this change. The code ran correctly and every test passed, but `git`
reclassified the file as binary. `git diff` printed "Binary files differ", so
the change was invisible to human review and to any automated reviewer that
reads the diff.

A defect that hides the diff it lives in is worth failing the build over.
`source-files-are-text.test.ts` scans every `.ts` and `.tsx` file under
`server/src` and fails with the file name and byte offset if a NUL is found.

## Related PRs

Searched the open PR list for work on blocked issues, unblock descriptors and
wakeups. Two open PRs touch the same area. Neither does what this PR does, but
both edit nearby lines:

- #11955 — changes **who may be named** as an unblock owner. It refactors the
  same descriptor block in `routes/issues.ts` that this PR reads from, and
  replaces `updateFields.unblockDescriptor` with a
  `resolveRequestedUnblockDescriptor(...)` helper. That is an authorization
  change; this PR is a delivery change. They are complementary, and they will
  conflict textually. Whichever merges second should rebase and take the
  helper. This PR then benefits, because the helper also finds a descriptor
  sent only in the request body.
- #11952 — preserves requested blocked-descriptor semantics. Also edits
  `routes/issues.ts` in the same handler.

No open PR adds the missing notify call sites or changes the wakeup
idempotency key, so this work is not a duplicate.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking, with
tool use and code execution (repository search, file editing, local test runs,
and read-only SQL against a live instance to characterise the defect).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — not applicable; this restores intended behaviour and adds no new API surface
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — running at the time of writing
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — review pending
- [x] I will address all Greptile and reviewer comments before requesting merge
