### PR TITLE
feat(heartbeat): pick reviewer-reworked issues next in the assignee queue

### DIFF
--- a/server/src/__tests__/heartbeat-queued-run-pickup-order.test.ts
+++ b/server/src/__tests__/heartbeat-queued-run-pickup-order.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareQueuedRunPickup,
+  type QueuedRunPickupCandidate,
+} from "../services/heartbeat.ts";
+
+function candidate(overrides: Partial<QueuedRunPickupCandidate> = {}): QueuedRunPickupCandidate {
+  return {
+    createdAtMs: 0,
+    hasIssue: true,
+    isDependencyReady: true,
+    issueStatus: "in_progress",
+    issuePriority: "medium",
+    executionState: null,
+    ...overrides,
+  };
+}
+
+const reworkState: Record<string, unknown> = { status: "changes_requested" };
+
+/** Sort a copy the same way startNextQueuedRunForAgent does, returning labels. */
+function pickupOrder(items: Array<{ label: string; candidate: QueuedRunPickupCandidate }>): string[] {
+  return [...items]
+    .sort((left, right) => compareQueuedRunPickup(left.candidate, right.candidate))
+    .map((item) => item.label);
+}
+
+describe("compareQueuedRunPickup", () => {
+  it("picks a reviewer-reworked issue before an older same-priority in_progress peer", () => {
+    // Regression for the FIFO gap: rework carries the newest createdAt, so
+    // without the rework tiebreaker the older peer would win.
+    const order = pickupOrder([
+      { label: "peer", candidate: candidate({ createdAtMs: 1_000 }) },
+      { label: "rework", candidate: candidate({ createdAtMs: 5_000, executionState: reworkState }) },
+    ]);
+    expect(order).toEqual(["rework", "peer"]);
+  });
+
+  it("keeps the reviewer-rework boost above issue priority", () => {
+    // A human change-request is the highest-signal instruction: act on it next,
+    // even ahead of a higher-priority peer at the same status.
+    const order = pickupOrder([
+      { label: "critical", candidate: candidate({ issuePriority: "critical" }) },
+      { label: "rework", candidate: candidate({ issuePriority: "medium", executionState: reworkState }) },
+    ]);
+    expect(order).toEqual(["rework", "critical"]);
+  });
+
+  it("never lets the rework boost outrank dependency/status readiness", () => {
+    // A dependency-blocked rework (rank 3) still yields to a ready peer (rank 1).
+    const order = pickupOrder([
+      { label: "blockedRework", candidate: candidate({ isDependencyReady: false, executionState: reworkState }) },
+      { label: "ready", candidate: candidate({ issueStatus: "todo" }) },
+    ]);
+    expect(order).toEqual(["ready", "blockedRework"]);
+  });
+
+  it("leaves non-rework ordering unchanged (priority then FIFO)", () => {
+    const order = pickupOrder([
+      { label: "medOld", candidate: candidate({ issuePriority: "medium", createdAtMs: 1_000 }) },
+      { label: "high", candidate: candidate({ issuePriority: "high", createdAtMs: 9_000 }) },
+      { label: "medNew", candidate: candidate({ issuePriority: "medium", createdAtMs: 2_000 }) },
+    ]);
+    expect(order).toEqual(["high", "medOld", "medNew"]);
+  });
+
+  it("treats a resubmitted issue (marker cleared) as an ordinary run again", () => {
+    // Once resubmitted the executionState.status is no longer changes_requested,
+    // so the boost is gone and FIFO decides between equal peers.
+    const order = pickupOrder([
+      { label: "older", candidate: candidate({ createdAtMs: 1_000, executionState: { status: "pending" } }) },
+      { label: "newer", candidate: candidate({ createdAtMs: 2_000, executionState: { status: "pending" } }) },
+    ]);
+    expect(order).toEqual(["older", "newer"]);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3315,6 +3315,76 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+/** Resolved facts about a single queued run, used to order an agent's queue. */
+export interface QueuedRunPickupCandidate {
+  /** Epoch ms of the run's createdAt — the FIFO tiebreaker of last resort. */
+  createdAtMs: number;
+  /** Whether the run is tied to an issue at all. */
+  hasIssue: boolean;
+  /** Whether the issue's blockers are resolved. */
+  isDependencyReady: boolean;
+  /** The issue's board status (e.g. "in_progress"). */
+  issueStatus: string | null | undefined;
+  /** The issue's priority ("critical" | "high" | "medium" | "low"). */
+  issuePriority: string | null | undefined;
+  /** The issue's execution state, used to detect reviewer-requested rework. */
+  executionState: Record<string, unknown> | null | undefined;
+}
+
+function queuedRunPickupStatusRank(candidate: QueuedRunPickupCandidate): number {
+  if (!candidate.hasIssue) return 2;
+  if (!candidate.isDependencyReady) return 3;
+  return candidate.issueStatus === "in_progress" ? 0 : 1;
+}
+
+function queuedRunPickupPriorityRank(priority: string | null | undefined): number {
+  switch (priority) {
+    case "critical":
+      return 0;
+    case "high":
+      return 1;
+    case "medium":
+      return 2;
+    case "low":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+// Issues a reviewer sent back with requested changes carry
+// executionState.status === "changes_requested" until the assignee resubmits
+// them for review, at which point the marker clears itself. Detecting it lets
+// us pick the rework up next instead of at the back of the queue.
+function isReworkPickupCandidate(candidate: QueuedRunPickupCandidate): boolean {
+  return readNonEmptyString(candidate.executionState?.status) === "changes_requested";
+}
+
+/**
+ * Ordering that decides which of an agent's queued runs starts next.
+ * Precedence, highest first:
+ *   1. dependency/status rank (in_progress > ready > no-issue > blocked)
+ *   2. reviewer-requested rework — a just-reworked issue is picked next so the
+ *      assignee acts on human feedback right after its current task instead of
+ *      after the rest of its backlog
+ *   3. issue priority (critical > high > medium > low)
+ *   4. FIFO by createdAt
+ * Returns a negative number when `left` should run before `right`.
+ */
+export function compareQueuedRunPickup(
+  left: QueuedRunPickupCandidate,
+  right: QueuedRunPickupCandidate,
+): number {
+  const statusRank = queuedRunPickupStatusRank(left) - queuedRunPickupStatusRank(right);
+  if (statusRank !== 0) return statusRank;
+  const reworkRank = (isReworkPickupCandidate(left) ? 0 : 1) - (isReworkPickupCandidate(right) ? 0 : 1);
+  if (reworkRank !== 0) return reworkRank;
+  const priorityRank =
+    queuedRunPickupPriorityRank(left.issuePriority) - queuedRunPickupPriorityRank(right.issuePriority);
+  if (priorityRank !== 0) return priorityRank;
+  return left.createdAtMs - right.createdAtMs;
+}
+
 function sanitizeAgentSessionMessageText(value: unknown): string | null {
   const text = readNonEmptyString(value);
   if (!text) return null;
@@ -12592,21 +12662,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
   }
 
-  function issueRunPriorityRank(priority: string | null | undefined) {
-    switch (priority) {
-      case "critical":
-        return 0;
-      case "high":
-        return 1;
-      case "medium":
-        return 2;
-      case "low":
-        return 3;
-      default:
-        return 4;
-    }
-  }
-
   async function listQueuedRunDependencyReadiness(
     companyId: string,
     queuedRuns: Array<typeof heartbeatRuns.$inferSelect>,
@@ -14035,6 +14090,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           id: issues.id,
           status: issues.status,
           priority: issues.priority,
+          executionState: issues.executionState,
         })
         .from(issues)
         .where(
@@ -14044,23 +14100,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
       const issueById = new Map(issueRows.map((row) => [row.id, row]));
       const companyAgents = await listCompanyAgentOrgRows(agent.companyId);
-      const prioritizedRuns = [...queuedRuns].sort((left, right) => {
-        const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
-        const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
-        const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
-        const rightReadiness = rightIssueId ? dependencyReadiness.get(rightIssueId) : null;
-        const leftReady = leftIssueId ? (leftReadiness?.isDependencyReady ?? true) : true;
-        const rightReady = rightIssueId ? (rightReadiness?.isDependencyReady ?? true) : true;
-        const leftIssue = leftIssueId ? issueById.get(leftIssueId) : null;
-        const rightIssue = rightIssueId ? issueById.get(rightIssueId) : null;
-        const leftRank = leftIssueId ? (leftReady ? (leftIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        const rightRank = rightIssueId ? (rightReady ? (rightIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        if (leftRank !== rightRank) return leftRank - rightRank;
-        const leftPriorityRank = issueRunPriorityRank(leftIssue?.priority);
-        const rightPriorityRank = issueRunPriorityRank(rightIssue?.priority);
-        if (leftPriorityRank !== rightPriorityRank) return leftPriorityRank - rightPriorityRank;
-        return left.createdAt.getTime() - right.createdAt.getTime();
-      });
+      const toPickupCandidate = (run: typeof heartbeatRuns.$inferSelect): QueuedRunPickupCandidate => {
+        const issueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+        const issue = issueId ? issueById.get(issueId) : null;
+        return {
+          createdAtMs: run.createdAt.getTime(),
+          hasIssue: Boolean(issueId),
+          isDependencyReady: issueId ? (dependencyReadiness.get(issueId)?.isDependencyReady ?? true) : true,
+          issueStatus: issue?.status,
+          issuePriority: issue?.priority,
+          executionState: issue?.executionState,
+        };
+      };
+      const prioritizedRuns = [...queuedRuns].sort((left, right) =>
+        compareQueuedRunPickup(toPickupCandidate(left), toPickupCandidate(right)),
+      );
 
       const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
       for (const queuedRun of prioritizedRuns) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, where a human reviewer approves or requests changes on an agent's work.
> - When a reviewer requests changes, `applyIssueExecutionStageTransition` flips the issue back to `in_progress`, reassigns it to the engineer, and stamps `executionState.status = "changes_requested"`; a fresh queued `heartbeat_run` is enqueued for the assignee.
> - The assignee's next-task ordering lives in an in-memory comparator in `startNextQueuedRunForAgent` (dependency/status rank → issue priority → FIFO by `createdAt`).
> - Because the re-enqueued run gets the newest `createdAt`, among same-status/same-priority peers it lands **last** in the FIFO tiebreaker — so reviewer feedback waits behind the agent's whole backlog instead of being picked up next.
> - This pull request adds a "reviewer-requested rework" tiebreaker to that comparator so a just-reworked issue is picked next, right after the agent's current task.
> - The benefit is a tight human-in-the-loop review cycle: when a human requests changes, the agent acts on them immediately instead of after dozens of queued tasks.

## Issue (described in-PR, Enhancement)

_No public GitHub issue existed; describing it inline per CONTRIBUTING.md → "Link Issues or Describe Them In-PR", following the Enhancement template._

- **Existing behavior improved:** the assignee's queued-run pickup order in `startNextQueuedRunForAgent` (heartbeat scheduling).
- **Subsystem affected:** server / heartbeat run scheduling.
- **Current behavior:** when a reviewer requests changes on an `in_review` issue, it returns to `in_progress` and a new queued run is enqueued with a fresh `createdAt`. Among same-status/same-priority queued runs the comparator falls back to FIFO by `createdAt`, so the just-reworked run sorts **last** — the agent finishes its entire backlog before acting on the reviewer's comment.
- **Proposed behavior:** a reworked issue (`executionState.status === "changes_requested"`) is picked **next**, right after the agent's current task, instead of at the back of the queue. The marker clears itself once the assignee resubmits for review, so the boost never outlives the rework.
- **Reason and benefit:** keeps the human-in-the-loop review cycle tight — reviewer change-requests are the highest-signal instruction and should be acted on immediately.
- **Breaking changes:** none. No schema/migration/API change; pure re-ordering of already-queued runs.

## Duplicate / related PR search

Searched the GitHub PR list before starting. No PR reorders the assignee queue for reworked issues. Closest existing work, neither of which changes pickup ordering:
- #8774 (open) — routes engineer rework to the latest reviewer.
- #10650 (merged) — caps agent review rounds and escalates exhausted reviews to a human.

## What Changed

- Extracted the queued-run pickup ordering out of the inline `.sort()` closure in `startNextQueuedRunForAgent` into a pure, exported, unit-testable `compareQueuedRunPickup(left, right)` (plus a `QueuedRunPickupCandidate` shape). Behavior for existing cases is unchanged.
- Added a tiebreaker between the dependency/status rank and the priority rank: issues whose `executionState.status === "changes_requested"` sort ahead of their peers. The marker clears itself on resubmission.
- Selected `issues.executionState` in the pickup query so the comparator can read the rework marker.
- Added `server/src/__tests__/heartbeat-queued-run-pickup-order.test.ts` — a deterministic unit test covering the boost, its precedence vs priority, the dependency/status guard, unchanged non-rework ordering, and marker self-clearing.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-queued-run-pickup-order.test.ts` → 5/5 passing.
- Regression: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-dependency-scheduling.test.ts` → 6/6 passing (the extraction preserves the prior status → priority → FIFO ordering).
- `tsc --noEmit` for the server package is clean for the changed files.

## Risks

- Low risk. Pure re-ordering of already-queued runs for a single agent; no schema/migration change, no new columns, no API surface change. The rework marker is derived from existing `executionState` and self-clears, so a reworked issue cannot get "stuck" at the front. The comparator's dependency/status rank still gates everything, so a dependency-blocked rework never preempts ready work.
- Precedence choice worth a reviewer's eye: rework is ranked **above** issue priority (a human change-request preempts a higher-priority peer at the same status). Moving it below priority is a one-line change if maintainers prefer that; happy to adjust.

## Model Used

- Claude Opus 4.8 (Anthropic), extended thinking, via Claude Code with tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered documentation and no user-facing docs are affected by this internal scheduling change
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---

cc @nickyleach @devinfoley — could one of you take a look? Small, focused change to the review→rework loop with a deterministic unit test (Greptile 5/5, all CI green). Happy to adjust the rework-vs-priority precedence if you'd prefer it ranked below priority.
