### PR TITLE
DIG-2766: fix local adapter runtime API routing

### DIFF
--- a/docs/adapters/creating-an-adapter.md
+++ b/docs/adapters/creating-an-adapter.md
@@ -92,6 +92,8 @@ Key responsibilities:
 | `asString(v)` | `@paperclipai/adapter-utils` | Safe config value extraction |
 | `asNumber(v)` | `@paperclipai/adapter-utils` | Safe number extraction |
 
+For local child-process adapters, `buildPaperclipEnv(agent)` prefers the runtime control-plane origin over the advertised public hostname when the server exports `PAPERCLIP_RUNTIME_API_URL`. Use the injected `PAPERCLIP_API_URL` directly from the child process instead of reconstructing hosts or ports yourself.
+
 ### AdapterExecutionContext
 
 ```ts

--- a/docs/adapters/external-adapters.md
+++ b/docs/adapters/external-adapters.md
@@ -221,6 +221,8 @@ export async function execute(
 | `renderTemplate(template, data)` | `{{variable}}` substitution in prompt templates |
 | `asString(v)`, `asNumber(v)`, `asBoolean(v)` | Safe config value extraction |
 
+`buildPaperclipEnv(agent)` already handles Paperclip API base precedence. Local child-process adapters receive a `PAPERCLIP_API_URL` that prefers the runtime control-plane origin when available; remote or webhook-style adapters keep the advertised/public API URL. Do not hard-code `localhost`, public hostnames, or manual `Host` header workarounds in adapter code.
+
 ### src/server/test.ts
 
 Validates the adapter configuration before running. Returns structured diagnostics.

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -18,7 +18,8 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_INSTANCE_ID` | `default` | Instance identifier (for multiple local instances) |
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
-| `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_API_URL` | (auto-derived) | Advertised/public Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful when the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_RUNTIME_API_URL` | (auto-derived) | Internal runtime control-plane URL for local child-process adapters. Paperclip derives this from the listen host plus sanctioned private interface hosts so local heartbeats can reach `/api/*` without depending on the public hostname. |
 | `PAPERCLIP_HIDDEN_SETTINGS` | (unset) | Comma-separated settings surfaces to hide from the UI and floor at the API, for operators hosting Paperclip for others (managed cloud, internal shared server). See [Hiding settings surfaces](#hiding-settings-surfaces). |
 
 ### Hiding settings surfaces
@@ -63,7 +64,8 @@ These are set automatically by the server when invoking agents:
 |----------|-------------|
 | `PAPERCLIP_AGENT_ID` | Agent's unique ID |
 | `PAPERCLIP_COMPANY_ID` | Company ID |
-| `PAPERCLIP_API_URL` | Paperclip API base URL (inherits the server-level value; see Server Configuration above) |
+| `PAPERCLIP_API_URL` | Paperclip API base URL. External/cloud adapters inherit the advertised/public server value; local child-process adapters may instead receive the internal runtime control-plane URL so `curl "$PAPERCLIP_API_URL/api/agents/me"` works from the agent's actual execution surface. |
+| `PAPERCLIP_RUNTIME_API_URL` | Internal runtime control-plane URL exported alongside `PAPERCLIP_API_URL` for local adapters and debugging. |
 | `PAPERCLIP_API_KEY` | Short-lived JWT for API auth |
 | `PAPERCLIP_RUN_ID` | Current heartbeat run ID |
 | `PAPERCLIP_TASK_ID` | Issue that triggered this wake |

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -3085,15 +3085,16 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       : DEFAULT_SANDBOX_CALLBACK_BRIDGE_MAX_BODY_BYTES;
   // The bridge worker runs inside the same process that serves the Paperclip
   // API, so forwarded sandbox calls must target the LOCAL listen origin. The
-  // PAPERCLIP_RUNTIME_API_URL / PAPERCLIP_API_URL exports now prefer a
-  // configured public base URL, which is the origin browsers and external
-  // agents use; routing this in-process loopback hop through the network edge
-  // breaks deployments whose public origin sits behind a session-gated proxy
-  // (every forwarded agent API call is rejected at the edge). Server boot
-  // exports PAPERCLIP_LISTEN_HOST / PAPERCLIP_LISTEN_PORT before any run
-  // executes, and resolveDefaultPaperclipApiUrl() maps wildcard listen hosts
-  // to the loopback address of the same family (0.0.0.0 -> 127.0.0.1,
-  // :: -> [::1]), so the fallback is always loopback-reachable.
+  // runtime exports are now split: PAPERCLIP_API_URL may advertise a public
+  // browser-facing origin, while PAPERCLIP_RUNTIME_API_URL prefers the
+  // internal control-plane path local child processes use. This in-process
+  // bridge must still target the LOCAL listen origin directly; routing the hop
+  // through the network edge breaks deployments whose public origin sits
+  // behind a session-gated proxy. Server boot exports PAPERCLIP_LISTEN_HOST /
+  // PAPERCLIP_LISTEN_PORT before any run executes, and
+  // resolveDefaultPaperclipApiUrl() maps wildcard listen hosts to the loopback
+  // address of the same family (0.0.0.0 -> 127.0.0.1, :: -> [::1]), so the
+  // fallback is always loopback-reachable.
   // input.hostApiUrl stays available as an explicit override seam.
   const hostApiUrl = input.hostApiUrl?.trim() || resolveDefaultPaperclipApiUrl();
   const shellCommand = adapterExecutionTargetShellCommand(target);

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -2682,6 +2682,19 @@ describe("buildPaperclipEnv", () => {
     );
   });
 
+  it("treats the cursor adapter as local when exporting PAPERCLIP_API_URL", () => {
+    withEnv(
+      {
+        PAPERCLIP_API_URL: "https://paperclip.example.test",
+        PAPERCLIP_RUNTIME_API_URL: "http://10.42.0.42:8000",
+      },
+      () => {
+        const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1", adapterType: "cursor" });
+        expect(env.PAPERCLIP_API_URL).toBe("http://10.42.0.42:8000");
+      },
+    );
+  });
+
   it("falls back to the derived runtime URL when no explicit override is set", () => {
     withEnv({ PAPERCLIP_RUNTIME_API_URL: "http://203.0.113.7:3100" }, () => {
       const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -2654,17 +2654,30 @@ describe("buildPaperclipEnv", () => {
     }
   }
 
-  it("prefers an explicit PAPERCLIP_API_URL override over the derived runtime URL", () => {
+  it("keeps the public PAPERCLIP_API_URL override for non-local adapters", () => {
     withEnv(
       {
         PAPERCLIP_API_URL: "http://localhost:3100",
         PAPERCLIP_RUNTIME_API_URL: "http://203.0.113.7:3100",
       },
       () => {
-        const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+        const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1", adapterType: "cursor_cloud" });
         expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3100");
         expect(env.PAPERCLIP_AGENT_ID).toBe("agent-1");
         expect(env.PAPERCLIP_COMPANY_ID).toBe("company-1");
+      },
+    );
+  });
+
+  it("prefers the runtime control-plane URL for local child-process adapters", () => {
+    withEnv(
+      {
+        PAPERCLIP_API_URL: "https://paperclip.example.test",
+        PAPERCLIP_RUNTIME_API_URL: "http://10.42.0.42:8000",
+      },
+      () => {
+        const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1", adapterType: "codex_local" });
+        expect(env.PAPERCLIP_API_URL).toBe("http://10.42.0.42:8000");
       },
     );
   });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2075,7 +2075,11 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
-export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+export function buildPaperclipEnv(agent: {
+  id: string;
+  companyId: string;
+  adapterType?: string | null;
+}): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
@@ -2090,13 +2094,24 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
-  // An explicit PAPERCLIP_API_URL override must win over the URL derived from
-  // authPublicBaseUrl: the derived URL can be unreachable from inside the
-  // runtime container (e.g. when the public base URL is VPN/tailnet-only).
-  const apiUrl =
-    process.env.PAPERCLIP_API_URL ??
-    process.env.PAPERCLIP_RUNTIME_API_URL ??
-    `http://${runtimeHost}:${runtimePort}`;
+  const prefersRuntimeControlPlaneUrl =
+    agent.adapterType === "process"
+    || (typeof agent.adapterType === "string" && agent.adapterType.endsWith("_local"));
+  // Local child-process adapters need the runtime control-plane origin when the
+  // server exports one: their `PAPERCLIP_API_URL` must route to the live
+  // control plane from the agent's actual execution surface, not merely to the
+  // browser-facing/public origin.
+  const apiUrl = prefersRuntimeControlPlaneUrl
+    ? (
+      process.env.PAPERCLIP_RUNTIME_API_URL
+      ?? process.env.PAPERCLIP_API_URL
+      ?? `http://${runtimeHost}:${runtimePort}`
+    )
+    : (
+      process.env.PAPERCLIP_API_URL
+      ?? process.env.PAPERCLIP_RUNTIME_API_URL
+      ?? `http://${runtimeHost}:${runtimePort}`
+    );
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
 }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2080,6 +2080,7 @@ export function buildPaperclipEnv(agent: {
   companyId: string;
   adapterType?: string | null;
 }): Record<string, string> {
+  const localChildProcessAdapterTypes = new Set(["cursor", "process"]);
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
@@ -2095,8 +2096,10 @@ export function buildPaperclipEnv(agent: {
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
   const prefersRuntimeControlPlaneUrl =
-    agent.adapterType === "process"
-    || (typeof agent.adapterType === "string" && agent.adapterType.endsWith("_local"));
+    (typeof agent.adapterType === "string" && (
+      localChildProcessAdapterTypes.has(agent.adapterType)
+      || agent.adapterType.endsWith("_local")
+    ));
   // Local child-process adapters need the runtime control-plane origin when the
   // server exports one: their `PAPERCLIP_API_URL` must route to the live
   // control plane from the agent's actual execution surface, not merely to the

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -214,6 +214,96 @@ describe("codex remote execution", () => {
     }));
   });
 
+  it("keeps staged managed MCP gateway URLs on the advertised Paperclip origin for remote runs", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-remote-mcp-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+
+    let stagedConfigToml = "";
+    (syncDirectoryToSsh as unknown as {
+      mockImplementationOnce: (fn: (args: { localDir: string }) => Promise<void>) => void;
+    }).mockImplementationOnce(async (args: { localDir: string }) => {
+      stagedConfigToml = await readFile(path.join(args.localDir, "config.toml"), "utf8");
+    });
+
+    const originalApiUrl = process.env.PAPERCLIP_API_URL;
+    const originalRuntimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL;
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://10.42.0.42:8000";
+
+    try {
+      await execute({
+        runId: "run-remote-mcp",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "CodexCoder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "codex",
+          env: {
+            CODEX_HOME: codexHomeDir,
+          },
+        },
+        context: {
+          paperclipWorkspace: {
+            cwd: workspaceDir,
+            source: "project_primary",
+          },
+          paperclipManagedMcp: {
+            managedMcpOnly: true,
+            gateways: [{
+              name: "managed-only",
+              endpointPath: "/api/tool-gateway/gateways/manual/mcp",
+              bearerToken: "managed-token",
+            }],
+          },
+        },
+        executionTransport: {
+          remoteExecution: {
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteWorkspacePath: "/remote/workspace",
+            remoteCwd: "/remote/workspace",
+            privateKey: "PRIVATE KEY",
+            knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+            strictHostKeyChecking: true,
+          },
+        },
+        onLog: async () => {},
+      });
+    } finally {
+      if (originalApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
+      else process.env.PAPERCLIP_API_URL = originalApiUrl;
+      if (originalRuntimeApiUrl === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
+      else process.env.PAPERCLIP_RUNTIME_API_URL = originalRuntimeApiUrl;
+    }
+
+    expect(stagedConfigToml).toContain(
+      'url = "https://paperclip.example.test/api/tool-gateway/gateways/manual/mcp"',
+    );
+    expect(stagedConfigToml).not.toContain("http://10.42.0.42:8000");
+    expect(stagedConfigToml).not.toContain("http://127.0.0.1:4310");
+
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(call?.[3].env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:4310");
+  });
+
   it("stages only the allowlist into the home asset: keeps config.toml/skills/auth, drops session+sqlite state, no exclude", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-allowlist-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -728,6 +728,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       await onLog("stdout", `[paperclip] ${note}\n`);
     }
     const paperclipBaseEnv = buildPaperclipEnv(agent);
+    // The managed MCP block is written into CODEX_HOME/config.toml and may be
+    // staged to a remote target. Keep those persisted gateway URLs anchored to
+    // the advertised control-plane origin, not the runtime-only child-process
+    // URL that can be host-internal or bridge-local for this one run.
+    const managedMcpApiBaseUrl =
+      process.env.PAPERCLIP_API_URL?.trim() || paperclipBaseEnv.PAPERCLIP_API_URL;
     const runtimeMcpGateways = (ctx.runtimeMcp?.getServers() ?? []).map((server) => ({
       name: server.name,
       endpointPath: server.url,
@@ -739,7 +745,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
     const managedMcp = await writeManagedCodexMcpConfig({
       codexHome: effectiveCodexHome,
-      apiBaseUrl: paperclipBaseEnv.PAPERCLIP_API_URL,
+      apiBaseUrl: managedMcpApiBaseUrl,
       gateways: managedMcpGateways,
     });
     if (managedMcpGateways.length > 0) {

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -51,6 +51,17 @@ describe("buildPaperclipEnv", () => {
     expect(env.PAPERCLIP_API_URL).toBe("http://10.42.0.42:8000");
   });
 
+  it("treats the cursor adapter as local when exporting PAPERCLIP_API_URL", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://10.42.0.42:8000";
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    process.env.PAPERCLIP_LISTEN_HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_PORT = "8000";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1", adapterType: "cursor" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://10.42.0.42:8000");
+  });
+
   it("falls back to PAPERCLIP_RUNTIME_API_URL when no explicit override is set", () => {
     process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
     delete process.env.PAPERCLIP_API_URL;

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -29,15 +29,26 @@ afterEach(() => {
 });
 
 describe("buildPaperclipEnv", () => {
-  it("prefers an explicit PAPERCLIP_API_URL override over the derived runtime URL", () => {
+  it("keeps the advertised PAPERCLIP_API_URL for non-local adapters", () => {
     process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
     process.env.PAPERCLIP_API_URL = "http://localhost:4100";
     process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
     process.env.PAPERCLIP_LISTEN_PORT = "3101";
 
-    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1", adapterType: "cursor_cloud" });
 
     expect(env.PAPERCLIP_API_URL).toBe("http://localhost:4100");
+  });
+
+  it("prefers the runtime control-plane URL for local child-process adapters", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://10.42.0.42:8000";
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    process.env.PAPERCLIP_LISTEN_HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_PORT = "8000";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1", adapterType: "codex_local" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://10.42.0.42:8000");
   });
 
   it("falls back to PAPERCLIP_RUNTIME_API_URL when no explicit override is set", () => {

--- a/server/src/__tests__/private-hostname-guard.test.ts
+++ b/server/src/__tests__/private-hostname-guard.test.ts
@@ -1,77 +1,129 @@
 import { describe, expect, it, vi } from "vitest";
-import express from "express";
-import request from "supertest";
 import { privateHostnameGuard } from "../middleware/private-hostname-guard.js";
 
 const unknownHostname = "blocked-host.invalid";
 
-function createApp(opts: { enabled: boolean; allowedHostnames?: string[]; bindHost?: string }) {
-  const app = express();
-  app.use(
-    privateHostnameGuard({
-      enabled: opts.enabled,
-      allowedHostnames: opts.allowedHostnames ?? [],
-      bindHost: opts.bindHost ?? "0.0.0.0",
-    }),
-  );
-  app.get("/api/health", (_req, res) => {
-    res.status(200).json({ status: "ok" });
+function runGuard(
+  opts: {
+    enabled: boolean;
+    allowedHostnames?: string[];
+    bindHost?: string;
+    networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+  },
+  input: {
+    host?: string;
+    path?: string;
+    accepts?: string;
+  } = {},
+) {
+  const middleware = privateHostnameGuard({
+    enabled: opts.enabled,
+    allowedHostnames: opts.allowedHostnames ?? [],
+    bindHost: opts.bindHost ?? "0.0.0.0",
+    networkInterfacesMap: opts.networkInterfacesMap ?? {},
   });
-  app.get("/dashboard", (_req, res) => {
-    res.status(200).send("ok");
-  });
-  return app;
+  const req = {
+    path: input.path ?? "/api/health",
+    header: (name: string) => (name.toLowerCase() === "host" ? input.host : undefined),
+    accepts: () => input.accepts ?? "json",
+  } as any;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    type: vi.fn().mockReturnThis(),
+    send: vi.fn(),
+    json: vi.fn(),
+  } as any;
+  const next = vi.fn();
+  middleware(req, res, next);
+  return { res, next };
+}
+
+function allowInternalInterfaceMap(): NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]> {
+  return {
+    eth0: [
+      {
+        address: "10.42.0.42",
+        family: "IPv4",
+        internal: false,
+        netmask: "255.255.255.0",
+        cidr: "10.42.0.42/24",
+        mac: "00:00:00:00:00:00",
+      },
+    ],
+  };
+}
+
+function createAppOpts(opts: {
+  enabled: boolean;
+  allowedHostnames?: string[];
+  bindHost?: string;
+  networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+}) {
+  return {
+    enabled: opts.enabled,
+    allowedHostnames: opts.allowedHostnames ?? [],
+    bindHost: opts.bindHost ?? "0.0.0.0",
+    networkInterfacesMap: opts.networkInterfacesMap ?? {},
+  };
 }
 
 describe("privateHostnameGuard", () => {
   it("allows requests when disabled", async () => {
-    const app = createApp({ enabled: false });
-    const res = await request(app).get("/api/health").set("Host", "dotta-macbook-pro:3100");
-    expect(res.status).toBe(200);
+    const { next } = runGuard(createAppOpts({ enabled: false }), { host: "dotta-macbook-pro:3100" });
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it("allows loopback hostnames", async () => {
-    const app = createApp({ enabled: true });
-    const res = await request(app).get("/api/health").set("Host", "localhost:3100");
-    expect(res.status).toBe(200);
+    const { next } = runGuard(createAppOpts({ enabled: true }), { host: "localhost:3100" });
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it("allows explicitly configured hostnames", async () => {
-    const app = createApp({ enabled: true, allowedHostnames: ["dotta-macbook-pro"] });
-    const res = await request(app).get("/api/health").set("Host", "dotta-macbook-pro:3100");
-    expect(res.status).toBe(200);
+    const { next } = runGuard(
+      createAppOpts({ enabled: true, allowedHostnames: ["dotta-macbook-pro"] }),
+      { host: "dotta-macbook-pro:3100" },
+    );
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("allows discovered internal interface hosts without a manual Host override", async () => {
+    const { next } = runGuard(createAppOpts({
+      enabled: true,
+      networkInterfacesMap: allowInternalInterfaceMap(),
+    }), { host: "10.42.0.42:8000" });
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it("blocks unknown hostnames with a static remediation command", async () => {
-    const app = createApp({ enabled: true, allowedHostnames: ["some-other-host"] });
-    const res = await request(app).get("/api/health").set("Host", `${unknownHostname}:3100`);
-    expect(res.status).toBe(403);
+    const { next, res } = runGuard(
+      createAppOpts({ enabled: true, allowedHostnames: ["some-other-host"] }),
+      { host: `${unknownHostname}:3100` },
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
     // The remediation command carries a static `<host>` placeholder. It never
     // interpolates the request Host header into the command.
-    expect(res.body?.error).toContain("run npx paperclipai allowed-hostname <host>");
-    expect(res.body?.error).not.toContain(unknownHostname);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining("run npx paperclipai allowed-hostname <host>"),
+      }),
+    );
+    expect(JSON.stringify(res.json.mock.calls)).not.toContain(unknownHostname);
   });
 
   it("blocks unknown hostnames on page routes with a static plain-text remediation command", async () => {
-    const middleware = privateHostnameGuard({
-      enabled: true,
-      allowedHostnames: ["some-other-host"],
-      bindHost: "0.0.0.0",
-    });
-    const req = {
-      path: "/dashboard",
-      header: (name: string) => (name.toLowerCase() === "host" ? `${unknownHostname}:3100` : undefined),
-      accepts: () => "html",
-    } as any;
-    const res = {
-      status: vi.fn().mockReturnThis(),
-      type: vi.fn().mockReturnThis(),
-      send: vi.fn(),
-      json: vi.fn(),
-    } as any;
-    const next = vi.fn();
-
-    middleware(req, res, next);
+    const { next, res } = runGuard(
+      createAppOpts({
+        enabled: true,
+        allowedHostnames: ["some-other-host"],
+        bindHost: "0.0.0.0",
+      }),
+      {
+        host: `${unknownHostname}:3100`,
+        path: "/dashboard",
+        accepts: "html",
+      },
+    );
 
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(403);
@@ -88,12 +140,19 @@ describe("privateHostnameGuard", () => {
     // operator or an agent cannot paste an attacker-controlled span into a
     // shell. Use a harmless, nonexistent command name inside the span.
     const hostileHost = "evil$(echo marker)host";
-    const app = createApp({ enabled: true, allowedHostnames: ["some-other-host"] });
-    const res = await request(app).get("/api/health").set("Host", hostileHost);
-    expect(res.status).toBe(403);
-    expect(res.body?.error).toContain("run npx paperclipai allowed-hostname <host>");
-    expect(res.body?.error).not.toContain("evil");
-    expect(res.body?.error).not.toContain("$(");
-    expect(res.body?.error).not.toContain("marker");
+    const { res } = runGuard(
+      createAppOpts({ enabled: true, allowedHostnames: ["some-other-host"] }),
+      { host: hostileHost },
+    );
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining("run npx paperclipai allowed-hostname <host>"),
+      }),
+    );
+    const payload = JSON.stringify(res.json.mock.calls);
+    expect(payload).not.toContain("evil");
+    expect(payload).not.toContain("$(");
+    expect(payload).not.toContain("marker");
   });
 });

--- a/server/src/__tests__/private-hostname-guard.test.ts
+++ b/server/src/__tests__/private-hostname-guard.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import { privateHostnameGuard } from "../middleware/private-hostname-guard.js";
 
@@ -8,7 +9,7 @@ function runGuard(
     enabled: boolean;
     allowedHostnames?: string[];
     bindHost?: string;
-    networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+    networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
   },
   input: {
     host?: string;
@@ -38,7 +39,7 @@ function runGuard(
   return { res, next };
 }
 
-function allowInternalInterfaceMap(): NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]> {
+function allowInternalInterfaceMap(): NodeJS.Dict<os.NetworkInterfaceInfo[]> {
   return {
     eth0: [
       {
@@ -57,7 +58,7 @@ function createAppOpts(opts: {
   enabled: boolean;
   allowedHostnames?: string[];
   bindHost?: string;
-  networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 }) {
   return {
     enabled: opts.enabled,

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildLocalRuntimeApiCandidateUrls,
   buildRuntimeApiCandidateUrls,
+  choosePrimaryLocalRuntimeApiUrl,
   choosePrimaryRuntimeApiUrl,
   collectReachableInterfaceHosts,
 } from "../runtime-api.js";
@@ -104,6 +106,70 @@ describe("runtime API discovery", () => {
       "http://127.0.0.1:3102",
       "http://host.docker.internal:3102",
     ]);
+  });
+
+  it("prefers internal runtime candidates over the public Paperclip origin for local adapters", () => {
+    expect(
+      buildLocalRuntimeApiCandidateUrls({
+        publicApiUrl: "https://paperclip.example.test/app",
+        allowedHostnames: [
+          "paperclip.example.test",
+          "app-paperclip.exe.xyz",
+        ],
+        bindHost: "0.0.0.0",
+        port: 8000,
+        networkInterfacesMap: {
+          eth0: [
+            {
+              address: "10.42.0.42",
+              family: "IPv4",
+              internal: false,
+              netmask: "255.255.255.0",
+              cidr: "10.42.0.42/24",
+              mac: "00:00:00:00:00:00",
+            },
+            {
+              address: "172.18.0.1",
+              family: "IPv4",
+              internal: false,
+              netmask: "255.255.0.0",
+              cidr: "172.18.0.1/16",
+              mac: "00:00:00:00:00:00",
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      "http://10.42.0.42:8000",
+      "http://172.18.0.1:8000",
+      "http://app-paperclip.exe.xyz:8000",
+      "http://127.0.0.1:8000",
+      "http://host.docker.internal:8000",
+      "https://paperclip.example.test",
+    ]);
+  });
+
+  it("chooses the internal control-plane origin before the advertised public URL", () => {
+    expect(
+      choosePrimaryLocalRuntimeApiUrl({
+        publicApiUrl: "https://paperclip.example.test/app",
+        allowedHostnames: ["paperclip.example.test", "app-paperclip.exe.xyz"],
+        bindHost: "0.0.0.0",
+        port: 8000,
+        networkInterfacesMap: {
+          eth0: [
+            {
+              address: "10.42.0.42",
+              family: "IPv4",
+              internal: false,
+              netmask: "255.255.255.0",
+              cidr: "10.42.0.42/24",
+              mac: "00:00:00:00:00:00",
+            },
+          ],
+        },
+      }),
+    ).toBe("http://10.42.0.42:8000");
   });
 
   it("prefers usable interface hosts and skips link-local addresses", () => {

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -172,6 +172,32 @@ describe("runtime API discovery", () => {
     ).toBe("http://10.42.0.42:8000");
   });
 
+  it("keeps loopback first when the server is only bound to loopback", () => {
+    expect(
+      buildLocalRuntimeApiCandidateUrls({
+        publicApiUrl: "http://127.0.0.1:3210",
+        allowedHostnames: ["192.168.1.50"],
+        bindHost: "127.0.0.1",
+        port: 3210,
+        networkInterfacesMap: {
+          eth0: [
+            {
+              address: "10.42.0.42",
+              family: "IPv4",
+              internal: false,
+              netmask: "255.255.255.0",
+              cidr: "10.42.0.42/24",
+              mac: "00:00:00:00:00:00",
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      "http://127.0.0.1:3210",
+      "http://host.docker.internal:3210",
+    ]);
+  });
+
   it("prefers usable interface hosts and skips link-local addresses", () => {
     expect(
       collectReachableInterfaceHosts({

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -670,10 +670,12 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.apiUrl).toBe("http://custom-api:3100");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://custom-api:3100");
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
-      expect.arrayContaining(["http://custom-api:3100"]),
-    );
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")[0]).toBe("http://custom-api:3100");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
+    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual([
+      "http://127.0.0.1:3210",
+      "http://host.docker.internal:3210",
+      "http://custom-api:3100",
+    ]);
   });
 
   it("falls back to host-based URL when PAPERCLIP_API_URL is not set", async () => {
@@ -693,9 +695,11 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.apiUrl).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
-    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
-      expect.arrayContaining(["http://127.0.0.1:3210", "http://192.168.1.50:3210"]),
-    );
+    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual([
+      "http://192.168.1.50:3210",
+      "http://127.0.0.1:3210",
+      "http://host.docker.internal:3210",
+    ]);
   });
 
   it("preserves explicit-port external auth public URLs when detect-port selects a new port", async () => {
@@ -713,7 +717,7 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     // URL that leaked to spawned agents as a dead PAPERCLIP_API_URL. (BRO-1558)
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("http://my-host.ts.net:3100");
-    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://my-host.ts.net:3100");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3110");
   });
 
   it("keeps no-port auth public URLs stable when detect-port selects a new port", async () => {
@@ -728,6 +732,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
-    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3110");
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -641,6 +641,8 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     loadConfigMock.mockReturnValue(buildTestConfig());
     process.env.BETTER_AUTH_SECRET = "test-secret";
     delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_RUNTIME_API_URL;
+    delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
   });
 
   afterEach(() => {
@@ -696,7 +698,6 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3210");
     expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual([
-      "http://192.168.1.50:3210",
       "http://127.0.0.1:3210",
       "http://host.docker.internal:3210",
     ]);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -80,7 +80,11 @@ import {
   reconcileAdapterAvailability,
 } from "./services/adapter-registry-bootstrap.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
-import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
+import {
+  buildLocalRuntimeApiCandidateUrls,
+  choosePrimaryLocalRuntimeApiUrl,
+  choosePrimaryRuntimeApiUrl,
+} from "./runtime-api.js";
 import { isLoopbackHost, rewriteLoopbackUrlPort } from "./url-utils.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import {
@@ -870,16 +874,23 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
-  const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
+  const advertisedApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
   });
-  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
-  const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
-    preferredApiUrl: configuredApiUrl,
-    authPublicBaseUrl: config.authPublicBaseUrl ?? null,
+  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || advertisedApiUrl;
+  const runtimeApiCandidates = buildLocalRuntimeApiCandidateUrls({
+    preferredRuntimeApiUrl: process.env.PAPERCLIP_RUNTIME_API_URL?.trim() || null,
+    publicApiUrl: configuredApiUrl,
+    allowedHostnames: config.allowedHostnames,
+    bindHost: runtimeListenHost,
+    port: listenPort,
+  });
+  const runtimeApiUrl = choosePrimaryLocalRuntimeApiUrl({
+    preferredRuntimeApiUrl: process.env.PAPERCLIP_RUNTIME_API_URL?.trim() || null,
+    publicApiUrl: configuredApiUrl,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -881,15 +881,18 @@ export async function startServer(): Promise<StartedServer> {
     port: listenPort,
   });
   const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || advertisedApiUrl;
+  // PAPERCLIP_RUNTIME_API_URL is a per-server export, not a startup override.
+  // A nested/local server may start inside an agent shell that already carries
+  // the parent server's runtime URL, which can be a public origin or a dead
+  // port for the new process. Always derive a fresh runtime control-plane URL
+  // for this server instance.
   const runtimeApiCandidates = buildLocalRuntimeApiCandidateUrls({
-    preferredRuntimeApiUrl: process.env.PAPERCLIP_RUNTIME_API_URL?.trim() || null,
     publicApiUrl: configuredApiUrl,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
   });
   const runtimeApiUrl = choosePrimaryLocalRuntimeApiUrl({
-    preferredRuntimeApiUrl: process.env.PAPERCLIP_RUNTIME_API_URL?.trim() || null,
     publicApiUrl: configuredApiUrl,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -1,4 +1,7 @@
 import type { Request, RequestHandler } from "express";
+import {
+  collectInternalRuntimeInterfaceHosts,
+} from "../runtime-api.js";
 
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.trim().toLowerCase();
@@ -28,13 +31,22 @@ function normalizeAllowedHostnames(values: string[]): string[] {
   return Array.from(unique);
 }
 
-export function resolvePrivateHostnameAllowSet(opts: { allowedHostnames: string[]; bindHost: string }): Set<string> {
+export function resolvePrivateHostnameAllowSet(opts: {
+  allowedHostnames: string[];
+  bindHost: string;
+  networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+}): Set<string> {
   const configuredAllow = normalizeAllowedHostnames(opts.allowedHostnames);
   const bindHost = opts.bindHost.trim().toLowerCase();
   const allowSet = new Set<string>(configuredAllow);
 
   if (bindHost && bindHost !== "0.0.0.0") {
     allowSet.add(bindHost);
+  }
+  for (const host of collectInternalRuntimeInterfaceHosts({
+    networkInterfacesMap: opts.networkInterfacesMap,
+  })) {
+    allowSet.add(host.toLowerCase());
   }
   allowSet.add("localhost");
   allowSet.add("127.0.0.1");
@@ -57,6 +69,7 @@ export function privateHostnameGuard(opts: {
   enabled: boolean;
   allowedHostnames: string[];
   bindHost: string;
+  networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
 }): RequestHandler {
   if (!opts.enabled) {
     return (_req, _res, next) => next();
@@ -65,6 +78,7 @@ export function privateHostnameGuard(opts: {
   const allowSet = resolvePrivateHostnameAllowSet({
     allowedHostnames: opts.allowedHostnames,
     bindHost: opts.bindHost,
+    networkInterfacesMap: opts.networkInterfacesMap,
   });
 
   return (req, res, next) => {

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import type { Request, RequestHandler } from "express";
 import {
   collectInternalRuntimeInterfaceHosts,
@@ -34,7 +35,7 @@ function normalizeAllowedHostnames(values: string[]): string[] {
 export function resolvePrivateHostnameAllowSet(opts: {
   allowedHostnames: string[];
   bindHost: string;
-  networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 }): Set<string> {
   const configuredAllow = normalizeAllowedHostnames(opts.allowedHostnames);
   const bindHost = opts.bindHost.trim().toLowerCase();
@@ -69,7 +70,7 @@ export function privateHostnameGuard(opts: {
   enabled: boolean;
   allowedHostnames: string[];
   bindHost: string;
-  networkInterfacesMap?: NodeJS.Dict<NodeJS.NetworkInterfaceInfo[]>;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 }): RequestHandler {
   if (!opts.enabled) {
     return (_req, _res, next) => next();

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { isIP } from "node:net";
 
 function normalizeHost(value: string | null | undefined): string {
   return (value ?? "").trim();
@@ -46,6 +47,59 @@ function pushCandidate(
   }
 }
 
+function parseIpv4Address(address: string): [number, number, number, number] | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+  const parsed = parts.map((part) => {
+    if (!/^\d+$/.test(part)) return NaN;
+    return Number(part);
+  });
+  if (parsed.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return null;
+  return parsed as [number, number, number, number];
+}
+
+function normalizeOrigin(rawUrl: string | null | undefined): string | null {
+  const trimmed = rawUrl?.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHostname(host: string | null | undefined): string | null {
+  const trimmed = normalizeHost(host).toLowerCase();
+  if (!trimmed) return null;
+  return trimmed.replace(/^\[|\]$/g, "");
+}
+
+function sameHostname(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeHostname(left);
+  const normalizedRight = normalizeHostname(right);
+  return normalizedLeft !== null && normalizedLeft === normalizedRight;
+}
+
+export function isInternalRuntimeHost(host: string): boolean {
+  const normalized = normalizeHostname(host);
+  if (!normalized) return false;
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) {
+    const octets = parseIpv4Address(normalized);
+    if (!octets) return false;
+    const [a, b] = octets;
+    if (a === 10) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    return false;
+  }
+  if (ipVersion === 6) {
+    return normalized.startsWith("fc") || normalized.startsWith("fd");
+  }
+  return false;
+}
+
 export function choosePrimaryRuntimeApiUrl(input: {
   authPublicBaseUrl?: string | null;
   allowedHostnames: string[];
@@ -83,7 +137,14 @@ export function choosePrimaryRuntimeApiUrl(input: {
 export function collectReachableInterfaceHosts(input: {
   networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 } = {}): string[] {
-  const interfaces = input.networkInterfacesMap ?? os.networkInterfaces();
+  const interfaces = (() => {
+    if (input.networkInterfacesMap) return input.networkInterfacesMap;
+    try {
+      return os.networkInterfaces();
+    } catch {
+      return {};
+    }
+  })();
   const rankedHosts: Array<{ host: string; rank: number; index: number }> = [];
   const seen = new Set<string>();
   let index = 0;
@@ -106,6 +167,12 @@ export function collectReachableInterfaceHosts(input: {
   return rankedHosts
     .sort((left, right) => left.rank - right.rank || left.index - right.index)
     .map((entry) => entry.host);
+}
+
+export function collectInternalRuntimeInterfaceHosts(input: {
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+} = {}): string[] {
+  return collectReachableInterfaceHosts(input).filter((host) => isInternalRuntimeHost(host));
 }
 
 export function buildRuntimeApiCandidateUrls(input: {
@@ -168,4 +235,94 @@ export function buildRuntimeApiCandidateUrls(input: {
   }
 
   return candidates;
+}
+
+export function buildLocalRuntimeApiCandidateUrls(input: {
+  preferredRuntimeApiUrl?: string | null;
+  publicApiUrl?: string | null;
+  allowedHostnames: string[];
+  bindHost: string;
+  port: number;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+}): string[] {
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  const publicOrigin = normalizeOrigin(input.publicApiUrl);
+  const publicHostname = publicOrigin ? new URL(publicOrigin).hostname : null;
+  const bindHost = normalizeHost(input.bindHost);
+  const internalInterfaceHosts = collectInternalRuntimeInterfaceHosts({
+    networkInterfacesMap: input.networkInterfacesMap,
+  });
+  const otherInterfaceHosts = collectReachableInterfaceHosts({
+    networkInterfacesMap: input.networkInterfacesMap,
+  }).filter((host) => !internalInterfaceHosts.includes(host));
+  const loopbackOrigin = (() => {
+    if (bindHost === "0.0.0.0") return formatOrigin("http:", "127.0.0.1", input.port);
+    if (bindHost === "::") return formatOrigin("http:", "::1", input.port);
+    if (bindHost && isLoopbackHost(bindHost)) return formatOrigin("http:", bindHost, input.port);
+    return null;
+  })();
+
+  pushCandidate(candidates, seen, input.preferredRuntimeApiUrl);
+
+  if (bindHost && !isWildcardHost(bindHost) && !isLoopbackHost(bindHost) && !sameHostname(bindHost, publicHostname)) {
+    pushCandidate(candidates, seen, formatOrigin("http:", bindHost, input.port));
+  }
+
+  for (const host of internalInterfaceHosts) {
+    if (sameHostname(host, publicHostname)) continue;
+    pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+  }
+
+  for (const rawHost of input.allowedHostnames) {
+    const host = normalizeHost(rawHost);
+    if (!host || sameHostname(host, publicHostname)) continue;
+    pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+  }
+
+  if (loopbackOrigin) {
+    pushCandidate(candidates, seen, loopbackOrigin);
+    pushCandidate(candidates, seen, formatOrigin("http:", "host.docker.internal", input.port));
+  }
+
+  for (const host of otherInterfaceHosts) {
+    if (sameHostname(host, publicHostname)) continue;
+    pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+  }
+
+  pushCandidate(candidates, seen, publicOrigin);
+
+  if (candidates.length === 0) {
+    pushCandidate(
+      candidates,
+      seen,
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: input.publicApiUrl,
+        allowedHostnames: input.allowedHostnames,
+        bindHost: input.bindHost,
+        port: input.port,
+      }),
+    );
+  }
+
+  return candidates;
+}
+
+export function choosePrimaryLocalRuntimeApiUrl(input: {
+  preferredRuntimeApiUrl?: string | null;
+  publicApiUrl?: string | null;
+  allowedHostnames: string[];
+  bindHost: string;
+  port: number;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+}): string {
+  return (
+    buildLocalRuntimeApiCandidateUrls(input)[0]
+    ?? choosePrimaryRuntimeApiUrl({
+      authPublicBaseUrl: input.publicApiUrl,
+      allowedHostnames: input.allowedHostnames,
+      bindHost: input.bindHost,
+      port: input.port,
+    })
+  );
 }

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -250,6 +250,7 @@ export function buildLocalRuntimeApiCandidateUrls(input: {
   const publicOrigin = normalizeOrigin(input.publicApiUrl);
   const publicHostname = publicOrigin ? new URL(publicOrigin).hostname : null;
   const bindHost = normalizeHost(input.bindHost);
+  const bindHostIsLoopback = bindHost !== "" && isLoopbackHost(bindHost);
   const internalInterfaceHosts = collectInternalRuntimeInterfaceHosts({
     networkInterfacesMap: input.networkInterfacesMap,
   });
@@ -265,29 +266,38 @@ export function buildLocalRuntimeApiCandidateUrls(input: {
 
   pushCandidate(candidates, seen, input.preferredRuntimeApiUrl);
 
-  if (bindHost && !isWildcardHost(bindHost) && !isLoopbackHost(bindHost) && !sameHostname(bindHost, publicHostname)) {
-    pushCandidate(candidates, seen, formatOrigin("http:", bindHost, input.port));
-  }
-
-  for (const host of internalInterfaceHosts) {
-    if (sameHostname(host, publicHostname)) continue;
-    pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
-  }
-
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHost(rawHost);
-    if (!host || sameHostname(host, publicHostname)) continue;
-    pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
-  }
-
-  if (loopbackOrigin) {
+  if (bindHostIsLoopback && loopbackOrigin) {
     pushCandidate(candidates, seen, loopbackOrigin);
     pushCandidate(candidates, seen, formatOrigin("http:", "host.docker.internal", input.port));
   }
 
-  for (const host of otherInterfaceHosts) {
-    if (sameHostname(host, publicHostname)) continue;
-    pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+  if (bindHost && !isWildcardHost(bindHost) && !isLoopbackHost(bindHost) && !sameHostname(bindHost, publicHostname)) {
+    pushCandidate(candidates, seen, formatOrigin("http:", bindHost, input.port));
+  }
+
+  if (!bindHostIsLoopback) {
+    for (const host of internalInterfaceHosts) {
+      if (sameHostname(host, publicHostname)) continue;
+      pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+    }
+
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHost(rawHost);
+      if (!host || sameHostname(host, publicHostname)) continue;
+      pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+    }
+  }
+
+  if (!bindHostIsLoopback && loopbackOrigin) {
+    pushCandidate(candidates, seen, loopbackOrigin);
+    pushCandidate(candidates, seen, formatOrigin("http:", "host.docker.internal", input.port));
+  }
+
+  if (!bindHostIsLoopback) {
+    for (const host of otherInterfaceHosts) {
+      if (sameHostname(host, publicHostname)) continue;
+      pushCandidate(candidates, seen, formatOrigin("http:", host, input.port));
+    }
   }
 
   pushCandidate(candidates, seen, publicOrigin);


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs agents through a control plane and managed runtime tools.
> - Local child-process adapters use `PAPERCLIP_API_URL` inside the child process during a heartbeat.
> - This branch split the advertised Paperclip API origin from the runtime-only control-plane origin so local heartbeats can use a reachable internal URL.
> - `codex_local` also writes managed MCP gateway entries into `CODEX_HOME/config.toml`, and that file can be staged to remote targets.
> - The staged config could still rebase context-only managed gateway paths against the runtime-only URL.
> - A remote Codex target could then receive a host-internal MCP gateway URL that it could not reach.
> - This pull request keeps persisted managed MCP gateway URLs on the advertised Paperclip origin and keeps the runtime-only URL only in the child process environment.
> - The benefit is that local heartbeat auth stays fixed and remote Codex MCP routing stays reachable.

## Linked Issues or Issue Description

**What happened?**
A local adapter run can now export a runtime-only Paperclip API URL so the child heartbeat process can reach the live control plane. `codex_local` also used that runtime-only URL when it wrote managed MCP gateway entries into `CODEX_HOME/config.toml`. When Paperclip staged that home to a remote target, context-only managed gateways could point at a host-internal URL that the remote target could not reach.

**Expected behavior**
The child process environment should use the runtime or bridge URL for heartbeat API calls. The persisted managed MCP config should keep using the advertised Paperclip origin so staged remote Codex homes keep reachable gateway URLs.

**Steps to reproduce**
1. Start Paperclip with a public `PAPERCLIP_API_URL` and a different internal `PAPERCLIP_RUNTIME_API_URL`.
2. Run `codex_local` on a remote SSH or sandbox target with `paperclipManagedMcp` context and a managed `CODEX_HOME`.
3. Inspect the staged `config.toml`.
4. Before this fix, a context-only managed gateway can resolve against the internal runtime origin instead of the advertised Paperclip origin.

**Paperclip version or commit**
`46c45e333`

**Deployment mode**
Local dev (`pnpm dev`) with remote Codex execution coverage.

Related PR search: reviewed the active GitHub PR list and confirmed the fork duplicate is `rudyjellis/paperclip#44`.

## What Changed

- Use the advertised Paperclip API origin, not the runtime-only child-process URL, when `codex_local` writes managed MCP gateway entries into `CODEX_HOME/config.toml`.
- Keep the runtime or bridge URL in the child process environment so local heartbeat API calls still route through the live control plane.
- Add a remote Codex regression test that stages `CODEX_HOME`, injects a relative managed MCP gateway path, and proves the staged config keeps the public origin while the runtime env keeps the bridge URL.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/execute.remote.test.ts packages/adapters/codex-local/src/server/codex-home.test.ts`
- `pnpm -C server exec vitest run src/__tests__/runtime-api.test.ts src/__tests__/paperclip-env.test.ts src/__tests__/server-startup-feedback-export.test.ts`
- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts -t "buildPaperclipEnv"`

## Risks

- Low risk.
- The code change only affects the base URL used for persisted managed MCP entries in `codex_local`.
- Local child-process heartbeat routing still uses the runtime or bridge URL.
- Other adapters are unchanged.

## Model Used

- OpenAI Codex, `gpt-5.4`, tool use enabled, reasoning mode `xhigh`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
