### PR TITLE
fix(adapter-utils): skip unsupported ACP session config options instead of failing the run

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -162,6 +162,8 @@ async function runExecutor(
     runtimeMcp?: AdapterRuntimeMcpAccess;
     prepareRemoteManagedHome?: AcpxEngineExecutorOptions["prepareRemoteManagedHome"];
     startupTraceContext?: AdapterExecutionContext["startupTraceContext"];
+    onSetConfigOption?: (input: { key: string; value: string }) => void;
+    expectExitCode?: number;
   } = {},
 ) {
   const runtimeOptions: Record<string, unknown>[] = [];
@@ -174,10 +176,13 @@ async function runExecutor(
     ...(options.prepareRemoteManagedHome
       ? { prepareRemoteManagedHome: options.prepareRemoteManagedHome }
       : {}),
-    createRuntime: (options) => {
-      runtimeOptions.push(options as unknown as Record<string, unknown>);
+    createRuntime: (runtimeCreateOptions) => {
+      runtimeOptions.push(runtimeCreateOptions as unknown as Record<string, unknown>);
       return buildRuntime(
-        ({ key, value }) => configOptions.push({ key, value }),
+        (input) => {
+          configOptions.push({ key: input.key, value: input.value });
+          options.onSetConfigOption?.(input);
+        },
         (input) => sessionInputs.push(input),
       ) as never;
     },
@@ -208,7 +213,7 @@ async function runExecutor(
     },
   } as never);
 
-  expect(result.exitCode).toBe(0);
+  expect(result.exitCode).toBe(options.expectExitCode ?? 0);
   return { logs, meta, events, runtimeOptions, configOptions, sessionInputs, result };
 }
 
@@ -515,6 +520,49 @@ describe("shared ACPX engine runtime behavior", () => {
       { key: "model", value: "gemini-2.5-pro" },
       { key: "effort", value: "high" },
     ]);
+  });
+
+  it("completes the run when the backend does not advertise a session config option", async () => {
+    const { logs, configOptions } = await runExecutor(
+      { agent: "claude", model: "claude-sonnet-4-6", thinkingEffort: "low" },
+      {
+        onSetConfigOption: ({ key }) => {
+          if (key === "effort") {
+            const err = new Error(
+              "ACP session does not advertise config option 'effort'. Supported config options: mode, model.",
+            ) as Error & { code?: string };
+            err.code = "ACP_BACKEND_UNSUPPORTED_CONTROL";
+            throw err;
+          }
+        },
+      },
+    );
+
+    // The unsupported option was attempted, then skipped instead of failing the run.
+    expect(configOptions).toContainEqual({ key: "effort", value: "low" });
+    expect(
+      logs.some(
+        (entry) =>
+          entry.stream === "stderr" &&
+          entry.text.includes("does not advertise config option 'effort'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("still fails the run when a session config option errors for a non-capability reason", async () => {
+    const { result } = await runExecutor(
+      { agent: "claude", model: "claude-sonnet-4-6", thinkingEffort: "low" },
+      {
+        expectExitCode: 1,
+        onSetConfigOption: ({ key }) => {
+          if (key === "effort") {
+            throw new Error("acp transport crashed");
+          }
+        },
+      },
+    );
+
+    expect(result.errorCode).toBe("acpx_session_config_failed");
   });
 
   it("does not inject CODEX_CONFIG or session config when Codex overrides are absent", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -2164,11 +2164,25 @@ async function applySessionConfigOptions(input: {
     throw new Error(message);
   }
   for (const option of options) {
-    await input.runtime.setConfigOption({
-      handle: input.handle,
-      key: option.key,
-      value: option.value,
-    });
+    try {
+      await input.runtime.setConfigOption({
+        handle: input.handle,
+        key: option.key,
+        value: option.value,
+      });
+    } catch (err) {
+      // A backend that does not advertise this control (older ACP CLI build)
+      // must not tank the whole run — mirror the CLI `--effort` graceful
+      // omission and skip just this option. Any other failure still propagates.
+      if (describeErrorDiagnostics(err).acpCode === "ACP_BACKEND_UNSUPPORTED_CONTROL") {
+        await input.onLog(
+          "stderr",
+          `[paperclip] ACPX ${input.prepared.acpxAgent} backend does not advertise config option '${option.key}'; omitting ${option.key}=${option.value}. Upgrade the ACP CLI/backend to restore it.\n`,
+        );
+        continue;
+      }
+      throw err;
+    }
     await input.onLog(
       "stdout",
       `[paperclip] Applied ACPX ${input.prepared.acpxAgent} config ${option.key}=${option.value}\n`,


### PR DESCRIPTION
## Problem

When the ACP backend does not advertise a session config control, the run fails outright during `configure_session`. Concretely: a `claude_local` agent on a Claude Code CLI build whose ACP backend only advertises `mode` and `model` (observed with Claude Code 2.1.92) throws when the engine sets `effort`:

```
ACP session ... does not advertise config option 'effort'. Supported config options: mode, model.
  acpCode: ACP_BACKEND_UNSUPPORTED_CONTROL   phase: configure_session
```

The run terminates in <1s with `errorCode: acpx_session_config_failed` / `stopReason: adapter_failed`. Any agent that resolves a reasoning-`effort` value (e.g. via the `cheap`/recovery model-profile default) is effectively down against such a backend.

## Fix

`applySessionConfigOptions` (the shared chokepoint for all acpx agents) now wraps each `setConfigOption` in try/catch:

- On `ACP_BACKEND_UNSUPPORTED_CONTROL`, it logs a warning and skips just that option, letting the run proceed — mirroring the graceful omission the CLI `--effort` path already performs.
- Any other `setConfigOption` failure still propagates unchanged.

Because this is the single chokepoint, it fixes the class generically (claude/gemini/custom), not just `effort`.

## Tests

Added two tests to `execute.test.ts`:

1. A run whose backend rejects an unsupported control (`effort`) now **completes** and logs the omission warning.
2. A `setConfigOption` failure for a **non-capability** reason still fails the run (`acpx_session_config_failed`) — guards against over-broad swallowing.

Written test-first (verified red → green). `tsc --noEmit` clean on `packages/adapter-utils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)