### PR TITLE
fix(db): stream JS-engine backups through gzip, add atomic write+verify and disk-floor refusal

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -567,4 +567,156 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
     },
     20_000,
   );
+
+  it(
+    "never materializes a bare .sql file on disk during a javascript-engine backup (AGE-1204 red repro)",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-no-raw-sql-");
+      const sourceSql = postgres(sourceConnectionString, { max: 1, onnotice: () => {} });
+
+      try {
+        await sourceSql.unsafe(`
+          CREATE TABLE "public"."no_raw_sql_probe" (
+            "id" serial PRIMARY KEY,
+            "payload" text NOT NULL
+          );
+        `);
+        const payload = "x".repeat(4096);
+        for (let index = 0; index < 300; index += 1) {
+          await sourceSql`
+            INSERT INTO "public"."no_raw_sql_probe" ("payload") VALUES (${payload})
+          `;
+        }
+
+        const seenNames = new Set<string>();
+        let polling = true;
+        const pollTimer = setInterval(() => {
+          if (!polling || !fs.existsSync(backupDir)) return;
+          for (const name of fs.readdirSync(backupDir)) {
+            seenNames.add(name);
+          }
+        }, 5);
+
+        try {
+          const result = await runDatabaseBackup({
+            connectionString: sourceConnectionString,
+            backupDir,
+            retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+            filenamePrefix: "paperclip-no-raw-sql-test",
+            backupEngine: "javascript",
+          });
+          for (const name of fs.readdirSync(backupDir)) seenNames.add(name);
+
+          // A bare (non-.sql.gz, non-.tmp) .sql file must never have existed on
+          // disk at any point during a JS-engine backup. On unfixed main this
+          // assertion fails because the JS engine writes a full plaintext
+          // `<prefix>-<ts>.sql` file and only gzips it after the entire dump
+          // completes.
+          const bareSqlFiles = [...seenNames].filter(
+            (name) => name.endsWith(".sql") && !name.endsWith(".sql.gz"),
+          );
+          expect(bareSqlFiles).toEqual([]);
+          expect(result.backupFile.endsWith(".sql.gz")).toBe(true);
+          expect(fs.existsSync(result.backupFile)).toBe(true);
+        } finally {
+          polling = false;
+          clearInterval(pollTimer);
+        }
+      } finally {
+        await sourceSql.end();
+      }
+    },
+    60_000,
+  );
+
+  it(
+    "cleans up only the .tmp file on a forced pg_dump failure, leaving prior backups untouched",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-atomic-failure-");
+      const originalPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      process.env.PAPERCLIP_PG_DUMP_PATH = "/bin/false";
+
+      const priorBackupName = "paperclip-atomic-test-existing.sql.gz";
+      const priorBackup = path.join(backupDir, priorBackupName);
+      fs.writeFileSync(priorBackup, "prior-backup-content");
+
+      try {
+        await expect(
+          runDatabaseBackup({
+            connectionString: sourceConnectionString,
+            backupDir,
+            retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+            filenamePrefix: "paperclip-atomic-test",
+            backupEngine: "pg_dump",
+          }),
+        ).rejects.toThrow();
+
+        const entries = fs.readdirSync(backupDir);
+        expect(entries).toEqual([priorBackupName]);
+        expect(fs.readFileSync(priorBackup, "utf8")).toBe("prior-backup-content");
+      } finally {
+        if (originalPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = originalPgDumpPath;
+        }
+      }
+    },
+    30_000,
+  );
+
+  it(
+    "refuses to start a backup before touching disk when free space would drop below the configured floor",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-disk-floor-");
+
+      await expect(
+        runDatabaseBackup({
+          connectionString: sourceConnectionString,
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+          filenamePrefix: "paperclip-disk-floor-test",
+          backupEngine: "javascript",
+          minFreeBytesAfter: 1024 * 1024 * 1024,
+          statfs: async () => ({ bavail: 100, bsize: 4096 }),
+        }),
+      ).rejects.toThrow(/Refusing to start database backup/);
+
+      expect(fs.existsSync(backupDir)).toBe(true);
+      expect(fs.readdirSync(backupDir)).toEqual([]);
+    },
+    30_000,
+  );
+
+  it(
+    "keeps the newly-written backup even under an aggressive dailyDays:1 retention window",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-aggressive-retention-");
+
+      const staleBackupName = "paperclip-aggressive-test-stale.sql.gz";
+      const staleBackup = path.join(backupDir, staleBackupName);
+      fs.writeFileSync(staleBackup, "stale");
+      const staleDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(staleBackup, staleDate, staleDate);
+
+      const result = await runDatabaseBackup({
+        connectionString: sourceConnectionString,
+        backupDir,
+        retention: { dailyDays: 1, weeklyWeeks: 1, monthlyMonths: 1 },
+        filenamePrefix: "paperclip-aggressive-test",
+        backupEngine: "javascript",
+      });
+
+      expect(fs.existsSync(result.backupFile)).toBe(true);
+      expect(fs.existsSync(staleBackup)).toBe(false);
+      const remaining = fs.readdirSync(backupDir);
+      expect(remaining.length).toBeGreaterThanOrEqual(1);
+      expect(remaining).toContain(path.basename(result.backupFile));
+    },
+    30_000,
+  );
 });

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -2,7 +2,7 @@ import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync
 import { basename, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { spawn } from "node:child_process";
-import { open as openFile } from "node:fs/promises";
+import { open as openFile, rename as renameFile, statfs as statFilesystem } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 import { createGunzip, createGzip } from "node:zlib";
 import postgres from "postgres";
@@ -28,6 +28,19 @@ export type RunDatabaseBackupOptions = {
   excludeTables?: string[];
   nullifyColumns?: Record<string, string[]>;
   backupEngine?: "auto" | "pg_dump" | "javascript";
+  /**
+   * Minimum free bytes that must remain on the backup directory's filesystem
+   * after the projected backup footprint. Defaults to the
+   * PAPERCLIP_BACKUP_MIN_FREE_BYTES env var, or a built-in floor if that is
+   * also unset. Set to 0 to disable the pre-flight disk-floor check.
+   */
+  minFreeBytesAfter?: number;
+  /**
+   * Test-only injection point for filesystem free-space probing. Defaults to
+   * fs.promises.statfs. Must return { bavail, bsize } (free blocks available
+   * to unprivileged users, block size in bytes) like Node's native statfs.
+   */
+  statfs?: (path: string) => Promise<{ bavail: number; bsize: number }>;
 };
 
 export type RunDatabaseBackupResult = {
@@ -72,6 +85,13 @@ const BACKUP_CLI_STDERR_BYTES = 64 * 1024;
 const BACKUP_BREAKPOINT_DETECT_BYTES = 64 * 1024;
 
 const STATEMENT_BREAKPOINT = "-- paperclip statement breakpoint 69f6f3f1-42fd-46a6-bf17-d1d85f8f3900";
+
+const BACKUP_TMP_SUFFIX = ".tmp";
+// Fixed overhead on top of live DB size when projecting worst-case backup
+// footprint. Defense-in-depth only: the JS engine no longer materializes a
+// full uncompressed copy, so this is a safety margin, not the primary guard.
+const BACKUP_DISK_FLOOR_SAFETY_MARGIN_BYTES = 10 * 1024 * 1024;
+const DEFAULT_BACKUP_MIN_FREE_BYTES_AFTER = 256 * 1024 * 1024;
 
 function sanitizeRestoreErrorMessage(error: unknown): string {
   if (error && typeof error === "object") {
@@ -442,23 +462,19 @@ async function* readRestoreStatements(backupFile: string): AsyncGenerator<string
   }
 }
 
-export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
-  const filePromise = openFile(filePath, "w");
+type BackupFileSink = {
+  write: (chunk: string | Buffer) => Promise<void>;
+  finish: () => Promise<void>;
+  abort: () => Promise<void>;
+};
+
+function createBufferedWriter(sink: BackupFileSink, maxBufferedBytes: number) {
   const flushThreshold = Math.max(1, Math.trunc(maxBufferedBytes));
   let bufferedLines: string[] = [];
   let bufferedBytes = 0;
   let firstChunk = true;
   let closed = false;
   let pendingWrite = Promise.resolve();
-
-  const writeChunk = async (chunk: string | Buffer): Promise<void> => {
-    const file = await filePromise;
-    if (typeof chunk === "string") {
-      await file.write(chunk, null, "utf8");
-    } else {
-      await file.write(chunk);
-    }
-  };
 
   const flushBufferedLines = () => {
     if (bufferedLines.length === 0) return;
@@ -468,13 +484,13 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
     const chunkBody = linesToWrite.join("\n");
     const chunk = firstChunk ? chunkBody : `\n${chunkBody}`;
     firstChunk = false;
-    pendingWrite = pendingWrite.then(() => writeChunk(chunk));
+    pendingWrite = pendingWrite.then(() => sink.write(chunk));
   };
 
   return {
     emit(line: string) {
       if (closed) {
-        throw new Error(`Cannot write to closed backup file: ${filePath}`);
+        throw new Error("Cannot write to closed backup file");
       }
       bufferedLines.push(line);
       bufferedBytes += Buffer.byteLength(line, "utf8") + 1;
@@ -484,18 +500,18 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
     },
     async drain() {
       if (closed) {
-        throw new Error(`Cannot drain closed backup file: ${filePath}`);
+        throw new Error("Cannot drain closed backup file");
       }
       flushBufferedLines();
       await pendingWrite;
     },
     async writeRaw(chunk: string | Buffer) {
       if (closed) {
-        throw new Error(`Cannot write to closed backup file: ${filePath}`);
+        throw new Error("Cannot write to closed backup file");
       }
       flushBufferedLines();
       firstChunk = false;
-      pendingWrite = pendingWrite.then(() => writeChunk(chunk));
+      pendingWrite = pendingWrite.then(() => sink.write(chunk));
       await pendingWrite;
     },
     async close() {
@@ -503,8 +519,7 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
       closed = true;
       flushBufferedLines();
       await pendingWrite;
-      const file = await filePromise;
-      await file.close();
+      await sink.finish();
     },
     async abort() {
       if (closed) return;
@@ -512,6 +527,27 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
       bufferedLines = [];
       bufferedBytes = 0;
       await pendingWrite.catch(() => {});
+      await sink.abort();
+    },
+  };
+}
+
+export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
+  const filePromise = openFile(filePath, "w");
+  const sink: BackupFileSink = {
+    write: async (chunk) => {
+      const file = await filePromise;
+      if (typeof chunk === "string") {
+        await file.write(chunk, null, "utf8");
+      } else {
+        await file.write(chunk);
+      }
+    },
+    finish: async () => {
+      const file = await filePromise;
+      await file.close();
+    },
+    abort: async () => {
       await filePromise.then((file) => file.close()).catch(() => {});
       if (existsSync(filePath)) {
         try {
@@ -522,6 +558,139 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
       }
     },
   };
+  return createBufferedWriter(sink, maxBufferedBytes);
+}
+
+function writeToStream(
+  stream: { write: (chunk: string | Buffer, cb: (err?: Error | null) => void) => boolean },
+  chunk: string | Buffer,
+): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    stream.write(chunk, (err) => {
+      if (err) rejectPromise(err);
+      else resolvePromise();
+    });
+  });
+}
+
+/**
+ * Streams buffered text lines straight through gzip to disk so no bare
+ * uncompressed intermediate file is ever materialized. Replaces the old
+ * write-plaintext-then-gzip-afterward two-phase JS engine write path.
+ */
+function createBufferedGzipFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
+  const gzip = createGzip();
+  const out = createWriteStream(filePath);
+  const pipelineDone = pipeline(gzip, out);
+  let pipelineFailed: Error | null = null;
+  pipelineDone.catch((error) => {
+    pipelineFailed = error instanceof Error ? error : new Error(String(error));
+  });
+
+  const sink: BackupFileSink = {
+    write: async (chunk) => {
+      if (pipelineFailed) throw pipelineFailed;
+      await writeToStream(gzip, chunk);
+    },
+    finish: async () => {
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        gzip.end((err?: Error | null) => {
+          if (err) rejectPromise(err);
+          else resolvePromise();
+        });
+      });
+      await pipelineDone;
+    },
+    abort: async () => {
+      gzip.destroy();
+      out.destroy();
+      await pipelineDone.catch(() => {});
+      if (existsSync(filePath)) {
+        try {
+          unlinkSync(filePath);
+        } catch {
+          // Preserve the original backup failure if temporary file cleanup also fails.
+        }
+      }
+    },
+  };
+  return createBufferedWriter(sink, maxBufferedBytes);
+}
+
+/**
+ * Fully decompresses filePath and discards the output. Throws if the gzip
+ * stream is truncated or corrupt. Used as the post-write integrity gate
+ * before a backup's .tmp file is renamed to its final name.
+ */
+async function verifyGzipIntegrity(filePath: string): Promise<void> {
+  await pipeline(
+    createReadStream(filePath),
+    createGunzip(),
+    async function drain(source: AsyncIterable<unknown>) {
+      for await (const _chunk of source) {
+        // Discard — we only care that decompression completes without error.
+      }
+    },
+  );
+}
+
+/**
+ * Verifies gzip integrity of a completed .tmp backup file, then atomically
+ * renames it to its final name. The final name never exists in a
+ * partially-written state: it is only ever created by this rename.
+ */
+async function finalizeBackupFile(tmpFile: string, finalFile: string): Promise<void> {
+  await verifyGzipIntegrity(tmpFile);
+  await renameFile(tmpFile, finalFile);
+}
+
+function resolveMinFreeBytesAfter(opts: RunDatabaseBackupOptions): number {
+  if (typeof opts.minFreeBytesAfter === "number") {
+    return Math.max(0, opts.minFreeBytesAfter);
+  }
+  const envValue = process.env.PAPERCLIP_BACKUP_MIN_FREE_BYTES;
+  if (envValue !== undefined && envValue.trim().length > 0) {
+    const parsed = Number(envValue);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return DEFAULT_BACKUP_MIN_FREE_BYTES_AFTER;
+}
+
+/**
+ * Pre-flight disk-floor refusal: compares free space on the backup
+ * directory's filesystem against a projected worst-case backup footprint
+ * (live DB size + a fixed safety margin), and throws BEFORE any file is
+ * created if the projected free space after the backup would drop below the
+ * configured floor. This is defense-in-depth, not the primary fix — the JS
+ * engine no longer materializes a full raw copy (see
+ * createBufferedGzipFileWriter above).
+ */
+async function assertSufficientDiskSpace(
+  opts: RunDatabaseBackupOptions,
+  sql: ReturnType<typeof postgres>,
+): Promise<void> {
+  const floor = resolveMinFreeBytesAfter(opts);
+  if (floor <= 0) return;
+
+  const statfsFn = opts.statfs ?? ((path: string) => statFilesystem(path));
+  const [freeSpace, dbSizeRows] = await Promise.all([
+    statfsFn(opts.backupDir),
+    sql.unsafe<{ size: string }[]>("SELECT pg_database_size(current_database())::text AS size"),
+  ]);
+
+  const freeBytes = freeSpace.bavail * freeSpace.bsize;
+  const dbSizeBytes = Number(dbSizeRows[0]?.size ?? 0);
+  const projectedFootprintBytes = dbSizeBytes + BACKUP_DISK_FLOOR_SAFETY_MARGIN_BYTES;
+  const projectedFreeAfter = freeBytes - projectedFootprintBytes;
+
+  if (projectedFreeAfter < floor) {
+    throw new Error(
+      `Refusing to start database backup: projected free disk space after backup ` +
+        `(${projectedFreeAfter} bytes) would drop below the configured floor (${floor} bytes). ` +
+        `Live DB size ~${dbSizeBytes} bytes, current free space ${freeBytes} bytes on ${opts.backupDir}. ` +
+        `Set minFreeBytesAfter/PAPERCLIP_BACKUP_MIN_FREE_BYTES lower or free disk space before retrying.`,
+    );
+  }
 }
 
 export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise<RunDatabaseBackupResult> {
@@ -540,21 +709,31 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     await sql.end();
   };
   mkdirSync(opts.backupDir, { recursive: true });
-  const sqlFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql`);
-  const backupFile = `${sqlFile}.gz`;
-  const writer = createBufferedTextFileWriter(sqlFile);
+  // Both engines write to a `.tmp` staging name and are only ever exposed at
+  // the final `.sql.gz` name via finalizeBackupFile's rename-after-verify, so
+  // the final name never exists in a partially-written state.
+  const backupFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql.gz`);
+  const tmpFile = `${backupFile}${BACKUP_TMP_SUFFIX}`;
+  const removeTmpFile = () => {
+    if (existsSync(tmpFile)) {
+      try { unlinkSync(tmpFile); } catch { /* ignore */ }
+    }
+  };
+  let writer: ReturnType<typeof createBufferedGzipFileWriter> | undefined;
 
   try {
+    await sql`SELECT 1`;
+    await assertSufficientDiskSpace(opts, sql);
+
     if (backupEngine === "pg_dump" || (backupEngine === "auto" && canUsePgDump)) {
-      await sql`SELECT 1`;
       try {
         await closeSql();
         await runPgDumpBackup({
           connectionString: opts.connectionString,
-          backupFile,
+          backupFile: tmpFile,
           connectTimeout,
         });
-        await writer.abort();
+        await finalizeBackupFile(tmpFile, backupFile);
         const sizeBytes = statSync(backupFile).size;
         const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
         return {
@@ -563,9 +742,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           prunedCount,
         };
       } catch (error) {
-        if (existsSync(backupFile)) {
-          try { unlinkSync(backupFile); } catch { /* ignore */ }
-        }
+        removeTmpFile();
         if (backupEngine === "pg_dump") {
           throw error;
         }
@@ -576,7 +753,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
 
     await sql`SELECT 1`;
 
-    const emit = (line: string) => writer.emit(line);
+    writer = createBufferedGzipFileWriter(tmpFile);
+    const activeWriter = writer;
+
+    const emit = (line: string) => activeWriter.emit(line);
     const emitStatement = (statement: string) => {
       emit(statement);
       emit(STATEMENT_BREAKPOINT);
@@ -904,19 +1084,19 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       const nullifiedColumns = nullifiedColumnsByTable.get(currentTableKey) ?? new Set<string>();
       if (backupEngine !== "javascript" && nullifiedColumns.size === 0) {
         emit(`COPY ${qualifiedTableName} (${colNames}) FROM stdin;`);
-        await writer.writeRaw("\n");
+        await activeWriter.writeRaw("\n");
         const copySql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
         try {
           const copyStream = await copySql
             .unsafe(`COPY ${qualifiedTableName} (${colNames}) TO STDOUT`)
             .readable();
           for await (const chunk of copyStream) {
-            await writer.writeRaw(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+            await activeWriter.writeRaw(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
           }
         } finally {
           await copySql.end();
         }
-        await writer.writeRaw("\\.\n");
+        await activeWriter.writeRaw("\\.\n");
         emitStatementBoundary();
         emit("");
         continue;
@@ -933,7 +1113,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           );
           emitStatement(`INSERT INTO ${qualifiedTableName} (${colNames}) VALUES (${values.join(", ")});`);
         }
-        await writer.drain();
+        await activeWriter.drain();
       }
       emit("");
     }
@@ -959,13 +1139,8 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     emitStatement("COMMIT;");
     emit("");
 
-    await writer.close();
-
-    // Compress the SQL file with gzip
-    const sqlReadStream = createReadStream(sqlFile);
-    const gzWriteStream = createWriteStream(backupFile);
-    await pipeline(sqlReadStream, createGzip(), gzWriteStream);
-    unlinkSync(sqlFile);
+    await activeWriter.close();
+    await finalizeBackupFile(tmpFile, backupFile);
 
     const sizeBytes = statSync(backupFile).size;
     const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
@@ -976,13 +1151,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       prunedCount,
     };
   } catch (error) {
-    await writer.abort();
-    if (existsSync(backupFile)) {
-      try { unlinkSync(backupFile); } catch { /* ignore */ }
+    if (writer) {
+      await writer.abort();
     }
-    if (existsSync(sqlFile)) {
-      try { unlinkSync(sqlFile); } catch { /* ignore */ }
-    }
+    removeTmpFile();
     throw error;
   } finally {
     await closeSql();


### PR DESCRIPTION
## What happened?

`packages/db/src/backup-lib.ts::runDatabaseBackup`'s JS-fallback backup engine (used whenever `backupEngine==="javascript"`, whenever `backupEngine==="auto"` falls back after `pg_dump` fails, or whenever `excludeTables`/`nullifyColumns` options are set) wrote the entire SQL dump as **plaintext** to a `.sql` file, then gzipped that file to the final `.sql.gz` name and deleted the raw file only after the whole dump finished. For the full duration of the backup, an uncompressed file roughly the size of the live database sat on disk. On a real deployment this grew to 7.4 GiB and dropped free disk space on the host to 175 MiB, degrading the whole box.

Separately, neither backup engine (`pg_dump`-based or JS-fallback) wrote atomically: both wrote directly to the final `<prefix>-<timestamp>.sql.gz` name, with no staging file and no post-write integrity check. A crash or failure mid-write left a truncated/corrupt file at that name, and every downstream reader (health checks, retention pruning, restore tooling) had no way to tell it apart from a valid completed backup.

Finally, there was no pre-flight check anywhere that compared the live database's size against the backup directory's free disk space before starting a write.

## Expected behavior

- The JS-fallback engine should stream its output through gzip as it is produced, the same way the `pg_dump` path already streams `pg_dump`'s stdout through `zlib.createGzip()` — no bare uncompressed `.sql` file should ever exist on disk during a backup.
- Both engines should write to a temporary name, verify the completed gzip stream is well-formed, and only then atomically rename it to the final `.sql.gz` name — so the final name is never observable in a partially-written or corrupt state.
- Before writing anything, the backup should compare the source database's on-disk size against the backup directory's free space and refuse to start (throwing before creating any file) if completing the backup would drop free space below a configurable floor.
- A failed backup should clean up only its own temporary file and must never touch previously-completed `.sql.gz` backups.

## Steps to reproduce

1. Run `runDatabaseBackup` with `backupEngine: "javascript"` (or with `excludeTables`/`nullifyColumns` set) against a Postgres database with a non-trivial amount of data.
2. While the dump is in progress, list the backup directory.
3. Observe a bare `paperclip-<timestamp>.sql` file present at close to the live database's uncompressed size — this is the intermediate plaintext file that the fix in this PR eliminates.

## Paperclip version or commit

`master` prior to this PR (repro verified via `git stash`/checkout against the pre-fix `backup-lib.ts`).

## What Changed

- **JS engine now streams through gzip.** Statement text is piped through `zlib.createGzip()` straight to disk as it's produced, the same principle as the existing `pg_dump` stdout piping. No bare uncompressed `.sql` file is ever materialized.
- **Atomic write + verify for both engines.** Both engines write to `<prefix>-<ts>.sql.gz.tmp`. After the write completes, gzip integrity is verified via a full decompress-read (`createGunzip()` piped to a draining sink). Only then is the `.tmp` file renamed to the final `.sql.gz` name — the final name is never observable in a partially-written state.
- **Pre-flight disk-floor refusal.** Before touching disk, queries live DB size (`pg_database_size(current_database())`) and free space on the backup directory's filesystem (`fs.promises.statfs`), and throws before creating any file if projected free space after the backup would drop below a floor. New `RunDatabaseBackupOptions.minFreeBytesAfter`, defaulting to the `PAPERCLIP_BACKUP_MIN_FREE_BYTES` env var, then a built-in 256 MiB floor. Also exposes `statfs` as a test-injection hook. This is defense-in-depth — the JS-engine streaming fix above is the primary fix, since the JS engine no longer materializes a full raw copy.
- **Failure cleanup** deletes only the `.tmp` file being written; previously-completed `.sql.gz` backups are never touched.
- **Retention ordering unchanged** — `pruneOldBackups` still runs immediately after a successful rename.

## Tests (`packages/db/src/backup-lib.test.ts`, extends the existing embedded-postgres harness)

- **Red repro, confirmed failing on unmodified `master`** (`git stash` verified locally) — asserts no bare `.sql` file ever exists on disk during a `backupEngine: "javascript"` run; fails on `master` with a real `paperclip-no-raw-sql-test-*.sql` file observed mid-write, passes after the fix.
- **Atomicity/integrity:** forces a `pg_dump` failure (`PAPERCLIP_PG_DUMP_PATH=/bin/false`, `backupEngine: "pg_dump"`) and asserts no `.sql.gz`/`.tmp` file is left behind and a pre-existing backup in the same directory is untouched.
- **Disk floor:** injects a `statfs` hook reporting near-zero free space and asserts `runDatabaseBackup` rejects before creating any file in `backupDir`.
- **Retention:** newest backup survives an aggressive `dailyDays: 1` window even with a ~400-day-old stale backup present.

### Verification run (this PR's branch)

```
$ npx vitest run src/backup-lib.test.ts -t "never materializes a bare|cleans up only the .tmp|refuses to start a backup|keeps the newly-written backup"
 Test Files  1 passed (1)
      Tests  4 passed | 7 skipped (11)
```

`npx tsc --noEmit -p packages/db/tsconfig.json` is clean.

**Known pre-existing flakiness, NOT introduced by this change:** running the full `backup-lib.test.ts` file back-to-back (11 tests, each spinning up its own embedded Postgres) times out intermittently under load on this dev machine — the *same* `"restores legacy public-only backups without migration history"` test (which doesn't touch `runDatabaseBackup` at all) also times out standalone on unmodified `master`. This looks like embedded-Postgres startup contention under concurrent test-suite load, not a regression from this diff. Each new/existing test passes reliably when run individually or in small groups. Flagging as `NOT VERIFIED` for a guaranteed-green full-file run under heavy concurrent load; CI is the authority here.

## Thinking Path

1. Reproduced the plaintext-intermediate-file bug directly against `master` before writing any fix, per the "Steps to reproduce" above.
2. Wrote the red regression test first, confirmed it failed on `master`, then implemented the streaming/atomic/disk-floor fixes, then confirmed the same test went green.
3. Kept the diff scoped to exactly `packages/db/src/backup-lib.ts` and its test file — no changes to `runPgDumpBackup`'s already-correct streaming or `pruneOldBackups`'s already-correct ordering.
4. Added atomicity via `.tmp` + integrity-verify + rename for both engines, and a pre-flight disk-floor refusal that throws before any file touches disk.
5. Ran the targeted new/changed tests to green; flagged full-file concurrent-run flakiness as a pre-existing, reproduced-on-`master` issue rather than silently working around it.

## Risks

- **Flaky full-suite run under concurrent embedded-Postgres load** (see Verification run section) — reproduced identically on unmodified `master` on a test unrelated to this diff (`"restores legacy public-only backups without migration history"`), so not attributable to this change, but not independently confirmed clean at CI concurrency. CI is the authority here.
- **Disk-floor default is a new behavior change**: any deployment relying on `backupEngine: "javascript"`/`"auto"` near its configured floor could see backups start refusing where they previously silently succeeded (by design — this is the requested fail-closed behavior, but it is an operator-visible change worth calling out).

## Model Used

Claude (Anthropic), via an internal automation harness.

## Search first / dedup

- [x] I searched for similar open/closed PRs against `paperclipai/paperclip` (raw-SQL backup atomicity, disk-floor refusal) and confirmed this is not a duplicate.

