### PR TITLE
fix(heartbeat): isolate per-agent timer ticks so one throwing agent can't kill the fleet scheduler

### DIFF
--- a/server/src/__tests__/heartbeat-timer-tick-agent-isolation.test.ts
+++ b/server/src/__tests__/heartbeat-timer-tick-agent-isolation.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companySkills,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  instanceSettings,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+// Holder for the id of the agent whose per-agent tick should throw. Populated by
+// each test before it calls tickTimers. Declared via vi.hoisted so it exists when
+// the mock factory below (hoisted above the imports) captures it.
+const mockState = vi.hoisted(() => ({ poisonAgentId: "" }));
+
+// Simulate a single agent whose wake/tick throws — e.g. a heartbeat-enabled agent
+// with a null defaultEnvironmentId, the exact shape that took down the fleet-wide
+// scheduler. evaluateAgentInvokability is the first per-agent call inside the
+// tickTimers loop, so throwing here reproduces "one agent aborts the whole tick".
+// All other agents fall through to the real implementation.
+vi.mock("../services/agent-invokability.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/agent-invokability.js")>();
+  return {
+    ...actual,
+    evaluateAgentInvokability: (
+      agent: Parameters<typeof actual.evaluateAgentInvokability>[0],
+      companyAgents: Parameters<typeof actual.evaluateAgentInvokability>[1],
+    ) => {
+      if (agent && agent.id === mockState.poisonAgentId) {
+        throw new Error(`simulated per-agent heartbeat tick failure for ${agent.id}`);
+      }
+      return actual.evaluateAgentInvokability(agent, companyAgents);
+    },
+  };
+});
+
+const { heartbeatService } = await import("../services/heartbeat.ts");
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat timer tick isolation tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat timer tick per-agent isolation", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-timer-tick-isolation-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockState.poisonAgentId = "";
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(agentRuntimeState);
+    await db.delete(companySkills);
+    await db.delete(agents);
+    await db.delete(companies);
+    await db.delete(instanceSettings);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  }, 60_000);
+
+  async function insertActiveCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      status: "active",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    return companyId;
+  }
+
+  async function insertHeartbeatAgent(
+    companyId: string,
+    name: string,
+    // A very large interval keeps healthy agents in the loop's "checked" phase
+    // without enqueuing a wake (and spawning a background run), so the test can
+    // assert isolation deterministically without draining live executions.
+    intervalSec: number,
+  ) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "engineer",
+      status: "idle",
+      // defaultEnvironmentId left null on purpose — this is the misconfiguration
+      // that made the real "PR Gate Lead" agent's tick throw.
+      defaultEnvironmentId: null,
+      adapterType: "process",
+      adapterConfig: {
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+      },
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec,
+          wakeOnDemand: true,
+        },
+      },
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  it("isolates a throwing agent so the rest of the fleet still ticks", async () => {
+    const companyId = await insertActiveCompany();
+
+    // One poison agent whose per-agent tick throws, plus three healthy agents.
+    const poisonAgentId = await insertHeartbeatAgent(companyId, "PR Gate Lead", 60);
+    const healthyIds = [
+      await insertHeartbeatAgent(companyId, "Healthy Agent A", 3_600_000),
+      await insertHeartbeatAgent(companyId, "Healthy Agent B", 3_600_000),
+      await insertHeartbeatAgent(companyId, "Healthy Agent C", 3_600_000),
+    ];
+    expect(healthyIds).toHaveLength(3);
+
+    mockState.poisonAgentId = poisonAgentId;
+
+    const heartbeat = heartbeatService(db, { runtimeEnv: {} });
+
+    // Before the fix the poison agent's uncaught throw propagates out of
+    // tickTimers, rejecting the whole tick and starving every other agent. After
+    // the fix tickTimers resolves and every healthy agent is still evaluated.
+    const result = await heartbeat.tickTimers(new Date());
+
+    // All three healthy agents were reached and counted despite the throwing
+    // agent; none was enqueued because their interval has not elapsed.
+    expect(result).toEqual({ checked: 3, enqueued: 0, skipped: 0 });
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -19658,48 +19658,58 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       let skipped = 0;
 
       for (const agent of allAgents) {
-        const invokability = evaluateAgentInvokability(toAgentOrgRow(agent), agentsByCompany.get(agent.companyId) ?? []);
-        if (!invokability.invokable) continue;
-        const policy = parseHeartbeatPolicy(agent);
-        if (!policy.enabled || policy.intervalSec <= 0) continue;
+        // Isolate each agent's tick so one throwing agent (e.g. a heartbeat-enabled
+        // agent with a null defaultEnvironmentId) cannot abort the tick for every
+        // agent after it in the loop and silently kill the fleet-wide scheduler.
+        try {
+          const invokability = evaluateAgentInvokability(toAgentOrgRow(agent), agentsByCompany.get(agent.companyId) ?? []);
+          if (!invokability.invokable) continue;
+          const policy = parseHeartbeatPolicy(agent);
+          if (!policy.enabled || policy.intervalSec <= 0) continue;
 
-        if (cutoff) {
-          const eligibleIssue = await db
-            .select({ id: issues.id })
-            .from(issues)
-            .where(and(
-              eq(issues.companyId, agent.companyId),
-              eq(issues.assigneeAgentId, agent.id),
-              inArray(issues.status, ["todo", "in_progress"]),
-              gte(issues.createdAt, cutoff),
-            ))
-            .limit(1)
-            .then((rows) => rows[0] ?? null);
-          if (!eligibleIssue) continue;
+          if (cutoff) {
+            const eligibleIssue = await db
+              .select({ id: issues.id })
+              .from(issues)
+              .where(and(
+                eq(issues.companyId, agent.companyId),
+                eq(issues.assigneeAgentId, agent.id),
+                inArray(issues.status, ["todo", "in_progress"]),
+                gte(issues.createdAt, cutoff),
+              ))
+              .limit(1)
+              .then((rows) => rows[0] ?? null);
+            if (!eligibleIssue) continue;
+          }
+
+          checked += 1;
+          const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
+          const elapsedMs = now.getTime() - baseline;
+          if (elapsedMs < policy.intervalSec * 1000) continue;
+          const timerClaim = await claimDueTimerHeartbeat(agent, now, policy.intervalSec);
+          if (!timerClaim) continue;
+
+          const run = await enqueueWakeup(agent.id, {
+            source: "timer",
+            triggerDetail: "system",
+            reason: "heartbeat_timer",
+            requestedByActorType: "system",
+            requestedByActorId: "heartbeat_scheduler",
+            contextSnapshot: {
+              source: "scheduler",
+              reason: "interval_elapsed",
+              now: now.toISOString(),
+              timerClaimWasFirstHeartbeat: timerClaim.wasFirstHeartbeat,
+            },
+          });
+          if (run) enqueued += 1;
+          else skipped += 1;
+        } catch (err) {
+          logger.error(
+            { err, agentId: agent.id, agentName: agent.name, companyId: agent.companyId },
+            "heartbeat timer tick failed for agent",
+          );
         }
-
-        checked += 1;
-        const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
-        const elapsedMs = now.getTime() - baseline;
-        if (elapsedMs < policy.intervalSec * 1000) continue;
-        const timerClaim = await claimDueTimerHeartbeat(agent, now, policy.intervalSec);
-        if (!timerClaim) continue;
-
-        const run = await enqueueWakeup(agent.id, {
-          source: "timer",
-          triggerDetail: "system",
-          reason: "heartbeat_timer",
-          requestedByActorType: "system",
-          requestedByActorId: "heartbeat_scheduler",
-          contextSnapshot: {
-            source: "scheduler",
-            reason: "interval_elapsed",
-            now: now.toISOString(),
-            timerClaimWasFirstHeartbeat: timerClaim.wasFirstHeartbeat,
-          },
-        });
-        if (run) enqueued += 1;
-        else skipped += 1;
       }
 
       const issueMonitors = await tickDueIssueMonitors(now);


### PR DESCRIPTION
## Outage & root cause

A single misconfigured agent caused a **~2-day fleet-wide heartbeat/timer outage across all three companies** on the platform.

`heartbeatService.tickTimers` (server/src/services/heartbeat.ts) loops over every active agent with **no per-agent error handling**. When one agent's wake/tick throws — e.g. a heartbeat-enabled agent with a null `defaultEnvironmentId` — the exception propagates out of the `for` loop and out of `tickTimers`, aborting the tick for **every agent after it** in the loop. The scheduler then silently stops firing timers/heartbeats fleet-wide. The specific agent that triggered it was "PR Gate Lead" (heartbeat-enabled, `defaultEnvironmentId: None`), but the failure mode is general: any single throwing agent starves the whole fleet.

## Fix

Wrap each agent's per-tick body in its own `try/catch`, mirroring the existing per-item handling already used in `tickDueIssueMonitors`. On a caught error we log it via `logger.error({ err, agentId, agentName, companyId }, "heartbeat timer tick failed for agent")` and continue to the next agent. The error is **not** swallowed silently — it stays visible in logs — but one misconfigured agent can no longer abort the rest of the loop.

The change is pure control-flow isolation; the per-agent logic is unchanged (the large diff is mostly indentation from wrapping the body in `try`).

## Tests

Adds `server/src/__tests__/heartbeat-timer-tick-agent-isolation.test.ts`, an embedded-Postgres regression test (same harness/skip-gating as the other heartbeat scheduler tests). It seeds one agent whose per-agent tick throws plus three healthy agents and asserts `tickTimers` still resolves and every healthy agent is processed. Verified locally: the test **fails without this fix** (the uncaught throw rejects the whole tick) and **passes with it**. The existing `tickTimers` suite (`heartbeat-worktree-suppression`, `heartbeat-archived-company-guard`, `heartbeat-stale-queue-invalidation`, `issue-monitor-scheduler`) was re-run — 45 tests, all passing, no regression.

## Status

**Unverified in production.** This was developed against `master` off a local checkout and needs @Srini / the platform team to review and deploy. It addresses the 2-day fleet-wide heartbeat outage described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)