### PR TITLE
Allow active watchdog runs to refresh stale scope

### DIFF
--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -23,6 +23,7 @@ export const API = {
   issues: `${API_PREFIX}/issues`,
   stalledReviewDecision: `${API_PREFIX}/issues/:issueId/stalled-review-decision`,
   issueWatchdog: `${API_PREFIX}/issues/:issueId/watchdog`,
+  issueWatchdogRefresh: `${API_PREFIX}/issues/:issueId/watchdog/refresh`,
   issueTreeControl: `${API_PREFIX}/issues/:issueId/tree-control`,
   issueTreeHolds: `${API_PREFIX}/issues/:issueId/tree-holds`,
   summarySlot: `${API_PREFIX}/companies/:companyId/summary-slots/:scopeKind/:slotKey`,

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -100,6 +100,11 @@ const mockTaskWatchdogService = vi.hoisted(() => ({
     allowed: true,
     classification: { state: "stopped", stopFingerprint: "task_watchdog_stop:test" },
   })),
+  refreshMutationScope: vi.fn(async () => ({
+    allowed: true,
+    changed: false,
+    classification: { state: "stopped", stopFingerprint: "task_watchdog_stop:test" },
+  })),
   reconcileForIssueAndAncestors: vi.fn(async () => ({
     checked: 0,
     triggered: 0,

--- a/server/src/__tests__/issue-watchdogs-routes.test.ts
+++ b/server/src/__tests__/issue-watchdogs-routes.test.ts
@@ -518,6 +518,85 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
     expect(allowedChild.body.parentId).toBe(watchedChildId);
   });
 
+  it("lets a watchdog refresh a stale stopped fingerprint before recording its finding", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Refreshing Watchdog" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root", identifier: "WDOG-REFRESH" });
+    const replacementAssigneeId = await seedAgent(companyId, { name: "Replacement assignee" });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Watchdog review",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const [runBeforeRefresh] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    const originalFingerprint = (runBeforeRefresh?.contextSnapshot as {
+      taskWatchdog?: { stopFingerprint?: string };
+    })?.taskWatchdog?.stopFingerprint;
+    expect(originalFingerprint).toMatch(/^task_watchdog_stop:/);
+
+    // This is a material stopped-subtree change, but it does not restore a
+    // live path. The run must explicitly re-read and re-pin before mutating.
+    await db
+      .update(issues)
+      .set({ assigneeAgentId: replacementAssigneeId, updatedAt: new Date() })
+      .where(eq(issues.id, watchedRootId));
+
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    const staleComment = await request(app)
+      .post(`/api/issues/${watchedRootId}/comments`)
+      .send({ body: "Finding before refresh" });
+    expect(staleComment.status, JSON.stringify(staleComment.body)).toBe(409);
+
+    const refreshed = await request(app).post(`/api/issues/${watchedRootId}/watchdog/refresh`);
+    expect(refreshed.status, JSON.stringify(refreshed.body)).toBe(200);
+    expect(refreshed.body).toMatchObject({ changed: true, stopFingerprint: expect.any(String) });
+    expect(refreshed.body.stopFingerprint).not.toBe(originalFingerprint);
+
+    const [runAfterRefresh] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect((runAfterRefresh?.contextSnapshot as {
+      taskWatchdog?: { stopFingerprint?: string };
+    })?.taskWatchdog?.stopFingerprint).toBe(refreshed.body.stopFingerprint);
+
+    const freshComment = await request(app)
+      .post(`/api/issues/${watchedRootId}/comments`)
+      .send({ body: "Finding after refresh" });
+    expect(freshComment.status, JSON.stringify(freshComment.body)).toBe(201);
+
+    const refreshActivity = await db
+      .select({ details: activityLog.details })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.entityId, watchedRootId),
+        eq(activityLog.action, "issue.task_watchdog_scope_refreshed"),
+      ));
+    expect(refreshActivity).toHaveLength(1);
+    expect(refreshActivity[0]?.details).toMatchObject({
+      previousStopFingerprint: originalFingerprint,
+      stopFingerprint: refreshed.body.stopFingerprint,
+      changed: true,
+    });
+  });
+
   it("routes watchdog-discovered product bugs outside the watched source tree with evidence links", async () => {
     const companyId = await seedCompany();
     const watchdogAgentId = await seedAgent(companyId, { name: "Product Bug Watchdog" });

--- a/server/src/__tests__/issue-watchdogs-routes.test.ts
+++ b/server/src/__tests__/issue-watchdogs-routes.test.ts
@@ -597,6 +597,107 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
     });
   });
 
+  it.each(["live", "already_reviewed", "not_applicable"] as const)(
+    "keeps refresh deny-by-default when the watched subtree is %s",
+    async (state) => {
+      const companyId = await seedCompany();
+      const watchdogAgentId = await seedAgent(companyId, { name: `Deny ${state} watchdog` });
+      const watchedRootId = await seedIssue(companyId, { title: "Watched root" });
+      const watchdogIssueId = await seedIssue(companyId, {
+        title: "Watchdog review",
+        parentId: watchedRootId,
+        assigneeAgentId: watchdogAgentId,
+        originKind: "task_watchdog",
+        originId: watchedRootId,
+      });
+      const runId = await seedWatchdogRun({
+        companyId,
+        watchdogAgentId,
+        watchedIssueId: watchedRootId,
+        watchdogIssueId,
+      });
+      const [runBeforeRefresh] = await db
+        .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      const originalFingerprint = (runBeforeRefresh?.contextSnapshot as {
+        taskWatchdog?: { stopFingerprint?: string };
+      })?.taskWatchdog?.stopFingerprint;
+
+      if (state === "live") {
+        await db.insert(heartbeatRuns).values({
+          companyId,
+          agentId: watchdogAgentId,
+          status: "running",
+          contextSnapshot: { issueId: watchedRootId },
+        });
+      } else if (state === "already_reviewed") {
+        await db
+          .update(issueWatchdogs)
+          .set({ lastReviewedFingerprint: originalFingerprint })
+          .where(and(
+            eq(issueWatchdogs.companyId, companyId),
+            eq(issueWatchdogs.issueId, watchedRootId),
+          ));
+      } else {
+        await db
+          .update(issues)
+          .set({ originKind: "task_watchdog", updatedAt: new Date() })
+          .where(eq(issues.id, watchedRootId));
+      }
+
+      const app = createApp(companyId, {
+        type: "agent",
+        agentId: watchdogAgentId,
+        companyId,
+        runId,
+        source: "agent_jwt",
+      });
+      const refreshed = await request(app).post(`/api/issues/${watchedRootId}/watchdog/refresh`);
+      expect(refreshed.status, JSON.stringify(refreshed.body)).toBe(409);
+      expect(refreshed.body.details.currentState).toBe(state);
+
+      const [runAfterRefresh] = await db
+        .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      expect((runAfterRefresh?.contextSnapshot as {
+        taskWatchdog?: { stopFingerprint?: string };
+      })?.taskWatchdog?.stopFingerprint).toBe(originalFingerprint);
+    },
+  );
+
+  it("rejects a refresh from a watchdog run that is no longer in flight", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Terminal watchdog" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root" });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Watchdog review",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    await db.update(heartbeatRuns).set({ status: "succeeded" }).where(eq(heartbeatRuns.id, runId));
+
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    const refreshed = await request(app).post(`/api/issues/${watchedRootId}/watchdog/refresh`);
+    expect(refreshed.status, JSON.stringify(refreshed.body)).toBe(409);
+    expect(refreshed.body.error).toContain("no longer in flight");
+  });
+
   it("routes watchdog-discovered product bugs outside the watched source tree with evidence links", async () => {
     const companyId = await seedCompany();
     const watchdogAgentId = await seedAgent(companyId, { name: "Product Bug Watchdog" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6781,6 +6781,76 @@ export function issueRoutes(
     res.json(watchdog);
   });
 
+  router.post("/issues/:id/watchdog/refresh", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await getAccessibleResource(req, res, getIssueById(req, id), "Issue not found");
+    if (!issue) return;
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+    if (req.actor.type !== "agent") {
+      res.status(403).json({ error: "Only an in-flight task-watchdog run can refresh its mutation scope." });
+      return;
+    }
+    const runId = requireAgentRunId(req, res);
+    if (!runId) return;
+    const scope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    if (scope.kind !== "watchdog") {
+      res.status(403).json({
+        error: scope.kind === "invalid"
+          ? scope.detail
+          : "This agent run does not have a task-watchdog mutation scope to refresh.",
+      });
+      return;
+    }
+    if (scope.watchedIssueId !== issue.id) {
+      res.status(403).json({ error: "Task-watchdog runs can only refresh the watched source issue scope." });
+      return;
+    }
+
+    const refreshed = await taskWatchdogsSvc.refreshMutationScope({
+      ...scope,
+      runId,
+      agentId: req.actor.agentId,
+    });
+    if (!refreshed.allowed) {
+      res.status(409).json({
+        error: refreshed.reason,
+        details: {
+          watchedIssueId: scope.watchedIssueId,
+          watchdogId: scope.watchdogId,
+          runStopFingerprint: scope.stopFingerprint,
+          currentState: refreshed.classification?.state ?? null,
+          currentStopFingerprint: refreshed.classification && "stopFingerprint" in refreshed.classification
+            ? refreshed.classification.stopFingerprint
+            : null,
+        },
+      });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      agentApiKeyId: actor.agentApiKeyId,
+      action: "issue.task_watchdog_scope_refreshed",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        watchdogId: scope.watchdogId,
+        previousStopFingerprint: scope.stopFingerprint,
+        stopFingerprint: refreshed.classification.stopFingerprint,
+        changed: refreshed.changed,
+      },
+    });
+    res.json({
+      stopFingerprint: refreshed.classification.stopFingerprint,
+      changed: refreshed.changed,
+    });
+  });
+
   router.delete("/issues/:id/watchdog", async (req, res) => {
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, getIssueById(req, id), "Issue not found");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -420,6 +420,24 @@ function noopTaskWatchdogService(): TaskWatchdogService {
         pendingInteractionsByIssueId: {},
       },
     }),
+    refreshMutationScope: async () => ({
+      allowed: true,
+      changed: false,
+      classification: {
+        state: "stopped",
+        reason: "Task watchdog service unavailable in this route context.",
+        includedIssueIds: [],
+        stopFingerprint: "task_watchdog_stop:unavailable",
+        stoppedLeaves: [],
+        stopSnapshot: {
+          version: 2,
+          fingerprint: "task_watchdog_stop:unavailable",
+          materialLeaves: [],
+          waitsByIssueId: {},
+        },
+        pendingInteractionsByIssueId: {},
+      },
+    }),
   };
 }
 
@@ -6790,6 +6808,11 @@ export function issueRoutes(
       res.status(403).json({ error: "Only an in-flight task-watchdog run can refresh its mutation scope." });
       return;
     }
+    const agentId = req.actor.agentId;
+    if (!agentId) {
+      res.status(401).json({ error: "Agent authentication required" });
+      return;
+    }
     const runId = requireAgentRunId(req, res);
     if (!runId) return;
     const scope = await resolveTaskWatchdogMutationScope(db, req.actor);
@@ -6809,7 +6832,7 @@ export function issueRoutes(
     const refreshed = await taskWatchdogsSvc.refreshMutationScope({
       ...scope,
       runId,
-      agentId: req.actor.agentId,
+      agentId,
     });
     if (!refreshed.allowed) {
       res.status(409).json({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2332,6 +2332,15 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "post",
+  path: "/api/issues/{id}/watchdog/refresh",
+  tags: ["issues"],
+  summary: "Refresh an in-flight task-watchdog run's stopped-subtree mutation scope",
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound, 409: r.conflict },
+});
+
+registry.registerPath({
   method: "delete",
   path: "/api/issues/{id}/watchdog",
   tags: ["issues"],

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1657,6 +1657,96 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     };
   }
 
+  async function refreshMutationScope(scope: {
+    kind: "watchdog";
+    watchdogId: string;
+    companyId: string;
+    watchedIssueId: string;
+    stopFingerprint: string | null;
+    runId: string;
+    agentId: string;
+  }) {
+    const revalidated = await revalidateMutationScope(scope);
+    if (revalidated.allowed) {
+      return {
+        allowed: true as const,
+        changed: false as const,
+        classification: revalidated.classification,
+      };
+    }
+
+    const watchdog = await db
+      .select()
+      .from(issueWatchdogs)
+      .where(and(
+        eq(issueWatchdogs.id, scope.watchdogId),
+        eq(issueWatchdogs.companyId, scope.companyId),
+        eq(issueWatchdogs.issueId, scope.watchedIssueId),
+        eq(issueWatchdogs.watchdogAgentId, scope.agentId),
+        eq(issueWatchdogs.status, "active"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    if (!watchdog) {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog run context is not backed by an active persisted watchdog.",
+      };
+    }
+
+    const input = await collectClassifierInput(watchdog.companyId, watchdog);
+    const classification = classifyTaskWatchdogSubtree(input);
+    if (classification.state !== "stopped") {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog review cannot refresh because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path.",
+        classification,
+      };
+    }
+
+    const [run] = await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: sql`
+          case
+            when jsonb_typeof(${heartbeatRuns.contextSnapshot}->'taskWatchdog') = 'object'
+              then jsonb_set(
+                ${heartbeatRuns.contextSnapshot},
+                '{taskWatchdog,stopFingerprint}',
+                to_jsonb(${classification.stopFingerprint}::text),
+                true
+              )
+            else jsonb_set(
+              coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb),
+              '{taskWatchdog}',
+              jsonb_build_object(
+                'watchedIssueId', ${scope.watchedIssueId},
+                'stopFingerprint', ${classification.stopFingerprint}
+              ),
+              true
+            )
+          end
+        `,
+      })
+      .where(and(
+        eq(heartbeatRuns.id, scope.runId),
+        eq(heartbeatRuns.companyId, scope.companyId),
+        eq(heartbeatRuns.agentId, scope.agentId),
+      ))
+      .returning({ id: heartbeatRuns.id });
+    if (!run) {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog run context is no longer available to refresh.",
+      };
+    }
+
+    return {
+      allowed: true as const,
+      changed: scope.stopFingerprint !== classification.stopFingerprint,
+      classification,
+    };
+  }
+
   return {
     getActiveForIssue: async (companyId: string, issueId: string): Promise<IssueWatchdog | null> => {
       const row = await db
@@ -1811,5 +1901,6 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     },
 
     revalidateMutationScope,
+    refreshMutationScope,
   };
 }

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1666,6 +1666,25 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     runId: string;
     agentId: string;
   }) {
+    // A completed run must not be able to regain its mutation grant by
+    // refreshing its historical context snapshot.
+    const activeRun = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.id, scope.runId),
+        eq(heartbeatRuns.companyId, scope.companyId),
+        eq(heartbeatRuns.agentId, scope.agentId),
+        eq(heartbeatRuns.status, "running"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    if (!activeRun) {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog run is no longer in flight and cannot refresh its mutation scope.",
+      };
+    }
+
     const revalidated = await revalidateMutationScope(scope);
     if (revalidated.allowed) {
       return {
@@ -1731,6 +1750,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         eq(heartbeatRuns.id, scope.runId),
         eq(heartbeatRuns.companyId, scope.companyId),
         eq(heartbeatRuns.agentId, scope.agentId),
+        eq(heartbeatRuns.status, "running"),
       ))
       .returning({ id: heartbeatRuns.id });
     if (!run) {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1738,8 +1738,8 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
               coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb),
               '{taskWatchdog}',
               jsonb_build_object(
-                'watchedIssueId', ${scope.watchedIssueId},
-                'stopFingerprint', ${classification.stopFingerprint}
+                'watchedIssueId', ${scope.watchedIssueId}::text,
+                'stopFingerprint', ${classification.stopFingerprint}::text
               ),
               true
             )


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Task watchdogs keep issue work moving through verified recovery paths.
> - A watchdog run uses a pinned stop fingerprint to prevent stale mutations.
> - A permitted watchdog record update can change that fingerprint during the same run.
> - The run then cannot record its completed work, even when its watched scope is still stopped.
> - This pull request adds a guarded refresh path for the active run and tests its allowed and denied cases.
> - The benefit is that a valid watchdog run can finish its approved work without weakening stale-scope protection.

## Linked Issues or Issue Description

**What happened?**

An active task-watchdog run could update its persisted watchdog record, move the watched scope's stop fingerprint, and then fail its later gated mutation because the pinned fingerprint was stale.

**Expected behavior**

An active watchdog run can refresh its own pinned stop fingerprint only when its persisted scope is still stopped. The route rejects a refreshed fingerprint for a live, reviewed, not-applicable, or no-longer-running scope.

**Steps to reproduce**

1. Start a task-watchdog run for a stopped issue subtree.
2. Make an allowed watchdog-record update that changes the material stop fingerprint.
3. Attempt a later gated mutation using the original pinned fingerprint.

**Paperclip version or commit**

8f6c40428afe3b7ff6cb94cc70c57832c35f891b

**Deployment mode**

Built from source.

Related public work: #10224, #10331, #10857, and #11111.

## What Changed

- Add an active-run endpoint that refreshes a persisted watchdog scope fingerprint after it confirms the scope is still stopped.
- Preserve deny-by-default behavior for live, reviewed, not-applicable, and inactive-run states.
- Add route coverage for the success case and all refresh denials.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-watchdogs-routes.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- `git diff --check origin/master...HEAD`

## Risks

Low risk. The new refresh route can only update the active run's persisted fingerprint after it revalidates the scoped subtree as stopped. It does not change the underlying watchdog mutation guards.

## Model Used

OpenAI Codex, GPT-5.6, 114k-token context window, agentic reasoning with shell and code-execution tools. The model assisted with publication validation and this PR description. The code commits were inherited and not changed in this delivery task.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details (the inherited branch is retained unchanged to publish its approved commits)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (the API contract and OpenAPI route are self-describing; no operator documentation changes are required)
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
