### PR TITLE
fix(skills): sync new skill description with tagline

### DIFF
--- a/ui/src/lib/skill-create.test.ts
+++ b/ui/src/lib/skill-create.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeSkillDraftSlug,
   skillCreateDraftToPayload,
   splitCategoryDraft,
+  updateSkillDraftTagline,
 } from "./skill-create";
 
 function skill(overrides: Partial<CompanySkillDetail> = {}): CompanySkillDetail {
@@ -93,6 +94,29 @@ describe("skill create helpers", () => {
     expect(draft.forkedFromName).toBe("Demo Skill");
     expect(draft.folderId).toBeNull();
     expect(draft.markdown).toContain("name: Demo Skill Fork");
+  });
+
+  it("keeps a new skill description synchronized with the full tagline", () => {
+    let draft = buildBlankSkillDraft();
+
+    draft = updateSkillDraftTagline(draft, "E");
+    draft = updateSkillDraftTagline(draft, "Evaluate pull requests with clear evidence.");
+
+    expect(draft.description).toBe("Evaluate pull requests with clear evidence.");
+    expect(draft.markdown).toContain("description: Evaluate pull requests with clear evidence.");
+    expect(skillCreateDraftToPayload({ ...draft, name: "Review" }).description)
+      .toBe("Evaluate pull requests with clear evidence.");
+  });
+
+  it("preserves a fork's source description when its tagline changes", () => {
+    const draft = buildForkSkillDraft(skill({
+      description: "A detailed source description.",
+      tagline: "Original tagline.",
+    }));
+    const updated = updateSkillDraftTagline(draft, "A revised fork tagline.");
+
+    expect(updated.description).toBe("A detailed source description.");
+    expect(updated.tagline).toBe("A revised fork tagline.");
   });
 
   it("converts drafts to create payloads with fallback slug and markdown", () => {

--- a/ui/src/lib/skill-create.ts
+++ b/ui/src/lib/skill-create.ts
@@ -74,6 +74,21 @@ export function defaultSkillMarkdown(name: string, tagline: string) {
   ].join("\n");
 }
 
+export function updateSkillDraftTagline(draft: SkillCreateDraft, tagline: string): SkillCreateDraft {
+  const markdown = draft.markdown === defaultSkillMarkdown(draft.name, draft.tagline)
+    ? defaultSkillMarkdown(draft.name, tagline)
+    : draft.markdown;
+
+  return {
+    ...draft,
+    tagline,
+    // A new skill has no independent description field, so keep its derived
+    // description in sync. A fork preserves the source description instead.
+    description: draft.forkedFromSkillId !== null ? draft.description : tagline,
+    markdown,
+  };
+}
+
 export function skillAccentColor(key: string, explicit: string | null | undefined): string {
   const trimmed = explicit?.trim();
   if (trimmed) return trimmed;

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -84,6 +84,7 @@ import {
   skillAccentColor,
   skillCreateDraftToPayload,
   splitCategoryDraft,
+  updateSkillDraftTagline,
   type SkillCreateDraft,
 } from "../lib/skill-create";
 import { SkillCardIcon } from "../components/SkillCardIcon";
@@ -1564,14 +1565,7 @@ function NewSkillWizard({
           <Textarea
             value={draft.tagline}
             onChange={(event) => {
-              const nextTagline = event.target.value;
-              patchDraft({
-                tagline: nextTagline,
-                description: draft.description ? draft.description : nextTagline,
-                markdown: draft.markdown === defaultSkillMarkdown(draft.name, draft.tagline)
-                  ? defaultSkillMarkdown(draft.name, nextTagline)
-                  : draft.markdown,
-              });
+              setDraft((current) => updateSkillDraftTagline(current, event.target.value));
             }}
             placeholder="One-line promise for the skill"
             className="min-h-20"

--- a/ui/src/pages/SkillStudio.test.tsx
+++ b/ui/src/pages/SkillStudio.test.tsx
@@ -366,6 +366,48 @@ describe("SkillStudio create mode", () => {
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/skills/studio/created-skill"));
   });
 
+  it("uses the full tagline as a new skill description instead of its first character (#11862)", async () => {
+    const node = await renderStudio();
+
+    await waitFor(() => expect(node.querySelector("#skill-name")).toBeTruthy());
+    await inputValue(node.querySelector("#skill-name") as HTMLInputElement, "Code Review");
+    const tagline = node.querySelector("#skill-tagline") as HTMLTextAreaElement;
+    await inputValue(tagline, "E");
+    await inputValue(tagline, "Evaluate pull requests with clear evidence.");
+    await click(buttonsNamed(node, "Create skill")[0] as HTMLButtonElement);
+
+    await waitFor(() => expect(mockCompanySkillsApi.create).toHaveBeenCalled());
+    expect(mockCompanySkillsApi.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        description: "Evaluate pull requests with clear evidence.",
+      }),
+    );
+  });
+
+  it("preserves a fork's source description when its tagline changes", async () => {
+    routeState.search = "?forkFrom=source-skill";
+
+    const node = await renderStudio();
+
+    await waitFor(() => expect(node.textContent).toContain("Forking Demo Skill"));
+    await inputValue(
+      node.querySelector("#skill-tagline") as HTMLTextAreaElement,
+      "A revised fork tagline.",
+    );
+    await click(buttonsNamed(node, "Create fork")[0] as HTMLButtonElement);
+
+    await waitFor(() => expect(mockCompanySkillsApi.create).toHaveBeenCalled());
+    expect(mockCompanySkillsApi.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        description: "A demo skill.",
+        forkedFromSkillId: "source-skill",
+        tagline: "A revised fork tagline.",
+      }),
+    );
+  });
+
   it("forwards the folderId query param so the new skill is filed there (PAP-14086)", async () => {
     routeState.search = "?folderId=folder-my-skills";
 

--- a/ui/src/pages/SkillStudio.tsx
+++ b/ui/src/pages/SkillStudio.tsx
@@ -64,6 +64,7 @@ import {
   skillAccentColor,
   skillCreateDraftToPayload,
   splitCategoryDraft,
+  updateSkillDraftTagline,
   type SkillCreateDraft,
 } from "@/lib/skill-create";
 import { getRecentStudioSkillIds, trackRecentStudioSkill } from "@/lib/recent-skills";
@@ -579,14 +580,7 @@ function StudioNewSkillPanel({
             id="skill-tagline"
             value={draft.tagline}
             onChange={(event) => {
-              const nextTagline = event.target.value;
-              patchDraft({
-                tagline: nextTagline,
-                description: draft.description ? draft.description : nextTagline,
-                markdown: draft.markdown === defaultSkillMarkdown(draft.name, draft.tagline)
-                  ? defaultSkillMarkdown(draft.name, nextTagline)
-                  : draft.markdown,
-              });
+              setDraft((current) => updateSkillDraftTagline(current, event.target.value));
             }}
             placeholder="Review repository changes for correctness, tests, and maintainability."
             className="min-h-20"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Skill Studio lets users create company skills.
> - A new skill derives its description from its tagline.
> - The create form saves the first typed character as the description.
> - Later tagline edits do not update that description.
> - This pull request keeps the description in sync with the tagline for new skills.
> - It keeps the source description when a user forks a skill.
> - The benefit is that saved skill descriptions match the user input.

## Linked Issues or Issue Description

Refs: #11862

Related pull request:

- #8715 handles a separate skill creation validation-feedback concern.
  It does not change description synchronization.

This pull request fixes only the description synchronization defect.
It does not add the client-side 120-character tagline limit.

## What Changed

- Add one shared helper for tagline updates in a skill draft.
- Update the Skill Studio create flow to use the helper.
- Update the secondary Company Skills create flow to use the helper.
- Keep the source description when a user forks a skill.
- Keep custom Markdown unchanged.
- Add unit and UI regression tests.

## Verification

- Run `pnpm exec vitest run ui/src/lib/skill-create.test.ts ui/src/pages/SkillStudio.test.tsx ui/src/pages/CompanySkills.test.tsx`.
  The command passes 42 tests in 3 files.
- Run `pnpm run typecheck`.
  The command passes.
- Run `pnpm --filter @paperclipai/ui build`.
  The command passes.
- Run `pnpm check:token-gates`.
  The command passes.
- Run `git diff --check`.
  The command passes.
- The UI test enters a one-character tagline and then a full tagline.
  It verifies that the create request uses the full description.
- The UI test changes a fork tagline.
  It verifies that the source description stays unchanged.
- The full workspace test command showed failures in server runtime suites in this environment.
  This pull request does not mark the full test suite as passed.

## Risks

- Low risk.
- The change updates the derived description only for new skill drafts.
- Fork drafts keep their existing source description.
- Existing custom Markdown stays unchanged.
- This change does not change the API, database, or migrations.
- The current create form has no independent description field.
  A future independent description field needs its own edit state.

## Model Used

OpenAI Codex with GPT-5.
The hosted exact model revision and context window are not exposed in this session.
Reasoning, tool use, and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge