### PR TITLE
fix(ui): ignore color literals in UI test comments

### DIFF
--- a/scripts/check-token-gates.mjs
+++ b/scripts/check-token-gates.mjs
@@ -94,14 +94,73 @@ export function isUiTestFile(relPath) {
 
 /**
  * Replace line and block comments with spaces so match indices and line
- * numbers stay aligned with the original source. Strings and
- * template-literal interpolations are preserved. `://` is not treated as
- * a line comment so URLs in JSX text survive.
+ * numbers stay aligned with the original source. Strings, template-literal
+ * interpolations, and regex literals are preserved. `://` is not treated as
+ * a line comment so URLs in JSX text survive. Regex literals are copied as
+ * code so an escaped slash plus the closing delimiter (`\/` `/`) is not
+ * mistaken for a line comment.
  */
 export function stripJsCommentsPreservingNewlines(source) {
   let output = "";
   let index = 0;
   const length = source.length;
+
+  function isLineTerminator(ch) {
+    return ch === "\n" || ch === "\r";
+  }
+
+  function looksLikeRegexLiteralStart() {
+    let cursor = index - 1;
+    while (cursor >= 0 && (source[cursor] === " " || source[cursor] === "\t")) {
+      cursor -= 1;
+    }
+    if (cursor < 0 || isLineTerminator(source[cursor])) return true;
+
+    const prev = source[cursor];
+    if (prev === "+" && cursor > 0 && source[cursor - 1] === "+") return false;
+    if (prev === "-" && cursor > 0 && source[cursor - 1] === "-") return false;
+
+    if (/[A-Za-z0-9_)$\]]/.test(prev)) {
+      if (!/[A-Za-z0-9_$]/.test(prev)) return false;
+      let start = cursor;
+      while (start >= 0 && /[A-Za-z0-9_$]/.test(source[start])) start -= 1;
+      const word = source.slice(start + 1, cursor + 1);
+      return /^(?:return|case|throw|typeof|void|delete|new|in|of|await|yield|else)$/.test(word);
+    }
+    return true;
+  }
+
+  function copyRegexLiteral() {
+    output += "/";
+    index += 1;
+    let inCharClass = false;
+    while (index < length) {
+      const ch = source[index];
+      if (isLineTerminator(ch)) return;
+      if (ch === "\\") {
+        output += ch;
+        index += 1;
+        if (index < length && !isLineTerminator(source[index])) {
+          output += source[index];
+          index += 1;
+        }
+        continue;
+      }
+      if (ch === "[" && !inCharClass) inCharClass = true;
+      else if (ch === "]" && inCharClass) inCharClass = false;
+      else if (ch === "/" && !inCharClass) {
+        output += ch;
+        index += 1;
+        while (index < length && /[gimsuy]/.test(source[index])) {
+          output += source[index];
+          index += 1;
+        }
+        return;
+      }
+      output += ch;
+      index += 1;
+    }
+  }
 
   function copyCode(stopAtUnmatchedBrace) {
     let braceDepth = 0;
@@ -119,7 +178,7 @@ export function stripJsCommentsPreservingNewlines(source) {
       }
 
       if (ch === "/" && next === "/" && source[index - 1] !== ":") {
-        while (index < length && source[index] !== "\n" && source[index] !== "\r") {
+        while (index < length && !isLineTerminator(source[index])) {
           output += " ";
           index += 1;
         }
@@ -135,9 +194,14 @@ export function stripJsCommentsPreservingNewlines(source) {
             index += 2;
             break;
           }
-          output += source[index] === "\n" || source[index] === "\r" ? source[index] : " ";
+          output += isLineTerminator(source[index]) ? source[index] : " ";
           index += 1;
         }
+        continue;
+      }
+
+      if (ch === "/" && looksLikeRegexLiteralStart()) {
+        copyRegexLiteral();
         continue;
       }
 

--- a/scripts/check-token-gates.mjs
+++ b/scripts/check-token-gates.mjs
@@ -64,6 +64,13 @@
  * entire sites' surrounding functional code rather than individual
  * characters.
  *
+ * Test files (`*.test.*`, `*.spec.*`) still run through gates 1–3, but
+ * line comments and block comments (including JSX block comments) are
+ * stripped first. Comments are not rendered, so a test that documents a
+ * previously hardcoded hex must not fail the gate. String literals and
+ * executable code in tests are still scanned. Non-test files keep
+ * scanning comments.
+ *
  * Exit code: 0 if all three gates are clean (prints a per-gate summary).
  * Exit code: 1 if any gate has violations (lists them, grouped by gate).
  *
@@ -79,6 +86,106 @@ const REPO_ROOT = resolve(__dirname, "..");
 const UI_SRC = resolve(REPO_ROOT, "ui/src");
 const SCAN_DIRS = ["components", "pages"];
 const CSS_PATH = resolve(UI_SRC, "index.css");
+export const UI_TEST_FILE_RE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+
+export function isUiTestFile(relPath) {
+  return UI_TEST_FILE_RE.test(relPath);
+}
+
+/**
+ * Replace line and block comments with spaces so match indices and line
+ * numbers stay aligned with the original source. Strings and
+ * template-literal interpolations are preserved. `://` is not treated as
+ * a line comment so URLs in JSX text survive.
+ */
+export function stripJsCommentsPreservingNewlines(source) {
+  let output = "";
+  let index = 0;
+  const length = source.length;
+
+  function copyCode(stopAtUnmatchedBrace) {
+    let braceDepth = 0;
+    while (index < length) {
+      const ch = source[index];
+      const next = index + 1 < length ? source[index + 1] : "";
+
+      if (stopAtUnmatchedBrace && ch === "}" && braceDepth === 0) {
+        return;
+      }
+
+      if (ch === "'" || ch === '"' || ch === "`") {
+        copyString(ch);
+        continue;
+      }
+
+      if (ch === "/" && next === "/" && source[index - 1] !== ":") {
+        while (index < length && source[index] !== "\n" && source[index] !== "\r") {
+          output += " ";
+          index += 1;
+        }
+        continue;
+      }
+
+      if (ch === "/" && next === "*") {
+        output += "  ";
+        index += 2;
+        while (index < length) {
+          if (source[index] === "*" && source[index + 1] === "/") {
+            output += "  ";
+            index += 2;
+            break;
+          }
+          output += source[index] === "\n" || source[index] === "\r" ? source[index] : " ";
+          index += 1;
+        }
+        continue;
+      }
+
+      if (ch === "{") braceDepth += 1;
+      else if (ch === "}") braceDepth = Math.max(0, braceDepth - 1);
+
+      output += ch;
+      index += 1;
+    }
+  }
+
+  function copyString(quote) {
+    output += quote;
+    index += 1;
+    while (index < length) {
+      const ch = source[index];
+      if (ch === "\\") {
+        output += ch;
+        index += 1;
+        if (index < length) {
+          output += source[index];
+          index += 1;
+        }
+        continue;
+      }
+      if (quote === "`" && ch === "$" && source[index + 1] === "{") {
+        output += "${";
+        index += 2;
+        copyCode(true);
+        if (index < length && source[index] === "}") {
+          output += "}";
+          index += 1;
+        }
+        continue;
+      }
+      output += ch;
+      index += 1;
+      if (ch === quote) return;
+    }
+  }
+
+  copyCode(false);
+  return output;
+}
+
+export function prepareScanContent(relPath, content) {
+  return isUiTestFile(relPath) ? stripJsCommentsPreservingNewlines(content) : content;
+}
 
 // ── Allowlist parsing ────────────────────────────────────────────────────
 // Reads the machine-readable "* allow <path> — <reason>" lines from the
@@ -139,7 +246,7 @@ const HEX_COLOR_RE = /(?<![a-zA-Z0-9_/])#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-
 // MUST match (literal numeric channels).
 const COLOR_FN_LITERAL_RE = /\b(?:rgb|rgba|hsl|hsla|oklch)\(\s*(?!var\()[0-9.%-]/g;
 
-function findColorLiteralIssues(content) {
+export function findColorLiteralIssues(content) {
   const issues = [];
   for (const m of content.matchAll(HEX_COLOR_RE)) {
     issues.push({ index: m.index, snippet: m[0] });
@@ -197,7 +304,7 @@ function bracketCarriesValue(raw) {
   return false;
 }
 
-function findArbitraryBracketIssues(content) {
+export function findArbitraryBracketIssues(content) {
   const issues = [];
   for (const m of content.matchAll(BRACKET_RE)) {
     const [full, , word, raw] = m;
@@ -231,7 +338,7 @@ const FONT_SIZE_CLASS_RE = /\btext-\[(?:[0-9.]+(?:px|rem|em)|[0-9.]+\/[0-9.]+)\]
 const FONT_SIZE_INLINE_RE = /\bfontSize\s*:\s*["'][0-9][^"']*["']/g;
 const FONT_SIZE_CSS_PROP_RE = /(?<!-)\bfont-size\s*:\s*["'`][0-9][^"'`]*["'`]/g;
 
-function findFontSizeIssues(content) {
+export function findFontSizeIssues(content) {
   const issues = [];
   for (const m of content.matchAll(FONT_SIZE_CLASS_RE)) {
     issues.push({ index: m.index, snippet: m[0] });
@@ -256,7 +363,7 @@ function findLegacyHslVarWrapperIssues(content) {
   }));
 }
 
-function lineNumberAt(content, index) {
+export function lineNumberAt(content, index) {
   return content.slice(0, index).split("\n").length;
 }
 
@@ -272,10 +379,11 @@ function main() {
     const relPathPosix = relPathToPosix(filePath);
 
     const allowed = isAllowlisted(relPathPosix, allowlist);
+    const scanContent = prepareScanContent(relPathPosix, content);
 
-    const g1 = findColorLiteralIssues(content);
-    const g2 = findArbitraryBracketIssues(content);
-    const g3 = findFontSizeIssues(content);
+    const g1 = findColorLiteralIssues(scanContent);
+    const g2 = findArbitraryBracketIssues(scanContent);
+    const g3 = findFontSizeIssues(scanContent);
 
     if (allowed) {
       allowlistedSkips += g1.length + g2.length + g3.length;
@@ -283,13 +391,13 @@ function main() {
     }
 
     for (const issue of g1) {
-      violations.gate1.push({ file: relPathPosix, line: lineNumberAt(content, issue.index), snippet: issue.snippet });
+      violations.gate1.push({ file: relPathPosix, line: lineNumberAt(scanContent, issue.index), snippet: issue.snippet });
     }
     for (const issue of g2) {
-      violations.gate2.push({ file: relPathPosix, line: lineNumberAt(content, issue.index), snippet: issue.snippet });
+      violations.gate2.push({ file: relPathPosix, line: lineNumberAt(scanContent, issue.index), snippet: issue.snippet });
     }
     for (const issue of g3) {
-      violations.gate3.push({ file: relPathPosix, line: lineNumberAt(content, issue.index), snippet: issue.snippet });
+      violations.gate3.push({ file: relPathPosix, line: lineNumberAt(scanContent, issue.index), snippet: issue.snippet });
     }
   }
 
@@ -338,4 +446,10 @@ function relPathToPosix(filePath) {
   return ("ui/src/" + relative(UI_SRC, filePath)).split("\\").join("/");
 }
 
-main();
+function isMainModule() {
+  return Boolean(process.argv[1]) && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  main();
+}

--- a/scripts/check-token-gates.test.mjs
+++ b/scripts/check-token-gates.test.mjs
@@ -83,3 +83,23 @@ test("prepareScanContent ignores JSX block-comment hexes in tests", () => {
   const scan = prepareScanContent("ui/src/components/Foo.test.tsx", source);
   assert.deepEqual(findColorLiteralIssues(scan), []);
 });
+
+test("regex literals with escaped slashes do not swallow the rest of the line", () => {
+  // Mirrors DocumentAnnotationLayer.test.tsx: `\/` plus the closing delimiter
+  // looks like `//` if the stripper is not regex-aware.
+  const source =
+    '        || /^(dark:|hover:|dark:hover:)?bg-yellow-\\d+\\//.test(className); const color = "#cdd6f4";\n';
+  const stripped = stripJsCommentsPreservingNewlines(source);
+  assert.equal(stripped.includes(".test(className)"), true);
+  assert.equal(stripped.includes("#cdd6f4"), true);
+  const scan = prepareScanContent("ui/src/components/DocumentAnnotationLayer.test.tsx", source);
+  const issues = findColorLiteralIssues(scan);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].snippet, "#cdd6f4");
+});
+
+test("line comments after a regex literal are still stripped", () => {
+  const source = 'const ok = /\\d+\\//; // leftover #cdd6f4\n';
+  const scan = prepareScanContent("ui/src/components/Foo.test.ts", source);
+  assert.deepEqual(findColorLiteralIssues(scan), []);
+});

--- a/scripts/check-token-gates.test.mjs
+++ b/scripts/check-token-gates.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  findColorLiteralIssues,
+  isUiTestFile,
+  lineNumberAt,
+  prepareScanContent,
+  stripJsCommentsPreservingNewlines,
+} from "./check-token-gates.mjs";
+
+const CATPPUCCIN_COMMENT = `/* The rendered code block used to be pinned to the Catppuccin literals
+   #1e1e2e / #cdd6f4, in the normal AND the prose-invert variables. A code
+   block therefore stayed dark in light mode. These tests fail if any of
+   those surfaces is pinned to a literal again, rather than riding a token
+   that carries a \`.dark\` override. */`;
+
+test("isUiTestFile matches colocated UI tests and specs", () => {
+  assert.equal(isUiTestFile("ui/src/components/MarkdownCodeBlockStyles.test.ts"), true);
+  assert.equal(isUiTestFile("ui/src/pages/CompanySettings.test.tsx"), true);
+  assert.equal(isUiTestFile("ui/src/components/Foo.spec.tsx"), true);
+  assert.equal(isUiTestFile("ui/src/components/MarkdownCodeBlockStyles.ts"), false);
+  assert.equal(isUiTestFile("ui/src/components/test-utils.ts"), false);
+});
+
+test("stripJsCommentsPreservingNewlines keeps length and line count", () => {
+  const source = `${CATPPUCCIN_COMMENT}\nconst color = "#cdd6f4";\n`;
+  const stripped = stripJsCommentsPreservingNewlines(source);
+  assert.equal(stripped.length, source.length);
+  assert.equal(stripped.split("\n").length, source.split("\n").length);
+  assert.equal(stripped.includes("#1e1e2e"), false);
+  assert.equal(stripped.includes("#cdd6f4"), true);
+});
+
+test("stripJsCommentsPreservingNewlines leaves string literals intact", () => {
+  const source = `const url = "https://example.com/#1e1e2e"; // leftover #cdd6f4\n`;
+  const stripped = stripJsCommentsPreservingNewlines(source);
+  assert.match(stripped, /#1e1e2e/);
+  assert.equal(stripped.includes("#cdd6f4"), false);
+});
+
+test("stripJsCommentsPreservingNewlines strips comments inside template interpolations", () => {
+  const source = "const x = `bg ${/* was #1e1e2e */ \"var(--muted)\"}`;\n";
+  const stripped = stripJsCommentsPreservingNewlines(source);
+  assert.equal(stripped.includes("#1e1e2e"), false);
+  assert.match(stripped, /var\(--muted\)/);
+});
+
+test("prepareScanContent ignores Catppuccin hexes in a test-file block comment", () => {
+  const rel = "ui/src/components/MarkdownCodeBlockStyles.test.ts";
+  const scan = prepareScanContent(rel, CATPPUCCIN_COMMENT);
+  assert.deepEqual(findColorLiteralIssues(scan), []);
+});
+
+test("prepareScanContent still flags the same hexes in a non-test file comment", () => {
+  const rel = "ui/src/components/MarkdownCodeBlockStyles.ts";
+  const scan = prepareScanContent(rel, CATPPUCCIN_COMMENT);
+  const issues = findColorLiteralIssues(scan);
+  assert.equal(issues.length, 2);
+  assert.deepEqual(
+    issues.map((issue) => issue.snippet),
+    ["#1e1e2e", "#cdd6f4"],
+  );
+});
+
+test("prepareScanContent still flags executable hex literals in tests", () => {
+  const source = `/* history #1e1e2e */\nconst color = "#cdd6f4";\n`;
+  const scan = prepareScanContent("ui/src/components/Foo.test.ts", source);
+  const issues = findColorLiteralIssues(scan);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].snippet, "#cdd6f4");
+  assert.equal(lineNumberAt(scan, issues[0].index), 2);
+});
+
+test("prepareScanContent ignores a trailing line-comment hex in tests", () => {
+  const source = `const x = 1; // leftover #cdd6f4 from the old pin\n`;
+  const scan = prepareScanContent("ui/src/components/Foo.test.tsx", source);
+  assert.deepEqual(findColorLiteralIssues(scan), []);
+});
+
+test("prepareScanContent ignores JSX block-comment hexes in tests", () => {
+  const source = `render(<div>{/* was #1e1e2e */}</div>);\n`;
+  const scan = prepareScanContent("ui/src/components/Foo.test.tsx", source);
+  assert.deepEqual(findColorLiteralIssues(scan), []);
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The UI design system forbids hardcoded visual values in `ui/src/components` and `ui/src/pages`
> - `pnpm check:token-gates` is the mechanical gate for that rule
> - Tests colocated next to components are scanned by the same script
> - The scanner treated comments as source, so a test that documents a previously hardcoded hex failed the required check
> - This pull request strips comments in UI test files before gates 1–3
> - The benefit is that tests can document forbidden literals without breaking the check, while real hardcoded values still fail

## Linked Issues or Issue Description

No public GitHub issue exists for this failure. Search of open issues and PRs for `check:token-gates`, token-gate comments, and hardcoded hex in tests found no duplicate.

**What happened?**
`pnpm check:token-gates` reports Gate 1 color-literal violations for hex values that appear only inside comments in colocated UI test files, for example `#1e1e2e` and `#cdd6f4` in a block comment in `ui/src/components/MarkdownCodeBlockStyles.test.ts`.

**Expected behavior**
Comments in test files do not count as token-gate violations. String literals and executable code in tests still fail the gate.

**Steps to reproduce**
1. Put a hex color such as `#1e1e2e` in a block comment in a `ui/src/components/*.test.ts` file.
2. Run `pnpm check:token-gates`.
3. Gate 1 fails on that comment even though no rendered value changed.

**Paperclip version or commit**
Reproduced against current `master` plus a colocated UI test comment that documents old Catppuccin literals.

**Deployment mode**
Local dev (pnpm dev)

**Agent adapter(s) involved**
Not adapter-specific (core bug)

**Database mode**
Not database-related

## What Changed

- `scripts/check-token-gates.mjs` now strips line and block comments in `*.test.*` / `*.spec.*` files before gates 1–3, while preserving line numbers.
- Executable color literals, arbitrary bracket values, and raw font-size declarations in test code still fail.
- Non-test files still scan comments.
- Added `scripts/check-token-gates.test.mjs` for the comment-stripping contract, including the Catppuccin-comment regression.
- Wired the new test into `test:check-token-gates` and `test:release-registry`.

## Verification

- `node --test scripts/check-token-gates.test.mjs` — 9/9 pass
- `pnpm check:token-gates` — all four gates CLEAN on this branch
- Confirmed a hex in a test-file comment is ignored, and the same hex in a non-test file comment or in a test string literal still fails

## Risks

Low risk. The change only ignores comments in UI test/spec files. A hardcoded color in a test assertion or string still fails. A false negative would require a hex that exists only inside a comment, which is not a rendered value.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider: xAI
- Model: Grok 4.6 (`grok-4.6`)
- Reasoning effort: Extra High
- Capabilities: tool use, code execution, repository editing
- This change was produced with Grok 4.6 in an agent coding session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
