### PR TITLE
fix(hermes-adapter): forward resolved runtime env to the gateway per run

### DIFF
--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -226,6 +226,49 @@ describe("execute", () => {
     expect(haystack).toContain("leaked");
   });
 
+  it("does not scrub common short sensitive-keyed values from legitimate output", async () => {
+    // Regression for over-redaction: a sensitive-looking key with a common
+    // short value (AUTH_ENABLED=true, ADMIN_SECRET=admin) must NOT be
+    // registered for literal text redaction, or it would strike identical
+    // substrings in real agent output and corrupt it.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/v1/runs")) {
+        return new Response(JSON.stringify({ run_id: "run-red-2", status: "started" }), { status: 200 });
+      }
+      if (url.endsWith("/events")) {
+        return new Response(
+          sseStream(
+            ["event: run.completed", `data: {"status":"completed","output":"the statement is true and the admin approved it","session_id":"s2"}`, ""].join("\n"),
+          ),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(JSON.stringify({ status: "completed", output: "ok" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = makeCtx({
+      apiBaseUrl: "http://127.0.0.1:8642",
+      apiKey: "secret-key",
+      timeoutSec: 5,
+      env: { AUTH_ENABLED: "true", ADMIN_SECRET: "admin", SITE_URL: "https://thebikeratlas.com" },
+    });
+    const result = await execute(ctx);
+
+    // The common values still reach the gateway as env...
+    const calls = fetchMock.mock.calls as Array<[RequestInfo | URL, RequestInit?]>;
+    const createCall = calls.find(([input]) => String(input).endsWith("/v1/runs"));
+    const sentEnv = JSON.parse(String((createCall?.[1] as RequestInit).body)).env;
+    expect(sentEnv.AUTH_ENABLED).toBe("true");
+    expect(sentEnv.ADMIN_SECRET).toBe("admin");
+    // ...but they are NOT redacted out of legitimate agent output.
+    const haystack = (ctx.onLog as ReturnType<typeof vi.fn>).mock.calls
+      .map(([, line]) => String(line)).join("\n") + "\n" + JSON.stringify(result);
+    expect(haystack).toContain("statement is true");
+    expect(haystack).toContain("admin approved");
+  });
+
   it("sends the task brief once on fresh runs and compacts it on stable-session resumes", async () => {
     const description = "Update launch-card.svg and change the CTA to Try Team free.";
     const fullTaskMarkdown = [

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -144,6 +144,88 @@ describe("execute", () => {
     expect(body.session_id).toBe("paperclip:company:company-1:agent:agent-1:issue:issue-1");
   });
 
+  it("forwards resolved string env values and drops unresolved binding objects", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/v1/runs")) {
+        return new Response(JSON.stringify({ run_id: "run-env-1", status: "started" }), { status: 200 });
+      }
+      if (url.endsWith("/events")) {
+        return new Response(
+          sseStream(
+            ["event: run.completed", 'data: {"status":"completed","output":"ok","session_id":"s1"}', ""].join("\n"),
+          ),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(JSON.stringify({ status: "completed", output: "ok" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await execute(makeCtx({
+      apiBaseUrl: "http://127.0.0.1:8642",
+      apiKey: "secret-key",
+      timeoutSec: 5,
+      env: {
+        SITE_URL: "https://thebikeratlas.com",
+        DIRECTORY_API_URL: "https://thebikeratlas.com/api",
+        DIRECTORY_AGENT_EMAIL: "agents@thebikeratlas.com",
+        BIKER_ATLAS_DB_DISABLED: "true",
+        DIRECTORY_AGENT_PASSWORD: "sup3r-s3cr3t-value",
+        LEAKY_BINDING: { type: "plain", value: "true" } as unknown as string,
+      },
+    }));
+
+    const calls = fetchMock.mock.calls as Array<[RequestInfo | URL, RequestInit?]>;
+    const createCall = calls.find(([input]) => String(input).endsWith("/v1/runs"));
+    const body = JSON.parse(String((createCall?.[1] as RequestInit).body));
+
+    expect(body.env).toEqual({
+      SITE_URL: "https://thebikeratlas.com",
+      DIRECTORY_API_URL: "https://thebikeratlas.com/api",
+      DIRECTORY_AGENT_EMAIL: "agents@thebikeratlas.com",
+      BIKER_ATLAS_DB_DISABLED: "true",
+      DIRECTORY_AGENT_PASSWORD: "sup3r-s3cr3t-value",
+    });
+    expect(body.env).not.toHaveProperty("LEAKY_BINDING");
+    expect(body.env).not.toHaveProperty("DATABASE_URL");
+    expect(typeof body.env.BIKER_ATLAS_DB_DISABLED).toBe("string");
+  });
+
+  it("never emits secret env values in adapter logs or summary", async () => {
+    const secret = "sup3r-s3cr3t-value";
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/v1/runs")) {
+        return new Response(JSON.stringify({ run_id: "run-red-1", status: "started" }), { status: 200 });
+      }
+      if (url.endsWith("/events")) {
+        return new Response(
+          sseStream(
+            ["event: run.completed", `data: {"status":"completed","output":"leaked ${secret} here","session_id":"s1"}`, ""].join("\n"),
+          ),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(JSON.stringify({ status: "completed", output: "ok" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = makeCtx({
+      apiBaseUrl: "http://127.0.0.1:8642",
+      apiKey: "secret-key",
+      timeoutSec: 5,
+      env: { DIRECTORY_AGENT_PASSWORD: secret, SITE_URL: "https://thebikeratlas.com" },
+    });
+    const result = await execute(ctx);
+
+    const logText = (ctx.onLog as ReturnType<typeof vi.fn>).mock.calls
+      .map(([, line]) => String(line)).join("\n");
+    const haystack = logText + "\n" + JSON.stringify(result);
+    expect(haystack).not.toContain(secret);
+    expect(haystack).toContain("leaked");
+  });
+
   it("sends the task brief once on fresh runs and compacts it on stable-session resumes", async () => {
     const description = "Update launch-card.svg and change the CTA to Try Team free.";
     const fullTaskMarkdown = [

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -98,6 +98,26 @@ function nonEmpty(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function resolveRuntimeEnv(rawEnv: unknown): Record<string, string> {
+  const source = asRecord(rawEnv);
+  if (!source) return {};
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof key === "string" && key.length > 0 && typeof value === "string") {
+      resolved[key] = value;
+    }
+  }
+  return resolved;
+}
+
+function collectSecretEnvValues(env: Record<string, string>): string[] {
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (SENSITIVE_KEY_PATTERN.test(key) && value.length > 0) out.push(value);
+  }
+  return out;
+}
+
 function parseNonNegativeNumber(value: unknown, fallback: number): number {
   const parsed = typeof value === "number"
     ? value
@@ -319,7 +339,11 @@ function buildInput(ctx: AdapterExecutionContext, paperclipApiUrl: string | null
   return lines.filter((line) => line !== null && line !== undefined).join("\n").trim();
 }
 
-function buildRunBody(ctx: AdapterExecutionContext, sessionKey: string | null): Record<string, unknown> {
+function buildRunBody(
+  ctx: AdapterExecutionContext,
+  sessionKey: string | null,
+  runtimeEnv: Record<string, string>,
+): Record<string, unknown> {
   const paperclipApiUrl = nonEmpty(ctx.config.paperclipApiUrl);
   const payloadTemplate = parseObject(ctx.config.payloadTemplate);
   const input = nonEmpty(payloadTemplate.input) ?? buildInput(ctx, paperclipApiUrl);
@@ -331,6 +355,7 @@ function buildRunBody(ctx: AdapterExecutionContext, sessionKey: string | null): 
     ...payloadTemplate,
     input,
     instructions,
+    ...(Object.keys(runtimeEnv).length > 0 ? { env: runtimeEnv } : {}),
     ...(sessionKey ? { session_id: sessionKey } : {}),
   };
 }
@@ -846,13 +871,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     extraHeaders,
     accept: "text/event-stream",
   });
+  const runtimeEnv = resolveRuntimeEnv(ctx.config.env);
   const redactText = createTextRedactor([
     apiKey,
     sessionKey,
     runHeaders.Authorization,
     runHeaders["X-Hermes-Session-Key"],
+    ...collectSecretEnvValues(runtimeEnv),
   ]);
-  const body = buildRunBody(ctx, sessionKey);
+  const body = buildRunBody(ctx, sessionKey, runtimeEnv);
   const createRunUrl = apiUrl(baseUrl, "/v1/runs");
 
   await ctx.onMeta?.({

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -110,10 +110,21 @@ function resolveRuntimeEnv(rawEnv: unknown): Record<string, string> {
   return resolved;
 }
 
+// Minimum length for a per-run env value to be registered for literal text
+// redaction. Real secrets (tokens, keys, passwords) are long and high-entropy.
+// A short common value such as "true", "admin", or "prod" -- even under a
+// sensitive-looking key like AUTH_ENABLED -- must NOT be globally scrubbed,
+// because it would also strike identical substrings in legitimate agent output
+// (SSE deltas, logs, summaries, final results) and corrupt it. 8 keeps
+// realistic credentials redacted while excluding common non-secret values.
+const MIN_REDACTABLE_SECRET_LENGTH = 8;
+
 function collectSecretEnvValues(env: Record<string, string>): string[] {
   const out: string[] = [];
   for (const [key, value] of Object.entries(env)) {
-    if (SENSITIVE_KEY_PATTERN.test(key) && value.length > 0) out.push(value);
+    if (SENSITIVE_KEY_PATTERN.test(key) && value.length >= MIN_REDACTABLE_SECRET_LENGTH) {
+      out.push(value);
+    }
   }
   return out;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Hermes gateway adapter (`packages/adapters/hermes`) starts each agent run by calling the Hermes `POST /v1/runs` endpoint.
> - A company/environment can define runtime variables. The adapter resolves them (`heartbeat` → `resolveExecutionRunAdapterConfig` → `ctx.config.env`).
> - `buildRunBody()` never put those resolved variables into the request body. The agent started without its environment (for example `SITE_URL`, `DIRECTORY_API_URL`, `BIKER_ATLAS_DB_DISABLED`).
> - This pull request forwards the resolved environment in the `POST /v1/runs` body.
> - The benefit is that gateway-driven agents receive their per-company runtime configuration, so environment-dependent work runs correctly.

## Linked Issues or Issue Description

No public issue exists. The problem is described inline below.

**What happened?**
The Hermes gateway adapter resolved a company's runtime variables but did not send them to the gateway. `buildRunBody()` omitted the resolved `ctx.config.env`, so each agent run started with an empty environment.

**Expected behavior**
The resolved per-run environment reaches the agent. String values are forwarded; unresolved binding wrappers are dropped; secret-keyed values do not leak into logs or output.

**Steps to reproduce**
1. Configure a company/environment with runtime variables (for example `SITE_URL`).
2. Start an agent run through the Hermes gateway adapter.
3. Observe that the `POST /v1/runs` request body contains no `env`, and the agent runs without the configured variables.

**Paperclip version or commit**
Reproduced against current `master` (adapter package `@paperclipai/hermes-paperclip-adapter@0.3.1`).

I searched the open PR list for similar adapter env-forwarding changes and found none.

## What Changed

- `buildRunBody()` includes an `env` object built from `ctx.config.env`.
- String values only. Unresolved binding objects (for example `{ type: "plain", value: "true" }`) are dropped, never forwarded.
- `env` is omitted when empty, so env-less runs are unchanged.
- Secret env values (keys matching the existing `SENSITIVE_KEY_PATTERN`) are registered with the run's `createTextRedactor`, so they are scrubbed from logs, SSE dumps, errors, and summaries.
- Over-redaction guard: only values of 8 characters or more are registered for literal redaction. A short common value such as `AUTH_ENABLED=true` is not scrubbed, so it cannot corrupt legitimate agent output. (Addresses Greptile Issue 1.)

## Verification

- `pnpm --filter @paperclipai/hermes-paperclip-adapter exec vitest run src/gateway/server/execute.test.ts` → **25 passed** (env forwarding, binding drop, `DATABASE_URL` never fabricated, secret never emitted, and the new common-value guard test).
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` → **clean**.
- Note: 3 tests fail in `src/server/command-resolution.test.ts` and `src/server/detect-model.test.ts`. These are **pre-existing and unrelated** — they fail identically on `master` with this branch's changes stashed. This PR does not touch those modules.
- The package `lint` script (`eslint src/`) cannot run: `eslint` is not declared in any `package.json` and there is no eslint config in the repo. `tsc` covers static checks. Happy to wire up eslint separately if wanted.

## Risks

Low risk. The change adds one optional body field. Against an un-patched gateway the extra `env` key is ignored, so behavior is identical to today. No schema or database migration. This PR pairs with a Hermes-agent PR that accepts and applies the per-run env; each side is independently safe.

## Model Used

Claude (Anthropic), model `claude-opus-4-8` (Opus 4.8), extended thinking, with tool use and code execution (ran the test suite locally).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (new/affected tests green; unrelated pre-existing failures noted)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (unrelated pre-existing test failures remain; see Verification)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
