### PR TITLE
Add canonical semantic action catalog to Paperclip Runner

### DIFF
--- a/packages/paperclip-runner/README.md
+++ b/packages/paperclip-runner/README.md
@@ -12,11 +12,14 @@ sessions, persists an ACK-driven outbox and command journal, and reconnects with
 a short-lived lease. The Rust runner now includes a Codex-only app-server
 provider bridge with durable thread resume, cancellation, structured questions,
 and provider-neutral event normalization. No server code starts or invokes it.
-The package does not add a server adapter, semantic-tool authorization, or
-production Paperclip behavior.
+The package also publishes the canonical semantic action declarations and
+their input and output schemas. It does not add a server adapter,
+semantic-action authorization, dispatch, or production Paperclip behavior.
 
 The first and only installed provider is Codex. Dynamic semantic tools remain
-undiscoverable because the catalog and authorization layers have not landed.
+undiscoverable because catalog membership does not grant authority and the
+run-scoped authorization layer has not landed. See
+[`SEMANTIC_ACTIONS.md`](SEMANTIC_ACTIONS.md) for the catalog boundary.
 
 The root export is intentionally narrow. The `./testing` entry point and package
 release boundary will arrive with the later package-boundary change.
@@ -48,6 +51,9 @@ Use `generate:protocol-manifest` after a schema or fixture change,
 `generate:protocol-types` after a schema change, and
 `generate:replay-goldens` after an intentional reducer change. Commit generated
 outputs with their sources; do not edit them by hand.
+
+Use `generate:semantic-action-catalog` after changing a semantic action
+declaration. Its checked-in JSON inventory must land with the source change.
 
 The gate compiles every schema with AJV 2020-12, validates accepted fixtures,
 rejects unsupported required versions, checks generated TypeScript schema

--- a/packages/paperclip-runner/SEMANTIC_ACTIONS.md
+++ b/packages/paperclip-runner/SEMANTIC_ACTIONS.md
@@ -1,0 +1,42 @@
+# Semantic action catalog
+
+The package exports a versioned, provider-neutral catalog for the first Codex
+runner slice. Each declaration has a stable operation ID, placement metadata,
+required claims, supported task modes, an effect class, and JSON Schema input
+and output contracts.
+
+The catalog is descriptive. Importing it or finding an operation in it does not
+grant permission to show or call that operation. This change deliberately adds
+no run-scoped projection, authorization decision, dispatcher, application
+binding, credential, or server route. Until those layers land, Codex receives
+no dynamic Paperclip tools.
+
+The initial catalog excludes scenario-only and lab operations, other-provider
+extensions, and a generic API escape hatch. Those additions need their own
+reviewed schemas and authority boundaries.
+
+## Public API
+
+```ts
+import {
+  PAPERCLIP_SEMANTIC_ACTION_CATALOG,
+  paperclipSemanticAction,
+} from "@paperclipai/paperclip-runner";
+
+const writeDocument = paperclipSemanticAction("write_document");
+```
+
+`PAPERCLIP_SEMANTIC_ACTION_CATALOG` and every nested declaration are frozen.
+`paperclipSemanticAction` returns `undefined` for unknown operation IDs.
+
+## Generated inventory
+
+`generated/semantic-action-catalog.json` is a deterministic projection of the
+runtime declarations. Change the TypeScript source, then run:
+
+```sh
+pnpm --filter @paperclipai/paperclip-runner generate:semantic-action-catalog
+```
+
+The package build and catalog tests compare the checked-in inventory byte for
+byte. Do not edit the generated file directly.

--- a/packages/paperclip-runner/generated/semantic-action-catalog.json
+++ b/packages/paperclip-runner/generated/semantic-action-catalog.json
@@ -1,0 +1,1914 @@
+[
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read the active task, actor, wake context, ancestors, and budget summary.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "get_task_context",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Get active task context",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read bounded comments on the active task.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "get_task_history",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Get active task history",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "List revisioned documents on the active task.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "list_documents",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "List task documents",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read the current revision of one active-task document.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "description": "Stable issue-document key.",
+          "maxLength": 120,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "operationId": "read_document",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Read task document",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read bounded revision history for one active-task document.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "description": "Stable issue-document key.",
+          "maxLength": 120,
+          "minLength": 1,
+          "type": "string"
+        },
+        "limit": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "operationId": "list_document_revisions",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "List document revisions",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Append a durable progress comment to the active task.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "description": "Multiline progress update.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "body"
+      ],
+      "type": "object"
+    },
+    "operationId": "report_progress",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Report durable progress",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Append an answer to a status-only wake without changing task disposition.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "description": "Concise status answer.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "body"
+      ],
+      "type": "object"
+    },
+    "operationId": "answer_status_question",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Answer status question",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Create or update an active-task document with optimistic revision safety.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "baseRevisionId": {
+          "description": "Current revision id, or null when creating.",
+          "maxLength": 240,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "body": {
+          "description": "Markdown document body.",
+          "maxLength": 200000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "changeSummary": {
+          "description": "Optional revision summary.",
+          "maxLength": 20000,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "key": {
+          "description": "Stable issue-document key.",
+          "maxLength": 120,
+          "minLength": 1,
+          "type": "string"
+        },
+        "title": {
+          "description": "Document title.",
+          "maxLength": 300,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "key",
+        "title",
+        "body",
+        "baseRevisionId"
+      ],
+      "type": "object"
+    },
+    "operationId": "write_document",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Write revisioned document",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Create a typed, durable interaction on the active task.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "continuationPolicy": {
+          "enum": [
+            "none",
+            "wake_assignee",
+            "wake_assignee_on_accept"
+          ]
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "interactionKind": {
+          "enum": [
+            "confirmation",
+            "checkbox",
+            "questions",
+            "suggest_tasks",
+            "item_verdicts"
+          ]
+        },
+        "payload": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "prompt": {
+          "description": "Question or decision prompt.",
+          "maxLength": 10000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "targetRevisionId": {
+          "description": "Optional bound document revision.",
+          "maxLength": 240,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Interaction card title.",
+          "maxLength": 300,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "interactionKind",
+        "title",
+        "prompt",
+        "continuationPolicy"
+      ],
+      "type": "object"
+    },
+    "operationId": "request_human_input",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Request structured human input",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Register attachment metadata and its work product without returning bytes or credentials.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "byteSize": {
+          "maximum": 100000000,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "contentRef": {
+          "description": "Opaque content reference.",
+          "maxLength": 2000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "contentType": {
+          "description": "Media type.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "filename": {
+          "description": "Display filename.",
+          "maxLength": 500,
+          "minLength": 1,
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[a-fA-F0-9]{64}$",
+          "type": "string"
+        },
+        "title": {
+          "description": "Work-product title.",
+          "maxLength": 500,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "filename",
+        "contentType",
+        "byteSize",
+        "sha256",
+        "contentRef",
+        "title"
+      ],
+      "type": "object"
+    },
+    "operationId": "register_deliverable",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Register inspectable deliverable",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Finish the active task with a durable summary.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "summary": {
+          "description": "Completion summary.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "summary"
+      ],
+      "type": "object"
+    },
+    "operationId": "finish_task",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Finish active task",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Block the active task with a durable reason and optional first-class dependencies.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "blockedByTaskIds": {
+          "description": "Task identifiers that block this task.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "reason": {
+          "description": "Block reason.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "operationId": "block_task",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Block active task",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Move the active task to review with a durable summary.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "summary": {
+          "description": "Review handoff summary.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "summary"
+      ],
+      "type": "object"
+    },
+    "operationId": "request_review",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "always",
+    "requiredClaims": [],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Request task review",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "List redacted actor profiles in the run company.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "list_agents",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "discovery:agents:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "List company agents",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read one redacted actor profile in the run company.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "actorId": {
+          "description": "Actor identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "actorId"
+      ],
+      "type": "object"
+    },
+    "operationId": "get_agent",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "discovery:agents:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Get company agent",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Search tasks by text and status within the run company.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "query": {
+          "maxLength": 500,
+          "type": "string"
+        },
+        "statuses": {
+          "items": {
+            "enum": [
+              "backlog",
+              "todo",
+              "in_progress",
+              "in_review",
+              "done",
+              "blocked",
+              "cancelled"
+            ]
+          },
+          "maxItems": 7,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "search_tasks",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "discovery:tasks:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Search company tasks",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "List approvals in the run company.",
+    "effect": "governance",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "list_approvals",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "governance:approvals:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "List approvals",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read one approval without protected data.",
+    "effect": "governance",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "approvalId": {
+          "description": "Approval identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "approvalId"
+      ],
+      "type": "object"
+    },
+    "operationId": "get_approval",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "governance:approvals:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Get approval",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read one approval, its comments, and linked tasks.",
+    "effect": "governance",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "approvalId": {
+          "description": "Approval identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "approvalId"
+      ],
+      "type": "object"
+    },
+    "operationId": "get_approval_context",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "governance:approvals:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Get approval context",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Read active-task workspace services.",
+    "effect": "read",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "required": [],
+      "type": "object"
+    },
+    "operationId": "get_workspace_runtime",
+    "outputSchema": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "workspace:read"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Get workspace runtime",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Start or stop one active-task workspace service.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "enum": [
+            "start",
+            "stop"
+          ]
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "serviceId": {
+          "description": "Workspace service identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "serviceId",
+        "action"
+      ],
+      "type": "object"
+    },
+    "operationId": "control_workspace_service",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "workspace:control"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Control workspace service",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Replace the active task's first-class blocker set.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "blockedByTaskIds": {
+          "description": "Replacement blocker task identifiers.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "blockedByTaskIds"
+      ],
+      "type": "object"
+    },
+    "operationId": "set_dependencies",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "dependencies:write"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Set task dependencies",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Create one child task under the active task.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "assigneeActorId": {
+          "description": "Optional actor assignee.",
+          "maxLength": 200,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "blockedByTaskIds": {
+          "description": "Initial blocker task identifiers.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "description": {
+          "description": "Child task description.",
+          "maxLength": 20000,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "priority": {
+          "enum": [
+            "critical",
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "title": {
+          "description": "Child task title.",
+          "maxLength": 500,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "title"
+      ],
+      "type": "object"
+    },
+    "operationId": "create_task",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "delegation:tasks:create"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Create child task",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Create a governed approval and waiting posture.",
+    "effect": "governance",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "approvalType": {
+          "description": "Stable approval type.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "payload": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "approvalType",
+        "payload"
+      ],
+      "type": "object"
+    },
+    "operationId": "request_approval",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "governance:approvals:request"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Request approval",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "allowedRoles": [
+      "board",
+      "approver",
+      "security"
+    ],
+    "description": "Decide an approval as an explicitly authorized approver.",
+    "effect": "governance",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "approvalId": {
+          "description": "Approval identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "decision": {
+          "enum": [
+            "approved",
+            "rejected",
+            "cancelled"
+          ]
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "note": {
+          "description": "Decision note.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "approvalId",
+        "decision",
+        "note"
+      ],
+      "type": "object"
+    },
+    "operationId": "decide_approval",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "governance:approvals:decide"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Decide approval",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "ask",
+      "planning",
+      "skill_test"
+    ],
+    "description": "Add a durable comment to an approval.",
+    "effect": "governance",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "approvalId": {
+          "description": "Approval identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "body": {
+          "description": "Approval comment.",
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "approvalId",
+        "body"
+      ],
+      "type": "object"
+    },
+    "operationId": "comment_on_approval",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "governance:approvals:comment"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Comment on approval",
+    "version": 1
+  },
+  {
+    "allowedModes": [
+      "standard",
+      "skill_test"
+    ],
+    "description": "Schedule a bounded continuation wake.",
+    "effect": "write",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "delaySeconds": {
+          "maximum": 86400,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "idempotencyKey": {
+          "description": "Caller-stable retry key.",
+          "maxLength": 240,
+          "minLength": 1,
+          "type": "string"
+        },
+        "payload": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "reason": {
+          "enum": [
+            "manual",
+            "issue_commented",
+            "interaction_resolved",
+            "approval_resolved",
+            "blockers_resolved",
+            "scheduled_retry",
+            "resume"
+          ]
+        }
+      },
+      "required": [
+        "idempotencyKey",
+        "reason",
+        "delaySeconds"
+      ],
+      "type": "object"
+    },
+    "operationId": "schedule_wake",
+    "outputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "description": "Stable command identifier.",
+          "maxLength": 200,
+          "minLength": 1,
+          "type": "string"
+        },
+        "disposition": {
+          "enum": [
+            "applied",
+            "duplicate"
+          ]
+        },
+        "entityRefs": {
+          "description": "Entities affected by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "scheduledWakeIds": {
+          "description": "Wake identifiers scheduled by the operation.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 200,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "stateRevision": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "commandId",
+        "disposition",
+        "stateRevision",
+        "entityRefs",
+        "scheduledWakeIds"
+      ],
+      "type": "object"
+    },
+    "placement": "optional",
+    "requiredClaims": [
+      "control_plane:wakes"
+    ],
+    "schema": "paperclip.semantic-action.v1",
+    "title": "Schedule bounded wake",
+    "version": 1
+  }
+]

--- a/packages/paperclip-runner/package.json
+++ b/packages/paperclip-runner/package.json
@@ -19,11 +19,11 @@
     "README.md"
   ],
   "scripts": {
-    "build": "pnpm run check:protocol-manifest && pnpm run build:typescript && node scripts/generate-replay-goldens.mjs --check",
+    "build": "pnpm run check:protocol-manifest && pnpm run build:typescript && node scripts/generate-replay-goldens.mjs --check && node scripts/generate-semantic-action-catalog.mjs --check",
     "build:typescript": "pnpm run check:protocol-types && tsc -p tsconfig.json",
     "build:rust": "cargo build --manifest-path runner/Cargo.toml --locked --workspace --bins",
     "typecheck": "pnpm run typecheck:typescript && pnpm run typecheck:rust",
-    "typecheck:typescript": "node --check scripts/protocol-contract.mjs && node --check scripts/generate-protocol-manifest.mjs && node --check scripts/generate-protocol-schema-module.mjs && node --check scripts/generate-replay-goldens.mjs && pnpm run check:protocol-types && tsc -p tsconfig.json --noEmit",
+    "typecheck:typescript": "node --check scripts/protocol-contract.mjs && node --check scripts/generate-protocol-manifest.mjs && node --check scripts/generate-protocol-schema-module.mjs && node --check scripts/generate-replay-goldens.mjs && node --check scripts/generate-semantic-action-catalog.mjs && pnpm run check:protocol-types && tsc -p tsconfig.json --noEmit",
     "typecheck:rust": "cargo fmt --manifest-path runner/Cargo.toml --all -- --check && cargo check --manifest-path runner/Cargo.toml --locked --workspace",
     "test": "pnpm run test:typescript && pnpm run test:rust",
     "test:typescript": "node --test test/protocol-contract.test.mjs && vitest run",
@@ -36,6 +36,8 @@
     "check:protocol-types": "node scripts/generate-protocol-schema-module.mjs --check",
     "generate:replay-goldens": "pnpm run build:typescript && node scripts/generate-replay-goldens.mjs",
     "check:replay-goldens": "pnpm run build:typescript && node scripts/generate-replay-goldens.mjs --check",
+    "generate:semantic-action-catalog": "pnpm run build:typescript && node scripts/generate-semantic-action-catalog.mjs",
+    "check:semantic-action-catalog": "pnpm run build:typescript && node scripts/generate-semantic-action-catalog.mjs --check",
     "check:protocol": "pnpm run typecheck:typescript && pnpm run check:protocol-manifest && pnpm run test:typescript && pnpm run check:replay-goldens",
     "check:conformance-parity": "cargo test --manifest-path runner/Cargo.toml --locked -p paperclip-runner-core runs_the_mock_core_path_with_stable_output",
     "check:replay-parity": "cargo test --manifest-path runner/Cargo.toml --locked -p paperclip-runner-core replay_fixture_parity",

--- a/packages/paperclip-runner/scripts/generate-semantic-action-catalog.mjs
+++ b/packages/paperclip-runner/scripts/generate-semantic-action-catalog.mjs
@@ -1,0 +1,26 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { canonicalPaperclipSemanticActionCatalog } from "../dist/catalog/semantic-action-catalog.js";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outputPath = resolve(
+  packageRoot,
+  "generated/semantic-action-catalog.json",
+);
+const generated = canonicalPaperclipSemanticActionCatalog();
+
+if (process.argv.includes("--check")) {
+  const current = await readFile(outputPath, "utf8").catch(() => "");
+  if (current !== generated) {
+    process.stderr.write(
+      "generated/semantic-action-catalog.json is stale; run generate:semantic-action-catalog\n",
+    );
+    process.exitCode = 1;
+  }
+} else {
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, generated);
+  process.stdout.write(`wrote ${outputPath}\n`);
+}

--- a/packages/paperclip-runner/src/catalog/index.ts
+++ b/packages/paperclip-runner/src/catalog/index.ts
@@ -1,0 +1,2 @@
+export * from "./semantic-action-catalog.js";
+export * from "./semantic-action-types.js";

--- a/packages/paperclip-runner/src/catalog/semantic-action-catalog.test.ts
+++ b/packages/paperclip-runner/src/catalog/semantic-action-catalog.test.ts
@@ -1,0 +1,106 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Ajv2020 from "ajv/dist/2020.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  PAPERCLIP_SEMANTIC_ACTION_CATALOG,
+  canonicalPaperclipSemanticActionCatalog,
+  paperclipSemanticAction,
+} from "./semantic-action-catalog.js";
+
+const packageRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+describe("semantic action catalog", () => {
+  it("defines one immutable v1 declaration for each Codex-spine action", () => {
+    const operationIds = PAPERCLIP_SEMANTIC_ACTION_CATALOG.map(
+      (action) => action.operationId,
+    );
+
+    expect(operationIds).toHaveLength(27);
+    expect(new Set(operationIds).size).toBe(operationIds.length);
+    expect(operationIds).not.toContain("generic_api_request");
+    expect(Object.isFrozen(PAPERCLIP_SEMANTIC_ACTION_CATALOG)).toBe(true);
+    expect(
+      Object.isFrozen(paperclipSemanticAction("write_document")?.inputSchema),
+    ).toBe(true);
+  });
+
+  it("compiles every operation input and output schema", () => {
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: true,
+    });
+
+    for (const action of PAPERCLIP_SEMANTIC_ACTION_CATALOG) {
+      expect(
+        () => ajv.compile(action.inputSchema),
+        `${action.operationId} input`,
+      ).not.toThrow();
+      expect(
+        () => ajv.compile(action.outputSchema),
+        `${action.operationId} output`,
+      ).not.toThrow();
+    }
+  });
+
+  it("keeps bounded mutation inputs and rejects undeclared fields", () => {
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: true,
+    });
+    const writeDocument = paperclipSemanticAction("write_document");
+    const taskContext = paperclipSemanticAction("get_task_context");
+    expect(writeDocument).toBeDefined();
+    expect(taskContext).toBeDefined();
+
+    const validateWrite = ajv.compile(writeDocument!.inputSchema);
+    expect(
+      validateWrite({
+        idempotencyKey: "write-1",
+        key: "plan",
+        title: "Plan",
+        body: "A bounded body",
+        baseRevisionId: null,
+      }),
+    ).toBe(true);
+    expect(
+      validateWrite({
+        key: "plan",
+        title: "Plan",
+        body: "Body",
+        baseRevisionId: null,
+      }),
+    ).toBe(false);
+
+    const validateContext = ajv.compile(taskContext!.inputSchema);
+    expect(validateContext({})).toBe(true);
+    expect(validateContext({ companyId: "forged-company" })).toBe(false);
+  });
+
+  it("matches the checked-in generated inventory byte for byte", async () => {
+    const generated = await readFile(
+      resolve(packageRoot, "generated/semantic-action-catalog.json"),
+      "utf8",
+    );
+
+    expect(generated).toBe(canonicalPaperclipSemanticActionCatalog());
+  });
+
+  it("does not carry executable authorization or binding hooks", () => {
+    for (const action of PAPERCLIP_SEMANTIC_ACTION_CATALOG) {
+      const keys = Object.keys(action);
+      expect(keys).not.toContain("authorize");
+      expect(keys).not.toContain("execute");
+      expect(keys).not.toContain("binding");
+    }
+  });
+});

--- a/packages/paperclip-runner/src/catalog/semantic-action-catalog.ts
+++ b/packages/paperclip-runner/src/catalog/semantic-action-catalog.ts
@@ -1,0 +1,566 @@
+import type {
+  PaperclipJsonSchema,
+  PaperclipSemanticActionDescriptor,
+  PaperclipSemanticActionId,
+  PaperclipSemanticActionMode,
+} from "./semantic-action-types.js";
+
+const ALL_MODES = ["standard", "ask", "planning", "skill_test"] as const;
+const WORK_MODES = ["standard", "planning", "skill_test"] as const;
+const STANDARD_MODE = ["standard", "skill_test"] as const;
+
+const text = (
+  description: string,
+  maxLength = 20_000,
+): PaperclipJsonSchema => ({
+  type: "string",
+  description,
+  minLength: 1,
+  maxLength,
+});
+
+const nullableText = (
+  description: string,
+  maxLength = 20_000,
+): PaperclipJsonSchema => ({
+  type: ["string", "null"],
+  description,
+  maxLength,
+});
+
+const stringArray = (description: string): PaperclipJsonSchema => ({
+  type: "array",
+  description,
+  items: { type: "string", minLength: 1 },
+  maxItems: 200,
+  uniqueItems: true,
+});
+
+const object = (
+  properties: Readonly<Record<string, PaperclipJsonSchema>> = {},
+  required: readonly string[] = [],
+): PaperclipJsonSchema => ({
+  type: "object",
+  properties,
+  required,
+  additionalProperties: false,
+});
+
+const openObject: PaperclipJsonSchema = {
+  type: "object",
+  additionalProperties: true,
+};
+const idempotency = {
+  idempotencyKey: text("Caller-stable retry key.", 240),
+} as const;
+const operationReceipt = object(
+  {
+    commandId: text("Stable command identifier.", 200),
+    disposition: { enum: ["applied", "duplicate"] },
+    stateRevision: { type: "integer", minimum: 0 },
+    entityRefs: stringArray("Entities affected by the operation."),
+    scheduledWakeIds: stringArray(
+      "Wake identifiers scheduled by the operation.",
+    ),
+  },
+  [
+    "commandId",
+    "disposition",
+    "stateRevision",
+    "entityRefs",
+    "scheduledWakeIds",
+  ],
+);
+
+interface DescriptorInput {
+  readonly operationId: PaperclipSemanticActionId;
+  readonly title: string;
+  readonly description: string;
+  readonly placement?: "always" | "optional";
+  readonly effect?: "read" | "write" | "governance";
+  readonly requiredClaims?: readonly string[];
+  readonly allowedModes?: readonly PaperclipSemanticActionMode[];
+  readonly allowedRoles?: readonly string[];
+  readonly inputSchema?: PaperclipJsonSchema;
+  readonly outputSchema?: PaperclipJsonSchema;
+}
+
+function descriptor(input: DescriptorInput): PaperclipSemanticActionDescriptor {
+  return {
+    schema: "paperclip.semantic-action.v1",
+    operationId: input.operationId,
+    version: 1,
+    title: input.title,
+    description: input.description,
+    placement: input.placement ?? "always",
+    effect: input.effect ?? "read",
+    requiredClaims: input.requiredClaims ?? [],
+    allowedModes: input.allowedModes ?? ALL_MODES,
+    ...(input.allowedRoles === undefined
+      ? {}
+      : { allowedRoles: input.allowedRoles }),
+    inputSchema: input.inputSchema ?? object(),
+    outputSchema: input.outputSchema ?? openObject,
+  };
+}
+
+const descriptors: readonly PaperclipSemanticActionDescriptor[] = [
+  descriptor({
+    operationId: "get_task_context",
+    title: "Get active task context",
+    description:
+      "Read the active task, actor, wake context, ancestors, and budget summary.",
+  }),
+  descriptor({
+    operationId: "get_task_history",
+    title: "Get active task history",
+    description: "Read bounded comments on the active task.",
+    inputSchema: object({
+      limit: { type: "integer", minimum: 1, maximum: 200, default: 50 },
+    }),
+  }),
+  descriptor({
+    operationId: "list_documents",
+    title: "List task documents",
+    description: "List revisioned documents on the active task.",
+  }),
+  descriptor({
+    operationId: "read_document",
+    title: "Read task document",
+    description: "Read the current revision of one active-task document.",
+    inputSchema: object({ key: text("Stable issue-document key.", 120) }, [
+      "key",
+    ]),
+  }),
+  descriptor({
+    operationId: "list_document_revisions",
+    title: "List document revisions",
+    description: "Read bounded revision history for one active-task document.",
+    inputSchema: object(
+      {
+        key: text("Stable issue-document key.", 120),
+        limit: { type: "integer", minimum: 1, maximum: 200, default: 50 },
+      },
+      ["key"],
+    ),
+  }),
+  descriptor({
+    operationId: "report_progress",
+    title: "Report durable progress",
+    description: "Append a durable progress comment to the active task.",
+    effect: "write",
+    inputSchema: object(
+      { ...idempotency, body: text("Multiline progress update.") },
+      ["idempotencyKey", "body"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "answer_status_question",
+    title: "Answer status question",
+    description:
+      "Append an answer to a status-only wake without changing task disposition.",
+    effect: "write",
+    inputSchema: object(
+      { ...idempotency, body: text("Concise status answer.") },
+      ["idempotencyKey", "body"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "write_document",
+    title: "Write revisioned document",
+    description:
+      "Create or update an active-task document with optimistic revision safety.",
+    effect: "write",
+    allowedModes: WORK_MODES,
+    inputSchema: object(
+      {
+        ...idempotency,
+        key: text("Stable issue-document key.", 120),
+        title: text("Document title.", 300),
+        body: text("Markdown document body.", 200_000),
+        baseRevisionId: nullableText(
+          "Current revision id, or null when creating.",
+          240,
+        ),
+        changeSummary: nullableText("Optional revision summary."),
+      },
+      ["idempotencyKey", "key", "title", "body", "baseRevisionId"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "request_human_input",
+    title: "Request structured human input",
+    description: "Create a typed, durable interaction on the active task.",
+    effect: "write",
+    allowedModes: ALL_MODES,
+    inputSchema: object(
+      {
+        ...idempotency,
+        interactionKind: {
+          enum: [
+            "confirmation",
+            "checkbox",
+            "questions",
+            "suggest_tasks",
+            "item_verdicts",
+          ],
+        },
+        title: text("Interaction card title.", 300),
+        prompt: text("Question or decision prompt.", 10_000),
+        payload: openObject,
+        targetRevisionId: nullableText(
+          "Optional bound document revision.",
+          240,
+        ),
+        continuationPolicy: {
+          enum: ["none", "wake_assignee", "wake_assignee_on_accept"],
+        },
+      },
+      [
+        "idempotencyKey",
+        "interactionKind",
+        "title",
+        "prompt",
+        "continuationPolicy",
+      ],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "register_deliverable",
+    title: "Register inspectable deliverable",
+    description:
+      "Register attachment metadata and its work product without returning bytes or credentials.",
+    effect: "write",
+    allowedModes: WORK_MODES,
+    inputSchema: object(
+      {
+        ...idempotency,
+        filename: text("Display filename.", 500),
+        contentType: text("Media type.", 200),
+        byteSize: { type: "integer", minimum: 0, maximum: 100_000_000 },
+        sha256: { type: "string", pattern: "^[a-fA-F0-9]{64}$" },
+        contentRef: text("Opaque content reference.", 2_000),
+        title: text("Work-product title.", 500),
+      },
+      [
+        "idempotencyKey",
+        "filename",
+        "contentType",
+        "byteSize",
+        "sha256",
+        "contentRef",
+        "title",
+      ],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "finish_task",
+    title: "Finish active task",
+    description: "Finish the active task with a durable summary.",
+    effect: "write",
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      { ...idempotency, summary: text("Completion summary.") },
+      ["idempotencyKey", "summary"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "block_task",
+    title: "Block active task",
+    description:
+      "Block the active task with a durable reason and optional first-class dependencies.",
+    effect: "write",
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        reason: text("Block reason."),
+        blockedByTaskIds: stringArray("Task identifiers that block this task."),
+      },
+      ["idempotencyKey", "reason"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "request_review",
+    title: "Request task review",
+    description: "Move the active task to review with a durable summary.",
+    effect: "write",
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      { ...idempotency, summary: text("Review handoff summary.") },
+      ["idempotencyKey", "summary"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "list_agents",
+    title: "List company agents",
+    description: "List redacted actor profiles in the run company.",
+    placement: "optional",
+    requiredClaims: ["discovery:agents:read"],
+  }),
+  descriptor({
+    operationId: "get_agent",
+    title: "Get company agent",
+    description: "Read one redacted actor profile in the run company.",
+    placement: "optional",
+    requiredClaims: ["discovery:agents:read"],
+    inputSchema: object({ actorId: text("Actor identifier.", 200) }, [
+      "actorId",
+    ]),
+  }),
+  descriptor({
+    operationId: "search_tasks",
+    title: "Search company tasks",
+    description: "Search tasks by text and status within the run company.",
+    placement: "optional",
+    requiredClaims: ["discovery:tasks:read"],
+    inputSchema: object({
+      query: { type: "string", maxLength: 500 },
+      statuses: {
+        type: "array",
+        items: {
+          enum: [
+            "backlog",
+            "todo",
+            "in_progress",
+            "in_review",
+            "done",
+            "blocked",
+            "cancelled",
+          ],
+        },
+        maxItems: 7,
+        uniqueItems: true,
+      },
+      limit: { type: "integer", minimum: 1, maximum: 200, default: 50 },
+    }),
+  }),
+  descriptor({
+    operationId: "list_approvals",
+    title: "List approvals",
+    description: "List approvals in the run company.",
+    placement: "optional",
+    effect: "governance",
+    requiredClaims: ["governance:approvals:read"],
+  }),
+  descriptor({
+    operationId: "get_approval",
+    title: "Get approval",
+    description: "Read one approval without protected data.",
+    placement: "optional",
+    effect: "governance",
+    requiredClaims: ["governance:approvals:read"],
+    inputSchema: object({ approvalId: text("Approval identifier.", 200) }, [
+      "approvalId",
+    ]),
+  }),
+  descriptor({
+    operationId: "get_approval_context",
+    title: "Get approval context",
+    description: "Read one approval, its comments, and linked tasks.",
+    placement: "optional",
+    effect: "governance",
+    requiredClaims: ["governance:approvals:read"],
+    inputSchema: object({ approvalId: text("Approval identifier.", 200) }, [
+      "approvalId",
+    ]),
+  }),
+  descriptor({
+    operationId: "get_workspace_runtime",
+    title: "Get workspace runtime",
+    description: "Read active-task workspace services.",
+    placement: "optional",
+    requiredClaims: ["workspace:read"],
+  }),
+  descriptor({
+    operationId: "control_workspace_service",
+    title: "Control workspace service",
+    description: "Start or stop one active-task workspace service.",
+    placement: "optional",
+    effect: "write",
+    requiredClaims: ["workspace:control"],
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        serviceId: text("Workspace service identifier.", 200),
+        action: { enum: ["start", "stop"] },
+      },
+      ["idempotencyKey", "serviceId", "action"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "set_dependencies",
+    title: "Set task dependencies",
+    description: "Replace the active task's first-class blocker set.",
+    placement: "optional",
+    effect: "write",
+    requiredClaims: ["dependencies:write"],
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        blockedByTaskIds: stringArray("Replacement blocker task identifiers."),
+      },
+      ["idempotencyKey", "blockedByTaskIds"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "create_task",
+    title: "Create child task",
+    description: "Create one child task under the active task.",
+    placement: "optional",
+    effect: "write",
+    requiredClaims: ["delegation:tasks:create"],
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        title: text("Child task title.", 500),
+        description: nullableText("Child task description."),
+        assigneeActorId: nullableText("Optional actor assignee.", 200),
+        priority: { enum: ["critical", "high", "medium", "low"] },
+        blockedByTaskIds: stringArray("Initial blocker task identifiers."),
+      },
+      ["idempotencyKey", "title"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "request_approval",
+    title: "Request approval",
+    description: "Create a governed approval and waiting posture.",
+    placement: "optional",
+    effect: "governance",
+    requiredClaims: ["governance:approvals:request"],
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        approvalType: text("Stable approval type.", 200),
+        payload: openObject,
+      },
+      ["idempotencyKey", "approvalType", "payload"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "decide_approval",
+    title: "Decide approval",
+    description: "Decide an approval as an explicitly authorized approver.",
+    placement: "optional",
+    effect: "governance",
+    requiredClaims: ["governance:approvals:decide"],
+    allowedRoles: ["board", "approver", "security"],
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        approvalId: text("Approval identifier.", 200),
+        decision: { enum: ["approved", "rejected", "cancelled"] },
+        note: text("Decision note."),
+      },
+      ["idempotencyKey", "approvalId", "decision", "note"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "comment_on_approval",
+    title: "Comment on approval",
+    description: "Add a durable comment to an approval.",
+    placement: "optional",
+    effect: "governance",
+    requiredClaims: ["governance:approvals:comment"],
+    inputSchema: object(
+      {
+        ...idempotency,
+        approvalId: text("Approval identifier.", 200),
+        body: text("Approval comment."),
+      },
+      ["idempotencyKey", "approvalId", "body"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+  descriptor({
+    operationId: "schedule_wake",
+    title: "Schedule bounded wake",
+    description: "Schedule a bounded continuation wake.",
+    placement: "optional",
+    effect: "write",
+    requiredClaims: ["control_plane:wakes"],
+    allowedModes: STANDARD_MODE,
+    inputSchema: object(
+      {
+        ...idempotency,
+        reason: {
+          enum: [
+            "manual",
+            "issue_commented",
+            "interaction_resolved",
+            "approval_resolved",
+            "blockers_resolved",
+            "scheduled_retry",
+            "resume",
+          ],
+        },
+        payload: openObject,
+        delaySeconds: { type: "integer", minimum: 1, maximum: 86_400 },
+      },
+      ["idempotencyKey", "reason", "delaySeconds"],
+    ),
+    outputSchema: operationReceipt,
+  }),
+];
+
+const byId = new Map(
+  descriptors.map((item) => [item.operationId, deepFreeze(item)]),
+);
+if (byId.size !== descriptors.length)
+  throw new Error("duplicate semantic action operation id");
+
+/**
+ * Canonical declarations only. Consumers must not treat membership as
+ * permission to expose or invoke an action.
+ */
+export const PAPERCLIP_SEMANTIC_ACTION_CATALOG = Object.freeze([
+  ...byId.values(),
+]);
+
+export function paperclipSemanticAction(
+  operationId: string,
+): PaperclipSemanticActionDescriptor | undefined {
+  return byId.get(operationId as PaperclipSemanticActionId);
+}
+
+export function canonicalPaperclipSemanticActionCatalog(): string {
+  return `${JSON.stringify(sortKeys(PAPERCLIP_SEMANTIC_ACTION_CATALOG), null, 2)}\n`;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value))
+    return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (typeof value !== "object" || value === null) return value;
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .map((key) => [key, sortKeys(record[key])]),
+  );
+}

--- a/packages/paperclip-runner/src/catalog/semantic-action-types.ts
+++ b/packages/paperclip-runner/src/catalog/semantic-action-types.ts
@@ -1,0 +1,84 @@
+export type PaperclipSemanticActionId =
+  | "get_task_context"
+  | "get_task_history"
+  | "list_documents"
+  | "read_document"
+  | "list_document_revisions"
+  | "report_progress"
+  | "answer_status_question"
+  | "write_document"
+  | "request_human_input"
+  | "register_deliverable"
+  | "finish_task"
+  | "block_task"
+  | "request_review"
+  | "list_agents"
+  | "get_agent"
+  | "search_tasks"
+  | "list_approvals"
+  | "get_approval"
+  | "get_approval_context"
+  | "get_workspace_runtime"
+  | "control_workspace_service"
+  | "set_dependencies"
+  | "create_task"
+  | "request_approval"
+  | "decide_approval"
+  | "comment_on_approval"
+  | "schedule_wake";
+
+export type PaperclipSemanticActionPlacement = "always" | "optional";
+export type PaperclipSemanticActionMode =
+  "standard" | "ask" | "planning" | "skill_test";
+export type PaperclipSemanticActionEffect = "read" | "write" | "governance";
+
+export type PaperclipJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly PaperclipJsonValue[]
+  | { readonly [key: string]: PaperclipJsonValue };
+
+/** The JSON Schema subset used by the v1 semantic action catalog. */
+export interface PaperclipJsonSchema {
+  readonly type?: string | readonly string[];
+  readonly title?: string;
+  readonly description?: string;
+  readonly properties?: Readonly<Record<string, PaperclipJsonSchema>>;
+  readonly required?: readonly string[];
+  readonly additionalProperties?: boolean | PaperclipJsonSchema;
+  readonly items?: PaperclipJsonSchema;
+  readonly enum?: readonly PaperclipJsonValue[];
+  readonly oneOf?: readonly PaperclipJsonSchema[];
+  readonly anyOf?: readonly PaperclipJsonSchema[];
+  readonly minimum?: number;
+  readonly maximum?: number;
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minItems?: number;
+  readonly maxItems?: number;
+  readonly uniqueItems?: boolean;
+  readonly pattern?: string;
+  readonly format?: string;
+  readonly default?: PaperclipJsonValue;
+}
+
+/**
+ * A transport-neutral declaration. Catalog membership never grants discovery
+ * or invocation authority; a run-scoped authorization layer must do that.
+ */
+export interface PaperclipSemanticActionDescriptor {
+  readonly schema: "paperclip.semantic-action.v1";
+  readonly operationId: PaperclipSemanticActionId;
+  readonly version: 1;
+  readonly title: string;
+  readonly description: string;
+  readonly placement: PaperclipSemanticActionPlacement;
+  readonly effect: PaperclipSemanticActionEffect;
+  readonly requiredClaims: readonly string[];
+  readonly allowedModes: readonly PaperclipSemanticActionMode[];
+  readonly allowedRoles?: readonly string[];
+  readonly inputSchema: PaperclipJsonSchema;
+  readonly outputSchema: PaperclipJsonSchema;
+}

--- a/packages/paperclip-runner/src/index.ts
+++ b/packages/paperclip-runner/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./catalog/index.js";
 export * from "./contracts/completion-result.js";
 export * from "./contracts/question-set.js";
 export * from "./protocol/replay-contract.js";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip Runner now has a durable PRP transport and a Codex provider bridge.
> - Codex must use stable, provider-neutral action contracts before Paperclip can grant run-scoped tool access.
> - A catalog must describe actions without granting permission to discover or invoke them.
> - Generated inventory must stay synchronized with its TypeScript source.
> - This pull request adds the canonical Codex-spine semantic action catalog inside the runner package.
> - The benefit is a small review unit for schemas and inventory before authorization and dispatch land.

## Linked Issues or Issue Description

**Subsystem affected**

Cross-cutting. This pull request extends private runner infrastructure in `packages/paperclip-runner`.

**Problem or motivation**

The Codex provider bridge has no canonical description of the Paperclip actions that a later authorization layer can project into a run. Independent operation lists can drift in names, claims, task modes, effects, and input bounds.

**Proposed solution**

Add one immutable v1 catalog for the first 27 Codex-spine actions. Give each action a stable identifier, placement, effect, required claims, supported task modes, and JSON Schema input and output contracts. Generate a deterministic JSON inventory from that source and fail package checks on drift.

**Alternatives considered**

The combined runner branch contains larger live and scenario catalogs with authorization, bindings, labs, and other providers. That change is too large for this review unit. A generic API escape hatch would also bypass the operation-level boundary, so this catalog excludes it.

**Roadmap alignment**

This work supports the governed tool access direction in `ROADMAP.md`. It does not add a tool gateway, application binding, server endpoint, or production authorization decision.

**Additional context**

Refs #12111 and #11962. Pull request #12111 was squash-merged first. This branch starts at the resulting `master` commit. Its delta is 10 files.

## What Changed

- Added 27 versioned, provider-neutral semantic action declarations for the Codex spine.
- Added bounded JSON Schema input contracts and normalized operation receipt output contracts.
- Added placement, effect, claim, mode, and role metadata.
- Added a deeply frozen public catalog and an operation lookup helper.
- Added a deterministic checked-in JSON inventory and generation commands.
- Added a byte-for-byte drift gate to the package build.
- Added AJV schema compilation, mutation-bound, forged-field, immutability, inventory, and non-executable-boundary tests.
- Exported only the catalog types and declarations from the existing package root.
- Documented that catalog membership does not grant discovery, authorization, dispatch, or application binding.
- Kept server code, UI code, other providers, scenario-only actions, labs, generic API access, authorization, dispatch, and receipts processing out of this pull request.

## Verification

- `pnpm --filter @paperclipai/paperclip-runner check:all` passes.
- TypeScript protocol tests pass: 8 Node tests and 49 Vitest tests.
- All package Rust tests and conformance and replay parity checks pass.
- `pnpm --filter @paperclipai/paperclip-runner check:semantic-action-catalog` passes.
- `pnpm -r typecheck` passes.
- `pnpm build` passes.
- `pnpm check:token-gates` passes.
- Prettier and `git diff --check` pass for the changed source and documentation files.
- The generated catalog matches its source byte for byte.
- The secret scan is clean.
- The delta against `master` is 10 files. `pnpm-lock.yaml` is unchanged.
- `pnpm test:run` completed locally with 4,692 passing tests, 19 skipped tests, and 24 failures in 8 unchanged server test files. The failures reproduce the established local macOS path-alias, listener, and workspace-runtime baseline. No changed-file test failed. Linux CI remains the repository handoff authority.
- The full Linux PR workflow passes, including the aggregate `verify` gate.
- Snyk, Socket, Superagent security, and supply-chain checks pass.
- Greptile is 5/5 with no actionable comments, recommendations, or follow-ups.
- Storybook visual regression skipped by design because this pull request changes no UI file.
- Browser and migration tests are not applicable because this pull request changes no server, UI, database, or migration file.

## Risks

Production behavior is unchanged because no consumer projects this catalog into a provider run. The main risks are contract drift, unbounded mutation input, forged scope fields, accidental executable authority, and generated inventory drift. Closed input schemas, explicit bounds, a frozen catalog, tests, and the byte drift gate cover these risks. The later authorization layer must still bind every action to the active run and company before discovery or invocation.

I checked `ROADMAP.md`. This change is private contract infrastructure for the governed tool access direction. It does not duplicate a shipped or public product surface.

## Model Used

OpenAI Codex with GPT-5 was used. The exact serving model ID and context size were not exposed. The model used high reasoning, repository tools, GitHub tools, and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
