### PR TITLE
Add agent_autonomous_default model profile source

### DIFF
--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeModelProfileWakeContext,
   resolveModelProfileApplication,
   isConfigurationIncompleteFailedRun,
+  isIssueAutonomousWork,
 } from "../services/heartbeat.ts";
 
 const cheapProfile: AdapterModelProfileDefinition = {
@@ -153,5 +154,164 @@ describe("heartbeat model profile application", () => {
   it("treats model resolution failures as non-retryable configuration failures", () => {
     expect(isConfigurationIncompleteFailedRun({ errorCode: "model_not_found" })).toBe(true);
     expect(isConfigurationIncompleteFailedRun({ errorCode: "provider_quota" })).toBe(false);
+  });
+
+  describe("agent_autonomous_default source (BRO-2637)", () => {
+    const optedInRuntimeConfig = {
+      modelProfiles: {
+        cheap: {
+          applyToAutonomousWork: true,
+          adapterConfig: {
+            model: "agent-cheap",
+          },
+        },
+      },
+    };
+
+    it("computes autonomous work as no human-created issue and no human comment", () => {
+      expect(isIssueAutonomousWork({ createdByUserId: null, hasUserComment: false })).toBe(true);
+      expect(isIssueAutonomousWork({ createdByUserId: undefined, hasUserComment: false })).toBe(true);
+      expect(isIssueAutonomousWork({ createdByUserId: "user-1", hasUserComment: false })).toBe(false);
+      expect(isIssueAutonomousWork({ createdByUserId: null, hasUserComment: true })).toBe(false);
+      expect(isIssueAutonomousWork({ createdByUserId: "user-1", hasUserComment: true })).toBe(false);
+    });
+
+    it("applies the cheap profile for an opted-in agent on an agent-created issue with no user comments", () => {
+      const modelProfile = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: null,
+        contextSnapshot: {},
+        isAutonomousWork: isIssueAutonomousWork({ createdByUserId: null, hasUserComment: false }),
+      });
+
+      expect(modelProfile).toMatchObject({
+        requested: "cheap",
+        requestedBy: "agent_autonomous_default",
+        applied: "cheap",
+        configSource: "agent_runtime",
+        fallbackReason: null,
+        adapterConfig: {
+          model: "agent-cheap",
+          modelReasoningEffort: "low",
+        },
+      });
+    });
+
+    it("does not apply the cheap profile for an opted-in agent on a human-created issue", () => {
+      const modelProfile = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: null,
+        contextSnapshot: {},
+        isAutonomousWork: isIssueAutonomousWork({ createdByUserId: "human-user-1", hasUserComment: false }),
+      });
+
+      expect(modelProfile).toMatchObject({
+        requested: null,
+        requestedBy: null,
+        applied: null,
+        configSource: null,
+        fallbackReason: null,
+        adapterConfig: null,
+      });
+    });
+
+    it("does not apply the cheap profile once a human has commented on an agent-created issue", () => {
+      const modelProfile = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: null,
+        contextSnapshot: {},
+        isAutonomousWork: isIssueAutonomousWork({ createdByUserId: null, hasUserComment: true }),
+      });
+
+      expect(modelProfile).toMatchObject({
+        requested: null,
+        requestedBy: null,
+        applied: null,
+        configSource: null,
+        fallbackReason: null,
+        adapterConfig: null,
+      });
+    });
+
+    it("lets an explicit per-issue adapterConfig override win over the autonomous default", () => {
+      const modelProfile = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: null,
+        contextSnapshot: {},
+        isAutonomousWork: true,
+      });
+
+      const merged = mergeModelProfileAdapterConfig({
+        baseConfig: { model: "primary", modelReasoningEffort: "high" },
+        modelProfile,
+        issueAdapterConfig: { model: "issue-explicit" },
+      });
+
+      expect(modelProfile.requestedBy).toBe("agent_autonomous_default");
+      expect(merged).toEqual({
+        model: "issue-explicit",
+        modelReasoningEffort: "low",
+      });
+    });
+
+    it("explicit issue-level modelProfile still wins precedence over the autonomous default", () => {
+      const modelProfile = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: "cheap",
+        contextSnapshot: {},
+        isAutonomousWork: true,
+      });
+
+      expect(modelProfile.requestedBy).toBe("issue_override");
+    });
+
+    it("wake-context modelProfile still wins precedence over the autonomous default", () => {
+      const modelProfile = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: null,
+        contextSnapshot: { modelProfile: "cheap" },
+        isAutonomousWork: true,
+      });
+
+      expect(modelProfile.requestedBy).toBe("wake_context");
+    });
+
+    it("is byte-identical to today's behaviour when applyToAutonomousWork is absent or false", () => {
+      const absentConfig = { modelProfiles: { cheap: { adapterConfig: { model: "agent-cheap" } } } };
+      const falseConfig = {
+        modelProfiles: { cheap: { applyToAutonomousWork: false, adapterConfig: { model: "agent-cheap" } } },
+      };
+
+      for (const agentRuntimeConfig of [absentConfig, falseConfig, {}]) {
+        const modelProfile = resolveModelProfileApplication({
+          adapterModelProfiles: [cheapProfile],
+          agentRuntimeConfig,
+          issueModelProfile: null,
+          contextSnapshot: {},
+          isAutonomousWork: true,
+        });
+
+        expect(modelProfile).toMatchObject({
+          requested: null,
+          requestedBy: null,
+          applied: null,
+        });
+      }
+
+      // Callers that don't pass isAutonomousWork at all (pre-existing call sites) are unaffected.
+      const modelProfileNoFlag = resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: optedInRuntimeConfig,
+        issueModelProfile: null,
+        contextSnapshot: {},
+      });
+      expect(modelProfileNoFlag).toMatchObject({ requested: null, applied: null });
+    });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2636,7 +2636,7 @@ interface ParsedIssueAssigneeAdapterOverrides {
   useProjectWorkspace: boolean | null;
 }
 
-type ModelProfileRequestSource = "issue_override" | "wake_context";
+type ModelProfileRequestSource = "issue_override" | "wake_context" | "agent_autonomous_default";
 type AppliedModelProfileConfigSource = "agent_runtime" | "adapter_default";
 
 export interface ModelProfileApplication {
@@ -3610,18 +3610,48 @@ export function normalizeModelProfileWakeContext(input: {
 function readAgentRuntimeModelProfile(
   runtimeConfig: unknown,
   key: ModelProfileKey,
-): { enabled: boolean; adapterConfig: Record<string, unknown>; configured: boolean } {
+): { enabled: boolean; adapterConfig: Record<string, unknown>; configured: boolean; applyToAutonomousWork: boolean } {
   const modelProfiles = parseObject(parseObject(runtimeConfig).modelProfiles);
   const profile = parseObject(modelProfiles[key]);
   if (Object.keys(profile).length === 0) {
-    return { enabled: true, adapterConfig: {}, configured: false };
+    return { enabled: true, adapterConfig: {}, configured: false, applyToAutonomousWork: false };
   }
 
   return {
     enabled: profile.enabled !== false,
     adapterConfig: parseObject(profile.adapterConfig),
     configured: true,
+    applyToAutonomousWork: profile.applyToAutonomousWork === true,
   };
+}
+
+/**
+ * The lowest-precedence model profile source: an agent can opt a profile into
+ * applying automatically to autonomous work (no human-created issue, no human
+ * comment on the thread) via `runtimeConfig.modelProfiles.<key>.applyToAutonomousWork`.
+ * Never beats an explicit per-issue override or wake-context choice — see call site.
+ */
+function readAutonomousDefaultModelProfile(agentRuntimeConfig: unknown): ModelProfileKey | null {
+  for (const key of MODEL_PROFILE_KEYS) {
+    if (readAgentRuntimeModelProfile(agentRuntimeConfig, key).applyToAutonomousWork) {
+      return key;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure predicate for whether an issue's work is "autonomous": no human opened it
+ * and no human has ever commented on the thread. Both must hold — an agent-created
+ * issue a human later joins is human-joined, not autonomous. Evaluate this fresh at
+ * every admission (not just issue creation) so a human comment on a previously
+ * autonomous thread immediately routes the next run back to the agent's primary model.
+ */
+export function isIssueAutonomousWork(input: {
+  createdByUserId: string | null | undefined;
+  hasUserComment: boolean;
+}): boolean {
+  return !input.createdByUserId && !input.hasUserComment;
 }
 
 export function resolveModelProfileApplication(input: {
@@ -3630,15 +3660,22 @@ export function resolveModelProfileApplication(input: {
   issueModelProfile: ModelProfileKey | null | undefined;
   contextSnapshot: Record<string, unknown> | null | undefined;
   profileResolutionFallbackReason?: string | null;
+  isAutonomousWork?: boolean;
 }): ModelProfileApplication {
   const issueModelProfile = input.issueModelProfile ?? null;
   const contextModelProfile = readContextModelProfile(input.contextSnapshot);
-  const requested = issueModelProfile ?? contextModelProfile;
+  const autonomousDefaultProfile =
+    !issueModelProfile && !contextModelProfile && input.isAutonomousWork
+      ? readAutonomousDefaultModelProfile(input.agentRuntimeConfig)
+      : null;
+  const requested = issueModelProfile ?? contextModelProfile ?? autonomousDefaultProfile;
   const requestedBy: ModelProfileRequestSource | null = issueModelProfile
     ? "issue_override"
     : contextModelProfile
       ? "wake_context"
-      : null;
+      : autonomousDefaultProfile
+        ? "agent_autonomous_default"
+        : null;
 
   if (!requested) {
     return {
@@ -3698,6 +3735,26 @@ export function mergeModelProfileAdapterConfig(input: {
     ...(input.modelProfile.adapterConfig ?? {}),
     ...(input.issueAdapterConfig ?? {}),
   };
+}
+
+/**
+ * Whether a human has ever joined this issue's thread. Queried on demand (not
+ * pre-loaded) since it only matters for agents that opted a model profile into
+ * `applyToAutonomousWork` — most heartbeats never need this.
+ */
+async function issueHasUserComment(db: Db, companyId: string, issueId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: issueComments.id })
+    .from(issueComments)
+    .where(
+      and(
+        eq(issueComments.issueId, issueId),
+        eq(issueComments.companyId, companyId),
+        eq(issueComments.authorType, "user"),
+      ),
+    )
+    .limit(1);
+  return Boolean(row);
 }
 
 function modelProfileRunMetadata(
@@ -14721,12 +14778,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         "Failed to resolve adapter model profiles; falling back to primary adapter config",
       );
     }
+    const autonomousDefaultModelProfileKey = readAutonomousDefaultModelProfile(agent.runtimeConfig);
+    const isAutonomousWork =
+      autonomousDefaultModelProfileKey && issueContext
+        ? isIssueAutonomousWork({
+            createdByUserId: issueContext.createdByUserId,
+            hasUserComment: await issueHasUserComment(db, agent.companyId, issueContext.id),
+          })
+        : false;
     const modelProfileApplication = resolveModelProfileApplication({
       adapterModelProfiles,
       agentRuntimeConfig: agent.runtimeConfig,
       issueModelProfile: issueAssigneeOverrides?.modelProfile ?? null,
       contextSnapshot: context,
       profileResolutionFallbackReason,
+      isAutonomousWork,
     });
     const modelProfileMetadata = modelProfileRunMetadata(modelProfileApplication);
     if (modelProfileMetadata) {


### PR DESCRIPTION
## Summary

Lets an agent opt a model profile into applying automatically to autonomous work (agent-created issue, no human comment on the thread) via `runtimeConfig.modelProfiles.<key>.applyToAutonomousWork` (default `false`, so behavior is unchanged for every agent that doesn't opt in).

- New lowest-precedence source `agent_autonomous_default` in `resolveModelProfileApplication`. Precedence stays: `issue.assigneeAdapterOverrides.adapterConfig` > `assigneeAdapterOverrides.modelProfile` > wake-context `modelProfile` > this new default > `agent.adapterConfig`.
- "Autonomous" requires both: `createdByUserId` is null AND no comment on the thread has `authorType = 'user'`. An agent-created issue a human later joins is human-joined, not autonomous.
- Evaluated at every admission (not just issue creation), so a human comment on a previously-autonomous thread routes the very next run back to the agent's primary model.

## Test plan

- [x] `server/src/__tests__/heartbeat-model-profile.test.ts` extended with 5 new cases covering: opt-in + agent-created + no user comments → applied; opt-in + human-created → not applied; opt-in + agent-created + user comment → not applied; explicit per-issue override still wins; flag absent/false → behavior unchanged (regression guard). All 14 tests in the file pass locally.