### PR TITLE
Treat scheduled issue monitors as live watchdog paths

### DIFF
--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -357,6 +357,44 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdogIssues).toHaveLength(0);
   });
 
+  it("does not trigger while an agent-owned issue has a future monitor", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId);
+    const sourceId = await seedIssue(companyId, {
+      identifier: "WDOG-MONITOR",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+    });
+    const nextCheckAt = new Date(Date.now() + 60_000);
+    await db.update(issues).set({
+      assigneeUserId: null,
+      monitorNextCheckAt: nextCheckAt,
+      monitorScheduledBy: "assignee",
+      monitorAttemptCount: 0,
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor: {
+          nextCheckAt: nextCheckAt.toISOString(),
+          scheduledBy: "assignee",
+          kind: "external_service",
+          serviceName: "github",
+          externalRef: "paperclipai/paperclip#915",
+          timeoutAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+          maxAttempts: 16,
+        },
+      },
+    }).where(eq(issues.id, sourceId));
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(0);
+  });
+
   it("does not keep the source live for runs under a nested task-watchdog issue", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-NEST", status: "done" });

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -22,6 +22,7 @@ import { logActivity } from "./activity-log.js";
 import { evaluateAgentInvokabilityFromDb } from "./agent-invokability.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
+import { hasScheduledIssueMonitorPath } from "./recovery/issue-graph-liveness.js";
 import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
 
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
@@ -74,6 +75,10 @@ export type TaskWatchdogClassifierIssue = Pick<
   latestCommentAt?: Date | string | null;
   latestDocumentAt?: Date | string | null;
   latestWorkProductAt?: Date | string | null;
+  executionPolicy?: Record<string, unknown> | null;
+  executionState?: Record<string, unknown> | null;
+  monitorNextCheckAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
 };
 
 export type TaskWatchdogClassifierPath = {
@@ -408,15 +413,24 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
 
   const includedIds = included.map((issue) => issue.id);
   const includedIdSet = new Set(includedIds);
+  const monitorEvaluatedAt = input.evaluatedAt ?? new Date();
   const liveIssueIds = [
     ...pathIssueIds(input.activeRuns, input.watchdog.companyId),
     ...pathIssueIds(input.queuedWakeRequests, input.watchdog.companyId),
+    ...included
+      .filter((issue) =>
+        ["in_progress", "in_review"].includes(issue.status) &&
+        Boolean(issue.assigneeAgentId) &&
+        !issue.assigneeUserId &&
+        hasScheduledIssueMonitorPath(issue, monitorEvaluatedAt)
+      )
+      .map((issue) => issue.id),
   ].filter((issueId) => includedIdSet.has(issueId));
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
     return {
       state: "live",
-      reason: "At least one issue in the watched subtree has a live run, queued wake, or scheduled retry.",
+      reason: "At least one issue in the watched subtree has a live run, queued wake, scheduled retry, or issue monitor.",
       includedIssueIds: includedIds,
       liveIssueIds: uniqueLiveIssueIds,
     };
@@ -872,6 +886,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           parent_id,
           assignee_agent_id,
           assignee_user_id,
+          execution_policy,
+          execution_state,
+          monitor_next_check_at,
+          monitor_attempt_count,
           origin_kind,
           updated_at,
           created_at,
@@ -891,6 +909,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           child.parent_id,
           child.assignee_agent_id,
           child.assignee_user_id,
+          child.execution_policy,
+          child.execution_state,
+          child.monitor_next_check_at,
+          child.monitor_attempt_count,
           child.origin_kind,
           child.updated_at,
           child.created_at,
@@ -912,6 +934,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         parent_id AS "parentId",
         assignee_agent_id AS "assigneeAgentId",
         assignee_user_id AS "assigneeUserId",
+        execution_policy AS "executionPolicy",
+        execution_state AS "executionState",
+        monitor_next_check_at AS "monitorNextCheckAt",
+        monitor_attempt_count AS "monitorAttemptCount",
         origin_kind AS "originKind",
         updated_at AS "updatedAt",
         created_at AS "createdAt"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Task watchdogs verify that watched issue trees still have a valid action path
> - A persisted issue monitor is a valid future action path for its agent assignee
> - The watchdog classifier only loaded active runs and queued wake requests
> - It could therefore report monitored work as stopped and start an incorrect watchdog review
> - This pull request adds eligible issue monitors to the existing live-path classification
> - The benefit is that watchdog reviews only start when the monitored work has no valid future path

## Linked Issues or Issue Description

**What happened?**

The task watchdog classified an issue tree as stopped when an in-progress, agent-owned issue had a future issue monitor. The classifier did not load the monitor state.

**Expected behavior**

A future issue monitor must count as a live path when the issue has an agent assignee, has no user assignee, and is in progress or in review. An expired or exhausted monitor must not count as live.

**Steps to reproduce**

1. Create an in-progress issue with an agent assignee and no user assignee.
2. Schedule an issue monitor with a future check time, timeout, and attempt limit.
3. Run the task watchdog reconciler for the issue tree.
4. Observe that the watchdog starts a stopped-subtree review before this fix.

**Paperclip version or commit**

`2862e1848` plus this pull request.

**Deployment mode**

Built from source. The bug is in the core server classifier.

## What Changed

- Load monitor policy, monitor state, next check time, and attempt count with the watched issue tree.
- Reuse the shared monitor liveness check and add a database regression test for an agent-owned future GitHub monitor.

## Verification

- `pnpm exec vitest run server/src/__tests__/task-watchdogs-classifier.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts`
- Result: 2 test files passed. All 38 tests passed.

## Risks

Low risk. The change only adds scheduler-eligible future monitors to the live-path set. The shared liveness check still rejects due, expired, and exhausted monitors.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5. The exact deployment ID and context window were not exposed to the agent. The run used high-reasoning mode, shell tools, code editing, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
