### PR TITLE
fix(cli): reject conflicting board token expirations

### DIFF
--- a/cli/src/__tests__/token.test.ts
+++ b/cli/src/__tests__/token.test.ts
@@ -234,6 +234,14 @@ describe("token commands", () => {
       "--ttl-days", "14",
     ], { from: "user" })).rejects.toThrow("exit:1");
 
+    await expect(createProgram().parseAsync([
+      "token", "board", "create",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+      "--never-expires",
+      "--ttl-days", " ",
+    ], { from: "user" })).rejects.toThrow("exit:1");
+
     expect(fetchMock).not.toHaveBeenCalled();
     expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("Choose only one board token expiration mode");
   });

--- a/cli/src/__tests__/token.test.ts
+++ b/cli/src/__tests__/token.test.ts
@@ -210,6 +210,34 @@ describe("token commands", () => {
     });
   });
 
+  it("rejects conflicting board token expiration options before creating a key", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    await expect(createProgram().parseAsync([
+      "token", "board", "create",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+      "--never-expires",
+      "--ttl-days", "14",
+    ], { from: "user" })).rejects.toThrow("exit:1");
+
+    await expect(createProgram().parseAsync([
+      "token", "board", "create",
+      "--api-base", "http://localhost:3100",
+      "--api-key", "board-token",
+      "--expires-at", "2026-06-06T00:00:00.000Z",
+      "--ttl-days", "14",
+    ], { from: "user" })).rejects.toThrow("exit:1");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("Choose only one board token expiration mode");
+  });
+
   it("lists and revokes board tokens", async () => {
     const fetchMock = vi
       .fn()

--- a/cli/src/commands/client/token.ts
+++ b/cli/src/commands/client/token.ts
@@ -229,13 +229,21 @@ async function resolveAgent(api: { get<T>(path: string): Promise<T | null> }, co
 }
 
 function resolveBoardKeyExpiresAt(opts: BoardTokenOptions): Date | null | undefined {
+  const hasExpiresAt = Boolean(opts.expiresAt?.trim());
+  const hasTtlDays = Boolean(opts.ttlDays?.trim());
+  if (opts.neverExpires && (hasExpiresAt || hasTtlDays)) {
+    throw new Error("Choose only one board token expiration mode: --never-expires, --expires-at, or --ttl-days.");
+  }
+  if (hasExpiresAt && hasTtlDays) {
+    throw new Error("Choose only one board token expiration mode: --expires-at or --ttl-days.");
+  }
   if (opts.neverExpires) return null;
-  if (opts.expiresAt?.trim()) {
+  if (hasExpiresAt) {
     const date = new Date(opts.expiresAt.trim());
     if (!Number.isFinite(date.getTime())) throw new Error(`Invalid --expires-at value: ${opts.expiresAt}`);
     return date;
   }
-  if (opts.ttlDays?.trim()) {
+  if (hasTtlDays) {
     const days = Number(opts.ttlDays);
     if (!Number.isFinite(days) || days <= 0) throw new Error(`Invalid --ttl-days value: ${opts.ttlDays}`);
     return new Date(Date.now() + Math.floor(days * 24 * 60 * 60 * 1000));

--- a/cli/src/commands/client/token.ts
+++ b/cli/src/commands/client/token.ts
@@ -229,8 +229,8 @@ async function resolveAgent(api: { get<T>(path: string): Promise<T | null> }, co
 }
 
 function resolveBoardKeyExpiresAt(opts: BoardTokenOptions): Date | null | undefined {
-  const hasExpiresAt = Boolean(opts.expiresAt?.trim());
-  const hasTtlDays = Boolean(opts.ttlDays?.trim());
+  const hasExpiresAt = opts.expiresAt !== undefined;
+  const hasTtlDays = opts.ttlDays !== undefined;
   if (opts.neverExpires && (hasExpiresAt || hasTtlDays)) {
     throw new Error("Choose only one board token expiration mode: --never-expires, --expires-at, or --ttl-days.");
   }
@@ -239,12 +239,16 @@ function resolveBoardKeyExpiresAt(opts: BoardTokenOptions): Date | null | undefi
   }
   if (opts.neverExpires) return null;
   if (hasExpiresAt) {
-    const date = new Date(opts.expiresAt.trim());
+    const rawExpiresAt = opts.expiresAt?.trim();
+    if (!rawExpiresAt) throw new Error("Invalid --expires-at value: expected a non-empty ISO timestamp.");
+    const date = new Date(rawExpiresAt);
     if (!Number.isFinite(date.getTime())) throw new Error(`Invalid --expires-at value: ${opts.expiresAt}`);
     return date;
   }
   if (hasTtlDays) {
-    const days = Number(opts.ttlDays);
+    const rawTtlDays = opts.ttlDays?.trim();
+    if (!rawTtlDays) throw new Error("Invalid --ttl-days value: expected a positive number.");
+    const days = Number(rawTtlDays);
     if (!Number.isFinite(days) || days <= 0) throw new Error(`Invalid --ttl-days value: ${opts.ttlDays}`);
     return new Date(Date.now() + Math.floor(days * 24 * 60 * 60 * 1000));
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents for work.
> - Board API keys are part of the CLI/auth surface that lets operators automate board-level actions.
> - The `token board create` command exposes three expiration modes: absolute timestamp, TTL, and non-expiring.
> - Before this change, conflicting expiration flags were accepted locally and `--never-expires` silently won over bounded-expiration options.
> - That creates an avoidable safety footgun: an operator can believe they minted a bounded token while actually creating a non-expiring one.
> - This pull request makes the CLI reject conflicting expiration modes before it sends any create request.
> - The benefit is safer token lifecycle handling with a small, local, easy-to-review guard and focused regression coverage.

## Linked Issues or Issue Description

Bug report (no public issue exists):

Pre-submission checklist:

- I searched existing open PRs/issues for board token expiration flag handling and did not find a duplicate.
- I can reproduce this on `master` at commit `fc9e9b70`.
- I confirmed the behavior originates in the Paperclip CLI input handling, not an adapter, API provider, or local configuration.

What happened?

`paperclipai token board create` accepts conflicting expiration flags. For example, passing `--never-expires --ttl-days 14` silently treats the request as non-expiring because `--never-expires` wins locally before the payload is sent.

Expected behavior

The CLI should reject commands that specify more than one board token expiration mode, so operators cannot accidentally mint a token with a broader lifetime than intended.

Steps to reproduce

1. From a checkout of `master`, run `paperclipai token board create --api-base http://localhost:3100 --api-key <board-token> --never-expires --ttl-days 14`.
2. Observe that the CLI accepts the conflicting options and sends `expiresAt: null`.
3. Repeat with `--expires-at 2026-06-06T00:00:00.000Z --ttl-days 14` and observe that one bounded mode silently wins instead of the command being rejected.

Paperclip version or commit

- `fc9e9b70`

Deployment mode

- Local dev (`pnpm dev`)

Installation method

- Built from source (`pnpm dev` / `pnpm build`)

Agent adapter(s) involved

- Not adapter-specific (core bug)

Database mode

- Not database-related

Access context

- Board (human operator)

Node.js version

- `v24.12.0`

Operating system

- macOS (Apple Silicon)

Relevant logs or output

- No server logs required; this is a local CLI validation bug.

Relevant config

- Not applicable.

Additional context

- This PR keeps the change local to CLI validation and adds regression coverage that no network request is made for conflicting modes.

Privacy checklist

- I reviewed this inline issue description for PII and did not include secrets, usernames, tokens, company names, or local file paths.

## What Changed

- Added local validation that rejects mutually exclusive board token expiration modes before parsing the API payload.
- Covered `--never-expires` + `--ttl-days` and `--expires-at` + `--ttl-days` conflicts in `token.test.ts`.
- Asserted conflicting commands make no network request.

## Verification

- `node_modules/.bin/vitest run cli/src/__tests__/token.test.ts`
- `git diff --check`

Note: I also tried `pnpm test:run -- cli/src/__tests__/token.test.ts`, but in this fresh worktree it stopped during pnpm dependency setup because pnpm requires `approve-builds` for ignored build scripts before the test runner starts. The direct Vitest command above ran the focused suite successfully after dependencies were linked.

## Risks

- Low risk: this only rejects invalid CLI flag combinations that were ambiguous before.
- Existing valid modes are unchanged: default expiration, `--ttl-days`, `--expires-at`, and `--never-expires` still work individually.
- No schema, server API, or lockfile changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5-Codex via Codex desktop, with repository file access, shell command execution, GitHub CLI usage, and focused local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

