### PR TITLE
fix(server): let an agent read its own configuration and revisions

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -42,6 +42,7 @@ const baseAgent = {
 const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
   list: vi.fn(),
+  listConfigRevisions: vi.fn(),
   create: vi.fn(),
   activatePendingApproval: vi.fn(),
   terminate: vi.fn(),
@@ -1768,6 +1769,43 @@ describe.sequential("agent permission routes", () => {
   });
 
   describe("agent configuration read gate", () => {
+    it("allows an agent to list its own redacted configuration revisions without grants", async () => {
+      mockAgentService.listConfigRevisions.mockResolvedValue([{
+        id: "revision-1",
+        agentId,
+        companyId,
+        beforeConfig: { adapterConfig: { env: { TOKEN: { type: "secret_ref", secretId: "secret-1" } } } },
+        afterConfig: { adapterConfig: { env: { TOKEN: { type: "secret_ref", secretId: "secret-1" } } } },
+        changedKeys: ["adapterConfig"],
+        createdAt: new Date("2026-08-23T00:00:00.000Z"),
+      }]);
+      mockAccessService.decide.mockResolvedValue({
+        allowed: true,
+        reason: "allow_self",
+        explanation: "Allowed because the actor is reading its own agent configuration.",
+      });
+
+      const app = await createApp({
+        type: "agent",
+        agentId,
+        companyId,
+        runId: "run-1",
+        source: "agent_key",
+      });
+
+      const res = await request(app).get(`/api/agents/${agentId}/config-revisions`);
+
+      expect(res.status).toBe(200);
+      expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+        action: "agent_config:read",
+        resource: { type: "agent", companyId, agentId },
+      }));
+      expect(res.body[0].afterConfig.adapterConfig.env.TOKEN).toEqual({
+        type: "secret_ref",
+        secretId: "secret-1",
+      });
+    });
+
     it("allows a board member without agents:create to read agent configuration", async () => {
       // Board (human) users with company membership but no agents:create
       // grant should still be able to view agent configuration — this is
@@ -1820,7 +1858,7 @@ describe.sequential("agent permission routes", () => {
       expect(res.status).toBe(403);
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
         action: "agent_config:read",
-        resource: { type: "company", companyId },
+        resource: { type: "agent", companyId, agentId: peerAgentId },
       }));
     });
 
@@ -1861,7 +1899,7 @@ describe.sequential("agent permission routes", () => {
       expect(res.status).toBe(200);
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
         action: "agent_config:read",
-        resource: { type: "company", companyId },
+        resource: { type: "agent", companyId, agentId: peerAgentId },
       }));
     });
   });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3176,7 +3176,7 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    await assertCanReadConfigurations(req, agent.companyId);
+    await assertCanReadAgent(req, agent);
     res.json(redactAgentConfiguration(agent));
   });
 
@@ -3187,7 +3187,7 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    await assertCanReadConfigurations(req, agent.companyId);
+    await assertCanReadAgent(req, agent);
     const revisions = await svc.listConfigRevisions(id);
     res.json(revisions.map((revision) => redactConfigRevision(revision)));
   });
@@ -3200,7 +3200,7 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    await assertCanReadConfigurations(req, agent.companyId);
+    await assertCanReadAgent(req, agent);
     const revision = await svc.getConfigRevision(id, revisionId);
     if (!revision) {
       res.status(404).json({ error: "Revision not found" });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The agent configuration API lets a caller read an agent record, its redacted configuration, and its configuration revision history
> - Three of those read routes gate on `assertCanReadConfigurations`, which decides with a company-scoped resource
> - The authorization service allows a self-read only when the resource is agent-scoped, so the self branch is unreachable from these routes
> - An agent therefore cannot read its own configuration history, and the denial cites a grant that the code comment reserves for peer reads
> - This pull request points the three read routes at `assertCanReadAgent`, which decides with an agent-scoped resource
> - The benefit is that an agent can audit its own configuration history, and the peer gate stays as strict as before

## Linked Issues or Issue Description

No matching issue exists. I searched this repository for `config-revisions`, `assertCanReadConfigurations`, `agent_config:read`, and `suggest-changes`. I found related work, but no duplicate:

- Refs #3725 — merged. It stopped these read endpoints from requiring `agents:create` for board members. It did not change the agent-actor path.
- Refs #8064 — open. It proposes a new `canReadAgentConfig` permission key in the same helper. It changes the grant ladder for peer reads. It does not add a self path, so the two changes address different cases.

**What happened?**

An agent cannot read its own configuration revisions. `GET /agents/:id/config-revisions` returns HTTP 403 with `Missing permission: agents:suggest-changes` and reason `deny_missing_grant`. The call fails even when `:id` is the calling agent itself.

The cause is the resource type. The three read routes call `assertCanReadConfigurations`, which decides with `resource: { type: "company", companyId }`. The self branch for `agent_config:read` in `services/authorization.ts` matches only `resource.type === "agent"` with `resource.agentId === actorAgentId`. A company-scoped resource never reaches that branch. The request falls through to the configure/suggest grant ladder, which is the peer path.

The comment on `assertCanReadConfigurations` states the intent. The stricter agent ladder exists so that one agent cannot inspect a peer agent's configuration for a proposed diff. A self-read was not the target. `GET /agents/me` already returns the caller's own redacted configuration with no grant.

**Expected behavior**

An agent can read its own configuration and its own configuration revisions with no extra grant. Values stay redacted. A peer agent still needs `agents:configure` or `agents:suggest-changes`.

**Steps to reproduce**

1. Start a self-hosted server.
2. Create an agent with no `agents:configure` grant and no `agents:suggest-changes` grant.
3. Create an agent API key for that agent.
4. Call `GET /api/agents/me` with the key. The call returns HTTP 200 and shows the agent's own redacted configuration.
5. Call `GET /api/agents/<the same agent id>/config-revisions` with the same key.
6. The call returns HTTP 403 `Missing permission: agents:suggest-changes`.

**Paperclip version or commit**

Reproduced on a `master` build at `0fa318b`. This branch is rebased on `ae6761e`.

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Access context**

Agent actor with an agent API key. Board actors are not affected.

## What Changed

- `GET /agents/:id/configuration` now gates on `assertCanReadAgent`.
- `GET /agents/:id/config-revisions` now gates on `assertCanReadAgent`.
- `GET /agents/:id/config-revisions/:revisionId` now gates on `assertCanReadAgent`.
- A new test asserts that an agent lists its own revisions with no grant. It also asserts that a `secret_ref` entry comes back as its type and `secretId` only.
- The two existing peer tests now assert the agent-scoped resource. They keep their deny-without-grant and allow-with-grant results.

`assertCanReadAgent` already exists in this file and already guards other agent read routes. It keeps board behavior, because it delegates to `assertCanReadConfigurations` for board actors. For an agent actor it decides with `resource: { type: "agent", companyId, agentId }`. That resolves to `allow_self` for the caller itself, and it falls through to the same configure/suggest ladder for every other agent.

## Verification

Run the focused suite from `server/`:

```
./node_modules/.bin/vitest run src/__tests__/agent-permissions-routes.test.ts
```

Result on this branch: 1 file passed, 55 tests passed. The three cases that matter are `allows an agent to list its own redacted configuration revisions without grants`, `denies an agent actor without configure or suggest grants when reading peer config`, and the matching allow-with-grant case.

I also confirmed the denial on a running self-hosted server before the change. An agent asking for its own `/config-revisions` received HTTP 403 `deny_missing_grant`, while a board caller read the identical revisions from the same instance. That board read also confirms the redaction path: `adapterConfig.env` returns names and types only.

## Risks

Low. The change moves three read routes to a helper that this file already uses, and it does not touch the authorization service.

Two behavioral notes:

1. Board behavior is unchanged. `assertCanReadAgent` delegates to `assertCanReadConfigurations` for board actors, so company access is still the only requirement.
2. A cross-company agent caller now receives HTTP 404 `Agent not found` instead of HTTP 403 `Agent key cannot access another company`. These routes load the agent with an unscoped `getById`, so the gate is the only company check. The new response no longer confirms that a foreign agent id exists. This aligns these three routes with `getAccessibleAgent`, which already returns 404 in that case.

Redaction is unchanged. Responses still pass through `redactAgentConfiguration` and `redactConfigRevision`.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing documentation covers this gate
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not yet run at the time of opening
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not yet run at the time of opening
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
