### PR TITLE
fix(hermes): default quiet on and drop prompt-echo responses

### DIFF
--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -205,3 +205,92 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     }
   });
 });
+
+function lastRunArgs(): string[] {
+  const mocked = vi.mocked(serverUtils.runChildProcess);
+  const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+  return lastCall[2] as string[];
+}
+
+describe("hermes-local quiet default and prompt-echo guard (#11976)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes -Q when quiet is unset so runtime matches the schema default", async () => {
+    const { ctx } = makeCtx();
+    await execute(ctx as any);
+    expect(lastRunArgs()).toContain("-Q");
+  });
+
+  it("passes -Q when quiet is true", async () => {
+    const { ctx } = makeCtx({ quiet: true });
+    await execute(ctx as any);
+    expect(lastRunArgs()).toContain("-Q");
+  });
+
+  it("omits -Q when quiet is explicitly false", async () => {
+    const { ctx } = makeCtx({ quiet: false });
+    await execute(ctx as any);
+    expect(lastRunArgs()).not.toContain("-Q");
+  });
+
+  it("rejects a Query: # prompt echo even when exit code is 0", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "Query: # Agent instructions\nYou are the CTO of Evermail.\n",
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx({ quiet: false });
+    const result = await execute(ctx as any);
+
+    expect(result.resultJson).toMatchObject({ result: "" });
+    expect(result.summary).toBeUndefined();
+    expect(result.errorMessage).toMatch(/echoed the input prompt/i);
+  });
+
+  it("rejects stdout as the agent response when exit code is non-zero", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "Looks like a model answer but the process failed.\n",
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx();
+    const result = await execute(ctx as any);
+
+    expect(result.resultJson).toMatchObject({ result: "" });
+    expect(result.summary).toBeUndefined();
+    expect(result.errorMessage).toBe("Hermes exited with code 1");
+  });
+
+  it("keeps a successful quiet-mode response", async () => {
+    vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "Patched quiet default.\n\nsession_id: sess_abc123\n",
+      stderr: "",
+      pid: null,
+      startedAt: null,
+    });
+
+    const { ctx } = makeCtx();
+    const result = await execute(ctx as any);
+
+    expect(result.resultJson).toMatchObject({
+      result: "Patched quiet default.",
+      session_id: "sess_abc123",
+    });
+    expect(result.summary).toBe("Patched quiet default.");
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -226,6 +226,9 @@ const TOKEN_USAGE_REGEX =
 /** Regex to extract cost from Hermes output. */
 const COST_REGEX = /(?:cost|spent)[:\s]*\$?([\d.]+)/i;
 
+/** Hermes non-quiet mode echoes the prompt as "Query: # ..." on provider failure. */
+const PROMPT_ECHO_REGEX = /^\s*Query:\s*#/m;
+
 interface ParsedOutput {
   sessionId?: string;
   response?: string;
@@ -415,8 +418,9 @@ export async function execute(
   }
 
   // ── Build command args ─────────────────────────────────────────────────
-  // Use -Q (quiet) to get clean output: just response + session_id line
-  const useQuiet = cfgBoolean(config.quiet) === true; // default false
+  // Use -Q (quiet) to get clean output: just response + session_id line.
+  // Default true so runtime matches config-schema and README (#11976).
+  const useQuiet = cfgBoolean(config.quiet) !== false;
   const args: string[] = ["chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 
@@ -543,6 +547,18 @@ export async function execute(
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
+  // Never treat a prompt echo or non-zero exit stdout as agent output (#11976).
+  if (
+    parsed.response &&
+    (PROMPT_ECHO_REGEX.test(parsed.response) ||
+      (result.exitCode !== 0 && result.exitCode != null))
+  ) {
+    if (PROMPT_ECHO_REGEX.test(parsed.response) && !parsed.errorMessage) {
+      parsed.errorMessage =
+        "Hermes echoed the input prompt instead of producing a response (provider failure or quiet mode off).";
+    }
+    parsed.response = undefined;
+  }
 
   await ctx.onLog(
     "stdout",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The built-in `hermes_local` adapter starts `hermes chat` for each heartbeat and treats stdout as the agent reply.
> - The UI and config schema default Quiet output to on, but the runtime treated an unset `quiet` key as off.
> - In non-quiet mode Hermes prints `Query: ` plus the full prompt to stdout before the model runs.
> - When every provider fails, that echo is often the only stdout, and the adapter still stored it as `resultJson.result`.
> - Paperclip then posted the agent instructions as an issue comment and marked the run succeeded.
> - This pull request defaults quiet to on, drops a `Query: #` prompt echo, and drops stdout when the process exits non-zero.
> - The benefit is a failed provider path stays a failed run and does not dump AGENTS.md into the issue thread.

## Linked Issues or Issue Description

Fixes #11976

Related public work (not duplicates of this full fix):

- #10929 — strips a leading `Query:` line in `cleanResponse()`. That is not enough for #11976: Hermes echoes the whole prompt after `Query: #`, so the remaining instruction body would still become the reply. #10929 also does not change the quiet runtime default and does not drop stdout on a non-zero exit. Last update 2026-08-06.
- #10445 — hardens session-id parsing. Different bug.

### What happened?

Unset `adapterConfig.quiet` resolved to false at runtime while the schema default is true. On a provider outage, Hermes printed `Query: #` plus the agent instructions, and the adapter posted that stdout as the agent reply.

### Expected behavior

Unset quiet should pass `-Q`. A `Query: #` echo or a non-zero exit must not become `resultJson.result`.

### Steps to reproduce

1. Create a `hermes_local` agent in the UI. Do not touch the Quiet output toggle.
2. Confirm `adapterConfig` has no `quiet` key while the form shows Quiet output on.
3. Make every provider in the Hermes fallback chain fail (for example HTTP 402 or 429).
4. Wake the agent on any issue.
5. Observed before this change: a comment that starts with `Query: #` and contains the instructions file; run status succeeded.
6. Expected after this change: no prompt-echo comment; the run surfaces as a failure.

### Paperclip version or commit

`@paperclipai/hermes-paperclip-adapter` 2026.817.0. Reproduced on current `master` (`execute.ts` still uses `cfgBoolean(config.quiet) === true`).

### Deployment mode

Self-hosted local Paperclip (`local_trusted`) with the managed npm CLI install.

## What Changed

- Runtime quiet default now matches the schema: unset `quiet` passes Hermes `-Q`. Explicit `quiet: false` still omits `-Q`.
- After parse, discard `parsed.response` when it matches `/^\s*Query:\s*#/m`.
- After parse, discard `parsed.response` when `exitCode` is a non-zero number.
- If the discarded text is a prompt echo and there is no error yet, set `errorMessage` to a short prompt-echo diagnostic.
- Add unit tests for the quiet flag, prompt-echo discard, non-zero-exit discard, and a successful quiet-mode reply.

## Verification

From the hermes adapter package:

```sh
cd packages/adapters/hermes
pnpm test -- src/server/execute.onspawn.test.ts
```

Expected: 13 tests pass.

These tests mock `runChildProcess`. They do not need a live Hermes binary.

I also ran `pnpm test` in that package. 74 tests passed. 3 tests failed because this sparse checkout has no working Hermes CLI or API keys (`command-resolution` and `detect-model` environment checks). Those failures are unrelated to this diff.

## Risks

Low and limited to `hermes_local` execute:

- Agents that never wrote `quiet` will start using `-Q`. That matches the UI toggle they already see as on.
- Operators who want non-quiet transcripts must set `quiet: false` explicitly.
- A real model reply that starts with `Query: #` would be discarded. Hermes prompt echoes use that shape. Normal agent replies do not.
- Non-zero-exit stdout is no longer treated as a successful reply. Timeout and null-exit signal cancellation still skip the generic exit-code error path.

## Model Used

- Provider: Cursor (xAI Grok)
- Model: Cursor Grok 4.6
- Mode: agentic tool use with GitHub CLI, vitest, and repository reads
- Context window: not exposed by this session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (README already documents quiet default true)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
