### PR TITLE
fix(claude-local): terminate quota probe process groups on timeout

### DIFF
--- a/packages/adapters/claude-local/src/server/__fixtures__/quota-probe-child.cjs
+++ b/packages/adapters/claude-local/src/server/__fixtures__/quota-probe-child.cjs
@@ -1,0 +1,12 @@
+const fs = require("node:fs");
+
+const [mode, pidFile, signalFile] = process.argv.slice(2);
+
+fs.appendFileSync(pidFile, `${process.pid}\n`);
+process.on("SIGTERM", () => {
+  fs.appendFileSync(signalFile, "SIGTERM\n");
+  if (mode === "accept") process.exit(0);
+});
+if (mode === "ignore") process.on("SIGHUP", () => {});
+
+setInterval(() => {}, 1_000);

--- a/packages/adapters/claude-local/src/server/quota.test.ts
+++ b/packages/adapters/claude-local/src/server/quota.test.ts
@@ -1,0 +1,132 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { executeClaudeCliShellProbe } from "./quota.js";
+
+const fixturePath = fileURLToPath(
+  new URL("./__fixtures__/quota-probe-child.cjs", import.meta.url),
+);
+const supportsScriptPty =
+  process.platform !== "win32"
+  && spawnSync("script", ["--version"], { stdio: "ignore" }).status === 0;
+
+const temporaryDirectories: string[] = [];
+
+function quoteForShell(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function readLines(filePath: string): Promise<string[]> {
+  try {
+    return (await fs.readFile(filePath, "utf8"))
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function waitForLines(filePath: string, count: number): Promise<string[]> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const lines = await readLines(filePath);
+    if (lines.length >= count) return lines;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for ${count} lines in ${filePath}`);
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function expectProcessesGone(pids: number[]): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (pids.every((pid) => !isProcessAlive(pid))) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  const survivors = pids.filter(isProcessAlive);
+  const processDetails = spawnSync(
+    "ps",
+    ["-o", "pid=,ppid=,pgid=,sid=,stat=,args=", "-p", survivors.join(",")],
+    { encoding: "utf8" },
+  ).stdout.trim();
+  expect(
+    survivors,
+    `probe descendants still alive: ${processDetails}`,
+  ).toEqual([]);
+}
+
+async function runTimedOutProbe(mode: "accept" | "ignore") {
+  const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-quota-probe-"));
+  temporaryDirectories.push(temporaryDirectory);
+  const pidFile = path.join(temporaryDirectory, "pids");
+  const signalFile = path.join(temporaryDirectory, "signals");
+  const childCommand = [
+    `echo $$ >> ${quoteForShell(pidFile)}; exec`,
+    quoteForShell(process.execPath),
+    quoteForShell(fixturePath),
+    mode,
+    quoteForShell(pidFile),
+    quoteForShell(signalFile),
+  ].join(" ");
+  const command = [
+    `sh -c ${quoteForShell(`echo $$ >> ${quoteForShell(pidFile)}; exec sleep 30`)}`,
+    "|",
+    `sh -c ${quoteForShell(`echo $$ >> ${quoteForShell(pidFile)}; exec script -q -e -f -c ${quoteForShell(childCommand)} /dev/null`)}`,
+  ].join(" ");
+
+  const killSpy = vi.spyOn(process, "kill");
+  const execution = executeClaudeCliShellProbe(command, {
+    env: process.env,
+    timeoutMs: 500,
+    terminationGraceMs: 300,
+  });
+  const pids = (await waitForLines(pidFile, 3)).map(Number);
+
+  await expect(execution).rejects.toThrow("timed out after 500ms");
+  await expectProcessesGone(pids);
+
+  return {
+    signals: await readLines(signalFile),
+    dispatchedSignals: killSpy.mock.calls
+      .map(([, signal]) => signal)
+      .filter((signal) => signal === "SIGTERM" || signal === "SIGKILL"),
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    fs.rm(directory, { recursive: true, force: true })
+  ));
+});
+
+describe.skipIf(!supportsScriptPty)("executeClaudeCliShellProbe process groups", () => {
+  it("uses SIGTERM only and leaves no descendants when the pty child accepts it", async () => {
+    const result = await runTimedOutProbe("accept");
+
+    expect(result.signals).toEqual(["SIGTERM"]);
+    expect(result.dispatchedSignals.length).toBeGreaterThan(0);
+    expect(result.dispatchedSignals.every((signal) => signal === "SIGTERM")).toBe(true);
+  });
+
+  it("uses SIGTERM before SIGKILL and leaves no descendants when the pty child ignores TERM", async () => {
+    const result = await runTimedOutProbe("ignore");
+
+    expect(result.signals[0]).toBe("SIGTERM");
+    expect(result.dispatchedSignals[0]).toBe("SIGTERM");
+    expect(result.dispatchedSignals).toContain("SIGKILL");
+  });
+});

--- a/packages/adapters/claude-local/src/server/quota.test.ts
+++ b/packages/adapters/claude-local/src/server/quota.test.ts
@@ -129,4 +129,39 @@ describe.skipIf(!supportsScriptPty)("executeClaudeCliShellProbe process groups",
     expect(result.dispatchedSignals[0]).toBe("SIGTERM");
     expect(result.dispatchedSignals).toContain("SIGKILL");
   });
+
+  it("terminates the probe immediately when the output goes over maxBuffer", async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "paperclip-quota-probe-"),
+    );
+    temporaryDirectories.push(temporaryDirectory);
+    const pidFile = path.join(temporaryDirectory, "pids");
+
+    // The child floods stdout and then stays alive. Only an immediate termination
+    // can settle this probe, because the timeout is far away.
+    const command = [
+      `sh -c ${quoteForShell(`echo $$ >> ${quoteForShell(pidFile)}; exec sleep 30`)}`,
+      "|",
+      `sh -c ${quoteForShell(
+        `echo $$ >> ${quoteForShell(pidFile)}; exec script -q -e -f -c ${quoteForShell(
+          `echo $$ >> ${quoteForShell(pidFile)}; yes paperclip`,
+        )} /dev/null`,
+      )}`,
+    ].join(" ");
+
+    const startedAt = Date.now();
+    const execution = executeClaudeCliShellProbe(command, {
+      env: process.env,
+      timeoutMs: 30_000,
+      terminationGraceMs: 300,
+      maxBufferBytes: 1_024,
+    });
+    const pids = (await waitForLines(pidFile, 3)).map(Number);
+
+    await expect(execution).rejects.toMatchObject({
+      code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+    });
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+    await expectProcessesGone(pids);
+  });
 });

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -1,4 +1,5 @@
-import { execFile } from "node:child_process";
+import { execFile, execFileSync, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -9,6 +10,8 @@ const execFileAsync = promisify(execFile);
 
 const CLAUDE_USAGE_SOURCE_OAUTH = "anthropic-oauth";
 const CLAUDE_USAGE_SOURCE_CLI = "claude-cli";
+const CLAUDE_CLI_PROBE_TERMINATION_GRACE_MS = 1_000;
+const CLAUDE_CLI_PROBE_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
 export function claudeConfigDir(): string {
   const fromEnv = process.env.CLAUDE_CONFIG_DIR;
@@ -437,13 +440,240 @@ function buildClaudeCliShellProbeCommand(): string {
   return `${feed} | script -q -e -f -c ${quoteForShell(claudeCommand)} /dev/null`;
 }
 
+interface ClaudeCliShellProbeOptions {
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  terminationGraceMs?: number;
+  maxBufferBytes?: number;
+}
+
+function snapshotClaudeCliProbeProcessGroups(rootPid: number): number[] {
+  if (process.platform === "win32") return [];
+  if (process.platform === "linux") {
+    const groupsByDepth = new Map<number, number>([[rootPid, 0]]);
+    const pending = [{ pid: rootPid, depth: 0 }];
+    const visited = new Set<number>();
+    while (pending.length > 0) {
+      const current = pending.pop()!;
+      if (visited.has(current.pid)) continue;
+      visited.add(current.pid);
+      let childPids: number[];
+      try {
+        childPids = readFileSync(
+          `/proc/${current.pid}/task/${current.pid}/children`,
+          "utf8",
+        ).trim().split(/\s+/).filter(Boolean).map(Number);
+      } catch {
+        continue;
+      }
+      for (const childPid of childPids) {
+        try {
+          const stat = readFileSync(`/proc/${childPid}/stat`, "utf8");
+          const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+          const processGroupId = Number(fields[2]);
+          if (Number.isInteger(processGroupId) && processGroupId > 0) {
+            groupsByDepth.set(processGroupId, Math.max(
+              groupsByDepth.get(processGroupId) ?? 0,
+              current.depth + 1,
+            ));
+          }
+          pending.push({ pid: childPid, depth: current.depth + 1 });
+        } catch {
+          // A descendant can exit while /proc is being read.
+        }
+      }
+    }
+    return [...groupsByDepth]
+      .sort((left, right) => right[1] - left[1])
+      .map(([processGroupId]) => processGroupId);
+  }
+  let processTable: string;
+  try {
+    processTable = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], { encoding: "utf8" });
+  } catch {
+    return [rootPid];
+  }
+
+  const childrenByParent = new Map<number, Array<{ pid: number; processGroupId: number }>>();
+  for (const line of processTable.split("\n")) {
+    const [pid, parentPid, processGroupId] = line.trim().split(/\s+/).map(Number);
+    if (![pid, parentPid, processGroupId].every(Number.isInteger)) continue;
+    const children = childrenByParent.get(parentPid) ?? [];
+    children.push({ pid, processGroupId });
+    childrenByParent.set(parentPid, children);
+  }
+
+  const groupsByDepth = new Map<number, number>();
+  const pending = [{ pid: rootPid, depth: 0 }];
+  const visited = new Set<number>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (visited.has(current.pid)) continue;
+    visited.add(current.pid);
+    for (const child of childrenByParent.get(current.pid) ?? []) {
+      groupsByDepth.set(child.processGroupId, Math.max(
+        groupsByDepth.get(child.processGroupId) ?? 0,
+        current.depth + 1,
+      ));
+      pending.push({ pid: child.pid, depth: current.depth + 1 });
+    }
+  }
+  groupsByDepth.set(rootPid, 0);
+  return [...groupsByDepth]
+    .filter(([processGroupId]) => processGroupId > 0)
+    .sort((left, right) => right[1] - left[1])
+    .map(([processGroupId]) => processGroupId);
+}
+
+function signalClaudeCliProbeTarget(
+  child: ReturnType<typeof spawn>,
+  processGroupId: number | null,
+  signal: NodeJS.Signals,
+): void {
+  if (process.platform !== "win32" && processGroupId !== null) {
+    try {
+      process.kill(-processGroupId, signal);
+    } catch {
+      // A descendant can exit between the process snapshot and the signal.
+    }
+    return;
+  }
+  if (child.exitCode === null && child.signalCode === null) child.kill(signal);
+}
+
+function aliveClaudeCliProbeGroups(processGroupIds: number[]): number[] {
+  return processGroupIds.filter((processGroupId) => {
+    try {
+      process.kill(-processGroupId, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+async function waitForClaudeCliProbeGroupsToExit(
+  processGroupIds: number[],
+  timeoutMs: number,
+): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let alive = aliveClaudeCliProbeGroups(processGroupIds);
+  while (alive.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    alive = aliveClaudeCliProbeGroups(alive);
+  }
+  return alive;
+}
+
+export function executeClaudeCliShellProbe(
+  command: string,
+  options: ClaudeCliShellProbeOptions,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let timedOut = false;
+    let settled = false;
+    let outputExceededMaxBuffer = false;
+    let stdout = "";
+    let stderr = "";
+    const maxBufferBytes = options.maxBufferBytes ?? CLAUDE_CLI_PROBE_MAX_BUFFER_BYTES;
+    const child = spawn("sh", ["-c", command], {
+      detached: process.platform !== "win32",
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const appendOutput = (current: string, chunk: string): string => {
+      if (Buffer.byteLength(current) + Buffer.byteLength(chunk) > maxBufferBytes) {
+        outputExceededMaxBuffer = true;
+        return current;
+      }
+      return current + chunk;
+    };
+    child.stdout.on("data", (chunk: string) => {
+      stdout = appendOutput(stdout, chunk);
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr = appendOutput(stderr, chunk);
+    });
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      void (async () => {
+        const processGroupIds =
+          typeof child.pid === "number" && child.pid > 0
+            ? snapshotClaudeCliProbeProcessGroups(child.pid)
+            : [];
+        const terminationGraceMs =
+          options.terminationGraceMs ?? CLAUDE_CLI_PROBE_TERMINATION_GRACE_MS;
+        if (process.platform === "win32") {
+          signalClaudeCliProbeTarget(child, null, "SIGTERM");
+          await new Promise((resolveDelay) => setTimeout(
+            resolveDelay,
+            terminationGraceMs,
+          ));
+          if (child.exitCode === null && child.signalCode === null) {
+            signalClaudeCliProbeTarget(child, null, "SIGKILL");
+          }
+        } else {
+          // Stop nested pty groups before their parents so script(1) can reap
+          // the child instead of leaving a reparented zombie behind.
+          for (const processGroupId of processGroupIds) {
+            signalClaudeCliProbeTarget(child, processGroupId, "SIGTERM");
+            const stillAlive = await waitForClaudeCliProbeGroupsToExit(
+              [processGroupId],
+              terminationGraceMs,
+            );
+            if (stillAlive.length === 0) continue;
+            signalClaudeCliProbeTarget(child, processGroupId, "SIGKILL");
+            await waitForClaudeCliProbeGroupsToExit(stillAlive, 1_000);
+          }
+        }
+        if (settled) return;
+        settled = true;
+        const timeoutError = new Error(`Claude CLI usage probe timed out after ${options.timeoutMs}ms`);
+        Object.assign(timeoutError, { stdout, stderr, code: "ETIMEDOUT" });
+        reject(timeoutError);
+      })();
+    }, options.timeoutMs);
+
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      if (settled || timedOut) return;
+      settled = true;
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timeout);
+      if (settled || timedOut) return;
+      settled = true;
+      if (outputExceededMaxBuffer) {
+        const error = new Error("Claude CLI usage probe exceeded maxBuffer");
+        Object.assign(error, {
+          stdout,
+          stderr,
+          code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+        });
+        reject(error);
+        return;
+      }
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      const error = new Error(`Claude CLI usage probe exited with ${signal ?? `code ${code}`}`);
+      Object.assign(error, { stdout, stderr, code, signal });
+      reject(error);
+    });
+  });
+}
+
 export async function captureClaudeCliUsageText(timeoutMs = 12_000): Promise<string> {
   const command = buildClaudeCliShellProbeCommand();
   try {
-    const { stdout, stderr } = await execFileAsync("sh", ["-c", command], {
+    const { stdout, stderr } = await executeClaudeCliShellProbe(command, {
       env: createClaudeQuotaEnv(),
-      timeout: timeoutMs,
-      maxBuffer: 8 * 1024 * 1024,
+      timeoutMs,
     });
     const output = `${stdout}${stderr}`;
     const cleaned = cleanTerminalText(output);

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -1,4 +1,5 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -565,12 +566,42 @@ async function waitForClaudeCliProbeGroupsToExit(
   return alive;
 }
 
+async function terminateClaudeCliProbe(
+  child: ChildProcess,
+  terminationGraceMs: number,
+): Promise<void> {
+  const processGroupIds =
+    typeof child.pid === "number" && child.pid > 0
+      ? snapshotClaudeCliProbeProcessGroups(child.pid)
+      : [];
+  if (process.platform === "win32") {
+    signalClaudeCliProbeTarget(child, null, "SIGTERM");
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, terminationGraceMs));
+    if (child.exitCode === null && child.signalCode === null) {
+      signalClaudeCliProbeTarget(child, null, "SIGKILL");
+    }
+    return;
+  }
+  // Stop nested pty groups before their parents so script(1) can reap
+  // the child instead of leaving a reparented zombie behind.
+  for (const processGroupId of processGroupIds) {
+    signalClaudeCliProbeTarget(child, processGroupId, "SIGTERM");
+    const stillAlive = await waitForClaudeCliProbeGroupsToExit(
+      [processGroupId],
+      terminationGraceMs,
+    );
+    if (stillAlive.length === 0) continue;
+    signalClaudeCliProbeTarget(child, processGroupId, "SIGKILL");
+    await waitForClaudeCliProbeGroupsToExit(stillAlive, 1_000);
+  }
+}
+
 export function executeClaudeCliShellProbe(
   command: string,
   options: ClaudeCliShellProbeOptions,
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    let timedOut = false;
+    let terminating = false;
     let settled = false;
     let outputExceededMaxBuffer = false;
     let stdout = "";
@@ -583,9 +614,35 @@ export function executeClaudeCliShellProbe(
     });
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
+
+    // execFile kills the child as soon as the output goes over maxBuffer. Keep that
+    // contract: terminate the whole probe group now and fail with the maxBuffer code,
+    // instead of letting a noisy probe run on and surface as a timeout.
+    const terminateAndReject = (buildError: () => Error): void => {
+      if (terminating || settled) return;
+      terminating = true;
+      clearTimeout(timeout);
+      void (async () => {
+        await terminateClaudeCliProbe(
+          child,
+          options.terminationGraceMs ?? CLAUDE_CLI_PROBE_TERMINATION_GRACE_MS,
+        );
+        if (settled) return;
+        settled = true;
+        reject(buildError());
+      })();
+    };
+
+    const buildMaxBufferError = (): Error => {
+      const error = new Error("Claude CLI usage probe exceeded maxBuffer");
+      Object.assign(error, { stdout, stderr, code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" });
+      return error;
+    };
+
     const appendOutput = (current: string, chunk: string): string => {
       if (Buffer.byteLength(current) + Buffer.byteLength(chunk) > maxBufferBytes) {
         outputExceededMaxBuffer = true;
+        terminateAndReject(buildMaxBufferError);
         return current;
       }
       return current + chunk;
@@ -598,54 +655,22 @@ export function executeClaudeCliShellProbe(
     });
 
     const timeout = setTimeout(() => {
-      timedOut = true;
-      void (async () => {
-        const processGroupIds =
-          typeof child.pid === "number" && child.pid > 0
-            ? snapshotClaudeCliProbeProcessGroups(child.pid)
-            : [];
-        const terminationGraceMs =
-          options.terminationGraceMs ?? CLAUDE_CLI_PROBE_TERMINATION_GRACE_MS;
-        if (process.platform === "win32") {
-          signalClaudeCliProbeTarget(child, null, "SIGTERM");
-          await new Promise((resolveDelay) => setTimeout(
-            resolveDelay,
-            terminationGraceMs,
-          ));
-          if (child.exitCode === null && child.signalCode === null) {
-            signalClaudeCliProbeTarget(child, null, "SIGKILL");
-          }
-        } else {
-          // Stop nested pty groups before their parents so script(1) can reap
-          // the child instead of leaving a reparented zombie behind.
-          for (const processGroupId of processGroupIds) {
-            signalClaudeCliProbeTarget(child, processGroupId, "SIGTERM");
-            const stillAlive = await waitForClaudeCliProbeGroupsToExit(
-              [processGroupId],
-              terminationGraceMs,
-            );
-            if (stillAlive.length === 0) continue;
-            signalClaudeCliProbeTarget(child, processGroupId, "SIGKILL");
-            await waitForClaudeCliProbeGroupsToExit(stillAlive, 1_000);
-          }
-        }
-        if (settled) return;
-        settled = true;
+      terminateAndReject(() => {
         const timeoutError = new Error(`Claude CLI usage probe timed out after ${options.timeoutMs}ms`);
         Object.assign(timeoutError, { stdout, stderr, code: "ETIMEDOUT" });
-        reject(timeoutError);
-      })();
+        return timeoutError;
+      });
     }, options.timeoutMs);
 
     child.once("error", (error) => {
       clearTimeout(timeout);
-      if (settled || timedOut) return;
+      if (settled || terminating) return;
       settled = true;
       reject(error);
     });
     child.once("close", (code, signal) => {
       clearTimeout(timeout);
-      if (settled || timedOut) return;
+      if (settled || terminating) return;
       settled = true;
       if (outputExceededMaxBuffer) {
         const error = new Error("Claude CLI usage probe exceeded maxBuffer");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `claude-local` adapter reports Anthropic subscription quota through `getQuotaWindows()`
> - That function reads the OAuth token first. If the OAuth read fails, it falls back to a CLI probe
> - The CLI probe drives the interactive Claude CLI through a pty: `sh -c '... | script -q -e -f -c "claude --tools \"\"" /dev/null'`
> - The probe runs under `execFileAsync` with a 12 s timeout. The Node timeout signals only the direct `sh` child
> - The `script` pty and the `claude` process below it survive the timeout. init adopts them and they keep their memory
> - This pull request gives the probe its own process group and terminates the whole group on timeout
> - The benefit is that a slow CLI no longer leaks a process pair on every timeout

## Linked Issues or Issue Description

Refs #8970

Related open pull requests. They fix the same class of defect in different code paths. This pull request does not overlap with them:

- #11389 terminates escaped descendant trees in `adapter-utils` and the server service supervisor
- #11495 reaps the ACPX descendant tree through the `acpx` patch

## What Changed

- Add `executeClaudeCliShellProbe()` in `packages/adapters/claude-local/src/server/quota.ts`. It spawns the probe with `detached: true`, so the probe gets its own process group.
- Add `snapshotClaudeCliProbeProcessGroups()`. It walks `/proc/<pid>/task/<pid>/children` on Linux and falls back to `ps -axo pid=,ppid=,pgid=` elsewhere. It returns the descendant process groups, innermost first.
- On timeout, signal each group in that order. Send SIGTERM first. Wait a short grace period. Send SIGKILL only to the members that stay alive. The innermost-first order lets `script(1)` reap its own child instead of leaving a reparented zombie.
- Point `captureClaudeCliUsageText()` at the new helper. The timeout error keeps the `ETIMEDOUT` code, the partial `stdout`, and the partial `stderr`.
- Keep the previous `maxBuffer` behavior. The helper reports `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` when output goes over the limit.
- Add `quota.test.ts` and the `__fixtures__/quota-probe-child.cjs` fixture.

## Verification

`pnpm --filter @paperclipai/adapter-claude-local typecheck` passes.

The new test builds the real `sh -> script/pty -> child` chain. It records every pid and every signal that the child receives. It covers two cases:

- the pty child accepts SIGTERM
- the pty child ignores SIGTERM

Both cases assert three things. The probe rejects with a timeout. No descendant survives. SIGTERM is always the first signal. The second case also asserts that the probe escalates to SIGKILL.

A third case covers the `maxBuffer` contract. The pty child runs `yes` under a 1 KiB `maxBufferBytes` and a 30 s `timeoutMs`. It asserts the `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` code, a settle time under 10 s, and no surviving descendant.

Test run on Linux (`vitest run quota.test.ts`):

```
 ✓ uses SIGTERM only and leaves no descendants when the pty child accepts it  557ms
 ✓ uses SIGTERM before SIGKILL and leaves no descendants when the pty child ignores TERM  866ms
 ✓ terminates the probe immediately when the output goes over maxBuffer  59ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The test skips on Windows and on hosts without `script(1)`, because the defect and the fix are POSIX only.

We also ran this change in a production deployment for about 12 hours. It ran clean. We measured the defect before the change: a host accumulated 125 orphaned pairs, about 24.6 GB of resident memory, and the machine ran out of memory.

## Risks

Low to medium.

- The change is limited to one function in one adapter. It does not change the shape of the quota result.
- The signal path is POSIX only. On Windows the helper keeps the previous behavior and signals the child handle directly.
- `snapshotClaudeCliProbeProcessGroups()` reads `/proc` while processes exit. Every read sits inside a `try`/`catch`, because a descendant can exit between the snapshot and the signal.
- Sending a signal to a process group is wider than sending it to one process. The group only holds the probe and its own descendants, because the spawn is `detached`.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution. The fix and the test were authored with the model and verified by running the test suite and two mutation checks: with the group-signal path disabled the first two tests fail on surviving descendants, and with the maxBuffer termination removed the third test fails and takes 5006 ms instead of 59 ms.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

<sub>The documentation box is unchecked because this is an internal behavior fix with no user-facing surface. Tell me if you want a note in the adapter docs.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
