### PR TITLE
fix(adapters): unblock a fresh gemini_local agent's first heartbeat (session-resume, workspace trust, stale model)

### DIFF
--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -14,9 +14,11 @@ export const models = [
   { id: DEFAULT_GEMINI_LOCAL_MODEL, label: "Auto" },
   { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
   { id: "gemini-3.1-pro-preview-customtools", label: "Gemini 3.1 Pro Preview (Custom Tools)" },
+  { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
+  { id: "gemini-3.5-flash-lite", label: "Gemini 3.5 Flash Lite" },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-  { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
+  { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite (deprecated for new API keys)" },
   { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
   { id: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
 ];
@@ -27,7 +29,7 @@ export const modelProfiles: AdapterModelProfileDefinition[] = [
     label: "Cheap",
     description: "Use Gemini Flash Lite as the budget Gemini CLI lane while preserving the primary model.",
     adapterConfig: {
-      model: "gemini-2.5-flash-lite",
+      model: "gemini-3.5-flash-lite",
     },
     source: "adapter_default",
   },

--- a/packages/adapters/gemini-local/src/server/execute.acp-fallback.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.acp-fallback.test.ts
@@ -118,6 +118,17 @@ describe("gemini_local ACP startup fallback", () => {
     );
   });
 
+  it("trusts the workspace for local (non-remote) headless execution too", async () => {
+    const ctx = buildContext();
+
+    await execute(ctx as never);
+
+    const call = runAdapterExecutionTargetProcess.mock.calls[0] as unknown as
+      | [string, unknown, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(call?.[4].env.GEMINI_CLI_TRUST_WORKSPACE).toBe("true");
+  });
+
   it("keeps explicit ACP strict when startup fails", async () => {
     const ctx = buildContext({ engine: "acp" });
 

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -309,7 +309,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionTargetIsRemote,
     executionCwd: effectiveExecutionCwd,
   });
-  if (executionTargetIsRemote && typeof env.GEMINI_CLI_TRUST_WORKSPACE !== "string") {
+  // Paperclip's headless runner never has an interactive TTY to answer the
+  // Gemini CLI's "trust this folder?" prompt, for local execution just as
+  // much as remote — the workspace is either a fresh fallback dir (no
+  // persistent project) or effectively new to the CLI's per-project trust
+  // store on every run. Without this, every local invocation without an
+  // already-trusted folder hard-fails headlessly.
+  if (typeof env.GEMINI_CLI_TRUST_WORKSPACE !== "string") {
     env.GEMINI_CLI_TRUST_WORKSPACE = "true";
   }
   if (authToken) {
@@ -516,9 +522,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
     notes.push("Added --approval-mode yolo for unattended execution.");
     notes.push("Set headless terminal/browser env so Gemini fails fast instead of opening interactive auth or color prompts.");
-    if (executionTargetIsRemote) {
-      notes.push("Set GEMINI_CLI_TRUST_WORKSPACE=true for remote headless execution.");
-    }
+    notes.push("Set GEMINI_CLI_TRUST_WORKSPACE=true for headless execution.");
     if (!instructionsFilePath) return notes;
     if (instructionsPrefix.length > 0) {
       notes.push(

--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -157,6 +157,12 @@ describe("isGeminiSessionUnrecoverableError", () => {
     expect(isGeminiSessionUnrecoverableError("", "Resumed session abc-123 not found on disk")).toBe(true);
   });
 
+  it("matches the Gemini CLI's actual 'no previous sessions found for this project' error", () => {
+    expect(
+      isGeminiSessionUnrecoverableError("", "Error resuming session: No previous sessions found for this project."),
+    ).toBe(true);
+  });
+
   it("matches 'exceeds the maximum number of tokens' (compression overflow)", () => {
     const stderr =
       '_ApiError: {"error":{"code":400,"message":"The input token count exceeds the maximum number of tokens allowed 1048576","status":"INVALID_ARGUMENT"}} at ChatCompressionService.compress';

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -206,7 +206,7 @@ export function isGeminiSessionUnrecoverableError(stdout: string, stderr: string
     .filter(Boolean)
     .join("\n");
 
-  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|exceeds\s+the\s+maximum\s+number\s+of\s+tokens|input\s+token\s+count\s+exceeds/i.test(
+  return /unknown\s+session|session\s+.*\s+not\s+found|no\s+(?:previous\s+)?sessions?\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|exceeds\s+the\s+maximum\s+number\s+of\s+tokens|input\s+token\s+count\s+exceeds/i.test(
     haystack,
   );
 }

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -275,7 +275,7 @@ describe("server adapter registry", () => {
     await expect(listAdapterModelProfiles("gemini_local")).resolves.toEqual([
       expect.objectContaining({
         key: "cheap",
-        adapterConfig: expect.objectContaining({ model: "gemini-2.5-flash-lite" }),
+        adapterConfig: expect.objectContaining({ model: "gemini-3.5-flash-lite" }),
         source: "adapter_default",
       }),
     ]);


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `gemini_local` adapter drives the Gemini CLI headlessly for agent heartbeats and tasks
> - An agent without a persistent project workspace gets a fresh fallback workspace directory on every run, so it can never resume a Gemini CLI session and always hits the CLI's own "not trusted" and "no previous session" headless gates
> - Neither gate was actually handled: the session-resume retry regex did not match the CLI's real error string, and the workspace-trust bypass only applied to remote execution targets
> - This pull request fixes both gates, plus a stale default model that the Gemini API now rejects for new API keys
> - The benefit is that a freshly configured `gemini_local` agent (a very common first-run case) can complete a heartbeat at all, instead of failing every single run

## Linked Issues or Issue Description

Fixes: #6806

Additional issue not yet filed publicly (workspace-trust gate and stale model), described here per the feature/bug template:

- **Subsystem affected:** `gemini_local` adapter, local (non-remote) execution path.
- **Problem or motivation:** Two more headless-execution gates block a fresh `gemini_local` agent from ever completing a run: (1) the Gemini CLI's per-project trust prompt has no way to be satisfied headlessly for local execution (`GEMINI_CLI_TRUST_WORKSPACE` was only set for remote execution targets), so every local run without an already-trusted folder hard-fails with "Gemini CLI is not running in a trusted directory"; (2) `gemini-2.5-flash-lite`, hardcoded as the `modelProfiles` "cheap" lane default and listed in the model picker, is rejected by the live Gemini API for new API keys ("This model ... is no longer available to new users").
- **Proposed solution:** Set `GEMINI_CLI_TRUST_WORKSPACE=true` unconditionally for headless execution (local and remote alike — Paperclip's runner never has an interactive TTY either way), and replace the deprecated default model with `gemini-3.5-flash-lite`, verified against the live API.
- **Alternatives considered:** Only fixing the regex (from #6806) is not sufficient on its own — a fresh agent still fails on the trust gate immediately after the session-resume retry succeeds, and then again on the deprecated model. All three needed fixing together to get a single heartbeat to actually complete.
- **Roadmap alignment:** Bug fix in an existing adapter, not core feature work.

**Dedup search (PR list):** searched `gemini session`, `gemini trust workspace`, `gemini-local` across open and closed PRs.

- #6885 (**closed**, unmerged) previously attempted the exact same regex fix for #6806, but never landed — the bug is still present on current `master` (reproduced live on 2026-08-23). This PR carries that same regex change forward, plus the two additional fixes needed to actually unblock a run end-to-end.
- #11231 (**open**) fixes a related-but-distinct bug: the ACP execution engine's `session/set_config_option` call is unimplemented by Gemini's ACP server. This PR does not touch the ACP path (`packages/adapter-utils/src/acpx-engine/`) at all — it's scoped entirely to the CLI/local execution path in `packages/adapters/gemini-local/`. No overlap.
- #2877, #3159, #3667, #10214, #10782, #10783, #11963 are older or differently-scoped `gemini-local` fixes (Windows compatibility, sandbox-target handling, cost reporting, error classification) that don't touch this code path.

## What Changed

- `packages/adapters/gemini-local/src/server/parse.ts`: added `no\s+(?:previous\s+)?sessions?\s+found` to `isGeminiSessionUnrecoverableError`'s regex, matching the Gemini CLI's actual `Error resuming session: No previous sessions found for this project.` message so the existing fresh-session retry in `execute.ts` fires instead of the run failing outright.
- `packages/adapters/gemini-local/src/server/execute.ts`: `GEMINI_CLI_TRUST_WORKSPACE=true` is now set for local execution too, not only `executionTargetIsRemote`. Paperclip's headless runner has no interactive TTY to answer the trust prompt either way, and an agent without a persistent project gets a brand-new fallback workspace directory (never in the CLI's trust store) on every single run.
- `packages/adapters/gemini-local/src/index.ts`: added `gemini-3.5-flash` / `gemini-3.5-flash-lite` to the model picker; replaced the deprecated `gemini-2.5-flash-lite` default in the `cheap` model profile with `gemini-3.5-flash-lite` (verified working against the live Gemini API); labeled the still-listed `gemini-2.5-flash-lite` entry as deprecated for new API keys rather than removing it, since some existing configs may still resolve it successfully on older API keys/projects.
- `server/src/__tests__/adapter-registry.test.ts`: updated the `cheap` model-profile assertion to match.
- New tests: a regression case for the CLI's actual error string in `parse.test.ts`, and a new case in `execute.acp-fallback.test.ts` asserting local (non-remote) execution also sets `GEMINI_CLI_TRUST_WORKSPACE=true`.

## Verification

```bash
pnpm --filter @paperclipai/adapter-gemini-local typecheck   # passes
pnpm --filter @paperclipai/server typecheck                  # passes
npx vitest run packages/adapters/gemini-local/ server/src/__tests__/adapter-registry.test.ts
# 63/64 passing — the 1 failure ("Could not determine remote file size...") is pre-existing
# and unrelated: confirmed identical with this PR's changes stashed out, on unmodified branch HEAD.
```

End-to-end verified live against a real Google AI Studio API key on a self-hosted instance, for a freshly created `gemini_local` agent with no persistent project (the common first-run case this PR targets):

- **Before this PR:** every heartbeat failed instantly. First with `Error resuming session: No previous sessions found for this project.` (exit 42, the #6806 bug). After manually clearing the stored session, the CLI mode's `--model` flag also surfaced the deprecated-model error from Google. After switching to a valid model, it then hit `Gemini CLI is not running in a trusted directory.`
- **After this PR:** the same agent's heartbeat runs to completion (`exit_code: 0`, a real Gemini session created), with no manual intervention.

## Risks

Low. `GEMINI_CLI_TRUST_WORKSPACE=true` widens an existing remote-only bypass to local execution — this only affects the CLI's own headless trust gate for workspace directories Paperclip itself already manages and passes as `cwd`/`--include-directories`; it does not change file-system permissions or expose anything new. The model-list change is additive (old entries kept, so existing per-agent configs referencing `gemini-2.5-flash-lite` keep working if their key/project still permits it) except for the `cheap` profile's default, which was actively broken for any new API key.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), used interactively: root-caused all three issues by reproducing the failure chain live against a running self-hosted instance (manual `gemini` CLI invocations inside the container, direct Gemini API `models` endpoint queries to identify the current valid model set), fixed and verified each fix in turn against the same live instance before writing the corresponding regression test.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/gemini-session-resume-detection`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no user-facing docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
