### PR TITLE
fix(ci): unstick the lockfile refresh PR's required checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Test release verify workflow wiring
         run: node --test ./scripts/__tests__/release-verify-workflow.test.mjs
 
+      - name: Test lockfile refresh workflow wiring
+        run: node --test ./scripts/__tests__/refresh-lockfile-workflow.test.mjs
+
       - name: Test standalone package build concurrency
         run: node --test ./scripts/__tests__/build-standalone-concurrency.test.mjs
 

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -21,6 +21,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # A branch pushed with the default GITHUB_TOKEN triggers no
+          # pull_request workflows, so the lockfile PR's required checks
+          # never start and the auto-merge below waits forever with master
+          # desynced. Prefer a bot credential that does trigger workflows:
+          # a fine-grained PAT with contents + pull-requests write, stored
+          # as the LOCKFILE_BOT_TOKEN secret. Falls back to GITHUB_TOKEN,
+          # in which case the verification step below fails loudly instead
+          # of leaving the PR silently stuck.
+          token: ${{ secrets.LOCKFILE_BOT_TOKEN || github.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -53,7 +63,7 @@ jobs:
       - name: Create or update pull request
         id: upsert-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LOCKFILE_BOT_TOKEN || github.token }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           if git diff --quiet -- pnpm-lock.yaml; then
@@ -91,6 +101,46 @@ jobs:
       - name: Enable auto-merge for lockfile PR
         if: steps.upsert-pr.outputs.pr_url != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LOCKFILE_BOT_TOKEN || github.token }}
         run: |
           gh pr merge --auto --squash --delete-branch "${{ steps.upsert-pr.outputs.pr_url }}"
+
+      # Auto-merge only fires once the required checks report. If the push
+      # above went out on the default GITHUB_TOKEN, they never start: the
+      # PR sits BLOCKED while every frozen-lockfile install on master keeps
+      # failing. Turn that silent stall into a red run with instructions.
+      - name: Verify required checks started on the lockfile PR
+        if: steps.upsert-pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.LOCKFILE_BOT_TOKEN || github.token }}
+          PR_URL: ${{ steps.upsert-pr.outputs.pr_url }}
+        run: |
+          head_sha="$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)"
+          for attempt in 1 2 3 4; do
+            sleep 45
+            count="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/check-runs" --jq .total_count)"
+            echo "check runs on ${head_sha}: ${count} (attempt ${attempt})"
+            if [ "${count:-0}" -ge 8 ]; then
+              echo "Required checks are running; auto-merge will complete the refresh."
+              exit 0
+            fi
+          done
+          {
+            echo "## Lockfile PR is stuck without required checks"
+            echo ""
+            echo "The push used the default GITHUB_TOKEN, which does not trigger"
+            echo "pull_request workflows, so ${PR_URL} cannot pass its required"
+            echo "checks and auto-merge will never fire. Until it merges, every"
+            echo "frozen-lockfile install on master fails."
+            echo ""
+            echo "Durable fix: create a fine-grained PAT (contents + pull-requests"
+            echo "write on this repository) and store it as the LOCKFILE_BOT_TOKEN"
+            echo "secret."
+            echo ""
+            echo "Immediate recovery (either works):"
+            echo '- push an empty commit to chore/refresh-lockfile with any human'
+            echo '  credential: git commit --allow-empty -m "chore: trigger checks"'
+            echo "- or close and reopen the PR from a human account"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Lockfile PR has no required checks running; see the job summary for recovery."
+          exit 1

--- a/scripts/__tests__/refresh-lockfile-workflow.test.mjs
+++ b/scripts/__tests__/refresh-lockfile-workflow.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workflow = readFileSync(
+  path.join(repoRoot, ".github/workflows/refresh-lockfile.yml"),
+  "utf8"
+);
+
+test("lockfile refresh pushes and manages its PR with a workflow-triggering credential", () => {
+  // A push made with the default GITHUB_TOKEN triggers no pull_request
+  // workflows, so the lockfile PR's required checks never start and
+  // auto-merge waits forever while master's frozen installs keep failing.
+  // Every credential surface must prefer the bot PAT and fall back to the
+  // default token.
+  const coalesce = /\$\{\{ secrets\.LOCKFILE_BOT_TOKEN \|\| github\.token \}\}/g;
+  const occurrences = workflow.match(coalesce) ?? [];
+  assert.ok(
+    occurrences.length >= 4,
+    `expected the LOCKFILE_BOT_TOKEN fallback on checkout, PR upsert, auto-merge, and verification (found ${occurrences.length})`
+  );
+  assert.doesNotMatch(
+    workflow,
+    /GH_TOKEN: \$\{\{ github\.token \}\}/,
+    "no credential surface may use the bare default token"
+  );
+});
+
+test("a lockfile PR whose required checks never start fails the run loudly", () => {
+  assert.match(workflow, /Verify required checks started on the lockfile PR/);
+  assert.match(workflow, /check-runs/);
+  assert.match(
+    workflow,
+    /::error::Lockfile PR has no required checks running/,
+    "the stuck state must surface as a red run with recovery guidance"
+  );
+});
+
+test("auto-merge remains enabled so a green refresh lands without a human", () => {
+  assert.match(workflow, /gh pr merge --auto --squash --delete-branch/);
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The lockfile policy has CI own pnpm-lock.yaml: manifest-only PRs merge green against a regenerated artifact, and refresh-lockfile.yml lands the real lockfile right after through an auto-merge PR
> - That PR is pushed with the default GITHUB_TOKEN, which triggers no pull_request workflows, so its required checks never start and auto-merge never fires
> - Master's frozen-lockfile installs then fail on every branch until a human notices the silently stuck PR and pokes it
> - This pull request makes the refresh push with a workflow-triggering bot credential and fail loudly when checks have not started
> - The benefit is a lockfile loop that actually closes itself, and a red run instead of a silent stall when it cannot

## Linked Issues or Issue Description

**What happened?**

After #12095 and #12100 merged (manifest changes, no lockfile — green via the pr-lockfile artifact), every CI job on every branch failed at `pnpm install --frozen-lockfile` for over an hour. The automation had already pushed the correct fix to `chore/refresh-lockfile` (#12094) with auto-merge enabled — but the branch was pushed with `GITHUB_TOKEN`, so no `pull_request` workflow ran, the required checks stayed absent, merge state stayed `BLOCKED`, and nothing surfaced anywhere. Recovery required a human to push an empty commit to the branch to trigger the checks.

**Expected behavior**

The refresh PR runs its required checks and auto-merges unattended; if it ever cannot, the refresh workflow run fails visibly with recovery instructions.

**Steps to reproduce**

Merge any PR that changes a workspace `package.json` without lockfile entries, then watch `chore/refresh-lockfile`: the PR appears with only third-party scanner checks, `mergeStateStatus: BLOCKED`, and auto-merge pending forever.

**Paperclip version or commit**

master at `b76e36d6c`.

## What Changed

- `refresh-lockfile.yml`: every credential surface (checkout/push, PR upsert, auto-merge, verification) prefers a `LOCKFILE_BOT_TOKEN` secret — a fine-grained PAT with contents + pull-requests write — falling back to `GITHUB_TOKEN`.
- New step after auto-merge enablement: poll the PR head's check-runs for ~3 minutes; if required checks never start, fail the run with `::error::` and a job summary carrying the durable fix (mint the PAT) and both immediate recovery paths (empty commit from a human credential, or close/reopen).
- `scripts/__tests__/refresh-lockfile-workflow.test.mjs` pins the credential coalescing, the loud-failure step, and auto-merge; the pr.yml policy job runs it.

## Verification

- `node --test scripts/__tests__/refresh-lockfile-workflow.test.mjs` — 3 pass.
- Both workflow files re-parsed as YAML.
- The failure mode and both recovery paths were exercised live today on #12094 (the empty-commit path is how it was unstuck).
- Not exercised: the PAT path needs the `LOCKFILE_BOT_TOKEN` secret to exist — a maintainer must mint it (fine-grained PAT scoped to this repository: contents read/write, pull requests read/write). Until then the workflow behaves as today plus the loud failure, which is strictly better than the silent stall.

## Risks

- Low: without the secret, behavior only gains the verification failure. With the secret, pushes come from the PAT's owner — use a machine account if attribution matters.

## Model Used

Claude Fable 5 (Claude Code)

## Pre-submission checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template