### PR TITLE
fix(adapter-utils): resolve sandbox executable symlinks

### DIFF
--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -96,6 +96,60 @@ describe("local process sandbox", () => {
     expect(target.args.slice(-3)).toEqual([process.execPath, "-e", "console.log('ok')"]);
   });
 
+  it("launches the resolved target of an executable below a moving symlink", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-executable-link-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    const release = path.join(root, "releases", "2026.824.0");
+    const packageRoot = path.join(release, "node_modules", "example-tool");
+    const executable = path.join(packageRoot, "bin", "tool.js");
+    const current = path.join(root, "current");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(path.dirname(executable), { recursive: true });
+    await fs.writeFile(path.join(packageRoot, "package.json"), '{"name":"example-tool"}\n', "utf8");
+    await fs.writeFile(executable, "#!/usr/bin/env node\n", { mode: 0o755 });
+    await fs.symlink(release, current, "dir");
+    const linkedExecutable = path.join(current, "node_modules", "example-tool", "bin", "tool.js");
+
+    const directTarget = await buildLocalProcessSandboxSpawnTarget({
+      executable: linkedExecutable,
+      args: ["--version"],
+      cwd: workspace,
+      options: {
+        workspaceDir: workspace,
+        filesystemScope: "workspace",
+      },
+    });
+
+    expect(directTarget.args.slice(-2)).toEqual([executable, "--version"]);
+    expect(directTarget.args).toEqual(expect.arrayContaining(["--ro-bind", packageRoot, packageRoot]));
+
+    const bridgedTarget = await buildLocalProcessSandboxSpawnTarget({
+      executable: linkedExecutable,
+      args: ["--version"],
+      cwd: workspace,
+      options: {
+        workspaceDir: workspace,
+        filesystemScope: "workspace",
+        networkScope: "allowlist",
+        networkAllowlist: ["api.example.com"],
+      },
+    });
+
+    try {
+      const delimiterIndex = bridgedTarget.args.indexOf("--");
+      expect(bridgedTarget.args.slice(delimiterIndex + 1)).toEqual([
+        process.execPath,
+        expect.stringMatching(/bridge\.cjs$/),
+        expect.stringMatching(/proxy\.sock$/),
+        executable,
+        "--version",
+      ]);
+    } finally {
+      await bridgedTarget.cleanup?.();
+    }
+  });
+
   it("binds a confined absolute alias to the synchronized workspace", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-alias-"));
     cleanup.push(root);

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -381,7 +381,14 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
   const args = ["--die-with-parent", "--new-session", "--unshare-pid", "--unshare-ipc", "--unshare-uts"];
   const env: Record<string, string | undefined> = {};
   let cleanup: (() => Promise<void>) | undefined;
-  let executable = input.executable;
+  // A configured executable can sit below a moving symlink such as
+  // `.../current/node_modules/.bin/tool`. The fresh sandbox root mounts the
+  // real package, but it does not recreate every intermediate host symlink.
+  // Launch the resolved target so the executable remains reachable there.
+  const sandboxedInputExecutable = filesystemScope === "workspace"
+    ? await fs.realpath(input.executable).catch(() => input.executable)
+    : input.executable;
+  let executable = sandboxedInputExecutable;
   let executableArgs = input.args;
 
   if (filesystemScope === "workspace") {
@@ -403,7 +410,7 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
       created.add(normalized);
     };
     for (const systemPath of SYSTEM_READ_PATHS) await mount(systemPath, "ro");
-    for (const executablePath of await executableReadPaths(input.executable)) await mount(executablePath, "ro");
+    for (const executablePath of await executableReadPaths(sandboxedInputExecutable)) await mount(executablePath, "ro");
     if (networkScope === "allowlist") {
       for (const nodePath of await executableReadPaths(process.execPath)) await mount(nodePath, "ro");
     }
@@ -442,7 +449,7 @@ export async function buildLocalProcessSandboxSpawnTarget(input: {
       });
       await mount(tempDir, "rw");
       executable = process.execPath;
-      executableArgs = [bridgePath, socketPath, input.executable, ...input.args];
+      executableArgs = [bridgePath, socketPath, sandboxedInputExecutable, ...input.args];
       cleanup = async () => {
         await proxy.close();
         await fs.rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs local agents through adapter processes.
> - The workspace filesystem scope creates a fresh Bubblewrap root.
> - A configured executable can be below a moving package symlink such as `current`.
> - The sandbox mounts the resolved package, but it can still launch the unresolved alias path.
> - The fresh root does not contain each intermediate host symlink, so the process can fail before the agent starts.
> - This pull request launches the resolved executable inside workspace-scoped sandboxes.
> - The benefit is that versioned and globally installed adapter commands start without reducing the filesystem boundary.

## Linked Issues or Issue Description

Refs #10496 and #11159. Those pull requests address merged-`/usr` system path mounts. They do not address executable aliases below moving package symlinks.

**What happened?**

A workspace-scoped local process can use an executable below a moving symlink. Paperclip mounts the real package path into the fresh root. Paperclip then launches the original alias path. The fresh root does not recreate the intermediate symlink. The process fails with an executable-not-found error before the agent starts. The allowlist proxy bridge also receives the unresolved path.

**Expected behavior**

Paperclip must launch the executable path that it mounted into the fresh root. The direct launch path and the allowlist bridge path must use the same resolved target.

**Steps to reproduce**

1. Create a versioned tool package below a release directory.
2. Create a `current` directory symlink that points to that release.
3. Configure the local adapter command through the `current` path.
4. Enable the workspace filesystem scope.
5. Start the adapter and observe that the fresh root cannot launch the unresolved path.

**Paperclip version or commit**

The runtime failure occurred on `2026.817.0`. The regression test reproduces the path construction on `master` at `88a0f885e`.

**Deployment mode**

Self-hosted server.

**Installation method**

npm global install. The source verification uses a clean fork.

**Agent adapter(s) involved**

Codex exposed the problem. The defect is in the shared local-process sandbox.

**Database mode**

Not database-related.

**Access context**

Agent process startup.

**Node.js version**

v26.7.0.

**Operating system**

Linux x64 with Bubblewrap.

**Privacy checklist**

I reviewed this description for private paths, credentials, company names, and instance-local references.

## What Changed

- Resolve the configured executable before the workspace-scoped fresh root launches it.
- Mount the package paths from the same resolved executable.
- Give the resolved executable to the network allowlist bridge.
- Add a regression test for direct and bridged launches below a moving directory symlink.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/local-process-sandbox.test.ts --reporter=dot` — 11 passed and 4 integration tests skipped by their existing environment gates.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `pnpm --filter @paperclipai/adapter-utils build` — passed.
- `git diff --check` — passed.

## Risks

- Low risk. The change applies only when `filesystemScope` is `workspace`.
- A symlinked executable now sees its resolved path as the process path. Tools that inspect their launch alias can observe this difference.
- Network-only processes keep the current behavior because they use the host root.
- The change does not add filesystem mounts or widen network access.

> This is a focused bug fix. `ROADMAP.md` includes broader cloud and sandbox work, but this change does not add a roadmap feature.

## Model Used

- OpenAI Codex, model `openai/gpt-5.6-sol`, with tool use and local code execution. The context-window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation change is required for this focused runtime fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
