### PR TITLE
fix(recovery): preserve backlog when resolving stale actions

### DIFF
--- a/cli/src/__tests__/issue-subresources.test.ts
+++ b/cli/src/__tests__/issue-subresources.test.ts
@@ -101,6 +101,30 @@ describe("issue subresource commands", () => {
     ]);
   });
 
+  it("passes an intentional backlog disposition to recovery resolution", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await run([
+      "issue", "recovery:resolve", ISSUE_ID,
+      "--outcome", "restored",
+      "--source-issue-status", "backlog",
+      "--action-id", APPROVAL_ID,
+      "--resolution-note", "The source issue is intentionally parked in backlog.",
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`http://localhost:3100/api/issues/${ISSUE_ID}/recovery-actions/resolve`);
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      actionId: APPROVAL_ID,
+      outcome: "restored",
+      sourceIssueStatus: "backlog",
+      resolutionNote: "The source issue is intentionally parked in backlog.",
+    });
+  });
+
   it("wraps document and work product endpoints", async () => {
     const fetchMock = vi
       .fn()

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -517,7 +517,7 @@ export function registerIssueCommands(program: Command): void {
       .description("Resolve an issue recovery action")
       .argument("<issueId>", "Issue ID")
       .requiredOption("--outcome <outcome>", "restored, false_positive, blocked, or cancelled")
-      .requiredOption("--source-issue-status <status>", "todo, done, or in_review for restored outcomes; blocked is only valid for blocked outcomes")
+      .requiredOption("--source-issue-status <status>", "backlog preserves intentional parking and requires --resolution-note; todo, done, or in_review resolve active work; blocked requires a blocked outcome")
       .option("--action-id <id>", "Specific recovery action ID")
       .option("--resolution-note <text>", "Resolution note")
       .action(async (issueId: string, opts: IssueRecoveryResolveOptions) => {

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -409,6 +409,8 @@ Source-scoped recovery actions are snapshots of the source issue's liveness stat
 
 When newer source activity restores a valid live or waiting path, the recovery action is stale and should be folded through the explicit recovery lifecycle instead of being hidden or deleted. Folding means resolving or cancelling the recovery action with a resolution outcome and note that preserve the audit trail.
 
+An explicitly retained `backlog` disposition is terminal for the stale recovery action, but not for the source issue. The recovery-resolution operation must preserve that status atomically while resolving or cancelling the action with a required audit note. `backlog` is preserve-only in this operation: it cannot move a source issue into backlog. The operation must not wake or check out an agent, enqueue a retry, manufacture a blocker, or transiently move the source issue through another status. Only a structured resume request should restore a live source-work path.
+
 Plain comments alone do not make a recovery action stale. A comment can provide evidence, but the recovery action should remain visible when the source issue is still stalled and the comment does not create a valid action-path primitive such as a wake, monitor, interaction, approval, blocker, human owner, execution participant, terminal disposition, or delegated follow-up.
 
 ### Agent-assigned `todo`

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -211,6 +211,35 @@ describe("issue validators", () => {
     ).toBe(false);
   });
 
+  it("allows recovery resolutions to preserve an intentional backlog disposition", () => {
+    for (const outcome of ["restored", "false_positive", "cancelled"] as const) {
+      expect(
+        resolveIssueRecoveryActionSchema.parse({
+          outcome,
+          sourceIssueStatus: "backlog",
+          resolutionNote: "The source issue is intentionally parked in backlog.",
+        }),
+      ).toMatchObject({ outcome, sourceIssueStatus: "backlog" });
+    }
+
+    expect(
+      resolveIssueRecoveryActionSchema.safeParse({
+        outcome: "blocked",
+        sourceIssueStatus: "backlog",
+      }).success,
+    ).toBe(false);
+
+    for (const resolutionNote of [undefined, null, "   "]) {
+      expect(
+        resolveIssueRecoveryActionSchema.safeParse({
+          outcome: "restored",
+          sourceIssueStatus: "backlog",
+          resolutionNote,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
   it("allows cancelled recovery resolutions to atomically restore the source issue status", () => {
     expect(
       resolveIssueRecoveryActionSchema.parse({

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -379,18 +379,27 @@ const RESOLVE_ISSUE_RECOVERY_ACTION_OUTCOMES = [
 export const resolveIssueRecoveryActionSchema = z.object({
   actionId: z.string().guid().optional(),
   outcome: z.enum(RESOLVE_ISSUE_RECOVERY_ACTION_OUTCOMES),
-  sourceIssueStatus: z.enum(["todo", "done", "in_review", "blocked"]),
+  sourceIssueStatus: z.enum(["backlog", "todo", "done", "in_review", "blocked"]),
   resolutionNote: multilineTextSchema.optional().nullable(),
 }).strict().superRefine((value, ctx) => {
+  if (value.sourceIssueStatus === "backlog" && !value.resolutionNote?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Backlog-preserving recovery resolutions require a resolution note",
+      path: ["resolutionNote"],
+    });
+  }
+
   if (value.outcome === "restored") {
     if (
+      value.sourceIssueStatus !== "backlog" &&
       value.sourceIssueStatus !== "todo" &&
       value.sourceIssueStatus !== "done" &&
       value.sourceIssueStatus !== "in_review"
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Restored recovery actions must move the source issue to todo, done, or in_review",
+        message: "Restored recovery actions must preserve backlog or move the source issue to todo, done, or in_review",
         path: ["sourceIssueStatus"],
       });
     }
@@ -410,12 +419,13 @@ export const resolveIssueRecoveryActionSchema = z.object({
 
   if (value.outcome === "false_positive" || value.outcome === "cancelled") {
     if (
+      value.sourceIssueStatus !== "backlog" &&
       value.sourceIssueStatus !== "done" &&
       value.sourceIssueStatus !== "in_review"
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "This recovery outcome requires sourceIssueStatus to be done or in_review",
+        message: "This recovery outcome requires sourceIssueStatus to be backlog, done, or in_review",
         path: ["sourceIssueStatus"],
       });
     }

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1628,6 +1628,196 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
+  it("keeps a backlogged source unchanged when the service cancels its stale recovery action", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ status: "backlog", assigneeAgentId: null, assigneeUserId: "board-user" })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "successful_run_missing_issue_disposition",
+      fingerprint: "missing-disposition:intentional-backlog-service",
+      evidence: { sourceRunId: "run-1" },
+      nextAction: "Confirm the intentional backlog disposition.",
+      wakePolicy: { type: "manual" },
+    });
+
+    const cancelled = await recoveryActionSvc.resolveActiveForIssue({
+      companyId,
+      sourceIssueId,
+      actionId: action.id,
+      status: "cancelled",
+      outcome: "cancelled",
+      resolutionNote: "The source issue is intentionally parked in backlog.",
+    });
+
+    expect(cancelled).toMatchObject({
+      id: action.id,
+      status: "cancelled",
+      outcome: "cancelled",
+      resolutionNote: "The source issue is intentionally parked in backlog.",
+    });
+    expect(cancelled?.resolvedAt).toBeTruthy();
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({
+      status: "backlog",
+      assigneeAgentId: null,
+      assigneeUserId: "board-user",
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+  });
+
+  it("rejects backlog preservation when the locked source is not already backlog", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "successful_run_missing_issue_disposition",
+      fingerprint: "missing-disposition:not-backlog",
+      evidence: { sourceRunId: "run-1" },
+      nextAction: "Confirm the source disposition.",
+      wakePolicy: { type: "manual" },
+    });
+
+    await request(createApp())
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "backlog",
+        resolutionNote: "This request must not move active work into backlog.",
+      })
+      .expect(409);
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({ status: "in_progress" });
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toMatchObject({
+      id: action.id,
+      status: "active",
+    });
+    expect(
+      await db
+        .select()
+        .from(activityLog)
+        .where(eq(activityLog.entityId, sourceIssueId)),
+    ).toHaveLength(0);
+  });
+
+  it("lets only the recovery owner resolve an action while preserving a board-owned backlog", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ status: "backlog", assigneeAgentId: null, assigneeUserId: "board-user" })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "successful_run_missing_issue_disposition",
+      fingerprint: "missing-disposition:intentional-backlog-route",
+      evidence: { sourceRunId: "run-1" },
+      nextAction: "Confirm the intentional backlog disposition.",
+      wakePolicy: { type: "manual" },
+    });
+    const managerRunId = randomUUID();
+    const peerRunId = randomUUID();
+    await seedHeartbeatRun({ companyId, agentId: managerId, runId: managerRunId, issueId: sourceIssueId });
+    await seedHeartbeatRun({ companyId, agentId: coderId, runId: peerRunId, issueId: sourceIssueId });
+    const enqueueRecoveryActionWakeup = vi.fn(async () => null);
+    const routeOptions = { recoveryActionEnqueueWakeup: enqueueRecoveryActionWakeup };
+
+    await request(createApp({
+      type: "agent",
+      agentId: coderId,
+      companyId,
+      runId: peerRunId,
+      source: "agent_jwt",
+    }, routeOptions))
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "backlog",
+        resolutionNote: "A peer must not clear another owner's action.",
+      })
+      .expect(403);
+
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toMatchObject({
+      id: action.id,
+      status: "active",
+    });
+
+    const resolved = await request(createApp({
+      type: "agent",
+      agentId: managerId,
+      companyId,
+      runId: managerRunId,
+      source: "agent_jwt",
+    }, routeOptions))
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "backlog",
+        resolutionNote: "The source issue is intentionally parked in backlog.",
+      })
+      .expect(200);
+
+    expect(resolved.body.issue).toMatchObject({
+      id: sourceIssueId,
+      status: "backlog",
+      assigneeAgentId: null,
+      assigneeUserId: "board-user",
+      checkoutRunId: null,
+      executionRunId: null,
+      activeRecoveryAction: null,
+    });
+    expect(resolved.body.recoveryAction).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "restored",
+      resolutionNote: "The source issue is intentionally parked in backlog.",
+    });
+    expect(resolved.body.recoveryAction.resolvedAt).toBeTruthy();
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+    expect(enqueueRecoveryActionWakeup).not.toHaveBeenCalled();
+    expect(await db.select().from(agentWakeupRequests)).toHaveLength(0);
+    expect(await db.select().from(heartbeatRuns)).toHaveLength(2);
+    expect(await db.select().from(issueRelations)).toHaveLength(0);
+    expect(
+      await db.select().from(issues).where(eq(issues.status, "blocked")),
+    ).toHaveLength(0);
+    expect(await db.select().from(issueInboxArchives)).toHaveLength(0);
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, sourceIssueId));
+    expect(activityRows.map((row) => row.action)).not.toContain("issue.updated");
+    expect(activityRows.find((row) => row.action === "issue.recovery_action_resolved")?.details).toMatchObject({
+      recoveryActionId: action.id,
+      recoveryActionStatus: "resolved",
+      outcome: "restored",
+      sourceIssueStatus: "backlog",
+      resolutionNote: "The source issue is intentionally parked in backlog.",
+    });
+  });
+
   it("hands restored work back to the recorded return owner and records the outcome", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6882,6 +6882,11 @@ export function issueRoutes(
         { source: "recovery_action_resolution" },
       );
 
+      const preservesBacklog = sourceIssueStatus === "backlog";
+      if (preservesBacklog && lockedIssue.status !== "backlog") {
+        throw conflict("Backlog-preserving recovery resolution requires the source issue to remain backlog");
+      }
+
       let issue = lockedIssue;
       const sourceStatusChanged = sourceIssueStatus !== lockedIssue.status;
       if (outcome === "blocked" && sourceStatusChanged) {
@@ -7018,7 +7023,9 @@ export function issueRoutes(
     });
     for (const publication of postCommitActivityPublications) publishActivity(publication);
 
-    await routinesSvc.syncRunStatusForIssue(result.issue.id);
+    if (sourceIssueStatus !== "backlog") {
+      await routinesSvc.syncRunStatusForIssue(result.issue.id);
+    }
 
     if (sourceIssueStatus && existing.status !== result.issue.status) {
       await logActivity(db, {

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -173,7 +173,7 @@ export const issuesApi = {
     data: {
       actionId?: string;
       outcome: "restored" | "false_positive" | "blocked" | "cancelled";
-      sourceIssueStatus: "todo" | "done" | "in_review" | "blocked";
+      sourceIssueStatus: "backlog" | "todo" | "done" | "in_review" | "blocked";
       resolutionNote?: string | null;
     },
   ) => api.post<ResolveRecoveryActionResponse>(`/issues/${id}/recovery-actions/resolve`, data),

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -2430,7 +2430,7 @@ export function IssueDetail() {
     mutationFn: (data: {
       actionId?: string;
       outcome: ResolveRecoveryActionOutcome;
-      sourceIssueStatus: "todo" | "done" | "in_review" | "blocked";
+      sourceIssueStatus: "backlog" | "todo" | "done" | "in_review" | "blocked";
       resolutionNote?: string | null;
     }) => issuesApi.resolveRecoveryAction(issueId!, data),
     onSuccess: ({ issue: nextIssue }) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane people use to manage AI agents and their work.
> - Recovery actions keep stalled issue work visible and auditable.
> - The recovery resolution endpoint changes the source issue status and closes the action in one transaction.
> - The endpoint cannot express an intentional `backlog` disposition.
> - An operator must therefore revive the issue or record a false terminal state to close a stale action.
> - This pull request adds a preserve-only `backlog` resolution path with the existing ownership controls.
> - The benefit is an atomic audit record with no wake, checkout, retry, blocker, or source status change.

## Linked Issues or Issue Description

**What happened?**

`POST /api/issues/{id}/recovery-actions/resolve` rejects `sourceIssueStatus: "backlog"`. A source issue can already be intentionally parked in `backlog` while its old recovery action remains active. The current contract cannot close that action without first changing the source issue to an active or terminal status.

Related pull requests use different policies. #10318 mutates recovery state during a read. #11548 requires a parked label. #11609 adds a new outcome and can move active work into backlog. This pull request keeps resolution explicit and makes `backlog` preserve-only.

**Expected behavior**

An authorized actor can close an active recovery action while the locked source issue remains `backlog`. The request must include an audit note. The request must not move another issue into backlog or create an automatic execution path.

**Steps to reproduce**

1. Create a source issue with status `backlog`.
2. Create an active source-scoped recovery action for the issue.
3. Call the recovery resolution endpoint with `sourceIssueStatus: "backlog"`.
4. Observe that validation rejects the request on `master`.

**Paperclip version or commit**

Reproduced on `9964b034`.

**Deployment mode**

Local dev from source.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

Not adapter-specific. This is a core API contract.

**Database mode**

Embedded PostgreSQL test database.

**Access context**

Board and agent bearer-key contexts.

**Node.js version**

v24.14.1

**Operating system**

macOS on Apple Silicon.

**Privacy checklist**

I reviewed the content for private identifiers, host names, paths, and credentials.

## What Changed

- Accept `backlog` in the recovery resolution request for resolved and board-only cancellation outcomes.
- Require a non-empty resolution note for every backlog-preserving request.
- Lock and verify that the source is already in backlog before the action closes.
- Keep the source row unchanged and skip routine synchronization and restored-work wake logic.
- Keep existing recovery owner checks and board-only outcome checks unchanged.
- Update the CLI, API client types, execution semantics, and focused tests.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts packages/shared/src/validators/issue.test.ts cli/src/__tests__/issue-subresources.test.ts ui/src/api/issues.test.ts` passed on the refreshed head: 100 tests, including embedded PostgreSQL.
- Shared, CLI, UI, and server typechecks passed.
- `git diff --check` passed.
- A repository-wide `pnpm test:run` attempt was not green. It produced unrelated failures in `workspace-runtime.test.ts` and `company-skills-service.test.ts`. The run also closed a temporary PostgreSQL connection while unrelated background heartbeat cleanup was active. The focused embedded-PostgreSQL recovery suite passed separately.

## Risks

- This is a small public API enum expansion. Older clients continue to use the existing statuses.
- The server rejects the request if the locked source is not already in backlog. This prevents the endpoint from becoming a new backlog transition path.
- No database migration is required.
- No read route mutates recovery state.

> This is a focused recovery bug fix. ROADMAP.md lists recovery as shipped work, and this pull request does not add a new roadmap capability.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`. The run used repository tools, code execution, tests, and high-reasoning agent work. The context-window size was not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

