### PR TITLE
perf(server): gate the decision retention sweep and probe for newer runs per failed-run key

### DIFF
--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -944,6 +944,74 @@ describeEmbeddedPostgres("attention service", () => {
     expect(feed.items.filter((item) => item.sourceKind === "failed_run")).toEqual([]);
   });
 
+  it("suppresses a context-less failed run only after a newer context-less run of the same agent", async () => {
+    const { companyId, workerId, reviewerId } = await seedCompany("ATN");
+    const issueId = await insertIssue({
+      companyId,
+      identifier: "ATN-1",
+      title: "Unrelated issue",
+      status: "in_progress",
+    });
+    const exhaustedAt = new Date("2026-07-09T12:00:00.000Z");
+    const exhaustedRun = (id: string, agentId: string) => ({
+      id,
+      companyId,
+      agentId,
+      invocationSource: "automation" as const,
+      status: "failed" as const,
+      error: "adapter failed",
+      contextSnapshot: null,
+      createdAt: exhaustedAt,
+      updatedAt: exhaustedAt,
+      finishedAt: exhaustedAt,
+    });
+    const workerRunId = randomUUID();
+    const reviewerRunId = randomUUID();
+    await db.insert(heartbeatRuns).values([
+      exhaustedRun(workerRunId, workerId),
+      exhaustedRun(reviewerRunId, reviewerId),
+      {
+        // Newer run, but on an issue: does not clear the worker's context-less failure.
+        id: randomUUID(),
+        companyId,
+        agentId: workerId,
+        invocationSource: "automation",
+        status: "succeeded",
+        contextSnapshot: { issueId },
+        createdAt: new Date("2026-07-09T12:01:00.000Z"),
+        updatedAt: new Date("2026-07-09T12:01:00.000Z"),
+        finishedAt: new Date("2026-07-09T12:01:00.000Z"),
+      },
+      {
+        // Newer context-less run: clears the reviewer's failure.
+        id: randomUUID(),
+        companyId,
+        agentId: reviewerId,
+        invocationSource: "timer",
+        status: "succeeded",
+        contextSnapshot: {},
+        createdAt: new Date("2026-07-09T12:01:00.000Z"),
+        updatedAt: new Date("2026-07-09T12:01:00.000Z"),
+        finishedAt: new Date("2026-07-09T12:01:00.000Z"),
+      },
+    ]);
+    await db.insert(heartbeatRunEvents).values([workerRunId, reviewerRunId].map((runId, index) => ({
+      companyId,
+      runId,
+      agentId: index === 0 ? workerId : reviewerId,
+      seq: 1,
+      eventType: "lifecycle",
+      message: "Bounded retry exhausted after 4 scheduled attempts; no further automatic retry will be queued",
+      createdAt: new Date("2026-07-09T12:00:01.000Z"),
+    })));
+
+    const feed = await attentionService(db).list(companyId, { userId: "board-user" });
+
+    expect(feed.items.filter((item) => item.sourceKind === "failed_run").map((item) => item.subject.id)).toEqual([
+      workerRunId,
+    ]);
+  });
+
   it("enriches interaction details with project, workspace, plan metadata, and images", async () => {
     const { companyId, workerId } = await seedCompany("ATE");
     const projectId = randomUUID();

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -86,6 +86,7 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  decisionRetentionSweepIntervalMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -348,6 +349,10 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    decisionRetentionSweepIntervalMs: Math.max(
+      10000,
+      Number(process.env.PAPERCLIP_DECISION_RETENTION_SWEEP_INTERVAL_MS) || 5 * 60_000,
+    ),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1419,6 +1419,27 @@ export async function startServer(): Promise<StartedServer> {
       return { archived, ...notifications };
     };
     await runRetentionSweep();
+    // The sweep rebuilds every active company's full attention feed
+    // (dismissed rows included, unscoped). On a large instance one build takes
+    // longer than a scheduler tick, so it runs on its own interval and never
+    // overlaps itself: a tick that finds a sweep in flight skips it.
+    let retentionSweepInFlight: Promise<void> | null = null;
+    let retentionSweepLastStartedAt = Date.now();
+    const scheduleRetentionSweep = () => {
+      if (retentionSweepInFlight) return;
+      const now = Date.now();
+      if (now - retentionSweepLastStartedAt < config.decisionRetentionSweepIntervalMs) return;
+      retentionSweepLastStartedAt = now;
+      retentionSweepInFlight = runRetentionSweep()
+        .then(() => undefined)
+        .catch((err: unknown) => {
+          logger.error({ err }, "decision retention sweep failed");
+        })
+        .finally(() => {
+          retentionSweepInFlight = null;
+        });
+      trackHeartbeatSchedulerWork(retentionSweepInFlight);
+    };
 
     startHeartbeatSchedulerInterval(() => {
       // Track the outer async callback as well as the work it starts. Shutdown
@@ -1429,9 +1450,7 @@ export async function startServer(): Promise<StartedServer> {
         trackHeartbeatSchedulerWork(decisionExecutor.sweepExpired().catch((err: unknown) => {
           logger.error({ err }, "decision expiry sweep failed");
         }));
-        trackHeartbeatSchedulerWork(runRetentionSweep().catch((err: unknown) => {
-          logger.error({ err }, "decision retention sweep failed");
-        }));
+        scheduleRetentionSweep();
         const sweptRuntimeStatuses = heartbeat.sweepExpiredRuntimeStatuses();
         if (sweptRuntimeStatuses > 0) {
           logger.info(

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -1067,6 +1067,82 @@ function readRunIssueId(contextSnapshot: Record<string, unknown> | null) {
   return typeof issueId === "string" && issueId.length > 0 ? issueId : null;
 }
 
+type FailedRunKey = { agentId: string; issueId: string | null; createdAt: Date };
+
+const FAILED_RUN_KEY_PROBE_CHUNK_SIZE = 500;
+
+function failedRunKey(agentId: string, issueId: string | null) {
+  return `${agentId}:${issueId ?? ""}`;
+}
+
+/**
+ * Returns the keys (see failedRunKey) that have at least one run created after
+ * the key's createdAt for the same agent and issue context. Matching mirrors
+ * readRunIssueId: a run is on issue X when context_snapshot.issueId is X, or
+ * when issueId is absent and taskId is X; a run has no issue context when
+ * both are absent or empty. Each EXISTS is a plain conjunction with created_at
+ * in it, so the planner serves it as a bounded range on the
+ * heartbeat_runs_company_ctx_{issue,task}_created_idx expression indexes.
+ */
+async function failedRunKeysWithNewerRun(db: Db, companyId: string, keys: FailedRunKey[]) {
+  const found = new Set<string>();
+  const keyed = keys.filter((key) => key.issueId !== null);
+  const unkeyed = keys.filter((key) => key.issueId === null);
+  for (let i = 0; i < keyed.length; i += FAILED_RUN_KEY_PROBE_CHUNK_SIZE) {
+    const chunk = keyed.slice(i, i + FAILED_RUN_KEY_PROBE_CHUNK_SIZE);
+    const rows = (await db.execute(sql`
+      SELECT k.agent_id, k.issue_id
+      FROM (VALUES ${sql.join(
+        chunk.map((key) => sql`(${key.agentId}::uuid, ${key.issueId}::text, ${key.createdAt.toISOString()}::timestamptz)`),
+        sql`, `,
+      )}) AS k(agent_id, issue_id, created_at)
+      WHERE EXISTS (
+        SELECT 1
+        FROM ${heartbeatRuns} r
+        WHERE r.company_id = ${companyId}
+          AND (r.context_snapshot ->> 'issueId') = k.issue_id
+          AND r.created_at > k.created_at
+          AND r.agent_id = k.agent_id
+      ) OR EXISTS (
+        SELECT 1
+        FROM ${heartbeatRuns} r
+        WHERE r.company_id = ${companyId}
+          AND (r.context_snapshot ->> 'issueId') IS NULL
+          AND (r.context_snapshot ->> 'taskId') = k.issue_id
+          AND r.created_at > k.created_at
+          AND r.agent_id = k.agent_id
+      )
+    `)) as unknown as Array<{ agent_id: string; issue_id: string }>;
+    for (const row of rows) found.add(failedRunKey(row.agent_id, row.issue_id));
+  }
+  for (let i = 0; i < unkeyed.length; i += FAILED_RUN_KEY_PROBE_CHUNK_SIZE) {
+    const chunk = unkeyed.slice(i, i + FAILED_RUN_KEY_PROBE_CHUNK_SIZE);
+    const rows = (await db.execute(sql`
+      SELECT k.agent_id
+      FROM (VALUES ${sql.join(
+        chunk.map((key) => sql`(${key.agentId}::uuid, ${key.createdAt.toISOString()}::timestamptz)`),
+        sql`, `,
+      )}) AS k(agent_id, created_at)
+      WHERE (
+        -- Newest-first with LIMIT 1 walks (company_id, created_at DESC) from the
+        -- present and stops at the agent's latest context-less run, instead of
+        -- reading the agent's whole history through the agent index.
+        SELECT 1
+        FROM ${heartbeatRuns} r
+        WHERE r.company_id = ${companyId}
+          AND r.agent_id = k.agent_id
+          AND r.created_at > k.created_at
+          AND ((r.context_snapshot ->> 'issueId') IS NULL OR (r.context_snapshot ->> 'issueId') = '')
+          AND ((r.context_snapshot ->> 'taskId') IS NULL OR (r.context_snapshot ->> 'taskId') = '')
+        ORDER BY r.created_at DESC
+        LIMIT 1
+      ) IS NOT NULL
+    `)) as unknown as Array<{ agent_id: string }>;
+    for (const row of rows) found.add(failedRunKey(row.agent_id, null));
+  }
+  return found;
+}
+
 export function attentionService(db: Db, serviceOptions: AttentionServiceOptions = {}) {
   const openDecisionLimit = Math.min(
     Math.max(Math.trunc(serviceOptions.openDecisionLimit ?? OPEN_DECISION_DEFAULT_LIMIT), 1),
@@ -1754,49 +1830,37 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
       }
       const failedRows = [...latestExhaustedByRunId.values()];
       const failedIssueIds = failedRows.map((row) => readRunIssueId(row.contextSnapshot));
-      const failedAgentIds = [...new Set(failedRows.map((row) => row.agentId))];
-      const oldestFailedRunCreatedAt = failedRows.reduce<Date | null>((oldest, row) => {
-        if (!oldest || row.createdAt < oldest) return row.createdAt;
-        return oldest;
-      }, null);
-      const [failedIssueMap, failedImageMap, newerRuns] = await Promise.all([
+      // One probe per distinct (agent, issue) key instead of scanning every run
+      // newer than the oldest exhausted run. On a long-lived instance that
+      // window spans months and the scan detoasts context_snapshot for every
+      // row (tens of seconds per feed build); the probes ride the
+      // heartbeat_runs_company_ctx_{issue,task}_created_idx expression indexes
+      // and stop at the first newer run.
+      const failedRunKeys = new Map<string, FailedRunKey>();
+      for (const row of failedRows) {
+        const issueId = readRunIssueId(row.contextSnapshot);
+        const key = failedRunKey(row.agentId, issueId);
+        const existing = failedRunKeys.get(key);
+        if (!existing || row.createdAt > existing.createdAt) {
+          failedRunKeys.set(key, { agentId: row.agentId, issueId, createdAt: row.createdAt });
+        }
+      }
+      const [failedIssueMap, failedImageMap, keysWithNewerRun] = await Promise.all([
         issueSummaryMap(
           db,
           companyId,
           failedIssueIds,
         ),
         issueImageMap(db, companyId, failedIssueIds),
-        oldestFailedRunCreatedAt && failedAgentIds.length > 0
-          ? db
-            .select({
-              agentId: heartbeatRuns.agentId,
-              createdAt: heartbeatRuns.createdAt,
-              // Project just the ids readRunIssueId needs; pulling the whole
-              // context_snapshot detoasts megabytes per feed build.
-              runIssueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`,
-              runTaskId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskId'`,
-            })
-            .from(heartbeatRuns)
-            .where(and(
-              eq(heartbeatRuns.companyId, companyId),
-              inArray(heartbeatRuns.agentId, failedAgentIds),
-              gt(heartbeatRuns.createdAt, oldestFailedRunCreatedAt),
-            ))
-          : Promise.resolve([]),
+        failedRunKeysWithNewerRun(db, companyId, [...failedRunKeys.values()]),
       ]);
-      const latestRunCreatedAtByKey = new Map<string, Date>();
-      for (const newerRun of newerRuns) {
-        const newerRunIssueId = readRunIssueId({ issueId: newerRun.runIssueId, taskId: newerRun.runTaskId });
-        const newerRunKey = `${newerRun.agentId}:${newerRunIssueId ?? ""}`;
-        const latestCreatedAt = latestRunCreatedAtByKey.get(newerRunKey);
-        if (!latestCreatedAt || newerRun.createdAt > latestCreatedAt) {
-          latestRunCreatedAtByKey.set(newerRunKey, newerRun.createdAt);
-        }
-      }
       for (const run of failedRows) {
         const issueId = readRunIssueId(run.contextSnapshot);
-        const runKey = `${run.agentId}:${issueId ?? ""}`;
-        const hasNewerRun = (latestRunCreatedAtByKey.get(runKey)?.getTime() ?? 0) > run.createdAt.getTime();
+        const runKey = failedRunKey(run.agentId, issueId);
+        // A later exhausted run for the same key is itself a newer run, so only
+        // the latest failed row per key can surface.
+        const latestFailedAt = failedRunKeys.get(runKey)?.createdAt.getTime() ?? 0;
+        const hasNewerRun = keysWithNewerRun.has(runKey) || latestFailedAt > run.createdAt.getTime();
         if (hasNewerRun) continue;
 
         const issue = issueId ? failedIssueMap.get(issueId) ?? null : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server runs a scheduler tick, and that tick calls the decision retention sweep
> - The sweep rebuilds every active company's attention feed, and the failed-run source inside it scans every `heartbeat_runs` row newer than the *oldest* exhausted run
> - On a long-lived instance that window is months wide, so one build reads ~100k rows and detoasts `context_snapshot` for each one
> - The scan takes 72.6 s mean, which is longer than the 30 s tick, so sweeps overlap 3–7 deep and starve the connection pool
> - This pull request gives the sweep its own interval with an in-flight guard, and replaces the bulk scan with one bounded `EXISTS` probe per `(agent, issue)` key
> - The benefit is that the same suppression decision costs 1.25 s instead of 73 s, and the API stops stretching to 60–120 s behind overlapping sweeps

## Linked Issues or Issue Description

No public issue exists for this. The underlying bug, per `.github/ISSUE_TEMPLATE/bug_report.yml`:

**What happened?**

Since 2026.817.0 the scheduler tick calls `runRetentionSweep()` every 30 s with no in-flight guard. Each sweep rebuilds every active company's full attention feed (`includeDismissed`, unscoped). Inside that build, the failed-run source scans every `heartbeat_runs` row newer than the *oldest* `Bounded retry exhausted` run for the failed agents, and projects `context_snapshot ->> 'issueId'` per row. Because the projected expression forces a heap and TOAST visit, no covering index can help — index-only scans are not used for `->>` expression columns.

**Expected behavior**

The sweep is a retention job with a TTL measured in days. It must not run more often than it can finish, and deciding "is there a newer run for this key?" must not read the agent's whole history.

**Steps to reproduce**

1. Run an instance long enough to accumulate months of `heartbeat_runs` (ours: 181k runs, 3 GB table, 1,946 exhausted runs back to May).
2. Let at least one agent reach `Bounded retry exhausted`.
3. Read `pg_stat_statements` for the failed-run source query.

Observed on our instance: `select agent_id, created_at, context_snapshot->>$29, context_snapshot->>$30 from heartbeat_runs where … created_at > $28` returns **100,543 rows per build at 72.6 s mean**, 545 calls in 4.5 h, wait events `IO/DataFileRead` (TOAST detoast). Sweeps overlap 3–7 deep because 72 s > 30 s. The instance API (issue list, comment POST) stretches to 60–120 s and the routine scheduler logs `CONNECTION_CLOSED`.

**Paperclip version or commit**

2026.817.0 and later.

**Relevant logs or output**

`CONNECTION_CLOSED` from the routine scheduler, concurrent with the overlapping sweeps above.

**Additional context**

Dedup search of open PRs for "retention sweep", "attention feed", and "heartbeat_runs" found three adjacent PRs, none of which duplicate this change (numbers in code spans so this PR does not spam their threads):

- `#9283` — indexes jsonb `issueId` lookups on `heartbeat_runs`. Complementary: it adds the expression indexes; this PR changes the query so the planner can use one.
- `#5176` — adds retention/pruning for heartbeat run logs. That shrinks the table; this PR fixes the scan shape, which is the cost driver even on a pruned table.
- `#2120` — `unref()` on background `setInterval` timers. Touches the same timer setup in `index.ts` but for clean process exit, not cadence.

## What Changed

- **`index.ts`** — the retention sweep runs on its own interval (`PAPERCLIP_DECISION_RETENTION_SWEEP_INTERVAL_MS`, default 5 min, floor 10 s). A tick that finds a sweep in flight skips it. Archive TTL is measured in days, so a minutes-scale cadence loses nothing. Startup still runs one sweep before the scheduler starts.
- **`services/attention.ts`** — replace the bulk newer-runs scan with one `EXISTS` probe per distinct `(agent, issue)` key, bounded by that key's *latest* exhausted run. An older exhausted run for the same key is already superseded by the later one, so the narrower bound is equivalent. Each probe is a plain conjunction with `created_at` in it, so the planner serves it as a bounded range on the existing `heartbeat_runs_company_ctx_{issue,task}_created_idx` expression indexes (migration 0209).
- **`services/attention.ts`** — the context-less case (`issueId`/`taskId` absent) walks `(company_id, created_at DESC)` newest-first with `LIMIT 1`. It stops at the agent's most recent timer run instead of reading its whole history through the agent index.
- **`attention-service.test.ts`** — new test for the context-less path.

Matching mirrors `readRunIssueId`: a run is on issue X when `issueId = X`, or when `issueId` is absent and `taskId = X`. A run is context-less when both are absent or empty.

## Verification

- `EXPLAIN ANALYZE` on the same data: keyed probes **1.25 s** (614 keys, Index Cond includes `created_at > k.created_at`), context-less probes **0.99 s** (15 keys) — against 73 s for the scan they replace.
- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/attention-service.test.ts` — 26/26 pass.
- Existing `suppresses failed-run attention after a newer run for the same issue` covers the keyed path.
- New `suppresses a context-less failed run only after a newer context-less run of the same agent` covers the unkeyed path, and asserts that a newer *issue* run does not clear a context-less failure.

## Risks

Low risk, with two things a reviewer should weigh.

- **Behavioral shift in sweep cadence.** The sweep moves from every 30 s to every 5 min by default. Archive TTL is in days, so nothing expires late, but an operator who relied on the tick cadence can restore it with `PAPERCLIP_DECISION_RETENTION_SWEEP_INTERVAL_MS`.
- **Narrower bound on the newer-run probe.** The probe is bounded by the *latest* exhausted run for a key rather than the oldest across all keys. This is the intended semantics — an older exhausted run for the same key is superseded — but it is the one place where suppression could differ from before, so it is worth a reviewer's eye.
- No migration. No schema change. No API change.
- Startup still awaits a full sweep before the scheduler starts. On large instances that delays readiness by one feed build. Left as-is here; it is a separate change.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking enabled, with tool use and code execution (Claude Code).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs change; the new env var is documented in-code at its read site
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending this description fix
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
