### PR TITLE
fix(codex-local): expose managed auth in sandbox

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -87,6 +87,7 @@ import {
   resolveCodexAuthPrecedence,
 } from "./auth-precedence.js";
 import { prepareCodexRuntimeConfig } from "./runtime-config.js";
+import { resolveCodexLocalSandboxManagedPaths } from "./local-sandbox-managed-paths.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
@@ -973,12 +974,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const billingType = resolveCodexBillingType(effectiveEnv);
     const networkScope = parseLocalProcessNetworkScope(config.networkScope);
     const filesystemScope = parseLocalProcessFilesystemScope(config.filesystemScope);
+    const localSandboxManagedPaths = (filesystemScope || networkScope) && !executionTargetIsRemote
+      ? await resolveCodexLocalSandboxManagedPaths({
+          effectiveCodexHome,
+          sharedCodexHome: resolveSharedCodexHomeDir(process.env),
+          filesystemScope,
+        })
+      : [];
     const localProcessSandbox: LocalProcessSandboxOptions | null =
       (filesystemScope || networkScope) && !executionTargetIsRemote
         ? {
             workspaceDir: effectiveExecutionCwd,
             filesystemScope,
-            managedPaths: [{ path: effectiveCodexHome, access: "rw" }],
+            managedPaths: localSandboxManagedPaths,
             extraPaths: parseLocalProcessSandboxExtraPaths(config.filesystemExtraPaths),
             pathAliases: targetWorkspaceRealization?.mode === "copy"
               ? targetWorkspaceRealization.pathAliases

--- a/packages/adapters/codex-local/src/server/local-sandbox-managed-paths.test.ts
+++ b/packages/adapters/codex-local/src/server/local-sandbox-managed-paths.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCodexLocalSandboxManagedPaths } from "./local-sandbox-managed-paths.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((candidate) => fs.rm(candidate, { recursive: true, force: true })));
+});
+
+async function makeHomes() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-local-sandbox-paths-"));
+  cleanup.push(root);
+  const effectiveCodexHome = path.join(root, "managed-home");
+  const sharedCodexHome = path.join(root, "shared-home");
+  await fs.mkdir(effectiveCodexHome);
+  await fs.mkdir(sharedCodexHome);
+  return { root, effectiveCodexHome, sharedCodexHome };
+}
+
+describe("Codex local sandbox managed paths", () => {
+  it("mounts the shared target of the managed auth symlink as read-only", async () => {
+    const { effectiveCodexHome, sharedCodexHome } = await makeHomes();
+    const sharedAuthPath = path.join(sharedCodexHome, "auth.json");
+    await fs.writeFile(sharedAuthPath, "{}\n", { mode: 0o600 });
+    await fs.symlink(sharedAuthPath, path.join(effectiveCodexHome, "auth.json"));
+
+    await expect(resolveCodexLocalSandboxManagedPaths({
+      effectiveCodexHome,
+      sharedCodexHome,
+      filesystemScope: "workspace",
+    })).resolves.toEqual([
+      { path: effectiveCodexHome, access: "rw" },
+      { path: sharedAuthPath, access: "ro" },
+    ]);
+  });
+
+  it("does not add a host path for a regular managed auth file", async () => {
+    const { effectiveCodexHome, sharedCodexHome } = await makeHomes();
+    await fs.writeFile(path.join(effectiveCodexHome, "auth.json"), "{}\n", { mode: 0o600 });
+    await fs.writeFile(path.join(sharedCodexHome, "auth.json"), "{}\n", { mode: 0o600 });
+
+    await expect(resolveCodexLocalSandboxManagedPaths({
+      effectiveCodexHome,
+      sharedCodexHome,
+      filesystemScope: "workspace",
+    })).resolves.toEqual([
+      { path: effectiveCodexHome, access: "rw" },
+    ]);
+  });
+
+  it("does not expose an unrelated symlink target", async () => {
+    const { root, effectiveCodexHome, sharedCodexHome } = await makeHomes();
+    const unrelatedAuthPath = path.join(root, "unrelated-auth.json");
+    await fs.writeFile(unrelatedAuthPath, "{}\n", { mode: 0o600 });
+    await fs.writeFile(path.join(sharedCodexHome, "auth.json"), "{}\n", { mode: 0o600 });
+    await fs.symlink(unrelatedAuthPath, path.join(effectiveCodexHome, "auth.json"));
+
+    await expect(resolveCodexLocalSandboxManagedPaths({
+      effectiveCodexHome,
+      sharedCodexHome,
+      filesystemScope: "workspace",
+    })).resolves.toEqual([
+      { path: effectiveCodexHome, access: "rw" },
+    ]);
+  });
+
+  it("keeps network-only launches on the existing managed-home mount", async () => {
+    const { effectiveCodexHome, sharedCodexHome } = await makeHomes();
+    const sharedAuthPath = path.join(sharedCodexHome, "auth.json");
+    await fs.writeFile(sharedAuthPath, "{}\n", { mode: 0o600 });
+    await fs.symlink(sharedAuthPath, path.join(effectiveCodexHome, "auth.json"));
+
+    await expect(resolveCodexLocalSandboxManagedPaths({
+      effectiveCodexHome,
+      sharedCodexHome,
+      filesystemScope: null,
+    })).resolves.toEqual([
+      { path: effectiveCodexHome, access: "rw" },
+    ]);
+  });
+});

--- a/packages/adapters/codex-local/src/server/local-sandbox-managed-paths.ts
+++ b/packages/adapters/codex-local/src/server/local-sandbox-managed-paths.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { LocalProcessSandboxPath } from "@paperclipai/adapter-utils/local-process-sandbox";
+
+export async function resolveCodexLocalSandboxManagedPaths(input: {
+  effectiveCodexHome: string;
+  sharedCodexHome: string;
+  filesystemScope: "workspace" | null;
+}): Promise<LocalProcessSandboxPath[]> {
+  const managedPaths: LocalProcessSandboxPath[] = [
+    { path: input.effectiveCodexHome, access: "rw" },
+  ];
+  if (input.filesystemScope !== "workspace") return managedPaths;
+
+  const managedAuthPath = path.join(input.effectiveCodexHome, "auth.json");
+  const managedAuthEntry = await fs.lstat(managedAuthPath).catch(() => null);
+  if (!managedAuthEntry?.isSymbolicLink()) return managedPaths;
+
+  // The managed home is writable by the agent. Mount only Paperclip's known
+  // shared credential target, not an arbitrary symlink created in that home.
+  const sharedAuthPath = path.join(input.sharedCodexHome, "auth.json");
+  const [managedAuthTarget, sharedAuthTarget] = await Promise.all([
+    fs.realpath(managedAuthPath).catch(() => null),
+    fs.realpath(sharedAuthPath).catch(() => null),
+  ]);
+  if (!managedAuthTarget || managedAuthTarget !== sharedAuthTarget) return managedPaths;
+
+  managedPaths.push({ path: managedAuthTarget, access: "ro" });
+  return managedPaths;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs Codex agents with managed per-company homes.
> - A managed Codex home links `auth.json` to the shared host credential.
> - The workspace filesystem scope mounts the managed home into a fresh Bubblewrap root.
> - The fresh root does not contain the shared credential target outside that home.
> - The link is present, but Codex cannot follow it, so the agent stops before work starts.
> - This pull request mounts only the expected shared credential target as read-only.
> - The benefit is that managed Codex agents can start inside the filesystem boundary without exposing an arbitrary host path.

## Linked Issues or Issue Description

Refs #9621 and #8581. Those pull requests address credential copy-back and transient home sync. They do not make a managed host credential link readable in a local Bubblewrap root.

**What happened?**

A managed Codex home contains an `auth.json` symlink to the shared Codex home. A workspace-scoped local run mounts the managed home as writable. It does not mount the symlink target outside that home. Codex sees a broken credential link in the fresh root and stops before the agent starts.

**Expected behavior**

The local sandbox must make Paperclip's expected shared credential target readable. The target must stay read-only. Paperclip must not mount an arbitrary symlink target from the writable managed home.

**Steps to reproduce**

1. Put a usable `auth.json` in the shared Codex home.
2. Let Paperclip seed a managed Codex home from that shared home.
3. Enable `filesystemScope: "workspace"` for a local Codex adapter.
4. Start the adapter.
5. Observe that the managed `auth.json` link is broken inside the fresh root.

**Paperclip version or commit**

The runtime failure occurred on `2026.817.0`. The source path is present on `master` at `88a0f885e`.

**Deployment mode**

Self-hosted server.

**Installation method**

npm global install. The source verification uses a clean fork.

**Agent adapter(s) involved**

Codex.

**Database mode**

Not database-related.

**Access context**

Agent process startup.

**Node.js version**

v26.7.0.

**Operating system**

Linux x64 with Bubblewrap.

**Privacy checklist**

I reviewed this description for private paths, credentials, company names, and instance-local references.

## What Changed

- Build the Codex local sandbox managed-path list in a focused helper.
- Detect when the managed `auth.json` entry is a symlink to the expected shared credential.
- Mount that exact resolved target as read-only for workspace-scoped runs.
- Reject unrelated symlink targets from the writable managed home.
- Keep regular managed credentials and network-only runs unchanged.
- Add tests for the allowed target and all guard paths.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/execute.auth.test.ts packages/adapters/codex-local/src/server/local-sandbox-managed-paths.test.ts --reporter=dot` — 11 passed.
- `pnpm --filter @paperclipai/adapter-codex-local typecheck` — passed.
- `pnpm --filter @paperclipai/adapter-codex-local build` — passed.
- `git diff --check` — passed.

## Risks

- Low risk. The extra mount is active only for a workspace-scoped local process.
- The helper follows the managed link only when it resolves to the canonical shared `auth.json` target.
- The target is read-only inside the sandbox.
- A regular credential in the managed home keeps the current writable-home behavior.
- Network-only and remote runs keep the current behavior.

> This is a focused bug fix. `ROADMAP.md` includes broader cloud and sandbox work, but this change does not add a roadmap feature.

## Model Used

- OpenAI Codex, model `openai/gpt-5.6-sol`, with tool use and local code execution. The context-window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation change is required for this focused runtime fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
