### PR TITLE
fix(KEWL-3859): delete retained Codex run homes

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2023,6 +2023,180 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(await pathExists(path.join(cwd, ".claude", "settings.local.json"))).toBe(false);
   });
 
+  it("retains only sanitized run-local Codex session JSONL after the runtime closes", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-sentinel";
+    const fakeToken = `pcp_board_${"01234567".repeat(6)}`;
+    const runSessionFile = path.join(
+      stateDir,
+      "codex-run-homes",
+      runId,
+      "home",
+      "sessions",
+      "2026",
+      "08",
+      "session.jsonl",
+    );
+    const closeOrder: string[] = [];
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        startTurn: () => ({
+          events: (async function* () {
+            await fs.mkdir(path.dirname(runSessionFile), { recursive: true });
+            await fs.writeFile(
+              runSessionFile,
+              `${JSON.stringify({ type: "message", text: `token=${fakeToken}` })}\n`,
+              "utf8",
+            );
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {
+          closeOrder.push("close");
+          await fs.appendFile(
+            runSessionFile,
+            `${JSON.stringify({ type: "close", text: `Authorization: Bearer ${fakeToken}` })}\n`,
+            "utf8",
+          );
+        },
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    const result = await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "codex",
+        stateDir,
+        warmHandleIdleMs: 60_000,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(closeOrder).toEqual(["close"]);
+
+    const retainedFile = path.join(
+      stateDir,
+      "codex-session-retention",
+      runId,
+      "sessions",
+      "2026",
+      "08",
+      "session.jsonl",
+    );
+    const retained = await fs.readFile(retainedFile, "utf8");
+    expect(retained).not.toContain(fakeToken);
+    expect(retained).toContain("***REDACTED***");
+    expect(retained).toContain("\"type\":\"close\"");
+    expect((await fs.stat(retainedFile)).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(path.dirname(retainedFile))).mode & 0o777).toBe(0o700);
+
+    const runHome = path.join(stateDir, "codex-run-homes", runId, "home");
+    expect(await pathExists(runHome)).toBe(false);
+    expect(logs.some((entry) => entry.text.includes("Retained 1 sanitized ACPX Codex session JSONL"))).toBe(true);
+    expect(logs.some((entry) => entry.text.includes(`Deleted raw run home "${runHome}" after successful sanitized-session retention.`))).toBe(true);
+    expect(logs.every((entry) => !entry.text.includes("acpx.codex_session_retention.quarantine"))).toBe(true);
+  });
+
+  it("keeps the raw run home and emits an incident event when Codex session retention fails", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-retention-fail";
+    const retainedRunPath = path.join(stateDir, "codex-session-retention", runId);
+    const runSessionFile = path.join(
+      stateDir,
+      "codex-run-homes",
+      runId,
+      "home",
+      "sessions",
+      "session.jsonl",
+    );
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        startTurn: () => ({
+          events: (async function* () {
+            await fs.mkdir(path.dirname(runSessionFile), { recursive: true });
+            await fs.writeFile(runSessionFile, `${JSON.stringify({ type: "message", text: "keep me" })}\n`, "utf8");
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {
+          await fs.mkdir(path.dirname(retainedRunPath), { recursive: true });
+          await fs.writeFile(retainedRunPath, "not a directory\n", "utf8");
+        },
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    const result = await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "codex",
+        stateDir,
+        warmHandleIdleMs: 60_000,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    const runHome = path.join(stateDir, "codex-run-homes", runId, "home");
+    const incidentEvent = logs.find((entry) => entry.text.includes("acpx.codex_session_retention.quarantine"));
+
+    expect(result.exitCode).toBe(0);
+    expect(await pathExists(runHome)).toBe(true);
+    expect(await fs.readFile(runSessionFile, "utf8")).toContain("keep me");
+    expect(incidentEvent?.stream).toBe("stdout");
+    expect(JSON.parse(incidentEvent?.text ?? "{}")).toMatchObject({
+      type: "acpx.codex_session_retention.quarantine",
+      severity: "incident",
+      runHome,
+      retainedSessionsDir: path.join(retainedRunPath, "sessions"),
+    });
+    expect(logs.some((entry) => entry.stream === "stderr" && entry.text.includes("raw run home is quarantined"))).toBe(true);
+    expect(logs.every((entry) => !entry.text.includes("Deleted raw run home"))).toBe(true);
+  });
+
   it("changes the ACPX session fingerprint when the resolved secret manifest rotates", async () => {
     const root = await makeTempRoot();
     const baseConfig = {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -139,6 +139,7 @@ import {
   type StartupStepMeasureOptions,
   type StartupTraceContext,
 } from "./startup-timing.js";
+import { redactCommandText } from "../command-redaction.js";
 
 const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
@@ -439,6 +440,7 @@ interface AcpxPreparedRuntime {
   skillsIdentity: Record<string, unknown>;
   childStderrLogPath: string | null;
   paperclipClaudeSettings: PaperclipClaudeSettingsResult | null;
+  codexSessionRetention: CodexSessionRetentionContext | null;
   mcpServers: NonNullable<AcpRuntimeOptions["mcpServers"]>;
   mcpIdentity: Array<{ name: string; url: string; connectionId: string }>;
   // Per-step round-trip / provider-duration readers sourced from the sandbox
@@ -447,6 +449,11 @@ interface AcpxPreparedRuntime {
   // `acp.handshake` `measureStartupStep` call in the executor (the other six
   // boundaries live inside `buildRuntime` and read it directly).
   stepMetrics: StartupStepMeasureOptions;
+}
+
+interface CodexSessionRetentionContext {
+  runHome: string;
+  retainedSessionsDir: string;
 }
 
 const defaultWarmHandles = new Map<string, RuntimeCacheEntry>();
@@ -791,6 +798,148 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   await fs.copyFile(source, target);
 }
 
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+async function chmodPrivateTree(root: string): Promise<void> {
+  const stat = await fs.lstat(root).catch(() => null);
+  if (!stat) return;
+  if (stat.isDirectory()) {
+    await fs.chmod(root, 0o700).catch(() => {});
+    const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
+    await Promise.all(entries.map((entry) => chmodPrivateTree(path.join(root, entry.name))));
+    return;
+  }
+  if (stat.isFile()) {
+    await fs.chmod(root, 0o600).catch(() => {});
+  }
+}
+
+async function removeDirectoryContents(dir: string): Promise<void> {
+  const entries = await fs.readdir(dir).catch(() => []);
+  await Promise.all(entries.map((entry) => fs.rm(path.join(dir, entry), { recursive: true, force: true })));
+}
+
+async function prepareRunIsolatedCodexHome(input: {
+  sourceHome: string;
+  runHome: string;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  await fs.rm(input.runHome, { recursive: true, force: true });
+  await fs.mkdir(input.runHome, { recursive: true, mode: 0o700 });
+
+  const authJson = path.join(input.sourceHome, "auth.json");
+  if (await pathExists(authJson)) await ensureSymlink(path.join(input.runHome, "auth.json"), authJson);
+
+  for (const name of ["config.json", "config.toml", "instructions.md"]) {
+    const source = path.join(input.sourceHome, name);
+    if (await pathExists(source)) await ensureCopiedFile(path.join(input.runHome, name), source);
+  }
+
+  await chmodPrivateTree(input.runHome);
+  await input.onLog(
+    "stdout",
+    `[paperclip] Using run-isolated ACPX Codex home "${input.runHome}" (seeded from "${input.sourceHome}").\n`,
+  );
+}
+
+async function listCodexSessionJsonlFiles(input: {
+  root: string;
+  dir: string;
+  relativeDir?: string;
+}): Promise<string[]> {
+  const entries = await fs.readdir(input.dir, { withFileTypes: true }).catch(() => []);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relativePath = input.relativeDir ? path.join(input.relativeDir, entry.name) : entry.name;
+    const absolutePath = path.join(input.dir, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      files.push(...await listCodexSessionJsonlFiles({
+        root: input.root,
+        dir: absolutePath,
+        relativeDir: relativePath,
+      }));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const resolved = path.resolve(absolutePath);
+    const root = path.resolve(input.root) + path.sep;
+    if (!resolved.startsWith(root)) continue;
+    files.push(relativePath);
+  }
+  return files;
+}
+
+async function retainSanitizedCodexSessionJsonl(input: {
+  retention: CodexSessionRetentionContext;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  const sessionsDir = path.join(input.retention.runHome, "sessions");
+  await chmodPrivateTree(input.retention.runHome);
+  const sessionFiles = await listCodexSessionJsonlFiles({
+    root: sessionsDir,
+    dir: sessionsDir,
+  });
+
+  await fs.mkdir(input.retention.retainedSessionsDir, { recursive: true, mode: 0o700 });
+  await removeDirectoryContents(input.retention.retainedSessionsDir);
+
+  for (const relativePath of sessionFiles) {
+    const source = path.join(sessionsDir, relativePath);
+    const target = path.join(input.retention.retainedSessionsDir, relativePath);
+    const raw = await fs.readFile(source, "utf8");
+    await writeFileAtomically({
+      target,
+      contents: redactCommandText(raw),
+      mode: 0o600,
+    });
+  }
+
+  await chmodPrivateTree(input.retention.retainedSessionsDir);
+  await input.onLog(
+    "stdout",
+    `[paperclip] Retained ${sessionFiles.length} sanitized ACPX Codex session JSONL file(s) in "${input.retention.retainedSessionsDir}".\n`,
+  );
+}
+
+async function retainSanitizedCodexSessionsAfterClose(input: {
+  prepared: AcpxPreparedRuntime;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  if (!input.prepared.codexSessionRetention) return;
+  const { runHome, retainedSessionsDir } = input.prepared.codexSessionRetention;
+  try {
+    await retainSanitizedCodexSessionJsonl({
+      retention: input.prepared.codexSessionRetention,
+      onLog: input.onLog,
+    });
+    await fs.rm(runHome, { recursive: true, force: true });
+    await input.onLog(
+      "stdout",
+      `[paperclip] Deleted raw run home "${runHome}" after successful sanitized-session retention.\n`,
+    );
+  } catch (err) {
+    await chmodPrivateTree(runHome).catch(() => {});
+    await fs.rm(retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+    await input.onLog(
+      "stdout",
+      `${JSON.stringify({
+        type: "acpx.codex_session_retention.quarantine",
+        severity: "incident",
+        runHome,
+        retainedSessionsDir,
+        message: err instanceof Error ? err.message : String(err),
+      })}\n`,
+    );
+    await input.onLog(
+      "stderr",
+      `[paperclip] Failed to retain sanitized ACPX Codex session JSONL; raw run home is quarantined at "${runHome}": ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
 async function prepareManagedCodexHome(input: {
   companyId: string;
   sourceHome: string;
@@ -1017,7 +1166,10 @@ async function prepareCodexSkillRuntime(input: {
   companyId: string;
   config: Record<string, unknown>;
   env: Record<string, string>;
+  adapterType: string;
   moduleDir: string;
+  runId: string;
+  stateDir: string;
   onLog: AdapterExecutionContext["onLog"];
   // Step-timing seam: threaded from `buildRuntime` so the nested
   // `skills.reconcile` boundary (step 3) can emit its own `run.startup.step`
@@ -1031,7 +1183,7 @@ async function prepareCodexSkillRuntime(input: {
   // same host→sandbox counters as its siblings (0 here — skill prep is
   // host-only — which is itself the answer to "does this step exec?").
   stepMetrics?: StartupStepMeasureOptions;
-}): Promise<{ identity: Record<string, unknown>; commandNotes: string[] }> {
+}): Promise<{ identity: Record<string, unknown>; commandNotes: string[]; retention: CodexSessionRetentionContext | null }> {
   const now = input.now ?? (() => Date.now());
   const envConfig = parseObject(input.config.env);
   const configuredCodexHome =
@@ -1043,13 +1195,29 @@ async function prepareCodexSkillRuntime(input: {
       ? path.resolve(process.env.CODEX_HOME.trim())
       : path.join(os.homedir(), ".codex");
   const managedCodexHome = resolveManagedCodexHomeDir(input.companyId);
-  const effectiveCodexHome = configuredCodexHome ??
+  const seededCodexHome = configuredCodexHome ??
     await prepareManagedCodexHome({
       companyId: input.companyId,
       sourceHome: sourceCodexHome,
       targetHome: managedCodexHome,
       onLog: input.onLog,
     });
+  let effectiveCodexHome = seededCodexHome;
+  let retention: CodexSessionRetentionContext | null = null;
+  if (input.adapterType === "codex_local") {
+    const runKey = safePathSegment(input.runId);
+    const runHome = path.join(input.stateDir, "codex-run-homes", runKey, "home");
+    retention = {
+      runHome,
+      retainedSessionsDir: path.join(input.stateDir, "codex-session-retention", runKey, "sessions"),
+    };
+    await prepareRunIsolatedCodexHome({
+      sourceHome: seededCodexHome,
+      runHome,
+      onLog: input.onLog,
+    });
+    effectiveCodexHome = runHome;
+  }
   const { allSkills, selectedSkills, desiredSkillNames } = await resolveSelectedRuntimeSkills(input.config, input.moduleDir);
   const skillSetKey = await buildSkillSetKey({ skills: selectedSkills, label: "codex" });
   const skillsHome = path.join(effectiveCodexHome, "skills");
@@ -1105,6 +1273,7 @@ async function prepareCodexSkillRuntime(input: {
       skillsHome,
     },
     commandNotes: [`Prepared ACPX Codex skill home at ${skillsHome}.`],
+    retention,
   };
 }
 
@@ -1740,6 +1909,7 @@ async function buildRuntime(input: {
   let skillsIdentity: Record<string, unknown> = { mode: "unsupported" };
   const skillCommandNotes: string[] = [];
   let paperclipClaudeSettings: PaperclipClaudeSettingsResult | null = null;
+  let codexSessionRetention: CodexSessionRetentionContext | null = null;
   if (acpxAgent === "claude") {
     const preparedSkills = await prepareClaudeSkillRuntime({
       stateDir,
@@ -1770,7 +1940,10 @@ async function buildRuntime(input: {
         companyId: agent.companyId,
         config,
         env,
+        adapterType: input.engine.adapterType,
         moduleDir: input.engine.moduleDir,
+        runId,
+        stateDir,
         onLog: input.ctx.onLog,
         onEvent: input.ctx.onEvent,
         now: nowMs,
@@ -1780,6 +1953,7 @@ async function buildRuntime(input: {
     );
     skillsIdentity = preparedSkills.identity;
     skillCommandNotes.push(...preparedSkills.commandNotes);
+    codexSessionRetention = preparedSkills.retention;
   } else if (acpxAgent === "gemini") {
     const preparedSkills = await prepareGeminiSkillRuntime({
       config,
@@ -2216,6 +2390,7 @@ async function buildRuntime(input: {
     },
     childStderrLogPath,
     paperclipClaudeSettings,
+    codexSessionRetention,
     mcpServers,
     mcpIdentity,
     stepMetrics,
@@ -4310,7 +4485,11 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           // Host lane: save a clean persistent warm-eligible turn, but carry the
           // live run-scoped credential so the gate blocks the transfer.
           if (!slots.has("acp_runtime")) return null;
-          const permits = clean && prepared.mode === "persistent" && warmIdleMs > 0;
+          const permits =
+            clean &&
+            prepared.mode === "persistent" &&
+            warmIdleMs > 0 &&
+            !prepared.codexSessionRetention;
           if (!permits) return null;
           return { kind: "host", causePermitsSave: true, liveRunScopedCredentials: [LIVE_RUN_SCOPED_API_KEY] };
         },
@@ -4425,6 +4604,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
                 : reason.completion.cause;
           const report = await settleAcpRun(runResourceLedger, cause, settlementSteps);
           recordDispositionReport(report);
+          await retainSanitizedCodexSessionsAfterClose({ prepared, onLog: ctx.onLog });
           if (childStderrState) flushChildStderr(childStderrState);
         },
         reproduceResult: (): AdapterExecutionResult => {

--- a/packages/adapter-utils/src/command-redaction.test.ts
+++ b/packages/adapter-utils/src/command-redaction.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_COMMAND_TEXT_VALUE, redactDiagnosticText } from "./command-redaction.js";
+import { REDACTED_COMMAND_TEXT_VALUE, redactCommandText, redactDiagnosticText } from "./command-redaction.js";
+
+const BOARD_TOKEN = `pcp_board_${"a1b2c3d4".repeat(6)}`;
+const CLI_AUTH_TOKEN = `pcp_cli_auth_${"f0e1d2c3".repeat(6)}`;
 
 describe("redactDiagnosticText", () => {
   it("redacts a JSON secret field value", () => {
@@ -77,5 +80,78 @@ describe("redactDiagnosticText", () => {
     const output = redactDiagnosticText(input);
     expect(output).not.toContain("MARKERBACKSLASH_B");
     expect(output).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+});
+
+describe("redactCommandText - Paperclip bearer credentials", () => {
+  it("redacts a bare board token with no surrounding secret-name hint", () => {
+    const out = redactCommandText(BOARD_TOKEN);
+    expect(out).not.toContain(BOARD_TOKEN);
+    expect(out).toBe(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts a board token inside a serialized header dump", () => {
+    const out = redactCommandText(`{"headers":{"x-api-key":"${BOARD_TOKEN}"}}`);
+    expect(out).not.toContain(BOARD_TOKEN);
+  });
+
+  it("redacts a board token in a curl invocation", () => {
+    const out = redactCommandText(`curl -sS -H 'x-api-key: ${BOARD_TOKEN}' http://localhost:3100/api/agents/me`);
+    expect(out).not.toContain(BOARD_TOKEN);
+  });
+
+  it("redacts CLI auth secrets", () => {
+    const out = redactCommandText(`stored credential ${CLI_AUTH_TOKEN} for localhost`);
+    expect(out).not.toContain(CLI_AUTH_TOKEN);
+  });
+
+  it("covers future pcp_<kind>_ credential prefixes generically", () => {
+    const future = `pcp_runner_${"0f1e2d3c".repeat(6)}`;
+    expect(redactCommandText(future)).not.toContain(future);
+  });
+
+  it("leaves non-credential pcp_ identifiers alone", () => {
+    // Short/non-hex suffixes are not credentials; a run or company id must survive.
+    const notASecret = "pcp_run_12";
+    expect(redactCommandText(notASecret)).toContain(notASecret);
+  });
+});
+
+describe("redactCommandText - Slack tokens", () => {
+  it("redacts bot tokens", () => {
+    const token = ["xoxb", "1234567890", "9876543210", "AbCdEfGhIjKlMnOpQrStUvWx"].join("-");
+    expect(redactCommandText(token)).not.toContain(token);
+  });
+
+  it("redacts app-level tokens", () => {
+    const token = ["xapp", "1", "A012BCDEFGH", "1234567890123", "abcdef0123456789"].join("-");
+    expect(redactCommandText(token)).not.toContain(token);
+  });
+
+  it("redacts a bot token inside a postMessage command", () => {
+    const token = ["xoxb", "1111111111", "2222222222", "ZzYyXxWwVvUuTtSsRrQqPpOo"].join("-");
+    const out = redactCommandText(
+      `curl -X POST https://slack.com/api/chat.postMessage -H "Authorization: Bearer ${token}"`,
+    );
+    expect(out).not.toContain(token);
+  });
+});
+
+describe("redactCommandText - existing behavior is preserved", () => {
+  it("still redacts OpenAI-style and Anthropic keys", () => {
+    const openai = ["sk", "proj", "abcdefghijklmnop123456"].join("-");
+    const anthropic = ["sk", "ant", "api03", "abcdefghijklmnopqrstuvwx"].join("-");
+    expect(redactCommandText(openai)).not.toContain(openai);
+    expect(redactCommandText(anthropic)).not.toContain(anthropic);
+  });
+
+  it("still redacts GitHub tokens", () => {
+    const token = ["ghp", "abcdefghijklmnopqrstuvwxyz0123456789"].join("_");
+    expect(redactCommandText(token)).not.toContain(token);
+  });
+
+  it("leaves ordinary command text untouched", () => {
+    const plain = "pnpm vitest run packages/adapter-utils";
+    expect(redactCommandText(plain)).toBe(plain);
   });
 });

--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -14,6 +14,15 @@ const COMMAND_ENV_SECRET_ASSIGNMENT_RE = new RegExp(
 const COMMAND_AUTHORIZATION_BEARER_RE = /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const COMMAND_OPENAI_KEY_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const COMMAND_GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+// Paperclip-issued bearer credentials. Minted in server/src/services/board-auth.ts as
+// `pcp_board_<48 hex>` and `pcp_cli_auth_<48 hex>`; the prefix segment is matched
+// generically so a future `pcp_<kind>_` credential is covered without another edit.
+// These are value-shaped: they leak as bare tokens in process stdout and in HTTP
+// header dumps, where no adjacent `key=` or `--flag` gives the name-based rules a handle.
+const COMMAND_PAPERCLIP_TOKEN_RE = /\bpcp_[a-z][a-z0-9_]*_[0-9a-f]{24,}\b/gi;
+// Slack tokens: bot (xoxb), user (xoxp), app (xoxa/xoxr), refresh (xoxs), and
+// app-level (xapp).
+const COMMAND_SLACK_TOKEN_RE = /\b(?:xox[abprs]|xapp)-[A-Za-z0-9-]{10,}\b/g;
 const COMMAND_JWT_RE =
   /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
 const COMMAND_SECRET_HINTS = [
@@ -35,6 +44,12 @@ const COMMAND_SECRET_HINTS = [
   "ghu_",
   "ghs_",
   "ghr_",
+  // Value-prefix hints. Without these, a chunk carrying a bare `pcp_board_...` or
+  // `xoxb-...` and nothing else can short-circuit out of redactCommandText before
+  // the patterns above ever run.
+  "pcp_",
+  "xox",
+  "xapp-",
 ] as const;
 
 function maybeContainsSecretText(command: string) {
@@ -54,6 +69,8 @@ export function redactCommandText(command: string, redactedValue = REDACTED_COMM
     )
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
+    .replace(COMMAND_PAPERCLIP_TOKEN_RE, redactedValue)
+    .replace(COMMAND_SLACK_TOKEN_RE, redactedValue)
     .replace(COMMAND_JWT_RE, redactedValue);
 }
 


### PR DESCRIPTION
## Summary
- port run-isolated Codex homes onto current master without push-protected ancestor history
- delete the raw Codex run home after sanitized session retention succeeds
- emit a structured quarantine incident event while preserving the existing quarantine log on retention failure

## Verification
- pnpm vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts packages/adapter-utils/src/command-redaction.test.ts -t "retains only sanitized run-local Codex session JSONL after the runtime closes|keeps the raw run home|redactCommandText - Paperclip bearer credentials|redactCommandText - Slack tokens|redactCommandText - existing behavior is preserved|redactDiagnosticText"
- pnpm --filter @paperclipai/adapter-utils typecheck (fails on existing current-master ACPX type drift: spawnCwd/onAgentStderr are not in installed AcpRuntimeOptions types)

## Notes
- Earlier push of the runtime-tool-policy ancestry was rejected by GitHub push protection on existing ancestor commits. Filed KEWL-3873 for Scotty-clip before using this clean-ancestry port.
- Live Paperclip run-home deletion proof still requires loading this branch/commit into the service and observing a real terminal run close.