### PR TITLE
fix(issues): treat eligible scheduled monitors as live continuation

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -405,6 +405,13 @@ export interface IssueBlockerAttentionIssueSummary {
   id: string;
   identifier: string | null;
   title: string;
+  status?: string;
+  assigneeAgentId?: string | null;
+  assigneeUserId?: string | null;
+  monitorNextCheckAt?: string | null;
+  monitorAttemptCount?: number;
+  monitorEligibleLive?: boolean;
+  executionPolicy?: unknown;
 }
 
 export interface IssueBlockerAttention {

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -411,6 +411,7 @@ export interface IssueBlockerAttentionIssueSummary {
   monitorNextCheckAt?: string | null;
   monitorAttemptCount?: number;
   monitorEligibleLive?: boolean;
+  monitorStatus?: IssueExecutionMonitorStateStatus | null;
   executionPolicy?: unknown;
 }
 

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -100,6 +100,9 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originId?: string | null;
     originFingerprint?: string | null;
     executionState?: Record<string, unknown> | null;
+    executionPolicy?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
+    monitorAttemptCount?: number;
     description?: string | null;
   }) {
     const id = input.id ?? randomUUID();
@@ -117,6 +120,9 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       originId: input.originId ?? null,
       originFingerprint: input.originFingerprint ?? "default",
       executionState: input.executionState ?? null,
+      executionPolicy: input.executionPolicy ?? null,
+      monitorNextCheckAt: input.monitorNextCheckAt ?? null,
+      monitorAttemptCount: input.monitorAttemptCount ?? 0,
       description: input.description ?? null,
     });
     return id;
@@ -992,6 +998,83 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(rows.map((row) => row.id)).toEqual([assignedParentId]);
 
     await expect(svc.count(companyId, { attention: "blocked", assigneeAgentId: agentId })).resolves.toBe(1);
+  });
+
+  it("classifies an eligible scheduled monitor leaf as covered and live", async () => {
+    const { companyId, agentId } = await createCompany("PBM");
+    const parentId = await insertIssue({ companyId, identifier: "PBM-1", title: "Parent", status: "blocked" });
+    const nextCheckAt = new Date("2026-08-23T18:00:00.000Z");
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBM-2",
+      title: "Monitor leaf",
+      status: "in_progress",
+      parentId,
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 0,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: nextCheckAt.toISOString(),
+          serviceName: "github",
+          maxAttempts: 12,
+        },
+      },
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_child",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      attentionBlockerCount: 0,
+      blockingTreeLive: true,
+      terminalBlocker: expect.objectContaining({
+        id: blockerId,
+        identifier: "PBM-2",
+        status: "in_progress",
+        monitorNextCheckAt: nextCheckAt.toISOString(),
+        monitorEligibleLive: true,
+      }),
+    });
+  });
+
+  it("does not treat an exhausted monitor timestamp as coverage", async () => {
+    const { companyId, agentId } = await createCompany("PBE");
+    const parentId = await insertIssue({ companyId, identifier: "PBE-1", title: "Parent", status: "blocked" });
+    const nextCheckAt = new Date("2026-08-23T18:00:00.000Z");
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBE-2",
+      title: "Exhausted monitor leaf",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 12,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: nextCheckAt.toISOString(),
+          maxAttempts: 12,
+        },
+      },
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      coveredBlockerCount: 0,
+      blockingTreeLive: true,
+      terminalBlocker: expect.objectContaining({
+        id: blockerId,
+        monitorEligibleLive: false,
+      }),
+    });
   });
 
   it("rejects malformed assigneeAgentId filter values on the blocked-inbox path", async () => {

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -1042,6 +1042,72 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("projects persisted-only monitor metadata onto the terminal blocker snapshot", async () => {
+    const { companyId, agentId } = await createCompany("PBP");
+    const parentId = await insertIssue({ companyId, identifier: "PBP-1", title: "Parent", status: "blocked" });
+    const nextCheckAt = new Date("2026-08-23T18:00:00.000Z");
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBP-2",
+      title: "Persisted monitor leaf",
+      status: "in_progress",
+      parentId,
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 1,
+      executionPolicy: { stages: [] },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: nextCheckAt.toISOString(),
+          lastTriggeredAt: null,
+          attemptCount: 1,
+          notes: "Check deployment",
+          scheduledBy: "assignee",
+          kind: "external_service",
+          serviceName: "github",
+          maxAttempts: 12,
+          externalRef: "https://example.test/pr/12?token=secret",
+          timeoutAt: null,
+          recoveryPolicy: "wake_owner",
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      blockingTreeLive: true,
+      terminalBlocker: expect.objectContaining({
+        id: blockerId,
+        monitorEligibleLive: true,
+        monitorStatus: "scheduled",
+        executionPolicy: expect.objectContaining({
+          monitor: expect.objectContaining({
+            kind: "external_service",
+            serviceName: "github",
+            maxAttempts: 12,
+            externalRef: "[redacted]",
+          }),
+        }),
+      }),
+    });
+    expect(JSON.stringify(parent?.blockerAttention)).not.toContain("token=secret");
+  });
+
   it("does not treat an exhausted monitor timestamp as coverage", async () => {
     const { companyId, agentId } = await createCompany("PBE");
     const parentId = await insertIssue({ companyId, identifier: "PBE-1", title: "Parent", status: "blocked" });

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -2134,6 +2134,40 @@ describe("isEligibleIssueMonitorLive", () => {
     }), now)).toBe(true);
   });
 
+  it("treats persisted monitor columns as live when executionPolicy has no monitor", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue({
+      monitorNotes: "Check deployment",
+      monitorScheduledBy: "assignee",
+      executionPolicy: { stages: [] },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: futureCheck,
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: "Check deployment",
+          scheduledBy: "assignee",
+          kind: "external_service",
+          serviceName: "github",
+          timeoutAt: null,
+          maxAttempts: 12,
+          recoveryPolicy: "wake_owner",
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+    }), now)).toBe(true);
+  });
+
   it("does not treat timestamps as coverage for ineligible assignees or statuses", () => {
     expect(isEligibleIssueMonitorLive(liveIssue({ assigneeUserId: "board-user" }), now)).toBe(false);
     expect(isEligibleIssueMonitorLive(liveIssue({ assigneeAgentId: null }), now)).toBe(false);
@@ -2182,6 +2216,7 @@ describe("isEligibleIssueMonitorLive", () => {
       executionPolicy: {
         monitor: {
           nextCheckAt: futureCheck,
+          notes: "Check deployment",
           serviceName: "github",
           maxAttempts: 12,
           externalRef: secret,
@@ -2192,7 +2227,11 @@ describe("isEligibleIssueMonitorLive", () => {
     expect(projection.monitorNextCheckAt).toBe(futureCheck);
     expect(projection.monitorAttemptCount).toBe(0);
     expect(projection.monitorEligibleLive).toBe(true);
-    expect(projection.executionPolicy?.monitor?.externalRef).toBe(REDACTED_ISSUE_MONITOR_EXTERNAL_REF);
+    expect(projection.executionPolicy?.monitor).toEqual(expect.objectContaining({
+      notes: "Check deployment",
+      nextCheckAt: futureCheck,
+      externalRef: REDACTED_ISSUE_MONITOR_EXTERNAL_REF,
+    }));
     expect(JSON.stringify(projection)).not.toContain(secret);
   });
 });

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { applyIssueExecutionPolicyTransition, normalizeIssueExecutionPolicy, parseIssueExecutionState } from "../services/issue-execution-policy.ts";
+import {
+  applyIssueExecutionPolicyTransition,
+  compactIssueMonitorProjection,
+  isEligibleIssueMonitorLive,
+  normalizeIssueExecutionPolicy,
+  parseIssueExecutionState,
+  REDACTED_ISSUE_MONITOR_EXTERNAL_REF,
+} from "../services/issue-execution-policy.ts";
 import type { IssueExecutionPolicy, IssueExecutionState } from "@paperclipai/shared";
 
 const coderAgentId = "11111111-1111-4111-8111-111111111111";
@@ -2083,5 +2090,109 @@ describe("review round circuit breaker", () => {
       currentParticipant: { type: "user", userId: boardUserId },
       changesRequestedCount: 1,
     });
+  });
+});
+
+describe("isEligibleIssueMonitorLive", () => {
+  const agentId = coderAgentId;
+  const futureCheck = "2026-08-23T18:00:00.000Z";
+  const pastCheck = "2026-08-23T16:00:00.000Z";
+  const now = new Date("2026-08-23T17:00:00.000Z");
+
+  function liveIssue(overrides: Record<string, unknown> = {}) {
+    return {
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      monitorNextCheckAt: futureCheck,
+      monitorAttemptCount: 0,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: futureCheck,
+          serviceName: "github",
+          maxAttempts: 12,
+        },
+      },
+      ...overrides,
+    };
+  }
+
+  it("treats a future eligible monitor as live", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue(), now)).toBe(true);
+  });
+
+  it("treats a due-but-unfired eligible monitor as live", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue({
+      monitorNextCheckAt: pastCheck,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: pastCheck,
+          serviceName: "github",
+          maxAttempts: 12,
+        },
+      },
+    }), now)).toBe(true);
+  });
+
+  it("does not treat timestamps as coverage for ineligible assignees or statuses", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue({ assigneeUserId: "board-user" }), now)).toBe(false);
+    expect(isEligibleIssueMonitorLive(liveIssue({ assigneeAgentId: null }), now)).toBe(false);
+    expect(isEligibleIssueMonitorLive(liveIssue({ status: "blocked" }), now)).toBe(false);
+    expect(isEligibleIssueMonitorLive(liveIssue({ status: "backlog" }), now)).toBe(false);
+    expect(isEligibleIssueMonitorLive(liveIssue({ status: "done" }), now)).toBe(false);
+  });
+
+  it("does not treat exhausted or cleared monitors as live", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue({
+      monitorAttemptCount: 12,
+      executionPolicy: {
+        monitor: { nextCheckAt: futureCheck, maxAttempts: 12 },
+      },
+    }), now)).toBe(false);
+    expect(isEligibleIssueMonitorLive(liveIssue({
+      monitorNextCheckAt: null,
+      executionPolicy: { stages: [] },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "cleared",
+          nextCheckAt: null,
+          lastTriggeredAt: null,
+          attemptCount: 1,
+          notes: null,
+          scheduledBy: "assignee",
+          clearedAt: now.toISOString(),
+          clearReason: "manual",
+        },
+      },
+    }), now)).toBe(false);
+  });
+
+  it("projects compact monitor fields with redacted externalRef", () => {
+    const secret = "https://example.test/deploy?token=secret";
+    const projection = compactIssueMonitorProjection(liveIssue({
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: futureCheck,
+          serviceName: "github",
+          maxAttempts: 12,
+          externalRef: secret,
+        },
+      },
+    }), now);
+
+    expect(projection.monitorNextCheckAt).toBe(futureCheck);
+    expect(projection.monitorAttemptCount).toBe(0);
+    expect(projection.monitorEligibleLive).toBe(true);
+    expect(projection.executionPolicy?.monitor?.externalRef).toBe(REDACTED_ISSUE_MONITOR_EXTERNAL_REF);
+    expect(JSON.stringify(projection)).not.toContain(secret);
   });
 });

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -2134,38 +2134,80 @@ describe("isEligibleIssueMonitorLive", () => {
     }), now)).toBe(true);
   });
 
+  function idleState(monitor: Record<string, unknown>) {
+    return {
+      status: "idle",
+      currentStageId: null,
+      currentStageIndex: null,
+      currentStageType: null,
+      currentParticipant: null,
+      returnAssignee: null,
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+      monitor,
+    };
+  }
+
   it("treats persisted monitor columns as live when executionPolicy has no monitor", () => {
     expect(isEligibleIssueMonitorLive(liveIssue({
       monitorNotes: "Check deployment",
       monitorScheduledBy: "assignee",
       executionPolicy: { stages: [] },
-      executionState: {
-        status: "idle",
-        currentStageId: null,
-        currentStageIndex: null,
-        currentStageType: null,
-        currentParticipant: null,
-        returnAssignee: null,
-        completedStageIds: [],
-        lastDecisionId: null,
-        lastDecisionOutcome: null,
-        monitor: {
-          status: "scheduled",
-          nextCheckAt: futureCheck,
-          lastTriggeredAt: null,
-          attemptCount: 0,
-          notes: "Check deployment",
-          scheduledBy: "assignee",
-          kind: "external_service",
-          serviceName: "github",
-          timeoutAt: null,
-          maxAttempts: 12,
-          recoveryPolicy: "wake_owner",
-          clearedAt: null,
-          clearReason: null,
-        },
-      },
+      executionState: idleState({
+        status: "scheduled",
+        nextCheckAt: futureCheck,
+        lastTriggeredAt: null,
+        attemptCount: 0,
+        notes: "Check deployment",
+        scheduledBy: "assignee",
+        kind: "external_service",
+        serviceName: "github",
+        timeoutAt: null,
+        maxAttempts: 12,
+        recoveryPolicy: "wake_owner",
+        clearedAt: null,
+        clearReason: null,
+      }),
     }), now)).toBe(true);
+  });
+
+  it("does not treat a stale timestamp as live when the monitor is triggered", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue({
+      executionPolicy: { stages: [] },
+      executionState: idleState({
+        status: "triggered",
+        nextCheckAt: null,
+        lastTriggeredAt: now.toISOString(),
+        attemptCount: 1,
+        notes: null,
+        scheduledBy: "assignee",
+        kind: "external_service",
+        serviceName: "github",
+        maxAttempts: 12,
+        clearedAt: null,
+        clearReason: null,
+      }),
+    }), now)).toBe(false);
+  });
+
+  it("does not treat a stale timestamp as live when the monitor is cleared", () => {
+    expect(isEligibleIssueMonitorLive(liveIssue({
+      executionPolicy: { stages: [] },
+      executionState: idleState({
+        status: "cleared",
+        nextCheckAt: null,
+        lastTriggeredAt: now.toISOString(),
+        attemptCount: 1,
+        notes: null,
+        scheduledBy: "assignee",
+        kind: "external_service",
+        serviceName: "github",
+        maxAttempts: 12,
+        clearedAt: now.toISOString(),
+        clearReason: "manual",
+      }),
+    }), now)).toBe(false);
   });
 
   it("does not treat timestamps as coverage for ineligible assignees or statuses", () => {
@@ -2230,6 +2272,46 @@ describe("isEligibleIssueMonitorLive", () => {
     expect(projection.executionPolicy?.monitor).toEqual(expect.objectContaining({
       notes: "Check deployment",
       nextCheckAt: futureCheck,
+      externalRef: REDACTED_ISSUE_MONITOR_EXTERNAL_REF,
+    }));
+    expect(JSON.stringify(projection)).not.toContain(secret);
+  });
+
+  it("projects compact monitor metadata from persisted state when executionPolicy has no monitor", () => {
+    const secret = "https://example.test/deploy?token=secret";
+    const projection = compactIssueMonitorProjection(liveIssue({
+      monitorNotes: "Check deployment",
+      monitorScheduledBy: "assignee",
+      monitorAttemptCount: 1,
+      executionPolicy: { stages: [] },
+      executionState: idleState({
+        status: "scheduled",
+        nextCheckAt: futureCheck,
+        lastTriggeredAt: null,
+        attemptCount: 1,
+        notes: "Check deployment",
+        scheduledBy: "assignee",
+        kind: "external_service",
+        serviceName: "github",
+        timeoutAt: null,
+        maxAttempts: 12,
+        recoveryPolicy: "wake_owner",
+        externalRef: secret,
+        clearedAt: null,
+        clearReason: null,
+      }),
+    }), now);
+
+    expect(projection.monitorEligibleLive).toBe(true);
+    expect(projection.monitorStatus).toBe("scheduled");
+    expect(projection.monitorNextCheckAt).toBe(futureCheck);
+    expect(projection.monitorAttemptCount).toBe(1);
+    expect(projection.executionPolicy?.monitor).toEqual(expect.objectContaining({
+      nextCheckAt: futureCheck,
+      notes: "Check deployment",
+      kind: "external_service",
+      serviceName: "github",
+      maxAttempts: 12,
       externalRef: REDACTED_ISSUE_MONITOR_EXTERNAL_REF,
     }));
     expect(JSON.stringify(projection)).not.toContain(secret);

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -540,4 +540,40 @@ describe.sequential("issue goal context routes", () => {
       ],
     }));
   });
+
+  it("projects monitorNextCheckAt and redacted eligibility fields on heartbeat-context", async () => {
+    const secret = "https://example.test/pr/12?token=secret";
+    const nextCheckAt = new Date("2026-08-23T18:00:00.123Z");
+    const monitoredIssue = {
+      ...legacyProjectLinkedIssue,
+      status: "in_progress",
+      workMode: "standard",
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 1,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: nextCheckAt.toISOString(),
+          serviceName: "github",
+          maxAttempts: 12,
+          externalRef: secret,
+        },
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(monitoredIssue);
+
+    const [full, compact] = await Promise.all([
+      request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111"),
+      request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context"),
+    ]);
+
+    expect(full.status).toBe(200);
+    expect(compact.status).toBe(200);
+    expect(compact.body.issue.monitorNextCheckAt).toBe(nextCheckAt.toISOString());
+    expect(compact.body.issue.monitorAttemptCount).toBe(1);
+    expect(compact.body.issue.monitorEligibleLive).toBe(true);
+    expect(compact.body.issue.executionPolicy?.monitor?.externalRef).toBe("[redacted]");
+    expect(JSON.stringify(compact.body)).not.toContain(secret);
+    expect(new Date(full.body.monitorNextCheckAt).toISOString()).toBe(compact.body.issue.monitorNextCheckAt);
+    expect(compact.body.issue.monitorEligibleLive).toBe(true);
+  });
 });

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -576,4 +576,66 @@ describe.sequential("issue goal context routes", () => {
     expect(new Date(full.body.monitorNextCheckAt).toISOString()).toBe(compact.body.issue.monitorNextCheckAt);
     expect(compact.body.issue.monitorEligibleLive).toBe(true);
   });
+
+  it("projects persisted-only monitor metadata into heartbeat-context", async () => {
+    const secret = "https://example.test/pr/12?token=secret";
+    const nextCheckAt = new Date("2026-08-23T18:00:00.000Z");
+    const monitoredIssue = {
+      ...legacyProjectLinkedIssue,
+      status: "in_progress",
+      workMode: "standard",
+      assigneeAgentId: "11111111-1111-4111-8111-111111111111",
+      assigneeUserId: null,
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 1,
+      executionPolicy: { stages: [] },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt: nextCheckAt.toISOString(),
+          lastTriggeredAt: null,
+          attemptCount: 1,
+          notes: "Check deployment",
+          scheduledBy: "assignee",
+          kind: "external_service",
+          serviceName: "github",
+          maxAttempts: 12,
+          externalRef: secret,
+          timeoutAt: null,
+          recoveryPolicy: "wake_owner",
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(monitoredIssue);
+
+    const [full, compact] = await Promise.all([
+      request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111"),
+      request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context"),
+    ]);
+
+    expect(full.status).toBe(200);
+    expect(compact.status).toBe(200);
+    expect(compact.body.issue.monitorEligibleLive).toBe(true);
+    expect(compact.body.issue.monitorStatus).toBe("scheduled");
+    expect(compact.body.issue.monitorNextCheckAt).toBe(nextCheckAt.toISOString());
+    expect(compact.body.issue.executionPolicy?.monitor).toEqual(expect.objectContaining({
+      kind: "external_service",
+      serviceName: "github",
+      maxAttempts: 12,
+      externalRef: "[redacted]",
+    }));
+    expect(JSON.stringify(compact.body)).not.toContain(secret);
+    expect(new Date(full.body.monitorNextCheckAt).toISOString()).toBe(compact.body.issue.monitorNextCheckAt);
+  });
 });

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -441,6 +441,45 @@ describe("task watchdog subtree classifier", () => {
     expect(JSON.stringify(result)).not.toMatch(/task_watchdog_stop:/);
   });
 
+  it("does not treat a stale timestamp as coverage after the monitor has triggered", () => {
+    const result = classify({
+      issues: [issue({
+        status: "in_progress",
+        monitorNextCheckAt: "2026-08-23T18:00:00.000Z",
+        monitorAttemptCount: 1,
+        executionPolicy: { stages: [] },
+        executionState: {
+          status: "idle",
+          currentStageId: null,
+          currentStageIndex: null,
+          currentStageType: null,
+          currentParticipant: null,
+          returnAssignee: null,
+          completedStageIds: [],
+          lastDecisionId: null,
+          lastDecisionOutcome: null,
+          monitor: {
+            status: "triggered",
+            nextCheckAt: null,
+            lastTriggeredAt: "2026-08-23T17:00:00.000Z",
+            attemptCount: 1,
+            notes: null,
+            scheduledBy: "assignee",
+            kind: "external_service",
+            serviceName: "github",
+            maxAttempts: 12,
+            clearedAt: null,
+            clearReason: null,
+          },
+        },
+      })],
+    });
+
+    expect(result.state).toBe("stopped");
+    if (result.state !== "stopped") return;
+    expect(result.stopFingerprint).toMatch(/^task_watchdog_stop:/);
+  });
+
   it("does not treat ineligible monitor timestamps as coverage", () => {
     const userAssigned = classify({
       issues: [issue({

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -387,4 +387,105 @@ describe("task watchdog subtree classifier", () => {
 
     expect(result.state).toBe("not_applicable");
   });
+
+  it("treats an eligible future monitor on a terminal leaf as a live subtree", () => {
+    const result = classify({
+      issues: [
+        issue({ status: "blocked" }),
+        issue({
+          id: childId,
+          identifier: "PAP-2",
+          parentId: sourceId,
+          status: "in_progress",
+          monitorNextCheckAt: "2026-08-23T18:00:00.000Z",
+          monitorAttemptCount: 0,
+          executionPolicy: {
+            monitor: {
+              nextCheckAt: "2026-08-23T18:00:00.000Z",
+              serviceName: "github",
+              maxAttempts: 12,
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(result).toMatchObject({
+      state: "live",
+      liveIssueIds: [childId],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/task_watchdog_stop:/);
+  });
+
+  it("treats a due-but-unfired eligible monitor as live", () => {
+    const result = classify({
+      issues: [
+        issue({
+          status: "in_progress",
+          monitorNextCheckAt: "2026-08-23T16:00:00.000Z",
+          monitorAttemptCount: 0,
+          executionPolicy: {
+            monitor: {
+              nextCheckAt: "2026-08-23T16:00:00.000Z",
+              maxAttempts: 12,
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(result).toMatchObject({
+      state: "live",
+      liveIssueIds: [sourceId],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/task_watchdog_stop:/);
+  });
+
+  it("does not treat ineligible monitor timestamps as coverage", () => {
+    const userAssigned = classify({
+      issues: [issue({
+        status: "in_progress",
+        assigneeUserId: "board-user",
+        monitorNextCheckAt: "2026-08-23T18:00:00.000Z",
+      })],
+    });
+    const blocked = classify({
+      issues: [issue({
+        status: "blocked",
+        monitorNextCheckAt: "2026-08-23T18:00:00.000Z",
+      })],
+    });
+    const exhausted = classify({
+      issues: [issue({
+        status: "in_progress",
+        monitorNextCheckAt: "2026-08-23T18:00:00.000Z",
+        monitorAttemptCount: 12,
+        executionPolicy: {
+          monitor: { nextCheckAt: "2026-08-23T18:00:00.000Z", maxAttempts: 12 },
+        },
+      })],
+    });
+    const noAgent = classify({
+      issues: [issue({
+        status: "in_progress",
+        assigneeAgentId: null,
+        monitorNextCheckAt: "2026-08-23T18:00:00.000Z",
+      })],
+    });
+
+    expect(userAssigned.state).toBe("stopped");
+    expect(blocked.state).toBe("stopped");
+    expect(exhausted.state).toBe("stopped");
+    expect(noAgent.state).toBe("stopped");
+  });
+
+  it("still emits a stop fingerprint for a true in_progress stall with no monitor", () => {
+    const result = classify({
+      issues: [issue({ status: "in_progress", monitorNextCheckAt: null })],
+    });
+
+    expect(result.state).toBe("stopped");
+    if (result.state !== "stopped") return;
+    expect(result.stopFingerprint).toMatch(/^task_watchdog_stop:/);
+  });
 });

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -107,6 +107,9 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       originKind: overrides.originKind,
       originId: overrides.originId,
       originFingerprint: overrides.originFingerprint,
+      executionPolicy: overrides.executionPolicy,
+      monitorNextCheckAt: overrides.monitorNextCheckAt,
+      monitorAttemptCount: overrides.monitorAttemptCount,
       updatedAt: overrides.updatedAt,
       // Default to an "established" issue (created well before the first-run
       // grace window) so the pending-first-run guard does not defer it. Tests
@@ -327,6 +330,55 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "task_watchdog")));
     expect(watchdogIssues).toHaveLength(0);
+  });
+
+  it("does not trigger while a descendant has an eligible scheduled monitor", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-MON", status: "blocked" });
+    const nextCheckAt = new Date("2026-08-23T18:00:00.000Z");
+    const agentId = await seedAgent(companyId);
+    await seedIssue(companyId, {
+      parentId: sourceId,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 0,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: nextCheckAt.toISOString(),
+          serviceName: "github",
+          maxAttempts: 12,
+        },
+      },
+    });
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(0);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedFingerprint ?? "").not.toMatch(/^task_watchdog_stop:/);
+    expect(JSON.stringify(wakes)).not.toMatch(/task_watchdog_stop:/);
+  });
+
+  it("still stops an in_progress leaf with no monitor, run, review, or recovery path", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, {
+      identifier: "WDOG-STALL",
+      status: "in_progress",
+      assigneeAgentId: await seedAgent(companyId),
+      monitorNextCheckAt: null,
+    });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 1 });
+    expect(wakes[0]?.opts?.idempotencyKey).toMatch(/^task_watchdog:[^:]+:task_watchdog_stop:/);
   });
 
   it("does not trigger while a descendant has a queued assignment wake", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -213,6 +213,7 @@ import {
 } from "../services/company-search-rate-limit.js";
 import {
   applyIssueExecutionPolicyTransition,
+  compactIssueMonitorProjection,
   normalizeIssueExecutionPolicy,
   parseIssueExecutionState,
   redactIssueMonitorExternalRef,
@@ -6441,6 +6442,7 @@ export function issueRoutes(
       includeForIssueComment: wakeCommentId !== null,
     });
 
+    const compactMonitor = compactIssueMonitorProjection(issue);
     const response = {
       issue: {
         id: issue.id,
@@ -6465,6 +6467,10 @@ export function issueRoutes(
         originKind: issue.originKind,
         originId: issue.originId,
         updatedAt: issue.updatedAt,
+        monitorNextCheckAt: compactMonitor.monitorNextCheckAt,
+        monitorAttemptCount: compactMonitor.monitorAttemptCount,
+        monitorEligibleLive: compactMonitor.monitorEligibleLive,
+        executionPolicy: compactMonitor.executionPolicy,
       },
       ancestors: ancestors.map((ancestor) => ({
         id: ancestor.id,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6470,6 +6470,7 @@ export function issueRoutes(
         monitorNextCheckAt: compactMonitor.monitorNextCheckAt,
         monitorAttemptCount: compactMonitor.monitorAttemptCount,
         monitorEligibleLive: compactMonitor.monitorEligibleLive,
+        monitorStatus: compactMonitor.monitorStatus,
         executionPolicy: compactMonitor.executionPolicy,
       },
       ancestors: ancestors.map((ancestor) => ({

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -168,10 +168,10 @@ function derivePersistedMonitorState(input: {
     scheduledByRaw === "assignee" || scheduledByRaw === "board" ? scheduledByRaw : null;
   const metadata = scheduledMonitor ? monitorMetadataFromPolicy(scheduledMonitor) : monitorMetadataFromState(fromState);
 
-  if (nextCheckAt) {
+  if (scheduledMonitor?.nextCheckAt) {
     return {
       status: "scheduled",
-      nextCheckAt,
+      nextCheckAt: isoString(input.issue.monitorNextCheckAt) ?? scheduledMonitor.nextCheckAt ?? fromState?.nextCheckAt ?? null,
       lastTriggeredAt,
       attemptCount,
       notes,
@@ -193,7 +193,35 @@ function derivePersistedMonitorState(input: {
     };
   }
 
-  if (fromState?.status === "triggered" || lastTriggeredAt || attemptCount > 0) {
+  if (fromState?.status === "triggered") {
+    return {
+      status: "triggered",
+      nextCheckAt: null,
+      lastTriggeredAt,
+      attemptCount,
+      notes,
+      scheduledBy,
+      ...metadata,
+      clearedAt: null,
+      clearReason: null,
+    };
+  }
+
+  if (nextCheckAt) {
+    return {
+      status: "scheduled",
+      nextCheckAt,
+      lastTriggeredAt,
+      attemptCount,
+      notes,
+      scheduledBy,
+      ...metadata,
+      clearedAt: null,
+      clearReason: null,
+    };
+  }
+
+  if (lastTriggeredAt || attemptCount > 0) {
     return {
       status: "triggered",
       nextCheckAt: null,
@@ -302,13 +330,9 @@ export function isEligibleIssueMonitorLive(issue: IssueLike, now: Date = new Dat
   const policy = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
   const state = parseIssueExecutionState(issue.executionState);
   const persisted = derivePersistedMonitorState({ issue, state, policy });
-  if (!persisted || persisted.status === "cleared") return false;
+  if (!persisted || persisted.status !== "scheduled") return false;
 
-  const nextCheckAt =
-    toMillisecondIso(issue.monitorNextCheckAt) ??
-    persisted.nextCheckAt ??
-    policy?.monitor?.nextCheckAt ??
-    null;
+  const nextCheckAt = persisted.nextCheckAt ?? policy?.monitor?.nextCheckAt ?? null;
   if (!nextCheckAt) return false;
 
   const attemptCount = issue.monitorAttemptCount ?? persisted.attemptCount ?? 0;
@@ -320,19 +344,59 @@ export type CompactIssueMonitorProjection = {
   monitorNextCheckAt: string | null;
   monitorAttemptCount: number;
   monitorEligibleLive: boolean;
+  monitorStatus: IssueExecutionMonitorState["status"] | null;
   executionPolicy: IssueExecutionPolicy | null;
 };
+
+function compactMonitorPolicyFromPersisted(
+  persisted: IssueExecutionMonitorState,
+): IssueExecutionMonitorPolicy | null {
+  if (persisted.status !== "scheduled" || !persisted.nextCheckAt) return null;
+  return {
+    nextCheckAt: persisted.nextCheckAt,
+    notes: persisted.notes ?? null,
+    scheduledBy: persisted.scheduledBy ?? "assignee",
+    kind: persisted.kind ?? undefined,
+    serviceName: persisted.serviceName ?? undefined,
+    externalRef: redactIssueMonitorExternalRef(persisted.externalRef),
+    timeoutAt: persisted.timeoutAt ?? undefined,
+    maxAttempts: persisted.maxAttempts ?? undefined,
+    recoveryPolicy: persisted.recoveryPolicy ?? undefined,
+  };
+}
+
+function compactExecutionPolicy(
+  policy: IssueExecutionPolicy | null,
+  monitor: IssueExecutionMonitorPolicy | null,
+): IssueExecutionPolicy | null {
+  if (!monitor) return policy;
+  return {
+    mode: policy?.mode ?? "normal",
+    commentRequired: policy?.commentRequired ?? true,
+    stages: policy?.stages ?? [],
+    monitor,
+    ...(policy?.reviewPreset ? { reviewPreset: policy.reviewPreset } : {}),
+    ...(policy?.authorizationPolicy ? { authorizationPolicy: policy.authorizationPolicy } : {}),
+    ...(policy?.maxReviewRounds != null ? { maxReviewRounds: policy.maxReviewRounds } : {}),
+  };
+}
 
 export function compactIssueMonitorProjection(
   issue: IssueLike,
   now: Date = new Date(),
 ): CompactIssueMonitorProjection {
   const policy = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
+  const state = parseIssueExecutionState(issue.executionState);
+  const persisted = derivePersistedMonitorState({ issue, state, policy });
+  const compactMonitor = policy?.monitor ?? (persisted ? compactMonitorPolicyFromPersisted(persisted) : null);
   return {
-    monitorNextCheckAt: toMillisecondIso(issue.monitorNextCheckAt) ?? policy?.monitor?.nextCheckAt ?? null,
-    monitorAttemptCount: issue.monitorAttemptCount ?? 0,
+    monitorNextCheckAt: persisted?.status === "scheduled"
+      ? persisted.nextCheckAt ?? compactMonitor?.nextCheckAt ?? null
+      : null,
+    monitorAttemptCount: issue.monitorAttemptCount ?? persisted?.attemptCount ?? 0,
     monitorEligibleLive: isEligibleIssueMonitorLive(issue, now),
-    executionPolicy: policy,
+    monitorStatus: persisted?.status ?? null,
+    executionPolicy: compactExecutionPolicy(policy, compactMonitor),
   };
 }
 

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -24,7 +24,7 @@ type IssueLike = AssigneeLike & {
   createdByUserId?: string | null;
   executionPolicy?: IssueExecutionPolicy | Record<string, unknown> | null;
   executionState?: IssueExecutionState | Record<string, unknown> | null;
-  monitorNextCheckAt?: Date | null;
+  monitorNextCheckAt?: Date | string | null;
   monitorWakeRequestedAt?: Date | null;
   monitorLastTriggeredAt?: Date | null;
   monitorAttemptCount?: number | null;
@@ -264,6 +264,75 @@ function buildClearedMonitorState(input: {
 
 function issueAllowsMonitor(status: string, assigneeAgentId: string | null, assigneeUserId: string | null) {
   return Boolean(assigneeAgentId) && !assigneeUserId && (status === "in_progress" || status === "in_review");
+}
+
+export function toMillisecondIso(value: Date | string | null | undefined): string | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function monitorBoundsFromPersisted(input: {
+  nextCheckAt: string;
+  policy: IssueExecutionPolicy | null;
+  persisted: IssueExecutionMonitorState;
+}): IssueExecutionMonitorPolicy {
+  return {
+    nextCheckAt: input.nextCheckAt,
+    scheduledBy: input.persisted.scheduledBy ?? input.policy?.monitor?.scheduledBy ?? "assignee",
+    kind: input.policy?.monitor?.kind ?? input.persisted.kind ?? undefined,
+    serviceName: input.policy?.monitor?.serviceName ?? input.persisted.serviceName ?? undefined,
+    timeoutAt: input.policy?.monitor?.timeoutAt ?? input.persisted.timeoutAt ?? undefined,
+    maxAttempts: input.policy?.monitor?.maxAttempts ?? input.persisted.maxAttempts ?? undefined,
+    recoveryPolicy: input.policy?.monitor?.recoveryPolicy ?? input.persisted.recoveryPolicy ?? undefined,
+  };
+}
+
+/**
+ * Eligible persisted issue monitors are a live continuation path.
+ * Future nextCheckAt and due-but-unfired monitors both count; exhausted or
+ * cleared monitors and ineligible assignees/statuses do not.
+ */
+export function isEligibleIssueMonitorLive(issue: IssueLike, now: Date = new Date()): boolean {
+  if (!issueAllowsMonitor(issue.status, issue.assigneeAgentId ?? null, issue.assigneeUserId ?? null)) {
+    return false;
+  }
+  const policy = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
+  const state = parseIssueExecutionState(issue.executionState);
+  const persisted = derivePersistedMonitorState({ issue, state, policy });
+  if (!persisted || persisted.status === "cleared") return false;
+
+  const nextCheckAt =
+    toMillisecondIso(issue.monitorNextCheckAt) ??
+    persisted.nextCheckAt ??
+    policy?.monitor?.nextCheckAt ??
+    null;
+  if (!nextCheckAt) return false;
+
+  const attemptCount = issue.monitorAttemptCount ?? persisted.attemptCount ?? 0;
+  const bounds = policy?.monitor ?? monitorBoundsFromPersisted({ nextCheckAt, policy, persisted });
+  return exhaustedMonitorClearReason({ monitor: bounds, attemptCount, now }) == null;
+}
+
+export type CompactIssueMonitorProjection = {
+  monitorNextCheckAt: string | null;
+  monitorAttemptCount: number;
+  monitorEligibleLive: boolean;
+  executionPolicy: IssueExecutionPolicy | null;
+};
+
+export function compactIssueMonitorProjection(
+  issue: IssueLike,
+  now: Date = new Date(),
+): CompactIssueMonitorProjection {
+  const policy = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
+  return {
+    monitorNextCheckAt: toMillisecondIso(issue.monitorNextCheckAt) ?? policy?.monitor?.nextCheckAt ?? null,
+    monitorAttemptCount: issue.monitorAttemptCount ?? 0,
+    monitorEligibleLive: isEligibleIssueMonitorLive(issue, now),
+    executionPolicy: policy,
+  };
 }
 
 function monitorClearReasonForIssue(

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -280,6 +280,7 @@ function monitorBoundsFromPersisted(input: {
 }): IssueExecutionMonitorPolicy {
   return {
     nextCheckAt: input.nextCheckAt,
+    notes: input.policy?.monitor?.notes ?? input.persisted.notes ?? null,
     scheduledBy: input.persisted.scheduledBy ?? input.policy?.monitor?.scheduledBy ?? "assignee",
     kind: input.policy?.monitor?.kind ?? input.persisted.kind ?? undefined,
     serviceName: input.policy?.monitor?.serviceName ?? input.persisted.serviceName ?? undefined,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -87,7 +87,12 @@ import {
   type ParsedExecutionWorkspaceMode,
 } from "./execution-workspace-policy.js";
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
-import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+import {
+  buildInitialIssueMonitorFields,
+  compactIssueMonitorProjection,
+  isEligibleIssueMonitorLive,
+  normalizeIssueExecutionPolicy,
+} from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -1939,13 +1944,30 @@ type IssueBlockerAttentionNode = {
   executionRunId?: string | null;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  executionPolicy?: Record<string, unknown> | null;
+  executionState?: Record<string, unknown> | null;
+  monitorNextCheckAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
 };
 type IssueBlockerAttentionInputNode =
   Pick<
     IssueBlockerAttentionNode,
-    "id" | "companyId" | "parentId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId"
+    | "id"
+    | "companyId"
+    | "parentId"
+    | "identifier"
+    | "title"
+    | "status"
+    | "assigneeAgentId"
+    | "assigneeUserId"
   >
-  & { executionRunId?: string | null };
+  & {
+    executionRunId?: string | null;
+    executionPolicy?: Record<string, unknown> | null;
+    executionState?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | string | null;
+    monitorAttemptCount?: number | null;
+  };
 
 type IssueBlockerAttentionEdge = {
   issueId: string;
@@ -2376,6 +2398,10 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -2400,6 +2426,10 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
         })
         .from(issues)
         .where(
@@ -2438,6 +2468,10 @@ async function listIssueBlockerAttentionMap(
           executionRunId: row.executionRunId,
           assigneeAgentId: row.assigneeAgentId,
           assigneeUserId: row.assigneeUserId,
+          executionPolicy: row.executionPolicy,
+          executionState: row.executionState,
+          monitorNextCheckAt: row.monitorNextCheckAt,
+          monitorAttemptCount: row.monitorAttemptCount,
         });
         nextFrontier.add(row.blockerIssueId);
       }
@@ -2650,6 +2684,9 @@ async function listIssueBlockerAttentionMap(
     if (explicitWaitingIssueIds.has(node.id)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
+    if (isEligibleIssueMonitorLive(node)) {
+      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+    }
     if (node.assigneeUserId && node.status !== "cancelled") {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
@@ -2758,7 +2795,8 @@ async function listIssueBlockerAttentionMap(
       node.status === "in_progress" ||
       activeIssueIds.has(node.id) ||
       explicitWaitingIssueIds.has(node.id) ||
-      Boolean(node.assigneeUserId)
+      Boolean(node.assigneeUserId) ||
+      isEligibleIssueMonitorLive(node)
     ) return true;
 
     const nextSeen = new Set(seen);
@@ -2854,6 +2892,10 @@ async function listIssueBlockerAttentionMap(
             id: terminalBlockerNode.id,
             identifier: terminalBlockerNode.identifier,
             title: terminalBlockerNode.title,
+            status: terminalBlockerNode.status,
+            assigneeAgentId: terminalBlockerNode.assigneeAgentId,
+            assigneeUserId: terminalBlockerNode.assigneeUserId,
+            ...compactIssueMonitorProjection(terminalBlockerNode),
           }
         : null,
     }));

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -23,6 +23,7 @@ import { evaluateAgentInvokabilityFromDb } from "./agent-invokability.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
+import { isEligibleIssueMonitorLive } from "./issue-execution-policy.js";
 
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
 const TASK_WATCHDOG_SUBTREE_MAX_DEPTH = 100;
@@ -74,6 +75,10 @@ export type TaskWatchdogClassifierIssue = Pick<
   latestCommentAt?: Date | string | null;
   latestDocumentAt?: Date | string | null;
   latestWorkProductAt?: Date | string | null;
+  executionPolicy?: IssueRow["executionPolicy"] | Record<string, unknown> | null;
+  executionState?: IssueRow["executionState"] | Record<string, unknown> | null;
+  monitorNextCheckAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
 };
 
 export type TaskWatchdogClassifierPath = {
@@ -411,12 +416,14 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
   const liveIssueIds = [
     ...pathIssueIds(input.activeRuns, input.watchdog.companyId),
     ...pathIssueIds(input.queuedWakeRequests, input.watchdog.companyId),
+    ...included.filter((issue) => isEligibleIssueMonitorLive(issue)).map((issue) => issue.id),
   ].filter((issueId) => includedIdSet.has(issueId));
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
     return {
       state: "live",
-      reason: "At least one issue in the watched subtree has a live run, queued wake, or scheduled retry.",
+      reason:
+        "At least one issue in the watched subtree has a live run, queued wake, scheduled retry, or eligible issue monitor.",
       includedIssueIds: includedIds,
       liveIssueIds: uniqueLiveIssueIds,
     };
@@ -875,6 +882,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           origin_kind,
           updated_at,
           created_at,
+          execution_policy,
+          execution_state,
+          monitor_next_check_at,
+          monitor_attempt_count,
           0 AS depth
         FROM issues
         WHERE company_id = ${companyId}
@@ -894,6 +905,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           child.origin_kind,
           child.updated_at,
           child.created_at,
+          child.execution_policy,
+          child.execution_state,
+          child.monitor_next_check_at,
+          child.monitor_attempt_count,
           watched_issues.depth + 1
         FROM issues child
         JOIN watched_issues ON child.parent_id = watched_issues.id
@@ -914,7 +929,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         assignee_user_id AS "assigneeUserId",
         origin_kind AS "originKind",
         updated_at AS "updatedAt",
-        created_at AS "createdAt"
+        created_at AS "createdAt",
+        execution_policy AS "executionPolicy",
+        execution_state AS "executionState",
+        monitor_next_check_at AS "monitorNextCheckAt",
+        monitor_attempt_count AS "monitorAttemptCount"
       FROM watched_issues
     `);
 


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeats, blocker attention, and the task watchdog all decide whether a tree is still live.
> - An eligible scheduled issue monitor is a live continuation path. A future `nextCheckAt` and a due-but-unfired monitor both keep work alive.
> - Compact heartbeat-context and blocker snapshots omitted persisted monitor fields. The watchdog then treated a monitor-live `in_progress` leaf as stopped.
> - This pull request projects compact monitor eligibility, treats eligible monitors as live, and keeps true stalls without a monitor/run/review/recovery path as stops.
> - The benefit is that compact views match the full issue, and `task_watchdog_stop:*` is not emitted for a live monitor.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Related open PRs that are not duplicates:

- #11847 treats a scheduled future monitor as a covered `in_review` blocker path.
- #10502 covers monitor-backed `in_review` blocker lanes.
- #10398 counts a scheduled monitor as a covered blocker path.

This change is different. It fixes compact heartbeat/blocker projection and the watchdog stop classifier for `in_progress` leaves with eligible monitors.

**What happened?**
Compact `GET /heartbeat-context` omitted `monitorNextCheckAt` and compact eligibility fields. The task-watchdog classifier then emitted `task_watchdog_stop:*` while the terminal leaf still had an eligible persisted monitor.

**Expected behavior**
Compact heartbeat and blocker snapshots include `monitorNextCheckAt` and eligibility fields. An eligible future or due-but-unfired monitor keeps the tree covered and live. Compact payloads redact `externalRef`. True stalls with no monitor, run, review, or recovery path still stop.

**Steps to reproduce**
1. Put a terminal leaf in `in_progress` with an agent assignee, no user assignee, and a scheduled future monitor (`maxAttempts=12`).
2. Compare `GET /api/issues/:id` with `GET /api/issues/:id/heartbeat-context`.
3. Run a watchdog/scheduler tick against that tree.

**Paperclip version or commit**
Reproduced against `f572e08678d57de7afcf3dcb7788f792190a3291`.

**Deployment mode**
Self-hosted server.

## What Changed

- Added a shared `isEligibleIssueMonitorLive` predicate for agent-assigned `in_progress`/`in_review` issues with a persisted, non-cleared monitor and remaining attempts.
- Loaded monitor fields into the watchdog subtree snapshot and treated eligible monitors as live execution paths.
- Marked eligible monitor leaves as covered/live in blocker attention and projected compact monitor eligibility onto `terminalBlocker`.
- Projected `monitorNextCheckAt`, compact eligibility fields, and redacted `executionPolicy.monitor` into heartbeat-context.
- Included required `notes` on persisted monitor bounds so TypeScript matches `IssueExecutionMonitorPolicy`.

## Verification

```
cd server && pnpm exec vitest run \
  src/__tests__/issue-execution-policy.test.ts \
  src/__tests__/task-watchdogs-classifier.test.ts \
  src/__tests__/task-watchdogs-scheduler.test.ts \
  src/__tests__/issue-blocker-attention.test.ts \
  src/__tests__/issues-goal-context-routes.test.ts
```

Local result: 153 passing. Compact vs full: heartbeat-context includes millisecond-normalized `monitorNextCheckAt`, `monitorEligibleLive=true`, and redacted `externalRef`; compact liveness matches the full issue.

## Risks

Low risk. The live-monitor predicate is narrow (agent assignee, no user assignee, `in_progress`/`in_review`, persisted monitor, attempts remaining, not cleared). True stalls without a monitor/run/review/recovery path still emit a stop fingerprint. Compact payloads redact `externalRef`. No schema or API contract break beyond additive compact fields.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

xAI Grok 4.6 (tool-using coding agent; this PR and the CI follow-up).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
