### PR TITLE
fix: restore review assignee without consuming a native verdict

### DIFF
--- a/docs/guides/execution-policy.md
+++ b/docs/guides/execution-policy.md
@@ -48,7 +48,7 @@ Tracks where the issue currently sits in its policy workflow:
 
 ```ts
 interface IssueExecutionState {
-  status: "idle" | "pending" | "changes_requested" | "completed";
+  status: "idle" | "pending" | "changes_requested" | "precondition_returned" | "completed";
   currentStageId: string | null;
   currentStageIndex: number | null;
   currentStageType: "review" | "approval" | null;
@@ -122,6 +122,24 @@ interface IssueExecutionDecision {
    - Sets `executionState.status` to `changes_requested`
 3. **Executor makes changes** and transitions to `done` again.
 4. Runtime routes back to the **same review stage** (not the beginning), with the same reviewer.
+
+### Precondition Return (not a verdict)
+
+A reviewer or watchdog can restore the executor without consuming the candidate verdict when required evidence or the review environment is not ready. The first line of the same `PATCH` comment must be `REVIEW_EVIDENCE_NOT_GREEN` or `REVIEW_ENVIRONMENT_BLOCKED` (optional markdown heading).
+
+```bash
+PATCH /api/issues/{issueId}
+{ "status": "todo", "comment": "## REVIEW_EVIDENCE_NOT_GREEN\n\nRequired checks are still running; no verdict was consumed." }
+```
+
+Runtime then:
+
+- Sets status to `in_progress` and reassigns to `returnAssignee`
+- Sets `executionState.status` to `precondition_returned`
+- Leaves `lastDecisionOutcome`, `lastDecisionId`, and `changesRequestedCount` unchanged
+- Does **not** insert an `issue_execution_decisions` row
+
+The executor later resubmits with `done`; the same exact-head stage becomes `pending` again. A later mention of those tokens in a changes-requested comment is still a real verdict.
 5. This loop continues until the reviewer approves.
 
 ### Policy Variants

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -539,7 +539,13 @@ export const ISSUE_EXECUTION_MONITOR_RECOVERY_POLICIES = [
 export type IssueExecutionMonitorRecoveryPolicy =
   (typeof ISSUE_EXECUTION_MONITOR_RECOVERY_POLICIES)[number];
 
-export const ISSUE_EXECUTION_STATE_STATUSES = ["idle", "pending", "changes_requested", "completed"] as const;
+export const ISSUE_EXECUTION_STATE_STATUSES = [
+  "idle",
+  "pending",
+  "changes_requested",
+  "precondition_returned",
+  "completed",
+] as const;
 export type IssueExecutionStateStatus = (typeof ISSUE_EXECUTION_STATE_STATUSES)[number];
 
 export const ISSUE_EXECUTION_MONITOR_STATE_STATUSES = ["scheduled", "triggered", "cleared"] as const;

--- a/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
+++ b/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
@@ -44,6 +44,7 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
     for (const wakeReason of [
       "execution_review_requested",
       "execution_changes_requested",
+      "execution_precondition_returned",
     ] as const) {
       expect(shouldResetTaskSessionForWake({ wakeReason })).toBe(false);
     }
@@ -103,6 +104,7 @@ describe("PF-4 describeSessionResetReason", () => {
   it("does not report review/change-request handoffs as reset reasons", () => {
     expect(describeSessionResetReason({ wakeReason: "execution_review_requested" })).toBeNull();
     expect(describeSessionResetReason({ wakeReason: "execution_changes_requested" })).toBeNull();
+    expect(describeSessionResetReason({ wakeReason: "execution_precondition_returned" })).toBeNull();
   });
 
   it("returns the forceFreshSession message when explicitly requested", () => {
@@ -128,6 +130,7 @@ describe("PF-4 describeSessionResetReason", () => {
       { wakeReason: "execution_approval_requested" },
       { wakeReason: "execution_review_participant_recovery" },
       { wakeReason: "execution_changes_requested" },
+      { wakeReason: "execution_precondition_returned" },
       { forceFreshSession: true },
       { wakeReason: "issue_commented" },
       { wakeReason: "transient_failure_retry" },

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1910,6 +1910,10 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_changes_requested" })).toBe(false);
   });
 
+  it("preserves session context on execution precondition-return handoff wakes", () => {
+    expect(shouldResetTaskSessionForWake({ wakeReason: "execution_precondition_returned" })).toBe(false);
+  });
+
   it("preserves session context on timer heartbeats", () => {
     expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(false);
   });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -3538,4 +3538,83 @@ describe.sequential("issue comment reopen routes", () => {
       }),
     ));
   });
+
+  it("REVIEW_EVIDENCE_NOT_GREEN restores the executor without a native verdict", async () => {
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: "33333333-3333-4333-8333-333333333333" },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: "33333333-3333-4333-8333-333333333333",
+        companyId: "company-1",
+        runId: "run-2",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        status: "todo",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        comment: "## REVIEW_EVIDENCE_NOT_GREEN\n\nRequired checks are still running; no verdict was consumed.",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.executionState).toMatchObject({
+      status: "precondition_returned",
+      currentStageId: policy.stages[0].id,
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+      changesRequestedCount: 0,
+    });
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        reason: "execution_precondition_returned",
+        payload: expect.objectContaining({
+          issueId: "11111111-1111-4111-8111-111111111111",
+          executionStage: expect.objectContaining({
+            wakeRole: "executor",
+            stageType: "review",
+            lastDecisionOutcome: null,
+            allowedActions: ["restore_precondition", "resubmit"],
+          }),
+        }),
+      }),
+    ));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "execution_changes_requested" }),
+    );
+  });
 });

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -466,6 +466,140 @@ describe("issue execution policy transitions", () => {
     });
   });
 
+  describe("review precondition return", () => {
+    const policy = twoStagePolicy();
+    const reviewStageId = policy.stages[0].id;
+
+    function pendingReviewIssue(stateOverrides: Record<string, unknown> = {}) {
+      return {
+        status: "in_review",
+        assigneeAgentId: qaAgentId,
+        assigneeUserId: null,
+        executionPolicy: policy,
+        executionState: {
+          status: "pending",
+          currentStageId: reviewStageId,
+          currentStageIndex: 0,
+          currentStageType: "review",
+          currentParticipant: { type: "agent", agentId: qaAgentId },
+          returnAssignee: { type: "agent", agentId: coderAgentId },
+          completedStageIds: [],
+          lastDecisionId: null,
+          lastDecisionOutcome: null,
+          changesRequestedCount: 0,
+          ...stateOverrides,
+        },
+      };
+    }
+
+    it("REVIEW_EVIDENCE_NOT_GREEN restores the return assignee without a native decision", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: pendingReviewIssue(),
+        policy,
+        requestedStatus: "todo",
+        requestedAssigneePatch: { assigneeAgentId: coderAgentId },
+        actor: { agentId: qaAgentId },
+        commentBody: [
+          "## REVIEW_EVIDENCE_NOT_GREEN",
+          "",
+          "Exact-head review precondition is not met; no verdict was consumed.",
+        ].join("\n"),
+      });
+
+      expect(result.decision).toBeUndefined();
+      expect(result.patch.status).toBe("in_progress");
+      expect(result.patch.assigneeAgentId).toBe(coderAgentId);
+      expect(result.patch.executionState).toMatchObject({
+        status: "precondition_returned",
+        currentStageId: reviewStageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: qaAgentId },
+        returnAssignee: { type: "agent", agentId: coderAgentId },
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+      });
+    });
+
+    it("REVIEW_ENVIRONMENT_BLOCKED is the same non-verdict return", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: pendingReviewIssue({ changesRequestedCount: 2 }),
+        policy,
+        requestedStatus: "in_progress",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: "REVIEW_ENVIRONMENT_BLOCKED\nProvider quota exhausted.",
+      });
+
+      expect(result.decision).toBeUndefined();
+      expect(result.patch.executionState).toMatchObject({
+        status: "precondition_returned",
+        lastDecisionOutcome: null,
+        changesRequestedCount: 2,
+      });
+    });
+
+    it("does not treat a later mention of the token as a precondition return", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: pendingReviewIssue(),
+        policy,
+        requestedStatus: "in_progress",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: "Please fix the tests. Do not send REVIEW_EVIDENCE_NOT_GREEN next time.",
+      });
+
+      expect(result.decision).toMatchObject({ outcome: "changes_requested" });
+      expect(result.patch.executionState).toMatchObject({
+        status: "changes_requested",
+        lastDecisionOutcome: "changes_requested",
+        changesRequestedCount: 1,
+      });
+    });
+
+    it("resubmits the same exact-head stage without duplicating a verdict", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: coderAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "precondition_returned",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+            changesRequestedCount: 0,
+          },
+        },
+        policy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        actor: { agentId: coderAgentId },
+        commentBody: "Required CI is green; resubmitting the unchanged head.",
+      });
+
+      expect(result.decision).toBeUndefined();
+      expect(result.patch.status).toBe("in_review");
+      expect(result.patch.assigneeAgentId).toBe(qaAgentId);
+      expect(result.patch.executionState).toMatchObject({
+        status: "pending",
+        currentStageId: reviewStageId,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: qaAgentId },
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+      });
+    });
+  });
+
   describe("review-only policy (no approval stage)", () => {
     const policy = reviewOnlyPolicy();
     const reviewStageId = policy.stages[0].id;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2339,6 +2339,45 @@ function buildExecutionStageWakeup(input: {
     };
   }
 
+  if (nextState.status === "precondition_returned") {
+    const agentId = nextState.returnAssignee?.type === "agent" ? (nextState.returnAssignee.agentId ?? null) : null;
+    const becamePreconditionReturned =
+      previousState?.status !== "precondition_returned" ||
+      !executionPrincipalsEqual(previousState?.returnAssignee ?? null, nextState.returnAssignee ?? null);
+    if (!agentId || !becamePreconditionReturned) return null;
+
+    const executionStage = buildExecutionStageWakeContext({
+      state: nextState,
+      wakeRole: "executor",
+      allowedActions: ["restore_precondition", "resubmit"],
+    });
+
+    return {
+      agentId,
+      wakeup: {
+        source: "assignment" as const,
+        triggerDetail: "system" as const,
+        reason: "execution_precondition_returned",
+        payload: {
+          issueId,
+          mutation: "update",
+          executionStage,
+          ...(interruptedRunId ? { interruptedRunId } : {}),
+        },
+        requestedByActorType: input.requestedByActorType,
+        requestedByActorId: input.requestedByActorId,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_precondition_returned",
+          source: "issue.execution_stage",
+          executionStage,
+          ...(interruptedRunId ? { interruptedRunId } : {}),
+        },
+      },
+    };
+  }
+
   return null;
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -813,6 +813,7 @@ const ISSUE_RESPONSIBLE_USER_WAKE_REASONS = new Set([
   "execution_review_requested",
   "execution_approval_requested",
   "execution_changes_requested",
+  "execution_precondition_returned",
   "approval_approved",
 ]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
@@ -4220,7 +4221,8 @@ function shouldRequireIssueCommentForWake(
     wakeReason === "issue_assigned" ||
     wakeReason === "execution_review_requested" ||
     wakeReason === "execution_approval_requested" ||
-    wakeReason === "execution_changes_requested"
+    wakeReason === "execution_changes_requested" ||
+    wakeReason === "execution_precondition_returned"
   );
 }
 

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -71,6 +71,8 @@ export const DEFAULT_MAX_REVIEW_ROUNDS = 3;
 const COMPLETED_STATUS: IssueExecutionState["status"] = "completed";
 const PENDING_STATUS: IssueExecutionState["status"] = "pending";
 const CHANGES_REQUESTED_STATUS: IssueExecutionState["status"] = "changes_requested";
+const PRECONDITION_RETURNED_STATUS: IssueExecutionState["status"] = "precondition_returned";
+const REVIEW_PRECONDITION_RETURN_KINDS = ["REVIEW_EVIDENCE_NOT_GREEN", "REVIEW_ENVIRONMENT_BLOCKED"] as const;
 const MONITOR_INVALID_MESSAGE = "Monitor can only be scheduled on issues assigned to an agent in in_progress or in_review";
 const MONITOR_BOUNDS_EXHAUSTED_MESSAGE = "Monitor bounds are already exhausted";
 const STAGE_DECISION_COMMENT_HINT = "Include the decision comment in the same PATCH request; prior comments are not considered.";
@@ -90,6 +92,19 @@ function normalizeMonitorText(value: string | null | undefined) {
 
 export function redactIssueMonitorExternalRef(value: string | null | undefined) {
   return normalizeMonitorText(value) ? REDACTED_ISSUE_MONITOR_EXTERNAL_REF : null;
+}
+
+export function isReviewPreconditionReturnComment(body: string | null | undefined): boolean {
+  if (typeof body !== "string") return false;
+  const firstLine = body.trim().split(/\r?\n/, 2)[0] ?? "";
+  const stripped = firstLine.replace(/^#+\s*/, "").replace(/^[*`]+/, "").replace(/[*`]+$/, "").trim();
+  return REVIEW_PRECONDITION_RETURN_KINDS.some(
+    (kind) => stripped === kind || stripped.startsWith(`${kind} `) || stripped.startsWith(`${kind}:`),
+  );
+}
+
+function executionStateReusesCurrentStage(state: IssueExecutionState | null): boolean {
+  return state?.status === CHANGES_REQUESTED_STATUS || state?.status === PRECONDITION_RETURNED_STATUS;
 }
 
 function monitorMetadataFromPolicy(monitor: IssueExecutionMonitorPolicy) {
@@ -611,6 +626,18 @@ function buildChangesRequestedState(
   };
 }
 
+function buildPreconditionReturnedState(
+  previous: IssueExecutionState,
+  currentStage: IssueExecutionStage,
+): IssueExecutionState {
+  return {
+    ...previous,
+    status: PRECONDITION_RETURNED_STATUS,
+    currentStageId: currentStage.id,
+    currentStageType: currentStage.type,
+  };
+}
+
 function buildPendingStagePatch(input: {
   patch: Record<string, unknown>;
   previous: IssueExecutionState | null;
@@ -849,6 +876,18 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
       }
 
       if (requestedStatus && requestedStatus !== "in_review") {
+        if (isReviewPreconditionReturnComment(input.commentBody)) {
+          if (!existingState?.returnAssignee) {
+            throw unprocessable("This execution stage has no return assignee");
+          }
+          patch.status = "in_progress";
+          Object.assign(patch, patchForPrincipal(existingState.returnAssignee));
+          patch.executionState = buildPreconditionReturnedState(existingState, activeStage);
+          return {
+            patch,
+            workflowControlledAssignment: true,
+          };
+        }
         if (!input.commentBody?.trim()) {
           throw unprocessable(`Requesting changes requires a comment. ${STAGE_DECISION_COMMENT_HINT}`);
         }
@@ -977,18 +1016,16 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
     return { patch };
   }
 
-  let pendingStage =
-    existingState?.status === CHANGES_REQUESTED_STATUS && currentStage
-      ? currentStage
-      : nextPendingStage(input.policy, existingState);
+  const reuseCurrentStage = executionStateReusesCurrentStage(existingState) && Boolean(currentStage);
+  let pendingStage = reuseCurrentStage ? currentStage : nextPendingStage(input.policy, existingState);
   if (!pendingStage) return { patch };
 
   const returnAssignee = existingState?.returnAssignee ?? currentAssignee;
   const skippedStageIds = [...(existingState?.completedStageIds ?? [])];
   let participant = selectStageParticipant(pendingStage, {
     preferred:
-      existingState?.status === CHANGES_REQUESTED_STATUS
-        ? explicitAssignee ?? existingState.currentParticipant ?? null
+      reuseCurrentStage
+        ? explicitAssignee ?? existingState?.currentParticipant ?? null
         : explicitAssignee,
     exclude: returnAssignee,
   });
@@ -1012,8 +1049,8 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
     }
     participant = selectStageParticipant(pendingStage, {
       preferred:
-        existingState?.status === CHANGES_REQUESTED_STATUS
-          ? explicitAssignee ?? existingState.currentParticipant ?? null
+        reuseCurrentStage
+          ? explicitAssignee ?? existingState?.currentParticipant ?? null
           : explicitAssignee,
       exclude: returnAssignee,
     });

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -85,6 +85,7 @@ If `currentParticipant` matches you, submit your decision via the normal update 
 
 - Approve: `PATCH /api/issues/{issueId}` with `{ "status": "done", "comment": "Approved: …" }`. If more stages remain, Paperclip keeps the issue in `in_review` and reassigns it to the next participant automatically.
 - Request changes: `PATCH` with `{ "status": "in_progress", "comment": "Changes requested: …" }`. Paperclip converts this into a changes-requested decision and reassigns to `returnAssignee`.
+- Precondition return (not a verdict): when required CI or the review environment is not ready, `PATCH` with a first-line `REVIEW_EVIDENCE_NOT_GREEN` or `REVIEW_ENVIRONMENT_BLOCKED` comment. Paperclip restores `returnAssignee` without creating a native decision, without incrementing `changesRequestedCount`, and keeps the same exact-head stage for later resubmission.
 
 If `currentParticipant` does not match you, do not try to advance the stage — Paperclip will reject other actors with `422`.
 

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -877,7 +877,11 @@ export function IssueProperties({
   // "anyone can approve") is what every issue already does, so it shows nothing.
   const reviewPolicyBadge = issueReviewPolicyBadge(issue.reviewPolicy);
   const nextRunnableExecutionStage = (() => {
-    if (issue.executionState?.status === "changes_requested" && issue.executionState.currentStageType) {
+    if (
+      (issue.executionState?.status === "changes_requested" ||
+        issue.executionState?.status === "precondition_returned") &&
+      issue.executionState.currentStageType
+    ) {
       return issue.executionState.currentStageType;
     }
     if (issue.executionState) return null;
@@ -907,6 +911,9 @@ export function IssueProperties({
       : null;
     if (issue.executionState.status === "changes_requested") {
       return `${stageLabel} requested changes${participantLabel ? ` by ${participantLabel}` : ""}`;
+    }
+    if (issue.executionState.status === "precondition_returned") {
+      return `${stageLabel} returned for evidence${participantLabel ? ` by ${participantLabel}` : ""}`;
     }
     return `${stageLabel} pending${participantLabel ? ` with ${participantLabel}` : ""}`;
   })();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Execution policy enforces review and approval stages on an issue
> - A reviewer PATCH that is not `done` currently records a native `changes_requested` decision
> - Task watchdogs need to return a candidate when required CI is not green without consuming that verdict
> - This pull request adds a typed precondition-return path for `REVIEW_EVIDENCE_NOT_GREEN` and `REVIEW_ENVIRONMENT_BLOCKED`
> - The benefit is that the same exact-head review stage can resume after evidence is green

## Linked Issues or Issue Description

**What happened?**
When the active review participant PATCHes the issue with `status: "todo"` (or `in_progress`) and a comment whose first line is `REVIEW_EVIDENCE_NOT_GREEN`, the server coerces the issue to `in_progress` and records `lastDecisionOutcome: "changes_requested"`. It also inserts an `issue_execution_decisions` row and increments `changesRequestedCount`.

**Expected behavior**
That PATCH should restore the return assignee and an actionable status. It must not create a native decision. It must not increment `changesRequestedCount`. The same exact-head review stage must remain available for later resubmission.

**Steps to reproduce**
1. Create an issue with one active native review stage. Set Staff as `currentParticipant` and the implementer as `returnAssignee`. Keep required CI pending.
2. As the current participant, PATCH the issue with a typed `REVIEW_EVIDENCE_NOT_GREEN` comment, `status: "todo"`, and the implementer as assignee.
3. Observe `lastDecisionOutcome: "changes_requested"` and a new execution decision.

**Paperclip version or commit**
`master` at `fc9e9b7`

**Deployment mode**
Self-hosted server

## What Changed

- Detect first-line `REVIEW_EVIDENCE_NOT_GREEN` and `REVIEW_ENVIRONMENT_BLOCKED` comments as a precondition return, not a verdict
- Restore `returnAssignee` with `executionState.status: "precondition_returned"` and no decision row
- Preserve `lastDecisionOutcome`, `lastDecisionId`, `changesRequestedCount`, and the current stage for later resubmission
- Wake the executor with `execution_precondition_returned` instead of `execution_changes_requested`
- Document the path in the execution-policy guide and the Paperclip skill

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-execution-policy.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-comment-reopen-routes.test.ts -t "REVIEW_EVIDENCE_NOT_GREEN|execution_changes_requested"`
- Focused heartbeat session-reset tests for the new wake reason

## Risks

- Reviewers who put a real change request after a first-line `REVIEW_EVIDENCE_NOT_GREEN` heading will not create a verdict. The first line is the discriminator on purpose.
- Hosts must upgrade Paperclip before watchdog returns stop consuming verdicts.

## Model Used

- Provider: xAI
- Model: grok-4.6
- Reasoning: medium
- Tool use: yes

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
