### PR TITLE
fix(tool-gateway): let gateway bearer tokens reach the MCP protocol routes

### DIFF
--- a/server/src/__tests__/mcp-gateway-endpoint-coverage.test.ts
+++ b/server/src/__tests__/mcp-gateway-endpoint-coverage.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  isMcpGatewayProtocolPath,
+  mcpGatewayApiEndpointPath,
+  mcpGatewayPublicEndpointPath,
+} from "../services/mcp-gateway-endpoints.js";
+
+const GATEWAY_ID = "819f6caa-92bb-41ee-a33c-3e35bd577a8f";
+const GATEWAY_PUBLIC_ID = "gw_61df2b661160478d9091986dbe51b2d8";
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+}
+
+/**
+ * Category safeguard.
+ *
+ * The failure class: Paperclip mints a credential for one of its own endpoints,
+ * and something upstream of the route rejects it. That failure is silent — an
+ * MCP client that cannot `initialize` just registers zero tools — so it has to
+ * be caught structurally rather than observed.
+ */
+describe("MCP gateway endpoint coverage", () => {
+  it("admits every endpoint path Paperclip builds for a gateway", () => {
+    expect(isMcpGatewayProtocolPath(mcpGatewayApiEndpointPath(GATEWAY_ID))).toBe(true);
+    expect(isMcpGatewayProtocolPath(mcpGatewayPublicEndpointPath(GATEWAY_PUBLIC_ID))).toBe(true);
+  });
+
+  it("does not admit neighbouring tool-gateway routes", () => {
+    // These are ordinary board/agent-authenticated routes. Widening the matcher
+    // to cover them would hand a gateway token API surface it must not reach.
+    expect(isMcpGatewayProtocolPath(`/api/tool-gateway/gateways/${GATEWAY_ID}`)).toBe(false);
+    expect(isMcpGatewayProtocolPath(`/api/tool-gateway/gateways/${GATEWAY_ID}/tokens`)).toBe(false);
+    expect(isMcpGatewayProtocolPath("/api/tool-gateway/tools/call")).toBe(false);
+    expect(isMcpGatewayProtocolPath("/api/tool-gateway/audit")).toBe(false);
+    expect(isMcpGatewayProtocolPath("/api/agents/me")).toBe(false);
+  });
+
+  it("keeps the runtime MCP server URL on a path the actor middleware admits", () => {
+    // `buildPaperclipRuntimeMcpServers` hands this URL to every adapter. If it
+    // is ever rebuilt inline again, this assertion is the thing that notices.
+    const heartbeat = readSource("../services/heartbeat.ts");
+    expect(heartbeat).toContain("mcpGatewayApiEndpointPath(gateway.id)");
+    expect(heartbeat).not.toMatch(/`\/api\/tool-gateway\/gateways\/\$\{[^}]+\}\/mcp`/);
+  });
+
+  it("keeps the gateway protocol routes mounted on the advertised paths", () => {
+    // The route file declares its own mount paths and echoes them back to
+    // clients in the discovery response. Both must stay in the admitted set.
+    const routes = readSource("../routes/tool-gateway.ts");
+    expect(routes).toContain('router.post("/mcp/gateways/:gatewayPublicId"');
+    expect(routes).toContain('router.post("/tool-gateway/gateways/:gatewayId/mcp"');
+  });
+});

--- a/server/src/__tests__/mcp-gateway-token-auth.test.ts
+++ b/server/src/__tests__/mcp-gateway-token-auth.test.ts
@@ -1,0 +1,125 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { agentApiKeys, agents, boardApiKeys, heartbeatRuns } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+// A gateway bearer token as minted by `createNamedGatewayToken`:
+// `pcgw_<tokenId>.<secret>`.
+const GATEWAY_TOKEN = "pcgw_f51c1739-7439-4c2a-9750-4ec198bcdd09.fNPhbkqw7zhgGvyPWaBhKsPXDfZH4tvw1ZEaa5rwztA";
+const GATEWAY_ID = "819f6caa-92bb-41ee-a33c-3e35bd577a8f";
+const GATEWAY_PUBLIC_ID = "gw_61df2b661160478d9091986dbe51b2d8";
+
+function createEmptyDb() {
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where() {
+          // No board key, no agent key, no agent, no run: every credential
+          // lookup misses, which is exactly the state a gateway token is in.
+          if (table === boardApiKeys || table === agentApiKeys || table === agents || table === heartbeatRuns) {
+            return Promise.resolve([]);
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+    update: () => ({ set: () => ({ where: () => Promise.resolve([]) }) }),
+    insert: () => ({ values: () => Promise.resolve([]) }),
+  } as any;
+}
+
+function createApp(deploymentMode: "authenticated" | "local_trusted" = "authenticated") {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    actorMiddleware(createEmptyDb(), {
+      deploymentMode,
+      resolveSession: async () => null,
+    }),
+  );
+  // Stand-ins for the two real MCP gateway protocol mounts. Both authenticate
+  // the bearer inside the handler, so reaching the handler at all is the
+  // behaviour under test.
+  const echoActor = (req: express.Request, res: express.Response) => {
+    res.json({ reached: true, actorType: req.actor.type, authorization: req.header("authorization") });
+  };
+  app.post("/mcp/gateways/:gatewayPublicId", echoActor);
+  app.post("/api/tool-gateway/gateways/:gatewayId/mcp", echoActor);
+  // An ordinary authenticated API route must stay closed to gateway tokens.
+  app.get("/api/agents/me", echoActor);
+  app.use(errorHandler);
+  return app;
+}
+
+describe("MCP gateway bearer tokens and the actor middleware", () => {
+  it("lets a gateway token reach the /api gateway mount the heartbeat hands to adapters", async () => {
+    const res = await request(createApp())
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reached).toBe(true);
+    // The route needs the raw credential to resolve its own gateway session.
+    expect(res.body.authorization).toBe(`Bearer ${GATEWAY_TOKEN}`);
+  });
+
+  it("lets a gateway token reach the public /mcp/gateways mount", async () => {
+    const res = await request(createApp())
+      .post(`/mcp/gateways/${GATEWAY_PUBLIC_ID}`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reached).toBe(true);
+  });
+
+  it("carries no ambient actor into the gateway route", async () => {
+    const res = await request(createApp())
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.body.actorType).toBe("none");
+  });
+
+  it("does not let a gateway token inherit the implicit board actor in local_trusted mode", async () => {
+    const res = await request(createApp("local_trusted"))
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.actorType).toBe("none");
+  });
+
+  it("still rejects a gateway token on any non-gateway route", async () => {
+    const res = await request(createApp())
+      .get("/api/agents/me")
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.reached).toBeUndefined();
+  });
+
+  it("still rejects a non-gateway bearer on a gateway route", async () => {
+    const res = await request(createApp())
+      .post(`/api/tool-gateway/gateways/${GATEWAY_ID}/mcp`)
+      .set("authorization", "Bearer not-a-gateway-token")
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(401);
+    expect(res.body.reached).toBeUndefined();
+  });
+
+  it("does not treat a gateway-token-prefixed path lookalike as a gateway route", async () => {
+    const res = await request(createApp())
+      .get("/api/agents/me")
+      .set("authorization", `Bearer ${GATEWAY_TOKEN}`)
+      .query({ path: `/api/tool-gateway/gateways/${GATEWAY_ID}/mcp` });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -17,6 +17,7 @@ import { isUuidLike, normalizeAgentApiKeyScope, type DeploymentMode } from "@pap
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
+import { isMcpGatewayProtocolPath } from "../services/mcp-gateway-endpoints.js";
 
 const CLOUD_TENANT_WRITE_DEBOUNCE_MS = 5_000;
 const CLOUD_TENANT_WRITE_DEBOUNCE_MAX = 1_000;
@@ -56,6 +57,26 @@ function hashToken(token: string) {
 
 function normalizeOptionalString(value: string | null | undefined) {
   return value?.trim() || null;
+}
+
+/**
+ * The MCP gateway protocol endpoints carry their own bearer credential — a
+ * `pcgw_` gateway token minted by the tool gateway — and authenticate it inside
+ * the route handler (`namedGatewaySessionFromBearer`). They never read
+ * `req.actor`.
+ *
+ * Without this carve-out the generic bearer path below treats a gateway token
+ * as a failed board/agent credential and rejects the request with 401 before
+ * the route runs. That is silent from the caller's side: an MCP client just
+ * sees the server fail to initialize and registers zero tools, so every
+ * Paperclip-managed MCP server disappears from every agent session even though
+ * the connection is enabled and healthy.
+ */
+const GATEWAY_BEARER_TOKEN_PREFIX = "pcgw_";
+
+export function isMcpGatewayProtocolRequest(input: { path: string; token: string }): boolean {
+  if (!input.token.startsWith(GATEWAY_BEARER_TOKEN_PREFIX)) return false;
+  return isMcpGatewayProtocolPath(input.path);
 }
 
 function invalidAgentTokenMessage(token: string) {
@@ -277,6 +298,16 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     const token = authHeader!.slice("bearer".length).trim();
     if (!token) {
       next(unauthorized("Empty bearer token; provide valid agent credentials and retry"));
+      return;
+    }
+
+    if (isMcpGatewayProtocolRequest({ path: req.path, token })) {
+      // Hand the credential to the gateway route untouched. Force "none" rather
+      // than falling through with the ambient actor so a gateway token can
+      // never inherit the implicit board actor that local_trusted mode seeds
+      // above — the route resolves its own company/agent scope from the token.
+      req.actor = { type: "none", source: "none" };
+      next();
       return;
     }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -159,6 +159,7 @@ import { issueService } from "./issues.js";
 import { projectService } from "./projects.js";
 import { authorizationService, type AuthorizationActor } from "./authorization.js";
 import { createToolGatewayService } from "./tool-gateway.js";
+import { mcpGatewayApiEndpointPath } from "./mcp-gateway-endpoints.js";
 import { toolAccessService } from "./tool-access.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { ISSUE_BLOCKERS_RESOLVED_WAKE_REASON } from "./issue-dependency-wakeups.js";
@@ -3472,7 +3473,7 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     });
     servers.push({
       name: connection.name,
-      url: `${paperclipApiBaseUrl()}/api/tool-gateway/gateways/${gateway.id}/mcp`,
+      url: `${paperclipApiBaseUrl()}${mcpGatewayApiEndpointPath(gateway.id)}`,
       token: token.token,
       connectionId: connection.id,
     });
@@ -3570,7 +3571,7 @@ async function createManagedMcpRunConfig(input: {
     managedGateways.push({
       id: gateway.id,
       name: gateway.name,
-      endpointPath: `/api/tool-gateway/gateways/${gateway.id}/mcp`,
+      endpointPath: mcpGatewayApiEndpointPath(gateway.id),
       bearerToken: token.token,
       tokenPrefix: token.tokenPrefix,
     });

--- a/server/src/services/mcp-gateway-endpoints.ts
+++ b/server/src/services/mcp-gateway-endpoints.ts
@@ -1,0 +1,35 @@
+/**
+ * One source of truth for the MCP gateway protocol endpoints.
+ *
+ * These endpoints are unusual: they authenticate their own bearer credential (a
+ * `pcgw_` gateway token) inside the route handler and never read `req.actor`.
+ * The global actor middleware therefore has to let that credential through
+ * untouched, and the heartbeat has to hand adapters a URL that matches one of
+ * these shapes.
+ *
+ * Keeping the builder and the matcher in the same module means a change to the
+ * URL shape can't silently desynchronize the two — see the guard in
+ * `mcp-gateway-endpoint-coverage.test.ts`. When those drifted apart the failure
+ * was invisible: every managed MCP server 401'd during `initialize`, MCP
+ * clients registered zero tools, and agents simply saw no `mcp__*` tools at
+ * all.
+ */
+
+/** Per-gateway mount under `/api`, keyed by gateway id. */
+export function mcpGatewayApiEndpointPath(gatewayId: string): string {
+  return `/api/tool-gateway/gateways/${gatewayId}/mcp`;
+}
+
+/** Public streamable-HTTP mount, keyed by `gateway_public_id`. */
+export function mcpGatewayPublicEndpointPath(gatewayPublicId: string): string {
+  return `/mcp/gateways/${gatewayPublicId}`;
+}
+
+const MCP_GATEWAY_PROTOCOL_PATH_PATTERNS = [
+  /^\/mcp\/gateways\/[^/]+\/?$/,
+  /^\/api\/tool-gateway\/gateways\/[^/]+\/mcp\/?$/,
+];
+
+export function isMcpGatewayProtocolPath(path: string): boolean {
+  return MCP_GATEWAY_PROTOCOL_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip can connect an agent to a remote MCP tool server. The tool gateway mints a short-lived bearer token for each run, and the adapter gives that token to the agent process.
> - No agent could use any MCP tool. This was true for every connection and every agent, not only one.
> - The connection record was correct. The token was correct. The adapter command line was correct. Only the MCP handshake failed.
> - The gateway routes read their own bearer token. They do not read `req.actor`. But `actorMiddleware` runs before all routes. It saw a token it did not know, and it answered 401.
> - This pull request lets the gateway token reach the gateway route. The route still checks the token itself.
> - The benefit is that Paperclip-managed MCP servers attach again, so agents get their MCP tools.

## Linked Issues or Issue Description

No public issue exists. The problem is described below.

**Duplicate search:** I searched the open and closed pull request list for MCP gateway, gateway token, and actor middleware changes. I found no other pull request for this problem. This pull request replaces #11996, which had the same commit on a branch name that contained an internal ticket id. #11996 is closed.

**What happened?**

No `mcp__*` tool is available in any agent session. This applies to every MCP connection and every agent. A tool search for MCP tools returns nothing.

**Expected behavior**

An enabled and healthy MCP connection gives the agent its tools.

**Steps to reproduce**

1. Connect a remote MCP server. Confirm the connection is `active` and `enabled`.
2. Start an agent run.
3. Search the agent session for `mcp__` tools. No tool is found.
4. Send an MCP `initialize` request to the gateway URL with the token the run minted. The server answers 401.

**Relevant logs or output**

```
POST /api/tool-gateway/gateways/<id>/mcp
Authorization: Bearer pcgw_...

HTTP/1.1 401 Unauthorized
{"error":"Agent token did not verify; obtain fresh credentials and retry"}
```

That message comes from `server/src/middleware/auth.ts`. It does not come from the gateway route.

**Paperclip version or commit**

`master` at c5050396c.

**Deployment mode**

`authenticated`. The fault also applies to `local_trusted`, because `actorMiddleware` rejects the bearer token before the deployment mode matters.

**Agent adapter(s) involved**

Not adapter-specific (core bug). The fault is in the server. Every adapter that receives a Paperclip-managed MCP server is affected.

**Additional context**

The token in that request was valid. It was not expired and not revoked. On the instance where this was found, 46 runtime gateway tokens were minted and 0 were ever used:

```sql
select count(*) total, count(last_used_at) used
  from tool_mcp_gateway_tokens where subject_type='heartbeat_run';
 total | used
-------+------
    46 |    0
```

No MCP request has ever reached the gateway service.

The cause is in `actorMiddleware`. It is mounted on the app, before all routes. It reads the bearer token, tries a board key, an agent key, and an agent JWT, and then fails the request:

```ts
const claims = verifyLocalAgentJwt(token);
if (!claims) {
  next(unauthorized(invalidAgentTokenMessage(token)));   // 401 — the route never runs
  return;
}
```

There is no branch for a gateway token. Both gateway mounts are affected: the public `/mcp/gateways/:publicId` mount and the `/api/tool-gateway/gateways/:id/mcp` mount that the heartbeat gives to adapters.

The failure is silent. Nothing writes an error. An MCP client that cannot complete `initialize` simply registers zero tools. To the agent this looks the same as "no MCP server is configured".

## What Changed

- `server/src/services/mcp-gateway-endpoints.ts` (new): holds the gateway URL builders and the path matcher together in one module.
- `server/src/middleware/auth.ts`: lets a `pcgw_`-prefixed bearer token continue to the route, but only on the two gateway protocol paths. The middleware sets `req.actor` to `"none"` first. This stops a gateway token from getting the implicit board actor that `local_trusted` mode sets.
- `server/src/services/heartbeat.ts`: builds the runtime MCP server URL with the shared builder. The URL does not change.
- `server/src/__tests__/mcp-gateway-token-auth.test.ts` (new): 7 tests for the authentication boundary.
- `server/src/__tests__/mcp-gateway-endpoint-coverage.test.ts` (new): a guard that keeps the builder and the matcher in agreement.

## Verification

```
npx vitest run server/src/__tests__/mcp-gateway-token-auth.test.ts \
               server/src/__tests__/mcp-gateway-endpoint-coverage.test.ts
npx tsc --noEmit          # in server/
```

- 11 new tests pass. All 29 server auth and gateway test files pass (419 tests). Typecheck is clean.
- Three of the new tests are negative tests. A gateway token on a route that is not a gateway route still gets 401. A token that is not a gateway token on a gateway route still gets 401. In `local_trusted` mode a gateway token gets no board actor.
- The tests were mutation-tested. When the carve-out is disabled, 4 of the 7 boundary tests fail. The 3 negative tests still pass. This shows they guard the boundary and not the success path.
- An end-to-end check was run against a live instance database. A real minted token was sent through the real routes:

```
initialize -> 200 {"jsonrpc":"2.0",...,"serverInfo":{"name":"Paperclip MCP Gateway","version":"1.0.0"}}
tools/list -> 200
tool names: [ ...:create-link, ...:delete-link, ...:list-my-links, ...:promote-link, ...:revise-link ]
```

## Risks

Low risk, but the change is in authentication code. Please review the boundary.

- The carve-out is narrow. It applies only when the token starts with `pcgw_` **and** the path is one of the two gateway protocol paths. All other paths and all other token shapes keep their current behaviour.
- The middleware sets `req.actor` to `"none"` before it calls `next()`. Without this line, a gateway token in `local_trusted` mode would get the implicit board actor. A test covers this case.
- The gateway routes do not become open. They still validate the token, the gateway status, the token expiry, the revocation state, and the allowed actions.
- A wider path pattern would be a security problem. The coverage test asserts that neighbouring authenticated routes, such as `/api/tool-gateway/gateways/:id/tokens` and `/api/tool-gateway/audit`, are **not** matched.
- No database migration. No change to any public URL.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context window, extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
