### PR TITLE
feat(routines): cancel stranded predecessor runs

### DIFF
--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -62,6 +62,7 @@ Fields:
 | `coalesce_if_active` (default) | Incoming run is immediately finalised as `coalesced` and linked to the active run — no new issue is created |
 | `skip_if_active` | Incoming run is immediately finalised as `skipped` and linked to the active run — no new issue is created |
 | `always_enqueue` | Always create a new run regardless of active runs |
+| `cancel_previous` | Cancel open predecessor issues with no live heartbeat, mark their runs failed, and create the newest run; coalesce when a predecessor still has a live heartbeat |
 
 **Catch-up policies:**
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -635,7 +635,12 @@ export type EnvironmentCustomImageSetupConnectionType =
 export const ROUTINE_STATUSES = ["active", "paused", "archived"] as const;
 export type RoutineStatus = (typeof ROUTINE_STATUSES)[number];
 
-export const ROUTINE_CONCURRENCY_POLICIES = ["coalesce_if_active", "always_enqueue", "skip_if_active"] as const;
+export const ROUTINE_CONCURRENCY_POLICIES = [
+  "coalesce_if_active",
+  "always_enqueue",
+  "skip_if_active",
+  "cancel_previous",
+] as const;
 export type RoutineConcurrencyPolicy = (typeof ROUTINE_CONCURRENCY_POLICIES)[number];
 
 export const ROUTINE_CATCH_UP_POLICIES = ["skip_missed", "enqueue_missed_with_cap"] as const;

--- a/packages/shared/src/validators/routine.test.ts
+++ b/packages/shared/src/validators/routine.test.ts
@@ -100,6 +100,12 @@ describe("routine validators", () => {
     expect(() => updateRoutineSchema.parse({ activityGateScope: "agent" })).toThrow();
   });
 
+  it("accepts the cancel_previous concurrency policy", () => {
+    expect(updateRoutineSchema.parse({ concurrencyPolicy: "cancel_previous" }).concurrencyPolicy).toBe(
+      "cancel_previous",
+    );
+  });
+
   it("accepts date variables with valid YYYY-MM-DD defaults", () => {
     expect(routineVariableSchema.parse({
       name: "startDate",

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1392,6 +1392,252 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
+  it("cancels stranded predecessor issues before creating the newest run", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "cancel_previous" })
+      .where(eq(routines.id, routine.id));
+
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+    await expect(
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, previousIssue.id)),
+    ).resolves.toEqual([{ status: "cancelled" }]);
+    await expect(
+      db
+        .select({
+          status: routineRuns.status,
+          failureReason: routineRuns.failureReason,
+          completedAt: routineRuns.completedAt,
+        })
+        .from(routineRuns)
+        .where(eq(routineRuns.id, previousRunId)),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        status: "failed",
+        failureReason: `Superseded by newer routine run ${run.id}`,
+        completedAt: expect.any(Date),
+      }),
+    ]);
+    await expect(
+      db
+        .select({ action: activityLog.action, entityId: activityLog.entityId })
+        .from(activityLog)
+        .where(eq(activityLog.entityId, previousIssue.id)),
+    ).resolves.toContainEqual({
+      action: "routine.predecessor_cancelled",
+      entityId: previousIssue.id,
+    });
+  });
+
+  it("preserves a live predecessor under cancel_previous", async () => {
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const liveHeartbeatRunId = randomUUID();
+
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "cancel_previous" })
+      .where(eq(routines.id, routine.id));
+
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "in_progress",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: liveHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: previousIssue.id },
+      startedAt: new Date("2026-03-20T12:01:00.000Z"),
+    });
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: liveHeartbeatRunId,
+        executionRunId: liveHeartbeatRunId,
+        executionLockedAt: new Date("2026-03-20T12:01:00.000Z"),
+      })
+      .where(eq(issues.id, previousIssue.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    await expect(
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, previousIssue.id)),
+    ).resolves.toEqual([{ status: "in_progress" }]);
+  });
+
+  it("preserves stranded predecessors from a different dispatch fingerprint", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "cancel_previous" })
+      .where(eq(routines.id, routine.id));
+
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+      originFingerprint: "different-dispatch-context",
+    });
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      dispatchFingerprint: "different-dispatch-context",
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("issue_created");
+    await expect(
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, previousIssue.id)),
+    ).resolves.toEqual([{ status: "blocked" }]);
+    await expect(
+      db.select({ status: routineRuns.status }).from(routineRuns).where(eq(routineRuns.id, previousRunId)),
+    ).resolves.toEqual([{ status: "issue_created" }]);
+  });
+
+  it("rechecks liveness after a concurrent predecessor checkout", async () => {
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const liveHeartbeatRunId = randomUUID();
+
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "cancel_previous" })
+      .where(eq(routines.id, routine.id));
+
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "in_progress",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+
+    let releaseCheckout!: () => void;
+    const checkoutCanCommit = new Promise<void>((resolve) => {
+      releaseCheckout = resolve;
+    });
+    let checkoutLocked!: () => void;
+    const checkoutHasLock = new Promise<void>((resolve) => {
+      checkoutLocked = resolve;
+    });
+    const checkout = db.transaction(async (tx) => {
+      await tx.select({ id: issues.id }).from(issues).where(eq(issues.id, previousIssue.id)).for("update");
+      checkoutLocked();
+      await checkoutCanCommit;
+      await tx.insert(heartbeatRuns).values({
+        id: liveHeartbeatRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId: previousIssue.id },
+        startedAt: new Date("2026-03-20T12:01:00.000Z"),
+      });
+      await tx
+        .update(issues)
+        .set({
+          checkoutRunId: liveHeartbeatRunId,
+          executionRunId: liveHeartbeatRunId,
+          executionLockedAt: new Date("2026-03-20T12:01:00.000Z"),
+        })
+        .where(eq(issues.id, previousIssue.id));
+    });
+
+    await checkoutHasLock;
+    const incomingRun = svc.runRoutine(routine.id, { source: "manual" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    releaseCheckout();
+    await checkout;
+
+    const run = await incomingRun;
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    await expect(
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, previousIssue.id)),
+    ).resolves.toEqual([{ status: "in_progress" }]);
+  });
+
   it("touches a coalesced routine issue for the manual runner's inbox", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const userId = randomUUID();

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -115,7 +115,7 @@ export interface BuiltInAgentBundleDefinition {
     description: string;
     status: "active" | "paused";
     priority: "critical" | "high" | "medium" | "low";
-    concurrencyPolicy: "always_enqueue" | "coalesce_if_active" | "skip_if_active";
+    concurrencyPolicy: "always_enqueue" | "coalesce_if_active" | "skip_if_active" | "cancel_previous";
     catchUpPolicy: "enqueue_missed_with_cap" | "skip_missed";
     variables: RoutineVariable[];
     triggers: Array<{
@@ -1363,7 +1363,7 @@ export function builtInAgentService(db: Db) {
       title: routine.title,
       description: routine.description ?? "",
       priority: routine.priority as "critical" | "high" | "medium" | "low",
-      concurrencyPolicy: routine.concurrencyPolicy as "always_enqueue" | "coalesce_if_active" | "skip_if_active",
+      concurrencyPolicy: routine.concurrencyPolicy as "always_enqueue" | "coalesce_if_active" | "skip_if_active" | "cancel_previous",
       catchUpPolicy: routine.catchUpPolicy as "enqueue_missed_with_cap" | "skip_missed",
       variables: routine.variables ?? [],
     }, triggers) : null;
@@ -1438,7 +1438,7 @@ export function builtInAgentService(db: Db) {
       title: routine.title,
       description: routine.description ?? "",
       priority: routine.priority as "critical" | "high" | "medium" | "low",
-      concurrencyPolicy: routine.concurrencyPolicy as "always_enqueue" | "coalesce_if_active" | "skip_if_active",
+      concurrencyPolicy: routine.concurrencyPolicy as "always_enqueue" | "coalesce_if_active" | "skip_if_active" | "cancel_previous",
       catchUpPolicy: routine.catchUpPolicy as "enqueue_missed_with_cap" | "skip_missed",
       variables: routine.variables ?? [],
     }, triggers) : null;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1564,6 +1564,107 @@ export function routineService(
       .then((rows) => rows[0] ?? null);
   }
 
+  async function cancelStrandedPredecessorIssues(input: {
+    routine: typeof routines.$inferSelect;
+    executor: Db;
+    issueOriginKind: string;
+    issueOriginId: string;
+    dispatchFingerprint: string;
+    supersedingRunId: string;
+    supersededAt: Date;
+  }) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(input.dispatchFingerprint);
+    const predecessors = await input.executor
+      .select({
+        issueId: issues.id,
+        runId: routineRuns.id,
+      })
+      .from(issues)
+      .innerJoin(
+        routineRuns,
+        and(
+          eq(routineRuns.companyId, issues.companyId),
+          sql`cast(${routineRuns.id} as text) = ${issues.originRunId}`,
+        ),
+      )
+      .where(
+        and(
+          eq(issues.companyId, input.routine.companyId),
+          eq(routineRuns.routineId, input.routine.id),
+          eq(issues.originKind, input.issueOriginKind),
+          eq(issues.originId, input.issueOriginId),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          visibleIssueCondition(),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      );
+
+    for (const predecessor of predecessors) {
+      const lockedIssue = await input.executor
+        .select({
+          id: issues.id,
+          identifier: issues.identifier,
+          status: issues.status,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.id, predecessor.issueId),
+            eq(issues.companyId, input.routine.companyId),
+            eq(issues.originKind, input.issueOriginKind),
+            eq(issues.originId, input.issueOriginId),
+            inArray(issues.status, OPEN_ISSUE_STATUSES),
+            ...(fingerprintCondition ? [fingerprintCondition] : []),
+          ),
+        )
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (!lockedIssue) continue;
+
+      const liveRun = await input.executor
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, input.routine.companyId),
+            inArray(heartbeatRuns.status, LIVE_HEARTBEAT_RUN_STATUSES),
+            or(
+              ...(lockedIssue.executionRunId ? [eq(heartbeatRuns.id, lockedIssue.executionRunId)] : []),
+              sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${lockedIssue.id}`,
+            ),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (liveRun) continue;
+
+      await issueSvc.update(lockedIssue.id, { status: "cancelled" }, input.executor);
+      await finalizeRun(predecessor.runId, {
+        status: "failed",
+        failureReason: `Superseded by newer routine run ${input.supersedingRunId}`,
+        completedAt: input.supersededAt,
+      }, input.executor);
+      await logActivity(input.executor, {
+        companyId: input.routine.companyId,
+        actorType: "system",
+        actorId: "routine-dispatch",
+        action: "routine.predecessor_cancelled",
+        entityType: "issue",
+        entityId: lockedIssue.id,
+        details: {
+          identifier: lockedIssue.identifier,
+          routineId: input.routine.id,
+          predecessorRunId: predecessor.runId,
+          supersedingRunId: input.supersedingRunId,
+          reason: "cancel_previous",
+        },
+      });
+    }
+
+    return predecessors.length;
+  }
+
   async function createWebhookSecret(
     companyId: string,
     routineId: string,
@@ -1843,6 +1944,17 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
+        if (input.routine.concurrencyPolicy === "cancel_previous") {
+          await cancelStrandedPredecessorIssues({
+            routine: input.routine,
+            executor: txDb,
+            issueOriginKind,
+            issueOriginId,
+            dispatchFingerprint,
+            supersedingRunId: createdRun.id,
+            supersededAt: triggeredAt,
+          });
+        }
         const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
           kind: issueOriginKind,
           id: issueOriginId,

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -70,6 +70,7 @@ Controls what happens when a trigger fires while the previous run issue is still
 | `coalesce_if_active` **(default)** | New run is marked `coalesced` and linked to the existing active run — no new issue created |
 | `skip_if_active` | New run is marked `skipped` and linked to the existing active run — no new issue created |
 | `always_enqueue` | Always create a new issue regardless of active runs |
+| `cancel_previous` | Cancel open predecessor issues with no live heartbeat, mark their runs failed, and create the newest run; coalesce when a predecessor still has a live heartbeat |
 
 ---
 

--- a/ui/src/components/routine-sections/editable-sections.tsx
+++ b/ui/src/components/routine-sections/editable-sections.tsx
@@ -53,6 +53,11 @@ const concurrencyPolicyOptions = [
     title: "Skip if active",
     description: "Drop overlapping trigger occurrences while the routine is already active.",
   },
+  {
+    value: "cancel_previous",
+    title: "Cancel previous",
+    description: "Cancel stranded earlier issues before starting the newest run. Keep a live run working.",
+  },
 ];
 
 const catchUpPolicyOptions = [

--- a/ui/src/lib/cron-fires.test.ts
+++ b/ui/src/lib/cron-fires.test.ts
@@ -70,7 +70,7 @@ describe("previewFirePolicies", () => {
   ];
 
   it("always queues the first fire regardless of policy", () => {
-    for (const policy of ["coalesce_if_active", "always_enqueue", "skip_if_active"]) {
+    for (const policy of ["coalesce_if_active", "always_enqueue", "skip_if_active", "cancel_previous"]) {
       expect(previewFirePolicies(fires, policy)[0]?.disposition).toBe("queued");
     }
   });
@@ -89,6 +89,11 @@ describe("previewFirePolicies", () => {
   it("queues every fire under always_enqueue", () => {
     const preview = previewFirePolicies(fires, "always_enqueue");
     expect(preview.every((e) => e.disposition === "queued")).toBe(true);
+  });
+
+  it("previews each fire as queued under cancel_previous", () => {
+    const preview = previewFirePolicies(fires, "cancel_previous");
+    expect(preview.map((entry) => entry.disposition)).toEqual(["queued", "queued", "queued"]);
   });
 
   it("defaults unknown policies to coalesce", () => {

--- a/ui/src/lib/cron-fires.ts
+++ b/ui/src/lib/cron-fires.ts
@@ -257,6 +257,9 @@ export function previewFirePolicies(
       case "skip_if_active":
         disposition = "skipped";
         break;
+      case "cancel_previous":
+        disposition = "queued";
+        break;
       case "coalesce_if_active":
       default:
         disposition = "coalesced";

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -65,12 +65,13 @@ import {
   type FolderSelection,
 } from "../components/folders/FolderControls";
 
-const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
+const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active", "cancel_previous"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
 const concurrencyPolicyDescriptions: Record<string, string> = {
   coalesce_if_active: "If a run is already active, keep just one follow-up run queued.",
   always_enqueue: "Queue every trigger occurrence, even if the routine is already running.",
   skip_if_active: "Drop new trigger occurrences while a run is still active.",
+  cancel_previous: "Cancel stranded earlier issues before starting the newest run. Keep a live run working.",
 };
 const catchUpPolicyDescriptions: Record<string, string> = {
   skip_missed: "Ignore windows that were missed while the scheduler or routine was paused.",


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates recurring agent work through routines.
> - Routine concurrency policies decide what happens when an earlier execution issue remains open.
> - An open execution issue can become stranded after its heartbeat ends without a valid disposition.
> - Existing policies either preserve that issue, skip new work, or enqueue more work beside it.
> - This pull request adds a policy that cancels stranded predecessor issues before it starts the newest run.
> - The benefit is that recurring work can recover without accumulating orphaned execution issues or killing a live agent run.

## Linked Issues or Issue Description

**Problem / Motivation**

A recurring routine can leave an open execution issue after the linked heartbeat is no longer queued, running, or waiting for retry. Later routine triggers do not have a policy that cleans up this stranded predecessor before starting current work.

**Proposed Solution**

Add a `cancel_previous` concurrency policy. The dispatcher holds the routine lock, cancels open predecessor issues with no live heartbeat, marks their routine runs failed with a supersession reason, and then creates the newest execution issue. If a predecessor still has a live heartbeat, the incoming run coalesces instead.

**Alternatives Considered**

Changing `skip_if_active` would break its existing contract. Cancelling live heartbeat runs would also terminate useful in-flight work and needs a separate cancellation design.

**Roadmap Alignment**

The roadmap calls for routine failure recovery that keeps issue lifecycle state aligned with execution outcomes.

## What Changed

- Add `cancel_previous` to the shared routine concurrency contract and routine editor controls.
- Cancel stranded predecessor issues and mark their routine runs failed inside the dispatch transaction.
- Preserve live predecessor executions by coalescing the incoming run.
- Add service, validator, and schedule-preview regression coverage.
- Document the new API and agent-skill behavior.

## Verification

- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts` (65 tests passed)
- `pnpm exec vitest run packages/shared/src/validators/routine.test.ts ui/src/lib/cron-fires.test.ts` (20 tests passed)

## Risks

- The new policy changes issue state only when a routine explicitly selects it.
- It does not cancel an issue that still has a queued, running, or scheduled-retry heartbeat.
- The routine row lock serializes dispatches for the same routine.

## Model Used

- OpenAI Codex on GPT-5. The runtime did not expose a more specific model ID or context-window size. The agent used reasoning, repository tools, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
