### PR TITLE
fix(plugin-worker-manager): queue and replay pre-bind login pseudo-terminal frames

### DIFF
--- a/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
@@ -14,6 +14,9 @@
 //     id; a test sets a wrong `sid` to prove the host drops a mismatched
 //     notification.
 //   - `exitCode`: when set, the fixture emits an exit notification after the outputs.
+//   - `outputsAfterExit`: an array of `{ chunk, sid? }`, same shape as `outputs`.
+//     The fixture emits these after the exit notification, so a test proves the
+//     host never delivers output that arrives behind a queued exit.
 //   - `closeMode`: "ack" | "bad-ack" | "no-ack" (default "ack"). It controls the
 //     close reply, so a test proves the host retires the worker on an unconfirmed
 //     close.
@@ -30,13 +33,12 @@ function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
 }
 
-// Serialize the scripted output and exit notifications as newline-delimited
-// lines. The batch mode writes these together with the open reply in one
-// stdout write. A test sets a wrong `sid` on one entry to force a mismatch.
-function scriptedOutputLines(directive, workerSessionId) {
-  const outputs = Array.isArray(directive.outputs) ? directive.outputs : [];
+// Serialize one array of `{ chunk, sid? }` entries as newline-delimited output
+// notification lines. A test sets a wrong `sid` on one entry to force a
+// mismatch.
+function outputLines(entries, workerSessionId) {
   let lines = "";
-  for (const entry of outputs) {
+  for (const entry of entries) {
     lines += `${JSON.stringify({
       jsonrpc: "2.0",
       method: "loginPty.output",
@@ -46,6 +48,19 @@ function scriptedOutputLines(directive, workerSessionId) {
       },
     })}\n`;
   }
+  return lines;
+}
+
+// Serialize the scripted output and exit notifications as newline-delimited
+// lines, in this fixed order: the pre-exit outputs, then the exit, then the
+// post-exit outputs. The batch mode writes these together with the open
+// reply in one stdout write.
+function scriptedOutputLines(directive, workerSessionId) {
+  const outputs = Array.isArray(directive.outputs) ? directive.outputs : [];
+  const outputsAfterExit = Array.isArray(directive.outputsAfterExit)
+    ? directive.outputsAfterExit
+    : [];
+  let lines = outputLines(outputs, workerSessionId);
   if (typeof directive.exitCode === "number") {
     lines += `${JSON.stringify({
       jsonrpc: "2.0",
@@ -53,6 +68,7 @@ function scriptedOutputLines(directive, workerSessionId) {
       params: { workerSessionId, exitCode: directive.exitCode },
     })}\n`;
   }
+  lines += outputLines(outputsAfterExit, workerSessionId);
   return lines;
 }
 

--- a/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
@@ -14,6 +14,10 @@
 //     id; a test sets a wrong `sid` to prove the host drops a mismatched
 //     notification.
 //   - `exitCode`: when set, the fixture emits an exit notification after the outputs.
+//   - `extraExits`: an array of `{ exitCode, sid? }`. The fixture emits each as a
+//     further exit notification, after the main `exitCode` exit. `sid` defaults
+//     to the real worker session id; a test sets a wrong `sid` to script a worker
+//     that sends a valid exit, then a mismatched exit, before the bind.
 //   - `outputsAfterExit`: an array of `{ chunk, sid? }`, same shape as `outputs`.
 //     The fixture emits these after the exit notification, so a test proves the
 //     host never delivers output that arrives behind a queued exit.
@@ -51,22 +55,31 @@ function outputLines(entries, workerSessionId) {
   return lines;
 }
 
+// Serialize one exit notification line for the given worker session id.
+function exitLine(workerSessionId, exitCode) {
+  return `${JSON.stringify({
+    jsonrpc: "2.0",
+    method: "loginPty.exit",
+    params: { workerSessionId, exitCode },
+  })}\n`;
+}
+
 // Serialize the scripted output and exit notifications as newline-delimited
-// lines, in this fixed order: the pre-exit outputs, then the exit, then the
-// post-exit outputs. The batch mode writes these together with the open
-// reply in one stdout write.
+// lines, in this fixed order: the pre-exit outputs, then the main exit, then
+// every extra exit, then the post-exit outputs. The batch mode writes these
+// together with the open reply in one stdout write.
 function scriptedOutputLines(directive, workerSessionId) {
   const outputs = Array.isArray(directive.outputs) ? directive.outputs : [];
   const outputsAfterExit = Array.isArray(directive.outputsAfterExit)
     ? directive.outputsAfterExit
     : [];
+  const extraExits = Array.isArray(directive.extraExits) ? directive.extraExits : [];
   let lines = outputLines(outputs, workerSessionId);
   if (typeof directive.exitCode === "number") {
-    lines += `${JSON.stringify({
-      jsonrpc: "2.0",
-      method: "loginPty.exit",
-      params: { workerSessionId, exitCode: directive.exitCode },
-    })}\n`;
+    lines += exitLine(workerSessionId, directive.exitCode);
+  }
+  for (const exit of extraExits) {
+    lines += exitLine(exit.sid ?? workerSessionId, exit.exitCode);
   }
   lines += outputLines(outputsAfterExit, workerSessionId);
   return lines;

--- a/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
@@ -20,7 +20,13 @@
 //     that sends a valid exit, then a mismatched exit, before the bind.
 //   - `outputsAfterExit`: an array of `{ chunk, sid? }`, same shape as `outputs`.
 //     The fixture emits these after the exit notification, so a test proves the
-//     host never delivers output that arrives behind a queued exit.
+//     host drops output that arrives behind a queued exit.
+//   - `sequence`: an array of `{ type: "output", chunk, sid? }` or
+//     `{ type: "exit", exitCode, sid? }` entries. When set, the fixture emits
+//     exactly this sequence, in order, instead of the fixed
+//     outputs/exitCode/extraExits/outputsAfterExit composition. A test uses
+//     this to script an arrival order the fixed composition cannot express,
+//     for example a mismatched exit that arrives before a valid one.
 //   - `closeMode`: "ack" | "bad-ack" | "no-ack" (default "ack"). It controls the
 //     close reply, so a test proves the host retires the worker on an unconfirmed
 //     close.
@@ -65,10 +71,22 @@ function exitLine(workerSessionId, exitCode) {
 }
 
 // Serialize the scripted output and exit notifications as newline-delimited
-// lines, in this fixed order: the pre-exit outputs, then the main exit, then
-// every extra exit, then the post-exit outputs. The batch mode writes these
-// together with the open reply in one stdout write.
+// lines. The `sequence` directive, when set, emits exactly that order. The
+// fixed composition otherwise emits, in order: the pre-exit outputs, then
+// the main exit, then every extra exit, then the post-exit outputs. The
+// batch mode writes these together with the open reply in one stdout write.
 function scriptedOutputLines(directive, workerSessionId) {
+  if (Array.isArray(directive.sequence)) {
+    let lines = "";
+    for (const entry of directive.sequence) {
+      if (entry.type === "output") {
+        lines += outputLines([{ chunk: entry.chunk, sid: entry.sid }], workerSessionId);
+      } else if (entry.type === "exit") {
+        lines += exitLine(entry.sid ?? workerSessionId, entry.exitCode);
+      }
+    }
+    return lines;
+  }
   const outputs = Array.isArray(directive.outputs) ? directive.outputs : [];
   const outputsAfterExit = Array.isArray(directive.outputsAfterExit)
     ? directive.outputsAfterExit

--- a/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-login-pty.cjs
@@ -6,7 +6,8 @@
 // The manager allowlists `command` to the fixed `CLAUDE_SETUP_TOKEN_COMMAND`. The
 // test encodes a JSON directive in the forwarded `providerLeaseId`, so one fixture
 // serves every route-gate case:
-//   - `mode`: "normal" | "malformed-open" | "no-open-reply" | "duplicate-open-reply"
+//   - `mode`: "normal" | "malformed-open" | "no-open-reply" | "duplicate-open-reply" |
+//     "exit-before-open-reply"
 //   - `workerSessionId`: the worker session id the open reply returns (default "ws-1")
 //   - `outputs`: an array of `{ chunk, sid? }`. The fixture emits each as an output
 //     notification after the open reply. `sid` defaults to the real worker session
@@ -16,10 +17,43 @@
 //   - `closeMode`: "ack" | "bad-ack" | "no-ack" (default "ack"). It controls the
 //     close reply, so a test proves the host retires the worker on an unconfirmed
 //     close.
+//   - `batchWithOpenReply`: when true, the fixture writes the open reply and the
+//     scripted outputs and exit in one stdout write. The host then reads the open
+//     reply and the notifications in one batch, so a test proves the host queues
+//     and replays a record that arrives before the route binds.
+//   - `mode: "exit-before-open-reply"`: the fixture emits the scripted outputs,
+//     then exits with no open reply, so a test proves the host clears the
+//     pre-bind queue on a worker exit during the open window.
 const readline = require("node:readline");
 
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+// Serialize the scripted output and exit notifications as newline-delimited
+// lines. The batch mode writes these together with the open reply in one
+// stdout write. A test sets a wrong `sid` on one entry to force a mismatch.
+function scriptedOutputLines(directive, workerSessionId) {
+  const outputs = Array.isArray(directive.outputs) ? directive.outputs : [];
+  let lines = "";
+  for (const entry of outputs) {
+    lines += `${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "loginPty.output",
+      params: {
+        workerSessionId: entry.sid ?? workerSessionId,
+        chunk: entry.chunk,
+      },
+    })}\n`;
+  }
+  if (typeof directive.exitCode === "number") {
+    lines += `${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "loginPty.exit",
+      params: { workerSessionId, exitCode: directive.exitCode },
+    })}\n`;
+  }
+  return lines;
 }
 
 // The registered terminals, keyed by the host route id. Each entry records the
@@ -71,41 +105,48 @@ rl.on("line", (line) => {
       // Never reply, so the host open call times out.
       return;
     }
-    if (mode === "malformed-open") {
-      // Reply with no worker session id, so the host terminalizes the route.
-      send({ jsonrpc: "2.0", id: message.id, result: {} });
+    if (mode === "exit-before-open-reply") {
+      // Emit the scripted pre-bind outputs, then exit with no open reply. The
+      // route never binds, so a test proves the worker-exit path clears the
+      // pre-bind queue.
+      process.stdout.write(scriptedOutputLines(directive, workerSessionId));
+      process.exit(1);
       return;
     }
 
-    const reply = () =>
-      send({ jsonrpc: "2.0", id: message.id, result: { workerSessionId } });
-    reply();
+    // A malformed reply carries no worker session id, so the host cannot bind
+    // and terminalizes the route.
+    const isMalformedOpen = mode === "malformed-open";
+    const openReplyLine = `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: isMalformedOpen ? {} : { workerSessionId },
+    })}\n`;
+
+    if (directive.batchWithOpenReply === true) {
+      // Write the open reply and the scripted outputs and exit in one stdout
+      // write. The host reads them in one batch, so an output or an exit
+      // notification arrives before the route binds — even a malformed reply
+      // that never binds. The host must queue and, on a bind, replay it; on a
+      // malformed reply, it must clear the queue instead.
+      process.stdout.write(openReplyLine + scriptedOutputLines(directive, workerSessionId));
+      return;
+    }
+
+    process.stdout.write(openReplyLine);
     if (mode === "duplicate-open-reply") {
       // Send a second open reply for the same request id. The host drops it.
-      reply();
+      process.stdout.write(openReplyLine);
+    }
+    if (isMalformedOpen) {
+      // No scripted output follows a non-batched malformed reply.
+      return;
     }
 
     // Emit the scripted output and the exit after the open reply, so the host
     // binds the route first.
     setImmediate(() => {
-      const outputs = Array.isArray(directive.outputs) ? directive.outputs : [];
-      for (const entry of outputs) {
-        send({
-          jsonrpc: "2.0",
-          method: "loginPty.output",
-          params: {
-            workerSessionId: entry.sid ?? workerSessionId,
-            chunk: entry.chunk,
-          },
-        });
-      }
-      if (typeof directive.exitCode === "number") {
-        send({
-          jsonrpc: "2.0",
-          method: "loginPty.exit",
-          params: { workerSessionId, exitCode: directive.exitCode },
-        });
-      }
+      process.stdout.write(scriptedOutputLines(directive, workerSessionId));
     });
     return;
   }

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4590,6 +4590,13 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
         title: "Child A",
         status: "done",
         priority: "medium",
+        // Give the children distinct, ordered issue numbers. The service
+        // sorts direct children by issueNumber, then createdAt. A batched
+        // insert gives every row in the statement the same defaultNow()
+        // createdAt, so without a distinct issueNumber the two children
+        // tie on both sort keys and the database is free to return them
+        // in either order.
+        issueNumber: 1,
       },
       {
         id: childB,
@@ -4598,6 +4605,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
         title: "Child B",
         status: "blocked",
         priority: "medium",
+        issueNumber: 2,
       },
     ]);
 

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1673,7 +1673,7 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
     }
   });
 
-  it("keeps a repeated pre-bind exit at its original arrival position with its latest exit code, against a filled output queue", async () => {
+  it("keeps a repeated pre-bind exit at its original arrival position with its first exit code, against a filled output queue", async () => {
     const handle = makeLoginPtyHandle({
       loginPtyLimits: { maxPreBindFrames: 50 },
     });
@@ -1682,10 +1682,10 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
       // Fill the pre-bind output queue with 40 records ahead of the first
       // exit, then repeat the exit for the same worker session id after more
       // output arrives. The host indexes the retained exit record by worker
-      // session id, so the repeat updates the SAME record in place instead
-      // of scanning the held queue for it, and the record keeps its
-      // ORIGINAL arrival position — right after the filler outputs, not at
-      // the later position of the repeat.
+      // session id, so the repeat check is an O(1) lookup, not a scan of the
+      // held queue. The FIRST retained exit wins: the repeat drops there and
+      // the record keeps its ORIGINAL arrival position — right after the
+      // filler outputs, not at the later position of the repeat.
       const fillerOutputs = Array.from({ length: 40 }, (_, index) => ({
         type: "output" as const,
         chunk: `filler-${index}`,
@@ -1705,12 +1705,12 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
       );
       const chunks: string[] = [];
       session.onData((chunk) => chunks.push(chunk));
-      // The wait settles with the LATEST exit code, proving the repeat
-      // updated the held record instead of adding a second one. The exit
-      // still terminal-cuts every output that arrived behind its original
+      // The wait settles with the FIRST exit code, proving the repeat
+      // dropped instead of overwriting the held record. The exit still
+      // terminal-cuts every output that arrived behind its original
       // position, so neither "between-exits" nor "after-repeat" reaches the
       // listener — proving the repeat did not move the record's position.
-      await expect(session.wait()).resolves.toEqual({ exitCode: 2 });
+      await expect(session.wait()).resolves.toEqual({ exitCode: 1 });
       expect(chunks).toEqual(fillerOutputs.map((entry) => entry.chunk));
       await session.close();
     } finally {

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1429,6 +1429,30 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
     }
   });
 
+  it("settles the wait with a valid pre-bind exit that a later mismatched exit cannot displace", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The worker batches a valid exit for the real worker session id, then a
+      // second exit for a forged worker session id, both before the open
+      // reply. The bind still verifies the real session id, so the held valid
+      // exit settles the wait, and the mismatched exit that arrived after it
+      // never displaces it.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          exitCode: 0,
+          extraExits: [{ exitCode: 1, sid: "ws-EVIL" }],
+        }),
+      );
+      await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
   it("delivers output that arrived behind a coalesced exit before the exit settles the wait", async () => {
     const handle = makeLoginPtyHandle();
     try {
@@ -1550,6 +1574,33 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
             // 15, past the 10-character bound, so the host terminalizes the
             // route before the bind can complete.
             outputs: [{ chunk: "aaaaa" }, { chunk: "bbbbb" }, { chunk: "ccccc" }],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("terminalizes the route when a third distinct pre-bind exit session passes the exit-slot bound", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The worker batches exits for three distinct worker session ids before
+      // the bind. The host holds one exit record per distinct session, up to
+      // its fixed exit-slot bound of two, so the third distinct session
+      // passes the bound and the host terminalizes the route before the bind
+      // can complete.
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            batchWithOpenReply: true,
+            workerSessionId: "ws-A",
+            exitCode: 0,
+            extraExits: [
+              { exitCode: 1, sid: "ws-B" },
+              { exitCode: 2, sid: "ws-C" },
+            ],
           }),
         ),
       ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -9,6 +9,24 @@ import {
   type HostServices,
   type HostToWorkerMethods,
 } from "@paperclipai/plugin-sdk";
+
+// Mock the shared logger, so a test reads the exact calls the manager makes
+// when it logs a route event. The child logger returns the same mock object,
+// so `log.warn`/`log.error` inside the manager are this mock's `warn`/`error`.
+vi.mock("../middleware/logger.js", () => {
+  const mockLogger: Record<string, unknown> = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(() => mockLogger),
+  };
+  return { logger: mockLogger, httpLogger: vi.fn() };
+});
+
+import { logger } from "../middleware/logger.js";
 import {
   appendStderrExcerpt,
   createPluginWorkerHandle,
@@ -1340,6 +1358,263 @@ describe("plugin worker manager setup-token pty route gate", () => {
       await expect(
         handle.openLoginPtySession(ptyOpenInput({ mode: "normal" })),
       ).rejects.toThrow();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Login pseudo-terminal pre-bind queue (GH #12122 / PAP-5132)
+// ---------------------------------------------------------------------------
+// The host reads the worker pipe and `readline` dispatches every line of one
+// chunk synchronously. The route only becomes `open` inside the `await`
+// continuation of the `loginPtyOpen` reply, which runs as a microtask after
+// the whole synchronous line loop. So a worker that batches an output or an
+// exit notification with the open reply floods the host before the bind. The
+// tests below prove the host queues these pre-bind records, in order, and
+// replays them through the live router right after the bind, instead of
+// dropping them.
+
+describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
+  it("queues and replays a coalesced output notification that arrives before the bind", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The fixture writes the open reply and the output notification in one
+      // stdout write, so the host reads both before the route binds.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          outputs: [{ chunk: "batched-output" }],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      // The bind already replayed the queued record into `buffered`, so
+      // `onData` drains it synchronously with no wait.
+      expect(chunks).toEqual(["batched-output"]);
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("delivers a coalesced output before the coalesced exit settles the wait", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          outputs: [{ chunk: "batched-output" }],
+          exitCode: 0,
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      // Both the output and the exit arrived before the bind and queued in
+      // order. The replay preserves that order, so the output reaches the
+      // listener before the wait settles.
+      await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
+      expect(chunks).toEqual(["batched-output"]);
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("drops a forged pre-bind worker session id sent before the valid bind", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          outputs: [
+            { chunk: "forged", sid: "ws-EVIL" },
+            { chunk: "good" },
+          ],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      // Both records queued before the bind, since the host cannot yet check
+      // a worker session id against a route that has not bound one. The
+      // replay applies the exact-match gate against the real bind ("ws-A"),
+      // so the forged record never reaches the listener.
+      expect(chunks).toEqual(["good"]);
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("terminalizes the route when batched pre-bind records pass the frame-count bound", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxPreBindFrames: 2 },
+    });
+    try {
+      await handle.start();
+      // The worker batches three output notifications with the open reply, so
+      // all three arrive, and queue, before the bind. The third record passes
+      // the frame-count bound, so the host terminalizes the route before the
+      // bind can complete, and the open call itself fails.
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            batchWithOpenReply: true,
+            outputs: [{ chunk: "a" }, { chunk: "b" }, { chunk: "c" }],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("terminalizes the route when batched pre-bind output passes the character bound", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxPreBindChars: 10 },
+    });
+    try {
+      await handle.start();
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            batchWithOpenReply: true,
+            // 5 + 5 = 10 admits; the third record brings the queued total to
+            // 15, past the 10-character bound, so the host terminalizes the
+            // route before the bind can complete.
+            outputs: [{ chunk: "aaaaa" }, { chunk: "bbbbb" }, { chunk: "ccccc" }],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("clears the pre-bind queue on a malformed open reply", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The malformed reply carries no worker session id, so the host cannot
+      // bind. It terminalizes the route and clears the queued output before
+      // it ever reaches a listener.
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            mode: "malformed-open",
+            batchWithOpenReply: true,
+            outputs: [{ chunk: "leaked" }],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+      // A later open on the same worker starts a fresh route and receives
+      // only its own scripted output, never the cleared queue.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({ mode: "normal", outputs: [{ chunk: "fresh" }] }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      await vi.waitFor(() => expect(chunks).toContain("fresh"));
+      expect(chunks).not.toContain("leaked");
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("clears the pre-bind queue when the worker exits during the open window", async () => {
+    const handle = makeLoginPtyHandle({ autoRestart: false });
+    try {
+      await handle.start();
+      // The fixture emits one output notification, then exits before it ever
+      // sends the open reply. The route never binds. The worker-exit path
+      // must clear the queued output along with the route.
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            mode: "exit-before-open-reply",
+            outputs: [{ chunk: "queued-before-exit" }],
+          }),
+        ),
+      ).rejects.toThrow();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("terminalizes at replay when the queued output would pass the cumulative total-chars bound", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxTotalChars: 10, maxPreBindFrames: 1000, maxPreBindChars: 1000 },
+    });
+    try {
+      await handle.start();
+      // The generous pre-bind bounds admit all three records at intake, so
+      // the bind completes and the replay runs. The replay sends each record
+      // through the same live router an open route uses, so the cumulative
+      // `maxTotalChars` gate still applies: the third record would bring the
+      // delivered total to 15, past the 10-character bound, so the replay
+      // terminalizes the route partway through. The directive carries no exit
+      // notification, so only a mid-replay terminalize can settle the wait;
+      // without the cumulative gate applying during replay, this call would
+      // hang.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          outputs: [{ chunk: "aaaaa" }, { chunk: "bbbbb" }, { chunk: "ccccc" }],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      await expect(session.wait()).resolves.toEqual({ exitCode: null });
+      // The terminalize clears `route.buffered` by design (a terminalized
+      // login route settles with a null exit code, so buffered data has no
+      // consumer), so even the two records the replay delivered before the
+      // bound tripped never reach the listener.
+      expect(chunks).toEqual([]);
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("never logs the raw chunk content, including on the pre-bind overflow path", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxPreBindFrames: 1 },
+    });
+    const secretMarker = "super-secret-login-code-must-never-reach-a-log-line";
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.error).mockClear();
+    vi.mocked(logger.info).mockClear();
+    vi.mocked(logger.debug).mockClear();
+    try {
+      await handle.start();
+      // The first record admits, then the second passes the frame-count
+      // bound and terminalizes the route. The overflow path logs a fixed
+      // warning that must never carry the chunk text.
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            batchWithOpenReply: true,
+            outputs: [{ chunk: secretMarker }, { chunk: "overflow" }],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+      const loggedText = [
+        ...vi.mocked(logger.warn).mock.calls,
+        ...vi.mocked(logger.error).mock.calls,
+        ...vi.mocked(logger.info).mock.calls,
+        ...vi.mocked(logger.debug).mock.calls,
+      ]
+        .flat()
+        .map((arg) => JSON.stringify(arg))
+        .join("\n");
+      expect(loggedText).not.toContain(secretMarker);
     } finally {
       await handle.stop().catch(() => undefined);
     }

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1646,46 +1646,16 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
     }
   });
 
-  it("terminalizes the route when a third distinct pre-bind exit session passes the exit-slot bound", async () => {
-    const handle = makeLoginPtyHandle();
-    try {
-      await handle.start();
-      // The worker batches exits for three distinct worker session ids before
-      // the bind. The host holds one exit record per distinct session, up to
-      // its fixed exit-slot bound of two, so the third distinct session
-      // passes the bound and the host terminalizes the route before the bind
-      // can complete.
-      await expect(
-        handle.openLoginPtySession(
-          ptyOpenInput({
-            batchWithOpenReply: true,
-            workerSessionId: "ws-A",
-            exitCode: 0,
-            extraExits: [
-              { exitCode: 1, sid: "ws-B" },
-              { exitCode: 2, sid: "ws-C" },
-            ],
-          }),
-        ),
-      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
-    } finally {
-      await handle.stop().catch(() => undefined);
-    }
-  });
-
-  it("keeps a repeated pre-bind exit at its original arrival position with its first exit code, against a filled output queue", async () => {
+  it("settles with the first exit code against a repeated pre-bind exit for the same session, behind a filled output queue", async () => {
     const handle = makeLoginPtyHandle({
       loginPtyLimits: { maxPreBindFrames: 50 },
     });
     try {
       await handle.start();
-      // Fill the pre-bind output queue with 40 records ahead of the first
-      // exit, then repeat the exit for the same worker session id after more
-      // output arrives. The host indexes the retained exit record by worker
-      // session id, so the repeat check is an O(1) lookup, not a scan of the
-      // held queue. The FIRST retained exit wins: the repeat drops there and
-      // the record keeps its ORIGINAL arrival position — right after the
-      // filler outputs, not at the later position of the repeat.
+      // Fill the pre-bind queue with 40 output records, then repeat the exit
+      // for the same worker session id after more output arrives. The first
+      // exit settles the route during the replay, so the repeat exit and the
+      // output around it never reach the listener.
       const fillerOutputs = Array.from({ length: 40 }, (_, index) => ({
         type: "output" as const,
         chunk: `filler-${index}`,
@@ -1705,13 +1675,38 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
       );
       const chunks: string[] = [];
       session.onData((chunk) => chunks.push(chunk));
-      // The wait settles with the FIRST exit code, proving the repeat
-      // dropped instead of overwriting the held record. The exit still
-      // terminal-cuts every output that arrived behind its original
-      // position, so neither "between-exits" nor "after-repeat" reaches the
-      // listener — proving the repeat did not move the record's position.
+      // The wait settles with the FIRST exit code, and the exit drops every
+      // output that arrived behind it, so neither "between-exits" nor
+      // "after-repeat" reaches the listener.
       await expect(session.wait()).resolves.toEqual({ exitCode: 1 });
       expect(chunks).toEqual(fillerOutputs.map((entry) => entry.chunk));
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("settles with the first exit code against N repeated pre-bind exits for the same session", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The worker sends five repeat exits for the same session before the
+      // bind. The first exit settles the route during the replay, so every
+      // repeat drops there and the wait still settles with the first code.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          exitCode: 1,
+          extraExits: [
+            { exitCode: 2 },
+            { exitCode: 3 },
+            { exitCode: 4 },
+            { exitCode: 5 },
+          ],
+        }),
+      );
+      await expect(session.wait()).resolves.toEqual({ exitCode: 1 });
       await session.close();
     } finally {
       await handle.stop().catch(() => undefined);

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1673,6 +1673,51 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
     }
   });
 
+  it("keeps a repeated pre-bind exit at its original arrival position with its latest exit code, against a filled output queue", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxPreBindFrames: 50 },
+    });
+    try {
+      await handle.start();
+      // Fill the pre-bind output queue with 40 records ahead of the first
+      // exit, then repeat the exit for the same worker session id after more
+      // output arrives. The host indexes the retained exit record by worker
+      // session id, so the repeat updates the SAME record in place instead
+      // of scanning the held queue for it, and the record keeps its
+      // ORIGINAL arrival position — right after the filler outputs, not at
+      // the later position of the repeat.
+      const fillerOutputs = Array.from({ length: 40 }, (_, index) => ({
+        type: "output" as const,
+        chunk: `filler-${index}`,
+      }));
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          sequence: [
+            ...fillerOutputs,
+            { type: "exit", exitCode: 1 },
+            { type: "output", chunk: "between-exits" },
+            { type: "exit", exitCode: 2 },
+            { type: "output", chunk: "after-repeat" },
+          ],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      // The wait settles with the LATEST exit code, proving the repeat
+      // updated the held record instead of adding a second one. The exit
+      // still terminal-cuts every output that arrived behind its original
+      // position, so neither "between-exits" nor "after-repeat" reaches the
+      // listener — proving the repeat did not move the record's position.
+      await expect(session.wait()).resolves.toEqual({ exitCode: 2 });
+      expect(chunks).toEqual(fillerOutputs.map((entry) => entry.chunk));
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
   it("clears the pre-bind queue on a malformed open reply", async () => {
     const handle = makeLoginPtyHandle();
     try {

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1646,6 +1646,59 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
     }
   });
 
+  it("charges the retained worker session id characters on the pre-bind output path", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxPreBindChars: 10 },
+    });
+    try {
+      await handle.start();
+      // A 6-character worker session id and one 5-character chunk charge 11
+      // characters against the 10-character bound on the very first record,
+      // even though the chunk alone is under the bound. Without the identifier
+      // charge, this single record would pass.
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            batchWithOpenReply: true,
+            workerSessionId: "ABCDEF",
+            outputs: [{ chunk: "aaaaa" }],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("terminalizes the route when batched pre-bind exit notifications with a large worker session id pass the character bound", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxPreBindChars: 10 },
+    });
+    try {
+      await handle.start();
+      await expect(
+        handle.openLoginPtySession(
+          ptyOpenInput({
+            batchWithOpenReply: true,
+            // An exit record carries no chunk, but it still retains the worker
+            // session id. This 5-character id makes 5 + 5 = 10 admit the first
+            // two exits; the third brings the queued total to 15, past the
+            // 10-character bound, so the host terminalizes the route before
+            // the bind can complete.
+            workerSessionId: "AAAAA",
+            sequence: [
+              { type: "exit", exitCode: 1 },
+              { type: "exit", exitCode: 2 },
+              { type: "exit", exitCode: 3 },
+            ],
+          }),
+        ),
+      ).rejects.toThrow("LOGIN_PTY_OPEN_FAILED");
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
   it("settles with the first exit code against a repeated pre-bind exit for the same session, behind a filled output queue", async () => {
     const handle = makeLoginPtyHandle({
       loginPtyLimits: { maxPreBindFrames: 50 },

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1372,9 +1372,12 @@ describe("plugin worker manager setup-token pty route gate", () => {
 // continuation of the `loginPtyOpen` reply, which runs as a microtask after
 // the whole synchronous line loop. So a worker that batches an output or an
 // exit notification with the open reply floods the host before the bind. The
-// tests below prove the host queues these pre-bind records, in order, and
-// replays them through the live router right after the bind, instead of
-// dropping them.
+// tests below prove the host queues these pre-bind records and replays them
+// through the live router right after the bind, instead of dropping them.
+// The host holds a queued exit apart from the queued output records, and it
+// always replays every held output record before the held exit, so a queued
+// exit never settles the session wait ahead of output the host already
+// queued — even when the worker sent the exit first.
 
 describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
   it("queues and replays a coalesced output notification that arrives before the bind", async () => {
@@ -1421,6 +1424,63 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
       await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
       expect(chunks).toEqual(["batched-output"]);
       await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("delivers output that arrived behind a coalesced exit before the exit settles the wait", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          exitCode: 0,
+          // The worker batched this output behind the exit. The host holds the
+          // exit apart from the output queue and replays every held output
+          // record first, so this record still reaches the listener even
+          // though the worker sent it after the exit.
+          outputsAfterExit: [{ chunk: "late-output" }],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
+      expect(chunks).toEqual(["late-output"]);
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("never settles the wait with a stale exit code when output queued behind the exit still terminalizes the route", async () => {
+    const handle = makeLoginPtyHandle({
+      loginPtyLimits: { maxTotalChars: 10, maxPreBindFrames: 1000, maxPreBindChars: 1000 },
+    });
+    try {
+      await handle.start();
+      // The worker batches an exit with the open reply, then an output record
+      // that would push the cumulative delivered total past the 10-character
+      // bound. The host replays every held output record before the held
+      // exit, so the bound violation terminalizes the route and settles the
+      // wait with the fixed null exit code. Before this fix, the queued exit
+      // replayed first and settled the wait with its own exit code, so the
+      // later terminalize call found the wait already settled and could
+      // never correct it — the runner would have read a false success.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          exitCode: 0,
+          outputsAfterExit: [{ chunk: "aaaaaaaaaaaa" }],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      await expect(session.wait()).resolves.toEqual({ exitCode: null });
+      expect(chunks).toEqual([]);
     } finally {
       await handle.stop().catch(() => undefined);
     }

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -1374,10 +1374,13 @@ describe("plugin worker manager setup-token pty route gate", () => {
 // exit notification with the open reply floods the host before the bind. The
 // tests below prove the host queues these pre-bind records and replays them
 // through the live router right after the bind, instead of dropping them.
-// The host holds a queued exit apart from the queued output records, and it
-// always replays every held output record before the held exit, so a queued
-// exit never settles the session wait ahead of output the host already
-// queued — even when the worker sent the exit first.
+// The host holds every pre-bind record — output and exit alike — in one
+// arrival-ordered queue, and it replays each record through the live router
+// in that exact order. A replayed exit that carries the bound worker session
+// identifier settles the route, so a record that arrived behind it — a real
+// worker process cannot emit output after it exits, so this only matters for
+// a forged or a queued record — replays into a route that already settled
+// and is dropped.
 
 describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
   it("queues and replays a coalesced output notification that arrives before the bind", async () => {
@@ -1453,7 +1456,35 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
     }
   });
 
-  it("delivers output that arrived behind a coalesced exit before the exit settles the wait", async () => {
+  it("delivers a pre-bind output, then the exit, and drops output that arrives behind the exit", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The worker batches an output, then a valid exit, then a further
+      // output, all before the open reply. The host replays the three held
+      // records in this exact arrival order. The exit settles the route
+      // right after the first output, so the record behind the exit finds a
+      // route that already settled and never reaches the listener.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          outputs: [{ chunk: "before-exit" }],
+          exitCode: 0,
+          outputsAfterExit: [{ chunk: "after-exit" }],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
+      expect(chunks).toEqual(["before-exit"]);
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("drops output that arrives behind a valid pre-bind exit", async () => {
     const handle = makeLoginPtyHandle();
     try {
       await handle.start();
@@ -1462,37 +1493,38 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
           batchWithOpenReply: true,
           workerSessionId: "ws-A",
           exitCode: 0,
-          // The worker batched this output behind the exit. The host holds the
-          // exit apart from the output queue and replays every held output
-          // record first, so this record still reaches the listener even
-          // though the worker sent it after the exit.
+          // The worker batched this output behind the exit. The replay sends
+          // the exit first, in arrival order, which settles the route. The
+          // output record behind it then finds a route that is no longer
+          // `open`, the same drop the live path applies to output a real
+          // worker process could never emit after its own exit.
           outputsAfterExit: [{ chunk: "late-output" }],
         }),
       );
       const chunks: string[] = [];
       session.onData((chunk) => chunks.push(chunk));
       await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
-      expect(chunks).toEqual(["late-output"]);
+      expect(chunks).toEqual([]);
       await session.close();
     } finally {
       await handle.stop().catch(() => undefined);
     }
   });
 
-  it("never settles the wait with a stale exit code when output queued behind the exit still terminalizes the route", async () => {
+  it("settles the wait with the valid exit code and drops output behind it, even past the total-chars bound", async () => {
     const handle = makeLoginPtyHandle({
       loginPtyLimits: { maxTotalChars: 10, maxPreBindFrames: 1000, maxPreBindChars: 1000 },
     });
     try {
       await handle.start();
-      // The worker batches an exit with the open reply, then an output record
-      // that would push the cumulative delivered total past the 10-character
-      // bound. The host replays every held output record before the held
-      // exit, so the bound violation terminalizes the route and settles the
-      // wait with the fixed null exit code. Before this fix, the queued exit
-      // replayed first and settled the wait with its own exit code, so the
-      // later terminalize call found the wait already settled and could
-      // never correct it — the runner would have read a false success.
+      // The worker batches a valid exit with the open reply, then an output
+      // record that would push the cumulative delivered total past the
+      // 10-character bound. The replay sends the exit first, in arrival
+      // order. The exit settles the route, so the replay drops the output
+      // record behind it before the total-chars check ever runs — the
+      // bound violation the check exists to catch never reaches it, because
+      // a real worker process could never emit that output in the first
+      // place.
       const session = await handle.openLoginPtySession(
         ptyOpenInput({
           batchWithOpenReply: true,
@@ -1503,8 +1535,40 @@ describe("plugin worker manager login pseudo-terminal pre-bind queue", () => {
       );
       const chunks: string[] = [];
       session.onData((chunk) => chunks.push(chunk));
-      await expect(session.wait()).resolves.toEqual({ exitCode: null });
+      await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
       expect(chunks).toEqual([]);
+      await session.close();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("delivers output that arrived behind a mismatched pre-bind exit and settles with the later valid exit", async () => {
+    const handle = makeLoginPtyHandle();
+    try {
+      await handle.start();
+      // The worker batches a mismatched exit, then a genuine output, then
+      // the valid exit, all before the open reply. The mismatched exit
+      // arrives first, but the exact-match gate fails it, so it changes no
+      // state and the replay continues. The output that follows it still
+      // reaches the listener, and the valid exit that follows the output
+      // settles the wait.
+      const session = await handle.openLoginPtySession(
+        ptyOpenInput({
+          batchWithOpenReply: true,
+          workerSessionId: "ws-A",
+          sequence: [
+            { type: "exit", exitCode: 1, sid: "ws-EVIL" },
+            { type: "output", chunk: "genuine-output" },
+            { type: "exit", exitCode: 0 },
+          ],
+        }),
+      );
+      const chunks: string[] = [];
+      session.onData((chunk) => chunks.push(chunk));
+      await expect(session.wait()).resolves.toEqual({ exitCode: 0 });
+      expect(chunks).toEqual(["genuine-output"]);
+      await session.close();
     } finally {
       await handle.stop().catch(() => undefined);
     }

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1478,16 +1478,16 @@ export function createPluginWorkerHandle(
     // exit records the same queue holds. An exit record never consumes this
     // budget, so it cannot crowd out a held output record.
     preBindOutputFrames: number;
-    // The distinct worker session identifiers among the exit records the
-    // queue retains, bounded by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS. The
-    // host cannot yet check an exit record's worker session identifier
-    // against the bound value, so it keeps every distinct-session record
-    // instead of only the last one — a later mismatched record can never
-    // displace an earlier record that later verifies. A second exit for a
-    // session already in this set updates the held record's exit code in
-    // place, at its original arrival position, which keeps memory constant
-    // against a repeat from one real session.
-    preBindExitSessions: Set<string>;
+    // The retained exit records, indexed by worker session identifier for an
+    // O(1) repeat-exit lookup, bounded by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS.
+    // Each value is the exact same object the queue holds in `preBind`, so
+    // an update through this index mutates the `preBind` entry in place, at
+    // its original arrival position — a repeat never rescans or reorders the
+    // queue. The host cannot yet check an exit record's worker session
+    // identifier against the bound value, so it keeps every distinct-session
+    // record instead of only the last one — a later mismatched record can
+    // never displace an earlier record that later verifies.
+    preBindExitRecordsBySessionId: Map<string, LoginPtyPreBindExitRecord>;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
   // blocks a second open until the manager confirms the first route's close.
@@ -1525,7 +1525,7 @@ export function createPluginWorkerHandle(
     route.preBind = [];
     route.preBindChars = 0;
     route.preBindOutputFrames = 0;
-    route.preBindExitSessions.clear();
+    route.preBindExitRecordsBySessionId.clear();
     // A terminalized route reports a null exit code, which the runner treats as a
     // failure.
     settleRouteWait(route, { exitCode: null });
@@ -1651,11 +1651,14 @@ export function createPluginWorkerHandle(
   // per distinct worker session identifier, up to
   // MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS, so a later mismatched exit never
   // displaces an earlier record the bind can still verify. A second exit for
-  // the same worker session identifier updates the held record's exit code
-  // in place, at its original arrival position, which keeps memory constant
-  // against a repeat from one real session. A distinct-session exit past the
-  // bound fails the route closed, the same fail-closed choice the output
-  // queue makes past its own bound.
+  // the same worker session identifier looks up the held record by an O(1)
+  // map index and updates its exit code in place, at its original arrival
+  // position — it never rescans the held queue, so an unbounded repeat count
+  // from one worker session costs constant work per repeat, not work
+  // proportional to the queue length. This keeps memory constant against a
+  // repeat from one real session. A distinct-session exit past the bound
+  // fails the route closed, the same fail-closed choice the output queue
+  // makes past its own bound.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1664,15 +1667,12 @@ export function createPluginWorkerHandle(
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    const existing = route.preBind.find(
-      (record): record is LoginPtyPreBindExitRecord =>
-        record.kind === "exit" && record.workerSessionId === workerSessionId,
-    );
+    const existing = route.preBindExitRecordsBySessionId.get(workerSessionId);
     if (existing) {
       existing.exitCode = exitCode;
       return;
     }
-    if (route.preBindExitSessions.size + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
+    if (route.preBindExitRecordsBySessionId.size + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
       log.warn(
         { pluginId },
         "login pseudo-terminal pre-bind exit slot exceeded a bound; terminalizing route",
@@ -1680,8 +1680,9 @@ export function createPluginWorkerHandle(
       void terminalizeLoginPtyRoute(route);
       return;
     }
-    route.preBindExitSessions.add(workerSessionId);
-    route.preBind.push({ kind: "exit", workerSessionId, exitCode });
+    const record: LoginPtyPreBindExitRecord = { kind: "exit", workerSessionId, exitCode };
+    route.preBindExitRecordsBySessionId.set(workerSessionId, record);
+    route.preBind.push(record);
   }
 
   // Replay the records a route held before it bound, in the exact order the
@@ -1708,7 +1709,7 @@ export function createPluginWorkerHandle(
     route.preBind = [];
     route.preBindChars = 0;
     route.preBindOutputFrames = 0;
-    route.preBindExitSessions.clear();
+    route.preBindExitRecordsBySessionId.clear();
     for (const record of held) {
       if (route.terminalized) return;
       if (record.kind === "output") {
@@ -1741,7 +1742,7 @@ export function createPluginWorkerHandle(
     route.preBind = [];
     route.preBindChars = 0;
     route.preBindOutputFrames = 0;
-    route.preBindExitSessions.clear();
+    route.preBindExitRecordsBySessionId.clear();
     settleRouteWait(route, { exitCode: null });
   }
 
@@ -1785,7 +1786,7 @@ export function createPluginWorkerHandle(
       preBind: [],
       preBindChars: 0,
       preBindOutputFrames: 0,
-      preBindExitSessions: new Set<string>(),
+      preBindExitRecordsBySessionId: new Map<string, LoginPtyPreBindExitRecord>(),
     };
     loginPtyRoute = route;
 

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -189,6 +189,19 @@ const MAX_LOGIN_PTY_PRE_BIND_FRAMES = 10_000;
  * route's pre-bind character bound.
  */
 const MAX_LOGIN_PTY_PRE_BIND_CHARS = 8 * 1024 * 1024;
+/**
+ * Maximum number of distinct-session exit records the host holds in the
+ * pre-bind exit slot for one login pseudo-terminal route. The host cannot
+ * check an exit record's worker session identifier against the bound value
+ * until the bind happens, so it must hold every distinct-session record it
+ * sees, not only the last one: a later record with a different worker
+ * session identifier must never displace an earlier one the bind can still
+ * verify. Two slots hold one genuine exit plus one mismatched exit, the
+ * pattern this bound exists to survive. A worker that sends a third
+ * distinct-session exit before the bind passes this bound, and the host
+ * fails the route closed instead of holding an unbounded number of records.
+ */
+const MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS = 2;
 /** The default open timeout for one login pseudo-terminal route, in milliseconds. */
 const LOGIN_PTY_OPEN_TIMEOUT_MS = 30_000;
 /** The default close timeout for one login pseudo-terminal route, in milliseconds. */
@@ -1424,7 +1437,7 @@ export function createPluginWorkerHandle(
   type LoginPtyPreBindRecord = { workerSessionId: string; chunk: string };
 
   // One login pseudo-terminal exit record that arrived before the route
-  // bound. The host holds it in the single `preBindExit` slot, never in the
+  // bound. The host holds it in the `preBindExits` slot, never in the
   // ordered output queue, so a queued exit can never jump ahead of output
   // the host already queued.
   interface LoginPtyPreBindExitRecord {
@@ -1448,11 +1461,16 @@ export function createPluginWorkerHandle(
     preBind: LoginPtyPreBindRecord[];
     // The cumulative output characters the pre-bind queue retains.
     preBindChars: number;
-    // The one exit record that arrived before the bind, held apart from the
-    // output queue. The bind replays every held output record first, then
-    // this exit last, so a queued exit never settles the session wait ahead
-    // of output the host already queued.
-    preBindExit: LoginPtyPreBindExitRecord | null;
+    // The exit records that arrived before the bind, held apart from the
+    // output queue, one per distinct worker session identifier and bounded
+    // by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS. The host cannot yet check a
+    // record's worker session identifier against the bound value, so it
+    // keeps every distinct-session record instead of only the last one — a
+    // later mismatched record can never displace an earlier record that
+    // later verifies. The bind replays every held output record first, then
+    // every held exit last, so a queued exit never settles the session wait
+    // ahead of output the host already queued.
+    preBindExits: LoginPtyPreBindExitRecord[];
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
   // blocks a second open until the manager confirms the first route's close.
@@ -1485,11 +1503,11 @@ export function createPluginWorkerHandle(
     route.state = "closed";
     route.listener = null;
     route.buffered = [];
-    // Clear the pre-bind output queue and the held exit. A terminalized route
+    // Clear the pre-bind output queue and the held exits. A terminalized route
     // never replays a held record.
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindExit = null;
+    route.preBindExits = [];
     // A terminalized route reports a null exit code, which the runner treats as a
     // failure.
     settleRouteWait(route, { exitCode: null });
@@ -1599,10 +1617,17 @@ export function createPluginWorkerHandle(
   }
 
   // Queue one login pseudo-terminal exit notification that arrived before the
-  // bind. The exit holds a single fixed-size slot apart from the output
-  // queue, so it never crowds out a queued output record and it carries no
-  // frame-count bound of its own. A later exit replaces an earlier held one:
-  // only the last exit the worker sent before the bind is real.
+  // bind. The exit holds a small fixed-size slot apart from the output queue,
+  // so it never crowds out a queued output record. The host cannot check the
+  // worker session identifier against the bound value yet, so it cannot tell
+  // a genuine exit from a mismatched one at this point: it keeps one record
+  // per distinct worker session identifier, up to
+  // MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS, so a later mismatched exit never
+  // displaces an earlier record the bind can still verify. A second exit for
+  // the same worker session identifier updates the held exit code in place,
+  // which keeps memory constant against a repeat from one real session. A
+  // distinct-session exit past the bound fails the route closed, the same
+  // fail-closed choice the output queue makes past its own bound.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1611,13 +1636,28 @@ export function createPluginWorkerHandle(
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    route.preBindExit = { workerSessionId, exitCode };
+    const existing = route.preBindExits.find(
+      (record) => record.workerSessionId === workerSessionId,
+    );
+    if (existing) {
+      existing.exitCode = exitCode;
+      return;
+    }
+    if (route.preBindExits.length + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
+      log.warn(
+        { pluginId },
+        "login pseudo-terminal pre-bind exit slot exceeded a bound; terminalizing route",
+      );
+      void terminalizeLoginPtyRoute(route);
+      return;
+    }
+    route.preBindExits.push({ workerSessionId, exitCode });
   }
 
   // Replay the records a route held before it bound. Remove the queue from
   // the route first, so a terminalize mid-replay clears no record twice.
-  // Replay every held output record first, in order, then the held exit
-  // last, so the exit can never settle the session wait ahead of output the
+  // Replay every held output record first, in order, then every held exit
+  // last, so an exit can never settle the session wait ahead of output the
   // host already queued — this matches a real worker's order, where the
   // process cannot emit output after it exits. Reconstruct one transient
   // notification per record and send it through the same live router the
@@ -1627,7 +1667,11 @@ export function createPluginWorkerHandle(
   // Never call `route.listener` directly and never reset
   // `route.deliveredChars`. A record that ends the route terminalizes it, and
   // every later record in the replay is a no-op, because the routing
-  // functions drop a record for a route that is not `open`.
+  // functions drop a record for a route that is not `open`. The held exits
+  // replay in arrival order too: at most one of them carries the worker
+  // session identifier the bind just verified, so the exact-match gate
+  // settles the session wait from that one record and drops every other held
+  // exit, regardless of which order they arrived in before the bind.
   function replayPreBindLoginPtyRecords(route: LoginPtyRoute): void {
     const held = route.preBind;
     route.preBind = [];
@@ -1640,9 +1684,10 @@ export function createPluginWorkerHandle(
         params: { workerSessionId: record.workerSessionId, chunk: record.chunk },
       });
     }
-    const heldExit = route.preBindExit;
-    route.preBindExit = null;
-    if (heldExit && !route.terminalized) {
+    const heldExits = route.preBindExits;
+    route.preBindExits = [];
+    for (const heldExit of heldExits) {
+      if (route.terminalized) return;
       routeLoginPtyExit({
         jsonrpc: "2.0",
         method: LOGIN_PTY_EXIT_NOTIFICATION,
@@ -1664,7 +1709,7 @@ export function createPluginWorkerHandle(
     route.buffered = [];
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindExit = null;
+    route.preBindExits = [];
     settleRouteWait(route, { exitCode: null });
   }
 
@@ -1707,7 +1752,7 @@ export function createPluginWorkerHandle(
       settleWait,
       preBind: [],
       preBindChars: 0,
-      preBindExit: null,
+      preBindExits: [],
     };
     loginPtyRoute = route;
 

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1479,14 +1479,15 @@ export function createPluginWorkerHandle(
     // budget, so it cannot crowd out a held output record.
     preBindOutputFrames: number;
     // The retained exit records, indexed by worker session identifier for an
-    // O(1) repeat-exit lookup, bounded by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS.
-    // Each value is the exact same object the queue holds in `preBind`, so
-    // an update through this index mutates the `preBind` entry in place, at
-    // its original arrival position — a repeat never rescans or reorders the
-    // queue. The host cannot yet check an exit record's worker session
-    // identifier against the bound value, so it keeps every distinct-session
-    // record instead of only the last one — a later mismatched record can
-    // never displace an earlier record that later verifies.
+    // O(1) repeat-exit check, bounded by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS.
+    // A repeat exit for a session this index already holds drops there — the
+    // host never rescans `preBind` to find it and never mutates the held
+    // record, so the FIRST retained exit for a session keeps its exit code
+    // and its original arrival position. The host cannot yet check an exit
+    // record's worker session identifier against the bound value, so it
+    // keeps every distinct-session record instead of only the last one — a
+    // later mismatched record can never displace an earlier record that
+    // later verifies.
     preBindExitRecordsBySessionId: Map<string, LoginPtyPreBindExitRecord>;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
@@ -1650,15 +1651,16 @@ export function createPluginWorkerHandle(
   // a genuine exit from a mismatched one at this point: it keeps one record
   // per distinct worker session identifier, up to
   // MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS, so a later mismatched exit never
-  // displaces an earlier record the bind can still verify. A second exit for
-  // the same worker session identifier looks up the held record by an O(1)
-  // map index and updates its exit code in place, at its original arrival
-  // position — it never rescans the held queue, so an unbounded repeat count
-  // from one worker session costs constant work per repeat, not work
-  // proportional to the queue length. This keeps memory constant against a
-  // repeat from one real session. A distinct-session exit past the bound
-  // fails the route closed, the same fail-closed choice the output queue
-  // makes past its own bound.
+  // displaces an earlier record the bind can still verify.
+  // `route.preBindExitRecordsBySessionId` is an O(1) index of the retained
+  // exit records by worker session identifier, so a repeat check never
+  // rescans the held queue. The FIRST retained exit for a session wins: a
+  // repeat exit for a session the index already holds drops here, and the
+  // host never updates the held record's exit code. This matches the live
+  // route, where the first valid exit closes the route and every later exit
+  // fails the `state !== "open"` guard — the replay path must settle the
+  // same way. A distinct-session exit past the bound fails the route closed,
+  // the same fail-closed choice the output queue makes past its own bound.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1666,12 +1668,8 @@ export function createPluginWorkerHandle(
     const params = isRecord(notification.params) ? notification.params : {};
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
+    if (route.preBindExitRecordsBySessionId.has(workerSessionId)) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    const existing = route.preBindExitRecordsBySessionId.get(workerSessionId);
-    if (existing) {
-      existing.exitCode = exitCode;
-      return;
-    }
     if (route.preBindExitRecordsBySessionId.size + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
       log.warn(
         { pluginId },

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -169,39 +169,10 @@ const MAX_EXECUTE_LOG_TOTAL_CHARS = 128 * 1024 * 1024;
 const MAX_LOGIN_PTY_CHUNK_CHARS = 1_000_000;
 /** Maximum cumulative output characters for one login pseudo-terminal route. */
 const MAX_LOGIN_PTY_TOTAL_CHARS = 8 * 1024 * 1024;
-/**
- * Default maximum number of output and exit records the host holds for one
- * login pseudo-terminal route before the worker session identifier binds. The
- * host reads the worker pipe and dispatches every line of one chunk
- * synchronously, so a worker can batch an output or an exit notification with
- * the open reply and the host reads both in one pipe read, before the bind.
- * The host queues these pre-bind records in order and replays them through
- * the live router right after the bind, so none of them is lost. This bound
- * mirrors the sibling duplex channel route's pre-bind frame bound; the login
- * route needs no tighter bound, because the existing 30-second open timeout
- * (`LOGIN_PTY_OPEN_TIMEOUT_MS`) already bounds how long the queue can live.
- */
+/** Default maximum output and exit records the host queues before the bind. */
 const MAX_LOGIN_PTY_PRE_BIND_FRAMES = 10_000;
-/**
- * Default maximum cumulative output characters the host holds in the pre-bind
- * queue for one login pseudo-terminal route. An exit record adds zero
- * characters to this count. This bound mirrors the sibling duplex channel
- * route's pre-bind character bound.
- */
+/** Default maximum cumulative output characters the host queues before the bind. */
 const MAX_LOGIN_PTY_PRE_BIND_CHARS = 8 * 1024 * 1024;
-/**
- * Maximum number of distinct-session exit records the host holds in the
- * pre-bind exit slot for one login pseudo-terminal route. The host cannot
- * check an exit record's worker session identifier against the bound value
- * until the bind happens, so it must hold every distinct-session record it
- * sees, not only the last one: a later record with a different worker
- * session identifier must never displace an earlier one the bind can still
- * verify. Two slots hold one genuine exit plus one mismatched exit, the
- * pattern this bound exists to survive. A worker that sends a third
- * distinct-session exit before the bind passes this bound, and the host
- * fails the route closed instead of holding an unbounded number of records.
- */
-const MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS = 2;
 /** The default open timeout for one login pseudo-terminal route, in milliseconds. */
 const LOGIN_PTY_OPEN_TIMEOUT_MS = 30_000;
 /** The default close timeout for one login pseudo-terminal route, in milliseconds. */
@@ -1431,28 +1402,20 @@ export function createPluginWorkerHandle(
 
   type LoginPtyRouteState = RouteState;
 
-  // One login pseudo-terminal output record that arrived before the route
-  // bound, normalized to a narrow scalar shape. The host retains only these
-  // bounded fields, never the raw notification object.
+  // One pre-bind login pseudo-terminal record: an output chunk or an exit,
+  // normalized to a narrow scalar shape (never the raw notification object).
   interface LoginPtyPreBindOutputRecord {
     kind: "output";
     workerSessionId: string;
     chunk: string;
   }
 
-  // One login pseudo-terminal exit record that arrived before the route
-  // bound, normalized the same way.
   interface LoginPtyPreBindExitRecord {
     kind: "exit";
     workerSessionId: string;
     exitCode: number | null;
   }
 
-  // One pre-bind login pseudo-terminal record, output or exit. The host
-  // holds every pre-bind record in one arrival-ordered queue and replays
-  // each record through the same live router the open route uses, in the
-  // exact order the host received it. The queue never groups a record by
-  // kind.
   type LoginPtyPreBindRecord = LoginPtyPreBindOutputRecord | LoginPtyPreBindExitRecord;
 
   interface LoginPtyRoute {
@@ -1464,31 +1427,10 @@ export function createPluginWorkerHandle(
     deliveredChars: number;
     terminalized: boolean;
     settleWait: (value: { exitCode: number | null }) => void;
-    // The bounded records — output and exit alike — that arrived before the
-    // bind, held in one arrival-ordered queue. The bind replays them through
-    // the live router in this exact order, so an early record is never
-    // lost, a forged worker session identifier still fails the exact-match
-    // gate, and a record that arrived behind a valid exit still replays
-    // behind it and finds a route the exit already settled.
+    // Every output and exit record that arrived before the bind, in arrival order.
     preBind: LoginPtyPreBindRecord[];
-    // The cumulative output characters the queue retains. An exit record
-    // adds zero characters to this count.
+    // The cumulative output characters `preBind` holds. An exit record adds zero.
     preBindChars: number;
-    // The count of output records the queue retains, counted apart from the
-    // exit records the same queue holds. An exit record never consumes this
-    // budget, so it cannot crowd out a held output record.
-    preBindOutputFrames: number;
-    // The retained exit records, indexed by worker session identifier for an
-    // O(1) repeat-exit check, bounded by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS.
-    // A repeat exit for a session this index already holds drops there — the
-    // host never rescans `preBind` to find it and never mutates the held
-    // record, so the FIRST retained exit for a session keeps its exit code
-    // and its original arrival position. The host cannot yet check an exit
-    // record's worker session identifier against the bound value, so it
-    // keeps every distinct-session record instead of only the last one — a
-    // later mismatched record can never displace an earlier record that
-    // later verifies.
-    preBindExitRecordsBySessionId: Map<string, LoginPtyPreBindExitRecord>;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
   // blocks a second open until the manager confirms the first route's close.
@@ -1521,12 +1463,9 @@ export function createPluginWorkerHandle(
     route.state = "closed";
     route.listener = null;
     route.buffered = [];
-    // Clear the pre-bind queue. A terminalized route never replays a held
-    // record.
+    // A terminalized route never replays a queued pre-bind record.
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindOutputFrames = 0;
-    route.preBindExitRecordsBySessionId.clear();
     // A terminalized route reports a null exit code, which the runner treats as a
     // failure.
     settleRouteWait(route, { exitCode: null });
@@ -1546,11 +1485,8 @@ export function createPluginWorkerHandle(
   // Route one login pseudo-terminal output notification to the per-session
   // listener. Deliver only while the route is `open` and the notification carries
   // the exact bound worker session identifier and valid bounded bytes. Queue the
-  // notification while the route is still `opening`: the host reads the worker
-  // pipe and dispatches every line of one chunk synchronously, so a worker can
-  // batch this notification with the open reply and the host reads both before
-  // the bind. Drop an unknown, late, malformed, or mismatched notification. Never
-  // log the raw bytes.
+  // notification while the route is still `opening`. Drop an unknown, late,
+  // malformed, or mismatched notification. Never log the raw bytes.
   function routeLoginPtyOutput(notification: JsonRpcNotification): void {
     const route = loginPtyRoute;
     if (!route) return;
@@ -1583,12 +1519,8 @@ export function createPluginWorkerHandle(
   // Route one login pseudo-terminal exit notification to the login wait. Resolve
   // only while the route is `open` and the notification carries the exact bound
   // worker session identifier. Queue the notification while the route is still
-  // `opening`, in the same order as a batched output notification. A resolved
-  // exit ends the route: move the state off `open`, so a later record — a live
-  // notification or a record replayed from the pre-bind queue — finds a route
-  // that is no longer `open` and drops there. A real worker process cannot emit
-  // output after it exits, so this only guards a forged or a queued record that
-  // still arrives behind a valid exit.
+  // `opening`. A resolved exit moves the state off `open`, so a later record —
+  // live or replayed — finds a closed route and drops there.
   function routeLoginPtyExit(notification: JsonRpcNotification): void {
     const route = loginPtyRoute;
     if (!route) return;
@@ -1606,12 +1538,8 @@ export function createPluginWorkerHandle(
   }
 
   // Queue one login pseudo-terminal output notification that arrived before the
-  // bind, in arrival order. Require a non-empty worker session identifier, a
-  // non-empty string chunk, and the existing per-chunk cap before the host
-  // retains the record, so the queue never grows on a malformed record.
-  // Terminalize the route fail-closed when the queue would pass the
-  // output-frame count or the output-character bound. Never log the raw
-  // chunk.
+  // bind, in arrival order. Terminalize the route fail-closed on a frame-count
+  // or character-bound breach. Never log the raw chunk.
   function queuePreBindLoginPtyOutput(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1628,7 +1556,7 @@ export function createPluginWorkerHandle(
       return;
     }
     if (
-      route.preBindOutputFrames + 1 > maxLoginPtyPreBindFrames ||
+      route.preBind.length + 1 > maxLoginPtyPreBindFrames ||
       route.preBindChars + chunk.length > maxLoginPtyPreBindChars
     ) {
       log.warn(
@@ -1639,28 +1567,12 @@ export function createPluginWorkerHandle(
       return;
     }
     route.preBind.push({ kind: "output", workerSessionId, chunk });
-    route.preBindOutputFrames += 1;
     route.preBindChars += chunk.length;
   }
 
   // Queue one login pseudo-terminal exit notification that arrived before the
-  // bind, in arrival order in the same queue the output records use. An exit
-  // record never consumes the output-frame or output-character budget, so it
-  // can never crowd out a held output record. The host cannot check the
-  // worker session identifier against the bound value yet, so it cannot tell
-  // a genuine exit from a mismatched one at this point: it keeps one record
-  // per distinct worker session identifier, up to
-  // MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS, so a later mismatched exit never
-  // displaces an earlier record the bind can still verify.
-  // `route.preBindExitRecordsBySessionId` is an O(1) index of the retained
-  // exit records by worker session identifier, so a repeat check never
-  // rescans the held queue. The FIRST retained exit for a session wins: a
-  // repeat exit for a session the index already holds drops here, and the
-  // host never updates the held record's exit code. This matches the live
-  // route, where the first valid exit closes the route and every later exit
-  // fails the `state !== "open"` guard — the replay path must settle the
-  // same way. A distinct-session exit past the bound fails the route closed,
-  // the same fail-closed choice the output queue makes past its own bound.
+  // bind, in the same queue the output records use. An exit record counts
+  // against the frame bound but adds zero characters.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1668,46 +1580,27 @@ export function createPluginWorkerHandle(
     const params = isRecord(notification.params) ? notification.params : {};
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
-    if (route.preBindExitRecordsBySessionId.has(workerSessionId)) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    if (route.preBindExitRecordsBySessionId.size + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
+    if (route.preBind.length + 1 > maxLoginPtyPreBindFrames) {
       log.warn(
         { pluginId },
-        "login pseudo-terminal pre-bind exit slot exceeded a bound; terminalizing route",
+        "login pseudo-terminal pre-bind queue exceeded a bound; terminalizing route",
       );
       void terminalizeLoginPtyRoute(route);
       return;
     }
-    const record: LoginPtyPreBindExitRecord = { kind: "exit", workerSessionId, exitCode };
-    route.preBindExitRecordsBySessionId.set(workerSessionId, record);
-    route.preBind.push(record);
+    route.preBind.push({ kind: "exit", workerSessionId, exitCode });
   }
 
-  // Replay the records a route held before it bound, in the exact order the
-  // host received them. Remove the queue from the route first, so a
-  // terminalize mid-replay clears no record twice. Send each record through
-  // the same live router the open route uses (`routeLoginPtyOutput` for an
-  // output record, `routeLoginPtyExit` for an exit record), so a forged
-  // worker session identifier still fails the exact-match gate and the
-  // cumulative `maxLoginPtyTotalChars` gate still applies before delivery.
-  // Never call `route.listener` directly and never reset
-  // `route.deliveredChars`. The replay never groups the records by kind: a
-  // real worker process cannot emit output after it exits, so the arrival
-  // order already carries that guarantee, and grouping the replay by kind
-  // would only reorder around it and let a later record win over an earlier
-  // one. A replayed exit that carries the bound worker session identifier
-  // settles the route and moves its state off `open`, so every later record
-  // in the replay is a no-op — the routers drop a record for a route that is
-  // not `open`. This drops output that arrived behind a valid exit, the same
-  // way the live path drops it. A replayed exit for a different worker
-  // session identifier fails the exact-match gate and changes nothing, so
-  // the replay continues to the next record.
+  // Replay the records a route held before it bound, in arrival order,
+  // through the same live router the open route uses (`routeLoginPtyOutput`,
+  // `routeLoginPtyExit`), so a forged worker session identifier still fails
+  // the exact-match gate and a replayed exit still closes the route and
+  // drops every record behind it.
   function replayPreBindLoginPtyRecords(route: LoginPtyRoute): void {
     const held = route.preBind;
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindOutputFrames = 0;
-    route.preBindExitRecordsBySessionId.clear();
     for (const record of held) {
       if (route.terminalized) return;
       if (record.kind === "output") {
@@ -1739,8 +1632,6 @@ export function createPluginWorkerHandle(
     route.buffered = [];
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindOutputFrames = 0;
-    route.preBindExitRecordsBySessionId.clear();
     settleRouteWait(route, { exitCode: null });
   }
 
@@ -1783,8 +1674,6 @@ export function createPluginWorkerHandle(
       settleWait,
       preBind: [],
       preBindChars: 0,
-      preBindOutputFrames: 0,
-      preBindExitRecordsBySessionId: new Map<string, LoginPtyPreBindExitRecord>(),
     };
     loginPtyRoute = route;
 
@@ -1821,9 +1710,7 @@ export function createPluginWorkerHandle(
     // Bind the worker session identifier one time and move the route to `open`.
     route.workerSessionId = workerSessionId;
     route.state = "open";
-    // Replay every output and exit record the route queued before the bind, in
-    // order, through the live router. A worker that batched one of these
-    // records with the open reply never loses it.
+    // Replay every record the route queued before the bind, in arrival order.
     replayPreBindLoginPtyRecords(route);
 
     return {

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -169,6 +169,26 @@ const MAX_EXECUTE_LOG_TOTAL_CHARS = 128 * 1024 * 1024;
 const MAX_LOGIN_PTY_CHUNK_CHARS = 1_000_000;
 /** Maximum cumulative output characters for one login pseudo-terminal route. */
 const MAX_LOGIN_PTY_TOTAL_CHARS = 8 * 1024 * 1024;
+/**
+ * Default maximum number of output and exit records the host holds for one
+ * login pseudo-terminal route before the worker session identifier binds. The
+ * host reads the worker pipe and dispatches every line of one chunk
+ * synchronously, so a worker can batch an output or an exit notification with
+ * the open reply and the host reads both in one pipe read, before the bind.
+ * The host queues these pre-bind records in order and replays them through
+ * the live router right after the bind, so none of them is lost. This bound
+ * mirrors the sibling duplex channel route's pre-bind frame bound; the login
+ * route needs no tighter bound, because the existing 30-second open timeout
+ * (`LOGIN_PTY_OPEN_TIMEOUT_MS`) already bounds how long the queue can live.
+ */
+const MAX_LOGIN_PTY_PRE_BIND_FRAMES = 10_000;
+/**
+ * Default maximum cumulative output characters the host holds in the pre-bind
+ * queue for one login pseudo-terminal route. An exit record adds zero
+ * characters to this count. This bound mirrors the sibling duplex channel
+ * route's pre-bind character bound.
+ */
+const MAX_LOGIN_PTY_PRE_BIND_CHARS = 8 * 1024 * 1024;
 /** The default open timeout for one login pseudo-terminal route, in milliseconds. */
 const LOGIN_PTY_OPEN_TIMEOUT_MS = 30_000;
 /** The default close timeout for one login pseudo-terminal route, in milliseconds. */
@@ -472,6 +492,10 @@ export interface WorkerStartOptions {
     maxChunkChars?: number;
     /** Max cumulative output characters for one login pseudo-terminal route. */
     maxTotalChars?: number;
+    /** Max number of pre-bind output and exit records the host queues before the bind. */
+    maxPreBindFrames?: number;
+    /** Max cumulative output characters the host queues before the bind. */
+    maxPreBindChars?: number;
     /** The open timeout for one login pseudo-terminal route, in milliseconds. */
     openTimeoutMs?: number;
     /** The close timeout for one login pseudo-terminal route, in milliseconds. */
@@ -909,6 +933,10 @@ export function createPluginWorkerHandle(
     options.loginPtyLimits?.maxChunkChars ?? MAX_LOGIN_PTY_CHUNK_CHARS;
   const maxLoginPtyTotalChars =
     options.loginPtyLimits?.maxTotalChars ?? MAX_LOGIN_PTY_TOTAL_CHARS;
+  const maxLoginPtyPreBindFrames =
+    options.loginPtyLimits?.maxPreBindFrames ?? MAX_LOGIN_PTY_PRE_BIND_FRAMES;
+  const maxLoginPtyPreBindChars =
+    options.loginPtyLimits?.maxPreBindChars ?? MAX_LOGIN_PTY_PRE_BIND_CHARS;
   const loginPtyOpenTimeoutMs =
     options.loginPtyLimits?.openTimeoutMs ?? LOGIN_PTY_OPEN_TIMEOUT_MS;
   const loginPtyCloseTimeoutMs =
@@ -1389,6 +1417,17 @@ export function createPluginWorkerHandle(
   }
 
   type LoginPtyRouteState = RouteState;
+
+  // One login pseudo-terminal record that arrived before the route bound,
+  // normalized to a narrow scalar shape. The host retains only these bounded
+  // fields, never the raw notification object. A `"output"` record carries a
+  // chunk; an `"exit"` record carries an exit code and consumes the same
+  // queue slot as a data record, so the two share strict first-in-first-out
+  // order.
+  type LoginPtyPreBindRecord =
+    | { kind: "output"; workerSessionId: string; chunk: string }
+    | { kind: "exit"; workerSessionId: string; exitCode: number | null };
+
   interface LoginPtyRoute {
     hostRouteId: string;
     state: LoginPtyRouteState;
@@ -1398,6 +1437,14 @@ export function createPluginWorkerHandle(
     deliveredChars: number;
     terminalized: boolean;
     settleWait: (value: { exitCode: number | null }) => void;
+    // The bounded output and exit records that arrived before the bind, held
+    // in order. The bind replays them through the live router, so an early
+    // record is never lost and a forged worker session identifier still fails
+    // the exact-match gate at replay.
+    preBind: LoginPtyPreBindRecord[];
+    // The cumulative output characters the pre-bind queue retains. An exit
+    // record adds zero characters.
+    preBindChars: number;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
   // blocks a second open until the manager confirms the first route's close.
@@ -1430,6 +1477,10 @@ export function createPluginWorkerHandle(
     route.state = "closed";
     route.listener = null;
     route.buffered = [];
+    // Clear the pre-bind queue and its character count. A terminalized route
+    // never replays a held record.
+    route.preBind = [];
+    route.preBindChars = 0;
     // A terminalized route reports a null exit code, which the runner treats as a
     // failure.
     settleRouteWait(route, { exitCode: null });
@@ -1448,11 +1499,20 @@ export function createPluginWorkerHandle(
 
   // Route one login pseudo-terminal output notification to the per-session
   // listener. Deliver only while the route is `open` and the notification carries
-  // the exact bound worker session identifier and valid bounded bytes. Drop an
-  // unknown, late, malformed, or mismatched notification. Never log the raw bytes.
+  // the exact bound worker session identifier and valid bounded bytes. Queue the
+  // notification while the route is still `opening`: the host reads the worker
+  // pipe and dispatches every line of one chunk synchronously, so a worker can
+  // batch this notification with the open reply and the host reads both before
+  // the bind. Drop an unknown, late, malformed, or mismatched notification. Never
+  // log the raw bytes.
   function routeLoginPtyOutput(notification: JsonRpcNotification): void {
     const route = loginPtyRoute;
-    if (!route || route.state !== "open") return;
+    if (!route) return;
+    if (route.state === "opening") {
+      queuePreBindLoginPtyOutput(route, notification);
+      return;
+    }
+    if (route.state !== "open") return;
     const params = isRecord(notification.params) ? notification.params : {};
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId || workerSessionId !== route.workerSessionId) return;
@@ -1476,15 +1536,113 @@ export function createPluginWorkerHandle(
 
   // Route one login pseudo-terminal exit notification to the login wait. Resolve
   // only while the route is `open` and the notification carries the exact bound
-  // worker session identifier.
+  // worker session identifier. Queue the notification while the route is still
+  // `opening`, in the same order as a batched output notification.
   function routeLoginPtyExit(notification: JsonRpcNotification): void {
     const route = loginPtyRoute;
-    if (!route || route.state !== "open") return;
+    if (!route) return;
+    if (route.state === "opening") {
+      queuePreBindLoginPtyExit(route, notification);
+      return;
+    }
+    if (route.state !== "open") return;
     const params = isRecord(notification.params) ? notification.params : {};
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId || workerSessionId !== route.workerSessionId) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
     settleRouteWait(route, { exitCode });
+  }
+
+  // Queue one login pseudo-terminal output notification that arrived before the
+  // bind, in order. Require a non-empty worker session identifier, a non-empty
+  // string chunk, and the existing per-chunk cap before the host retains the
+  // record, so the queue never grows on a malformed record. Terminalize the
+  // route fail-closed when the queue would pass the frame count or the
+  // character bound. Never log the raw chunk.
+  function queuePreBindLoginPtyOutput(
+    route: LoginPtyRoute,
+    notification: JsonRpcNotification,
+  ): void {
+    const params = isRecord(notification.params) ? notification.params : {};
+    const workerSessionId = readNonEmptyString(params.workerSessionId);
+    const chunk = params.chunk;
+    if (
+      !workerSessionId ||
+      typeof chunk !== "string" ||
+      chunk.length === 0 ||
+      chunk.length > maxLoginPtyChunkChars
+    ) {
+      return;
+    }
+    if (
+      route.preBind.length + 1 > maxLoginPtyPreBindFrames ||
+      route.preBindChars + chunk.length > maxLoginPtyPreBindChars
+    ) {
+      log.warn(
+        { pluginId },
+        "login pseudo-terminal pre-bind queue exceeded a bound; terminalizing route",
+      );
+      void terminalizeLoginPtyRoute(route);
+      return;
+    }
+    route.preBind.push({ kind: "output", workerSessionId, chunk });
+    route.preBindChars += chunk.length;
+  }
+
+  // Queue one login pseudo-terminal exit notification that arrived before the
+  // bind. The exit shares the same queue and the same frame-count bound as a
+  // queued output record, so it never gets a separate slot. Terminalize the
+  // route fail-closed when the queue would pass the frame count bound.
+  function queuePreBindLoginPtyExit(
+    route: LoginPtyRoute,
+    notification: JsonRpcNotification,
+  ): void {
+    const params = isRecord(notification.params) ? notification.params : {};
+    const workerSessionId = readNonEmptyString(params.workerSessionId);
+    if (!workerSessionId) return;
+    if (route.preBind.length + 1 > maxLoginPtyPreBindFrames) {
+      log.warn(
+        { pluginId },
+        "login pseudo-terminal pre-bind queue exceeded a bound; terminalizing route",
+      );
+      void terminalizeLoginPtyRoute(route);
+      return;
+    }
+    const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
+    route.preBind.push({ kind: "exit", workerSessionId, exitCode });
+  }
+
+  // Replay the records a route held before it bound, in strict first-in-
+  // first-out order. Remove the queue from the route first, so a terminalize
+  // mid-replay clears no record twice. Reconstruct one transient notification
+  // per record and send it through the same live router the open route uses
+  // (`routeLoginPtyOutput`, `routeLoginPtyExit`), so a forged worker session
+  // identifier still fails the exact-match gate and the cumulative
+  // `maxLoginPtyTotalChars` gate still applies before delivery. Never call
+  // `route.listener` directly and never reset `route.deliveredChars`. A record
+  // that ends the route terminalizes it, and every later record in the replay
+  // is a no-op, because the routing functions drop a record for a route that
+  // is not `open`.
+  function replayPreBindLoginPtyRecords(route: LoginPtyRoute): void {
+    const held = route.preBind;
+    route.preBind = [];
+    route.preBindChars = 0;
+    for (const record of held) {
+      if (route.terminalized) return;
+      if (record.kind === "output") {
+        routeLoginPtyOutput({
+          jsonrpc: "2.0",
+          method: LOGIN_PTY_OUTPUT_NOTIFICATION,
+          params: { workerSessionId: record.workerSessionId, chunk: record.chunk },
+        });
+      } else {
+        routeLoginPtyExit({
+          jsonrpc: "2.0",
+          method: LOGIN_PTY_EXIT_NOTIFICATION,
+          params: { workerSessionId: record.workerSessionId, exitCode: record.exitCode },
+        });
+      }
+    }
   }
 
   // Close the one route on a worker exit. The worker is gone, so the manager
@@ -1498,6 +1656,8 @@ export function createPluginWorkerHandle(
     route.state = "closed";
     route.listener = null;
     route.buffered = [];
+    route.preBind = [];
+    route.preBindChars = 0;
     settleRouteWait(route, { exitCode: null });
   }
 
@@ -1538,6 +1698,8 @@ export function createPluginWorkerHandle(
       deliveredChars: 0,
       terminalized: false,
       settleWait,
+      preBind: [],
+      preBindChars: 0,
     };
     loginPtyRoute = route;
 
@@ -1574,6 +1736,10 @@ export function createPluginWorkerHandle(
     // Bind the worker session identifier one time and move the route to `open`.
     route.workerSessionId = workerSessionId;
     route.state = "open";
+    // Replay every output and exit record the route queued before the bind, in
+    // order, through the live router. A worker that batched one of these
+    // records with the open reply never loses it.
+    replayPreBindLoginPtyRecords(route);
 
     return {
       onData(listener: (chunk: string) => void): void {

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1434,16 +1434,26 @@ export function createPluginWorkerHandle(
   // One login pseudo-terminal output record that arrived before the route
   // bound, normalized to a narrow scalar shape. The host retains only these
   // bounded fields, never the raw notification object.
-  type LoginPtyPreBindRecord = { workerSessionId: string; chunk: string };
+  interface LoginPtyPreBindOutputRecord {
+    kind: "output";
+    workerSessionId: string;
+    chunk: string;
+  }
 
   // One login pseudo-terminal exit record that arrived before the route
-  // bound. The host holds it in the `preBindExits` slot, never in the
-  // ordered output queue, so a queued exit can never jump ahead of output
-  // the host already queued.
+  // bound, normalized the same way.
   interface LoginPtyPreBindExitRecord {
+    kind: "exit";
     workerSessionId: string;
     exitCode: number | null;
   }
+
+  // One pre-bind login pseudo-terminal record, output or exit. The host
+  // holds every pre-bind record in one arrival-ordered queue and replays
+  // each record through the same live router the open route uses, in the
+  // exact order the host received it. The queue never groups a record by
+  // kind.
+  type LoginPtyPreBindRecord = LoginPtyPreBindOutputRecord | LoginPtyPreBindExitRecord;
 
   interface LoginPtyRoute {
     hostRouteId: string;
@@ -1454,23 +1464,30 @@ export function createPluginWorkerHandle(
     deliveredChars: number;
     terminalized: boolean;
     settleWait: (value: { exitCode: number | null }) => void;
-    // The bounded output records that arrived before the bind, held in
-    // order. The bind replays them through the live router, so an early
-    // record is never lost and a forged worker session identifier still fails
-    // the exact-match gate at replay.
+    // The bounded records — output and exit alike — that arrived before the
+    // bind, held in one arrival-ordered queue. The bind replays them through
+    // the live router in this exact order, so an early record is never
+    // lost, a forged worker session identifier still fails the exact-match
+    // gate, and a record that arrived behind a valid exit still replays
+    // behind it and finds a route the exit already settled.
     preBind: LoginPtyPreBindRecord[];
-    // The cumulative output characters the pre-bind queue retains.
+    // The cumulative output characters the queue retains. An exit record
+    // adds zero characters to this count.
     preBindChars: number;
-    // The exit records that arrived before the bind, held apart from the
-    // output queue, one per distinct worker session identifier and bounded
-    // by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS. The host cannot yet check a
-    // record's worker session identifier against the bound value, so it
-    // keeps every distinct-session record instead of only the last one — a
-    // later mismatched record can never displace an earlier record that
-    // later verifies. The bind replays every held output record first, then
-    // every held exit last, so a queued exit never settles the session wait
-    // ahead of output the host already queued.
-    preBindExits: LoginPtyPreBindExitRecord[];
+    // The count of output records the queue retains, counted apart from the
+    // exit records the same queue holds. An exit record never consumes this
+    // budget, so it cannot crowd out a held output record.
+    preBindOutputFrames: number;
+    // The distinct worker session identifiers among the exit records the
+    // queue retains, bounded by MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS. The
+    // host cannot yet check an exit record's worker session identifier
+    // against the bound value, so it keeps every distinct-session record
+    // instead of only the last one — a later mismatched record can never
+    // displace an earlier record that later verifies. A second exit for a
+    // session already in this set updates the held record's exit code in
+    // place, at its original arrival position, which keeps memory constant
+    // against a repeat from one real session.
+    preBindExitSessions: Set<string>;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
   // blocks a second open until the manager confirms the first route's close.
@@ -1503,11 +1520,12 @@ export function createPluginWorkerHandle(
     route.state = "closed";
     route.listener = null;
     route.buffered = [];
-    // Clear the pre-bind output queue and the held exits. A terminalized route
-    // never replays a held record.
+    // Clear the pre-bind queue. A terminalized route never replays a held
+    // record.
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindExits = [];
+    route.preBindOutputFrames = 0;
+    route.preBindExitSessions.clear();
     // A terminalized route reports a null exit code, which the runner treats as a
     // failure.
     settleRouteWait(route, { exitCode: null });
@@ -1564,7 +1582,12 @@ export function createPluginWorkerHandle(
   // Route one login pseudo-terminal exit notification to the login wait. Resolve
   // only while the route is `open` and the notification carries the exact bound
   // worker session identifier. Queue the notification while the route is still
-  // `opening`, in the same order as a batched output notification.
+  // `opening`, in the same order as a batched output notification. A resolved
+  // exit ends the route: move the state off `open`, so a later record — a live
+  // notification or a record replayed from the pre-bind queue — finds a route
+  // that is no longer `open` and drops there. A real worker process cannot emit
+  // output after it exits, so this only guards a forged or a queued record that
+  // still arrives behind a valid exit.
   function routeLoginPtyExit(notification: JsonRpcNotification): void {
     const route = loginPtyRoute;
     if (!route) return;
@@ -1577,15 +1600,17 @@ export function createPluginWorkerHandle(
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId || workerSessionId !== route.workerSessionId) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
+    route.state = "closed";
     settleRouteWait(route, { exitCode });
   }
 
   // Queue one login pseudo-terminal output notification that arrived before the
-  // bind, in order. Require a non-empty worker session identifier, a non-empty
-  // string chunk, and the existing per-chunk cap before the host retains the
-  // record, so the queue never grows on a malformed record. Terminalize the
-  // route fail-closed when the queue would pass the frame count or the
-  // character bound. Never log the raw chunk.
+  // bind, in arrival order. Require a non-empty worker session identifier, a
+  // non-empty string chunk, and the existing per-chunk cap before the host
+  // retains the record, so the queue never grows on a malformed record.
+  // Terminalize the route fail-closed when the queue would pass the
+  // output-frame count or the output-character bound. Never log the raw
+  // chunk.
   function queuePreBindLoginPtyOutput(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1602,7 +1627,7 @@ export function createPluginWorkerHandle(
       return;
     }
     if (
-      route.preBind.length + 1 > maxLoginPtyPreBindFrames ||
+      route.preBindOutputFrames + 1 > maxLoginPtyPreBindFrames ||
       route.preBindChars + chunk.length > maxLoginPtyPreBindChars
     ) {
       log.warn(
@@ -1612,22 +1637,25 @@ export function createPluginWorkerHandle(
       void terminalizeLoginPtyRoute(route);
       return;
     }
-    route.preBind.push({ workerSessionId, chunk });
+    route.preBind.push({ kind: "output", workerSessionId, chunk });
+    route.preBindOutputFrames += 1;
     route.preBindChars += chunk.length;
   }
 
   // Queue one login pseudo-terminal exit notification that arrived before the
-  // bind. The exit holds a small fixed-size slot apart from the output queue,
-  // so it never crowds out a queued output record. The host cannot check the
+  // bind, in arrival order in the same queue the output records use. An exit
+  // record never consumes the output-frame or output-character budget, so it
+  // can never crowd out a held output record. The host cannot check the
   // worker session identifier against the bound value yet, so it cannot tell
   // a genuine exit from a mismatched one at this point: it keeps one record
   // per distinct worker session identifier, up to
   // MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS, so a later mismatched exit never
   // displaces an earlier record the bind can still verify. A second exit for
-  // the same worker session identifier updates the held exit code in place,
-  // which keeps memory constant against a repeat from one real session. A
-  // distinct-session exit past the bound fails the route closed, the same
-  // fail-closed choice the output queue makes past its own bound.
+  // the same worker session identifier updates the held record's exit code
+  // in place, at its original arrival position, which keeps memory constant
+  // against a repeat from one real session. A distinct-session exit past the
+  // bound fails the route closed, the same fail-closed choice the output
+  // queue makes past its own bound.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1636,14 +1664,15 @@ export function createPluginWorkerHandle(
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    const existing = route.preBindExits.find(
-      (record) => record.workerSessionId === workerSessionId,
+    const existing = route.preBind.find(
+      (record): record is LoginPtyPreBindExitRecord =>
+        record.kind === "exit" && record.workerSessionId === workerSessionId,
     );
     if (existing) {
       existing.exitCode = exitCode;
       return;
     }
-    if (route.preBindExits.length + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
+    if (route.preBindExitSessions.size + 1 > MAX_LOGIN_PTY_PRE_BIND_EXIT_RECORDS) {
       log.warn(
         { pluginId },
         "login pseudo-terminal pre-bind exit slot exceeded a bound; terminalizing route",
@@ -1651,48 +1680,50 @@ export function createPluginWorkerHandle(
       void terminalizeLoginPtyRoute(route);
       return;
     }
-    route.preBindExits.push({ workerSessionId, exitCode });
+    route.preBindExitSessions.add(workerSessionId);
+    route.preBind.push({ kind: "exit", workerSessionId, exitCode });
   }
 
-  // Replay the records a route held before it bound. Remove the queue from
-  // the route first, so a terminalize mid-replay clears no record twice.
-  // Replay every held output record first, in order, then every held exit
-  // last, so an exit can never settle the session wait ahead of output the
-  // host already queued — this matches a real worker's order, where the
-  // process cannot emit output after it exits. Reconstruct one transient
-  // notification per record and send it through the same live router the
-  // open route uses (`routeLoginPtyOutput`, `routeLoginPtyExit`), so a forged
+  // Replay the records a route held before it bound, in the exact order the
+  // host received them. Remove the queue from the route first, so a
+  // terminalize mid-replay clears no record twice. Send each record through
+  // the same live router the open route uses (`routeLoginPtyOutput` for an
+  // output record, `routeLoginPtyExit` for an exit record), so a forged
   // worker session identifier still fails the exact-match gate and the
   // cumulative `maxLoginPtyTotalChars` gate still applies before delivery.
   // Never call `route.listener` directly and never reset
-  // `route.deliveredChars`. A record that ends the route terminalizes it, and
-  // every later record in the replay is a no-op, because the routing
-  // functions drop a record for a route that is not `open`. The held exits
-  // replay in arrival order too: at most one of them carries the worker
-  // session identifier the bind just verified, so the exact-match gate
-  // settles the session wait from that one record and drops every other held
-  // exit, regardless of which order they arrived in before the bind.
+  // `route.deliveredChars`. The replay never groups the records by kind: a
+  // real worker process cannot emit output after it exits, so the arrival
+  // order already carries that guarantee, and grouping the replay by kind
+  // would only reorder around it and let a later record win over an earlier
+  // one. A replayed exit that carries the bound worker session identifier
+  // settles the route and moves its state off `open`, so every later record
+  // in the replay is a no-op — the routers drop a record for a route that is
+  // not `open`. This drops output that arrived behind a valid exit, the same
+  // way the live path drops it. A replayed exit for a different worker
+  // session identifier fails the exact-match gate and changes nothing, so
+  // the replay continues to the next record.
   function replayPreBindLoginPtyRecords(route: LoginPtyRoute): void {
     const held = route.preBind;
     route.preBind = [];
     route.preBindChars = 0;
+    route.preBindOutputFrames = 0;
+    route.preBindExitSessions.clear();
     for (const record of held) {
       if (route.terminalized) return;
-      routeLoginPtyOutput({
-        jsonrpc: "2.0",
-        method: LOGIN_PTY_OUTPUT_NOTIFICATION,
-        params: { workerSessionId: record.workerSessionId, chunk: record.chunk },
-      });
-    }
-    const heldExits = route.preBindExits;
-    route.preBindExits = [];
-    for (const heldExit of heldExits) {
-      if (route.terminalized) return;
-      routeLoginPtyExit({
-        jsonrpc: "2.0",
-        method: LOGIN_PTY_EXIT_NOTIFICATION,
-        params: { workerSessionId: heldExit.workerSessionId, exitCode: heldExit.exitCode },
-      });
+      if (record.kind === "output") {
+        routeLoginPtyOutput({
+          jsonrpc: "2.0",
+          method: LOGIN_PTY_OUTPUT_NOTIFICATION,
+          params: { workerSessionId: record.workerSessionId, chunk: record.chunk },
+        });
+      } else {
+        routeLoginPtyExit({
+          jsonrpc: "2.0",
+          method: LOGIN_PTY_EXIT_NOTIFICATION,
+          params: { workerSessionId: record.workerSessionId, exitCode: record.exitCode },
+        });
+      }
     }
   }
 
@@ -1709,7 +1740,8 @@ export function createPluginWorkerHandle(
     route.buffered = [];
     route.preBind = [];
     route.preBindChars = 0;
-    route.preBindExits = [];
+    route.preBindOutputFrames = 0;
+    route.preBindExitSessions.clear();
     settleRouteWait(route, { exitCode: null });
   }
 
@@ -1752,7 +1784,8 @@ export function createPluginWorkerHandle(
       settleWait,
       preBind: [],
       preBindChars: 0,
-      preBindExits: [],
+      preBindOutputFrames: 0,
+      preBindExitSessions: new Set<string>(),
     };
     loginPtyRoute = route;
 

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1418,15 +1418,19 @@ export function createPluginWorkerHandle(
 
   type LoginPtyRouteState = RouteState;
 
-  // One login pseudo-terminal record that arrived before the route bound,
-  // normalized to a narrow scalar shape. The host retains only these bounded
-  // fields, never the raw notification object. A `"output"` record carries a
-  // chunk; an `"exit"` record carries an exit code and consumes the same
-  // queue slot as a data record, so the two share strict first-in-first-out
-  // order.
-  type LoginPtyPreBindRecord =
-    | { kind: "output"; workerSessionId: string; chunk: string }
-    | { kind: "exit"; workerSessionId: string; exitCode: number | null };
+  // One login pseudo-terminal output record that arrived before the route
+  // bound, normalized to a narrow scalar shape. The host retains only these
+  // bounded fields, never the raw notification object.
+  type LoginPtyPreBindRecord = { workerSessionId: string; chunk: string };
+
+  // One login pseudo-terminal exit record that arrived before the route
+  // bound. The host holds it in the single `preBindExit` slot, never in the
+  // ordered output queue, so a queued exit can never jump ahead of output
+  // the host already queued.
+  interface LoginPtyPreBindExitRecord {
+    workerSessionId: string;
+    exitCode: number | null;
+  }
 
   interface LoginPtyRoute {
     hostRouteId: string;
@@ -1437,14 +1441,18 @@ export function createPluginWorkerHandle(
     deliveredChars: number;
     terminalized: boolean;
     settleWait: (value: { exitCode: number | null }) => void;
-    // The bounded output and exit records that arrived before the bind, held
-    // in order. The bind replays them through the live router, so an early
+    // The bounded output records that arrived before the bind, held in
+    // order. The bind replays them through the live router, so an early
     // record is never lost and a forged worker session identifier still fails
     // the exact-match gate at replay.
     preBind: LoginPtyPreBindRecord[];
-    // The cumulative output characters the pre-bind queue retains. An exit
-    // record adds zero characters.
+    // The cumulative output characters the pre-bind queue retains.
     preBindChars: number;
+    // The one exit record that arrived before the bind, held apart from the
+    // output queue. The bind replays every held output record first, then
+    // this exit last, so a queued exit never settles the session wait ahead
+    // of output the host already queued.
+    preBindExit: LoginPtyPreBindExitRecord | null;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
   // blocks a second open until the manager confirms the first route's close.
@@ -1477,10 +1485,11 @@ export function createPluginWorkerHandle(
     route.state = "closed";
     route.listener = null;
     route.buffered = [];
-    // Clear the pre-bind queue and its character count. A terminalized route
+    // Clear the pre-bind output queue and the held exit. A terminalized route
     // never replays a held record.
     route.preBind = [];
     route.preBindChars = 0;
+    route.preBindExit = null;
     // A terminalized route reports a null exit code, which the runner treats as a
     // failure.
     settleRouteWait(route, { exitCode: null });
@@ -1585,14 +1594,15 @@ export function createPluginWorkerHandle(
       void terminalizeLoginPtyRoute(route);
       return;
     }
-    route.preBind.push({ kind: "output", workerSessionId, chunk });
+    route.preBind.push({ workerSessionId, chunk });
     route.preBindChars += chunk.length;
   }
 
   // Queue one login pseudo-terminal exit notification that arrived before the
-  // bind. The exit shares the same queue and the same frame-count bound as a
-  // queued output record, so it never gets a separate slot. Terminalize the
-  // route fail-closed when the queue would pass the frame count bound.
+  // bind. The exit holds a single fixed-size slot apart from the output
+  // queue, so it never crowds out a queued output record and it carries no
+  // frame-count bound of its own. A later exit replaces an earlier held one:
+  // only the last exit the worker sent before the bind is real.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1600,48 +1610,44 @@ export function createPluginWorkerHandle(
     const params = isRecord(notification.params) ? notification.params : {};
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
-    if (route.preBind.length + 1 > maxLoginPtyPreBindFrames) {
-      log.warn(
-        { pluginId },
-        "login pseudo-terminal pre-bind queue exceeded a bound; terminalizing route",
-      );
-      void terminalizeLoginPtyRoute(route);
-      return;
-    }
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    route.preBind.push({ kind: "exit", workerSessionId, exitCode });
+    route.preBindExit = { workerSessionId, exitCode };
   }
 
-  // Replay the records a route held before it bound, in strict first-in-
-  // first-out order. Remove the queue from the route first, so a terminalize
-  // mid-replay clears no record twice. Reconstruct one transient notification
-  // per record and send it through the same live router the open route uses
-  // (`routeLoginPtyOutput`, `routeLoginPtyExit`), so a forged worker session
-  // identifier still fails the exact-match gate and the cumulative
-  // `maxLoginPtyTotalChars` gate still applies before delivery. Never call
-  // `route.listener` directly and never reset `route.deliveredChars`. A record
-  // that ends the route terminalizes it, and every later record in the replay
-  // is a no-op, because the routing functions drop a record for a route that
-  // is not `open`.
+  // Replay the records a route held before it bound. Remove the queue from
+  // the route first, so a terminalize mid-replay clears no record twice.
+  // Replay every held output record first, in order, then the held exit
+  // last, so the exit can never settle the session wait ahead of output the
+  // host already queued — this matches a real worker's order, where the
+  // process cannot emit output after it exits. Reconstruct one transient
+  // notification per record and send it through the same live router the
+  // open route uses (`routeLoginPtyOutput`, `routeLoginPtyExit`), so a forged
+  // worker session identifier still fails the exact-match gate and the
+  // cumulative `maxLoginPtyTotalChars` gate still applies before delivery.
+  // Never call `route.listener` directly and never reset
+  // `route.deliveredChars`. A record that ends the route terminalizes it, and
+  // every later record in the replay is a no-op, because the routing
+  // functions drop a record for a route that is not `open`.
   function replayPreBindLoginPtyRecords(route: LoginPtyRoute): void {
     const held = route.preBind;
     route.preBind = [];
     route.preBindChars = 0;
     for (const record of held) {
       if (route.terminalized) return;
-      if (record.kind === "output") {
-        routeLoginPtyOutput({
-          jsonrpc: "2.0",
-          method: LOGIN_PTY_OUTPUT_NOTIFICATION,
-          params: { workerSessionId: record.workerSessionId, chunk: record.chunk },
-        });
-      } else {
-        routeLoginPtyExit({
-          jsonrpc: "2.0",
-          method: LOGIN_PTY_EXIT_NOTIFICATION,
-          params: { workerSessionId: record.workerSessionId, exitCode: record.exitCode },
-        });
-      }
+      routeLoginPtyOutput({
+        jsonrpc: "2.0",
+        method: LOGIN_PTY_OUTPUT_NOTIFICATION,
+        params: { workerSessionId: record.workerSessionId, chunk: record.chunk },
+      });
+    }
+    const heldExit = route.preBindExit;
+    route.preBindExit = null;
+    if (heldExit && !route.terminalized) {
+      routeLoginPtyExit({
+        jsonrpc: "2.0",
+        method: LOGIN_PTY_EXIT_NOTIFICATION,
+        params: { workerSessionId: heldExit.workerSessionId, exitCode: heldExit.exitCode },
+      });
     }
   }
 
@@ -1658,6 +1664,7 @@ export function createPluginWorkerHandle(
     route.buffered = [];
     route.preBind = [];
     route.preBindChars = 0;
+    route.preBindExit = null;
     settleRouteWait(route, { exitCode: null });
   }
 
@@ -1700,6 +1707,7 @@ export function createPluginWorkerHandle(
       settleWait,
       preBind: [],
       preBindChars: 0,
+      preBindExit: null,
     };
     loginPtyRoute = route;
 

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -1429,7 +1429,9 @@ export function createPluginWorkerHandle(
     settleWait: (value: { exitCode: number | null }) => void;
     // Every output and exit record that arrived before the bind, in arrival order.
     preBind: LoginPtyPreBindRecord[];
-    // The cumulative output characters `preBind` holds. An exit record adds zero.
+    // The cumulative characters `preBind` holds. Each record charges its
+    // `workerSessionId` characters, plus the `chunk` characters for an output
+    // record.
     preBindChars: number;
   }
   // At most one active credential pseudo-terminal per worker. A non-null route
@@ -1555,9 +1557,12 @@ export function createPluginWorkerHandle(
     ) {
       return;
     }
+    // Charge the record's full retained size: the worker session identifier
+    // plus the chunk. A record that retains only the identifier still counts.
+    const recordChars = workerSessionId.length + chunk.length;
     if (
       route.preBind.length + 1 > maxLoginPtyPreBindFrames ||
-      route.preBindChars + chunk.length > maxLoginPtyPreBindChars
+      route.preBindChars + recordChars > maxLoginPtyPreBindChars
     ) {
       log.warn(
         { pluginId },
@@ -1567,12 +1572,13 @@ export function createPluginWorkerHandle(
       return;
     }
     route.preBind.push({ kind: "output", workerSessionId, chunk });
-    route.preBindChars += chunk.length;
+    route.preBindChars += recordChars;
   }
 
   // Queue one login pseudo-terminal exit notification that arrived before the
-  // bind, in the same queue the output records use. An exit record counts
-  // against the frame bound but adds zero characters.
+  // bind, in the same queue the output records use. An exit record carries no
+  // chunk, but it still retains a worker session identifier, so it charges
+  // against the character bound too.
   function queuePreBindLoginPtyExit(
     route: LoginPtyRoute,
     notification: JsonRpcNotification,
@@ -1581,7 +1587,11 @@ export function createPluginWorkerHandle(
     const workerSessionId = readNonEmptyString(params.workerSessionId);
     if (!workerSessionId) return;
     const exitCode = typeof params.exitCode === "number" ? params.exitCode : null;
-    if (route.preBind.length + 1 > maxLoginPtyPreBindFrames) {
+    const recordChars = workerSessionId.length;
+    if (
+      route.preBind.length + 1 > maxLoginPtyPreBindFrames ||
+      route.preBindChars + recordChars > maxLoginPtyPreBindChars
+    ) {
       log.warn(
         { pluginId },
         "login pseudo-terminal pre-bind queue exceeded a bound; terminalizing route",
@@ -1590,6 +1600,7 @@ export function createPluginWorkerHandle(
       return;
     }
     route.preBind.push({ kind: "exit", workerSessionId, exitCode });
+    route.preBindChars += recordChars;
   }
 
   // Replay the records a route held before it bound, in arrival order,


### PR DESCRIPTION
## Thinking Path

> - Paperclip routes plugin worker messages to agent sessions.
> - The login pseudo-terminal route opens after the host receives the open reply.
> - `readline` can deliver later frames from the same pipe read before that reply continuation runs.
> - The host dropped early output and exit frames.
> - The fix queues valid early frames, preserves arrival order, and replays them after the route opens.
> - The route uses bounded memory and closes fail-closed when a bound breaks.
> - The final tests also pin child issue ordering so the serialized suite remains deterministic.

## Linked Issues or Issue Description

Fixes #12122

## What Changed

- Add a bounded queue for login pseudo-terminal output and exit frames during route opening.
- Validate session ids, chunk types, and per-chunk limits before queue insertion.
- Bound the queue by 10,000 frames and 8 MiB of characters.
- Charge retained worker session identifiers against the character bound.
- Preserve arrival order and stop replay after the first valid exit.
- Drop repeated exits without changing the first exit position or code.
- Bound the repeat-exit lookup and clear queued state on all terminal paths.
- Add regression tests and fixture support for coalesced frames, ordering, limits, cleanup, and log safety.
- Pin issue numbers in the child-wake test so its expected child order remains deterministic.

## Verification

- Build the plugin SDK with `pnpm --filter @paperclipai/plugin-sdk build`.
- Run `npx vitest run server/src/__tests__/plugin-worker-manager.test.ts` from the repository root.
- Run `npx vitest run server/src/__tests__/issues-service.test.ts` from the repository root.
- The focused plugin worker suite passes 66 of 66 tests at the prior reviewed head.
- The issue service file passes 120 of 120 tests in two isolated runs at the current head.
- Confirm that GitHub Actions passes all required checks.
- Confirm that Greptile reports 5/5 with no unresolved review threads.
- Storybook visual regression remains skipped because the PR has no `storybook-visual` label.

## Risks

- The queue adds bounded memory use while the login pseudo-terminal route opens.
- A queue limit breach closes the route and prevents unbounded buffering.
- A hostile worker can fail only its own login route when it breaches a bound.
- The first valid exit closes the route, so later records do not reach the session.
- The child-wake test now uses distinct issue numbers to match the service sort contract.

## Model Used

OpenAI Codex, GPT-5, extended reasoning, tool use, and code review support. The runtime does not expose a separate context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed that this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked the existing public issue with `Fixes: #12122`
- [x] I have not referenced internal Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation where needed
- [x] I have considered and documented risks above
- [x] All required Paperclip CI gates are green
- [x] Greptile is 5/5 with no unresolved review threads
- [x] I will address all Greptile and reviewer comments before requesting merge