### PR TITLE
Let agents name the board or a company user as unblock owner

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1,4 +1,5 @@
 import { Readable } from "node:stream";
+import { getTableName } from "drizzle-orm";
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -291,6 +292,9 @@ function createRunContextDb(
   contextSnapshot: Record<string, unknown> = {},
   runAgentOrRows: string | Record<string, unknown>[] = ownerAgentId,
   runId: string = ownerRunId,
+  // Rows keyed by physical table name, for lookups the generic selection-shape
+  // fallback below cannot tell apart (agents vs company_memberships both select `id`).
+  tableRowOverrides: Record<string, unknown[]> = {},
 ) {
   const runRows = Array.isArray(runAgentOrRows)
     ? runAgentOrRows
@@ -304,7 +308,20 @@ function createRunContextDb(
   const firstRun = runRows[0] ?? {};
   const runAgentId = typeof firstRun.agentId === "string" ? firstRun.agentId : ownerAgentId;
   const runAgentCompanyId = typeof firstRun.agentCompanyId === "string" ? firstRun.agentCompanyId : companyId;
-  const rowsForSelection = async (selection: Record<string, unknown>) => {
+  const overriddenTables = Object.keys(tableRowOverrides);
+  const rowsForTable = (table: unknown) => {
+    if (overriddenTables.length === 0 || !table) return undefined;
+    let tableName: string;
+    try {
+      tableName = getTableName(table as Parameters<typeof getTableName>[0]);
+    } catch {
+      return undefined;
+    }
+    return tableRowOverrides[tableName];
+  };
+  const rowsForSelection = async (selection: Record<string, unknown>, table?: unknown) => {
+    const overrideRows = rowsForTable(table);
+    if (overrideRows) return overrideRows;
     const keys = Object.keys(selection);
     if (keys.includes("entityId")) return [];
     if (keys.includes("contextSnapshot")) return runRows;
@@ -315,16 +332,16 @@ function createRunContextDb(
     }
     return [{ id: runAgentId, companyId: runAgentCompanyId, permissions: {}, role: "engineer", reportsTo: null }];
   };
-  const buildQuery = (selection: Record<string, unknown>) => {
+  const buildQuery = (selection: Record<string, unknown>, table?: unknown) => {
     const whereResult = {
       orderBy: vi.fn(async () => []),
       limit: vi.fn(() => ({
-        then: async (resolve: (limitedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection)),
+        then: async (resolve: (limitedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection, table)),
       })),
       for: vi.fn(() => ({
-        then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection)),
+        then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection, table)),
       })),
-      then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection)),
+      then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection, table)),
     };
     const query = {
       innerJoin: vi.fn(() => query),
@@ -335,7 +352,7 @@ function createRunContextDb(
   const dbStub = {
     transaction: async (callback: (tx: typeof dbStub) => Promise<unknown>) => callback(dbStub),
     select: vi.fn((selection: Record<string, unknown> = {}) => ({
-      from: vi.fn(() => buildQuery(selection)),
+      from: vi.fn((table: unknown) => buildQuery(selection, table)),
     })),
     insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
   };
@@ -1640,12 +1657,96 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["board", "board"],
     ["a company user", { userId: "board-user" }],
-  ])("rejects an agent naming %s as unblock owner", async (_label, unblockOwner) => {
-    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+  ])("allows an agent to name %s as unblock owner when entering blocked", async (_label, unblockOwner) => {
+    const existing = makeIssue({ status: "in_progress" });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...existing,
+      ...patch,
+    }));
 
     const res = await request(await createApp(ownerActor())).patch(`/api/issues/${issueId}`).send({
       status: "blocked",
       unblockDescriptor: { owner: unblockOwner, action: "Review the blocker" },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+        unblockDescriptor: { owner: unblockOwner, action: "Review the blocker" },
+      }),
+    );
+  });
+
+  it.each([
+    ["board", "board"],
+    ["a company user", { userId: "board-user" }],
+  ])("allows an agent to change an already-blocked issue owner to %s", async (_label, unblockOwner) => {
+    const existing = makeIssue({ status: "blocked" });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...existing,
+      ...patch,
+    }));
+
+    const res = await request(await createApp(ownerActor())).patch(`/api/issues/${issueId}`).send({
+      unblockDescriptor: { owner: unblockOwner, action: "Review the blocker" },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        unblockDescriptor: { owner: unblockOwner, action: "Review the blocker" },
+      }),
+    );
+  });
+
+  it("allows an agent to name itself as unblock owner", async () => {
+    const existing = makeIssue({ status: "in_progress" });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...existing,
+      ...patch,
+    }));
+
+    const res = await request(await createApp(ownerActor())).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: { owner: { agentId: ownerAgentId }, action: "Review the blocker" },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+        unblockDescriptor: { owner: { agentId: ownerAgentId }, action: "Review the blocker" },
+      }),
+    );
+  });
+
+  it("rejects an agent naming a user who is not an active company member", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    const routeDb = createRunContextDb({}, ownerAgentId, ownerRunId, { company_memberships: [] });
+
+    const res = await request(await createApp(ownerActor(), routeDb)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: { owner: { userId: "outsider-user" }, action: "Review the blocker" },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toBe("Unblock owner user must be an active company member");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent naming another agent as unblock owner", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+
+    const res = await request(await createApp(ownerActor())).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: { owner: { agentId: peerAgentId }, action: "Review the blocker" },
     });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
@@ -1653,18 +1754,17 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["board", "board"],
-    ["a company user", { userId: "board-user" }],
-  ])("rejects an agent changing an already-blocked issue owner to %s", async (_label, unblockOwner) => {
-    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked" }));
+  it("rejects an agent naming an agent outside the issue company as unblock owner", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    const routeDb = createRunContextDb({}, ownerAgentId, ownerRunId, { agents: [] });
 
-    const res = await request(await createApp(ownerActor())).patch(`/api/issues/${issueId}`).send({
-      unblockDescriptor: { owner: unblockOwner, action: "Review the blocker" },
+    const res = await request(await createApp(ownerActor(), routeDb)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: { owner: { agentId: peerAgentId }, action: "Review the blocker" },
     });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Agents may only name themselves as an unblock owner");
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toBe("Unblock owner agent must belong to the issue company");
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9693,10 +9693,10 @@ export function issueRoutes(
     }
     const descriptor = updateFields.unblockDescriptor ?? null;
     if (descriptor && typeof descriptor === "object") {
+      // Agents may route a human-only unblock action to the board or to an active
+      // company member; naming another *agent* stays self-only so an agent cannot
+      // park work on a peer.
       const owner = descriptor.owner;
-      if (req.actor.type === "agent" && (owner === "board" || "userId" in owner)) {
-        throw forbidden("Agents may only name themselves as an unblock owner");
-      }
       if (owner !== "board" && "agentId" in owner) {
         const target = await db.select({ id: agents.id }).from(agents).where(and(
           eq(agents.id, owner.agentId),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues have a `blocked` status, and `unblockDescriptor` records who must act next and what that action is
> - An agent can find a blocker only a human can clear, for example a missing repository permission
> - `PATCH /api/issues/:id` rejected every non-self owner from an agent actor, so the agent could only name itself
> - Naming itself is false, and the agent will never resolve that action, so the board view becomes misleading
> - This pull request lets an agent name the board or an active company user as the unblock owner
> - Agent owners stay self-only, so an agent still cannot park work on a peer
> - The benefit is that a blocked issue shows the real owner, and the attention list routes it to that human

## Linked Issues or Issue Description

No public GitHub issue exists for this. The bug is described below.

Refs #11955 — that open PR relaxes the same authorization block for a different case. It lets a child agent name the parent issue assignee, and it keeps the board and user restriction that this PR removes. The two changes are complementary in behavior but they touch the same lines, so whichever lands second needs a rebase.

Refs #10366 — related routing work on unblock owners. It is a different key, `reportsTo` ancestry, and it does not overlap this diff.

**What happened?**

`PATCH /api/issues/:id` returns `403 Agents may only name themselves as an unblock owner` when an agent actor sends `unblockDescriptor.owner` as `"board"` or `{"userId": "..."}`. The request schema accepts both shapes, and the union error message offers `"board"`, but the route authorization layer rejects them for agent actors. An agent that has verified it cannot clear a blocker has only two options. It can name itself, which is untrue and never self-resolves. It can avoid `blocked` altogether. Both give the board a wrong view of the work.

**Expected behavior**

An agent can name the board or an active company user as the unblock owner when the next action belongs to a human. The server keeps its other guarantees. An agent owner must still be the caller and must belong to the issue company. A user owner must still be an active member of the issue company. `unblockDescriptor` still requires `blocked` status.

**Steps to reproduce**

1. Authenticate as an agent with `issue:mutate` on an issue in its own company.
2. Send `PATCH /api/issues/:id` with `{"status":"blocked","unblockDescriptor":{"owner":"board","action":"Merge the approved PR"}}`.
3. The response is `403 Agents may only name themselves as an unblock owner`.
4. Repeat with `"owner": {"userId":"<active member id>"}` and get the same `403`.

**Paperclip version or commit**

`master` at 8d714c2d8.

**Agent adapter(s) involved**

Not adapter-specific (core bug). The gate is in the server route, so every adapter hits it.

**Access context**

Agent API key actor. Board and user actors were never blocked by this gate.

## What Changed

- `server/src/routes/issues.ts`: removed the blanket rejection of `"board"` and `{userId}` owners for agent actors in the `unblockDescriptor` authorization block.
- Kept the agent-owner rules unchanged: the owner agent must belong to the issue company (`422`), and an agent actor must name itself (`403`).
- Kept the user-owner rule unchanged: the owner must be an active company member (`422`).
- `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`: replaced the two rejection cases with acceptance cases, and added rejection cases for the rules that must stay.
- Made the test database stub table-aware, because the agent lookup and the membership lookup both select `id` and the previous stub could not tell them apart.

## Verification

Command:

```
npx vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
```

Result: `91 passed`.

New and changed cases in that file:

- An agent names `"board"` or `{userId}` when it enters `blocked`. Both return `200`, and the descriptor reaches `issues.update` unchanged.
- An agent changes the owner of an issue that is already `blocked` to `"board"` or `{userId}`. Both return `200`.
- An agent names itself. Returns `200`. This locks the preserved path.
- An agent names a user who is not an active member. Returns `422 Unblock owner user must be an active company member`.
- An agent names a different agent. Returns `403 Agents may only name themselves as an unblock owner`.
- An agent names an agent outside the issue company. Returns `422 Unblock owner agent must belong to the issue company`.

Related suites, to show no regression:

```
npx vitest run server/src/__tests__/routable-blocked.test.ts \
  server/src/__tests__/issue-dependency-wakeups-routes.test.ts \
  packages/shared/src/validators/issue.test.ts
```

Result: `43 passed`.

Typecheck:

```
cd server && npx tsc --noEmit
```

Result: clean.

Two related suites use an embedded Postgres and did not start in my sandbox: `server/src/__tests__/attention-service.test.ts` and `server/src/__tests__/low-trust-red-team-routes.test.ts`. I read both. Each one uses a board actor for its `unblockDescriptor` cases, and a board actor never met the removed gate. CI runs both.

## Risks

Low risk. The change removes one authorization branch and adds no new write path.

- The descriptor is still validated by the same schema, and it still requires `blocked` status.
- Membership and same-company checks are unchanged, so an agent cannot name a user outside the company or an agent in another company.
- `deliverAgentUnblockNotification` already returns early for `"board"` and `{userId}` owners, so no agent wake-up fires for a human owner.
- The attention service already builds a board item from a human-owned descriptor, so the new owners appear in the existing surface with no client change.
- To revert, restore the removed conditional in `server/src/routes/issues.ts` and the two rejection cases in the test file. There is no migration and no stored data shape change.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`, 1M context), extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation states this authorization rule. I searched `doc/`, `docs/`, and every tracked `.md`, `.yaml`, and `.json` file for `unblockDescriptor` and found no match. The rule lived only in the route and its tests.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
