### PR TITLE
fix(claude-local): stop reporting the terminal-result cleanup SIGTERM as a failure

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.terminal-result-cleanup.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.terminal-result-cleanup.test.ts
@@ -107,6 +107,31 @@ describe("claude_local terminal-result cleanup exit code", () => {
     });
   });
 
+  it("treats a force-killed cleanup the same way", async () => {
+    // SIGKILL after the grace period only means the leftover background task
+    // ignored SIGTERM. Both signals land after the terminal result was parsed,
+    // so the turn is no less complete than in the SIGTERM case.
+    runAdapterExecutionTargetProcess.mockResolvedValue(
+      procResult({
+        exitCode: 137,
+        terminalResultCleanup: {
+          kind: "terminal_result_cleanup",
+          stopped: true,
+          stopReason: "unmanaged_background_task_stopped",
+          reason: "unmanaged background task stopped; no durable live path",
+          terminalResultSeen: true,
+          signal: "SIGKILL",
+          forceKilled: true,
+        },
+      }),
+    );
+
+    const result = await execute(buildContext() as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.errorMessage ?? null).toBeNull();
+  });
+
   it("still reports a non-zero exit code when the cleanup did not stop the run", async () => {
     runAdapterExecutionTargetProcess.mockResolvedValue(procResult({ terminalResultCleanup: null }));
 

--- a/packages/adapters/claude-local/src/server/execute.terminal-result-cleanup.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.terminal-result-cleanup.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const successStream = [
+  JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }),
+  JSON.stringify({
+    type: "assistant",
+    session_id: "claude-session-1",
+    message: { content: [{ type: "text", text: "done" }] },
+  }),
+  JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    session_id: "claude-session-1",
+    result: "done",
+    usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+  }),
+].join("\n");
+
+const { runAdapterExecutionTargetProcess } = vi.hoisted(() => ({
+  runAdapterExecutionTargetProcess: vi.fn(),
+}));
+
+vi.mock("./acp.js", () => ({
+  createClaudeAcpExecutor: () => vi.fn(),
+  formatClaudeAcpFallbackMessage: (reason: string) => reason,
+  resolveClaudeExecutionEngineForRun: async () => ({ engine: "cli", explicit: true }),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+    ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+    resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "claude"),
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildContext() {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: {},
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+function procResult(extra: Record<string, unknown>) {
+  return {
+    exitCode: 143,
+    signal: null,
+    timedOut: false,
+    stdout: successStream,
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+describe("claude_local terminal-result cleanup exit code", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not report the harness's own cleanup SIGTERM as an adapter failure", async () => {
+    // The cleanup fires only after the turn's terminal result is already on the
+    // wire: the CLI is still held open by an unmanaged background task, so
+    // Paperclip SIGTERMs the process group and the CLI exits 143. That code is
+    // ours, not the CLI's — reporting it verbatim makes the heartbeat record a
+    // completed turn as `failed` with the default "Adapter failed" message, and
+    // the issue is then pushed to `blocked` by terminal run recovery.
+    runAdapterExecutionTargetProcess.mockResolvedValue(
+      procResult({
+        terminalResultCleanup: {
+          kind: "terminal_result_cleanup",
+          stopped: true,
+          stopReason: "unmanaged_background_task_stopped",
+          reason: "unmanaged background task stopped; no durable live path",
+          terminalResultSeen: true,
+          signal: "SIGTERM",
+          forceKilled: false,
+        },
+      }),
+    );
+
+    const result = await execute(buildContext() as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.errorMessage ?? null).toBeNull();
+    expect(result.resultJson).toMatchObject({
+      unmanagedBackgroundTask: { stopReason: "unmanaged_background_task_stopped" },
+    });
+  });
+
+  it("still reports a non-zero exit code when the cleanup did not stop the run", async () => {
+    runAdapterExecutionTargetProcess.mockResolvedValue(procResult({ terminalResultCleanup: null }));
+
+    const result = await execute(buildContext() as never);
+
+    expect(result.exitCode).toBe(143);
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1092,6 +1092,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // makes the heartbeat fail a run whose turn actually completed. Treat the
     // exit code as clean in that case; `parsedIsError` still decides whether
     // the turn itself failed.
+    //
+    // `forceKilled` is deliberately not part of the condition. It only records
+    // that the leftover background task ignored SIGTERM and had to be SIGKILLed
+    // after the grace period. Both signals land after the terminal result is
+    // already parsed, so neither says anything about the turn itself, and both
+    // exit codes are equally ours.
     const stoppedByTerminalResultCleanup =
       proc.terminalResultCleanup?.stopped === true &&
       proc.terminalResultCleanup.terminalResultSeen === true;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1085,7 +1085,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const parsedIsError = asBoolean(parsed.is_error, false);
     const parsedSubtype = asString(parsed.subtype, "").trim().toLowerCase();
     const parsedSucceeded = parsedSubtype === "success" && !parsedIsError;
-    const failed = !parsedSucceeded && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
+    // Paperclip's own terminal-result cleanup SIGTERMs the process group once
+    // the turn's terminal result is already on the wire but the CLI is still
+    // held open by an unmanaged background task. The resulting exit code (143)
+    // is produced by the harness, not by the CLI, so reporting it verbatim
+    // makes the heartbeat fail a run whose turn actually completed. Treat the
+    // exit code as clean in that case; `parsedIsError` still decides whether
+    // the turn itself failed.
+    const stoppedByTerminalResultCleanup =
+      proc.terminalResultCleanup?.stopped === true &&
+      proc.terminalResultCleanup.terminalResultSeen === true;
+    const effectiveExitCode = stoppedByTerminalResultCleanup ? 0 : proc.exitCode;
+    const failed = !parsedSucceeded && ((effectiveExitCode ?? 0) !== 0 || parsedIsError);
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
     // session id; if the last entry contains a non-`msg_`-prefixed
@@ -1112,7 +1123,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const errorMessage = failed
-      ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
+      ? describeClaudeFailure(parsed) ?? `Claude exited with code ${effectiveExitCode ?? -1}`
       : null;
     const providerQuota =
       failed &&
@@ -1190,7 +1201,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     return {
-      exitCode: proc.exitCode,
+      exitCode: effectiveExitCode,
       signal: proc.signal,
       timedOut: false,
       errorMessage,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat runner starts an adapter process for each agent turn and records the outcome in `heartbeat_runs`
> - `runChildProcess` stops a process group with SIGTERM when the turn result is on the wire but the CLI stays open because of an unmanaged background task
> - The exit code from that stop is 143, and `claude-local` reports it as the run exit code
> - The heartbeat reads a non-zero exit code as a failure, so a completed turn becomes a `failed` run with the default message `Adapter failed`
> - Terminal run recovery then moves the issue to `blocked`, and a person must clear it by hand
> - This pull request reports a clean exit code when Paperclip stops the run itself after it sees the terminal result
> - The benefit is that completed turns are recorded as completed, and issues stop moving to `blocked` for a stop that Paperclip performed on purpose

## Linked Issues or Issue Description

No matching public issue exists. The problem is described below with the bug report template.

**Pre-submission checklist**

I searched the open and merged pull requests for `unmanaged background`, `terminal result cleanup`, `SIGTERM`, and `exit 143`. I found no duplicate. I can reproduce the behavior on `master`. The defect is in Paperclip itself, in `packages/adapters/claude-local/src/server/execute.ts`.

**What happened?**

An agent turn completes. The CLI writes its terminal result. The CLI process stays open because the agent left a background task. After the cleanup grace period, Paperclip sends SIGTERM to the process group. The CLI exits with code 143. Paperclip records the run as `failed` with the message `Adapter failed` and no detail. Terminal run recovery moves the issue to `blocked`.

On one deployment, every run in a week with `error = 'Adapter failed'` and `exit_code = 143` also carried `result_json.unmanagedBackgroundTask` — 115 of 115:

```sql
select count(*) filter (where result_json ? 'unmanagedBackgroundTask') as with_evidence,
       count(*) as total
from heartbeat_runs
where error = 'Adapter failed' and exit_code = 143
  and created_at > now() - interval '7 days';
-- 115 | 115
```

The payload is the same in all of them. `terminalResultSeen` is `true`, so the turn produced its result. `forceKilled` is `false`, so SIGTERM was enough.

Over 30 days of the same table, the split shows how narrow the race is:

| status | exit_code | runs |
|---|---|---|
| `failed` | 143 | 143 |
| `succeeded` | 0 | 3 |

The 3 successes are the same event. The CLI exited on its own before the SIGTERM arrived.

**Expected behavior**

A run that Paperclip stops with its own cleanup, after it sees the terminal result, must not be recorded as an adapter failure. Paperclip already has the correct handling for this case — `hasUnmanagedBackgroundTaskEvidence` and the successful-run handoff. That code is on the successful-run path, so such a run never reaches it.

**Steps to reproduce**

1. Give a `claude_local` agent a task that starts a background shell command and does not wait for it.
2. Let the agent finish its turn and write the terminal result.
3. Keep the background command alive for more than `terminalResultCleanupGraceMs` (default 5000 ms).
4. Read the run row in `heartbeat_runs`. The status is `failed`, the error is `Adapter failed`, and `exit_code` is 143.

**Paperclip version or commit**

Reproduced on `master` at `05b35d466`. Measured on release `2026.817.0`.

**Deployment mode**

Local single-machine instance.

**Installation method**

npm package `paperclipai`.

**Agent adapter(s) involved**

Claude Code (`claude_local`).

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts` computes `effectiveExitCode`. It is `0` when `proc.terminalResultCleanup.stopped` is `true` and `terminalResultCleanup.terminalResultSeen` is `true`. Otherwise it is `proc.exitCode`.
- `failed`, the `errorMessage` fallback text, and the returned `exitCode` use `effectiveExitCode`.
- `packages/adapters/claude-local/src/server/execute.terminal-result-cleanup.test.ts` adds three tests.

The change affects only the branch where the stream parsed into a result. The branch for unparseable output is not changed. A run with no parseable result is a real failure.

## Verification

```bash
npx vitest run packages/adapters/claude-local/src/server/execute.terminal-result-cleanup.test.ts
# Test Files  1 passed (1)
# Tests  3 passed (3)
```

The two tests are:

- Exit code 143 with cleanup evidence and a `subtype: "success"` result. The adapter returns exit code `0` and no `errorMessage`. `resultJson.unmanagedBackgroundTask` is still present, so the liveness classifier keeps its signal.
- Exit code 137 with force-killed cleanup evidence. The adapter returns exit code `0`.
- Exit code 143 with no cleanup evidence. The adapter still returns 143.

The first test fails against the unpatched code with `expected 143 to be +0`.

I also ran the full adapter directory before and after the change. The same three files fail in both runs, and none of them touch exit-code handling. Each of those files passes when it runs alone, so the failures come from the shared run and not from this change.

```bash
npx vitest run packages/adapters/claude-local/src/server/
```

## Risks

Low risk. The new condition needs two fields that only Paperclip sets, and it sets them only after its own cleanup ran on a turn whose terminal result it already saw. A non-zero exit code with no cleanup evidence keeps its old value. `parsedIsError` still decides whether the turn itself failed, so a failed turn stays failed even when the cleanup ran.

`forceKilled` is deliberately not part of the condition. Greptile asked whether the force-killed state was considered, so the reasoning is written out here and in the code comment. `forceKilled` records only that the leftover background task ignored SIGTERM and had to be SIGKILLed after the grace period. Both signals land after the terminal result is already parsed, so neither tells you anything about the turn, and both exit codes are equally produced by Paperclip. A test covers the force-killed case. In the measured data every observed row had `forceKilled: false`, so this path is rare, but excluding it would leave the same defect for the rare case.

The cleanup evidence stays in `resultJson.unmanagedBackgroundTask`. Nothing that reads it loses its signal, so the liveness classifier and the successful-run handoff still see that the run ended this way.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
