### PR TITLE
fix(issues): arm a default wait monitor when an interaction parks the issue

### DIFF
--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -2972,6 +2972,26 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("re-reads the issue before it arms, so a concurrent monitor is not overwritten", async () => {
+    // The request snapshot is taken before the interaction is created. A policy
+    // written from that snapshot would discard whatever landed in between.
+    mockIssueService.getById
+      .mockResolvedValueOnce(createIssue())
+      .mockResolvedValue(createIssue({ monitorNextCheckAt: new Date("2026-01-09T10:00:00.000Z") }));
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions")
+      .send({
+        kind: "suggest_tasks",
+        payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.getById).toHaveBeenCalledTimes(2);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("does not arm for an interaction that never wakes the assignee", async () => {
     mockInteractionService.create.mockResolvedValue({
       id: "interaction-quiet",

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -25,6 +25,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   listReviewAttention: vi.fn(),
   addComment: vi.fn(),
+  update: vi.fn(),
 }));
 
 const mockInteractionService = vi.hoisted(() => ({
@@ -295,6 +296,7 @@ describe.sequential("issue thread interaction routes", () => {
       explanation: "Allowed by test grant.",
     }));
     mockIssueService.getById.mockResolvedValue(createIssue());
+    mockIssueService.update.mockResolvedValue(createIssue());
     mockIssueService.listReviewAttention.mockResolvedValue(new Map());
     mockInteractionService.listForIssue.mockResolvedValue([]);
     mockInteractionService.expireRequestConfirmationsSupersededByHistoricalComments.mockResolvedValue([]);
@@ -2917,5 +2919,94 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockInteractionService.answerQuestions).toHaveBeenCalledTimes(1);
     expect(mockDbTransaction).not.toHaveBeenCalled();
     expect(mockCrossIssueInfluence.inserted).toEqual([]);
+  });
+  it("arms a default wait monitor when a wake-on-response gate lands on an unmonitored issue", async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions")
+      .send({
+        kind: "suggest_tasks",
+        payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        monitorNextCheckAt: expect.any(Date),
+        executionPolicy: expect.objectContaining({
+          monitor: expect.objectContaining({
+            serviceName: "pending issue interaction",
+            nextCheckAt: expect.any(String),
+          }),
+        }),
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.monitor_scheduled",
+        details: expect.objectContaining({
+          source: "interaction.wait_monitor_default",
+          interactionId: "interaction-1",
+        }),
+      }),
+    );
+  });
+
+  it("leaves a monitor the agent already armed alone", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      createIssue({ monitorNextCheckAt: new Date("2026-01-09T10:00:00.000Z") }),
+    );
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions")
+      .send({
+        kind: "suggest_tasks",
+        payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("does not arm for an interaction that never wakes the assignee", async () => {
+    mockInteractionService.create.mockResolvedValue({
+      id: "interaction-quiet",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+    });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions")
+      .send({
+        kind: "request_confirmation",
+        continuationPolicy: "none",
+        payload: { version: 1, prompt: "Ship it?" },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("still returns the created gate when arming the wait monitor fails", async () => {
+    mockIssueService.update.mockRejectedValue(new Error("db down"));
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions")
+      .send({
+        kind: "suggest_tasks",
+        payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).toHaveBeenCalled();
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -213,11 +213,16 @@ import {
 } from "../services/company-search-rate-limit.js";
 import {
   applyIssueExecutionPolicyTransition,
+  applyIssueMonitorPolicyTransition,
   normalizeIssueExecutionPolicy,
   parseIssueExecutionState,
   redactIssueMonitorExternalRef,
   setIssueExecutionPolicyMonitorScheduledBy,
 } from "../services/issue-execution-policy.js";
+import {
+  buildInteractionWaitMonitorPolicy,
+  INTERACTION_WAIT_MONITOR_SERVICE_NAME,
+} from "../services/issue-interaction-wait-monitor.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 import {
@@ -11316,8 +11321,76 @@ export function issueRoutes(
       }, "failed to wake addressee on issue interaction creation"));
     }
 
+    // Best effort: the interaction is already committed, so a failure to arm the
+    // wait monitor must not turn a created gate into a 5xx the agent retries.
+    await armInteractionWaitMonitor(issue, interaction, actor).catch((err) => {
+      logger.warn(
+        { err, issueId: issue.id, interactionId: interaction.id },
+        "interaction wait monitor arming failed",
+      );
+    });
+
     res.status(201).json(interaction);
   });
+
+  /**
+   * A wake-on-response interaction parks the issue on an answer that may never
+   * come. Give the wait a server-owned floor: if the issue carries no monitor yet,
+   * arm a default one so the assignee is re-woken instead of aging out silently.
+   * An agent that arms its own monitor keeps it — this never overwrites.
+   */
+  async function armInteractionWaitMonitor(
+    issue: Awaited<ReturnType<typeof svc.getById>>,
+    interaction: { id: string; kind: string; continuationPolicy: string },
+    actor: ReturnType<typeof getActorInfo>,
+  ) {
+    if (!issue) return;
+    const policy = buildInteractionWaitMonitorPolicy({
+      issue,
+      interaction,
+      now: new Date(),
+    });
+    if (!policy) return;
+
+    const transition = applyIssueMonitorPolicyTransition({
+      issue,
+      policy,
+      previousPolicy: normalizeIssueExecutionPolicy(issue.executionPolicy ?? null),
+      requestedStatus: issue.status,
+      requestedAssigneePatch: {},
+      actor: { agentId: actor.agentId ?? null, userId: null },
+      monitorExplicitlyUpdated: true,
+    });
+    const updated = await svc.update(issue.id, {
+      ...transition.patch,
+      // The jsonb column takes a plain record; IssueExecutionPolicy has no index signature.
+      executionPolicy: policy as unknown as Record<string, unknown>,
+    });
+    if (!updated) return;
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      agentApiKeyId: actor.agentApiKeyId,
+      action: "issue.monitor_scheduled",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        source: "interaction.wait_monitor_default",
+        interactionId: interaction.id,
+        interactionKind: interaction.kind,
+        continuationPolicy: interaction.continuationPolicy,
+        nextCheckAt: policy.monitor?.nextCheckAt ?? null,
+        serviceName: INTERACTION_WAIT_MONITOR_SERVICE_NAME,
+        timeoutAt: policy.monitor?.timeoutAt ?? null,
+        maxAttempts: policy.monitor?.maxAttempts ?? null,
+      },
+    });
+  }
 
   router.post(
     "/issues/:id/interactions/:interactionId/accept",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -11323,7 +11323,7 @@ export function issueRoutes(
 
     // Best effort: the interaction is already committed, so a failure to arm the
     // wait monitor must not turn a created gate into a 5xx the agent retries.
-    await armInteractionWaitMonitor(issue, interaction, actor).catch((err) => {
+    await armInteractionWaitMonitor(issue.id, interaction, actor).catch((err) => {
       logger.warn(
         { err, issueId: issue.id, interactionId: interaction.id },
         "interaction wait monitor arming failed",
@@ -11338,12 +11338,18 @@ export function issueRoutes(
    * come. Give the wait a server-owned floor: if the issue carries no monitor yet,
    * arm a default one so the assignee is re-woken instead of aging out silently.
    * An agent that arms its own monitor keeps it — this never overwrites.
+   *
+   * The issue is read again here instead of reusing the request snapshot. Writing
+   * the whole `executionPolicy` from a snapshot taken before the interaction was
+   * created would discard stages or settings that landed in between, and the
+   * "already armed" guard has to see the current monitor to hold.
    */
   async function armInteractionWaitMonitor(
-    issue: Awaited<ReturnType<typeof svc.getById>>,
+    issueId: string,
     interaction: { id: string; kind: string; continuationPolicy: string },
     actor: ReturnType<typeof getActorInfo>,
   ) {
+    const issue = await svc.getById(issueId);
     if (!issue) return;
     const policy = buildInteractionWaitMonitorPolicy({
       issue,

--- a/server/src/services/issue-interaction-wait-monitor.test.ts
+++ b/server/src/services/issue-interaction-wait-monitor.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInteractionWaitMonitorPolicy,
+  DEFAULT_INTERACTION_WAIT_MONITOR_INTERVAL_MS,
+  DEFAULT_INTERACTION_WAIT_MONITOR_MAX_ATTEMPTS,
+  INTERACTION_WAIT_MONITOR_SERVICE_NAME,
+  isWakeOnResponseContinuationPolicy,
+} from "./issue-interaction-wait-monitor.js";
+
+const NOW = new Date("2026-01-05T10:00:00.000Z");
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+
+function issue(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "in_review",
+    assigneeAgentId: AGENT_ID,
+    assigneeUserId: null,
+    monitorNextCheckAt: null,
+    executionPolicy: null,
+    ...overrides,
+  };
+}
+
+function interaction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "22222222-2222-4222-8222-222222222222",
+    kind: "request_confirmation",
+    continuationPolicy: "wake_assignee",
+    ...overrides,
+  } as { id: string; kind: string; continuationPolicy: string };
+}
+
+describe("isWakeOnResponseContinuationPolicy", () => {
+  it("accepts the policies that resume the assignee", () => {
+    expect(isWakeOnResponseContinuationPolicy("wake_assignee")).toBe(true);
+    expect(isWakeOnResponseContinuationPolicy("wake_assignee_on_accept")).toBe(true);
+  });
+
+  it("rejects a policy that never wakes anyone", () => {
+    expect(isWakeOnResponseContinuationPolicy("none")).toBe(false);
+    expect(isWakeOnResponseContinuationPolicy(null)).toBe(false);
+  });
+});
+
+describe("buildInteractionWaitMonitorPolicy", () => {
+  it("arms a default monitor for a wake-on-response gate on an unmonitored issue", () => {
+    const policy = buildInteractionWaitMonitorPolicy({ issue: issue(), interaction: interaction(), now: NOW });
+
+    expect(policy?.monitor?.nextCheckAt).toBe(
+      new Date(NOW.getTime() + DEFAULT_INTERACTION_WAIT_MONITOR_INTERVAL_MS).toISOString(),
+    );
+    expect(policy?.monitor?.serviceName).toBe(INTERACTION_WAIT_MONITOR_SERVICE_NAME);
+    // externalRef is redacted on normalize, so the id has to survive in the notes.
+    expect(policy?.monitor?.notes).toContain(interaction().id);
+    expect(policy?.monitor?.maxAttempts).toBe(DEFAULT_INTERACTION_WAIT_MONITOR_MAX_ATTEMPTS);
+    expect(policy?.monitor?.timeoutAt).not.toBeNull();
+  });
+
+  it("arms on an in_progress issue too, because the gate is created before the park", () => {
+    const policy = buildInteractionWaitMonitorPolicy({
+      issue: issue({ status: "in_progress" }),
+      interaction: interaction(),
+      now: NOW,
+    });
+
+    expect(policy?.monitor?.nextCheckAt).toBeTruthy();
+  });
+
+  it("keeps existing execution stages when it adds the monitor", () => {
+    const policy = buildInteractionWaitMonitorPolicy({
+      issue: issue({
+        executionPolicy: {
+          mode: "normal",
+          commentRequired: false,
+          stages: [{ type: "review", approvalsNeeded: 1, participants: [{ type: "agent", agentId: AGENT_ID }] }],
+        },
+      }),
+      interaction: interaction(),
+      now: NOW,
+    });
+
+    expect(policy?.stages).toHaveLength(1);
+    expect(policy?.stages?.[0]?.type).toBe("review");
+    expect(policy?.monitor?.nextCheckAt).toBeTruthy();
+  });
+
+  it("does not arm when the interaction never wakes the assignee", () => {
+    expect(
+      buildInteractionWaitMonitorPolicy({
+        issue: issue(),
+        interaction: interaction({ continuationPolicy: "none" }),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not overwrite a monitor the agent already armed", () => {
+    expect(
+      buildInteractionWaitMonitorPolicy({
+        issue: issue({ monitorNextCheckAt: new Date("2026-01-06T10:00:00.000Z") }),
+        interaction: interaction(),
+        now: NOW,
+      }),
+    ).toBeNull();
+
+    expect(
+      buildInteractionWaitMonitorPolicy({
+        issue: issue({
+          executionPolicy: {
+            mode: "normal",
+            commentRequired: true,
+            stages: [],
+            monitor: { nextCheckAt: "2026-01-06T10:00:00.000Z", scheduledBy: "assignee" },
+          },
+        }),
+        interaction: interaction(),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not write a timestamp the scheduler would refuse to fire", () => {
+    // The tick only dispatches agent-assigned, non-user-assigned issues in
+    // in_progress/in_review. Arming outside that window is a dead timestamp.
+    expect(
+      buildInteractionWaitMonitorPolicy({ issue: issue({ status: "blocked" }), interaction: interaction(), now: NOW }),
+    ).toBeNull();
+    expect(
+      buildInteractionWaitMonitorPolicy({ issue: issue({ status: "todo" }), interaction: interaction(), now: NOW }),
+    ).toBeNull();
+    expect(
+      buildInteractionWaitMonitorPolicy({ issue: issue({ assigneeAgentId: null }), interaction: interaction(), now: NOW }),
+    ).toBeNull();
+    expect(
+      buildInteractionWaitMonitorPolicy({
+        issue: issue({ assigneeUserId: "33333333-3333-4333-8333-333333333333" }),
+        interaction: interaction(),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+});

--- a/server/src/services/issue-interaction-wait-monitor.ts
+++ b/server/src/services/issue-interaction-wait-monitor.ts
@@ -1,0 +1,102 @@
+import type { IssueExecutionPolicy, IssueThreadInteractionContinuationPolicy } from "@paperclipai/shared";
+import { normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+
+/**
+ * A pending `wake_assignee` interaction is only *reachable* — the board can answer
+ * it at any time — but nothing guarantees it is ever *reached*. Without a scheduled
+ * issue monitor the card ages silently: no timer wakes the assignee, so a gate that
+ * the board never notices has unbounded latency.
+ *
+ * Agents are told to arm a monitor in the same breath as the gate, but that rule is
+ * only documentation. This module makes the floor server-owned: when an agent parks
+ * work behind a wake-on-response interaction, the issue gets a default monitor unless
+ * one is already armed.
+ */
+export const INTERACTION_WAIT_MONITOR_SERVICE_NAME = "pending issue interaction";
+
+export const DEFAULT_INTERACTION_WAIT_MONITOR_INTERVAL_MS = 72 * 60 * 60 * 1000;
+export const DEFAULT_INTERACTION_WAIT_MONITOR_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
+export const DEFAULT_INTERACTION_WAIT_MONITOR_MAX_ATTEMPTS = 8;
+
+const WAKE_ON_RESPONSE_POLICIES: ReadonlySet<string> = new Set<IssueThreadInteractionContinuationPolicy>([
+  "wake_assignee",
+  "wake_assignee_on_accept",
+]);
+
+type MonitorIssueLike = {
+  status: string;
+  assigneeAgentId?: string | null;
+  assigneeUserId?: string | null;
+  monitorNextCheckAt?: Date | null;
+  executionPolicy?: IssueExecutionPolicy | Record<string, unknown> | null;
+};
+
+type MonitorInteractionLike = {
+  id: string;
+  kind: string;
+  continuationPolicy: string;
+};
+
+export function isWakeOnResponseContinuationPolicy(policy: string | null | undefined) {
+  return typeof policy === "string" && WAKE_ON_RESPONSE_POLICIES.has(policy);
+}
+
+/**
+ * Mirrors the monitor eligibility the scheduler enforces at tick time: a stored
+ * `monitorNextCheckAt` only ever fires for an agent-assigned issue with no user
+ * assignee that sits in `in_progress` or `in_review`. Arming outside that window
+ * would write a timestamp the tick refuses to act on.
+ */
+function issueCanCarryMonitor(issue: MonitorIssueLike) {
+  if (!issue.assigneeAgentId) return false;
+  if (issue.assigneeUserId) return false;
+  return issue.status === "in_progress" || issue.status === "in_review";
+}
+
+function hasArmedMonitor(issue: MonitorIssueLike, policy: IssueExecutionPolicy | null) {
+  if (issue.monitorNextCheckAt) return true;
+  return Boolean(policy?.monitor?.nextCheckAt);
+}
+
+/**
+ * Builds the execution policy that arms the default wait monitor for a freshly
+ * created interaction, or `null` when the issue needs no server-side floor:
+ * the interaction does not wake anyone, the issue cannot carry a monitor, or the
+ * agent already armed one itself.
+ */
+export function buildInteractionWaitMonitorPolicy(input: {
+  issue: MonitorIssueLike;
+  interaction: MonitorInteractionLike;
+  now: Date;
+  intervalMs?: number;
+}): IssueExecutionPolicy | null {
+  if (!isWakeOnResponseContinuationPolicy(input.interaction.continuationPolicy)) return null;
+  if (!issueCanCarryMonitor(input.issue)) return null;
+
+  const previousPolicy = normalizeIssueExecutionPolicy(input.issue.executionPolicy ?? null);
+  if (hasArmedMonitor(input.issue, previousPolicy)) return null;
+
+  const intervalMs = input.intervalMs ?? DEFAULT_INTERACTION_WAIT_MONITOR_INTERVAL_MS;
+  const nextCheckAt = new Date(input.now.getTime() + intervalMs);
+  const timeoutAt = new Date(input.now.getTime() + DEFAULT_INTERACTION_WAIT_MONITOR_TIMEOUT_MS);
+
+  return {
+    ...(previousPolicy ?? { mode: "normal" as const, commentRequired: true, stages: [] }),
+    monitor: {
+      nextCheckAt: nextCheckAt.toISOString(),
+      // `externalRef` is redacted on normalize, so the interaction id has to live in
+      // the notes to stay readable for whoever the monitor wakes.
+      notes:
+        `Default wait monitor for pending ${input.interaction.kind} interaction ${input.interaction.id}. `
+        + "Re-check whether the interaction is still pending and still asks the right question; "
+        + "re-arm the monitor in the same heartbeat if the wait continues.",
+      scheduledBy: "assignee" as const,
+      kind: "external_service" as const,
+      serviceName: INTERACTION_WAIT_MONITOR_SERVICE_NAME,
+      externalRef: null,
+      timeoutAt: timeoutAt.toISOString(),
+      maxAttempts: DEFAULT_INTERACTION_WAIT_MONITOR_MAX_ATTEMPTS,
+      recoveryPolicy: "wake_owner" as const,
+    },
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issue-thread interactions are the typed cards an agent uses to ask the board a question, and `wake_assignee` tells Paperclip to resume the agent after the board answers
> - A pending interaction makes the issue *reachable*: the board can answer at any moment. It does not make the issue *reached*. Nothing in the platform wakes the assignee while the card sits unanswered
> - The only thing that re-wakes an agent on its own is a scheduled issue monitor (`monitorNextCheckAt`). Agents are told to arm one together with the gate, but that rule lives only in agent instructions
> - Measured against one instance activity log, 295 of 325 wake-on-response gates (90.8%) had no monitor armed within 20 minutes of creation. The gap covers all 9 agents in that company and the board user, so it is not one agent that drifts
> - This pull request makes the floor server-owned. When an interaction parks an issue on a board answer, the server arms a default monitor if none is armed
> - The benefit is that a gate the board never notices now has a bounded wait instead of an unbounded one, and it does not depend on agent discipline

## Linked Issues or Issue Description

No public GitHub issue exists for this. Description follows the bug report template.

**What happened?**

An agent creates an issue-thread interaction with `continuationPolicy: wake_assignee` and moves the issue to `in_review`. The board never answers. The issue then sits forever. `monitorNextCheckAt` is `null`, so `tickDueIssueMonitors` never dispatches it, and no comment or blocker event exists to wake the assignee. The card stays `pending` and the issue ages with no owner action.

**What did you expect to happen?**

A wait that the platform created should have a bounded re-check. The assignee should be woken to re-read the gate and re-measure the state, even if the board stays quiet.

**How can we reproduce it?**

1. Create an issue, assign it to an agent, and set the status to `in_progress`.
2. `POST /api/issues/{id}/interactions` with `kind: request_confirmation` and `continuationPolicy: wake_assignee`.
3. Move the issue to `in_review`.
4. Read the issue. `monitorNextCheckAt` is `null`.
5. Wait. No wake ever occurs for that issue.

**Anything else?**

Measurement from one instance `activity_log`, correlating `issue.thread_interaction_created` against `issue.monitor_scheduled` on the same issue. A gate counts as covered when a monitor was active before it, or when one was armed within 20 minutes after it. The 20 minute window gives the creating agent its whole heartbeat.

| Window | Gates | No monitor | Share | Distinct actors |
|---|---|---|---|---|
| 7 days | 24 | 10 | 41.7% | 5 |
| 30 days | 118 | 88 | 74.6% | 8 |
| 93 days (all) | 325 | 295 | 90.8% | 10 |

The board user is one of the actors that creates uncovered gates. A rule that only addresses agents cannot reach that share.

**Related pull requests found in the duplicate search** (`monitor interaction wake_assignee`, `auto-arm monitor`, `default monitor interaction`, `schedule monitor on interaction create`). None of them arms a monitor at interaction creation, so this PR does not duplicate them:

- Refs #8721 — stops timer recovery from promoting a pending-interaction issue into active work. It protects the wait. This PR gives the wait a timer.
- Refs #10519 — makes a *resolved* interaction reach the assignee. This PR covers the case where no resolution ever arrives.
- Refs #11925 — a review path must keep moving to count as an action path. That detects a dead path after the fact. This PR stops one from being created.
- Refs #9128 — a company default execution policy that arms *review stages* when an issue is created. Different trigger and different policy field.

## What Changed

- New module `server/src/services/issue-interaction-wait-monitor.ts`. It decides whether a freshly created interaction needs a default wait monitor and builds the execution policy for it. The module is pure and has no database access.
- `POST /api/issues/:id/interactions` calls the new helper after it creates the interaction and writes the activity record. When the helper returns a policy, the route applies the standard monitor transition, updates the issue, and logs `issue.monitor_scheduled` with `source: "interaction.wait_monitor_default"`.
- The default arms only for `wake_assignee` and `wake_assignee_on_accept`. A `none` policy wakes nobody and needs no monitor.
- The default arms only when the issue can hold a monitor: an agent assignee, no user assignee, and status `in_progress` or `in_review`. This is the same condition the scheduler applies at tick time. Outside it, a stored timestamp never fires.
- The default never overwrites. If `monitorNextCheckAt` is set, or the execution policy already holds a monitor, the helper returns `null`.
- Default values: next check in 72 hours, timeout in 30 days, 8 attempts, `serviceName: "pending issue interaction"`, `recoveryPolicy: "wake_owner"`.
- Arming is best effort. The interaction is already committed, so a failure logs a warning and the route still returns 201.
- The interaction id goes into the monitor `notes`, not into `externalRef`. `normalizeIssueExecutionPolicy` replaces any `externalRef` with `[redacted]`, so an id placed there is not readable by the agent the monitor wakes.

## Verification

Run on this branch, on top of `origin/master` at `05b35d466`, after a full `pnpm install --frozen-lockfile`:

```
pnpm --filter @paperclipai/server typecheck      # clean
npx vitest run server/src/services/issue-interaction-wait-monitor.test.ts \
               server/src/__tests__/issue-thread-interaction-routes.test.ts
#  Test Files  2 passed (2)
#       Tests  82 passed (82)
```

New tests:

- Unit (`issue-interaction-wait-monitor.test.ts`, 8 cases): arms for a wake-on-response gate; arms on `in_progress` as well, because the gate is created before the park; keeps existing execution stages; does not arm for `continuationPolicy: none`; does not overwrite a monitor set through `monitorNextCheckAt` or through the execution policy; does not write a timestamp for `blocked`, `todo`, a missing agent assignee, or a user assignee.
- Route (`issue-thread-interaction-routes.test.ts`, 4 cases): the create route arms the monitor and logs `issue.monitor_scheduled` with the new source; it leaves an already armed monitor alone; it does not arm for a `none` gate; it still returns 201 when the issue update fails.

Manual check: create a `wake_assignee` interaction on an agent-assigned `in_progress` issue and read the issue back. `monitorNextCheckAt` is set 72 hours ahead, and `executionPolicy.monitor.serviceName` is `pending issue interaction`.

## Risks

- **Behavioural shift, low risk.** Issues that carry a pending wake-on-response interaction now hold a monitor where they held none. The monitor obeys the existing eligibility and clear rules: closing the issue clears it, and an invalid assignee or status clears it.
- **One extra wake per gate is possible.** If the board answers before the 72 hours elapse and the issue stays open, the monitor can still fire once. The agent then re-reads a resolved card and re-disposes the issue. A follow-up can clear the default monitor when the interaction resolves. This PR leaves that out to keep the change small.
- **No migration and no schema change.** The change writes only existing columns through the existing monitor transition.
- **No effect on existing gates.** The default applies to new interactions only.
- **Not a fix for monitor re-arm.** A monitor fires once and then nulls `monitorNextCheckAt`. This PR covers the create side. The re-arm side is a separate defect.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`, 1M context) with extended thinking, running as a Paperclip agent with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing document describes monitor defaults today. Tell me where you want this recorded and I will add it.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not yet run at the time of opening
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not yet reviewed
- [x] I will address all Greptile and reviewer comments before requesting merge
