### PR TITLE
fix(TSMC-21482): hermes session codec drops cwd, disabling TSMC-21089 convergence

### DIFF
--- a/packages/adapters/hermes/src/server/index.ts
+++ b/packages/adapters/hermes/src/server/index.ts
@@ -24,6 +24,36 @@ function readNonEmptyString(value: unknown): string | null {
  * Hermes Agent uses a single `sessionId` for cross-heartbeat session continuity
  * via the `--resume` CLI flag. The codec validates and normalizes this field.
  */
+/**
+ * TSMC-21482: read the workspace cwd under any spelling the CLI may use.
+ *
+ * The codec used to return `{ sessionId }` and drop everything else. That single
+ * omission disabled the TSMC-21089 convergence guard for hermes and only for
+ * hermes: `resolveRuntimeSessionParamsForWorkspace` rotates a saved session away
+ * when a project workspace appears, and converges via
+ * `previousCwd && previousCwd === projectCwd`. With no cwd persisted,
+ * `previousCwd` was always undefined, the guard could never fire, and the
+ * "rotate once" rotated on every run forever.
+ *
+ * Measured live 2026-08-24, before the fix: session rows carrying a cwd were
+ * codex 145/145, claude 34/34, antigravity 26/26 and hermes **0/17**; hermes
+ * resumed a saved session on **0 of 433 runs** in 24h despite 207 of them being
+ * repeat visits to a card the lane had already worked. Every one of those repeats
+ * recorded `taskSessionAvailable=true` alongside
+ * `resetReasons: ["project_workspace_migration_from_fallback"]` — the session was
+ * found and discarded, run after run, each time re-paying a ~32.8K cold-start
+ * prefix.
+ *
+ * Mirrors the codex codec, which reads the same three spellings.
+ */
+function readSessionCwd(record: Record<string, unknown>) {
+  return (
+    readNonEmptyString(record.cwd) ??
+    readNonEmptyString(record.workdir) ??
+    readNonEmptyString(record.folder)
+  );
+}
+
 export const sessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
@@ -32,7 +62,11 @@ export const sessionCodec: AdapterSessionCodec = {
       readNonEmptyString(record.sessionId) ??
       readNonEmptyString(record.session_id);
     if (!sessionId) return null;
-    return { sessionId };
+    const cwd = readSessionCwd(record);
+    // Spread conditionally: an always-present `cwd: undefined` would change the
+    // serialized shape for sessions that legitimately have no workspace, and the
+    // session config fingerprint hashes this object.
+    return { sessionId, ...(cwd ? { cwd } : {}) };
   },
   serialize(params: Record<string, unknown> | null) {
     if (!params) return null;
@@ -40,7 +74,8 @@ export const sessionCodec: AdapterSessionCodec = {
       readNonEmptyString(params.sessionId) ??
       readNonEmptyString(params.session_id);
     if (!sessionId) return null;
-    return { sessionId };
+    const cwd = readSessionCwd(params);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
   },
   getDisplayId(params: Record<string, unknown> | null) {
     if (!params) return null;

--- a/packages/adapters/hermes/src/server/session-codec.test.ts
+++ b/packages/adapters/hermes/src/server/session-codec.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { sessionCodec } from "./index.js";
+
+/**
+ * TSMC-21089 / TSMC-21482 — hermes must round-trip `cwd` through the session codec.
+ *
+ * Why this test exists. `resolveRuntimeSessionParamsForWorkspace` rotates a saved
+ * session away when a project workspace becomes available, and converges via:
+ *
+ *     if (previousCwd && previousCwd === projectCwd) { resume }
+ *
+ * That guard was added by TSMC-21089 precisely because the rotation was meant to
+ * happen ONCE and was instead repeating forever ("78 of 183 (agent, issue) pairs
+ * rotated more than once, worst 59 times ... burned 815,607 tokens").
+ *
+ * It only works if the adapter persists `cwd`. Hermes did not: the codec returned
+ * `{ sessionId }` and dropped everything else on BOTH serialize and deserialize,
+ * so `previousCwd` was always undefined and the guard could never fire.
+ *
+ * Measured live 2026-08-24 before this fix:
+ *   - session rows carrying `cwd`: codex 145/145, claude 34/34, antigravity 26/26,
+ *     hermes **0/17**
+ *   - hermes runs resuming a saved session: **0 of 433** in 24h, including 207
+ *     repeat visits to a card the lane had already worked
+ *   - every repeat visit recorded `taskSessionAvailable=true` with
+ *     `resetReasons: ["project_workspace_migration_from_fallback"]`
+ *
+ * The session was there. It was thrown away every single run.
+ */
+describe("hermes sessionCodec cwd round-trip (TSMC-21482)", () => {
+  const CWD = "/Users/glad0s/.paperclip/instances/default/projects/abc/def/_default";
+
+  it("preserves cwd through deserialize — the convergence guard reads this", () => {
+    const out = sessionCodec.deserialize({ sessionId: "20260824_140755_a25b32", cwd: CWD });
+    expect(out).not.toBeNull();
+    expect(out?.sessionId).toBe("20260824_140755_a25b32");
+    expect(out?.cwd).toBe(CWD);
+  });
+
+  it("preserves cwd through serialize — without this it is never persisted", () => {
+    const out = sessionCodec.serialize({ sessionId: "20260824_140755_a25b32", cwd: CWD });
+    expect(out).not.toBeNull();
+    expect(out?.cwd).toBe(CWD);
+  });
+
+  it("survives a full serialize -> deserialize round trip", () => {
+    const stored = sessionCodec.serialize({ sessionId: "20260824_140755_a25b32", cwd: CWD });
+    const loaded = sessionCodec.deserialize(stored);
+    expect(loaded?.cwd).toBe(CWD);
+  });
+
+  it("accepts the snake_case spellings the CLI may emit", () => {
+    const out = sessionCodec.deserialize({ session_id: "20260824_140755_a25b32", workdir: CWD });
+    expect(out?.sessionId).toBe("20260824_140755_a25b32");
+    expect(out?.cwd).toBe(CWD);
+  });
+
+  it("still requires a sessionId, and still returns null without one", () => {
+    expect(sessionCodec.deserialize({ cwd: CWD })).toBeNull();
+    expect(sessionCodec.serialize({ cwd: CWD })).toBeNull();
+    expect(sessionCodec.deserialize(null)).toBeNull();
+    expect(sessionCodec.deserialize("nope")).toBeNull();
+  });
+
+  it("omits cwd entirely when absent — no empty-string keys for the fingerprint to churn on", () => {
+    const out = sessionCodec.deserialize({ sessionId: "20260824_140755_a25b32" });
+    expect(out).toEqual({ sessionId: "20260824_140755_a25b32" });
+    expect(Object.keys(out ?? {})).not.toContain("cwd");
+  });
+
+  it("getDisplayId is unchanged", () => {
+    expect(sessionCodec.getDisplayId?.({ sessionId: "20260824_140755_a25b32", cwd: CWD }))
+      .toBe("20260824_140755_a25b32");
+  });
+});


### PR DESCRIPTION
## Thinking Path
Hermes resumed a saved session on 0 of 433 runs in 24h. The decision record showed `taskSessionAvailable=true`, `reuseDecision=reset`, `resetReasons=["project_workspace_migration_from_fallback"]` on every repeat visit. `resolveRuntimeSessionParamsForWorkspace`'s convergence guard (from the prior fix tracked in TSMC-21089) resumes once `previousCwd === projectCwd`, but the Hermes codec returned `{ sessionId }` and dropped everything else on both serialize and deserialize — `previousCwd` was always `undefined`, so the guard could never fire and the rotation repeated forever.

## What Changed
- `packages/adapters/hermes/src/server/index.ts`: mirror the codex codec — read `cwd` under `cwd`/`workdir`/`folder` and preserve it through serialize/deserialize. No change to the guard itself. `cwd` is spread conditionally so sessions without a workspace keep their exact previous shape (avoids fingerprint churn from an always-present `cwd: undefined`).
- `packages/adapters/hermes/src/server/session-codec.test.ts`: new focused suite, 7/7 green.

## Risks
Single-file production change, no schema change, no migration. Worst case if wrong: Hermes session convergence still fails to resume (status quo — no regression risk beyond the current broken state), since the change only adds a field that was previously dropped.

## Verification (commit 84d217f6c, rebased clean onto current upstream/master as afcd55f72)
- New suite `session-codec.test.ts`: 7/7 green.
- `heartbeat-workspace-session` (shared path for all adapters) unaffected — codex/claude/antigravity convergence untouched (no changes to shared guard logic).

## Model Used
Claude (claude_local / claude-sonnet-5)

## Rollback
Revert this commit to return Hermes to `{ sessionId }`; `persistSession` can independently be set back to `false` on pilot lanes.

Refs TSMC-21089, TSMC-21482, TSMC-21377.

- [x] Searched the GitHub PR list for similar/duplicate PRs — none found for this codec-level fix.

Fixes the Hermes session-codec cwd drop described in the linked internal tracking issue (TSMC-21482).

## Issue (inline, bug report format)

**Pre-submission checklist**
- [x] Searched existing open and closed issues — not a duplicate.
- [x] Reproducible on `master`.
- [x] Confirmed the error originates in Paperclip's Hermes adapter itself — not in an API provider or local agent configuration.

**What happened?**
Hermes sessions never resumed. Every wake logged `taskSessionAvailable=true`, `reuseDecision=reset`, `resetReasons=["project_workspace_migration_from_fallback"]`, even on repeat visits to the same workspace — measured at 0 resumes out of 433 Hermes runs in 24h.

**Expected behavior**
The convergence guard added for the same rotate-once problem in `resolveRuntimeSessionParamsForWorkspace` should resume a session once `previousCwd === projectCwd` (i.e., after the one-time rotation on workspace migration). It should fire on the second visit to a converged workspace.

**Steps to reproduce**
1. Run a Hermes-adapter agent against an issue whose workspace originates from a fallback path (`project_workspace_migration_from_fallback`).
2. Let the run complete and persist a session (`persistSession: true`).
3. Wake the same lane on the same (now-converged) workspace a second time.
4. Observe the decision record: `reuseDecision` stays `reset` forever instead of flipping to `resume` after the first rotation, because `resolveRuntimeSessionParamsForWorkspace` reads `previousCwd` from the persisted session, and the Hermes codec's serialize/deserialize discard every field except `sessionId` — `previousCwd` is always `undefined`, so `previousCwd === projectCwd` can never be true.

**Root cause**
`packages/adapters/hermes/src/server/index.ts` session codec returned `{ sessionId }` only, dropping `cwd` (and everything else) on both serialize and deserialize — unlike the codex codec, which already preserves `cwd`.

**Paperclip version or commit**: `upstream/master` @ `0dfa0fb98` (pre-fix)
