### PR TITLE
test(release-smoke): follow the mission-less onboarding reorder

### DIFF
--- a/tests/release-smoke/docker-auth-onboarding.spec.ts
+++ b/tests/release-smoke/docker-auth-onboarding.spec.ts
@@ -10,7 +10,6 @@ const ADMIN_PASSWORD =
   "paperclip-smoke-password";
 
 const COMPANY_NAME = `Release-Smoke-${Date.now()}`;
-const MISSION = "Ship a reliable release smoke suite for Paperclip.";
 const AGENT_NAME = "CEO";
 // Seeded by the wizard's launch step (DEFAULT_TASK_TITLE in
 // ui/src/components/OnboardingWizard.tsx).
@@ -47,19 +46,11 @@ test.describe("Docker authenticated onboarding smoke", () => {
     await signIn(page);
     await openOnboarding(page);
 
-    // Step 1: name the company.
+    // Step 1: name the company. "Next" creates the company itself and routes
+    // straight to the agent step — onboarding no longer asks for the mission
+    // (it is collected later, in the tenant app), so there is no step 2.
     await page.locator('input[placeholder="Acme Corp"]').fill(COMPANY_NAME);
     await page.getByRole("button", { name: "Next" }).click();
-
-    // Step 2: define the mission directly; confirming creates the company.
-    await expect(
-      page.locator("h3", { hasText: "Define your mission" })
-    ).toBeVisible({ timeout: 10_000 });
-    await page.getByRole("button", { name: "I know my mission" }).click();
-    await page
-      .locator('textarea[placeholder="What is your team trying to achieve?"]')
-      .fill(MISSION);
-    await page.getByRole("button", { name: "Confirm mission" }).click();
 
     // Step 3: give the team lead a role, then a name. The role gates "Next".
     const roleSelect = page.locator("#onboarding-agent-role");
@@ -111,25 +102,15 @@ test.describe("Docker authenticated onboarding smoke", () => {
     expect(ceoAgent!.role).toBe("ceo");
     expect(ceoAgent!.adapterType).not.toBe("process");
 
+    // Onboarding deliberately writes no goal: the mission is collected later
+    // in the tenant app, so a fresh company must come out of the wizard with
+    // an empty goal list rather than an unchosen one.
     const goalsRes = await page.request.get(
       `${baseUrl}/api/companies/${company!.id}/goals`
     );
     expect(goalsRes.ok()).toBe(true);
-    const goals = (await goalsRes.json()) as Array<{
-      id: string;
-      title: string;
-      level: string;
-      status: string;
-    }>;
-    expect(goals).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          title: MISSION,
-          level: "company",
-          status: "active",
-        }),
-      ])
-    );
+    const goals = (await goalsRes.json()) as Array<{ id: string }>;
+    expect(goals).toEqual([]);
 
     const issuesRes = await page.request.get(
       `${baseUrl}/api/companies/${company!.id}/issues`


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The nightly release lane publishes only after the release smoke suite passes against the newest canary
> - Onboarding was reordered: step 1 now creates the company and routes straight to the agent step, and the mission step is gone (collected later in the tenant app, deliberately writing no goal)
> - The smoke spec still walked the removed mission step, so the scheduled nightly has been red since the reorder shipped
> - This pull request updates the spec to the current flow and asserts the deliberate empty goal list
> - The benefit is a green nightly lane and an unblocked beta promotion from current master

## Linked Issues or Issue Description

**What happened?**

The scheduled `Release` nightly run fails in `smoke_nightly / smoke` since 2026-08-23 (runs 32630184811, 32710905212): `docker-auth-onboarding.spec.ts` waits for the `Define your mission` heading after step 1, but the wizard now routes 1 → 3 with no mission step (the step buttons literally skip from 1 to 3). The retry then fails on step 1 because the first attempt's company persists.

**Expected behavior**

The smoke passes against canaries carrying the reordered wizard, and the nightly lane publishes again.

**Steps to reproduce**

Run `scripts/docker-onboard-smoke.sh` with `PAPERCLIPAI_VERSION=2026.824.0-canary.7` and `pnpm run test:release-smoke` against it.

**Paperclip version or commit**

`2026.824.0-canary.7`

Related (not duplicates): #11565 updated this same spec for the chat-first rewrite; this is the follow-up for the mission-less reorder.

## What Changed

- Remove the mission-step interaction; step 1's "Next" now creates the company and the spec goes straight to the agent step.
- Replace the mission-goal API assertion with the truthful one: onboarding deliberately writes no goal, so a fresh company's goal list is empty.
- Update step comments to match the shipped flow.

## Verification

- Local run of the exact CI harness against `paperclipai@2026.824.0-canary.7`: 1 passed (6.8s), exit 0.
- The suite's remaining API assertions (company, CEO agent, seeded task assignment, landed issue URL, assignment-sourced heartbeat run) pass unchanged.

## Risks

- Low risk: test-only. The spec remains copy-coupled to the wizard — this is the third drift in two weeks; stable `data-testid` hooks in the wizard remain the durable fix and can follow separately.

## Model Used

Claude Fable 5 (Claude Code)

## Pre-submission checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template