### PR TITLE
fix(plugins): forward issue document base revisions

### DIFF
--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -1952,6 +1952,7 @@ export interface WorkerToHostMethods {
       title?: string;
       format?: string;
       changeSummary?: string;
+      baseRevisionId?: string | null;
     },
     result: IssueDocument,
   ];

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1868,6 +1868,16 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           }
           const now = new Date();
           const existing = issueDocuments.get(`${input.issueId}|${input.key}`);
+          if (existing) {
+            if (!input.baseRevisionId) {
+              throw new Error("Document update requires baseRevisionId");
+            }
+            if (input.baseRevisionId !== existing.latestRevisionId) {
+              throw new Error("Document was updated by someone else");
+            }
+          } else if (input.baseRevisionId) {
+            throw new Error("Document does not exist yet");
+          }
           const document: IssueDocument = {
             id: existing?.id ?? randomUUID(),
             companyId: input.companyId,

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -1175,7 +1175,7 @@ export interface PluginIssueDocumentsClient {
    *
    * Requires the `issue.documents.write` capability.
    *
-   * @param input - Document data including issueId, key, body, and optional title/format/changeSummary
+   * @param input - Document data including issueId, key, body, and optional title/format/changeSummary/baseRevisionId
    */
   upsert(input: {
     issueId: string;
@@ -1185,6 +1185,11 @@ export interface PluginIssueDocumentsClient {
     title?: string;
     format?: string;
     changeSummary?: string;
+    /**
+     * Current document revision id required when updating an existing
+     * document. Omit or pass null when creating a missing document.
+     */
+    baseRevisionId?: string | null;
   }): Promise<IssueDocument>;
 
   /**

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -1052,6 +1052,7 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
               title: input.title,
               format: input.format,
               changeSummary: input.changeSummary,
+              baseRevisionId: input.baseRevisionId,
             });
           },
 

--- a/packages/plugins/sdk/tests/issue-documents-cas.test.ts
+++ b/packages/plugins/sdk/tests/issue-documents-cas.test.ts
@@ -1,0 +1,265 @@
+import { createInterface } from "node:readline";
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createTestHarness } from "../src/testing.js";
+import { definePlugin } from "../src/define-plugin.js";
+import { createHostClientHandlers, type HostServices } from "../src/host-client-factory.js";
+import {
+  createRequest,
+  createSuccessResponse,
+  isJsonRpcRequest,
+  isJsonRpcResponse,
+  parseMessage,
+  serializeMessage,
+  type JsonRpcResponse,
+} from "../src/protocol.js";
+import { startWorkerRpcHost } from "../src/worker-rpc-host.js";
+import type { PaperclipPluginManifestV1 } from "../src/types.js";
+
+const manifest = {
+  id: "paperclip.test-issue-documents-cas",
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Issue Documents CAS Test",
+  description: "Test plugin",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: ["issue.documents.read", "issue.documents.write"],
+  entrypoints: {},
+} satisfies PaperclipPluginManifestV1;
+
+const issue = { id: "issue-a", companyId: "company-a" } as import("@paperclipai/shared").Issue;
+
+function createDocumentHarness() {
+  const harness = createTestHarness({ manifest });
+  harness.seed({ issues: [issue] });
+  return harness;
+}
+
+describe("issue document CAS in the SDK testing harness", () => {
+  it("requires the current revision for updates and rejects base revisions on creates", async () => {
+    const harness = createDocumentHarness();
+
+    const created = await harness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "plan",
+      body: "v1",
+      companyId: issue.companyId!,
+      baseRevisionId: null,
+    });
+    expect(created.latestRevisionNumber).toBe(1);
+
+    await expect(harness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "plan",
+      body: "blind update",
+      companyId: issue.companyId!,
+    })).rejects.toThrow("Document update requires baseRevisionId");
+
+    const afterBlindUpdate = await harness.ctx.issues.documents.get(issue.id, "plan", issue.companyId!);
+    expect(afterBlindUpdate).toMatchObject({
+      body: "v1",
+      latestRevisionId: created.latestRevisionId,
+      latestRevisionNumber: 1,
+    });
+
+    await expect(harness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "plan",
+      body: "stale update",
+      companyId: issue.companyId!,
+      baseRevisionId: "stale-revision",
+    })).rejects.toThrow("Document was updated by someone else");
+
+    const afterStaleUpdate = await harness.ctx.issues.documents.get(issue.id, "plan", issue.companyId!);
+    expect(afterStaleUpdate).toMatchObject({
+      body: "v1",
+      latestRevisionId: created.latestRevisionId,
+      latestRevisionNumber: 1,
+    });
+
+    const updated = await harness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "plan",
+      body: "v2",
+      companyId: issue.companyId!,
+      baseRevisionId: created.latestRevisionId,
+    });
+    expect(updated.latestRevisionNumber).toBe(2);
+    expect(updated.body).toBe("v2");
+
+    await expect(harness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "missing",
+      body: "must not create",
+      companyId: issue.companyId!,
+      baseRevisionId: updated.latestRevisionId,
+    })).rejects.toThrow("Document does not exist yet");
+    await expect(harness.ctx.issues.documents.get(issue.id, "missing", issue.companyId!)).resolves.toBeNull();
+  });
+
+  it("preserves capability and company-scope enforcement", async () => {
+    const noWriteHarness = createTestHarness({
+      manifest: { ...manifest, capabilities: ["issue.documents.read"] },
+    });
+    noWriteHarness.seed({ issues: [issue] });
+    await expect(noWriteHarness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "plan",
+      body: "denied",
+      companyId: issue.companyId!,
+    })).rejects.toThrow("issue.documents.write");
+
+    const harness = createDocumentHarness();
+    await expect(harness.ctx.issues.documents.upsert({
+      issueId: issue.id,
+      key: "plan",
+      body: "wrong company",
+      companyId: "company-b",
+    })).rejects.toThrow(`Issue not found: ${issue.id}`);
+  });
+});
+
+describe("worker issue document RPC forwarding", () => {
+  it("forwards baseRevisionId unchanged to the host", async () => {
+    const hostToWorker = new PassThrough();
+    const workerToHost = new PassThrough();
+    const hostReadline = createInterface({ input: workerToHost });
+    const pending = new Map<string, (response: JsonRpcResponse) => void>();
+    let nextRequestId = 1;
+    const forwarded: Array<Record<string, unknown>> = [];
+
+    const plugin = definePlugin({
+      async setup(ctx) {
+        ctx.data.register("upsert", async (params) => ctx.issues.documents.upsert({
+          issueId: issue.id,
+          key: "plan",
+          body: "v2",
+          companyId: issue.companyId!,
+          title: "Plan",
+          format: "markdown",
+          changeSummary: "advance",
+          baseRevisionId: params.baseRevisionId as string | null,
+        }));
+      },
+    });
+    const worker = startWorkerRpcHost({
+      plugin,
+      stdin: hostToWorker,
+      stdout: workerToHost,
+    });
+
+    const callWorker = (method: string, params: unknown) => {
+      const id = `host-${nextRequestId++}`;
+      const result = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, (response) => {
+          if ("error" in response && response.error) {
+            reject(new Error(response.error.message));
+            return;
+          }
+          resolve((response as { result?: unknown }).result);
+        });
+      });
+      hostToWorker.write(serializeMessage(createRequest(method, params, id)));
+      return result;
+    };
+
+    hostReadline.on("line", (line) => {
+      const message = parseMessage(line);
+      if (isJsonRpcResponse(message)) {
+        pending.get(String(message.id))?.(message);
+        pending.delete(String(message.id));
+        return;
+      }
+      if (!isJsonRpcRequest(message) || message.method !== "issues.documents.upsert") return;
+      forwarded.push(message.params as Record<string, unknown>);
+      hostToWorker.write(serializeMessage(createSuccessResponse(message.id, {
+        id: "document-a",
+        companyId: issue.companyId,
+        issueId: issue.id,
+        key: "plan",
+        title: "Plan",
+        format: "markdown",
+        body: "v2",
+        latestRevisionId: "revision-2",
+        latestRevisionNumber: 2,
+      })));
+    });
+
+    try {
+      await expect(callWorker("initialize", {
+        manifest,
+        config: {},
+        databaseNamespace: null,
+      })).resolves.toMatchObject({ ok: true });
+      await expect(callWorker("getData", {
+        key: "upsert",
+        companyId: issue.companyId,
+        params: { baseRevisionId: "revision-1" },
+      })).resolves.toMatchObject({ latestRevisionId: "revision-2" });
+      await expect(callWorker("getData", {
+        key: "upsert",
+        companyId: issue.companyId,
+        params: { baseRevisionId: null },
+      })).resolves.toMatchObject({ latestRevisionId: "revision-2" });
+      expect(forwarded).toEqual([
+        {
+          issueId: issue.id,
+          key: "plan",
+          body: "v2",
+          companyId: issue.companyId,
+          title: "Plan",
+          format: "markdown",
+          changeSummary: "advance",
+          baseRevisionId: "revision-1",
+        },
+        {
+          issueId: issue.id,
+          key: "plan",
+          body: "v2",
+          companyId: issue.companyId,
+          title: "Plan",
+          format: "markdown",
+          changeSummary: "advance",
+          baseRevisionId: null,
+        },
+      ]);
+    } finally {
+      worker.stop();
+      hostReadline.close();
+      hostToWorker.destroy();
+      workerToHost.destroy();
+    }
+  });
+});
+
+describe("plugin host client issue document forwarding", () => {
+  it("passes baseRevisionId through capability-gated host handlers", async () => {
+    const upsert = vi.fn(async (params: Record<string, unknown>) => params);
+    const handlers = createHostClientHandlers({
+      pluginId: manifest.id,
+      capabilities: ["issue.documents.write"],
+      services: {
+        issueDocuments: { upsert },
+      } as unknown as HostServices,
+    });
+    const params = {
+      issueId: issue.id,
+      key: "plan",
+      body: "v2",
+      companyId: issue.companyId!,
+      title: "Plan",
+      format: "markdown",
+      changeSummary: "advance",
+      baseRevisionId: "revision-1",
+    };
+
+    await expect(handlers["issues.documents.upsert"](
+      params,
+      { invocationScope: { companyId: issue.companyId! } },
+    )).resolves.toEqual(params);
+    expect(upsert).toHaveBeenCalledWith(params);
+  });
+});

--- a/server/src/__tests__/plugin-issue-documents-cas.test.ts
+++ b/server/src/__tests__/plugin-issue-documents-cas.test.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "node:crypto";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  createDb,
+  documentRevisions,
+  documents,
+  issueDocuments,
+  issues,
+} from "@paperclipai/db";
+
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { buildHostServices } from "../services/plugin-host-services.js";
+import { eq } from "drizzle-orm";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function createEventBusStub() {
+  return {
+    forPlugin() {
+      return {
+        emit: async () => {},
+        subscribe: () => {},
+        clear: () => {},
+      };
+    },
+  } as any;
+}
+
+describeEmbeddedPostgres("plugin issue document CAS bridge", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-document-cas-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(documentRevisions);
+    await db.delete(issueDocuments);
+    await db.delete(documents);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("forwards CAS to the core service and preserves conflicts without mutation", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "CAS Company",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "CAS-1",
+      title: "CAS issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.test", createEventBusStub());
+    try {
+      const created = await services.issueDocuments.upsert({
+        companyId,
+        issueId,
+        key: "plan",
+        body: "v1",
+        baseRevisionId: null,
+      });
+      expect(created.latestRevisionNumber).toBe(1);
+
+      const revisionCount = async () => db
+        .select({ revisionNumber: documentRevisions.revisionNumber })
+        .from(documentRevisions)
+        .where(eq(documentRevisions.documentId, created.id));
+
+      await expect(services.issueDocuments.upsert({
+        companyId,
+        issueId,
+        key: "plan",
+        body: "blind",
+      })).rejects.toMatchObject({
+        status: 409,
+        message: "Document update requires baseRevisionId",
+      });
+      await expect(revisionCount()).resolves.toHaveLength(1);
+
+      await expect(services.issueDocuments.upsert({
+        companyId,
+        issueId,
+        key: "plan",
+        body: "stale",
+        baseRevisionId: "stale-revision",
+      })).rejects.toMatchObject({
+        status: 409,
+        message: "Document was updated by someone else",
+      });
+      await expect(revisionCount()).resolves.toHaveLength(1);
+
+      const updated = await services.issueDocuments.upsert({
+        companyId,
+        issueId,
+        key: "plan",
+        body: "v2",
+        baseRevisionId: created.latestRevisionId,
+      });
+      expect(updated.latestRevisionNumber).toBe(2);
+      expect(updated.body).toBe("v2");
+
+      await expect(services.issueDocuments.upsert({
+        companyId,
+        issueId,
+        key: "missing",
+        body: "must not create",
+        baseRevisionId: updated.latestRevisionId,
+      })).rejects.toMatchObject({
+        status: 409,
+        message: "Document does not exist yet",
+      });
+      await expect(db.select().from(issueDocuments).where(eq(issueDocuments.issueId, issueId)))
+        .resolves.toHaveLength(1);
+    } finally {
+      services.dispose();
+    }
+  });
+
+  it("keeps company isolation at the plugin bridge", async () => {
+    const companyA = randomUUID();
+    const companyB = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values([
+      {
+        id: companyA,
+        name: "Company A",
+        issuePrefix: `A${companyA.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: companyB,
+        name: "Company B",
+        issuePrefix: `B${companyB.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: companyA,
+      identifier: "A-1",
+      title: "Company A issue",
+      status: "todo",
+      priority: "medium",
+    });
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.test", createEventBusStub());
+    try {
+      await expect(services.issueDocuments.upsert({
+        companyId: companyB,
+        issueId,
+        key: "plan",
+        body: "must be denied",
+        baseRevisionId: null,
+      })).rejects.toThrow("Issue not found");
+      await expect(db.select().from(issueDocuments)).resolves.toHaveLength(0);
+    } finally {
+      services.dispose();
+    }
+  });
+});

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2743,6 +2743,7 @@ export function buildHostServices(
           title: params.title ?? null,
           format: params.format ?? "markdown",
           changeSummary: params.changeSummary ?? null,
+          baseRevisionId: params.baseRevisionId,
         });
         await logPluginActivity({
           companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The plugin SDK lets plugin workers use bounded host services
> - The core issue document service uses a base revision to prevent lost updates
> - The plugin SDK did not carry that base revision to the core service
> - The SDK test harness also accepted blind updates that the real host rejected
> - This pull request carries the base revision through each plugin boundary and aligns the test harness with the host
> - The benefit is consistent compare-and-swap behavior for plugin issue documents

## Linked Issues or Issue Description

Fixes: #12015

## What Changed

- Add optional nullable `baseRevisionId` to the public plugin issue document upsert input.
- Forward `baseRevisionId` through the worker protocol, worker RPC host, and server plugin host bridge.
- Keep the core document service as the only conflict authority.
- Make the SDK test harness reject blind, stale, and create-with-base writes.
- Add focused tests for forwarding, conflict behavior, no-mutation behavior, capability checks, and company isolation.

## Verification

- `pnpm -r typecheck` passes for 33 of 34 workspace projects.
- `pnpm build` passes for 33 of 34 workspace projects.
- The focused regression command passes 50 tests in 5 files:
  `pnpm exec vitest run packages/plugins/sdk/tests/worker-rpc-host.test.ts packages/plugins/sdk/tests/host-client-factory.test.ts packages/plugins/sdk/tests/issue-documents-cas.test.ts server/src/__tests__/plugin-issue-documents-cas.test.ts server/src/__tests__/plugin-tenant-isolation.test.ts`
- The two new suites fail in 3 tests on base commit `05b35d4669cebea2e1d0bad194caf883b43d8550`. The failures show the blind fake update, dropped worker RPC field, and missing host bridge field.
- `pnpm test:run` completes with 4,609 passed, 5 skipped, and 35 failed tests in 8 unrelated workspace, skill discovery, and runtime exposure files. The local macOS run reports `/tmp` versus `/private/tmp`, unavailable port, stale worktree seed, and child Node toolchain failures. The changed and adjacent plugin suites pass separately.

## Risks

- Low production risk. The change forwards one optional field to existing core behavior.
- The SDK test harness now rejects blind updates. A plugin test that updates an existing document must first read and pass the current revision.
- There are no database, migration, REST, UI, capability, or lock changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6 Luna was the implementor with maximum reasoning, tool use, and code execution.
- OpenAI Codex with a GPT-5 family model was the supervisor and reviewer with tool use and code execution. The exact supervisor model ID and context window were not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
