### PR TITLE
fix(adapter): skip --resume for heartbeat_timer wakes in claude-local

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -381,11 +381,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(cwd));
-  const sessionId = canResumeSession ? runtimeSessionId : null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const isTimerWake = wakeReason === "heartbeat_timer";
+  const sessionId = canResumeSession && !isTimerWake ? runtimeSessionId : null;
   if (runtimeSessionId && !canResumeSession) {
     await onLog(
       "stdout",
       `[paperclip] Claude session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+  if (runtimeSessionId && canResumeSession && isTimerWake) {
+    await onLog(
+      "stdout",
+      `[paperclip] Skipping --resume for heartbeat_timer wake; starting fresh session.\n`,
     );
   }
   const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");


### PR DESCRIPTION
## Summary

- Timer heartbeats (`heartbeat_timer` wake reason) were incorrectly using `--resume <session-id>`, causing ~200 `adapter_failed`/day from Aug 1 onward (tracked as CUB-397, see also CUB-387).
- Root cause: `canResumeSession` only checked cwd match + session presence, never the wake reason. Timer wakes have a valid session ID and matching cwd, so `--resume` was always passed.
- Fix: add an `isTimerWake` guard (`wakeReason === "heartbeat_timer"`) and force `sessionId = null` for timer wakes. Issue-scoped runs are unaffected.

## Change

**File:** `packages/adapters/claude-local/src/server/execute.ts`

```diff
-  const sessionId = canResumeSession ? runtimeSessionId : null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const isTimerWake = wakeReason === "heartbeat_timer";
+  const sessionId = canResumeSession && !isTimerWake ? runtimeSessionId : null;
   if (runtimeSessionId && !canResumeSession) { ... }
+  if (runtimeSessionId && canResumeSession && isTimerWake) {
+    await onLog("stdout",
+      `[paperclip] Skipping --resume for heartbeat_timer wake; starting fresh session.\n`);
+  }
```

## Test plan

- [x] `npx tsc --noEmit` passes in `packages/adapters/claude-local`
- [ ] Deploy to staging; confirm `heartbeat_timer` runs no longer emit `--resume` in `commandArgs`
- [ ] Monitor `adapter_failed` count drops from ~200/day baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)