### PR TITLE
fix(productivity-review): do not treat a scheduled monitor wait as a long active episode

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -527,6 +527,37 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
   });
 
+  it("does not raise a long-active review while the source issue waits on a scheduled monitor", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const nextCheckAt = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+    await db
+      .update(issues)
+      .set({
+        executionPolicy: { monitor: { nextCheckAt: nextCheckAt.toISOString(), notes: "waiting for a date gate" } },
+        monitorNextCheckAt: nextCheckAt,
+      })
+      .where(eq(issues.id, seeded.issueId));
+    const service = productivityReviewService(db);
+
+    const waiting = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(waiting.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+
+    const afterMonitor = await service.reconcileProductivityReviews({
+      now: new Date(nextCheckAt.getTime() + 60 * 60 * 1000),
+      companyId: seeded.companyId,
+    });
+
+    expect(afterMonitor.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -16,6 +16,7 @@ import { logActivity } from "./activity-log.js";
 import { budgetService } from "./budgets.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
+import { hasScheduledIssueMonitorPath } from "./recovery/issue-graph-liveness.js";
 import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
@@ -547,7 +548,14 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    // A scheduled monitor is the supported way to express waiting: the issue is
+    // parked until nextCheckAt and the harness will wake it then. Counting that
+    // wait as an active episode raises a long_active review on every sweep until
+    // the monitor fires, so an issue waiting on a date collects reviews for as
+    // long as it waits.
+    const waitingOnScheduledMonitor = hasScheduledIssueMonitorPath(sourceIssue, now);
+    const longActive =
+      !waitingOnScheduledMonitor && elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The productivity review subsystem watches assigned issues and raises a review task when an agent looks stuck
> - One of its triggers, `long_active_duration`, measures the active episode from `status == "in_progress"` and `started_at` only
> - An issue that waits on a scheduled monitor is also `in_progress`, so the trigger cannot tell a date gate from a stall
> - Each sweep therefore raises a new review task, and the no-action brake does not stop it, because the harness writes an activity log entry on every monitor wake
> - This pull request skips the `long_active_duration` trigger while the issue has a live scheduled monitor
> - The benefit is that an issue that waits for a date no longer creates a review task on every sweep until that date

## Linked Issues or Issue Description

No public issue exists. The problem follows the bug report template.

**What happened?**

An issue with a scheduled monitor collects one productivity review task after another. The monitor is the supported way to wait: the harness wakes the issue at `nextCheckAt`, and `hasScheduledIssueMonitorPath` already treats it as a live continuation path. The `long_active_duration` trigger does not read the monitor. In `collectEvidence` the elapsed episode comes from `status === "in_progress"` and `started_at` alone. The words `monitor` and `nextCheckAt` do not occur in `productivity-review.ts`.

The built-in brake does not converge here. `countConsecutiveNoActionProductivityReviews` resets the streak on any `activity_log` entry on the source issue after the review was created. The harness checks the issue out on every monitor wake, and that is such an entry.

Measured on one company on 2026-08-24: nine date-gated issues had produced 27 review tasks. The farthest gate was 2026-09-20, so the count grows for another month. One issue with a correct monitor set to 2026-09-06 collected four review tasks in three days.

**Expected behavior**

An issue that waits on a live scheduled monitor does not trigger `long_active_duration`. After the monitor fires or expires, the trigger works as before.

**Steps to reproduce**

1. Assign an issue to an agent and set `status` to `in_progress` with `started_at` more than 6 hours in the past.
2. Set `executionPolicy.monitor.nextCheckAt` and `monitor_next_check_at` to a time 48 hours in the future.
3. Run `reconcileProductivityReviews()`.
4. A review task with `Primary trigger: long_active_duration` is created. Every later sweep creates another one.

**Paperclip version or commit**

Reproduced on `master` at `dc621184a`. Also seen on the released package `2026.817.0`.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

## What Changed

- `server/src/services/productivity-review.ts`: `long_active_duration` is now gated on `hasScheduledIssueMonitorPath(sourceIssue, now)`. While `nextCheckAt` is in the future, and the monitor is not exhausted by `timeoutAt` or `maxAttempts`, the wait does not count as an active episode.
- `server/src/__tests__/productivity-review-service.test.ts`: new case "does not raise a long-active review while the source issue waits on a scheduled monitor".

Nothing else changes. The `no_comment_streak` and `high_churn` triggers stay as they are, so an issue that burns runs or stays silent under a monitor is still reviewed. The `elapsedMs` value in the evidence body stays, so the report still shows the real elapsed time when another trigger fires. There is no schema change, no migration, and no new configuration field. The existing helper is reused, so the code does not get a second definition of "waiting".

## Verification

- `npx vitest run server/src/__tests__/productivity-review-service.test.ts` — 17 tests pass.
- The new test fails before the change with `expected 1 to be +0`, and passes after the change.
- `pnpm --filter @paperclipai/server typecheck` — clean.

## Risks

Low risk. The change makes one trigger less eager. It cannot create new review tasks, and it cannot change any other trigger.

The behavioral shift: an issue that sets a monitor and then really does stall gets no `long_active_duration` review until the monitor fires. The other two triggers still cover that issue, because a stalled agent either keeps running without comments (`no_comment_streak`) or spins up runs (`high_churn`). An issue that sets a monitor far in the future and then does nothing is already visible through the monitor itself.

No migration. No breaking change to the API or the schema.

## Model Used

Claude Opus 5 (`claude-opus-5`) through Claude Code, with extended thinking and tool use (repository search, file edits, local test runs).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — the closest open ones are #10666 (gates long-active reviews on run liveness and raises the threshold to 8h) and #9882 (snooze and backoff for permanently active sources). Neither reads the monitor, so neither fixes this case.
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no user-facing documentation describes this trigger
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
