### PR TITLE
fix(server): FAI-10190 make role-default seeding a bootstrap so revocation is durable

### DIFF
--- a/packages/db/src/migrations/0228_principal_role_default_seeds.sql
+++ b/packages/db/src/migrations/0228_principal_role_default_seeds.sql
@@ -1,0 +1,68 @@
+CREATE TABLE IF NOT EXISTS "principal_role_default_seeds" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"principal_type" text NOT NULL,
+	"principal_id" text NOT NULL,
+	"role" text NOT NULL,
+	"settled_by_user_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint
+		WHERE conname = 'principal_role_default_seeds_company_id_companies_id_fk'
+		  AND conrelid = 'principal_role_default_seeds'::regclass
+	) THEN
+		ALTER TABLE "principal_role_default_seeds"
+			ADD CONSTRAINT "principal_role_default_seeds_company_id_companies_id_fk"
+			FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id")
+			ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "principal_role_default_seeds_unique_idx" ON "principal_role_default_seeds" USING btree ("company_id","principal_type","principal_id");
+--> statement-breakpoint
+-- Every human membership that is not archived is already past its bootstrap:
+-- `backfillPrincipalAccessCompatibility` has swept it at every server start
+-- since the seeder existed, so its role defaults have been applied and whatever
+-- grant set it carries now is the answer. Marking them settled here is what
+-- makes an existing revocation durable from this deploy rather than from the
+-- next time each principal happens to be re-seeded.
+--
+-- Archived memberships are deliberately left unmarked. Removal deletes a
+-- principal's grants, so an archived membership has none to protect, and a
+-- marker would mean a re-added principal arrived with no permissions at all
+-- instead of their role's defaults.
+--
+-- The CASE mirrors `normalizeHumanRole(value, "operator")`: 'member' and every
+-- unrecognized or null role resolve to 'operator'.
+INSERT INTO "principal_role_default_seeds" (
+	"company_id",
+	"principal_type",
+	"principal_id",
+	"role",
+	"settled_by_user_id",
+	"created_at",
+	"updated_at"
+)
+SELECT
+	"company_id",
+	'user',
+	"principal_id",
+	CASE
+		WHEN "membership_role" IN ('owner', 'admin', 'operator', 'viewer') THEN "membership_role"
+		ELSE 'operator'
+	END,
+	NULL,
+	now(),
+	now()
+FROM "company_memberships"
+WHERE "principal_type" = 'user'
+	AND "status" <> 'archived'
+ON CONFLICT (
+	"company_id",
+	"principal_type",
+	"principal_id"
+) DO NOTHING;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1576,6 +1576,13 @@
       "when": 1787261199301,
       "tag": "0226_tan_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 228,
+      "version": "7",
+      "when": 1787900000000,
+      "tag": "0228_principal_role_default_seeds",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -14,6 +14,7 @@ export { cliAuthChallenges } from "./cli_auth_challenges.js";
 export { companyMemberships } from "./company_memberships.js";
 export { companyUserSidebarPreferences } from "./company_user_sidebar_preferences.js";
 export { principalPermissionGrants } from "./principal_permission_grants.js";
+export { principalRoleDefaultSeeds } from "./principal_role_default_seeds.js";
 export { companySkillPolicies } from "./company_skill_policies.js";
 export { invites } from "./invites.js";
 export { joinRequests } from "./join_requests.js";

--- a/packages/db/src/schema/principal_role_default_seeds.ts
+++ b/packages/db/src/schema/principal_role_default_seeds.ts
@@ -1,0 +1,71 @@
+import { pgTable, uuid, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+
+/**
+ * One row per principal whose role defaults have already been applied.
+ *
+ * `principal_permission_grants` has no way to say "this role default was
+ * deliberately revoked": absence is the only representation, and absence is
+ * exactly what the role-default seeder is built to fill. So a revocation looked
+ * like it took — the row was gone and the UI showed it gone — and the next
+ * server start, cloud-tenant sync, `setUserCompanyAccess` or company clone put
+ * it straight back (FAI-10190).
+ *
+ * This marker turns the seeder from seed-every-run into seed-once, which is
+ * what its name already claimed. Role defaults become a bootstrap: they are
+ * applied when a principal first holds a role, and after that the principal's
+ * grant set is whatever an operator has made it.
+ *
+ * A row here is not "the defaults were inserted" but "the defaults for this
+ * role are settled" — either the seeder applied them, or an operator wrote the
+ * principal's grant set explicitly and that set is now the answer. Both bar the
+ * seeder, and for the same reason: a grant set someone decided on must not be
+ * widened by a background sweep.
+ *
+ * `role` is what makes the difference legible after the fact, which is the
+ * audit half of the fix. Given the seeded role, a reader takes that role's
+ * default set and subtracts the principal's live grants: what is left was
+ * deliberately revoked. A key outside that set was never carried in the first
+ * place. Without the role recorded the two are indistinguishable, because both
+ * are just a missing row.
+ *
+ * Keyed on the principal's identity rather than on `company_memberships.id`,
+ * and with no foreign key to it, for the same reason the grants themselves are:
+ * nothing ties a grant to a membership row, and the membership row is not
+ * guaranteed to exist when a grant is written. Every removal path that deletes
+ * a principal's grants deletes this row alongside them, so a re-added principal
+ * is bootstrapped again rather than arriving with nothing.
+ *
+ * Only human principals ever get a row. Agent grants come from
+ * `built-in-agents` and company import, which write each permission
+ * deliberately rather than expanding a role.
+ */
+export const principalRoleDefaultSeeds = pgTable(
+  "principal_role_default_seeds",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    /**
+     * Cascades, unlike `principal_permission_grants`. A marker is bookkeeping
+     * about a company that no longer exists — there is no authority in it to
+     * audit, and nothing else to do with the row but drop it.
+     */
+    companyId: uuid("company_id")
+      .notNull()
+      .references(() => companies.id, { onDelete: "cascade" }),
+    principalType: text("principal_type").notNull(),
+    principalId: text("principal_id").notNull(),
+    /** The human role whose default set is settled, already normalized. */
+    role: text("role").notNull(),
+    /** Null when the bootstrap seeder settled it rather than a named operator. */
+    settledByUserId: text("settled_by_user_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    uniquePrincipalIdx: uniqueIndex("principal_role_default_seeds_unique_idx").on(
+      table.companyId,
+      table.principalType,
+      table.principalId,
+    ),
+  }),
+);

--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -22,6 +22,19 @@ function createSelectChain(rows: unknown[]) {
   };
 }
 
+/**
+ * The cloud-tenant sync seeds role-default grants, and since FAI-10190 that
+ * seeder reads its seed marker and the principal's membership standing in the
+ * same transaction it writes the grants in. Every double on this path has to
+ * offer one; it runs the callback on the double itself, because there is no
+ * isolation to model here, only the call shape.
+ */
+function withGrantSeederTransaction<T extends Record<string, unknown>>(db: T): T {
+  return Object.assign(db, {
+    transaction: vi.fn(async (run: (tx: T) => unknown) => run(db)),
+  });
+}
+
 function createDb() {
   return {
     select: vi
@@ -102,6 +115,7 @@ describe("actorMiddleware authenticated session profile", () => {
       delete: vi.fn(() => ({ where: () => Promise.resolve(undefined) })),
       select: vi.fn(() => createSelectChain([])),
     } as any;
+    withGrantSeederTransaction(db);
     const app = express();
     app.use(
       actorMiddleware(db, {
@@ -186,6 +200,7 @@ describe("actorMiddleware authenticated session profile", () => {
       insert: vi.fn(() => insertChain),
       delete: vi.fn(() => ({ where: () => Promise.resolve(undefined) })),
     } as any;
+    withGrantSeederTransaction(db);
     const app = express();
     app.use(
       actorMiddleware(db, {
@@ -362,6 +377,7 @@ describe("actorMiddleware authenticated session profile", () => {
         },
       })),
     } as any;
+    withGrantSeederTransaction(db);
     const app = express();
     app.use(
       actorMiddleware(db, {

--- a/server/src/__tests__/role-default-grant-revocation-postgres.test.ts
+++ b/server/src/__tests__/role-default-grant-revocation-postgres.test.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  companyMemberships,
+  createDb,
+  principalPermissionGrants,
+  principalRoleDefaultSeeds,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { accessService } from "../services/access.js";
+import { authorizationService } from "../services/authorization.js";
+import { grantsForHumanRole } from "../services/company-member-roles.js";
+import {
+  backfillPrincipalAccessCompatibility,
+  ensureHumanRoleDefaultGrants,
+} from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+/**
+ * Revoking a role default and having it stay revoked.
+ *
+ * `principal_permission_grants` has no way to say "deliberately revoked":
+ * absence is the only representation, and absence is exactly what the
+ * role-default seeder is built to fill. So every revocation of a default looked
+ * like it took — the row was gone, the UI showed it gone — and then silently
+ * reversed the next time any seeding path ran. There are four of those, and
+ * none needs a concurrent writer to reach: the startup backfill, a cloud-tenant
+ * sync, `setUserCompanyAccess`, and company clone (FAI-10190).
+ *
+ * These tests are about durability across those paths, which is why almost
+ * every one of them revokes and then *re-runs a seeder*. Asserting the row is
+ * gone right after the delete proves nothing; it was already true before the
+ * fix.
+ */
+describeEmbeddedPostgres("role-default grant revocation", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  /** An `operator` default, and the only key that role carries. */
+  const OPERATOR_DEFAULT = "tasks:assign" as const;
+  /** An `admin` default the `operator` role has never carried. */
+  const ADMIN_ONLY_DEFAULT = "agents:create" as const;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-role-default-revocation-");
+    db = createDb(tempDb.connectionString);
+  }, 900_000);
+
+  afterEach(async () => {
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /**
+   * A company with an owner — so the operator is never the last active owner
+   * and can be archived or demoted — and one active `operator` member who has
+   * been through the bootstrap already, which is the state every existing
+   * member is in.
+   */
+  async function seedBootstrappedOperator() {
+    const company = await db
+      .insert(companies)
+      .values({
+        name: `Role Defaults ${randomUUID()}`,
+        issuePrefix: `RD${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: `owner-${randomUUID()}`,
+      status: "active",
+      membershipRole: "owner",
+    });
+    const member = await db
+      .insert(companyMemberships)
+      .values({
+        companyId: company.id,
+        principalType: "user",
+        principalId: `member-${randomUUID()}`,
+        status: "active",
+        membershipRole: "operator",
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+
+    await backfillPrincipalAccessCompatibility(db);
+    expect(await permissionKeysFor(company.id, member.principalId)).toContain(OPERATOR_DEFAULT);
+
+    return { companyId: company.id, member };
+  }
+
+  async function permissionKeysFor(companyId: string, principalId: string) {
+    return db
+      .select({ permissionKey: principalPermissionGrants.permissionKey })
+      .from(principalPermissionGrants)
+      .where(
+        and(
+          eq(principalPermissionGrants.companyId, companyId),
+          eq(principalPermissionGrants.principalId, principalId),
+        ),
+      )
+      .then((rows) => rows.map((row) => row.permissionKey));
+  }
+
+  async function settledMarker(companyId: string, principalId: string) {
+    return db
+      .select()
+      .from(principalRoleDefaultSeeds)
+      .where(
+        and(
+          eq(principalRoleDefaultSeeds.companyId, companyId),
+          eq(principalRoleDefaultSeeds.principalId, principalId),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function decide(companyId: string, principalId: string, permissionKey: typeof OPERATOR_DEFAULT) {
+    return authorizationService(db).decidePrincipalGrant({
+      companyId,
+      principalType: "user",
+      principalId,
+      action: permissionKey,
+      permissionKey,
+    });
+  }
+
+  /**
+   * The reported defect, and the acceptance criterion, in the shape an operator
+   * meets it: revoke one permission, restart the server.
+   */
+  it("keeps a revoked role default revoked across the startup backfill", async () => {
+    const { companyId, member } = await seedBootstrappedOperator();
+    const access = accessService(db);
+
+    await access.setPrincipalPermission(
+      companyId,
+      "user",
+      member.principalId,
+      OPERATOR_DEFAULT,
+      false,
+      "revoking-admin",
+    );
+    await backfillPrincipalAccessCompatibility(db);
+
+    expect(await permissionKeysFor(companyId, member.principalId)).not.toContain(OPERATOR_DEFAULT);
+    const decision = await decide(companyId, member.principalId, OPERATOR_DEFAULT);
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("deny_missing_grant");
+  });
+
+  /**
+   * The other three seeding paths, driven directly. A cloud-tenant sync calls
+   * the seeder on every sync for the member it just upserted;
+   * `setUserCompanyAccess` re-states which companies a user belongs to; and a
+   * company clone copies the memberships and seeds each one.
+   *
+   * The clone is asserted on the *source*: it is the company holding the
+   * revocation, and the run must leave it alone. What the clone's own target
+   * company gets is a separate decision, covered below.
+   */
+  it("keeps a revoked role default revoked across a cloud sync, a company access update, and a clone", async () => {
+    const { companyId, member } = await seedBootstrappedOperator();
+    const access = accessService(db);
+
+    await access.setPrincipalPermission(
+      companyId,
+      "user",
+      member.principalId,
+      OPERATOR_DEFAULT,
+      false,
+      "revoking-admin",
+    );
+
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: member.principalId,
+      membershipRole: "operator",
+      grantedByUserId: null,
+    });
+    expect(await permissionKeysFor(companyId, member.principalId)).not.toContain(OPERATOR_DEFAULT);
+
+    await access.setUserCompanyAccess(member.principalId, [companyId], { actorUserId: "some-admin" });
+    expect(await permissionKeysFor(companyId, member.principalId)).not.toContain(OPERATOR_DEFAULT);
+
+    const clone = await db
+      .insert(companies)
+      .values({
+        name: `Clone ${randomUUID()}`,
+        issuePrefix: `CL${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    await access.copyActiveUserMemberships(companyId, clone.id);
+
+    expect(await permissionKeysFor(companyId, member.principalId)).not.toContain(OPERATOR_DEFAULT);
+    expect((await decide(companyId, member.principalId, OPERATOR_DEFAULT)).allowed).toBe(false);
+    // The clone is a different company, so its copy of this member has never
+    // been bootstrapped and gets the role's defaults. Revocations are scoped to
+    // the company they were made in; a clone does not inherit them, because it
+    // does not inherit the grants they were made against either.
+    expect(await permissionKeysFor(clone.id, member.principalId)).toContain(OPERATOR_DEFAULT);
+  });
+
+  /**
+   * The audit half. A missing grant row is the same shape whether it was
+   * revoked or never held, so the marker records the role that was settled and
+   * the reader recovers the difference from it (acceptance criterion 2).
+   */
+  it("records the settled role, so a revoked default is distinguishable from one never carried", async () => {
+    const { companyId, member } = await seedBootstrappedOperator();
+
+    await accessService(db).setPrincipalPermission(
+      companyId,
+      "user",
+      member.principalId,
+      OPERATOR_DEFAULT,
+      false,
+      "revoking-admin",
+    );
+
+    const marker = await settledMarker(companyId, member.principalId);
+    expect(marker?.role).toBe("operator");
+    expect(marker?.settledByUserId).toBe("revoking-admin");
+
+    const roleDefaults = grantsForHumanRole("operator").map((grant) => grant.permissionKey);
+    const held = await permissionKeysFor(companyId, member.principalId);
+    const revoked = roleDefaults.filter((key) => !held.includes(key));
+    expect(revoked).toEqual([OPERATOR_DEFAULT]);
+    // Never carried reads differently: it is not in the settled role's defaults
+    // at all, so it never appears in that subtraction.
+    expect(roleDefaults).not.toContain(ADMIN_ONLY_DEFAULT);
+    expect(held).not.toContain(ADMIN_ONLY_DEFAULT);
+  });
+
+  /**
+   * The bootstrap has to survive being turned into a one-shot. Removal deletes
+   * a principal's grants, so the marker goes with them — otherwise a re-added
+   * member arrives with no permissions at all instead of their role's defaults,
+   * which would be a worse bug than the one being fixed.
+   */
+  it("bootstraps a member again after they are removed and re-added", async () => {
+    const { companyId, member } = await seedBootstrappedOperator();
+    const access = accessService(db);
+
+    await access.archiveMember(companyId, member.id);
+    expect(await permissionKeysFor(companyId, member.principalId)).toHaveLength(0);
+    expect(await settledMarker(companyId, member.principalId)).toBeNull();
+
+    await access.ensureMembership(companyId, "user", member.principalId, "operator", "active");
+    await backfillPrincipalAccessCompatibility(db);
+
+    expect(await permissionKeysFor(companyId, member.principalId)).toContain(OPERATOR_DEFAULT);
+    expect((await decide(companyId, member.principalId, OPERATOR_DEFAULT)).allowed).toBe(true);
+  });
+
+  /**
+   * The same rule on the other removal path, which archives across several
+   * companies at once by leaving a user's company list.
+   */
+  it("bootstraps a member again after company access is taken away and restored", async () => {
+    const { companyId, member } = await seedBootstrappedOperator();
+    const access = accessService(db);
+
+    await access.setUserCompanyAccess(member.principalId, [], { actorUserId: "some-admin" });
+    expect(await permissionKeysFor(companyId, member.principalId)).toHaveLength(0);
+    expect(await settledMarker(companyId, member.principalId)).toBeNull();
+
+    await access.setUserCompanyAccess(member.principalId, [companyId], { actorUserId: "some-admin" });
+    await backfillPrincipalAccessCompatibility(db);
+
+    expect(await permissionKeysFor(companyId, member.principalId)).toContain(OPERATOR_DEFAULT);
+  });
+
+  /**
+   * Seed-once is per role, not per principal, so a promotion still hands over
+   * the new role's defaults — the marker no longer matches and the bootstrap
+   * runs again for that role. Only a new key added to a role someone already
+   * holds stops propagating, which is the documented trade in
+   * `grantsForHumanRole`.
+   */
+  it("applies the new role's defaults when a member is promoted", async () => {
+    const { companyId, member } = await seedBootstrappedOperator();
+    const access = accessService(db);
+
+    expect(await permissionKeysFor(companyId, member.principalId)).not.toContain(ADMIN_ONLY_DEFAULT);
+
+    await access.updateMember(companyId, member.id, { membershipRole: "admin" });
+    await backfillPrincipalAccessCompatibility(db);
+
+    expect(await permissionKeysFor(companyId, member.principalId)).toContain(ADMIN_ONLY_DEFAULT);
+    expect((await settledMarker(companyId, member.principalId))?.role).toBe("admin");
+  });
+
+  /**
+   * The narrowing that arrives before the bootstrap ever runs. The invite and
+   * plugin flows create a membership and then state its whole grant set, which
+   * can be deliberately smaller than the role's defaults — an empty set is the
+   * extreme. The seeder read that as a gap and filled it.
+   */
+  it("does not widen a grant set that was written narrower than the role's defaults", async () => {
+    const company = await db
+      .insert(companies)
+      .values({
+        name: `Narrowed ${randomUUID()}`,
+        issuePrefix: `NA${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const principalId = `invitee-${randomUUID()}`;
+    const access = accessService(db);
+
+    await access.ensureMembership(company.id, "user", principalId, "operator", "active");
+    await access.setPrincipalGrants(company.id, "user", principalId, [], "inviting-admin");
+
+    await backfillPrincipalAccessCompatibility(db);
+
+    expect(await permissionKeysFor(company.id, principalId)).toHaveLength(0);
+    expect((await decide(company.id, principalId, OPERATOR_DEFAULT)).allowed).toBe(false);
+  });
+
+  /**
+   * A role with no defaults still gets a marker. Nothing is inserted for a
+   * viewer, so without one the seeder could not tell "settled as a viewer" from
+   * "never seeded", and the audit subtraction above would have no baseline.
+   */
+  it("marks a viewer as settled even though the role seeds nothing", async () => {
+    const company = await db
+      .insert(companies)
+      .values({
+        name: `Viewer ${randomUUID()}`,
+        issuePrefix: `VW${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const principalId = `viewer-${randomUUID()}`;
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId,
+      status: "active",
+      membershipRole: "viewer",
+    });
+
+    await backfillPrincipalAccessCompatibility(db);
+
+    expect(await permissionKeysFor(company.id, principalId)).toHaveLength(0);
+    expect((await settledMarker(company.id, principalId))?.role).toBe("viewer");
+  });
+});

--- a/server/src/middleware/cloud-tenant-actor.test.ts
+++ b/server/src/middleware/cloud-tenant-actor.test.ts
@@ -71,6 +71,11 @@ function createFakeDb(options: {
         }),
       };
     },
+    // The role-default seeder reads its seed marker and the principal's
+    // membership standing in the same transaction it writes the grants in, so
+    // the double has to offer one. It runs the callback on itself: there is no
+    // isolation to model here, only the call shape (FAI-10190).
+    transaction: async (run: (tx: unknown) => unknown) => run(db),
   } as unknown as Db;
   return { db, insertedTables, deletedTables, selectWheres };
 }

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -5,12 +5,13 @@ import {
   instanceUserRoles,
   issues,
   principalPermissionGrants,
+  principalRoleDefaultSeeds,
 } from "@paperclipai/db";
 import type { PermissionKey, PrincipalType } from "@paperclipai/shared";
 import { conflict } from "../errors.js";
 import { assertAssignableAgent } from "./agent-assignability.js";
 import { authorizationService, type AuthorizationActor, type AuthorizationResource } from "./authorization.js";
-import { ensureHumanRoleDefaultGrants } from "./principal-access-compatibility.js";
+import { ensureHumanRoleDefaultGrants, settleRoleDefaults } from "./principal-access-compatibility.js";
 
 type MembershipRow = typeof companyMemberships.$inferSelect;
 type GrantInput = {
@@ -155,6 +156,18 @@ export function accessService(db: Db) {
           })),
         );
       }
+      // This set is now the answer, so the role-default seeder has nothing left
+      // to bootstrap. Without the marker it would put back every default this
+      // replacement left out at the next sweep, which is the whole defect
+      // (FAI-10190).
+      await settleRoleDefaults(tx, {
+        companyId,
+        principalType: member.principalType as PrincipalType,
+        principalId: member.principalId,
+        membershipStatus: member.status,
+        membershipRole: member.membershipRole,
+        settledByUserId: grantedByUserId,
+      });
     });
 
     return member;
@@ -250,6 +263,20 @@ export function accessService(db: Db) {
           })),
         );
       }
+      // Settled against the role being written, not the one being replaced.
+      // This is the one writer that changes the role and the grant set
+      // together, so it is also the only one where recording the previous role
+      // would leave the seeder a mismatch to act on — and it would act on it by
+      // adding the new role's whole default set on top of the set the operator
+      // just chose.
+      await settleRoleDefaults(tx, {
+        companyId,
+        principalType: existing.principalType as PrincipalType,
+        principalId: existing.principalId,
+        membershipStatus: nextStatus,
+        membershipRole: nextMembershipRole,
+        settledByUserId: grantedByUserId,
+      });
 
       return updated;
     });
@@ -393,6 +420,20 @@ export function accessService(db: Db) {
             eq(principalPermissionGrants.principalId, existing.principalId),
           ),
         );
+      // The marker goes with the grants it was protecting. It says "this
+      // principal's set is settled, do not bootstrap it", and once the set is
+      // deleted that is no longer true: leaving it behind would mean a re-added
+      // member arrived with no permissions at all rather than their role's
+      // defaults (FAI-10190).
+      await tx
+        .delete(principalRoleDefaultSeeds)
+        .where(
+          and(
+            eq(principalRoleDefaultSeeds.companyId, companyId),
+            eq(principalRoleDefaultSeeds.principalType, existing.principalType),
+            eq(principalRoleDefaultSeeds.principalId, existing.principalId),
+          ),
+        );
 
       const archived = await tx
         .update(companyMemberships)
@@ -502,6 +543,19 @@ export function accessService(db: Db) {
               inArray(principalPermissionGrants.companyId, toArchive.map((row) => row.companyId)),
             ),
           );
+        // Same rule as `archiveMember`: the settled marker only means anything
+        // for as long as the grants it describes exist, and a principal whose
+        // grants have been dropped has to be bootstrapped again if they are
+        // ever re-added (FAI-10190).
+        await tx
+          .delete(principalRoleDefaultSeeds)
+          .where(
+            and(
+              eq(principalRoleDefaultSeeds.principalType, "user"),
+              eq(principalRoleDefaultSeeds.principalId, userId),
+              inArray(principalRoleDefaultSeeds.companyId, toArchive.map((row) => row.companyId)),
+            ),
+          );
       }
 
       for (const companyId of target) {
@@ -573,6 +627,7 @@ export function accessService(db: Db) {
     grants: GrantInput[],
     grantedByUserId: string | null,
   ) {
+    const membership = await getMembership(companyId, principalType, principalId);
     await db.transaction(async (tx) => {
       await tx
         .delete(principalPermissionGrants)
@@ -583,19 +638,32 @@ export function accessService(db: Db) {
             eq(principalPermissionGrants.principalId, principalId),
           ),
         );
-      if (grants.length === 0) return;
-      await tx.insert(principalPermissionGrants).values(
-        grants.map((grant) => ({
-          companyId,
-          principalType,
-          principalId,
-          permissionKey: grant.permissionKey,
-          scope: grant.scope ?? null,
-          grantedByUserId,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        })),
-      );
+      if (grants.length > 0) {
+        await tx.insert(principalPermissionGrants).values(
+          grants.map((grant) => ({
+            companyId,
+            principalType,
+            principalId,
+            permissionKey: grant.permissionKey,
+            scope: grant.scope ?? null,
+            grantedByUserId,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })),
+        );
+      }
+      // The invite and plugin flows reach this with a set deliberately narrower
+      // than the role's defaults — a human accepted onto an invite that grants
+      // less than `operator` carries. Without the marker the next seeder sweep
+      // read that narrowing as a gap and filled it (FAI-10190).
+      await settleRoleDefaults(tx, {
+        companyId,
+        principalType,
+        principalId,
+        membershipStatus: membership?.status,
+        membershipRole: membership?.membershipRole,
+        settledByUserId: grantedByUserId,
+      });
     });
   }
 
@@ -661,16 +729,37 @@ export function accessService(db: Db) {
     scope: Record<string, unknown> | null = null,
   ) {
     if (!enabled) {
-      await db
-        .delete(principalPermissionGrants)
-        .where(
-          and(
-            eq(principalPermissionGrants.companyId, companyId),
-            eq(principalPermissionGrants.principalType, principalType),
-            eq(principalPermissionGrants.principalId, principalId),
-            eq(principalPermissionGrants.permissionKey, permissionKey),
-          ),
-        );
+      const membership = await getMembership(companyId, principalType, principalId);
+      // The delete and the marker commit together. Deleted-then-unmarked is the
+      // reported defect in miniature: the revocation holds until the next
+      // seeder sweep and then silently reverses.
+      //
+      // Only the revoking branch settles. The marker exists to stop the seeder
+      // *widening* a set someone narrowed, and a wholesale replacement and a
+      // revoke both narrow. Enabling one permission narrows nothing, and
+      // treating it as a statement of the whole set would mean a principal who
+      // was handed a single key before their first bootstrap never received
+      // their role's remaining defaults at all (FAI-10190).
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(principalPermissionGrants)
+          .where(
+            and(
+              eq(principalPermissionGrants.companyId, companyId),
+              eq(principalPermissionGrants.principalType, principalType),
+              eq(principalPermissionGrants.principalId, principalId),
+              eq(principalPermissionGrants.permissionKey, permissionKey),
+            ),
+          );
+        await settleRoleDefaults(tx, {
+          companyId,
+          principalType,
+          principalId,
+          membershipStatus: membership?.status,
+          membershipRole: membership?.membershipRole,
+          settledByUserId: grantedByUserId,
+        });
+      });
       return;
     }
 

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -18,6 +18,28 @@ export function normalizeHumanRole(
     : fallback;
 }
 
+/**
+ * A role's default grant set, applied once when a principal first holds that
+ * role and never again (`insertMissingPrincipalGrants`).
+ *
+ * **Adding a permission key here does not reach existing members.** Since
+ * FAI-10190 the seeder is a bootstrap: a principal already settled at this role
+ * is skipped outright, because "missing" has to be allowed to mean "revoked"
+ * for a revocation to survive a server restart. Propagation is therefore an
+ * explicit step, not a side effect of editing this function.
+ *
+ * Write the propagation as a backfill migration, the way
+ * `0087_backfill_environment_manage_human_defaults.sql` and
+ * `0111_backfill_skill_create_human_defaults.sql` already do: insert the one
+ * new key for the memberships whose role now carries it, `ON CONFLICT DO
+ * NOTHING`. That is deliberate rather than incidental — it states in the
+ * migration exactly which existing members gain the new authority, which a
+ * background sweep silently widening every member's grant set never did.
+ *
+ * Removing a key here is the mirror image: it stops being granted to principals
+ * seeded from now on, and members who already hold it keep it until a migration
+ * deletes it.
+ */
 export function grantsForHumanRole(
   role: HumanCompanyMembershipRole
 ): Array<{

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -113,6 +113,7 @@ export {
   backfillPrincipalAccessCompatibility,
   ensureHumanRoleDefaultGrants,
   insertMissingPrincipalGrants,
+  settleRoleDefaults,
   type PrincipalAccessCompatibilityBackfillStats,
 } from "./principal-access-compatibility.js";
 export { authorizationService } from "./authorization.js";

--- a/server/src/services/principal-access-compatibility.ts
+++ b/server/src/services/principal-access-compatibility.ts
@@ -1,7 +1,12 @@
 import { and, eq, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, companyMemberships, principalPermissionGrants } from "@paperclipai/db";
-import type { PermissionKey, PrincipalType } from "@paperclipai/shared";
+import {
+  agents,
+  companyMemberships,
+  principalPermissionGrants,
+  principalRoleDefaultSeeds,
+} from "@paperclipai/db";
+import type { HumanCompanyMembershipRole, PermissionKey, PrincipalType } from "@paperclipai/shared";
 import { grantsForHumanRole, normalizeHumanRole } from "./company-member-roles.js";
 
 type GrantInput = {
@@ -14,6 +19,105 @@ export type PrincipalAccessCompatibilityBackfillStats = {
   humanGrantsInserted: number;
 };
 
+/**
+ * Records that a principal's grant set is now settled at a role, so the
+ * bootstrap seeder leaves it alone.
+ *
+ * Called from two kinds of place, for one reason. The seeder calls it when it
+ * has just applied a role's defaults. Every writer that states a principal's
+ * grant set — the members UI, the principal-level replacement the invite and
+ * plugin flows use, a single permission toggle — calls it too, because a set
+ * someone decided on must not be widened afterwards by a background sweep. In
+ * both cases the answer is no longer the role's default set, and the seeder's
+ * job is done (FAI-10190).
+ *
+ * The membership standing and role are passed in rather than read here. On the
+ * writers they are the state being written, inside the same transaction — the
+ * state the marker has to describe — and a read here would see the pre-write
+ * row instead.
+ *
+ * Three states carry no marker.
+ *
+ * Agent principals: the seeder only ever expands a *human* role, so there is no
+ * default set for a marker to bound. Agent grants are written key by key by
+ * `built-in-agents` and company import.
+ *
+ * An absent membership: nothing names a role, and `decidePrincipalGrant`
+ * refuses every key behind a principal that is not an active member anyway, so
+ * there is no authority to protect.
+ *
+ * And `archived`, which is the tombstone every removal path leaves. Removal
+ * deletes the principal's grants, so there is nothing left to keep; a marker
+ * there would mean a re-added principal arrived with no permissions at all
+ * instead of their role's defaults. The removal paths delete the marker for the
+ * same reason.
+ */
+export async function settleRoleDefaults(
+  tx: Pick<Db, "insert">,
+  input: {
+    companyId: string;
+    principalType: PrincipalType;
+    principalId: string;
+    membershipStatus: string | null | undefined;
+    membershipRole: string | null | undefined;
+    settledByUserId: string | null;
+  },
+): Promise<void> {
+  if (input.principalType !== "user") return;
+  if (!input.membershipStatus || input.membershipStatus === "archived") return;
+
+  const now = new Date();
+  const settled = {
+    role: normalizeHumanRole(input.membershipRole, "operator"),
+    settledByUserId: input.settledByUserId,
+    updatedAt: now,
+  };
+  await tx
+    .insert(principalRoleDefaultSeeds)
+    .values({
+      companyId: input.companyId,
+      principalType: input.principalType,
+      principalId: input.principalId,
+      createdAt: now,
+      ...settled,
+    })
+    .onConflictDoUpdate({
+      target: [
+        principalRoleDefaultSeeds.companyId,
+        principalRoleDefaultSeeds.principalType,
+        principalRoleDefaultSeeds.principalId,
+      ],
+      set: settled,
+    });
+}
+
+/**
+ * Seeds a principal's role-default grants once, and only once per role.
+ *
+ * `ON CONFLICT DO NOTHING` made this idempotent against rows that exist when it
+ * runs, which is not the same as leaving a decision alone. A default an
+ * operator had deliberately revoked is, by definition, missing, so every run
+ * put it back: the revocation looked like it took — the row was gone and the UI
+ * showed it gone — and then silently reversed at the next server start, the
+ * member's next cloud-tenant sync, a `setUserCompanyAccess` call or a company
+ * clone (FAI-10190).
+ *
+ * The marker is what makes the difference representable, because absence in
+ * `principal_permission_grants` cannot be: it says "this role's defaults have
+ * already been applied", so a missing row afterwards is an answer rather than a
+ * gap to fill. Role defaults become a bootstrap, which is what this function's
+ * name already claimed.
+ *
+ * The check and the insert share a transaction so a marker cannot be read
+ * before another seeder's grants land and then written as if this run had
+ * applied them.
+ *
+ * `role` is part of the marker, not just the seeding, so a role *change* still
+ * propagates: promoted from operator to admin, the principal's settled role no
+ * longer matches and the new role's defaults are applied once. What does not
+ * propagate is a new permission key added to a role that existing members
+ * already hold — see `grantsForHumanRole` in `company-member-roles.ts`.
+ */
 export async function insertMissingPrincipalGrants(
   db: Db,
   input: {
@@ -22,36 +126,80 @@ export async function insertMissingPrincipalGrants(
     principalId: string;
     grants: GrantInput[];
     grantedByUserId: string | null;
+    /** The role whose default set `grants` is, recorded so this runs once. */
+    role: HumanCompanyMembershipRole;
   },
 ): Promise<number> {
-  if (input.grants.length === 0) return 0;
+  return db.transaction(async (tx) => {
+    const settledRole = await tx
+      .select({ role: principalRoleDefaultSeeds.role })
+      .from(principalRoleDefaultSeeds)
+      .where(
+        and(
+          eq(principalRoleDefaultSeeds.companyId, input.companyId),
+          eq(principalRoleDefaultSeeds.principalType, input.principalType),
+          eq(principalRoleDefaultSeeds.principalId, input.principalId),
+        ),
+      )
+      .then((rows) => rows[0]?.role ?? null);
+    if (settledRole === input.role) return 0;
 
-  const now = new Date();
-  const inserted = await db
-    .insert(principalPermissionGrants)
-    .values(
-      input.grants.map((grant) => ({
-        companyId: input.companyId,
-        principalType: input.principalType,
-        principalId: input.principalId,
-        permissionKey: grant.permissionKey,
-        scope: grant.scope ?? null,
-        grantedByUserId: input.grantedByUserId,
-        createdAt: now,
-        updatedAt: now,
-      })),
-    )
-    .onConflictDoNothing({
-      target: [
-        principalPermissionGrants.companyId,
-        principalPermissionGrants.principalType,
-        principalPermissionGrants.principalId,
-        principalPermissionGrants.permissionKey,
-      ],
-    })
-    .returning({ id: principalPermissionGrants.id });
+    // Read here rather than taken from the caller: the marker this run is about
+    // to write has to describe the standing the grants land against, and every
+    // caller establishes the membership on a separate handle before this
+    // transaction opens.
+    const membershipStatus = await tx
+      .select({ status: companyMemberships.status })
+      .from(companyMemberships)
+      .where(
+        and(
+          eq(companyMemberships.companyId, input.companyId),
+          eq(companyMemberships.principalType, input.principalType),
+          eq(companyMemberships.principalId, input.principalId),
+        ),
+      )
+      .then((rows) => rows[0]?.status ?? null);
 
-  return inserted.length;
+    const now = new Date();
+    // A role with no defaults — `viewer` — still gets a marker. Nothing is
+    // inserted, but "settled as a viewer" and "never seeded" have to stay
+    // distinguishable, or the audit reading of a missing grant loses its
+    // baseline.
+    const inserted = input.grants.length === 0 ? [] : await tx
+      .insert(principalPermissionGrants)
+      .values(
+        input.grants.map((grant) => ({
+          companyId: input.companyId,
+          principalType: input.principalType,
+          principalId: input.principalId,
+          permissionKey: grant.permissionKey,
+          scope: grant.scope ?? null,
+          grantedByUserId: input.grantedByUserId,
+          createdAt: now,
+          updatedAt: now,
+        })),
+      )
+      .onConflictDoNothing({
+        target: [
+          principalPermissionGrants.companyId,
+          principalPermissionGrants.principalType,
+          principalPermissionGrants.principalId,
+          principalPermissionGrants.permissionKey,
+        ],
+      })
+      .returning({ id: principalPermissionGrants.id });
+
+    await settleRoleDefaults(tx, {
+      companyId: input.companyId,
+      principalType: input.principalType,
+      principalId: input.principalId,
+      membershipStatus,
+      membershipRole: input.role,
+      settledByUserId: input.grantedByUserId,
+    });
+
+    return inserted.length;
+  });
 }
 
 export async function ensureHumanRoleDefaultGrants(
@@ -70,6 +218,7 @@ export async function ensureHumanRoleDefaultGrants(
     principalId: input.principalId,
     grants: grantsForHumanRole(role),
     grantedByUserId: input.grantedByUserId,
+    role,
   });
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Company access is decided by per-principal permission grants. A human role carries a set of default grants
> - A seeder applies those defaults. It runs at every server start, on every cloud-tenant sync, and on company creation and clone
> - The seeder inserts the role's whole default set with `ON CONFLICT DO NOTHING`. A default that an operator revoked is missing, so the seeder inserts it again
> - The revocation looks like it worked. The row is gone and the UI shows it gone. Then the permission comes back
> - The grants table cannot say "revoked". Absence is the only representation, and absence is what the seeder fills
> - This pull request makes the seeder a bootstrap. It records the role it applied, and it does not run again for that role
> - The benefit is that a revoked permission stays revoked

## Linked Issues or Issue Description

No public GitHub issue exists. The problem is described here.

**What happened?**

An operator revokes a role-default permission from a company member. For example, they revoke `tasks:assign` from an `operator`. The permission comes back on its own. It comes back at the next server start, or at the member's next cloud-tenant sync, or when an admin sets that user's company access, or on a company clone. No concurrent writer is necessary.

The cause is in `insertMissingPrincipalGrants` in `server/src/services/principal-access-compatibility.ts`. It inserts the role's entire default grant set with `ON CONFLICT DO NOTHING`. A default that someone revoked is missing, so the next run inserts it again. `backfillPrincipalAccessCompatibility` calls it for every active human membership at start-up, and `resolveCloudTenantActor` calls it on every cloud-tenant sync.

This is a privilege-restoration defect. The member gets authority back that an operator removed, and nobody is told.

**Expected behavior**

A revoked role default stays revoked. It stays revoked across a server restart, a cloud-tenant sync, a `setUserCompanyAccess` call, and a company clone. `decidePrincipalGrant` continues to deny the permission.

An audit reader can also tell the two cases apart. A default that was revoked must not look the same as a permission that the role never carried.

**Steps to reproduce**

1. Add a human member to a company with the `operator` role. The seeder gives them `tasks:assign`.
2. Revoke `tasks:assign` from that member.
3. Confirm the grant row is gone.
4. Restart the server, or wait for the member's next cloud-tenant sync.
5. The grant row is back. The member can assign tasks again.

**Paperclip version or commit**

Reproduces on `master` at `88a0f885e`.

**Database mode**

PostgreSQL. The regression tests use the embedded PostgreSQL harness.

**Access context**

Human company members with a role that carries default grants: `owner`, `admin`, and `operator`. Agent principals are not affected, because their grants are written key by key and never expanded from a role.

Related open PR: #12048 changes the same seeder to add grant expiry. Greptile raised this defect at that PR's live head. This defect is `master` behaviour, so it is fixed here and not in #12048. There is no other open PR for it.

## What Changed

- Add the table `principal_role_default_seeds`. One row per principal whose role defaults are settled, keyed on `(company_id, principal_type, principal_id)`. It records the `role` and `settled_by_user_id`.
- `insertMissingPrincipalGrants` now reads the settled role first. If it already names the role being seeded, the function returns `0` and writes nothing. If not, it seeds and stamps. The read, the insert and the stamp share one transaction.
- Four writers settle the marker after they state a principal's grant set: `setMemberPermissions`, `updateMemberAndPermissions`, `setPrincipalGrants`, and the **revoking** branch of `setPrincipalPermission`. A set that someone decided on must not be widened later by a background sweep. This also fixes the narrowing case, where a person joins on an invite that grants less than their role carries and the next sweep fills the gap.
- The **enabling** branch of `setPrincipalPermission` does not settle the marker. The marker stops the seeder from widening a set that someone narrowed. Enabling one key narrows nothing. If it settled the marker, a principal who got a single key before their first bootstrap would never get the rest of their role's defaults.
- `archiveMember` and `setUserCompanyAccess` delete the marker beside the grants they already delete. Without this, a member who is added again arrives with no permissions at all instead of their role's defaults.
- `updateMemberAndPermissions` stamps the role that is being written, not the role being replaced. It is the only writer that changes the role and the grant set together.
- Migration `0228_principal_role_default_seeds.sql` creates the table and marks every non-archived human membership as settled at its current normalized role.
- Document on `grantsForHumanRole` what happens when a permission key is added to a role after members exist.
- Add `server/src/__tests__/role-default-grant-revocation-postgres.test.ts`.
- Give the two auth-path db doubles a `transaction`, which the seeder now needs.

### Why not a deny or tombstone row on the grants table

A deny row is fail-open on every reader that is not updated. `principal_permission_grants` is read directly in several places, not only through `decidePrincipalGrant`. A reader that does not know the new row type sees a row and reads it as a grant. That turns a revocation into an escalation. The marker changes only the seeder. Every reader keeps its current meaning, and a revoked default is still represented as an absent row.

### Why a new table and not a column on `company_memberships`

A lock-ordering constraint decided this. The removal paths take the membership row lock first and the per-principal advisory key second. See the comments in `archiveMember` and `updateMemberAndPermissions`. A marker column on `company_memberships` would make the seeder, which holds the advisory key, update the membership row after it. That is advisory-then-row, and it closes a deadlock cycle against `archiveMember`.

The marker table is written under the advisory key that every grant writer already holds. It takes no membership row lock, so lock ordering does not change.

### A permission key added to a role after members exist

It does not propagate, and that is now explicit. Write the propagation as a backfill migration. The repository has two migrations of exactly this shape already: `0087_backfill_environment_manage_human_defaults.sql` and `0111_backfill_skill_create_human_defaults.sql`. The migration then states which existing members get the new authority. A background sweep that widened every member's set never did.

Role changes still propagate on their own, because the marker names a role. A member who is promoted no longer matches the marker, so the new role's defaults are applied once.

## Verification

Run the new suite:

```
cd server && npx vitest run src/__tests__/role-default-grant-revocation-postgres.test.ts
```

It uses the embedded PostgreSQL harness. Every durability test revokes and then runs a seeder again. A test that only asserts the row is gone after the delete proves nothing, because that was already true before this change.

The suite covers:

- A revoked default survives the start-up backfill. `decidePrincipalGrant` denies with `deny_missing_grant`.
- It survives a cloud-tenant sync, a `setUserCompanyAccess` call, and a company clone.
- The settled role makes a revoked default different from one that was never carried.
- A member who is removed and added again is bootstrapped again. Both removal paths are covered.
- A member who is promoted gets the new role's defaults.
- A grant set that is written narrower than the role's defaults is not widened.
- A `viewer` is marked as settled although the role seeds nothing.

Also run the neighbouring suites, which exercise the seeder:

```
cd server && npx vitest run src/__tests__/access-service.test.ts src/__tests__/auth-session-route.test.ts src/middleware/cloud-tenant-actor.test.ts
```

Migration checks:

```
pnpm --filter @paperclipai/db build
```

This runs `check-migration-numbering` and `check-migration-safety`. Both pass.

## Risks

- **Migration.** The table is new, so `CREATE TABLE` is additive. The backfill is one `INSERT ... SELECT` over `company_memberships`, which is a small table. `check-migration-safety` passes.
- **Migration number.** This is `0228`, not `0227`. PR #12048 is open and already gated at `0227`. If #12048 is abandoned, `0227` stays free. Drizzle applies migrations in journal order, so a gap is safe.
- **Behavioural shift, intended.** A permission key that is added to a role no longer reaches existing members on its own. This is the trade the fix makes, and it is documented on `grantsForHumanRole`. Adding such a key now needs a backfill migration.
- **Behavioural shift, guarded.** If the marker were left behind after a removal, a member who is added again would arrive with no permissions. Both removal paths delete the marker, and two tests cover it.
- **Existing installs.** The backfill marks non-archived human memberships as settled, so an existing revocation becomes durable at this deploy. Archived memberships are left unmarked on purpose, because removal already deleted their grants.
- **Not in scope.** The seeder on `master` holds no lock. This change does not add one. PR #12048 brings the seeder under the per-principal advisory lock, and the two compose: the marker read, the insert and the stamp already share a transaction.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking, with tool use and code execution through Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`)
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
