### PR TITLE
fix(recovery): keep source issue assignee on block

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5156,7 +5156,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(sourceIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: sourceAssigneeAgentId,
+      assigneeAgentId: agentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5156,7 +5156,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(sourceIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: agentId,
+      assigneeAgentId: sourceAssigneeAgentId,
     });
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -885,7 +885,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "in_review",
-      assigneeAgentId: coderId,
+      assigneeAgentId: managerId,
       monitorNextCheckAt: null,
     });
     const [assigneeRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, assigneeRunId));
@@ -946,7 +946,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: coderId,
+      assigneeAgentId: managerId,
     });
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -383,6 +383,70 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     },
   );
 
+  it("keeps the current source assignee as the recovery return owner when the latest run came from another agent", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const ceoId = randomUUID();
+    await db.insert(agents).values({
+      id: ceoId,
+      companyId,
+      name: "Claude CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: ceoId,
+        status: "failed",
+        error: "helper recovery run lost the process",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const [updatedIssue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerAgentId: coderId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "process_lost",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      coderId,
+      expect.objectContaining({
+        reason: "source_scoped_recovery_action",
+        payload: expect.objectContaining({
+          issueId: sourceIssue.id,
+          sourceIssueId: sourceIssue.id,
+          recoveryCause: "process_lost",
+        }),
+      }),
+    );
+  });
+
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({
@@ -1228,67 +1292,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     // Dedupe for structured notices is metadata-based: the short body no longer
     // carries the `Recovery action: \`id\`` marker line.
     expect(comments[0]?.body).not.toContain("Recovery action:");
-  expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
-  expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
-  });
-
-  it("preserves the source assignee and creates a recovery issue for manager fallback", async () => {
-    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
-    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
-    const enqueueWakeup = vi.fn(async () => null);
-    const recovery = recoveryService(db, { enqueueWakeup });
-
-    await recovery.escalateStrandedAssignedIssue({
-      issue: sourceIssue,
-      previousStatus: "in_progress",
-      latestRun: {
-        id: randomUUID(),
-        agentId: coderId,
-        status: "failed",
-        error: "worker exited unexpectedly",
-        errorCode: "process_lost",
-        contextSnapshot: { retryReason: "issue_continuation_needed" },
-        livenessState: "needs_followup",
-      },
-      comment: "Automatic continuation recovery failed.",
-    });
-
-    const [updatedSource] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(updatedSource).toMatchObject({
-      status: "blocked",
-      assigneeAgentId: coderId,
-    });
-
-    const recoveryIssues = await db
-      .select()
-      .from(issues)
-      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
-    expect(recoveryIssues).toHaveLength(1);
-    expect(recoveryIssues[0]).toMatchObject({
-      parentId: sourceIssue.id,
-      assigneeAgentId: managerId,
-      originId: sourceIssue.id,
-      status: "todo",
-    });
-
-    const relations = await db
-      .select()
-      .from(issueRelations)
-      .where(and(eq(issueRelations.issueId, recoveryIssues[0]!.id), eq(issueRelations.relatedIssueId, sourceIssue.id)));
-    expect(relations.some((row) => row.type === "blocks")).toBe(true);
-
-    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
-    expect(enqueueWakeup).toHaveBeenCalledWith(
-      managerId,
-      expect.objectContaining({
-        reason: "issue_assigned",
-        payload: expect.objectContaining({
-          issueId: recoveryIssues[0]!.id,
-          sourceIssueId: sourceIssue.id,
-          recoveryCause: "process_lost",
-        }),
-      }),
-    );
+    expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
+    expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -885,7 +885,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "in_review",
-      assigneeAgentId: managerId,
+      assigneeAgentId: coderId,
       monitorNextCheckAt: null,
     });
     const [assigneeRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, assigneeRunId));

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1228,8 +1228,67 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     // Dedupe for structured notices is metadata-based: the short body no longer
     // carries the `Recovery action: \`id\`` marker line.
     expect(comments[0]?.body).not.toContain("Recovery action:");
-    expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
-    expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
+  expect(noticeMetadataReferencesRecoveryAction(comments[0]?.metadata, actionRows[0]!.id)).toBe(true);
+  expect(comments[0]?.presentation).toMatchObject({ kind: "system_notice", tone: "danger" });
+  });
+
+  it("preserves the source assignee and creates a recovery issue for manager fallback", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, coderId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "worker exited unexpectedly",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedSource] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedSource).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(1);
+    expect(recoveryIssues[0]).toMatchObject({
+      parentId: sourceIssue.id,
+      assigneeAgentId: managerId,
+      originId: sourceIssue.id,
+      status: "todo",
+    });
+
+    const relations = await db
+      .select()
+      .from(issueRelations)
+      .where(and(eq(issueRelations.issueId, recoveryIssues[0]!.id), eq(issueRelations.relatedIssueId, sourceIssue.id)));
+    expect(relations.some((row) => row.type === "blocks")).toBe(true);
+
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: recoveryIssues[0]!.id,
+          sourceIssueId: sourceIssue.id,
+          recoveryCause: "process_lost",
+        }),
+      }),
+    );
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -946,7 +946,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
     expect(updatedIssue).toMatchObject({
       status: "blocked",
-      assigneeAgentId: managerId,
+      assigneeAgentId: coderId,
     });
     const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(updatedRun?.errorCode).toBe("configuration_incomplete");

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -447,6 +447,38 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
+  it("preserves a newer source assignee when stale recovery re-blocks the issue", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+    const [managerOwnedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+
+    const enqueueWakeup = vi.fn(async () => {
+      await db.update(issues).set({ assigneeAgentId: coderId }).where(eq(issues.id, sourceIssueId));
+      return null;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: managerOwnedIssue!,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: managerId,
+        status: "failed",
+        error: "recovery run lost the process after reassignment",
+        errorCode: "process_lost",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+  });
+
   it("stands down while the latest run was cancelled by a board operator", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2587,7 +2587,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // The issue assignee remains the owner of record even if a helper run
     // executes under another agent during recovery.
     const originalAgentId = input.issue.assigneeAgentId ?? input.latestRun?.agentId;
-    const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
+    const returnOwnerAgentId = originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
       input.recoveryCause === "codex_output_inactivity_monitor";
@@ -3339,21 +3339,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const executionState = parseIssueExecutionState(input.issue.executionState);
-    const stageParticipantAgentId = executionState?.status === "pending" && executionState.currentParticipant?.type === "agent"
-      ? executionState.currentParticipant.agentId
-      : null;
-    const preservesSourceAssignee =
-      Boolean(recoveryAction.ownerAgentId) &&
-      Boolean(input.issue.assigneeAgentId) &&
-      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId &&
-      recoveryAction.ownerAgentId !== stageParticipantAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: preservesSourceAssignee
-        ? input.issue.assigneeAgentId
-        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3502,11 +3490,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .from(issues)
         .where(eq(issues.id, input.issue.id))
         .limit(1);
-      if (
-        currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
-      ) {
+      if (currentIssue && currentIssue.status !== "blocked") {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3510,7 +3510,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
         });
         if (reblocked) return reblocked;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3336,11 +3336,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    let blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const preservesSourceAssignee =
+      Boolean(recoveryAction.ownerAgentId) &&
+      Boolean(input.issue.assigneeAgentId) &&
+      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
+    const takeoverRecoveryIssue = preservesSourceAssignee
+      ? await ensureStrandedIssueRecoveryIssue({
+        issue: input.issue,
+        latestRun: input.latestRun,
+        previousStatus: input.previousStatus,
+        recoveryCause,
+        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      })
+      : null;
+    if (takeoverRecoveryIssue) {
+      blockerIds = [...new Set([...blockerIds, takeoverRecoveryIssue.id])];
+    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      assigneeAgentId: preservesSourceAssignee
+        ? input.issue.assigneeAgentId
+        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;
@@ -3473,14 +3491,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       },
     });
 
-    await enqueueSourceScopedStrandedRecoveryWake({
-      action: recoveryAction,
-      issue: input.issue,
-      latestRun: input.latestRun,
-      recoveryCause,
-    });
+    if (!takeoverRecoveryIssue) {
+      await enqueueSourceScopedStrandedRecoveryWake({
+        action: recoveryAction,
+        issue: input.issue,
+        latestRun: input.latestRun,
+        recoveryCause,
+      });
+    }
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3341,7 +3341,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
       blockedByIssueIds: blockerIds,
     });
     if (!updated) return null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2584,7 +2584,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause: StrandedRecoveryCause;
     preferredOwnerAgentId?: string | null;
   }) {
-    const originalAgentId = input.latestRun?.agentId ?? input.issue.assigneeAgentId;
+    // The issue assignee remains the owner of record even if a helper run
+    // executes under another agent during recovery.
+    const originalAgentId = input.issue.assigneeAgentId ?? input.latestRun?.agentId;
     const returnOwnerAgentId = input.issue.assigneeAgentId ?? originalAgentId;
     const routeToOriginal = input.recoveryCause === "process_lost" ||
       input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
@@ -3336,23 +3338,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    let blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const preservesSourceAssignee =
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
       recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
-    const takeoverRecoveryIssue = preservesSourceAssignee
-      ? await ensureStrandedIssueRecoveryIssue({
-        issue: input.issue,
-        latestRun: input.latestRun,
-        previousStatus: input.previousStatus,
-        recoveryCause,
-        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
-      })
-      : null;
-    if (takeoverRecoveryIssue) {
-      blockerIds = [...new Set([...blockerIds, takeoverRecoveryIssue.id])];
-    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
@@ -3491,16 +3481,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       },
     });
 
-    if (!takeoverRecoveryIssue) {
-      await enqueueSourceScopedStrandedRecoveryWake({
-        action: recoveryAction,
-        issue: input.issue,
-        latestRun: input.latestRun,
-        recoveryCause,
-      });
-    }
+    await enqueueSourceScopedStrandedRecoveryWake({
+      action: recoveryAction,
+      issue: input.issue,
+      latestRun: input.latestRun,
+      recoveryCause,
+    });
 
-    if (!takeoverRecoveryIssue && recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
       const [currentIssue] = await db
         .select({
           status: issues.status,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3339,10 +3339,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const executionState = parseIssueExecutionState(input.issue.executionState);
+    const stageParticipantAgentId = executionState?.status === "pending" && executionState.currentParticipant?.type === "agent"
+      ? executionState.currentParticipant.agentId
+      : null;
     const preservesSourceAssignee =
       Boolean(recoveryAction.ownerAgentId) &&
       Boolean(input.issue.assigneeAgentId) &&
-      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId;
+      recoveryAction.ownerAgentId !== input.issue.assigneeAgentId &&
+      recoveryAction.ownerAgentId !== stageParticipantAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3341,6 +3341,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
+      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
       blockedByIssueIds: blockerIds,
     });
     if (!updated) return null;


### PR DESCRIPTION
## Summary
- keep the source issue assignee as the recovery return owner even when the latest failed run came from a helper agent
- avoid overwriting a newer source assignee if a stale recovery path re-blocks the issue later
- cover both paths with focused recovery action tests

## Testing
- pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts