### PR TITLE
fix(lockfile): sync pnpm-lock.yaml with paperclip-runner's devDependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,10 +450,23 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@7.3.1(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12))
 
   packages/paperclip-runner:
-    devDependencies:
+    dependencies:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      json-schema-to-ts:
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@7.3.1(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12))
 
   packages/plugins/create-paperclip-plugin:
     dependencies:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - CI installs with a frozen lockfile, so the lockfile must match every workspace package.json at the merged tree
> - The runner-supervision and PRP-transport merges added devDependencies to packages/paperclip-runner without landing the matching lockfile entries
> - Their PR runs passed because the lockfile-policy regenerates a PR lockfile as an artifact, which does not travel with the merge
> - This pull request lands the regenerated lockfile entries, unbreaking install for every branch
> - The benefit is CI works again, repo-wide

## Linked Issues or Issue Description

**What happened?**

Since #12095 merged (followed by #12100), every CI job on every branch fails in ~15 seconds at `pnpm install --frozen-lockfile`: `specifiers in the lockfile ({"ajv":"^8.20.0"}) don't match specs in package.json` for `packages/paperclip-runner`. Master's own push runs at 17:16 and 17:55 UTC failed the same way; the 16:38 run was green.

**Expected behavior**

`pnpm install --frozen-lockfile` succeeds on master.

**Steps to reproduce**

`npx pnpm@9.15.4 install --frozen-lockfile` on current master.

**Paperclip version or commit**

master at `b76e36d6c`.

## What Changed

- `pnpm-lock.yaml` regenerated with the CI-pinned pnpm 9.15.4 (`--lockfile-only`); the 15-line diff covers only the `packages/paperclip-runner` importer's new devDependencies.

## Verification

- `npx pnpm@9.15.4 install --frozen-lockfile` passes locally on this tree (fails on master without it).
- The diff touches no dependency versions outside the paperclip-runner importer.

## Risks

- Low: lockfile-only. Worth a follow-up look at the lockfile-policy flow — a PR can be green while its merge breaks master, which is what happened here.

## Model Used

Claude Fable 5 (Claude Code)

## Pre-submission checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template