### PR TITLE
fix(adapters): warn when a local adapter falls back to process.cwd()

### DIFF
--- a/packages/adapter-utils/src/resolve-adapter-cwd.test.ts
+++ b/packages/adapter-utils/src/resolve-adapter-cwd.test.ts
@@ -6,43 +6,61 @@ describe("resolveAdapterWorkingDirectory", () => {
     vi.restoreAllMocks();
   });
 
-  it("prefers the workspace cwd", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cwd = resolveAdapterWorkingDirectory({
+  it("prefers the workspace cwd", async () => {
+    const onLog = vi.fn(async () => {});
+    const cwd = await resolveAdapterWorkingDirectory({
       adapterType: "opencode_local",
       workspaceCwd: "/workspaces/project",
       configuredCwd: "/configured/elsewhere",
+      onLog,
     });
     expect(cwd).toBe("/workspaces/project");
-    expect(warn).not.toHaveBeenCalled();
+    expect(onLog).not.toHaveBeenCalled();
   });
 
-  it("falls back to the configured cwd without warning", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cwd = resolveAdapterWorkingDirectory({
+  it("falls back to the configured cwd without warning", async () => {
+    const onLog = vi.fn(async () => {});
+    const cwd = await resolveAdapterWorkingDirectory({
       adapterType: "claude_local",
       workspaceCwd: "",
       configuredCwd: "/configured/project",
+      onLog,
     });
     expect(cwd).toBe("/configured/project");
-    expect(warn).not.toHaveBeenCalled();
+    expect(onLog).not.toHaveBeenCalled();
   });
 
-  it("warns when neither resolves, naming the directory it fell back to", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const cwd = resolveAdapterWorkingDirectory({
+  it("reports the fallback through onLog so it reaches the run transcript", async () => {
+    const onLog = vi.fn(async () => {});
+    const cwd = await resolveAdapterWorkingDirectory({
       adapterType: "codex_local",
+      workspaceCwd: "",
+      configuredCwd: "",
+      onLog,
+    });
+
+    expect(cwd).toBe(process.cwd());
+    expect(onLog).toHaveBeenCalledTimes(1);
+
+    const [stream, chunk] = onLog.mock.calls[0] as unknown as [string, string];
+    expect(stream).toBe("stderr");
+    expect(chunk).toContain("codex_local");
+    expect(chunk).toContain(process.cwd());
+    // The remedy must be actionable, not just a notice that something happened.
+    expect(chunk).toMatch(/project workspace/i);
+    expect(chunk.endsWith("\n")).toBe(true);
+  });
+
+  it("falls back to console.warn when no onLog channel is supplied", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cwd = await resolveAdapterWorkingDirectory({
+      adapterType: "pi_local",
       workspaceCwd: "",
       configuredCwd: "",
     });
 
     expect(cwd).toBe(process.cwd());
     expect(warn).toHaveBeenCalledTimes(1);
-
-    const message = String(warn.mock.calls[0]?.[0] ?? "");
-    expect(message).toContain("codex_local");
-    expect(message).toContain(process.cwd());
-    // The remedy must be actionable, not just a notice that something happened.
-    expect(message).toMatch(/project workspace/i);
+    expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("pi_local");
   });
 });

--- a/packages/adapter-utils/src/resolve-adapter-cwd.test.ts
+++ b/packages/adapter-utils/src/resolve-adapter-cwd.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveAdapterWorkingDirectory } from "./server-utils.js";
+
+describe("resolveAdapterWorkingDirectory", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prefers the workspace cwd", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cwd = resolveAdapterWorkingDirectory({
+      adapterType: "opencode_local",
+      workspaceCwd: "/workspaces/project",
+      configuredCwd: "/configured/elsewhere",
+    });
+    expect(cwd).toBe("/workspaces/project");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the configured cwd without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cwd = resolveAdapterWorkingDirectory({
+      adapterType: "claude_local",
+      workspaceCwd: "",
+      configuredCwd: "/configured/project",
+    });
+    expect(cwd).toBe("/configured/project");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when neither resolves, naming the directory it fell back to", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cwd = resolveAdapterWorkingDirectory({
+      adapterType: "codex_local",
+      workspaceCwd: "",
+      configuredCwd: "",
+    });
+
+    expect(cwd).toBe(process.cwd());
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    const message = String(warn.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("codex_local");
+    expect(message).toContain(process.cwd());
+    // The remedy must be actionable, not just a notice that something happened.
+    expect(message).toMatch(/project workspace/i);
+  });
+});

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3529,3 +3529,34 @@ export async function runChildProcess(
       .catch(reject);
   });
 }
+
+/**
+ * Resolve the working directory a local adapter should execute in.
+ *
+ * Precedence is workspace cwd, then the agent's configured cwd. When neither
+ * resolves, the adapter previously fell back to `process.cwd()` silently — the
+ * paperclip-server process directory, which in the published image is `/app`,
+ * the server's own source tree.
+ *
+ * That fallback is almost never what the operator intended: the agent reads and
+ * writes a codebase unrelated to its task, and because the run otherwise
+ * succeeds the output looks authoritative. Warn loudly so the misconfiguration
+ * is visible in the run log instead of surfacing as confidently wrong work.
+ */
+export function resolveAdapterWorkingDirectory(input: {
+  adapterType: string;
+  workspaceCwd: string;
+  configuredCwd: string;
+}): string {
+  const resolved = input.workspaceCwd || input.configuredCwd;
+  if (resolved) return resolved;
+
+  const fallback = process.cwd();
+  console.warn(
+    `[${input.adapterType}] No workspace or configured working directory resolved; ` +
+      `falling back to the server process directory (${fallback}). ` +
+      "The agent will read and write there, which is unlikely to be the intended project. " +
+      "Set a cwd on the project workspace, or on the agent's adapter config.",
+  );
+  return fallback;
+}

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3540,23 +3540,30 @@ export async function runChildProcess(
  *
  * That fallback is almost never what the operator intended: the agent reads and
  * writes a codebase unrelated to its task, and because the run otherwise
- * succeeds the output looks authoritative. Warn loudly so the misconfiguration
- * is visible in the run log instead of surfacing as confidently wrong work.
+ * succeeds the output looks authoritative. Report it through `onLog` so the
+ * warning lands in the operator-visible run transcript rather than only on the
+ * server's stderr.
  */
-export function resolveAdapterWorkingDirectory(input: {
+export async function resolveAdapterWorkingDirectory(input: {
   adapterType: string;
   workspaceCwd: string;
   configuredCwd: string;
-}): string {
+  onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}): Promise<string> {
   const resolved = input.workspaceCwd || input.configuredCwd;
   if (resolved) return resolved;
 
   const fallback = process.cwd();
-  console.warn(
-    `[${input.adapterType}] No workspace or configured working directory resolved; ` +
-      `falling back to the server process directory (${fallback}). ` +
-      "The agent will read and write there, which is unlikely to be the intended project. " +
-      "Set a cwd on the project workspace, or on the agent's adapter config.",
-  );
+  const message =
+    `[paperclip] ${input.adapterType}: no workspace or configured working directory resolved. ` +
+    `Using the server process directory (${fallback}). ` +
+    "The agent reads and writes there, which is unlikely to be the intended project. " +
+    "Set a cwd on the project workspace, or on the agent's adapter config.\n";
+
+  if (input.onLog) {
+    await input.onLog("stderr", message);
+  } else {
+    console.warn(message.trim());
+  }
   return fallback;
 }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -49,6 +49,7 @@ import {
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseLocalProcessFilesystemScope,
@@ -194,7 +195,11 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "claude_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   const shapedWorkspaceEnv = shapePaperclipWorkspaceEnvForExecution({

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -195,10 +195,11 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "claude_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -627,10 +627,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = targetWorkspaceRealization?.mode === "in_place"
     ? targetWorkspaceRealization.authoritativeRoot
     : useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "codex_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   const envConfig = parseObject(config.env);
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -49,6 +49,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   joinPromptSections,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   parseLocalProcessFilesystemScope,
@@ -626,7 +627,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const effectiveWorkspaceCwd = targetWorkspaceRealization?.mode === "in_place"
     ? targetWorkspaceRealization.authoritativeRoot
     : useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "codex_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   const envConfig = parseObject(config.env);
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
   const configuredCodexHome =

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -228,10 +228,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "cursor",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -46,6 +46,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   joinPromptSections,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
 import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
@@ -227,7 +228,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "cursor",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const cursorSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -49,6 +49,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   runChildProcess,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GEMINI_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
 import {
@@ -252,7 +253,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "gemini_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const geminiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -253,10 +253,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "gemini_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -229,10 +229,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "grok_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -38,6 +38,7 @@ import {
   stringifyPaperclipWakePayload,
   refreshPaperclipWorkspaceEnvForExecution,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GROK_LOCAL_MODEL } from "../index.js";
 import { isGrokUnknownSessionError, parseGrokJsonl } from "./parse.js";
@@ -228,7 +229,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "grok_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 

--- a/packages/adapters/kimi-local/src/server/execute.ts
+++ b/packages/adapters/kimi-local/src/server/execute.ts
@@ -40,6 +40,7 @@ import {
   isPaperclipRecoveryWakePayload,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   SANDBOX_INSTALL_COMMAND,
@@ -226,7 +227,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "kimi_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const kimiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);

--- a/packages/adapters/kimi-local/src/server/execute.ts
+++ b/packages/adapters/kimi-local/src/server/execute.ts
@@ -227,10 +227,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "kimi_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -251,10 +251,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "opencode_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -46,6 +46,7 @@ import {
   readPaperclipRuntimeSkillEntries,
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
 import {
@@ -250,7 +251,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "opencode_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const openCodeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -47,6 +47,7 @@ import {
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   runChildProcess,
+  resolveAdapterWorkingDirectory,
 } from "@paperclipai/adapter-utils/server-utils";
 import { shellQuote } from "@paperclipai/adapter-utils/ssh";
 import { isPiUnknownSessionError, parsePiJsonl } from "./parse.js";
@@ -250,7 +251,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  const cwd = resolveAdapterWorkingDirectory({
+    adapterType: "pi_local",
+    workspaceCwd: effectiveWorkspaceCwd,
+    configuredCwd,
+  });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
 

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -251,10 +251,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
-  const cwd = resolveAdapterWorkingDirectory({
+  const cwd = await resolveAdapterWorkingDirectory({
     adapterType: "pi_local",
     workspaceCwd: effectiveWorkspaceCwd,
     configuredCwd,
+    onLog,
   });
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local adapters start each agent as a child process in a selected working directory
> - The directory comes from the realized workspace, or from the agent adapter config
> - When neither value is present, the adapter uses `process.cwd()` without a message
> - `process.cwd()` is the paperclip-server directory, which is `/app` in the published image
> - The agent then reads the server source tree and reports work against the wrong repository
> - This pull request adds a warning when an adapter uses that fallback
> - The benefit is that an operator sees the misconfiguration in the run log

## Linked Issues or Issue Description

Refs #1164 — that issue reports a project workspace being ignored, with a fallback message for the agent-home path. This pull request covers a different fallback in the same area. The `process.cwd()` path prints nothing today.

Related but different, and not duplicated by this change:

- Refs #10419 — binds the runtime working directory to the realized workspace
- Refs #11438 — passes the realized workspace to OpenCode with `--dir`
- Refs #3459 — sub-issue workspace resolution falls back to agent home

Those pull requests improve how the directory resolves. This pull request adds a message for when resolution still produces nothing.

**Bug description**

**What happened:**
A local adapter ran an agent in the paperclip-server directory. The agent read the server source tree. The agent produced a plan for that codebase and reported success. The run log gave no indication of the wrong directory.

**What I expected:**
A message that names the directory the adapter used.

**Steps to reproduce:**
1. Create a project. Do not set a `cwd` on the project workspace.
2. Create an agent with a local adapter. Do not set `cwd` in the adapter config.
3. Assign an issue to the agent and start a run.
4. Read the run transcript. The agent works in `/app`. No message explains this.

**Impact:**
The run succeeds, so the output looks correct. A second agent with the same missing setting reads the same directory. A review step then agrees with the first agent instead of finding the error.

## What Changed

- Add `resolveAdapterWorkingDirectory()` to `@paperclipai/adapter-utils/server-utils`. The function keeps the existing precedence. It reports through the adapter's `onLog` callback when it uses `process.cwd()`, so the message reaches the operator-visible run transcript. The message names the adapter type, the directory, and the two places an operator can set a directory. `console.warn` remains for callers that supply no log channel.
- Await the function in all eight local adapters and pass `onLog`. The adapters are: `claude-local`, `codex-local`, `cursor-local`, `gemini-local`, `grok-local`, `kimi-local`, `opencode-local`, `pi-local`. Each adapter had the same line.
- Add `packages/adapter-utils/src/resolve-adapter-cwd.test.ts` with four cases: workspace directory wins, configured directory wins, the fallback reports through `onLog`, and the fallback uses `console.warn` when no log channel exists.

## Verification

```
vitest run packages/adapter-utils/src/resolve-adapter-cwd.test.ts   # 4 passed
vitest run packages/adapter-utils/src/server-utils.test.ts          # 92 passed
```

The new test asserts that the message reaches `onLog` on the `stderr` stream, contains the adapter type, the directory, and remedy text, and ends with a newline. A future change that drops the message, or that routes it away from the transcript, fails the test.

## Risks

Low risk. The resolved directory is the same as before. Only the message is new.

The message uses `onLog("stderr", ...)`, which matches other `[paperclip] ...` messages in these adapter files. The resolver became `async`, so the eight call sites now await it. Each call site was already inside an async function.

A stronger option is to stop the run when no directory resolves. That option changes behaviour, so it is not part of this pull request. `CONTRIBUTING.md` asks contributors to discuss changes of that size in `#dev` first.

## Model Used

Claude Opus 5 (1M context), extended thinking, with tool use and code execution. The change was produced and tested inside a Paperclip instance running `v2026.817.0`, where this fallback caused two agents to plan work against the Paperclip source tree instead of the target project.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
