### PR TITLE
fix(tool-gateway): let gateway bearer tokens reach the MCP protocol routes

### DIFF
--- a/server/src/__tests__/mcp-gateway-endpoint-coverage.test.ts
+++ b/server/src/__tests__/mcp-gateway-endpoint-coverage.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  isMcpGatewayProtocolPath,
+  mcpGatewayApiEndpointPath,
+  mcpGatewayPublicEndpointPath,
+} from "../services/mcp-gateway-endpoints.js";
+
+const GATEWAY_ID = "819f6caa-92bb-41ee-a33c-3e35bd577a8f";
+const GATEWAY_PUBLIC_ID = "gw_61df2b661160478d9091986dbe51b2d8";
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+}
+
+/**
+ * Category safeguard for BRO-2546.
+ *
+ * The failure class: Paperclip mints a credential for one of its own endpoints,
+ * and something upstream of the route rejects it. That failure is silent — an
+ * MCP client that cannot `initialize` just registers zero tools — so it has to
+ * be caught structurally rather than observed.
+ */
+describe("MCP gateway endpoint coverage", () => {
+  it("admits every endpoint path Paperclip builds for a gateway", () => {
+    expect(isMcpGatewayProtocolPath(mcpGatewayApiEndpointPath(GATEWAY_ID))).toBe(true);
+    expect(isMcpGatewayProtocolPath(mcpGatewayPublicEndpointPath(GATEWAY_PUBLIC_ID))).toBe(true);
+  });
+
+  it("does not admit neighbouring tool-gateway routes", () => {
+    // These are ordinary board/agent-authenticated routes. Widening the matcher
+    // to cover them would hand a gateway token API surface it must not reach.
+    expect(isMcpGatewayProtocolPath(`/api/tool-gateway/gateways/${GATEWAY_ID}`)).toBe(false);
+    expect(isMcpGatewayProtocolPath(`/api/tool-gateway/gateways/${GATEWAY_ID}/tokens`)).toBe(false);
+    expect(isMcpGatewayProtocolPath("/api/tool-gateway/tools/call")).toBe(false);
+    expect(isMcpGatewayProtocolPath("/api/tool-gateway/audit")).toBe(false);
+    expect(isMcpGatewayProtocolPath("/api/agents/me")).toBe(false);
+  });
+
+  it("keeps the runtime MCP server URL on a path the actor middleware admits", () => {
+    // `buildPaperclipRuntimeMcpServers` hands this URL to every adapter. If it
+    // is ever rebuilt inline again, this assertion is the thing that notices.
+    const heartbeat = readSource("../services/heartbeat.ts");
+    expect(heartbeat).toContain("mcpGatewayApiEndpointPath(gateway.id)");
+    expect(heartbeat).not.toMatch(/`\/api\/tool-gateway\/gateways\/\$\{[^}]+\}\/mcp`/);
+  });
+
+  it("keeps the gateway protocol routes mounted on the advertised paths", () => {
+    // The route file declares its own mount paths and echoes them back to
+    // clients in the discovery response. Both must stay in the admitted set.
+    const routes = readSource("../routes/tool-gateway.ts");
+    expect(routes).toContain('router.post("/mcp/gateways/:gatewayPublicId"');
+    expect(routes).toContain('router.post("/tool-gateway/gateways/:gatewayId/mcp"');
+  });
+});

--- a/server/src/__tests__/mcp-gateway-token-auth.test.ts
+++ b/server/src/__tests__/mcp-gateway-token-auth.test.ts
@@ -1,0 +1,125 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { agentApiKeys, agents, boardApiKeys, heartbeatRuns } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+// A gateway bearer token as minted by `createNamedGatewayToken`:
+// `pcgw_<tokenId>.<secret>`.
+const GATEWAY_TOKEN = "pcgw_f51c1739-7439-4c2a-9750-4ec198bcdd09.fNPhbkqw7zhgGvyPWaBhKsPXDfZH4tvw1ZEaa5rwztA";
+const GATEWAY_ID = "819f6caa-92bb-41ee-a33c-3e35bd577a8f";
+const GATEWAY_PUBLIC_ID = "gw_61df2b661160478d9091986dbe51b2d8";
+
+function createEmptyDb() {
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where() {
+          // No board key, no agent key, no agent, no run: every credential
+          // lookup misses, which is exactly the state a gateway token is in.
+          if (table === boardApiKeys || table === agentApiKeys || table === agents || table === heartbeatRuns) {
+            return Promise.resolve([]);
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+    update: () => ({ set: () => ({ where: () => Promise.resolve([]) }) }),
+    insert: () => ({ values: () => Promise.resolve([]) }),
+  } as any;
+}
+
+function createApp(deploymentMode: "authenticated" | "local_trusted" = "authenticated") {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    actorMiddleware(createEmptyDb(), {
+      deploymentMode,
+      resolveSession: async () => null,
+    }),
+  );
+  // Stand-ins for the two real MCP gateway protocol mounts. Both authenticate
+  // the bearer inside the handler, so reaching the handler at all is the
+  // behaviour under test.
+  const echoActor = (req: express.Request, res: express.Response) => {
+    res.json({ reached: true, actorType: req.actor.type, authorization: req.header("authorization") });
+  };
+  app.post("/mcp/gateways/:gatewayPublicId", echoActor);
+  app.post("/api/tool-gateway/gateways/:gatewayId/mcp", echoActor);
+  // An ordinary authenticated API route must stay closed to gateway tokens.
+  app.get("/api/agents/me", echoActor);
+  app.use(errorHandler);
+  return app;
+}
+
+describe("MCP gateway bearer tokens and the actor middleware", () => {
+  it("lets a gateway token reach the /api gateway mount the heartbeat hands to adapters", async () => {
+    const res = await request(createApp())
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reached).toBe(true);
+    // The route needs the raw credential to resolve its own gateway session.
+    expect(res.body.authorization).toBe(`Bearer ${GATEWAY_TOKEN}`);
+  });
+
+  it("lets a gateway token reach the public /mcp/gateways mount", async () => {
+    const res = await request(createApp())
+      .post(`/mcp/gateways/${GATEWAY_PUBLIC_ID}`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reached).toBe(true);
+  });
+
+  it("carries no ambient actor into the gateway route", async () => {
+    const res = await request(createApp())
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.body.actorType).toBe("none");
+  });
+
+  it("does not let a gateway token inherit the implicit board actor in local_trusted mode", async () => {
+    const res = await request(createApp("local_trusted"))
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.actorType).toBe("none");
+  });
+
+  it("still rejects a gateway token on any non-gateway route", async () => {
+    const res = await request(createApp())
+      .get("/api/agents/me")
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.reached).toBeUndefined();
+  });
+
+  it("still rejects a non-gateway bearer on a gateway route", async () => {
+    const res = await request(createApp())
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", "Bearer not-a-gateway-token")
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(401);
+    expect(res.body.reached).toBeUndefined();
+  });
+
+  it("does not treat a gateway-token-prefixed path lookalike as a gateway route", async () => {
+    const res = await request(createApp())
+      .get("/api/agents/me")
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .query({ path: `/api/tool-gateway/gateways/${GATEWAY_ID}/mcp` });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -17,6 +17,7 @@ import { isUuidLike, normalizeAgentApiKeyScope, type DeploymentMode } from "@pap
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
+import { isMcpGatewayProtocolPath } from "../services/mcp-gateway-endpoints.js";
 
 const CLOUD_TENANT_WRITE_DEBOUNCE_MS = 5_000;
 const CLOUD_TENANT_WRITE_DEBOUNCE_MAX = 1_000;
@@ -56,6 +57,26 @@ function hashToken(token: string) {
 
 function normalizeOptionalString(value: string | null | undefined) {
   return value?.trim() || null;
+}
+
+/**
+ * The MCP gateway protocol endpoints carry their own bearer credential — a
+ * `pcgw_` gateway token minted by the tool gateway — and authenticate it inside
+ * the route handler (`namedGatewaySessionFromBearer`). They never read
+ * `req.actor`.
+ *
+ * Without this carve-out the generic bearer path below treats a gateway token
+ * as a failed board/agent credential and rejects the request with 401 before
+ * the route runs. That is silent from the caller's side: an MCP client just
+ * sees the server fail to initialize and registers zero tools, so every
+ * Paperclip-managed MCP server disappears from every agent session even though
+ * the connection is enabled and healthy (BRO-2546).
+ */
+const GATEWAY_BEARER_TOKEN_PREFIX = "pcgw_";
+
+export function isMcpGatewayProtocolRequest(input: { path: string; token: string }): boolean {
+  if (!input.token.startsWith(GATEWAY_BEARER_TOKEN_PREFIX)) return false;
+  return isMcpGatewayProtocolPath(input.path);
 }
 
 function invalidAgentTokenMessage(token: string) {
@@ -277,6 +298,16 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     const token = authHeader!.slice("bearer".length).trim();
     if (!token) {
       next(unauthorized("Empty bearer token; provide valid agent credentials and retry"));
+      return;
+    }
+
+    if (isMcpGatewayProtocolRequest({ path: req.path, token })) {
+      // Hand the credential to the gateway route untouched. Force "none" rather
+      // than falling through with the ambient actor so a gateway token can
+      // never inherit the implicit board actor that local_trusted mode seeds
+      // above — the route resolves its own company/agent scope from the token.
+      req.actor = { type: "none", source: "none" };
+      next();
       return;
     }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -159,6 +159,7 @@ import { issueService } from "./issues.js";
 import { projectService } from "./projects.js";
 import { authorizationService, type AuthorizationActor } from "./authorization.js";
 import { createToolGatewayService } from "./tool-gateway.js";
+import { mcpGatewayApiEndpointPath } from "./mcp-gateway-endpoints.js";
 import { toolAccessService } from "./tool-access.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { ISSUE_BLOCKERS_RESOLVED_WAKE_REASON } from "./issue-dependency-wakeups.js";
@@ -3472,7 +3473,7 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     });
     servers.push({
       name: connection.name,
-      url: `${paperclipApiBaseUrl()}/api/tool-gateway/gateways/${gateway.id}/mcp`,
+      url: `${paperclipApiBaseUrl()}${mcpGatewayApiEndpointPath(gateway.id)}`,
       token: token.token,
       connectionId: connection.id,
     });
@@ -3570,7 +3571,7 @@ async function createManagedMcpRunConfig(input: {
     managedGateways.push({
       id: gateway.id,
       name: gateway.name,
-      endpointPath: `/api/tool-gateway/gateways/${gateway.id}/mcp`,
+      endpointPath: mcpGatewayApiEndpointPath(gateway.id),
       bearerToken: token.token,
       tokenPrefix: token.tokenPrefix,
     });

--- a/server/src/services/mcp-gateway-endpoints.ts
+++ b/server/src/services/mcp-gateway-endpoints.ts
@@ -1,0 +1,35 @@
+/**
+ * One source of truth for the MCP gateway protocol endpoints.
+ *
+ * These endpoints are unusual: they authenticate their own bearer credential (a
+ * `pcgw_` gateway token) inside the route handler and never read `req.actor`.
+ * The global actor middleware therefore has to let that credential through
+ * untouched, and the heartbeat has to hand adapters a URL that matches one of
+ * these shapes.
+ *
+ * Keeping the builder and the matcher in the same module means a change to the
+ * URL shape can't silently desynchronize the two — see the guard in
+ * `mcp-gateway-endpoint-coverage.test.ts`. When those drifted apart the failure
+ * was invisible: every managed MCP server 401'd during `initialize`, MCP
+ * clients registered zero tools, and agents simply saw no `mcp__*` tools at all
+ * (BRO-2546).
+ */
+
+/** Per-gateway mount under `/api`, keyed by gateway id. */
+export function mcpGatewayApiEndpointPath(gatewayId: string): string {
+  return `/api/tool-gateway/gateways/${gatewayId}/mcp`;
+}
+
+/** Public streamable-HTTP mount, keyed by `gateway_public_id`. */
+export function mcpGatewayPublicEndpointPath(gatewayPublicId: string): string {
+  return `/mcp/gateways/${gatewayPublicId}`;
+}
+
+const MCP_GATEWAY_PROTOCOL_PATH_PATTERNS = [
+  /^\/mcp\/gateways\/[^/]+\/?$/,
+  /^\/api\/tool-gateway\/gateways\/[^/]+\/mcp\/?$/,
+];
+
+export function isMcpGatewayProtocolPath(path: string): boolean {
+  return MCP_GATEWAY_PROTOCOL_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}


### PR DESCRIPTION
## Problem

**No agent on this instance has any `mcp__*` tool — for any connection.** Not a config problem: the Tool Connection is enabled and healthy, the profile bindings are right, and the adapter hands the Claude CLI a fully correct `--mcp-config`.

The break is one layer further in. The MCP gateway protocol endpoints authenticate their own bearer credential — a `pcgw_` token minted by the tool gateway — inside the route handler (`namedGatewaySessionFromBearer`). They never read `req.actor`. But `actorMiddleware` is mounted app-level (`server/src/app.ts`), ahead of every route, and treats any bearer it can't resolve as a failed board/agent credential:

```ts
const claims = verifyLocalAgentJwt(token);
if (!claims) {
  next(unauthorized(invalidAgentTokenMessage(token)));   // 401 — route never runs
  return;
}
```

There is no branch for gateway tokens, so **every** `pcgw_` credential 401s before reaching the endpoint it was minted for. Both mounts are affected: the public `/mcp/gateways/:publicId` and the `/api/tool-gateway/gateways/:id/mcp` URL that `buildPaperclipRuntimeMcpServers` hands to adapters.

The failure is silent in both directions. Nothing logs an error; an MCP client that can't `initialize` just registers zero tools. From the agent's side that is indistinguishable from "no MCP servers configured."

## Evidence

Reproduced live before the fix:

```
$ curl -s -X POST "$API/api/tool-gateway/gateways/$GATEWAY_ID/mcp" \
    -H "Authorization: Bearer pcgw_..." -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
HTTP/1.1 401 Unauthorized
{"error":"Agent token did not verify; obtain fresh credentials and retry"}
```

That string is `server/src/middleware/auth.ts:72` — the middleware, not the route.

The token in that probe was live, unexpired, and unrevoked. Across the instance:

```sql
select count(*) total, count(last_used_at) used
  from tool_mcp_gateway_tokens where subject_type='heartbeat_run';
 total | used
-------+------
    46 |    0
```

**46 runtime tokens minted, 0 ever used** — no MCP request has ever reached the gateway service.

After the fix, driving a real minted token through the real routes against the live database:

```
initialize -> 200 {"jsonrpc":"2.0",...,"serverInfo":{"name":"Paperclip MCP Gateway","version":"1.0.0"}}
tools/list -> 200
tool names: [ ...:create-link, ...:delete-link, ...:list-my-links, ...:promote-link, ...:revise-link ]
```

## Fix

A narrow carve-out in `actorMiddleware` for `pcgw_`-prefixed bearers on the two MCP gateway protocol paths. It forces `req.actor` to `"none"` rather than falling through, so a gateway token can never inherit the implicit board actor that `local_trusted` mode seeds at the top of the middleware. Every other route, and every other credential shape, is untouched.

## Category safeguard

The class here is *"Paperclip mints a credential for its own endpoint and something upstream of the route rejects it"* — invisible by construction, so it needs a structural guard rather than observation.

`server/src/services/mcp-gateway-endpoints.ts` now owns both the URL builder and the path matcher, and `heartbeat.ts` builds its runtime MCP URL through it instead of inline. `mcp-gateway-endpoint-coverage.test.ts` asserts that every endpoint path Paperclip builds is one the middleware admits, that neighbouring authenticated tool-gateway routes are **not** admitted, and that the URL isn't rebuilt inline again. A future change to the URL shape fails CI instead of silently un-registering every MCP server.

## Verification

- `mcp-gateway-token-auth.test.ts` — 7 new tests, including three negative ones: a gateway token on a non-gateway route still 401s, a non-gateway bearer on a gateway route still 401s, and `local_trusted` grants no ambient board actor.
- Mutation-tested: disabling the carve-out fails 4 of the 7; the three security-negative tests still pass, so they're guarding the boundary rather than the happy path.
- All 29 server auth/gateway test files green (419 tests).
- `tsc --noEmit` clean.
- End-to-end probe against the live instance database, shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)