### PR TITLE
fix(ui): guard the full capabilities chain in FileViewerSheet

### DIFF
--- a/ui/src/components/FileViewerSheet.copy.test.tsx
+++ b/ui/src/components/FileViewerSheet.copy.test.tsx
@@ -170,6 +170,22 @@ describe("FileViewerSheet copy actions", () => {
     expect(previewPane?.className).not.toContain("rounded");
   });
 
+  it("degrades to no-preview instead of throwing when capabilities is missing from the resolved resource", () => {
+    const resourceWithoutCapabilities = { ...resolvedResource } as Partial<ResolvedWorkspaceResource>;
+    delete resourceWithoutCapabilities.capabilities;
+
+    useQueryMock.mockImplementation((options: { queryKey?: readonly unknown[] }) => {
+      const key = JSON.stringify(options.queryKey ?? []);
+      if (key.includes('"content"')) return ok(content);
+      return ok(resourceWithoutCapabilities);
+    });
+
+    expect(() => renderSheet()).not.toThrow();
+
+    expect(document.body.querySelector('a[aria-label="Download file"]')).toBeNull();
+    expect(document.body.textContent).toContain("Can't preview this file");
+  });
+
   it("defaults Markdown files to rendered mode and switches back to raw source", async () => {
     useQueryMock.mockImplementation((options: { queryKey?: readonly unknown[] }) => {
       const key = JSON.stringify(options.queryKey ?? []);

--- a/ui/src/components/FileViewerSheet.tsx
+++ b/ui/src/components/FileViewerSheet.tsx
@@ -512,8 +512,8 @@ export function FileViewerSheet({
   });
 
   const resolvedResource: ResolvedWorkspaceResource | undefined = resolveQuery.data;
-  const canPreview = resolvedResource?.capabilities.preview ?? false;
-  const downloadUrl = state && resolvedResource?.capabilities.download
+  const canPreview = resolvedResource?.capabilities?.preview ?? false;
+  const downloadUrl = state && resolvedResource?.capabilities?.download
     ? fileResourcesApi.downloadUrl(issueId, state)
     : null;
 


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - `FileViewerSheet` reads `resolvedResource.capabilities.preview` and `.download` to decide whether to show preview/download controls
> - The optional chaining only covered `resolvedResource`, not `capabilities` itself — a resolved resource with a present-but-`capabilities`-less shape crashes the viewer instead of degrading gracefully
> - This pull request chains the optional access through `capabilities` too
> - The benefit is the file viewer degrades to no-preview/no-download instead of throwing when a resolved resource's capabilities are absent

## Linked Issues or Issue Description

No existing public GitHub issue. Describing in-PR per the bug-report template (`.github/ISSUE_TEMPLATE/bug_report.yml`):

- **Subsystem affected:** `ui/src/components/FileViewerSheet.tsx`.
- **Problem or motivation:** `canPreview` and `downloadUrl` read `resolvedResource?.capabilities.preview` / `.download` — optional chaining stops at `resolvedResource`, so a resolved resource whose `capabilities` field is `undefined`/`null` throws a `TypeError` instead of the viewer degrading to "can't preview this file."
- **Proposed solution:** Chain the optional access through `capabilities` too: `resolvedResource?.capabilities?.preview` / `?.download`.
- **Roadmap alignment:** Small, isolated bug fix — no core/roadmap overlap.

## What Changed

- `ui/src/components/FileViewerSheet.tsx`: two-line fix, `?.capabilities.` → `?.capabilities?.`.
- `ui/src/components/FileViewerSheet.copy.test.tsx`: new test — a resolved resource missing `capabilities` renders without throwing, shows no download link, and shows the "can't preview" message.

## Verification

```bash
pnpm --filter @paperclipai/ui typecheck   # passes
npx vitest run ui/src/components/FileViewerSheet.copy.test.tsx   # 6/6 passing
```

Revert-and-retest: with the fix reverted, the new test fails with `TypeError: Cannot read properties of undefined (reading 'preview')` at the exact line the fix touches — confirms the test actually exercises the bug.

## Risks

None beyond the change itself. Purely additive null-safety: `capabilities` is currently typed as required on the resolved-resource shape, so this only changes behavior when the runtime value diverges from the type — exactly the crash this fixes. No behavior change for the (overwhelmingly common) case where `capabilities` is present.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), used interactively.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no user-facing docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---

**Scope note:** this PR originally also included an atomic-swap fix for `materializeRuntimeSkillFiles` in `server/src/services/company-skills.ts`. That part is removed from this PR — Greptile correctly flagged that the underlying `createDirectoryReplacement.commit()` helper still has a sub-millisecond window between its two `rename()` syscalls where a concurrent reader could observe the directory as briefly missing, and fixing that properly means changing a shared helper's contract for all four of its call sites, which needs its own separately-scoped PR and audit (symlink compatibility, etc.) rather than being folded into this narrower UI fix. This PR is now exactly the FileViewerSheet half, with no open caveats.
