### PR TITLE
fix(recovery): fail closed on ambiguous OpenClaw gateway wait timeouts

### DIFF
--- a/server/src/services/recovery/service.openclaw-wait-timeout.test.ts
+++ b/server/src/services/recovery/service.openclaw-wait-timeout.test.ts
@@ -70,6 +70,26 @@ describe("OpenClaw gateway wait timeout: fail-closed guard", () => {
     expect(c.kind).toBe("non_retryable");
   });
 
+  it("does not suppress retry when error message is prefixed before canonical text", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: `Error: ${OPENCLAW_TIMEOUT_ERROR}`,
+    }));
+    expect(c.kind).toBe("transient_infra");
+    expect(c.maxAttempts).toBeGreaterThan(0);
+  });
+
+  it("does not suppress retry when error message has a suffix after canonical text", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: `${OPENCLAW_TIMEOUT_ERROR}. Please retry.`,
+    }));
+    expect(c.kind).toBe("transient_infra");
+    expect(c.maxAttempts).toBeGreaterThan(0);
+  });
+
   it("does not suppress retry for a generic timeout (no OpenClaw message)", () => {
     const c = classifyContinuationFailure(run({
       errorCode: "timeout",
@@ -109,7 +129,7 @@ describe("OpenClaw gateway wait timeout: fail-closed guard", () => {
     expect(c.kind).toBe("transient_infra");
   });
 
-  it("returns null errorCode in the classification for OpenClaw timeout", () => {
+  it("preserves errorCode: timeout in the classification for OpenClaw timeout", () => {
     const c = classifyContinuationFailure(run({
       errorCode: "timeout",
       status: "timed_out",

--- a/server/src/services/recovery/service.openclaw-wait-timeout.test.ts
+++ b/server/src/services/recovery/service.openclaw-wait-timeout.test.ts
@@ -1,0 +1,306 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  createDb,
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+  activityLog,
+  agents,
+  agentWakeupRequests,
+  authUsers,
+  companies,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issueRecoveryActions,
+  issueRelations,
+  issueWorkProducts,
+  issues,
+} from "@paperclipai/db";
+import { classifyContinuationFailure, recoveryService } from "./service.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+// Helper: build a minimal LatestIssueRun-shaped object for classifyContinuationFailure.
+// Only errorCode, status, and error matter for this test suite.
+function run(opts: {
+  errorCode?: string | null;
+  status?: string;
+  error?: string | null;
+}): Parameters<typeof classifyContinuationFailure>[0] {
+  return {
+    errorCode: opts.errorCode ?? null,
+    status: opts.status ?? "timed_out",
+    error: opts.error ?? null,
+  } as unknown as Parameters<typeof classifyContinuationFailure>[0];
+}
+
+const OPENCLAW_TIMEOUT_ERROR = "OpenClaw gateway run timed out after 30000ms";
+
+describe("OpenClaw gateway wait timeout: fail-closed guard", () => {
+  it("classifies an OpenClaw gateway wait timeout as non_retryable", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: OPENCLAW_TIMEOUT_ERROR,
+    }));
+    expect(c.kind).toBe("non_retryable");
+    expect(c.maxAttempts).toBe(0);
+  });
+
+  it("matches various millisecond durations in the OpenClaw error message", () => {
+    for (const ms of [1000, 30000, 120000, 999999]) {
+      const c = classifyContinuationFailure(run({
+        errorCode: "timeout",
+        status: "timed_out",
+        error: `OpenClaw gateway run timed out after ${ms}ms`,
+      }));
+      expect(c.kind).toBe("non_retryable");
+    }
+  });
+
+  it("is case-insensitive on the error message", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: "openclaw gateway run timed out after 60000ms",
+    }));
+    expect(c.kind).toBe("non_retryable");
+  });
+
+  it("does not suppress retry for a generic timeout (no OpenClaw message)", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: null,
+    }));
+    expect(c.kind).toBe("transient_infra");
+    expect(c.maxAttempts).toBeGreaterThan(0);
+  });
+
+  it("does not suppress retry when error message contains unrelated timeout text", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: "Database query timed out after 5000ms",
+    }));
+    expect(c.kind).toBe("transient_infra");
+    expect(c.maxAttempts).toBeGreaterThan(0);
+  });
+
+  it("does not suppress retry when status is not timed_out (wrong terminal state)", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "failed",
+      error: OPENCLAW_TIMEOUT_ERROR,
+    }));
+    expect(c.kind).toBe("transient_infra");
+  });
+
+  it("does not suppress retry when errorCode is not timeout", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "adapter_failed",
+      status: "timed_out",
+      error: OPENCLAW_TIMEOUT_ERROR,
+    }));
+    // adapter_failed is in TRANSIENT_INFRA_CONTINUATION_ERROR_CODES
+    expect(c.kind).toBe("transient_infra");
+  });
+
+  it("returns null errorCode in the classification for OpenClaw timeout", () => {
+    const c = classifyContinuationFailure(run({
+      errorCode: "timeout",
+      status: "timed_out",
+      error: OPENCLAW_TIMEOUT_ERROR,
+    }));
+    expect(c.errorCode).toBe("timeout");
+  });
+});
+
+const OPENCLAW_TIMEOUT_ERROR_120S = "OpenClaw gateway run timed out after 120000ms";
+
+describeEmbeddedPostgres("OpenClaw gateway wait timeout: recoveryService behavioral path", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-openclaw-timeout-behavioral-");
+    db = createDb(tempDb.connectionString);
+    const now = new Date();
+    await db.insert(authUsers).values({
+      id: "responsible-user",
+      name: "Responsible User",
+      email: "responsible-user@example.test",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await db.delete(agentWakeupRequests);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(issueWorkProducts);
+    await db.delete(issueDocuments);
+    await db.delete(issueComments);
+    await db.delete(issueRecoveryActions);
+    await db.delete(issueRelations);
+    // Delete child issues before parents to respect FK constraints.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(issueComments);
+      try {
+        await db.delete(issues);
+        break;
+      } catch {
+        if (attempt === 4) throw new Error("Failed to clean up issues after 5 attempts");
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(activityLog);
+      try {
+        await db.delete(agents);
+        break;
+      } catch {
+        if (attempt === 4) throw new Error("Failed to clean up agents after 5 attempts");
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(activityLog);
+      try {
+        await db.delete(companies);
+        break;
+      } catch {
+        if (attempt === 4) throw new Error("Failed to clean up companies after 5 attempts");
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedOpenClawTimeoutIssue(status: "todo" | "in_progress") {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const now = new Date("2026-08-25T00:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Test",
+      issuePrefix,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "timed_out",
+      errorCode: "timeout",
+      error: OPENCLAW_TIMEOUT_ERROR_120S,
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      startedAt: now,
+      finishedAt: new Date("2026-08-25T00:02:00.000Z"),
+      updatedAt: new Date("2026-08-25T00:02:00.000Z"),
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue with OpenClaw wait timeout",
+      status,
+      priority: "medium",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      checkoutRunId: status === "in_progress" ? runId : null,
+      executionRunId: null,
+      responsibleUserId: "responsible-user",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId, runId };
+  }
+
+  it("TODO / assignment path: escalates to blocked and enqueues zero retry/redispatch wakeups for a persisted OpenClaw wait timeout", async () => {
+    const { issueId } = await seedOpenClawTimeoutIssue("todo");
+    const enqueueWakeup = vi.fn().mockResolvedValue(null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    // Source issue must be moved to blocked — no automatic retry dispatched.
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    // Any enqueueWakeup calls must be recovery escalation wakes (source_scoped_recovery_action /
+    // issue_assigned), never a retry redispatch (issue_assignment_recovery) or continuation
+    // (issue_continuation_needed). Those retry reasons are the invariant being guarded against.
+    const retryReasons = new Set(["issue_assignment_recovery", "issue_continuation_needed"]);
+    for (const [, opts] of enqueueWakeup.mock.calls) {
+      const reason = (opts as Record<string, unknown> | undefined)?.reason as string | undefined;
+      expect(retryReasons.has(reason ?? "")).toBe(false);
+      const ctx = (opts as Record<string, unknown> | undefined)?.contextSnapshot as Record<string, unknown> | undefined;
+      const wakeReason = ctx?.wakeReason as string | undefined;
+      expect(retryReasons.has(wakeReason ?? "")).toBe(false);
+    }
+  });
+
+  it("IN_PROGRESS / continuation path: escalates to blocked and enqueues zero retry/continuation wakeups for a persisted OpenClaw wait timeout", async () => {
+    const { issueId } = await seedOpenClawTimeoutIssue("in_progress");
+    const enqueueWakeup = vi.fn().mockResolvedValue(null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    // Source issue must follow the non-retryable escalation path — no continuation enqueued.
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    // Any enqueueWakeup calls must be recovery escalation wakes, never a retry continuation.
+    // issue_continuation_needed is the retry reason being guarded against.
+    const retryReasons = new Set(["issue_assignment_recovery", "issue_continuation_needed"]);
+    for (const [, opts] of enqueueWakeup.mock.calls) {
+      const reason = (opts as Record<string, unknown> | undefined)?.reason as string | undefined;
+      expect(retryReasons.has(reason ?? "")).toBe(false);
+      const ctx = (opts as Record<string, unknown> | undefined)?.contextSnapshot as Record<string, unknown> | undefined;
+      const wakeReason = ctx?.wakeReason as string | undefined;
+      expect(retryReasons.has(wakeReason ?? "")).toBe(false);
+    }
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -391,6 +391,16 @@ const PROVIDER_QUOTA_ERROR_RE =
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
   /(?:model_not_found|model [^\n]{0,120} not found|missing (?:api )?(?:key|credentials?)|credentials? (?:are |is )?missing|no (?:api )?(?:key|credentials?) (?:was |were )?(?:found|configured|provided)|api key (?:is )?(?:not set|unavailable))/i;
 
+// Matches the canonical OpenClaw gateway wait timeout message.
+// These timeouts are ambiguous: the run may have completed on the remote side.
+// Fail closed — do not auto-retry.
+const OPENCLAW_GATEWAY_WAIT_TIMEOUT_RE = /OpenClaw gateway run timed out after \d+ms/i;
+
+function isOpenClawGatewayWaitTimeout(latestRun: LatestIssueRun): boolean {
+  if (!latestRun || latestRun.status !== "timed_out" || latestRun.errorCode !== "timeout") return false;
+  return OPENCLAW_GATEWAY_WAIT_TIMEOUT_RE.test(latestRun.error ?? "");
+}
+
 export type AdapterFailureRecoveryClassification =
   | { kind: "provider_quota"; retryAt: Date; parsedResetTime: boolean }
   | { kind: "configuration_incomplete" }
@@ -519,6 +529,9 @@ export function classifyContinuationFailure(latestRun: LatestIssueRun): Continua
     };
   }
   if (errorCode && NON_RETRYABLE_CONTINUATION_ERROR_CODES.has(errorCode)) {
+    return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
+  }
+  if (isOpenClawGatewayWaitTimeout(latestRun)) {
     return { kind: "non_retryable", maxAttempts: 0, baseBackoffMs: 0, errorCode };
   }
   if (errorCode && TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(errorCode)) {
@@ -4568,6 +4581,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
                 "but it still has no live execution path. " +
                 "Moving it to `blocked` so it is visible for intervention.",
               title: "No live execution path",
+              tone: "danger",
+            },
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
+        if (isOpenClawGatewayWaitTimeout(latestRun)) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "todo",
+            latestRun,
+            notice: {
+              body:
+                "Paperclip detected an ambiguous OpenClaw gateway wait timeout on this issue's assignment wake. " +
+                "Failing closed: skipping automatic retry and moving it to `blocked` so it is visible for intervention.",
+              title: "Ambiguous OpenClaw timeout",
               tone: "danger",
             },
           });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -394,7 +394,7 @@ const CONFIGURATION_INCOMPLETE_ERROR_RE =
 // Matches the canonical OpenClaw gateway wait timeout message.
 // These timeouts are ambiguous: the run may have completed on the remote side.
 // Fail closed — do not auto-retry.
-const OPENCLAW_GATEWAY_WAIT_TIMEOUT_RE = /OpenClaw gateway run timed out after \d+ms/i;
+const OPENCLAW_GATEWAY_WAIT_TIMEOUT_RE = /^OpenClaw gateway run timed out after \d+ms$/i;
 
 function isOpenClawGatewayWaitTimeout(latestRun: LatestIssueRun): boolean {
   if (!latestRun || latestRun.status !== "timed_out" || latestRun.errorCode !== "timeout") return false;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The recovery service decides when stranded agent work can run again.
> - An OpenClaw gateway wait timeout does not prove that the remote work stopped.
> - The remote run can continue after Paperclip stops waiting for it.
> - A blind retry can repeat repository or tool side effects.
> - This pull request detects the persisted OpenClaw gateway wait-timeout signature and treats it as non-retryable.
> - The recovery service blocks and escalates the source issue instead of starting the work again.
> - The benefit is fail-closed recovery for ambiguous OpenClaw wait timeouts while generic timeouts keep their current retry behavior.

## Linked Issues or Issue Description

Refs #928

Refs #3305

Related pull requests reviewed during the duplicate search:

- Refs #9045. This PR retries only gateway dispatch request failures. It intentionally excludes wait, timeout, result, and agent-level failures.
- Refs #6461. This PR raises the default OpenClaw timeout budget. It is complementary and does not change recovery semantics after an ambiguous wait timeout.
- Refs #5336. This PR limits and deduplicates stranded recovery retries. It does not identify the persisted OpenClaw gateway wait-timeout signature used here.

No reviewed pull request duplicates this narrow fail-closed guard.

## What Changed

- Add a narrow detector for persisted OpenClaw gateway wait timeouts.
- Require `status = timed_out`, `errorCode = timeout`, and the canonical gateway wait-timeout error message.
- Classify this specific timeout as non-retryable in continuation recovery.
- Block and escalate the source issue in assignment recovery instead of redispatching it.
- Keep generic timeout failures retryable.
- Add unit tests for the timeout classification.
- Add behavioral recovery tests for both `todo` assignment recovery and `in_progress` continuation recovery.

## Verification

- Focused timeout recovery tests: 10 of 10 passed.
- Relevant sibling recovery tests: 28 of 28 passed.
- The behavioral tests call the real `recoveryService` path with embedded Postgres.
- The `todo` test confirms that the source issue becomes `blocked` and `dispatchRequeued` stays at `0`.
- The `in_progress` test confirms that the source issue becomes `blocked` and `continuationRequeued` stays at `0`.
- The tests confirm that no `issue_assignment_recovery` or `issue_continuation_needed` retry wake is created for the ambiguous timeout.
- `git diff --check` passed.
- The changed recovery service file adds no new type errors. Unrelated pre-existing type errors existed elsewhere in the local repository baseline.

## Risks

- This changes automatic recovery behavior for one specific persisted OpenClaw timeout signature.
- A matching timeout now requires reconciliation before retry.
- Generic `timeout` failures without the OpenClaw gateway wait-timeout signature keep the existing retry behavior.
- The detection depends on the persisted gateway timeout message format.
- No database schema, adapter protocol, runtime configuration, or timeout value changes.
- No documentation change is required because this is an internal recovery safety guard with focused test coverage.

ROADMAP.md was checked. Self-healing runs and automatic recovery are already shipped. This change is a narrow bug fix to that recovery behavior, not a new roadmap feature.

## Model Used

- Implementation and tests: Anthropic Claude Sonnet 4.6, exact model ID `claude-sonnet-4-6`, with tool use and code execution through the local Paperclip adapter. The runtime did not expose the context-window size.
- Pull request review and description assistance: OpenAI GPT-5.6 Sol, with GitHub repository inspection and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge