### PR TITLE
test(workspaces): stabilize shared-lock stale-owner regression

### DIFF
--- a/packages/shared/src/worktree-port-registry.test.ts
+++ b/packages/shared/src/worktree-port-registry.test.ts
@@ -24,6 +24,16 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
+async function waitForCondition(check: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!check()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Condition was not met within ${timeoutMs}ms`);
+    }
+    await delay(25);
+  }
+}
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -39,6 +49,8 @@ describe("worktree port registry lock", () => {
     let secondEntered = false;
 
     const first = withWorktreePortRegistryLock(homeDir, async () => {
+      const leaseHeartbeatMtime = fs.statSync(lockPath).mtimeMs;
+      await waitForCondition(() => fs.statSync(lockPath).mtimeMs > leaseHeartbeatMtime);
       fs.renameSync(path.join(lockPath, "owner.json"), path.join(lockPath, "owner.unavailable.json"));
       const backupOwnerPath = path.join(lockPath, "owner.backup.json");
       const owner = JSON.parse(fs.readFileSync(backupOwnerPath, "utf8"));
@@ -46,6 +58,8 @@ describe("worktree port registry lock", () => {
         ...owner,
         processIdentity: "unavailable-process-identity",
       })}\n`);
+      // Backdate immediately after a heartbeat tick so the contender sees a
+      // stale lease before the next background refresh can run.
       const oldTimestamp = new Date(Date.now() - 10_000);
       fs.utimesSync(lockPath, oldTimestamp, oldTimestamp);
       firstEntered.resolve();

--- a/packages/shared/src/worktree-port-registry.test.ts
+++ b/packages/shared/src/worktree-port-registry.test.ts
@@ -16,14 +16,6 @@ function makeTemporaryRoot(): string {
   return root;
 }
 
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
-
 async function waitForCondition(check: () => boolean, timeoutMs = 2_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!check()) {
@@ -44,9 +36,8 @@ describe("worktree port registry lock", () => {
   it("does not reclaim a stale lock while its fallback ownership probe responds", async () => {
     const homeDir = makeTemporaryRoot();
     const lockPath = path.join(homeDir, ".worktree-port-reservations.lock");
-    const firstEntered = deferred();
-    const releaseFirst = deferred();
     let secondEntered = false;
+    let second: Promise<void> | null = null;
 
     const first = withWorktreePortRegistryLock(homeDir, async () => {
       const leaseHeartbeatMtime = fs.statSync(lockPath).mtimeMs;
@@ -62,21 +53,24 @@ describe("worktree port registry lock", () => {
       // stale lease before the next background refresh can run.
       const oldTimestamp = new Date(Date.now() - 10_000);
       fs.utimesSync(lockPath, oldTimestamp, oldTimestamp);
-      firstEntered.resolve();
-      await releaseFirst.promise;
+      expect(Date.now() - fs.statSync(lockPath).mtimeMs).toBeGreaterThan(5_000);
+
+      // Start the contender before yielding so it races the stale lease, not a
+      // later heartbeat refresh.
+      const contender = withWorktreePortRegistryLock(homeDir, async () => {
+        secondEntered = true;
+      });
+      contender.catch(() => {});
+      second = contender;
+      await delay(100);
+
+      expect(secondEntered).toBe(false);
     });
-    await firstEntered.promise;
-
-    expect(Date.now() - fs.statSync(lockPath).mtimeMs).toBeGreaterThan(5_000);
-
-    const second = withWorktreePortRegistryLock(homeDir, async () => {
-      secondEntered = true;
-    });
-    await delay(100);
-
-    expect(secondEntered).toBe(false);
-    releaseFirst.resolve();
-    await Promise.all([first, second]);
+    await first;
+    if (!second) {
+      throw new Error("Expected the contender to start while the first lock holder was active");
+    }
+    await second;
     expect(secondEntered).toBe(true);
   }, 10_000);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent workspaces and shared runtime state.
> - The worktree port registry lock protects shared workspace port reservations.
> - This lock now uses a heartbeat and a fallback owner probe to decide when a lease is stale.
> - The stale-owner regression test must start the contender while the first holder still owns the lock.
> - The old test timing could let a later heartbeat refresh hide the stale lease window.
> - This pull request makes the contender start inside the first critical section and waits for a real heartbeat tick before it backdates the lease.
> - The benefit is a deterministic regression test for "responding owner must not be reclaimed" behavior.

## Linked Issues or Issue Description

Searched public issues and PRs for an existing report. I did not find a matching public issue for this test-only regression.

**What happened?**

The shared-lock regression test relied on timing that could slip past the stale-lease window. When that happened, the contender no longer raced the stale lease and the test could fail for the wrong reason.

**Expected behavior**

The contender should start while the first lock holder is still active and after the lease has been backdated. The test should deterministically prove that a responding owner is not reclaimed.

**Steps to reproduce**

1. Run `pnpm exec vitest run packages/shared/src/worktree-port-registry.test.ts`.
2. Repeat the command several times.
3. Observe that the stale-owner case can fail when the contender starts after a later heartbeat refresh.

**Paperclip version or commit**

`dc03d6e81afacb9a45bb629cb888c5b37730f189`

**Deployment mode**

Built from source (test run in a local development checkout).

**Installation method**

Built from source.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Database mode**

Not database-related.

**Access context**

Unclear / not applicable.

**Node.js version**

`v22.16.0`

**Operating system**

`Linux 6.12.93 x86_64`

## What Changed

- Wait for a real heartbeat mtime change before the test rewrites the owner record and backdates the lease.
- Start the contender inside the first critical section so it races the stale lease before the next heartbeat refresh.
- Keep the assertion that the contender stays blocked until the first holder exits.

## Verification

- `pnpm exec vitest run packages/shared/src/worktree-port-registry.test.ts`
- Repeated the same command 5 times in an unsandboxed shell. All 5 runs passed.

## Risks

- Low risk. This changes only the regression test.
- The test still requires a shell that can bind loopback ports.

## Model Used

- OpenAI GPT-5 Codex, via the Codex coding agent with terminal tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
