### PR TITLE
fix(dev-runner): let PAPERCLIP_UI_DEV_MIDDLEWARE default instead of override

### DIFF
--- a/scripts/dev-runner-env.mjs
+++ b/scripts/dev-runner-env.mjs
@@ -1,0 +1,9 @@
+const DEFAULT_UI_DEV_MIDDLEWARE = "true";
+
+// The dev runner used to hardcode this value, which silently discarded an
+// operator's explicit setting (e.g. a launchd/systemd unit exporting
+// PAPERCLIP_UI_DEV_MIDDLEWARE=false to serve a built ui/dist instead of Vite
+// dev middleware). Default instead of override so an explicit value wins.
+export function resolveUiDevMiddlewareEnv(sourceEnv) {
+  return sourceEnv.PAPERCLIP_UI_DEV_MIDDLEWARE ?? DEFAULT_UI_DEV_MIDDLEWARE;
+}

--- a/scripts/dev-runner-env.ts
+++ b/scripts/dev-runner-env.ts
@@ -1,0 +1,9 @@
+const DEFAULT_UI_DEV_MIDDLEWARE = "true";
+
+// The dev runner used to hardcode this value, which silently discarded an
+// operator's explicit setting (e.g. a launchd/systemd unit exporting
+// PAPERCLIP_UI_DEV_MIDDLEWARE=false to serve a built ui/dist instead of Vite
+// dev middleware). Default instead of override so an explicit value wins.
+export function resolveUiDevMiddlewareEnv(sourceEnv: NodeJS.ProcessEnv): string {
+  return sourceEnv.PAPERCLIP_UI_DEV_MIDDLEWARE ?? DEFAULT_UI_DEV_MIDDLEWARE;
+}

--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -80,7 +80,7 @@ if (process.env.npm_config_authenticated_private === "true") {
 
 const env = {
   ...process.env,
-  PAPERCLIP_UI_DEV_MIDDLEWARE: "true",
+  PAPERCLIP_UI_DEV_MIDDLEWARE: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true",
 };
 
 if (mode === "dev") {

--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { fileURLToPath } from "node:url";
+import { resolveUiDevMiddlewareEnv } from "./dev-runner-env.mjs";
 import { createCapturedOutputBuffer, parseJsonResponseWithLimit } from "./dev-runner-output.mjs";
 import { shouldTrackDevServerPath } from "./dev-runner-paths.mjs";
 
@@ -80,7 +81,7 @@ if (process.env.npm_config_authenticated_private === "true") {
 
 const env = {
   ...process.env,
-  PAPERCLIP_UI_DEV_MIDDLEWARE: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true",
+  PAPERCLIP_UI_DEV_MIDDLEWARE: resolveUiDevMiddlewareEnv(process.env),
 };
 
 if (mode === "dev") {

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { resolveUiDevMiddlewareEnv } from "./dev-runner-env.ts";
 import { createCapturedOutputBuffer, parseJsonResponseWithLimit } from "./dev-runner-output.ts";
 import { collectWatchedSnapshot as collectDevServerWatchedSnapshot, diffSnapshots } from "./dev-runner-snapshot.mjs";
 import { createDevServiceIdentity, repoRoot } from "./dev-service-profile.ts";
@@ -134,7 +135,7 @@ if (bindMode === "custom" && !bindHost) {
 
 const env: NodeJS.ProcessEnv = {
   ...process.env,
-  PAPERCLIP_UI_DEV_MIDDLEWARE: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true",
+  PAPERCLIP_UI_DEV_MIDDLEWARE: resolveUiDevMiddlewareEnv(process.env),
 };
 
 if (mode === "dev") {

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -134,7 +134,7 @@ if (bindMode === "custom" && !bindHost) {
 
 const env: NodeJS.ProcessEnv = {
   ...process.env,
-  PAPERCLIP_UI_DEV_MIDDLEWARE: "true",
+  PAPERCLIP_UI_DEV_MIDDLEWARE: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true",
 };
 
 if (mode === "dev") {

--- a/server/src/__tests__/dev-runner-env.test.ts
+++ b/server/src/__tests__/dev-runner-env.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveUiDevMiddlewareEnv } from "../../../scripts/dev-runner-env.mjs";
+
+describe("resolveUiDevMiddlewareEnv", () => {
+  it("defaults to true when unset", () => {
+    expect(resolveUiDevMiddlewareEnv({})).toBe("true");
+  });
+
+  it("respects an explicit false override", () => {
+    expect(resolveUiDevMiddlewareEnv({ PAPERCLIP_UI_DEV_MIDDLEWARE: "false" })).toBe("false");
+  });
+
+  it("respects an explicit true value", () => {
+    expect(resolveUiDevMiddlewareEnv({ PAPERCLIP_UI_DEV_MIDDLEWARE: "true" })).toBe("true");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server's local dev runner (`scripts/dev-runner.ts` / `scripts/dev-runner.mjs`) wraps `tsx src/index.ts`, controlling whether the server serves the UI through Vite's dev middleware or through a static `ui/dist` build
> - The dev runner unconditionally sets `PAPERCLIP_UI_DEV_MIDDLEWARE: "true"` on the child process environment, overwriting any value the parent process (or a launchd/systemd unit) already set for that variable
> - That makes it impossible for an operator running the server via `pnpm run dev` (which is what `scripts/dev-runner.ts` powers) to opt into static `ui/dist` serving in a long-running/production-like deployment — the explicit `"false"` they set is silently discarded and the server keeps a Vite dev server (and its module graph) alive
> - This PR changes the assignment to a default (`??`) instead of a mandate, so an explicit environment value wins, matching the existing `??=` pattern used a few lines below for `PAPERCLIP_MIGRATION_PROMPT` / `PAPERCLIP_MIGRATION_AUTO_APPLY`
> - It also extracts the resolution into a small pure function (`resolveUiDevMiddlewareEnv`, in a new `dev-runner-env.ts`/`.mjs` pair mirroring the existing `dev-runner-output`/`dev-runner-snapshot` split) so the fix has unit test coverage instead of living as untestable inline logic
> - The benefit is that `PAPERCLIP_UI_DEV_MIDDLEWARE=false` set by the caller now actually takes effect, letting operators serve a built UI instead of running the dev middleware

## What happened?

`scripts/dev-runner.ts` (and the published `scripts/dev-runner.mjs`) build the child process environment with a hard-coded `PAPERCLIP_UI_DEV_MIDDLEWARE: "true"`, which always overwrites whatever value was already present in `process.env` for that variable — including one explicitly set by the parent process/service manager.

## Steps to reproduce

1. Set `PAPERCLIP_UI_DEV_MIDDLEWARE=false` in the environment before starting the server (e.g. via a launchd/systemd `EnvironmentVariables` block).
2. Start the server with `pnpm run dev` (which runs `scripts/dev-runner.ts watch`).
3. Observe `server/src/config.ts` still reads `uiDevMiddleware: true`, because the dev runner overwrote the variable before `tsx src/index.ts` read it.

## Expected behavior

An explicit `PAPERCLIP_UI_DEV_MIDDLEWARE` value in the environment should be respected; the dev runner should only supply `"true"` as a default when the variable is unset.

## Paperclip version

Reproduced against `master` at the time of writing (Node 24, macOS).

## Deployment mode

Long-lived instance started through `scripts/dev-runner.ts watch` (the same entrypoint `pnpm run dev`/`pnpm run watch` use), not a one-off local `pnpm dev` session.

## Linked Issues or Issue Description

No existing public issue found for this. See the bug-report fields above (What happened / Steps to reproduce / Expected behavior / Paperclip version / Deployment mode).

## What Changed

- `scripts/dev-runner-env.ts` / `scripts/dev-runner-env.mjs` (new): `resolveUiDevMiddlewareEnv()`, a pure function returning `process.env.PAPERCLIP_UI_DEV_MIDDLEWARE ?? "true"`.
- `scripts/dev-runner.ts` / `scripts/dev-runner.mjs`: use `resolveUiDevMiddlewareEnv(process.env)` instead of the hard-coded `"true"`.
- `server/src/__tests__/dev-runner-env.test.ts` (new): unit tests for the default, an explicit `"false"` override, and an explicit `"true"` value.

## Verification

- `npx vitest run server/src/__tests__/dev-runner-env.test.ts server/src/__tests__/dev-runner-output.test.ts` — 7 passed.
- `node --check scripts/dev-runner.mjs` passes.
- `npx tsc --noEmit -p server` reports no errors touching the changed files.
- Manually traced `server/src/config.ts:314` (`uiDevMiddleware: process.env.PAPERCLIP_UI_DEV_MIDDLEWARE === "true"`) and `server/src/app.ts`'s static-serving branch to confirm an explicit `"false"` now reaches the server process and switches it to the `ui/dist` static path instead of Vite dev middleware.

## Risks

Low risk. Behavior is unchanged for anyone who does not set `PAPERCLIP_UI_DEV_MIDDLEWARE` themselves (default remains `"true"`, same as today). The only behavior change is that an operator's explicit value is now honored instead of silently discarded.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), via Claude Code, standard reasoning mode, with file read/edit/bash tool use. No extended thinking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have described the underlying bug inline (no existing public issue to link)
- [x] I have added a test covering the change
- [x] I searched for similar open/closed PRs and confirmed this is not a duplicate
