### PR TITLE
fix(claude-local): do not resume a keyless session when the bundle carries instructions

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -403,4 +403,71 @@ describe("claude remote execution", () => {
     expect(result.errorCode).toBe("duplex_channel_lost");
   });
 
+  it("does not resume a keyless saved session when the prompt bundle now carries agent instructions", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-remote-keyless-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const managedRemoteWorkspace =
+      "/remote/workspace/.paperclip-runtime/runs/run-ssh-keyless/workspace";
+    await mkdir(workspaceDir, { recursive: true });
+    const instructionsFilePath = path.join(rootDir, "AGENTS.md");
+    await writeFile(instructionsFilePath, "# Role\nYou are the fixture agent.\n", "utf8");
+
+    await execute({
+      runId: "run-ssh-keyless",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: { instructionsFilePath },
+      },
+      runtime: {
+        sessionId: "12345678-1234-4abc-9def-123456789012",
+        // Saved before promptBundleKey was persisted: every other resume precondition matches.
+        sessionParams: {
+          sessionId: "12345678-1234-4abc-9def-123456789012",
+          cwd: managedRemoteWorkspace,
+          remoteExecution: {
+            transport: "ssh",
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteCwd: managedRemoteWorkspace,
+          },
+        },
+        sessionDisplayId: "12345678-1234-4abc-9def-123456789012",
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+        instructionsFilePath,
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).not.toContain("--resume");
+    expect(call?.[2]).toContain("--append-system-prompt-file");
+  });
+
 });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -730,8 +730,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
   const runtimePromptBundleKey = asString(runtimeSessionParams.promptBundleKey, "");
   const runtimeMcpServerIdentity = asString(runtimeSessionParams.mcpServerIdentity, "");
+  // A session saved before `promptBundleKey` was persisted carries no key. Such a session must not
+  // be resumed when the current bundle supplies agent instructions: the resume path below skips
+  // `--append-system-prompt-file`, so the agent would keep running without its instructions and
+  // nothing in the run log would say so. Keyless sessions stay resumable when the bundle carries no
+  // instructions, because then there is nothing for the resume to drop.
   const hasMatchingPromptBundle =
-    runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
+    runtimePromptBundleKey.length === 0
+      ? promptBundle.instructionsFilePath === null
+      : runtimePromptBundleKey === promptBundle.bundleKey;
   const hasMatchingMcpServers =
     runtimeMcpServerIdentity.length === 0
       ? runtimeMcpServers.length === 0

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -315,6 +315,48 @@ async function setupExecuteEnv(
   };
 }
 
+/**
+ * Build the session parameters that a real saved session carries.
+ *
+ * The adapter refuses to resume a session whose `promptBundleKey` does not match the bundle it
+ * built for this run. A session with no key at all is also refused when the bundle supplies agent
+ * instructions, because such a session gives no evidence that it ever received them. The prompt
+ * bundle key is a content hash, so a test cannot write it down. This helper runs one throwaway
+ * fresh execution against the same instructions file and reads the key off the result.
+ */
+async function savedSessionParamsFor(input: {
+  root: string;
+  workspace: string;
+  instructionsFile: string;
+  sessionId: string;
+}): Promise<Record<string, unknown>> {
+  const primeCommandPath = path.join(input.root, "bin-prime", "claude");
+  await fs.mkdir(path.dirname(primeCommandPath), { recursive: true });
+  await writeFakeClaudeCommand(primeCommandPath);
+  const primed = await execute({
+    runId: "run-prime-session",
+    agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: { engine: "cli" } },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: {
+      engine: "cli",
+      command: primeCommandPath,
+      cwd: input.workspace,
+      env: {},
+      promptTemplate: "Do work.",
+      instructionsFilePath: input.instructionsFile,
+    },
+    context: {},
+    authToken: "tok",
+    onLog: async () => {},
+    onMeta: async () => {},
+  });
+  const params = (primed.sessionParams ?? {}) as Record<string, unknown>;
+  if (typeof params.promptBundleKey !== "string" || params.promptBundleKey.length === 0) {
+    throw new Error("priming run did not persist a promptBundleKey");
+  }
+  return { ...params, sessionId: input.sessionId };
+}
+
 function createLocalSandboxRunner() {
   let counter = 0;
   return {
@@ -453,7 +495,18 @@ describe("claude execute", () => {
       await execute({
         runId: "run-resume",
         agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: { engine: "cli" } },
-        runtime: { sessionId: "11111111-1111-4111-8111-111111111111", sessionParams: null, sessionDisplayId: null, taskKey: null },
+        runtime: {
+          sessionId: "11111111-1111-4111-8111-111111111111",
+          // A saved session must carry the prompt bundle key, otherwise the adapter starts fresh.
+          sessionParams: await savedSessionParamsFor({
+            root,
+            workspace,
+            instructionsFile,
+            sessionId: "11111111-1111-4111-8111-111111111111",
+          }),
+          sessionDisplayId: null,
+          taskKey: null,
+        },
         config: {
           engine: "cli",
           command: commandPath,
@@ -523,7 +576,18 @@ describe("claude execute", () => {
       await execute({
         runId: "run-notes-resume",
         agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: { engine: "cli" } },
-        runtime: { sessionId: "11111111-1111-4111-8111-111111111111", sessionParams: null, sessionDisplayId: null, taskKey: null },
+        runtime: {
+          sessionId: "11111111-1111-4111-8111-111111111111",
+          // A saved session must carry the prompt bundle key, otherwise the adapter starts fresh.
+          sessionParams: await savedSessionParamsFor({
+            root,
+            workspace,
+            instructionsFile,
+            sessionId: "11111111-1111-4111-8111-111111111111",
+          }),
+          sessionDisplayId: null,
+          taskKey: null,
+        },
         config: {
           engine: "cli",
           command: commandPath,
@@ -556,7 +620,18 @@ describe("claude execute", () => {
       const result = await execute({
         runId: "run-resume-fallback",
         agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: { engine: "cli" } },
-        runtime: { sessionId: "11111111-1111-4111-8111-111111111111", sessionParams: null, sessionDisplayId: null, taskKey: null },
+        runtime: {
+          sessionId: "11111111-1111-4111-8111-111111111111",
+          // A saved session must carry the prompt bundle key, otherwise the adapter starts fresh.
+          sessionParams: await savedSessionParamsFor({
+            root,
+            workspace,
+            instructionsFile,
+            sessionId: "11111111-1111-4111-8111-111111111111",
+          }),
+          sessionDisplayId: null,
+          taskKey: null,
+        },
         config: {
           engine: "cli",
           command: commandPath,


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100). -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The claude-local adapter builds a content-addressed prompt bundle for each run. The bundle holds the agent instructions file and the runtime skills.
> - The adapter saves the bundle key with the Claude session. On the next run it compares the saved key with the new key. A different key means the session must not be resumed.
> - A session that was saved before this field existed carries no key. The current code reads an empty key as a match.
> - The adapter then resumes that session, and the resume path does not pass `--append-system-prompt-file`. The agent runs without its instructions, and no line in the run log reports it.
> - This pull request makes an empty key count as a match only when the new bundle carries no instructions.
> - The benefit is that an old session can no longer hide newly configured agent instructions.

## Linked Issues or Issue Description

No public issue exists for this defect. The description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

**Describe the bug**
`packages/adapters/claude-local/src/server/execute.ts` computes `hasMatchingPromptBundle`:

```ts
const hasMatchingPromptBundle =
  runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
```

An absent `promptBundleKey` counts as a match. `canResumeSession` then becomes true, and the argument builder skips the instructions flag:

```ts
if (attemptInstructionsFilePath && !resumeSessionId) {
  args.push("--append-system-prompt-file", attemptInstructionsFilePath);
}
```

The prompt bundle key hashes the instructions contents. So a session that predates the `promptBundleKey` field, or that was saved by an older build, is resumed even after the instructions change or after instructions are configured for the first time. The agent keeps running on the older session prompt. The run log stays silent, because the only warning in this area needs a configured-but-unreadable path.

**To Reproduce**
1. Give an agent no instructions file, and let it save a Claude session.
2. Remove `promptBundleKey` from the saved session parameters, or use a session saved by a build that predates the field.
3. Set `adapterConfig.instructionsFilePath` to a readable file.
4. Start a run for the same task key.
5. The command carries `--resume` and no `--append-system-prompt-file`.

**Expected behavior**
The adapter starts a new session and injects the instructions.

**Impact**
An operator repaired `instructionsFilePath` on 10 agents in a downstream company. One agent had a keyless saved session and kept running without instructions after the repair. An operator had to clear that session by hand.

- [x] I have searched the GitHub PR list for similar PRs. I searched "promptBundleKey", "prompt bundle", "resume session", "instructions". The nearest open PRs are #11396 (surfaces instructions read failures) and #11519 (re-resolves a stale managed instructions root at heartbeat config-assembly). Both address a different step of the same subsystem, and neither touches `hasMatchingPromptBundle`. This PR touches no file that #11519 touches. It touches `packages/adapters/claude-local/src/server/execute.ts`, which #11396 also touches, but a different region of that file.

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts`: an empty `runtimePromptBundleKey` counts as a bundle match only when `promptBundle.instructionsFilePath` is `null`. A non-empty key keeps the previous exact comparison.
- `packages/adapters/claude-local/src/server/execute.remote.test.ts`: a new test asserts that a keyless saved session is not resumed when the bundle carries instructions, and that the run passes `--append-system-prompt-file`.

## Verification

```
npx vitest run \
  server/src/__tests__/claude-local-execute.test.ts \
  packages/adapters/claude-local/src/server/execute.remote.test.ts \
  packages/adapters/claude-local/src/server/execute.acp-fallback.test.ts
```

- `Tests 32 passed (32)`.
- With `execute.ts` reverted and the new test kept: `Tests 1 failed | 4 passed (5)` in `execute.remote.test.ts`. The failure is `expected [ '--print', … ] to not include '--resume'`.
- The existing test "resumes saved Claude sessions for remote SSH execution when the remote identity matches" also has no `promptBundleKey` and stays green. That agent has no instructions file, so the keyless path stays permitted for it. This is the intended narrow scope.

### About the second commit

The first push was red on `General tests (server (1/5))`. Three tests in `server/src/__tests__/claude-local-execute.test.ts` set `sessionParams: null` and then assert that the run resumes:

- "omits --append-system-prompt-file on a resumed session even when instructionsFile is set"
- "commandNotes is empty on a resumed session even when instructionsFile is set"
- "rebuilds the combined instructions file when an unknown resumed session falls back to fresh"

Each of these fixtures sets an instructions file, so each is exactly the case this PR changes. The fixtures stopped reaching the resume path.

The subject of all three tests is correct and is kept: a session that already carries the instructions must not receive them again. Only the fixtures were wrong. A prompt bundle key is a content hash, so a test cannot write it down. Each fixture now runs one throwaway fresh execution against the same instructions file and reads the key off `result.sessionParams`. The tests still assert `--resume`, so they still exercise the resume path, and they are now stronger: the session they resume provably carries the current bundle.

## Risks

Low risk, with one behavioral shift.

- A saved session with no `promptBundleKey` and an agent with an instructions file is no longer resumed. That run starts a new Claude session once. The run then writes `promptBundleKey` into the session parameters, so the next run resumes normally. The cost is one lost session continuation per affected task key, and only for sessions that predate the field.
- Sessions with a `promptBundleKey` are unaffected.
- Agents with no instructions file are unaffected.
- No migration and no schema change.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`, 1M context), extended thinking, run through Claude Code with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation describes this internal resume predicate
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


