### PR TITLE
feat: dedicated import pause reason with visible paused-assignee notices

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -669,7 +669,10 @@ export type RoutineRunStatus = (typeof ROUTINE_RUN_STATUSES)[number];
 export const ROUTINE_RUN_SOURCES = ["schedule", "manual", "api", "webhook"] as const;
 export type RoutineRunSource = (typeof ROUTINE_RUN_SOURCES)[number];
 
-export const PAUSE_REASONS = ["manual", "budget", "system", "company_archived"] as const;
+// "import" marks agents parked by a company import (safety default) so the UI
+// can explain the pause and offer a scoped bulk-resume; "system" remains the
+// reason for platform-managed pauses (plugins, built-ins).
+export const PAUSE_REASONS = ["manual", "budget", "system", "company_archived", "import"] as const;
 export type PauseReason = (typeof PAUSE_REASONS)[number];
 
 export const PROJECT_COLORS = [

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -2667,7 +2667,9 @@ describe("company portability", () => {
 
     expect(agentSvc.create).toHaveBeenCalledWith("company-imported", expect.objectContaining({
       status: "paused",
-      pauseReason: "system",
+      // The dedicated "import" reason lets the UI explain the pause and offer
+      // a scoped resume; "system" stays for platform-managed pauses.
+      pauseReason: "import",
       pausedAt: expect.any(Date),
     }));
     expect(routineSvc.create).toHaveBeenCalledWith("company-imported", expect.objectContaining({

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -5549,10 +5549,14 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             permissions: manifestAgent.permissions,
             metadata: manifestAgent.metadata,
           };
+          // "import", not "system": the UI reads this to explain that the
+          // agent was parked by the import safety default and to offer a
+          // scoped resume; "system" stays reserved for platform-managed
+          // pauses (plugins, built-ins).
           const automationPausePatch = pauseAutomations
             ? {
                 status: "paused",
-                pauseReason: "system",
+                pauseReason: "import",
                 pausedAt: importedAutomationPausedAt,
               }
             : {};

--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent } from "@paperclipai/shared";
 import {
+  IssueAssigneePausedNotice,
   IssueChatThread,
   VIRTUALIZED_THREAD_ROW_THRESHOLD,
   canStopIssueChatRun,
@@ -3913,5 +3914,82 @@ describe("IssueChatThread", () => {
       authorName: "Alice",
       avatarUrl: "/avatars/alice.png",
     });
+  });
+});
+
+describe("IssueAssigneePausedNotice", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function pausedAgent(pauseReason: string): Agent {
+    return {
+      id: "agent-1",
+      name: "CEO",
+      status: "paused",
+      pauseReason,
+    } as unknown as Agent;
+  }
+
+  it("explains an import pause and resumes the agent on click", () => {
+    const onResume = vi.fn();
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueAssigneePausedNotice agent={pausedAgent("import")} onResume={onResume} resuming={false} />,
+      );
+    });
+
+    expect(container.textContent).toContain("arrived paused from a company import");
+    const resumeButton = container.querySelector(
+      '[data-testid="issue-assignee-paused-resume"]',
+    ) as HTMLButtonElement | null;
+    expect(resumeButton).not.toBeNull();
+
+    act(() => {
+      resumeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onResume).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+
+  it("offers no resume action for budget pauses", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueAssigneePausedNotice agent={pausedAgent("budget")} onResume={vi.fn()} resuming={false} />,
+      );
+    });
+
+    expect(container.textContent).toContain("budget hard stop");
+    expect(container.querySelector('[data-testid="issue-assignee-paused-resume"]')).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  it("renders nothing for an active agent", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueAssigneePausedNotice
+          agent={{ id: "agent-1", name: "CEO", status: "idle" } as unknown as Agent}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="issue-assignee-paused-notice"]')).toBeNull();
+
+    act(() => root.unmount());
   });
 });

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -82,6 +82,7 @@ import {
   type IssueWorkModeChange,
 } from "../lib/issue-timeline-events";
 import { Button } from "@/components/ui/button";
+import { InlineBanner } from "@/components/InlineBanner";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -476,6 +477,9 @@ interface IssueChatThreadProps {
   issueAssigneeAgentId?: string | null;
   onResumeFromBacklog?: () => Promise<void> | void;
   resumeFromBacklogPending?: boolean;
+  /** Resume a paused assignee agent so runs can start again. */
+  onResumeAssignee?: () => Promise<void> | void;
+  resumeAssigneePending?: boolean;
   companyId?: string | null;
   projectId?: string | null;
   issueStatus?: string;
@@ -625,24 +629,50 @@ class IssueChatErrorBoundary extends Component<IssueChatErrorBoundaryProps, Issu
   }
 }
 
-function IssueAssigneePausedNotice({ agent }: { agent: Agent | null }) {
+export function IssueAssigneePausedNotice({
+  agent,
+  onResume,
+  resuming,
+}: {
+  agent: Agent | null;
+  onResume?: () => Promise<void> | void;
+  resuming?: boolean;
+}) {
   if (!agent || agent.status !== "paused") return null;
 
   const pauseDetail =
     agent.pauseReason === "budget"
       ? "It was paused by a budget hard stop."
-      : agent.pauseReason === "system"
-        ? "It was paused by the system."
-        : "It was paused manually.";
+      : agent.pauseReason === "import"
+        ? "It arrived paused from a company import — imported agents stay parked until you resume them."
+        : agent.pauseReason === "system"
+          ? "It was paused by the system."
+          : "It was paused manually.";
+  // Budget pauses clear on their own when the budget resets; resuming by hand
+  // would fight the hard stop, so the action is only offered for the rest.
+  const canResume = Boolean(onResume) && agent.pauseReason !== "budget";
 
   return (
-    <div className="mb-3 rounded-md border border-orange-300/70 bg-orange-50/90 px-3 py-2.5 text-sm text-orange-950 shadow-sm dark:border-orange-500/40 dark:bg-orange-500/10 dark:text-orange-100">
-      <div className="flex items-start gap-2">
-        <PauseCircle className="mt-0.5 h-4 w-4 shrink-0 text-orange-600 dark:text-orange-300" />
-        <p className="min-w-0 leading-5">
-          <span className="font-medium">{agent.name}</span> is paused. New runs will not start until the agent is resumed. {pauseDetail}
-        </p>
-      </div>
+    <div data-testid="issue-assignee-paused-notice" className="mb-3">
+      <InlineBanner
+        tone="warning"
+        icon={PauseCircle}
+        compact
+        title={<><span className="font-medium">{agent.name}</span> is paused.</>}
+        actions={canResume ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onResume}
+            disabled={resuming}
+            data-testid="issue-assignee-paused-resume"
+          >
+            {resuming ? "Resuming…" : "Resume agent"}
+          </Button>
+        ) : undefined}
+      >
+        New runs will not start until the agent is resumed. {pauseDetail}
+      </InlineBanner>
     </div>
   );
 }
@@ -4493,6 +4523,8 @@ export function IssueChatThread({
   assigneeUserId = null,
   onResumeFromBacklog,
   resumeFromBacklogPending = false,
+  onResumeAssignee,
+  resumeAssigneePending = false,
   externalReferences,
   linkCaseReferences = false,
 }: IssueChatThreadProps) {
@@ -5241,9 +5273,22 @@ export function IssueChatThread({
                         : null
                     }
                   />
-                  <IssueAssigneePausedNotice agent={assignedAgent} />
+                  <IssueAssigneePausedNotice
+                    agent={assignedAgent}
+                    onResume={onResumeAssignee}
+                    resuming={resumeAssigneePending}
+                  />
                 </div>
-              ) : null}
+              ) : (
+                // Read-only viewers still need to see why nothing is running.
+                <div data-testid="issue-chat-thread-notices" className="space-y-2">
+                  <IssueAssigneePausedNotice
+                    agent={assignedAgent}
+                    onResume={onResumeAssignee}
+                    resuming={resumeAssigneePending}
+                  />
+                </div>
+              )}
               {footer ? <div data-testid="issue-chat-thread-footer">{footer}</div> : null}
               <div ref={bottomAnchorRef} />
               {showComposer ? (

--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -548,6 +548,33 @@ describe("NewIssueDialog", () => {
     act(() => root.unmount());
   });
 
+  it("warns when the selected assignee is a paused imported agent", async () => {
+    dialogState.newIssueDefaults = {
+      title: "Compare onboarding flows",
+      assigneeAgentId: "agent-1",
+    };
+    mockAgentsApi.list.mockResolvedValue([
+      {
+        id: "agent-1",
+        name: "CEO",
+        status: "paused",
+        pauseReason: "import",
+        adapterType: "claude_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const { root } = renderDialog(container);
+    await waitForAssertion(() => {
+      expect(container.querySelector('[data-testid="new-issue-paused-assignee-note"]')).not.toBeNull();
+    });
+    expect(container.textContent).toContain("arrived paused from a company import");
+
+    act(() => root.unmount());
+  });
+
   it("restores the planning mode from dialog defaults", async () => {
     dialogState.newIssueDefaults = {
       title: "Planned from defaults",

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -61,6 +61,7 @@ import {
   Paperclip,
   FileText,
   Flag,
+  PauseCircle,
   Loader2,
   ListTree,
   X,
@@ -76,6 +77,7 @@ import { issueStatusText, issueStatusTextDefault, priorityColor, priorityColorDe
 import { SHOW_TASK_PRIORITY_UI } from "../lib/ui-flags";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { AgentIcon } from "./AgentIconPicker";
+import { InlineBanner } from "./InlineBanner";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
 import { getTrustPreset } from "../lib/trust-policy-ui";
 import { ReusableExecutionWorkspaceSelect } from "./ReusableExecutionWorkspaceSelect";
@@ -586,7 +588,11 @@ export function NewIssueDialog() {
   const selectedAssigneeAgentId = selectedAssignee.assigneeAgentId;
   const selectedAssigneeUserId = selectedAssignee.assigneeUserId;
 
-  const assigneeAdapterType = (agents ?? []).find((agent) => agent.id === selectedAssigneeAgentId)?.adapterType ?? null;
+  const selectedAssigneeAgent = useMemo(
+    () => (agents ?? []).find((agent) => agent.id === selectedAssigneeAgentId) ?? null,
+    [agents, selectedAssigneeAgentId],
+  );
+  const assigneeAdapterType = selectedAssigneeAgent?.adapterType ?? null;
   const supportsAssigneeOverrides = Boolean(
     assigneeAdapterType && ISSUE_OVERRIDE_ADAPTER_TYPES.has(assigneeAdapterType),
   );
@@ -2328,6 +2334,15 @@ export function NewIssueDialog() {
             <span className="leading-snug">
               Assigning implies executable intent - leave status as <span className="font-medium">Backlog</span> only to deliberately park this. The assignee will not be woken until status moves to <span className="font-medium">Todo</span> or <span className="font-medium">In Progress</span>.
             </span>
+          </div>
+        ) : null}
+
+        {selectedAssigneeAgent?.status === "paused" ? (
+          <div data-testid="new-issue-paused-assignee-note" className="mx-4 mb-2">
+            <InlineBanner tone="warning" icon={PauseCircle} compact>
+              <span className="font-medium">{selectedAssigneeAgent.name}</span> is paused and will not start work on this task until it is resumed
+              {selectedAssigneeAgent.pauseReason === "import" ? " — it arrived paused from a company import" : ""}. You can resume it from the task page after creating the task.
+            </InlineBanner>
           </div>
         ) : null}
 

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentProps } from "react";
-import { IssueChatThread } from "@/components/IssueChatThread";
+import { IssueChatThread, IssueAssigneePausedNotice } from "@/components/IssueChatThread";
 import {
   useLiveRunTranscripts,
   type RunTranscriptSource,
@@ -136,6 +136,8 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     blockedBy = [],
     blockerAttention,
     liveIssueIds,
+    onResumeAssignee,
+    resumeAssigneePending = false,
   } = props;
 
   const liveWorkLinks = useMemo(
@@ -642,6 +644,12 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     ],
   );
 
+  const assignedAgentForNotice = useMemo(() => {
+    if (!currentAssigneeValue?.startsWith("agent:")) return null;
+    const assigneeAgentId = currentAssigneeValue.slice("agent:".length);
+    return agentMap?.get(assigneeAgentId) ?? null;
+  }, [agentMap, currentAssigneeValue]);
+
   // Mobile (PAP-360): the app shell scrolls the DOCUMENT (Layout's main is
   // overflow-visible with auto height), so the desktop bounded h-dvh chain
   // collapses the absolute-inset transcript viewport to 0px. Render the thread
@@ -715,6 +723,15 @@ export function TaskChatThread(props: TaskChatThreadProps) {
           />
         )}
       </div>
+      {assignedAgentForNotice?.status === "paused" ? (
+        <div className="mx-auto w-full max-w-(--tc-shell-max-w) px-4 pt-2">
+          <IssueAssigneePausedNotice
+            agent={assignedAgentForNotice}
+            onResume={onResumeAssignee}
+            resuming={resumeAssigneePending}
+          />
+        </div>
+      ) : null}
       {showComposer ? (
         <div
           data-testid="task-chat-composer-dock"

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1048,6 +1048,8 @@ type IssueDetailChatTabProps = {
   assigneeUserId: string | null;
   onResumeFromBacklog?: () => Promise<void> | void;
   resumeFromBacklogPending?: boolean;
+  onResumeAssignee?: () => Promise<void> | void;
+  resumeAssigneePending?: boolean;
   externalReferences?: MarkdownExternalReferenceMap;
   linkCaseReferences?: boolean;
 };
@@ -1126,6 +1128,8 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   assigneeUserId,
   onResumeFromBacklog,
   resumeFromBacklogPending,
+  onResumeAssignee,
+  resumeAssigneePending,
   externalReferences,
   linkCaseReferences,
 }: IssueDetailChatTabProps) {
@@ -1401,6 +1405,8 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
         assigneeUserId={assigneeUserId}
         onResumeFromBacklog={onResumeFromBacklog}
         resumeFromBacklogPending={resumeFromBacklogPending}
+        onResumeAssignee={onResumeAssignee}
+        resumeAssigneePending={resumeAssigneePending}
         footer={footer}
         externalReferences={externalReferences}
         linkCaseReferences={linkCaseReferences}
@@ -4063,6 +4069,46 @@ export function IssueDetail() {
   const handleResumeFromBacklog = useCallback(async () => {
     await updateIssue.mutateAsync({ status: "todo" });
   }, [updateIssue.mutateAsync]);
+  // Resume a paused assignee agent straight from the thread notice: a paused
+  // assignee silently drops every assignment wake, so the fix belongs next to
+  // the explanation.
+  const issueAssigneeAgentIdForResume = issue?.assigneeAgentId ?? null;
+  const issueCompanyIdForResume = issue?.companyId ?? null;
+  const issueStatusForResume = issue?.status ?? null;
+  const issueIdForResume = issue?.id ?? null;
+  const resumeAssigneeAgent = useMutation({
+    mutationFn: async () => {
+      if (!issueAssigneeAgentIdForResume) throw new Error("No assignee agent");
+      await agentsApi.resume(issueAssigneeAgentIdForResume, issueCompanyIdForResume ?? undefined);
+      // The pause silently dropped this issue's assignment wake, so resuming
+      // alone would leave the task idle until some other trigger fires.
+      // Re-issue the wake for executable statuses; best-effort — the agent is
+      // resumed either way and the next comment or timer also wakes it.
+      if (issueIdForResume && (issueStatusForResume === "todo" || issueStatusForResume === "in_progress")) {
+        try {
+          await agentsApi.wakeup(
+            issueAssigneeAgentIdForResume,
+            {
+              source: "assignment",
+              reason: "Assignee resumed from the task page",
+              payload: { issueId: issueIdForResume, mutation: "assignee_resumed" },
+            },
+            issueCompanyIdForResume ?? undefined,
+          );
+        } catch {
+          // Non-fatal: the resume succeeded; the wake retries on the next trigger.
+        }
+      }
+    },
+    onSuccess: async () => {
+      if (issueCompanyIdForResume) {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(issueCompanyIdForResume) });
+      }
+    },
+  });
+  const handleResumeAssignee = useCallback(async () => {
+    await resumeAssigneeAgent.mutateAsync();
+  }, [resumeAssigneeAgent.mutateAsync]);
   const activeRecoveryActionId = issue?.activeRecoveryAction?.id;
   const handleResolveRecoveryAction = useCallback(
     (outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome) => {
@@ -5365,6 +5411,8 @@ export function IssueDetail() {
               resumeFromBacklogPending={
                 updateIssue.isPending && updateIssue.variables?.status === "todo"
               }
+              onResumeAssignee={issue.assigneeAgentId ? handleResumeAssignee : undefined}
+              resumeAssigneePending={resumeAssigneeAgent.isPending}
               externalReferences={externalObjectsState.isEnabled ? externalObjectsState.markdownReferences : undefined}
               linkCaseReferences={casesChipsEnabled}
             />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Company import parks every imported agent as a safety default, and issue assignment wakes are dropped for paused agents
> - The pause was recorded as the generic reason "system" and was almost invisible: the chat-style task thread showed nothing, the legacy notice had no action, and the new-task dialog gave no hint
> - Users assigned tasks in an imported company, nothing ran, and there was no explanation — the imported company looked broken
> - This pull request records a dedicated "import" pause reason and makes the paused state visible and fixable where the user is looking
> - The benefit is that a silent no-op becomes an explained state with a one-click resume

## Linked Issues or Issue Description

**What existing behavior does this improve?**

Working with a company whose agents arrived paused from a company import.

**Subsystem affected**

Shared constants (`PAUSE_REASONS`), company import service (`server/src/services/company-portability.ts`), task thread and new-task dialog UI.

**Current behavior**

Imported agents get `pauseReason: "system"`, the same value plugin-managed and built-in agent pauses use. Assigning an issue to a paused agent silently drops the wake. The chat-style task thread renders no paused notice; the legacy thread's notice says "It was paused by the system." with no action and only renders when the composer is shown.

**Proposed behavior**

Import writes `pauseReason: "import"`. The paused-assignee notice explains the import pause, offers an inline "Resume agent" button (suppressed for budget pauses, which clear on their own), and renders for read-only viewers. The chat-style task thread shows the same notice above the composer. The new-task dialog warns when the selected assignee is paused.

**Breaking changes**

None. `PAUSE_REASONS` is widened, not changed; the column already stores free-text values in other paths, and every consumer is an equality check with a manual fallback, so an older client shows the generic fallback copy for the new value.

## What Changed

- `packages/shared/src/constants.ts`: `"import"` added to `PAUSE_REASONS`.
- `server/src/services/company-portability.ts`: the import pause patch writes `pauseReason: "import"`.
- `ui/src/components/IssueChatThread.tsx`: `IssueAssigneePausedNotice` gains import copy, a Resume button, test ids, and is exported; it now renders even when the composer is hidden. New `onResumeAssignee` / `resumeAssigneePending` props.
- `ui/src/components/TaskChatThread.tsx`: renders the paused-assignee notice above the composer dock (the chat-style thread previously had no paused surface at all).
- `ui/src/pages/IssueDetail.tsx`: wires a resume mutation (`agentsApi.resume`) through both thread variants and invalidates the company agent list.
- `ui/src/components/NewIssueDialog.tsx`: inline note when the chosen assignee is paused, with import-specific copy.

## Verification

- `cd server && npx vitest run src/__tests__/company-portability.test.ts` — 82 tests pass (pause pin updated to `"import"`).
- `cd ui && npx vitest run src/components/IssueChatThread.test.tsx src/components/NewIssueDialog.test.tsx src/components/TaskChatThread.test.tsx` — 120 tests pass (new: notice copy per reason, resume click, budget suppression, active-agent null render, dialog note).
- `pnpm run typecheck` in `packages/shared`, `server`, and `ui` — clean.

## Risks

- Low risk. The resume action calls the existing `POST /agents/:id/resume` route with its existing guards. Existing rows keep `"system"` and fall back to the current generic copy; only new imports write `"import"`.

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic) with extended thinking and tool use, via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
