### PR TITLE
feat(fallback): fail a provider-quota run over to the next Claude subscription

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,69 @@
+## Thinking Path
+
+> - Paperclip runs AI agents whose intelligence comes from a subscription/provider adapter (e.g. `claude_local`).
+> - When that source hits a provider quota / rate limit, a run fails with `errorCode: "provider_quota"` and recovery reschedules the retry to wait out the reset window (up to an hour).
+> - Operators who hold more than one subscription would rather have the agent switch to a second subscription immediately than idle until the window clears — like a fallback provider chain.
+> - There was no way to express "if source A is exhausted, use source B": model profiles override config but can't switch auth, and no fallback-chain scaffolding exists on master.
+> - This pull request adds a per-agent `runtime_config.fallbackChain` and fails a quota-exhausted run over to the next **same-provider** source (a second Claude subscription — same adapter, different token) immediately instead of waiting.
+> - The benefit is continuity: agents keep working across a quota wall by rolling to the operator's next subscription, with no idle window.
+
+## Issue (described in-PR, Enhancement)
+
+_No public GitHub issue existed; describing it inline per CONTRIBUTING.md, following the Enhancement template._
+
+- **Existing behavior improved:** provider-quota recovery for a run (`heartbeat.ts` transient-continuation reschedule and the provider-quota wait monitor in `recovery/service.ts`).
+- **Subsystem affected:** server / heartbeat run scheduling + recovery.
+- **Current behavior:** a `provider_quota` failure reschedules the same source at the reset time; the agent idles until then, even if the operator has a second subscription that could serve the run now.
+- **Proposed behavior:** an agent may configure `runtime_config.fallbackChain` — ordered alternate sources. On a `provider_quota` failure, if the next source is same-provider (same `adapterType`, a different auth token), the retry is scheduled **immediately** with that source, and the executor authenticates against it.
+- **Reason and benefit:** keeps agents working across a quota wall by rolling to the next subscription instead of idling.
+- **Breaking changes:** none. Additive `runtime_config` field; no-op for agents without a `fallbackChain`.
+
+## Duplicate / related PR search
+
+Searched before starting. No merged fallback-chain exists; the prior attempts are stale/closed and this does not overlap them:
+- #2153 (closed, unmerged) — a simpler claude↔codex adapter failover.
+- #3497 (open, last updated Apr 2026) — per-agent failover model chains; abandoned.
+- #2946 (open) — a larger unified gateway-routing layer.
+
+## What Changed
+
+- **Schema:** `runtime_config.fallbackChain` — an ordered, `.max(4)` array of `{ adapterType, model?, effort?, env?, label? }` sources, added to `agentRuntimeConfigSchema` (reuses `agentAdapterTypeSchema` / `envConfigSchema`).
+- **Pure logic** (`server/src/services/intelligence-fallback.ts`): the exhaustion predicate (`provider_quota` only; never budget caps or real failures), chain reader, next-source selector, run-context override codec, and the same-adapter config overlay.
+- **Trigger:** on a `provider_quota` reschedule (both the transient-continuation path in `heartbeat.ts` and `ensureProviderQuotaWaitRecoveryMonitor` in `recovery/service.ts`), if an untried same-adapter fallback exists, schedule the retry at `now` with the source stamped on its context.
+- **Consume:** `executeRun` overlays the stamped source's `env`/`model`/`effort` before secret resolution, so the retry authenticates against the fallback subscription's token.
+- **Scope:** cross-provider sources (a different `adapterType`, e.g. Codex) are validated and stored but not switched yet — a deliberate follow-up, since switching adapters reworks session handling.
+
+## Verification
+
+- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/intelligence-fallback.test.ts` — 13 unit tests for the pure logic (trigger predicate, selection, overlay, override codec).
+- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-retry-scheduling.test.ts` — includes a new end-to-end test: a `provider_quota` run with a same-provider `fallbackChain` reschedules **immediately** (not the fake adapter's 2030 reset) with the fallback source stamped on the retry context. Existing quota-retry tests unchanged (30 → 31 passing).
+- Recovery suites (`src/services/recovery/`) green.
+
+## Risks
+
+- Low. No-op for agents without a `fallbackChain`; the trigger fires only on `provider_quota` (never budget exhaustion or real failures). The chain is capped at 4, so a misconfiguration cannot fan a stranded run into an unbounded retry storm. Cross-provider switching is intentionally deferred, so no session-handling paths change.
+
+## Model Used
+
+- Claude Opus 4.8 (Anthropic), extended thinking, via Claude Code with tool use / code execution.
+
+## Checklist
+
+- [x] I have included a thinking path that traces from project context to this change
+- [x] I have specified the model used (with version and capability details)
+- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
+- [x] I have searched GitHub for duplicate or related PRs and linked them above
+- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
+- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
+- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
+- [x] I have run tests locally and they pass
+- [x] I have added or updated tests where applicable
+- [x] I have considered documentation and no user-facing docs are affected by this internal scheduling change
+- [x] I have considered and documented any risks above
+- [ ] All Paperclip CI gates are green
+- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
+- [x] I will address all Greptile and reviewer comments before requesting merge
+
+---
+
+A focused first increment of an intelligence fallback chain (fail a quota-exhausted run over to a second Claude subscription immediately). Cross-provider (Codex) failover is a planned follow-up.

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -63,10 +63,29 @@ const agentModelProfileConfigSchema = z.object({
   adapterConfig: adapterConfigSchema,
 }).strict();
 
+// One entry in an agent's intelligence fallback chain: an alternate source the
+// executor retries a run against when the current source is exhausted by a
+// provider quota / rate limit. A second Claude subscription is just a different
+// `env` (e.g. a `secret_ref` for CLAUDE_CODE_OAUTH_TOKEN); a different provider
+// (e.g. Codex) additionally sets `adapterType`.
+export const agentFallbackSourceSchema = z.object({
+  adapterType: agentAdapterTypeSchema,
+  model: z.string().trim().min(1).optional(),
+  effort: z.string().trim().min(1).optional(),
+  env: envConfigSchema.optional(),
+  label: z.string().trim().min(1).optional(),
+}).strict();
+
+export type AgentFallbackSource = z.infer<typeof agentFallbackSourceSchema>;
+
 export const agentRuntimeConfigSchema = z.object({
   modelProfiles: z.object({
     cheap: agentModelProfileConfigSchema.optional(),
   }).strict().optional(),
+  // Ordered fallback sources tried, in order, when a run fails on provider
+  // quota/rate-limit exhaustion. Capped so a misconfiguration cannot fan a
+  // single stranded run into an unbounded retry storm.
+  fallbackChain: z.array(agentFallbackSourceSchema).max(4).optional(),
 }).catchall(z.unknown());
 
 export const createAgentSchema = z.object({

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -335,6 +335,7 @@ export {
   createAgentHireSchema,
   updateAgentSchema,
   agentRuntimeConfigSchema,
+  agentFallbackSourceSchema,
   agentInstructionsBundleModeSchema,
   updateAgentInstructionsBundleSchema,
   upsertAgentInstructionsFileSchema,
@@ -368,6 +369,7 @@ export {
   type ResetAgentSession,
   type TestAdapterEnvironment,
   type UpdateAgentPermissions,
+  type AgentFallbackSource,
 } from "./agent.js";
 
 export {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { drainHeartbeatRunsToQuiescence } from "./helpers/drain-heartbeat-runs.js";
 import { registerServerAdapter, unregisterServerAdapter } from "../adapters/index.ts";
+import { FALLBACK_SOURCE_CONTEXT_KEY } from "../services/intelligence-fallback.ts";
 import {
   BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
   INTERACTION_CONTINUATION_INFRA_RETRY_REASON,
@@ -293,6 +294,81 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         { timeout: 5_000, interval: 50 },
       )
       .toEqual({ status: "idle", errorReason: null });
+  });
+
+  it("switches a provider-quota run onto a same-provider fallback source immediately", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Fallback Test",
+      role: "engineer",
+      status: "idle",
+      adapterType: PROVIDER_QUOTA_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+        // A same-provider fallback: a second subscription's token on the same adapter.
+        fallbackChain: [
+          {
+            adapterType: PROVIDER_QUOTA_TEST_ADAPTER,
+            env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "second-subscription" } },
+            label: "Claude sub #2",
+          },
+        ],
+      },
+      permissions: {},
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("provider_quota");
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+            .then((rows) => rows.length),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(1);
+
+    const retryRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        scheduledRetryAt: heartbeatRuns.scheduledRetryAt,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun?.status).toBe("scheduled_retry");
+    // The fallback switches the retry to run now instead of waiting out the
+    // adapter's far-future quota reset window (2030 in the fake adapter).
+    expect(retryRun?.scheduledRetryAt?.getTime()).toBeLessThan(Date.now() + 60_000);
+    // The fallback source is stamped on the retry so executeRun applies its token.
+    const context = (retryRun?.contextSnapshot as Record<string, unknown> | null) ?? {};
+    expect(context[FALLBACK_SOURCE_CONTEXT_KEY]).toMatchObject({
+      index: 1,
+      adapterType: PROVIDER_QUOTA_TEST_ADAPTER,
+      label: "Claude sub #2",
+    });
   });
 
   async function seedMaxTurnFixture(input?: {

--- a/server/src/__tests__/intelligence-fallback.test.ts
+++ b/server/src/__tests__/intelligence-fallback.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   FALLBACK_SOURCE_CONTEXT_KEY,
   type FallbackSourceSpec,
+  applyFallbackSourceToConfig,
   isSourceExhaustionFailure,
   readFallbackChain,
   readFallbackSourceOverride,
@@ -65,6 +66,39 @@ describe("readFallbackChain", () => {
     expect(readFallbackChain({ fallbackChain: "nope" })).toEqual([]);
     // Entries without an adapterType are dropped.
     expect(readFallbackChain({ fallbackChain: [{ model: "gpt" }, null, 42] })).toEqual([]);
+  });
+});
+
+describe("applyFallbackSourceToConfig", () => {
+  const base = {
+    model: "sonnet",
+    env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "sub1" }, KEEP: { type: "plain", value: "x" } },
+  };
+
+  it("swaps the token while inheriting the rest of the env", () => {
+    const override = {
+      index: 1,
+      adapterType: "claude_local",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "sub2" } },
+    };
+    const out = applyFallbackSourceToConfig(base, override, "claude_local");
+    expect(out.env).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "sub2" },
+      KEEP: { type: "plain", value: "x" },
+    });
+    expect(out.model).toBe("sonnet"); // untouched when override omits it
+  });
+
+  it("overrides model/effort when the source specifies them", () => {
+    const out = applyFallbackSourceToConfig(base, { index: 1, adapterType: "claude_local", model: "opus", effort: "high" }, "claude_local");
+    expect(out.model).toBe("opus");
+    expect(out.effort).toBe("high");
+  });
+
+  it("leaves the config untouched with no override or a cross-adapter override", () => {
+    expect(applyFallbackSourceToConfig(base, null, "claude_local")).toBe(base);
+    // Cross-provider fallback is not applied via config overlay.
+    expect(applyFallbackSourceToConfig(base, { index: 1, adapterType: "codex_local" }, "claude_local")).toBe(base);
   });
 });
 

--- a/server/src/__tests__/intelligence-fallback.test.ts
+++ b/server/src/__tests__/intelligence-fallback.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  FALLBACK_SOURCE_CONTEXT_KEY,
+  type FallbackSourceSpec,
+  isSourceExhaustionFailure,
+  readFallbackChain,
+  readFallbackSourceOverride,
+  selectNextFallbackSource,
+} from "../services/intelligence-fallback.ts";
+
+const claudeAlt: FallbackSourceSpec = {
+  adapterType: "claude_local",
+  env: { CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "second-sub" } },
+  label: "Claude sub #2",
+};
+const codex: FallbackSourceSpec = { adapterType: "codex_local", label: "Codex" };
+
+describe("isSourceExhaustionFailure", () => {
+  it("triggers only on provider quota / rate-limit exhaustion", () => {
+    expect(isSourceExhaustionFailure({ errorCode: "provider_quota", errorFamily: null })).toBe(true);
+    expect(isSourceExhaustionFailure({ errorCode: "adapter_failed", errorFamily: "provider_quota" })).toBe(true);
+  });
+
+  it("never treats a real failure or a budget cap as source exhaustion", () => {
+    // Budget exhaustion is a deliberate spend cap, not a source problem.
+    expect(isSourceExhaustionFailure({ errorCode: "budget_exhausted", errorFamily: null })).toBe(false);
+    expect(isSourceExhaustionFailure({ errorCode: "adapter_failed", errorFamily: null })).toBe(false);
+    expect(isSourceExhaustionFailure({ errorCode: null, errorFamily: null })).toBe(false);
+  });
+});
+
+describe("selectNextFallbackSource", () => {
+  const chain = [claudeAlt, codex];
+
+  it("returns the first fallback after the default source runs", () => {
+    const next = selectNextFallbackSource(chain, 0);
+    expect(next).toMatchObject({ index: 1, adapterType: "claude_local", label: "Claude sub #2" });
+  });
+
+  it("advances to the next source on each subsequent exhaustion", () => {
+    expect(selectNextFallbackSource(chain, 1)).toMatchObject({ index: 2, adapterType: "codex_local" });
+  });
+
+  it("returns null once the chain is exhausted", () => {
+    expect(selectNextFallbackSource(chain, 2)).toBeNull();
+    expect(selectNextFallbackSource([], 0)).toBeNull();
+  });
+});
+
+describe("readFallbackChain", () => {
+  it("reads a valid chain from runtimeConfig", () => {
+    const chain = readFallbackChain({ fallbackChain: [claudeAlt, codex] });
+    expect(chain).toHaveLength(2);
+    expect(chain[1].adapterType).toBe("codex_local");
+  });
+
+  it("caps the chain length defensively", () => {
+    const many = Array.from({ length: 9 }, () => ({ adapterType: "codex_local" }));
+    expect(readFallbackChain({ fallbackChain: many })).toHaveLength(4);
+  });
+
+  it("returns an empty chain for missing or malformed config", () => {
+    expect(readFallbackChain(undefined)).toEqual([]);
+    expect(readFallbackChain({})).toEqual([]);
+    expect(readFallbackChain({ fallbackChain: "nope" })).toEqual([]);
+    // Entries without an adapterType are dropped.
+    expect(readFallbackChain({ fallbackChain: [{ model: "gpt" }, null, 42] })).toEqual([]);
+  });
+});
+
+describe("readFallbackSourceOverride", () => {
+  it("round-trips a persisted override off a run context snapshot", () => {
+    const override = { index: 1, adapterType: "codex_local", model: "gpt", env: { A: 1 }, label: "Codex" };
+    const snapshot = { issueId: "x", [FALLBACK_SOURCE_CONTEXT_KEY]: override };
+    expect(readFallbackSourceOverride(snapshot)).toEqual(override);
+  });
+
+  it("ignores absent or invalid overrides", () => {
+    expect(readFallbackSourceOverride({ issueId: "x" })).toBeNull();
+    expect(readFallbackSourceOverride(null)).toBeNull();
+    // index 0 is the default source, never a valid override.
+    expect(readFallbackSourceOverride({ [FALLBACK_SOURCE_CONTEXT_KEY]: { index: 0, adapterType: "codex_local" } })).toBeNull();
+    expect(readFallbackSourceOverride({ [FALLBACK_SOURCE_CONTEXT_KEY]: { index: 1 } })).toBeNull();
+  });
+});

--- a/server/src/__tests__/intelligence-fallback.test.ts
+++ b/server/src/__tests__/intelligence-fallback.test.ts
@@ -31,20 +31,28 @@ describe("isSourceExhaustionFailure", () => {
 });
 
 describe("selectNextFallbackSource", () => {
-  const chain = [claudeAlt, codex];
-
-  it("returns the first fallback after the default source runs", () => {
-    const next = selectNextFallbackSource(chain, 0);
+  it("returns the first same-provider fallback after the default source runs", () => {
+    const next = selectNextFallbackSource([claudeAlt, codex], 0, "claude_local");
     expect(next).toMatchObject({ index: 1, adapterType: "claude_local", label: "Claude sub #2" });
   });
 
-  it("advances to the next source on each subsequent exhaustion", () => {
-    expect(selectNextFallbackSource(chain, 1)).toMatchObject({ index: 2, adapterType: "codex_local" });
+  it("skips a deferred cross-provider entry to reach a later same-provider source", () => {
+    // Chain orders Codex (cross-provider, not runnable yet) BEFORE a second Claude
+    // subscription. Selection must jump past Codex to the reachable Claude sub at
+    // index 2 rather than stalling on the unsupported entry.
+    const next = selectNextFallbackSource([codex, claudeAlt], 0, "claude_local");
+    expect(next).toMatchObject({ index: 2, adapterType: "claude_local", label: "Claude sub #2" });
   });
 
-  it("returns null once the chain is exhausted", () => {
-    expect(selectNextFallbackSource(chain, 2)).toBeNull();
-    expect(selectNextFallbackSource([], 0)).toBeNull();
+  it("returns null when only cross-provider entries remain", () => {
+    // Codex-only chain from a Claude agent: nothing runnable, so the normal quota
+    // wait is left in place instead of a bogus switch.
+    expect(selectNextFallbackSource([codex], 0, "claude_local")).toBeNull();
+  });
+
+  it("returns null once the same-provider sources are exhausted", () => {
+    expect(selectNextFallbackSource([claudeAlt], 1, "claude_local")).toBeNull();
+    expect(selectNextFallbackSource([], 0, "claude_local")).toBeNull();
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -157,6 +157,13 @@ import {
   WORKTREE_INSTANCE_ROOT_METADATA_KEY,
 } from "./workspace-instance-cleanup.js";
 import { issueService } from "./issues.js";
+import {
+  FALLBACK_SOURCE_CONTEXT_KEY,
+  applyFallbackSourceToConfig,
+  readFallbackChain,
+  readFallbackSourceOverride,
+  selectNextFallbackSource,
+} from "./intelligence-fallback.js";
 import { projectService } from "./projects.js";
 import { getEnvironmentDriverTraits } from "./environment-driver-traits.js";
 import { authorizationService, type AuthorizationActor } from "./authorization.js";
@@ -11414,6 +11421,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         : baseSchedule;
 
+    // Intelligence fallback: on a provider-quota reschedule, if the agent has an
+    // untried same-provider fallback source (a second subscription's token), retry
+    // against it immediately instead of waiting out the reset window. The token
+    // swap itself happens in executeRun, driven by the source stamped on the
+    // retry's context. Cross-provider sources are stored but not switched here yet.
+    const nextFallbackSource =
+      transientRecovery?.errorFamily === "provider_quota"
+        ? selectNextFallbackSource(
+            readFallbackChain(agent.runtimeConfig),
+            readFallbackSourceOverride(contextSnapshot)?.index ?? 0,
+          )
+        : null;
+    const fallbackSource =
+      nextFallbackSource && nextFallbackSource.adapterType === agent.adapterType ? nextFallbackSource : null;
+    const effectiveDueAt = fallbackSource ? now : schedule.dueAt;
+    const fallbackSourceContext: Record<string, unknown> = fallbackSource
+      ? { [FALLBACK_SOURCE_CONTEXT_KEY]: fallbackSource }
+      : {};
+
     const requiresIssueGate =
       retryReason === MAX_TURN_CONTINUATION_RETRY_REASON ||
       retryReason === INTERACTION_CONTINUATION_INFRA_RETRY_REASON;
@@ -11482,12 +11508,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         : {}),
       ...(transientRecovery ? { errorFamily: transientRecovery.errorFamily } : {}),
       scheduledRetryAttempt: schedule.attempt,
-      scheduledRetryAt: schedule.dueAt.toISOString(),
+      scheduledRetryAt: effectiveDueAt.toISOString(),
       ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       ...(transientRecovery?.errorFamily === "provider_quota" && transientRetryNotBefore
         ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
         : {}),
       ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
+      ...fallbackSourceContext,
     }, "normal_model");
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const continuationRetryIdempotencyKey = retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
@@ -11714,12 +11741,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             retryReason,
             ...(transientRecovery ? { errorFamily: transientRecovery.errorFamily } : {}),
             scheduledRetryAttempt: schedule.attempt,
-            scheduledRetryAt: schedule.dueAt.toISOString(),
+            scheduledRetryAt: effectiveDueAt.toISOString(),
             ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
             ...(transientRecovery?.errorFamily === "provider_quota" && transientRetryNotBefore
               ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
               : {}),
             ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
+            ...fallbackSourceContext,
           }, "normal_model"),
           status: "queued",
           requestedByActorType: "system",
@@ -11743,7 +11771,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           responsibleUserId,
           sessionIdBefore: sessionBefore,
           retryOfRunId: run.id,
-          scheduledRetryAt: schedule.dueAt,
+          scheduledRetryAt: effectiveDueAt,
           scheduledRetryAttempt: schedule.attempt,
           scheduledRetryReason: retryReason,
           continuationAttempt: readContinuationAttempt(retryContextSnapshot.livenessContinuationAttempt),
@@ -14742,7 +14770,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueAdapterConfig: issueAssigneeOverrides?.adapterConfig ?? null,
     });
     const configSnapshot = buildExecutionWorkspaceConfigSnapshot(mergedConfig, selectedEnvironmentId);
-    const executionRunConfig = stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
+    // Intelligence fallback: if this run was rescheduled onto a same-provider
+    // fallback source (a second subscription's token), overlay that source's
+    // model/effort/env before secret resolution so the run authenticates against
+    // the fallback account. No-op for normal runs.
+    const fallbackSourceOverride = readFallbackSourceOverride(parseObject(run.contextSnapshot));
+    const executionRunConfig = applyFallbackSourceToConfig(
+      stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig),
+      fallbackSourceOverride,
+      agent.adapterType,
+    );
     const runScopedMentionedSkillKeys = await resolveRunScopedMentionedSkillKeys({
       db,
       companyId: agent.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11426,15 +11426,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // against it immediately instead of waiting out the reset window. The token
     // swap itself happens in executeRun, driven by the source stamped on the
     // retry's context. Cross-provider sources are stored but not switched here yet.
-    const nextFallbackSource =
+    const fallbackSource =
       transientRecovery?.errorFamily === "provider_quota"
         ? selectNextFallbackSource(
             readFallbackChain(agent.runtimeConfig),
             readFallbackSourceOverride(contextSnapshot)?.index ?? 0,
+            agent.adapterType,
           )
         : null;
-    const fallbackSource =
-      nextFallbackSource && nextFallbackSource.adapterType === agent.adapterType ? nextFallbackSource : null;
     const effectiveDueAt = fallbackSource ? now : schedule.dueAt;
     const fallbackSourceContext: Record<string, unknown> = fallbackSource
       ? { [FALLBACK_SOURCE_CONTEXT_KEY]: fallbackSource }

--- a/server/src/services/intelligence-fallback.ts
+++ b/server/src/services/intelligence-fallback.ts
@@ -92,17 +92,29 @@ export function readFallbackChain(runtimeConfig: unknown): FallbackSourceSpec[] 
  * source that just ran (0 = the agent's default, 1 = first fallback, …). Returns
  * the next source with its 1-based chain position, or null when the chain is
  * exhausted. The chain is bounded (max 4), so this always terminates.
+ *
+ * Only same-provider sources (matching `currentAdapterType`) can be executed today
+ * — a cross-provider switch reworks session handling and is a deferred follow-up.
+ * So a cross-provider entry is SKIPPED, not stalled on: selection walks past it to
+ * the next same-provider source and returns that source's real chain position. This
+ * keeps a later supported subscription reachable even when a deferred cross-provider
+ * entry sits ahead of it in the chain.
  */
 export function selectNextFallbackSource(
   chain: FallbackSourceSpec[],
   attemptedSourceIndex: number,
+  currentAdapterType: string,
 ): FallbackSourceOverride | null {
   // chain[0] is the FIRST fallback, i.e. it serves attemptedSourceIndex 0 (the
-  // default). So the next source after attempt N lives at chain[N].
-  const nextChainPos = Math.max(0, attemptedSourceIndex);
-  const next = chain[nextChainPos];
-  if (!next) return null;
-  return { index: nextChainPos + 1, ...next };
+  // default). So the next source after attempt N lives at chain[N] onward.
+  for (let pos = Math.max(0, attemptedSourceIndex); pos < chain.length; pos++) {
+    const next = chain[pos];
+    // Skip a deferred cross-provider source and keep looking for a runnable one,
+    // so its 1-based index advances past the skipped entry on the next round too.
+    if (next.adapterType !== currentAdapterType) continue;
+    return { index: pos + 1, ...next };
+  }
+  return null;
 }
 
 /**

--- a/server/src/services/intelligence-fallback.ts
+++ b/server/src/services/intelligence-fallback.ts
@@ -1,0 +1,124 @@
+/**
+ * Intelligence fallback chain: when a run fails because the current intelligence
+ * source is exhausted by a provider quota / rate limit, the executor retries the
+ * run against the next configured source (a second Claude subscription — just a
+ * different auth `env` — or a different provider such as Codex — a different
+ * `adapterType`). Selection is a pure function of the agent's configured chain
+ * and how many sources have already been attempted for this piece of work.
+ *
+ * Strict shape validation lives in `agentRuntimeConfigSchema`
+ * (packages/shared/src/validators/agent.ts) and runs when the agent is written;
+ * this module only reads the already-validated config structurally, so it stays
+ * free of the shared validator barrel (and its runtime import cost).
+ */
+
+/** Maximum fallback sources honoured, mirroring the write-time schema cap. */
+export const MAX_FALLBACK_SOURCES = 4;
+
+/** A resolved source the executor should run a single attempt against. */
+export interface FallbackSourceOverride {
+  /** 1-based position in the chain (source 0 is the agent's default). */
+  index: number;
+  adapterType: string;
+  model?: string;
+  effort?: string;
+  env?: Record<string, unknown>;
+  label?: string;
+}
+
+/** One configured source in an agent's fallback chain. */
+export interface FallbackSourceSpec {
+  adapterType: string;
+  model?: string;
+  effort?: string;
+  env?: Record<string, unknown>;
+  label?: string;
+}
+
+/** Marker persisted on a retry run's context so the executor applies the source. */
+export const FALLBACK_SOURCE_CONTEXT_KEY = "intelligenceFallbackSource" as const;
+
+/**
+ * Error codes that mean "this intelligence source is exhausted, try the next
+ * one". Deliberately narrow: only provider quota / rate-limit exhaustion, never
+ * budget exhaustion (a deliberate spend cap, not a source problem) and never a
+ * real adapter/code failure — those must surface, not silently switch sources.
+ */
+export function isSourceExhaustionFailure(input: {
+  errorCode: string | null | undefined;
+  errorFamily: string | null | undefined;
+}): boolean {
+  return input.errorCode === "provider_quota" || input.errorFamily === "provider_quota";
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readOptionalObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Read an agent's configured fallback chain from its (already write-validated)
+ * runtimeConfig, tolerating loose/absent input. Structural read only — entries
+ * missing an adapterType are dropped and the chain is capped.
+ */
+export function readFallbackChain(runtimeConfig: unknown): FallbackSourceSpec[] {
+  const config = readOptionalObject(runtimeConfig);
+  const raw = config?.fallbackChain;
+  if (!Array.isArray(raw)) return [];
+  const chain: FallbackSourceSpec[] = [];
+  for (const entry of raw) {
+    const record = readOptionalObject(entry);
+    const adapterType = record ? readOptionalString(record.adapterType) : undefined;
+    if (!adapterType) continue;
+    chain.push({
+      adapterType,
+      model: readOptionalString(record?.model),
+      effort: readOptionalString(record?.effort),
+      env: readOptionalObject(record?.env),
+      label: readOptionalString(record?.label),
+    });
+    if (chain.length >= MAX_FALLBACK_SOURCES) break;
+  }
+  return chain;
+}
+
+/**
+ * Pick the next source to try. `attemptedSourceIndex` is the 0-based index of the
+ * source that just ran (0 = the agent's default, 1 = first fallback, …). Returns
+ * the next source with its 1-based chain position, or null when the chain is
+ * exhausted. The chain is bounded (max 4), so this always terminates.
+ */
+export function selectNextFallbackSource(
+  chain: FallbackSourceSpec[],
+  attemptedSourceIndex: number,
+): FallbackSourceOverride | null {
+  // chain[0] is the FIRST fallback, i.e. it serves attemptedSourceIndex 0 (the
+  // default). So the next source after attempt N lives at chain[N].
+  const nextChainPos = Math.max(0, attemptedSourceIndex);
+  const next = chain[nextChainPos];
+  if (!next) return null;
+  return { index: nextChainPos + 1, ...next };
+}
+
+/** Parse a persisted source override off a run's context snapshot, if present. */
+export function readFallbackSourceOverride(contextSnapshot: unknown): FallbackSourceOverride | null {
+  const snapshot = readOptionalObject(contextSnapshot);
+  const value = snapshot ? readOptionalObject(snapshot[FALLBACK_SOURCE_CONTEXT_KEY]) : undefined;
+  if (!value) return null;
+  const adapterType = readOptionalString(value.adapterType);
+  const index = typeof value.index === "number" && Number.isInteger(value.index) ? value.index : null;
+  if (!adapterType || index === null || index < 1) return null;
+  return {
+    index,
+    adapterType,
+    model: readOptionalString(value.model),
+    effort: readOptionalString(value.effort),
+    env: readOptionalObject(value.env),
+    label: readOptionalString(value.label),
+  };
+}

--- a/server/src/services/intelligence-fallback.ts
+++ b/server/src/services/intelligence-fallback.ts
@@ -105,6 +105,30 @@ export function selectNextFallbackSource(
   return { index: nextChainPos + 1, ...next };
 }
 
+/**
+ * Overlay a same-provider fallback source's model/effort/env onto an adapter
+ * config for a retry. Returns the config unchanged when there is no override or
+ * the override targets a different adapter (cross-provider fallback is executed
+ * elsewhere, not by a config overlay). The override's env wins key-by-key, so a
+ * fallback source can swap the auth token (e.g. CLAUDE_CODE_OAUTH_TOKEN) while
+ * inheriting the rest of the agent's env.
+ */
+export function applyFallbackSourceToConfig(
+  config: Record<string, unknown>,
+  override: FallbackSourceOverride | null,
+  currentAdapterType: string,
+): Record<string, unknown> {
+  if (!override || override.adapterType !== currentAdapterType) return config;
+  const baseEnv = readOptionalObject(config.env) ?? {};
+  const next: Record<string, unknown> = { ...config };
+  if (override.model !== undefined) next.model = override.model;
+  if (override.effort !== undefined) next.effort = override.effort;
+  if (override.env && Object.keys(override.env).length > 0) {
+    next.env = { ...baseEnv, ...override.env };
+  }
+  return next;
+}
+
 /** Parse a persisted source override off a run's context snapshot, if present. */
 export function readFallbackSourceOverride(contextSnapshot: unknown): FallbackSourceOverride | null {
   const snapshot = readOptionalObject(contextSnapshot);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2757,14 +2757,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const quotaAgent = await getAgent(input.agentId);
     const currentSourceIndex =
       readFallbackSourceOverride(parseObject(input.latestRun?.contextSnapshot))?.index ?? 0;
-    const nextFallbackSource = selectNextFallbackSource(
+    // No agent (or no adapterType) → pass "" so nothing in the chain matches and
+    // selection returns null, leaving the normal quota wait in place.
+    const fallbackSource = selectNextFallbackSource(
       readFallbackChain(quotaAgent?.runtimeConfig),
       currentSourceIndex,
+      quotaAgent?.adapterType ?? "",
     );
-    const fallbackSource =
-      nextFallbackSource && quotaAgent && nextFallbackSource.adapterType === quotaAgent.adapterType
-        ? nextFallbackSource
-        : null;
     const retryAt = fallbackSource ? now : readProviderQuotaRetryAt(input.latestRun, now);
     const fallbackContext = fallbackSource
       ? { [FALLBACK_SOURCE_CONTEXT_KEY]: fallbackSource, retryReason: "provider_quota_fallback" }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -38,6 +38,12 @@ import { redactCurrentUserText } from "../../log-redaction.js";
 import { redactSensitiveText } from "../../redaction.js";
 import { isUniqueViolation } from "../../db-errors.js";
 import { logActivity } from "../activity-log.js";
+import {
+  FALLBACK_SOURCE_CONTEXT_KEY,
+  readFallbackChain,
+  readFallbackSourceOverride,
+  selectNextFallbackSource,
+} from "../intelligence-fallback.js";
 import { budgetService } from "../budgets.js";
 import { instanceSettingsService } from "../instance-settings.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
@@ -2744,7 +2750,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (existing) return existing;
 
     const now = new Date();
-    const retryAt = readProviderQuotaRetryAt(input.latestRun, now);
+    // If the agent has an untried same-provider fallback source, switch the retry
+    // to it immediately (a second subscription's token) instead of waiting out the
+    // quota window. Cross-provider fallbacks (a different adapterType) are stored
+    // but not executed here yet — they fall through to the normal quota wait.
+    const quotaAgent = await getAgent(input.agentId);
+    const currentSourceIndex =
+      readFallbackSourceOverride(parseObject(input.latestRun?.contextSnapshot))?.index ?? 0;
+    const nextFallbackSource = selectNextFallbackSource(
+      readFallbackChain(quotaAgent?.runtimeConfig),
+      currentSourceIndex,
+    );
+    const fallbackSource =
+      nextFallbackSource && quotaAgent && nextFallbackSource.adapterType === quotaAgent.adapterType
+        ? nextFallbackSource
+        : null;
+    const retryAt = fallbackSource ? now : readProviderQuotaRetryAt(input.latestRun, now);
+    const fallbackContext = fallbackSource
+      ? { [FALLBACK_SOURCE_CONTEXT_KEY]: fallbackSource, retryReason: "provider_quota_fallback" }
+      : {};
+    const idempotencySuffix = fallbackSource ? `:src${fallbackSource.index}` : "";
     return db.transaction(async (tx) => {
       const wakeup = await tx
         .insert(agentWakeupRequests)
@@ -2759,11 +2784,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             retryOfRunId: input.latestRun?.id ?? null,
             retryReason: "provider_quota_recovery",
             providerQuotaRetryNotBefore: retryAt.toISOString(),
+            ...fallbackContext,
           }, "normal_model"),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
-          idempotencyKey: `provider_quota_recovery:${input.issue.id}:${retryAt.toISOString()}`,
+          idempotencyKey: `provider_quota_recovery:${input.issue.id}:${retryAt.toISOString()}${idempotencySuffix}`,
           updatedAt: now,
         })
         .returning()
@@ -2787,6 +2813,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             wakeReason: "provider_quota_recovery",
             retryReason: "provider_quota_recovery",
             providerQuotaRetryNotBefore: retryAt.toISOString(),
+            ...fallbackContext,
           }, "normal_model"),
           updatedAt: now,
         })


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs AI agents whose intelligence comes from a subscription/provider adapter (e.g. `claude_local`).
> - When that source hits a provider quota / rate limit, a run fails with `errorCode: "provider_quota"` and recovery reschedules the retry to wait out the reset window (up to an hour).
> - Operators who hold more than one subscription would rather have the agent switch to a second subscription immediately than idle until the window clears — like a fallback provider chain.
> - There was no way to express "if source A is exhausted, use source B": model profiles override config but can't switch auth, and no fallback-chain scaffolding exists on master.
> - This pull request adds a per-agent `runtime_config.fallbackChain` and fails a quota-exhausted run over to the next **same-provider** source (a second Claude subscription — same adapter, different token) immediately instead of waiting.
> - The benefit is continuity: agents keep working across a quota wall by rolling to the operator's next subscription, with no idle window.

## Issue (described in-PR, Enhancement)

_No public GitHub issue existed; describing it inline per CONTRIBUTING.md, following the Enhancement template._

- **Existing behavior improved:** provider-quota recovery for a run (`heartbeat.ts` transient-continuation reschedule and the provider-quota wait monitor in `recovery/service.ts`).
- **Subsystem affected:** server / heartbeat run scheduling + recovery.
- **Current behavior:** a `provider_quota` failure reschedules the same source at the reset time; the agent idles until then, even if the operator has a second subscription that could serve the run now.
- **Proposed behavior:** an agent may configure `runtime_config.fallbackChain` — ordered alternate sources. On a `provider_quota` failure, if the next source is same-provider (same `adapterType`, a different auth token), the retry is scheduled **immediately** with that source, and the executor authenticates against it.
- **Reason and benefit:** keeps agents working across a quota wall by rolling to the next subscription instead of idling.
- **Breaking changes:** none. Additive `runtime_config` field; no-op for agents without a `fallbackChain`.

## Duplicate / related PR search

Searched before starting. No merged fallback-chain exists; the prior attempts are stale/closed and this does not overlap them:
- #2153 (closed, unmerged) — a simpler claude↔codex adapter failover.
- #3497 (open, last updated Apr 2026) — per-agent failover model chains; abandoned.
- #2946 (open) — a larger unified gateway-routing layer.

## What Changed

- **Schema:** `runtime_config.fallbackChain` — an ordered, `.max(4)` array of `{ adapterType, model?, effort?, env?, label? }` sources, added to `agentRuntimeConfigSchema` (reuses `agentAdapterTypeSchema` / `envConfigSchema`).
- **Pure logic** (`server/src/services/intelligence-fallback.ts`): the exhaustion predicate (`provider_quota` only; never budget caps or real failures), chain reader, next-source selector, run-context override codec, and the same-adapter config overlay.
- **Trigger:** on a `provider_quota` reschedule (both the transient-continuation path in `heartbeat.ts` and `ensureProviderQuotaWaitRecoveryMonitor` in `recovery/service.ts`), if an untried same-adapter fallback exists, schedule the retry at `now` with the source stamped on its context.
- **Consume:** `executeRun` overlays the stamped source's `env`/`model`/`effort` before secret resolution, so the retry authenticates against the fallback subscription's token.
- **Scope:** cross-provider sources (a different `adapterType`, e.g. Codex) are validated and stored but not switched yet — a deliberate follow-up, since switching adapters reworks session handling.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/intelligence-fallback.test.ts` — 13 unit tests for the pure logic (trigger predicate, selection, overlay, override codec).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-retry-scheduling.test.ts` — includes a new end-to-end test: a `provider_quota` run with a same-provider `fallbackChain` reschedules **immediately** (not the fake adapter's 2030 reset) with the fallback source stamped on the retry context. Existing quota-retry tests unchanged (30 → 31 passing).
- Recovery suites (`src/services/recovery/`) green.

## Risks

- Low. No-op for agents without a `fallbackChain`; the trigger fires only on `provider_quota` (never budget exhaustion or real failures). The chain is capped at 4, so a misconfiguration cannot fan a stranded run into an unbounded retry storm. Cross-provider switching is intentionally deferred, so no session-handling paths change.

## Model Used

- Claude Opus 4.8 (Anthropic), extended thinking, via Claude Code with tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered documentation and no user-facing docs are affected by this internal scheduling change
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---

A focused first increment of an intelligence fallback chain (fail a quota-exhausted run over to a second Claude subscription immediately). Cross-provider (Codex) failover is a planned follow-up.
