### PR TITLE
fix(heartbeat): fail closed after issues reach done

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1169,6 +1169,137 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels queued runs for terminal issues even when the wake carries a comment id or resume intent", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Closed before deferred comment wake started",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      completedAt: new Date("2026-08-22T21:41:43.290Z"),
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_commented",
+      invocationSource: "automation",
+      contextExtras: {
+        wakeCommentId: commentId,
+        resumeIntent: true,
+        followUpRequested: true,
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup, issue] = await Promise.all([
+      db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({
+          status: issues.status,
+          executionRunId: issues.executionRunId,
+          checkoutRunId: issues.checkoutRunId,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_terminal_status");
+    expect(wakeup?.status).toBe("skipped");
+    expect(issue).toMatchObject({
+      status: "done",
+      executionRunId: null,
+      checkoutRunId: null,
+    });
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("skips new wakes when the target issue is already done", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Already finished planning issue",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      completedAt: new Date("2026-08-22T21:41:43.290Z"),
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const runRows = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    const issue = await db
+      .select({
+        status: issues.status,
+        executionRunId: issues.executionRunId,
+        checkoutRunId: issues.checkoutRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "issue_terminal_status",
+    });
+    expect(runRows).toHaveLength(0);
+    expect(issue).toMatchObject({
+      status: "done",
+      executionRunId: null,
+      checkoutRunId: null,
+    });
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -663,6 +663,46 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
+  it("restores a checkout-reopened done issue instead of blocking it as stranded", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    const completedAt = new Date("2026-08-22T21:41:43.290Z");
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        completedAt,
+        updatedAt: new Date("2026-08-22T21:42:39.165Z"),
+      })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: coderId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "Process lost",
+      errorCode: "process_lost",
+      startedAt: new Date("2026-08-22T21:42:01.058Z"),
+      finishedAt: new Date("2026-08-22T21:44:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId, wakeReason: "process_lost_retry" },
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result.terminalStatusRestored).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "done",
+      assigneeAgentId: coderId,
+    });
+    expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
   it("still recovers system-cancelled runs with no operator attribution", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.insert(heartbeatRuns).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5757,6 +5757,74 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
+  it("checkout refuses to reopen a done issue even when expectedStatuses includes done", async () => {
+    // Queued/late runs must fail closed after a terminal transition. Including
+    // `done` in expectedStatuses must not promote the row back to in_progress.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const successorRunId = randomUUID();
+    const completedAt = new Date("2026-08-22T21:41:43.290Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: successorRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "automation",
+      startedAt: new Date("2026-08-22T21:42:01.058Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal issue must stay done",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      completedAt,
+    });
+
+    await expect(
+      svc.checkout(issueId, agentId, ["todo", "backlog", "blocked", "done"], successorRunId),
+    ).rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        completedAt: issues.completedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "done",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      completedAt,
+    });
+  });
+
   it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
     // Regression for PR #2482 checkout-adoption review finding: any adoption
     // helper that re-locks an existing in_progress issue (e.g. when the prior

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10273,6 +10273,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (issueId) {
+      const issueStatus = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0]?.status ?? null);
+      if (issueStatus === "done" || issueStatus === "cancelled") {
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: "Process-loss retry suppressed because the issue already reached a terminal status",
+          payload: { issueId, currentStatus: issueStatus },
+        });
+        await releaseIssueExecutionAndPromote(run);
+        return null;
+      }
+    }
     const retryReason = readNonEmptyString(contextSnapshot.wakeReason) === "issue_monitor_due"
       ? "issue_continuation_needed"
       : "process_lost";
@@ -10344,7 +10362,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionLockedAt: now,
             updatedAt: now,
           })
-          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
+          .where(and(
+            eq(issues.id, issueId),
+            eq(issues.companyId, run.companyId),
+            eq(issues.executionRunId, run.id),
+            notInArray(issues.status, ["done", "cancelled"]),
+          ));
       }
 
       return retryRun;
@@ -12770,6 +12793,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             // owns the issue execution lock shown as the active run.
             eq(issues.assigneeAgentId, claimed.agentId),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
+            notInArray(issues.status, ["done", "cancelled"]),
           ),
         );
     }
@@ -12879,7 +12903,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const wakeCommentId = deriveCommentId(context, null);
     const isInteractionWake = allowsIssueInteractionWake(context);
-    const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
     const interactionResolvedAt = readNonEmptyString(context.interactionResolvedAt);
@@ -12959,14 +12982,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
-      if (!resumeIntent && !wakeCommentId) {
-        return {
-          stale: true,
-          errorCode: "issue_terminal_status",
-          reason: `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`,
-          details: { issueId, currentStatus: issue.status },
-        };
-      }
+      return {
+        stale: true,
+        errorCode: "issue_terminal_status",
+        reason: `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`,
+        details: { issueId, currentStatus: issue.status },
+      };
     }
 
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON && issue.status !== "in_progress") {
@@ -14155,6 +14176,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
+    if (issueContext && (issueContext.status === "done" || issueContext.status === "cancelled")) {
+      const now = new Date();
+      const reason = `Cancelled because issue reached terminal status (${issueContext.status}) before adapter execution`;
+      await setRunStatus(runId, "cancelled", {
+        error: reason,
+        errorCode: "issue_terminal_status",
+        finishedAt: now,
+        resultJson: {
+          ...parseObject(run.resultJson),
+          stopReason: "issue_terminal_status",
+        },
+      });
+      await setWakeupStatus(run.wakeupRequestId, "skipped", {
+        finishedAt: now,
+        error: reason,
+      });
+      const cancelledRun = await getRun(runId);
+      if (cancelledRun) await releaseIssueExecutionAndPromote(cancelledRun);
+      return;
+    }
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
       : null;
@@ -17302,6 +17343,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
 
+        if (issue.status === "done" || issue.status === "cancelled") {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "skipped",
+              finishedAt: new Date(),
+              error: `Deferred wake suppressed because issue reached terminal status (${issue.status})`,
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
+
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
           (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";
@@ -18094,6 +18148,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             triggerDetail,
             reason: "issue_execution_issue_not_found",
             payload,
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
+        if (issue.status === "done" || issue.status === "cancelled") {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_terminal_status",
+            payload: {
+              ...(payload ?? {}),
+              issueId: issue.id,
+              heartbeatSkip: {
+                reason: "issue_terminal_status",
+                currentStatus: issue.status,
+              },
+            },
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8161,6 +8161,33 @@ export function issueService(db: Db) {
       await clearExecutionRunIfTerminal(id);
       await clearCheckoutRunIfTerminal(id);
 
+      // Checkout must not reopen terminal issues. Resume/reopen belongs on the
+      // comment/update path, which clears completedAt/cancelledAt first.
+      const checkoutableStatuses = expectedStatuses.filter(
+        (status) => status !== "done" && status !== "cancelled",
+      );
+      if (checkoutableStatuses.length === 0) {
+        const current = await db
+          .select({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!current) throw notFound("Issue not found");
+        throw conflict("Issue checkout conflict", {
+          issueId: current.id,
+          status: current.status,
+          assigneeAgentId: current.assigneeAgentId,
+          checkoutRunId: current.checkoutRunId,
+          executionRunId: current.executionRunId,
+        });
+      }
+
       const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
       const readiness = dependencyReadiness.get(id);
       const unresolvedBlockerIssueIds = readiness?.unresolvedBlockerIssueIds ?? [];
@@ -8200,7 +8227,7 @@ export function issueService(db: Db) {
         .where(
           and(
             eq(issues.id, id),
-            inArray(issues.status, expectedStatuses),
+            inArray(issues.status, checkoutableStatuses),
             or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
             executionLockCondition,
           ),
@@ -8226,6 +8253,16 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
+
+      if (current.status === "done" || current.status === "cancelled") {
+        throw conflict("Issue checkout conflict", {
+          issueId: current.id,
+          status: current.status,
+          assigneeAgentId: current.assigneeAgentId,
+          checkoutRunId: current.checkoutRunId,
+          executionRunId: current.executionRunId,
+        });
+      }
 
       if (
         current.assigneeAgentId === agentId &&
@@ -8306,7 +8343,7 @@ export function issueService(db: Db) {
             .where(
               and(
                 eq(issues.id, id),
-                inArray(issues.status, expectedStatuses),
+                inArray(issues.status, checkoutableStatuses),
                 eq(issues.executionRunId, current.executionRunId),
                 or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
               ),

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -4076,11 +4076,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       providerQuotaMonitored: 0,
       recentProgressExempted: 0,
       operatorCancelExempted: 0,
+      terminalStatusRestored: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
 
     for (const issue of candidates) {
+      const restoreStatus = issue.completedAt
+        ? "done"
+        : issue.cancelledAt
+          ? "cancelled"
+          : null;
+      if (restoreStatus && issue.status !== "done" && issue.status !== "cancelled") {
+        const restored = await issuesSvc.update(issue.id, { status: restoreStatus });
+        if (restored) {
+          result.terminalStatusRestored += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
+        continue;
+      }
+
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)
         : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Heartbeat dispatch, issue checkout, and stranded-run recovery share the issue execution lock
> - After an issue reaches `done`, a later queued or late-finishing automation run can still start
> - That run can check the issue out again, and recovery can then move it to `blocked` with no blockers
> - This pull request fails closed on terminal issues so later runs cannot reopen or regress them
> - The benefit is that completed work stays complete unless a real resume path reopens it first

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Related open PRs: Refs #10991, Refs #8134, Refs #8703, Refs #6163.

**What happened?**
After an issue transitions to `done`, a later automation run can still start. The run can check the issue out and reopen it to `in_progress`. Stranded-run recovery then moves the issue to `blocked` with an empty blocker list.

**Expected behavior**
After an issue reaches `done` or `cancelled`, later queued or late-finishing runs must fail closed. They must not check out the issue. They must not change its terminal status. Recovery must restore `done` if checkout already reopened a completed issue.

**Steps to reproduce**
1. Mark an assigned issue `done` in one heartbeat run.
2. Start a later queued automation run for the same issue, including a comment id or resume intent, without a real reopen.
3. Observe the later run start, check the issue out, fail with `process_lost`, and leave the issue `blocked` with no blockers.

**Paperclip version or commit**
`cc42a67` on `master` at the time of this change.

**Deployment mode**
Self-hosted server

## What Changed

- Skip new heartbeat wakes when the target issue is already `done` or `cancelled`.
- Cancel queued runs for terminal issues even when the wake carries a comment id or resume intent.
- Refuse issue checkout of `done` and `cancelled` rows even if those statuses appear in `expectedStatuses`.
- Do not stamp the execution lock or enqueue a process-loss retry on a terminal issue.
- Restore a checkout-reopened done issue instead of blocking it as stranded.

## Verification

- `cd server && pnpm exec vitest run --config vitest.config.ts src/__tests__/issues-service.test.ts -t "checkout refuses to reopen a done issue even when expectedStatuses includes done|checkout refuses to promote a 'done' issue"`
- `cd server && pnpm exec vitest run --config vitest.config.ts src/__tests__/heartbeat-stale-queue-invalidation.test.ts -t "cancels queued runs when the issue reaches a terminal status|cancels queued runs for terminal issues even when the wake carries a comment id|skips new wakes when the target issue is already done"`
- `cd server && pnpm exec vitest run --config vitest.config.ts src/__tests__/issue-recovery-actions.test.ts -t "restores a checkout-reopened done issue instead of blocking it as stranded|escalates stranded assigned work into a source action"`
- All listed tests passed locally.

## Risks

- A wake that arrives while an issue is still `done` no longer starts. Legitimate follow-up must reopen the issue first with `resume: true` or a human comment reopen.
- Recovery now treats a leftover `completedAt` on a non-terminal row as proof of an illegal reopen and restores `done`. A true resume path already clears `completedAt`.
- Low risk of migration issues. This change does not add a database migration.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

xAI Grok 4.6 (`grok-4.6`) via the Paperclip `grok_local` adapter. Tool use and code execution were enabled. No extended-thinking mode was selected.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
