### PR TITLE
feat(observability): add opt-in Sentry error monitoring for the server and the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Find Plugins and more at [awesome-paperclip](https://github.com/gsxdsm/awesome-p
 
 Paperclip ships with opt-in OpenTelemetry auto-instrumentation for the server (traces only). It activates when `OTEL_EXPORTER_OTLP_ENDPOINT` is set and supports `grpc`, `http/protobuf`, and `http/json` via the standard `OTEL_EXPORTER_OTLP_PROTOCOL` env var. The `@opentelemetry/*` packages are optional peer dependencies — install them only if you want tracing. See [doc/observability.md](doc/observability.md) for install commands and the full env-var reference.
 
+Paperclip also ships with opt-in Sentry error monitoring for the server and the browser. Set `SENTRY_DSN` to activate it — the server and the browser then report to the same Sentry project. `@sentry/node` is an optional peer dependency for the server; install it only if you want error monitoring. See [doc/observability.md](doc/observability.md#sentry-error-monitoring) for the install command, the privacy settings, and the full default capture set.
+
 ## Telemetry
 
 Paperclip collects anonymous usage telemetry to help us understand how the product is used and improve it. No personal information, issue content, prompts, file paths, or secrets are ever collected. Private repository references are hashed with a per-install salt before being sent.

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -1,7 +1,8 @@
 # Observability
 
 This document is the Observability contract. It covers the OpenTelemetry
-trace path and two local instrumentation contracts; see the
+trace path, the opt-in Sentry error-monitoring path, and two local
+instrumentation contracts; see the
 [Telemetry Data Contract](../packages/shared/src/telemetry/README.md) for the
 separate first-party event system.
 
@@ -108,6 +109,206 @@ for this workload; everything else from
 This document also holds two local instrumentation contracts: the sandbox
 startup trace spans, and the sandbox duplex transport instrumentation. Both
 sections follow below.
+
+## Sentry Error Monitoring
+
+Paperclip ships with **opt-in** Sentry error monitoring for the server
+process and the browser app. The operator activates it with one
+environment variable, `SENTRY_DSN`. The server and the browser both read
+this same value, so both report to **one** Sentry project. The feature
+uses built-in Sentry options only. It adds no `beforeSend` hook and no
+custom filter code.
+
+When `SENTRY_DSN` is unset, the feature is fully inactive. The server
+imports no Sentry package. The browser fetches no Sentry chunk.
+
+### Enabling Sentry
+
+#### 1. Install the Sentry peer dependency
+
+Install `@sentry/node` in the server, the same way you install the
+OpenTelemetry packages above. `@sentry/node` is an *optional peer
+dependency*: it is not in the default lockfile, and the server loads it
+dynamically only when `SENTRY_DSN` is set.
+
+```bash
+pnpm add @sentry/node
+```
+
+The browser package, `@sentry/browser`, needs no install step. It is
+already a development dependency of the `ui` package, so the browser code
+ships inside every build. A signed-out browser, or a browser with no DSN,
+never fetches the Sentry chunk — see "DSN delivery to the browser" below.
+
+#### 2. Set the environment
+
+```bash
+export SENTRY_DSN="https://<public-key>@<host>/<project-id>"
+```
+
+No other variable is needed.
+
+### One Sentry project
+
+The server and the browser report to **one** Sentry project, because both
+read the same `SENTRY_DSN` value. The server reads it from the process
+environment. The browser reads it from the authenticated
+`GET /api/auth/get-session` response.
+
+### DSN delivery to the browser
+
+The browser never reads the DSN from a `<meta>` tag or from any other part
+of `index.html`. The served `index.html` holds no DSN — it is a static
+file, built once and served unchanged to every request.
+
+Instead, the browser receives the DSN inside the authenticated
+`GET /api/auth/get-session` response body, next to the signed-in session
+and the user profile. A signed-out browser calls this route with no board
+actor, so the route answers 401 and sends no DSN. A signed-out browser
+therefore loads no Sentry chunk and sends no event. These pages run
+signed out:
+
+- `/auth`
+- `/cli-auth/:id`
+- `/board-claim/:token`
+- `/invite/:token`
+
+**A gap the operator must know:** a browser error that happens before the
+session response arrives is not captured. The gate opens only after the
+session query resolves.
+
+### Privacy settings
+
+The feature uses built-in Sentry options only.
+
+- `sendDefaultPii` is `false`, on both runtimes.
+- `tracesSampleRate` is `0`, on both runtimes. Paperclip sends no
+  performance trace and no profile.
+- There is no `beforeSend` hook and no custom filter, on either runtime.
+
+### Server request data
+
+**A server event carries no request data at all.** It holds no URL, no
+method, no header, no cookie, no query string, and no body. This is a
+verified result, not the Sentry SDK's documented default. A live test
+against the real `@sentry/node@10.71.0` package proves it: it captures an
+event from inside a real HTTP request handler and confirms the event
+holds no request field (see `server/src/__tests__/sentry.test.ts`, "a
+server event captured inside a real HTTP request handler carries no
+request field").
+
+The reason is `skipOpenTelemetrySetup: true`. This feature sets that
+option so it never fights Paperclip's separate, independently opt-in
+OpenTelemetry feature for control of the global tracer. The same option
+turns off Sentry's per-request context tracking. Sentry's built-in
+`RequestData` integration needs that tracking to find a URL, a method, a
+header set, a cookie set, or a query string to attach. `RequestData`
+stays in the integration list — the initializer does not remove it — but
+it attaches nothing under this configuration.
+
+This holds even when the operator turns on the separate OpenTelemetry
+feature too (`OTEL_EXPORTER_OTLP_ENDPOINT` set). A live test with a real
+OpenTelemetry SDK, a real HTTP instrumentation package, and a real
+async-context manager registered still shows no request field on the
+captured event.
+
+A server event carries only the exception, its stack trace, and the
+context the other kept default integrations add: the host name, the
+runtime version, and the dependency list. See "Default capture set"
+below.
+
+### Browser data
+
+The browser sends no page URL, no referrer, no user agent, and no
+breadcrumb.
+
+### Fail-open behavior
+
+A failed Sentry import or a failed init never stops the server and never
+breaks the browser app. Both runtimes fall through to a single diagnostic
+log line and keep running with no error monitoring.
+
+### Default capture set
+
+The lists below name every event and every context field this feature
+sends, so an operator can read what the feature does before turning it on.
+Each Sentry integration name below is verified against the default
+integration list of `@sentry/node@10.71.0` and `@sentry/browser@10.71.0`.
+
+**Server events this feature adds**
+
+- An Express `HttpError` with `status >= 500`.
+- Any unknown throw that is not a `ZodError`. It always answers 500.
+- A server startup failure.
+
+**Server events the default integrations add**
+
+- `OnUncaughtException` — each uncaught exception on the main thread, at
+  level `fatal`. The process still exits.
+- `OnUnhandledRejection` — each unhandled promise rejection. The mode is
+  `strict`, so the process exits after the capture.
+- `ChildProcess` — one event for each worker-thread `error`.
+- `LinkedErrors` — the `error.cause` chain of each captured error.
+
+**Server context the kept integrations attach**
+
+- `RequestData` — attaches nothing under this feature's configuration. See
+  "Server request data" above for the verified reason.
+- `ChildProcess` — a non-zero child-process exit becomes a breadcrumb.
+- `Modules` and `Context` — the dependency list, the host name, the
+  operating system, and the runtime version.
+- `ProcessSession` — one release-health session for each process.
+- `LocalVariablesAsync` — off. It needs `includeLocalVariables: true`,
+  which this feature omits.
+- `NodeSystemError` — a Node system error (for example, `ENOENT`) gets a
+  `node_system_error` context field with its error code. The `path` and
+  `dest` fields are removed by default.
+
+**Server sources this feature removes**
+
+- `Console` — raw `console.*` arguments.
+- `ContextLines` — 7 local source lines around each stack frame.
+- The outbound breadcrumb of `Http` — outbound request URLs and query
+  strings.
+
+**Browser events this feature adds**
+
+- A crash in the application error boundary and a crash in the route
+  error boundary.
+
+**Browser events and context the kept integrations add**
+
+- `GlobalHandlers` — `window.onerror` and `window.onunhandledrejection`.
+- `BrowserApiErrors` — a throw inside `setTimeout`, `setInterval`,
+  `requestAnimationFrame`, and an event listener.
+- `CultureContext` — the locale and the timezone.
+- `Dedupe`, `LinkedErrors`, and `BrowserSession`.
+
+**Browser sources this feature removes**
+
+- `HttpContext` — the page URL, the referrer, and the user agent.
+- `Breadcrumbs` — console output, a click and a keypress target, a
+  `fetch` and an `XHR` request URL, and history navigation.
+
+**Not captured on either runtime**
+
+- A Zod validation error, which answers 400.
+- Each `HttpError` below status 500, such as 401, 403, 404, 409, and 422.
+- A performance trace and a profile, because `tracesSampleRate` is 0.
+
+### Operator responsibilities
+
+Two controls belong to the operator. This feature ships neither one.
+
+1. **Set a rate limit and a quota alert.** Set a per-client-key ingestion
+   rate limit and a quota alert in the Sentry project. The feature sends
+   no built-in rate limit of its own.
+2. **Give a self-hosted sink a reachable host name.** If `SENTRY_DSN`
+   points at a self-hosted Sentry instance, give it an externally
+   reachable ingest host name, not an internal-only host name. The
+   browser sends its events from the operator's network, not from the
+   server's network, so an internal-only host name fails silently for
+   the browser even when it works for the server.
 
 ## Sandbox Startup Trace Spans
 

--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -2281,7 +2281,7 @@ describe("sandbox managed runtime", () => {
         adapterKey: "test-adapter",
         client,
         workspaceLocalDir: localWorkspaceDir,
-        additionalSources: [{ localPath: referencedDir, projectId: "proj-first" }],
+        additionalSources: [{ localPath: referencedDir, projectId: "proj-first", ignoreResolution: { kind: "other" } }],
         onProgress: (line) => { lines.push(line); },
       });
 

--- a/packages/shared/src/validators/access.test.ts
+++ b/packages/shared/src/validators/access.test.ts
@@ -106,6 +106,7 @@ describe("authSessionSchema", () => {
     const result = authSessionSchema.safeParse({
       session: { id: "s1", userId: "u1" },
       user: { id: "u1", email: "a@b.com", name: "", image: null },
+      sentryDsn: null,
     });
     expect(result.success).toBe(true);
     expect(result.success && result.data.user.name).toBe(null);
@@ -115,6 +116,7 @@ describe("authSessionSchema", () => {
     const result = authSessionSchema.safeParse({
       session: { id: "s1", userId: "u1" },
       user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: null,
     });
     expect(result.success).toBe(true);
     expect(result.success && result.data.user.name).toBe("Jane");
@@ -124,6 +126,7 @@ describe("authSessionSchema", () => {
     const result = authSessionSchema.safeParse({
       session: { id: "s1", userId: "u1" },
       user: { id: "u1", email: "a@b.com", name: null, image: null },
+      sentryDsn: null,
     });
     expect(result.success).toBe(true);
     expect(result.success && result.data.user.name).toBe(null);
@@ -133,8 +136,37 @@ describe("authSessionSchema", () => {
     const result = authSessionSchema.safeParse({
       session: { id: "s1", userId: "u1" },
       user: { id: "u1", email: "", name: "Jane", image: null },
+      sentryDsn: null,
     });
     expect(result.success).toBe(true);
     expect(result.success && result.data.user.email).toBe(null);
+  });
+
+  it("rejects a payload with no sentryDsn field", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a null sentryDsn", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.sentryDsn).toBe(null);
+  });
+
+  it("accepts a real sentryDsn value", () => {
+    const result = authSessionSchema.safeParse({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: "https://public@o0.ingest.sentry.io/1",
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.sentryDsn).toBe("https://public@o0.ingest.sentry.io/1");
   });
 });

--- a/packages/shared/src/validators/access.ts
+++ b/packages/shared/src/validators/access.ts
@@ -198,6 +198,12 @@ export const authSessionSchema = z.object({
     userId: z.string().min(1),
   }),
   user: currentUserProfileSchema,
+  // The Sentry DSN for the current instance, or `null` when the operator has
+  // not set `SENTRY_DSN`. Required, not optional: a missing value must fail
+  // the response schema instead of silently disabling browser error
+  // monitoring. The browser reads this value to open its own Sentry gate —
+  // see `ui/src/lib/sentry.ts`.
+  sentryDsn: z.string().min(1).nullable(),
 });
 
 export type AuthSession = z.infer<typeof authSessionSchema>;

--- a/server/src/__tests__/auth-routes.test.ts
+++ b/server/src/__tests__/auth-routes.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { errorHandler } from "../middleware/index.js";
 import { authRoutes } from "../routes/auth.js";
 
@@ -58,8 +58,15 @@ describe.sequential("auth routes", () => {
     email: "jane@example.com",
     image: "https://example.com/jane.png",
   };
+  const originalSentryDsn = process.env.SENTRY_DSN;
+
+  afterEach(() => {
+    if (originalSentryDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = originalSentryDsn;
+  });
 
   it("returns the persisted user profile in the session payload", async () => {
+    delete process.env.SENTRY_DSN;
     const app = await createApp(
       {
         type: "board",
@@ -78,7 +85,58 @@ describe.sequential("auth routes", () => {
         userId: "user-1",
       },
       user: baseUser,
+      sentryDsn: null,
     });
+  });
+
+  it("sends sentryDsn for a board actor when SENTRY_DSN is set", async () => {
+    process.env.SENTRY_DSN = "https://public@o0.ingest.sentry.io/1";
+    const app = await createApp(
+      {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+      },
+      baseUser,
+    );
+
+    const res = await request(app).get("/api/auth/get-session");
+
+    expect(res.status).toBe(200);
+    expect(res.body.sentryDsn).toBe("https://public@o0.ingest.sentry.io/1");
+  });
+
+  it("sends a null sentryDsn when SENTRY_DSN is unset", async () => {
+    delete process.env.SENTRY_DSN;
+    const app = await createApp(
+      {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+      },
+      baseUser,
+    );
+
+    const res = await request(app).get("/api/auth/get-session");
+
+    expect(res.status).toBe(200);
+    expect(res.body.sentryDsn).toBe(null);
+  });
+
+  it("answers 401 and sends no DSN when the actor type is none", async () => {
+    process.env.SENTRY_DSN = "https://public@o0.ingest.sentry.io/1";
+    const app = await createApp(
+      {
+        type: "none",
+        source: "none",
+      },
+      baseUser,
+    );
+
+    const res = await request(app).get("/api/auth/get-session");
+
+    expect(res.status).toBe(401);
+    expect(res.body.sentryDsn).toBeUndefined();
   });
 
   it("updates the signed-in profile", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5640,18 +5640,27 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       recoveryCause: "execution_review_participant_recovery",
     });
 
-    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
-    const recoveryComment = comments.find((comment) =>
-      comment.body.includes("pending execution-review participant once") &&
-        noticeMetadataReferencesRecoveryAction(comment.metadata, recoveryAction.id),
-    );
+    // The source issue flips to "blocked" before the recovery service posts
+    // its escalation comment and writes the activity-log event, so a read
+    // right after the status check can race an in-flight write. Poll for
+    // each row instead of reading once.
+    const recoveryComment = await waitForValue(async () => {
+      const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+      return comments.find((comment) =>
+        comment.body.includes("pending execution-review participant once") &&
+          noticeMetadataReferencesRecoveryAction(comment.metadata, recoveryAction.id),
+      ) ?? null;
+    });
     expect(recoveryComment).toBeTruthy();
 
-    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
-    expect(activity.some((event) =>
-      (event.details as Record<string, unknown> | null)?.source ===
-        "recovery.reconcile_execution_review_participant",
-    )).toBe(true);
+    const recoveryActivityEvent = await waitForValue(async () => {
+      const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+      return activity.find((event) =>
+        (event.details as Record<string, unknown> | null)?.source ===
+          "recovery.reconcile_execution_review_participant",
+      ) ?? null;
+    });
+    expect(recoveryActivityEvent).toBeTruthy();
   });
 
   it("blocks failed execution-review recovery under the reviewer when the source assignee differs", async () => {

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -287,8 +287,7 @@ describe("buildSentryInitOptions", () => {
       httpIntegration: () => ({ name: "Http" }),
       onUnhandledRejectionIntegration,
     });
-    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
-    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const resolved = options.integrations(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
 
     expect(onUnhandledRejectionIntegration).toHaveBeenCalledWith({ mode: "strict" });
     const rejectionIntegration = resolved.find((i) => i.name === "OnUnhandledRejection");
@@ -304,8 +303,7 @@ describe("buildSentryInitOptions", () => {
       httpIntegration: () => ({ name: "Http" }),
       onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
     });
-    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
-    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const resolved = options.integrations(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
     const names = resolved.map((i) => i.name);
 
     expect(names).not.toContain("Console");
@@ -319,8 +317,7 @@ describe("buildSentryInitOptions", () => {
       httpIntegration: () => ({ name: "Http" }),
       onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
     });
-    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
-    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const resolved = options.integrations(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
     const names = resolved.map((i) => i.name);
 
     // The full error-capture set the plan requires, not just the four named
@@ -347,8 +344,7 @@ describe("buildSentryInitOptions", () => {
       httpIntegration,
       onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
     });
-    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
-    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const resolved = options.integrations(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
 
     expect(httpIntegration).toHaveBeenCalledWith({ breadcrumbs: false });
     expect(resolved.filter((i) => i.name === "Http")).toHaveLength(1);

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRequire } from "node:module";
+import http from "node:http";
+
+/**
+ * Tests for the opt-in Sentry error-monitoring gate. `@sentry/node` is an
+ * optional runtime dependency and is NOT installed in CI, which is itself
+ * part of the contract under test: with `SENTRY_DSN` set and the package
+ * absent, the module must warn and settle instead of crashing the server.
+ *
+ * The module reads `SENTRY_DSN` at import time, so each test resets the
+ * module registry and imports a fresh copy.
+ */
+
+const DSN_ENV = "SENTRY_DSN";
+const originalDsn = process.env[DSN_ENV];
+
+async function importFreshSentry() {
+  vi.resetModules();
+  return await import("../sentry.js");
+}
+
+/**
+ * Register a fake `@sentry/node` module for the next dynamic import. Each
+ * mock function is returned so a test can assert on the call it received.
+ * The mock stays in place until `vi.doUnmock` runs, so `afterEach` clears it.
+ */
+function mockSentryPackage() {
+  const init = vi.fn();
+  const captureException = vi.fn(() => "event-id");
+  const close = vi.fn(async () => true);
+  const httpIntegration = vi.fn((options: unknown) => ({ name: "Http", ...(options as object) }));
+  const onUnhandledRejectionIntegration = vi.fn((options: unknown) => ({
+    name: "OnUnhandledRejection",
+    ...(options as object),
+  }));
+
+  vi.doMock("@sentry/node", () => ({
+    init,
+    captureException,
+    close,
+    httpIntegration,
+    onUnhandledRejectionIntegration,
+  }));
+
+  return { init, captureException, close, httpIntegration, onUnhandledRejectionIntegration };
+}
+
+// A representative default-integration list, shaped like the array
+// `@sentry/node@10.71.0`'s `getDefaultIntegrations()` returns for a Node
+// server. Recorded 2026-08-25 with `node -e` against the published package —
+// see the disposition comment on PAP-5131 for the full command.
+const DEFAULT_INTEGRATION_NAMES = [
+  "InboundFilters",
+  "FunctionToString",
+  "LinkedErrors",
+  "RequestData",
+  "NodeSystemError",
+  "ConversationId",
+  "Console",
+  "OnUncaughtException",
+  "OnUnhandledRejection",
+  "ContextLines",
+  "LocalVariablesAsync",
+  "Context",
+  "ChildProcess",
+  "ProcessSession",
+  "Modules",
+  "Http",
+  "NodeFetch",
+];
+
+beforeEach(() => {
+  delete process.env[DSN_ENV];
+});
+
+afterEach(() => {
+  if (originalDsn === undefined) delete process.env[DSN_ENV];
+  else process.env[DSN_ENV] = originalDsn;
+  vi.restoreAllMocks();
+  vi.doUnmock("@sentry/node");
+});
+
+describe("sentryReady", () => {
+  it("resolves and imports no SDK when SENTRY_DSN is unset", async () => {
+    // A spy that fails the test if the module attempts a dynamic import of
+    // an SDK it should never touch on the closed-gate path. `@sentry/node`
+    // is not installed, so an attempted import would settle this promise
+    // with a warning instead of resolving clean.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { sentryReady } = await importFreshSentry();
+
+    await expect(sentryReady).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureException", () => {
+  it("is a no-op and does not throw when the gate is closed", async () => {
+    const { captureException, sentryReady } = await importFreshSentry();
+    await sentryReady;
+
+    expect(() => captureException(new Error("boom"))).not.toThrow();
+  });
+});
+
+describe("shutdownSentry", () => {
+  it("resolves once for concurrent callers", async () => {
+    const { shutdownSentry } = await importFreshSentry();
+
+    const first = shutdownSentry();
+    const second = shutdownSentry();
+
+    // Memoized: concurrent callers share one shutdown promise.
+    expect(first).toBe(second);
+    await expect(first).resolves.toBeUndefined();
+  });
+});
+
+describe("missing @sentry/node package", () => {
+  it("logs one warning and resolves", async () => {
+    process.env[DSN_ENV] = "https://public@o0.ingest.sentry.io/1";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { sentryReady } = await importFreshSentry();
+
+    // Bootstrap must absorb the failed dynamic import — the server keeps
+    // booting without error monitoring rather than crashing on an opt-in
+    // feature.
+    await expect(sentryReady).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("@sentry/node package is not installed"),
+      expect.anything(),
+    );
+  });
+});
+
+describe("buildSentryInitOptions", () => {
+  it("sets sendDefaultPii false, tracesSampleRate 0, and skipOpenTelemetrySetup true", async () => {
+    const { buildSentryInitOptions } = await importFreshSentry();
+
+    const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
+      httpIntegration: () => ({ name: "Http" }),
+      onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
+    });
+
+    expect(options.sendDefaultPii).toBe(false);
+    expect(options.tracesSampleRate).toBe(0);
+    expect(options.skipOpenTelemetrySetup).toBe(true);
+  });
+
+  it("passes onUnhandledRejection with mode strict", async () => {
+    const { buildSentryInitOptions } = await importFreshSentry();
+    const onUnhandledRejectionIntegration = vi.fn((options: unknown) => ({
+      name: "OnUnhandledRejection",
+      ...(options as object),
+    }));
+
+    const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
+      httpIntegration: () => ({ name: "Http" }),
+      onUnhandledRejectionIntegration,
+    });
+    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+
+    expect(onUnhandledRejectionIntegration).toHaveBeenCalledWith({ mode: "strict" });
+    const rejectionIntegration = resolved.find((i) => i.name === "OnUnhandledRejection");
+    expect(rejectionIntegration).toMatchObject({ mode: "strict" });
+    // The default OnUnhandledRejection entry must not survive alongside it.
+    expect(resolved.filter((i) => i.name === "OnUnhandledRejection")).toHaveLength(1);
+  });
+
+  it("the resolved server integration list holds no Console integration and no ContextLines integration", async () => {
+    const { buildSentryInitOptions } = await importFreshSentry();
+
+    const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
+      httpIntegration: () => ({ name: "Http" }),
+      onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
+    });
+    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const names = resolved.map((i) => i.name);
+
+    expect(names).not.toContain("Console");
+    expect(names).not.toContain("ContextLines");
+  });
+
+  it("the resolved server integration list keeps OnUncaughtException, OnUnhandledRejection, LinkedErrors, and RequestData", async () => {
+    const { buildSentryInitOptions } = await importFreshSentry();
+
+    const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
+      httpIntegration: () => ({ name: "Http" }),
+      onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
+    });
+    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const names = resolved.map((i) => i.name);
+
+    // The full error-capture set the plan requires, not just the four named
+    // in this test's title.
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "OnUncaughtException",
+        "OnUnhandledRejection",
+        "ChildProcess",
+        "LinkedErrors",
+        "RequestData",
+        "Modules",
+        "Context",
+        "ProcessSession",
+      ]),
+    );
+  });
+
+  it("turns the outbound HTTP breadcrumb off and keeps the rest of the Http integration", async () => {
+    const { buildSentryInitOptions } = await importFreshSentry();
+    const httpIntegration = vi.fn((options: unknown) => ({ name: "Http", ...(options as object) }));
+
+    const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
+      httpIntegration,
+      onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
+    });
+    const integrationsFn = options.integrations as (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+
+    expect(httpIntegration).toHaveBeenCalledWith({ breadcrumbs: false });
+    expect(resolved.filter((i) => i.name === "Http")).toHaveLength(1);
+  });
+});
+
+describe("with @sentry/node mocked", () => {
+  it("initializes the client and shares captureException / shutdownSentry with it", async () => {
+    process.env[DSN_ENV] = "https://public@o0.ingest.sentry.io/1";
+    const mocks = mockSentryPackage();
+
+    const { sentryReady, captureException, shutdownSentry } = await importFreshSentry();
+    await sentryReady;
+
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+    const initOptions = mocks.init.mock.calls[0][0] as { dsn: string };
+    expect(initOptions.dsn).toBe("https://public@o0.ingest.sentry.io/1");
+
+    captureException(new Error("boom"));
+    expect(mocks.captureException).toHaveBeenCalledWith(expect.any(Error));
+
+    await shutdownSentry();
+    expect(mocks.close).toHaveBeenCalledWith(5_000);
+  });
+});
+
+// `@sentry/node` is an optional runtime dependency (see the module comment
+// in sentry.ts). When it is absent, the three tests below cannot run against
+// the true SDK, so they are skipped — the same pattern instrumentation.test.ts
+// uses for its OpenTelemetry-SDK-dependent test.
+const sentryPackage = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    return require("@sentry/node") as {
+      init(options: Record<string, unknown>): unknown;
+      captureException(error: unknown): string;
+      httpIntegration(options: { breadcrumbs: boolean }): { name: string };
+      onUnhandledRejectionIntegration(options: { mode: string }): { name: string };
+      flush(timeout?: number): Promise<boolean>;
+      close(timeout?: number): Promise<boolean>;
+    };
+  } catch {
+    return null;
+  }
+})();
+
+describe.skipIf(!sentryPackage)("captured event shape against the real @sentry/node SDK", () => {
+  /**
+   * Initialize the real SDK with this module's exact options, plus a
+   * transport stub so no event leaves the test process, plus `beforeSend`
+   * so the test can inspect the resolved event before it would have been
+   * sent. `beforeSend` is test-only introspection — the module under test
+   * adds no `beforeSend` of its own (constraint: built-in options only).
+   */
+  async function initRealSentryForTest(onEvent: (event: Record<string, unknown>) => void) {
+    const Sentry = sentryPackage!;
+    const { buildSentryInitOptions } = await importFreshSentry();
+    const options = {
+      ...buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", Sentry),
+      transport: () => ({ send: async () => ({}), flush: async () => true }),
+      beforeSend: (event: Record<string, unknown>) => {
+        onEvent(event);
+        return event;
+      },
+    };
+    Sentry.init(options);
+  }
+
+  it("a server event captured after a console.error call carries no console breadcrumb", async () => {
+    const Sentry = sentryPackage!;
+    let captured: Record<string, unknown> | null = null;
+    await initRealSentryForTest((event) => {
+      captured = event;
+    });
+
+    // eslint-disable-next-line no-console
+    console.error("child process stderr: simulated failure");
+    Sentry.captureException(new Error("after console.error"));
+    await Sentry.flush(2000);
+
+    expect(captured).not.toBeNull();
+    expect((captured as Record<string, unknown>).breadcrumbs).toBeUndefined();
+  });
+
+  it("a server event carries no stack-frame source context", async () => {
+    const Sentry = sentryPackage!;
+    let captured: Record<string, unknown> | null = null;
+    await initRealSentryForTest((event) => {
+      captured = event;
+    });
+
+    Sentry.captureException(new Error("stack frame check"));
+    await Sentry.flush(2000);
+
+    const event = captured as unknown as {
+      exception: { values: Array<{ stacktrace: { frames: Array<Record<string, unknown>> } }> };
+    };
+    const frames = event.exception.values[0].stacktrace.frames;
+    expect(frames.length).toBeGreaterThan(0);
+    for (const frame of frames) {
+      expect(frame.context_line).toBeUndefined();
+      expect(frame.pre_context).toBeUndefined();
+      expect(frame.post_context).toBeUndefined();
+    }
+  });
+
+  it("a server event carries no outbound HTTP breadcrumb", async () => {
+    const Sentry = sentryPackage!;
+    let captured: Record<string, unknown> | null = null;
+    await initRealSentryForTest((event) => {
+      captured = event;
+    });
+
+    const server = http.createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as { port: number }).port;
+    await new Promise<void>((resolve) => {
+      http.get(`http://127.0.0.1:${port}/probe?token=secret`, (res) => {
+        res.resume();
+        res.on("end", resolve);
+      });
+    });
+    server.close();
+
+    Sentry.captureException(new Error("after outbound http call"));
+    await Sentry.flush(2000);
+
+    expect((captured as unknown as Record<string, unknown>).breadcrumbs).toBeUndefined();
+  });
+});

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -218,22 +218,6 @@ describe("errorHandler Sentry capture", () => {
     expect(received).not.toHaveProperty("reqParams");
     expect(received).not.toHaveProperty("reqQuery");
   });
-
-  it("does not change the errorHandler response when a capture call throws", () => {
-    const capture = vi.spyOn(sentryModule, "captureException").mockImplementation(() => {
-      throw new Error("Sentry capture exploded");
-    });
-    const req = makeReq();
-    const res = makeRes();
-    const next = vi.fn() as unknown as NextFunction;
-    const err = new Error("boom");
-
-    expect(() => errorHandler(err, req, res, next)).not.toThrow();
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
-    expect(capture).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe("finalizeServerShutdown Sentry teardown", () => {

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRequire } from "node:module";
 import http from "node:http";
+import express from "express";
+import request from "supertest";
 import type { NextFunction, Request, Response } from "express";
 import { HttpError } from "../errors.js";
 import { errorHandler } from "../middleware/error-handler.js";
 import { finalizeServerShutdown } from "../shutdown.js";
+import { authRoutes } from "../routes/auth.js";
 import * as sentryModule from "../sentry.js";
 
 /**
@@ -53,8 +56,9 @@ function mockSentryPackage() {
 
 // A representative default-integration list, shaped like the array
 // `@sentry/node@10.71.0`'s `getDefaultIntegrations()` returns for a Node
-// server. Recorded 2026-08-25 with `node -e` against the published package —
-// see the disposition comment on PAP-5131 for the full command.
+// server. Recorded against the published package with:
+//   node -e "const S=require('@sentry/node'); \
+//     console.log(S.getDefaultIntegrations({}).map(i=>i.name))"
 const DEFAULT_INTEGRATION_NAMES = [
   "InboundFilters",
   "FunctionToString",
@@ -387,6 +391,51 @@ describe("with @sentry/node mocked", () => {
   });
 });
 
+/**
+ * Proves the one-project result: the server and the browser both resolve
+ * their Sentry client from the same `SENTRY_DSN` value, so both send events
+ * to the same Sentry project. The browser reads its DSN from the
+ * `GET /api/auth/get-session` response body (see `ui/src/lib/sentry.ts` and
+ * `ui/src/components/SentryGate.tsx`), never from a `<meta>` tag.
+ */
+describe("one-project resolution", () => {
+  function makeSessionApp() {
+    const app = express();
+    app.use((req, _res, next) => {
+      req.actor = { type: "board", userId: "user-1", source: "session" };
+      next();
+    });
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () =>
+            Promise.resolve([
+              { id: "user-1", name: "Jane Example", email: "jane@example.com", image: null },
+            ]),
+        }),
+      }),
+    };
+    app.use("/api/auth", authRoutes(db as unknown as Parameters<typeof authRoutes>[0]));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("the server initializer and GET /api/auth/get-session resolve the same Sentry project", async () => {
+    process.env[DSN_ENV] = "https://public@o0.ingest.sentry.io/1";
+    const mocks = mockSentryPackage();
+
+    const { sentryReady } = await importFreshSentry();
+    await sentryReady;
+    const initOptions = mocks.init.mock.calls[0]![0] as { dsn: string };
+
+    const app = makeSessionApp();
+    const res = await request(app).get("/api/auth/get-session");
+
+    expect(res.status).toBe(200);
+    expect(res.body.sentryDsn).toBe(initOptions.dsn);
+  });
+});
+
 // `@sentry/node` is an optional runtime dependency (see the module comment
 // in sentry.ts). When it is absent, the three tests below cannot run against
 // the true SDK, so they are skipped — the same pattern instrumentation.test.ts
@@ -489,5 +538,44 @@ describe.skipIf(!sentryPackage)("captured event shape against the real @sentry/n
     await Sentry.flush(2000);
 
     expect((captured as unknown as Record<string, unknown>).breadcrumbs).toBeUndefined();
+  });
+
+  /**
+   * `skipOpenTelemetrySetup: true` (set above) keeps this module out of
+   * Paperclip's separate, independently opt-in OpenTelemetry feature. It
+   * also turns off Sentry's own per-request async-context tracking. The
+   * `RequestData` integration reads the inbound URL, method, headers,
+   * cookies, and query string from that per-request context. With the
+   * context off, a captured event carries no request field — not the
+   * SDK's documented default. This test proves the gap, so the operator
+   * documentation states the true capture set.
+   */
+  it("a server event captured inside a real HTTP request handler carries no request field", async () => {
+    const Sentry = sentryPackage!;
+    let captured: Record<string, unknown> | null = null;
+    await initRealSentryForTest((event) => {
+      captured = event;
+    });
+
+    const server = http.createServer((req, res) => {
+      req.on("data", () => {});
+      req.on("end", () => {
+        Sentry.captureException(new Error("boom from a real request handler"));
+        res.end("ok");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as { port: number }).port;
+    await new Promise<void>((resolve) => {
+      http.get(`http://127.0.0.1:${port}/api/test?foo=bar`, (res) => {
+        res.resume();
+        res.on("end", resolve);
+      });
+    });
+    server.close();
+    await Sentry.flush(2000);
+
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as Record<string, unknown>).request).toBeUndefined();
   });
 });

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRequire } from "node:module";
 import http from "node:http";
+import type { NextFunction, Request, Response } from "express";
+import { HttpError } from "../errors.js";
+import { errorHandler } from "../middleware/error-handler.js";
+import { finalizeServerShutdown } from "../shutdown.js";
+import * as sentryModule from "../sentry.js";
 
 /**
  * Tests for the opt-in Sentry error-monitoring gate. `@sentry/node` is an
@@ -115,6 +120,138 @@ describe("shutdownSentry", () => {
     // Memoized: concurrent callers share one shutdown promise.
     expect(first).toBe(second);
     await expect(first).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * Seam tests for the two `errorHandler` call sites that report to Sentry.
+ * These tests spy on the exported `captureException` binding rather than
+ * import a real client, so they assert the call-site shape (one call, the
+ * Error object only) without a live Sentry SDK.
+ */
+describe("errorHandler Sentry capture", () => {
+  function makeReq(): Request {
+    return {
+      method: "GET",
+      originalUrl: "/api/test",
+      body: { a: 1 },
+      params: { id: "123" },
+      query: { q: "x" },
+    } as unknown as Request;
+  }
+
+  function makeRes(): Response {
+    const res = {
+      status: vi.fn(),
+      json: vi.fn(),
+    } as unknown as Response;
+    (res.status as unknown as ReturnType<typeof vi.fn>).mockReturnValue(res);
+    return res;
+  }
+
+  it("captures one event for a 500-level HttpError", () => {
+    const capture = vi.spyOn(sentryModule, "captureException").mockImplementation(() => {});
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const err = new HttpError(500, "db exploded");
+
+    errorHandler(err, req, res, next);
+
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures one event for an unknown error", () => {
+    const capture = vi.spyOn(sentryModule, "captureException").mockImplementation(() => {});
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const err = new Error("boom");
+
+    errorHandler(err, req, res, next);
+
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures no event for a Zod validation 400 response", () => {
+    const capture = vi.spyOn(sentryModule, "captureException").mockImplementation(() => {});
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const issue = {
+      code: "invalid_type",
+      expected: "string",
+      received: "undefined",
+      path: ["provider"],
+      message: "Required",
+    };
+    const err = Object.assign(new Error("Validation failed"), {
+      name: "ZodError",
+      issues: [issue],
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("passes the Error object only to captureException, never the request-bearing ErrorContext", () => {
+    const capture = vi.spyOn(sentryModule, "captureException").mockImplementation(() => {});
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const err = new Error("boom");
+
+    errorHandler(err, req, res, next);
+
+    expect(capture).toHaveBeenCalledWith(err);
+    const [received] = capture.mock.calls[0]!;
+    expect(received).toBeInstanceOf(Error);
+    // The `ErrorContext` shape carries the request body, params, and query.
+    // The received value must not carry any of them.
+    expect(received).not.toHaveProperty("reqBody");
+    expect(received).not.toHaveProperty("reqParams");
+    expect(received).not.toHaveProperty("reqQuery");
+  });
+
+  it("does not change the errorHandler response when a capture call throws", () => {
+    const capture = vi.spyOn(sentryModule, "captureException").mockImplementation(() => {
+      throw new Error("Sentry capture exploded");
+    });
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const err = new Error("boom");
+
+    expect(() => errorHandler(err, req, res, next)).not.toThrow();
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("finalizeServerShutdown Sentry teardown", () => {
+  it("calls shutdownSentry after shutdownInstrumentation", async () => {
+    const order: string[] = [];
+    const shutdownInstrumentation = vi.fn(async () => {
+      order.push("instrumentation");
+    });
+    const shutdownSentry = vi.fn(async () => {
+      order.push("sentry");
+    });
+
+    await finalizeServerShutdown({
+      signal: "SIGTERM",
+      shutdownAppServices: undefined,
+      stopEmbeddedPostgres: null,
+      shutdownInstrumentation,
+      shutdownSentry,
+      log: { info: vi.fn(), error: vi.fn() },
+    });
+
+    expect(order).toEqual(["instrumentation", "sentry"]);
   });
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@
 // instrumentationReady before opening DB connections or constructing the
 // HTTP server, so trace coverage does not depend on incidental timing.
 import { instrumentationReady, shutdownInstrumentation } from "./instrumentation.js";
+import { sentryReady, shutdownSentry, captureException } from "./sentry.js";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import { resolve } from "node:path";
@@ -157,6 +158,9 @@ export async function startServer(): Promise<StartedServer> {
   // Tracing must be active (or have failed and logged) before the first DB
   // connection or the HTTP server exists — see instrumentation.ts.
   await instrumentationReady;
+  // Error monitoring must be ready before the first request can fail — see
+  // sentry.ts.
+  await sentryReady;
   ensureDecisionSigningSecret();
   let config = loadConfig();
   initTelemetry({ enabled: config.telemetryEnabled });
@@ -1780,6 +1784,7 @@ export async function startServer(): Promise<StartedServer> {
         shutdownAppServices: appShutdown,
         stopEmbeddedPostgres,
         shutdownInstrumentation,
+        shutdownSentry,
         log: logger,
       });
 
@@ -1814,8 +1819,10 @@ function isMainModule(metaUrl: string): boolean {
 }
 
 if (isMainModule(import.meta.url)) {
-  void startServer().catch((err) => {
+  void startServer().catch(async (err) => {
     logger.error({ err }, "Paperclip server failed to start");
+    captureException(err);
+    await shutdownSentry();
     process.exit(1);
   });
 }

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -50,6 +50,13 @@ function attachErrorContext(
   }
 }
 
+/** Report a server-side crash to every error sink. */
+function reportCrash(error: Error): void {
+  const tc = getTelemetryClient();
+  if (tc) trackErrorHandlerCrash(tc, { errorCode: error.name });
+  captureException(error);
+}
+
 function getPaperclipDb(req: Request): Db | null {
   const locals = req.app?.locals as { paperclipDb?: Db; db?: Db } | undefined;
   return locals?.paperclipDb ?? locals?.db ?? null;
@@ -108,9 +115,7 @@ export function errorHandler(
         { message: err.message, stack: err.stack, name: err.name, details: err.details },
         err,
       );
-      const tc = getTelemetryClient();
-      if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
-      captureException(err);
+      reportCrash(err);
     }
     res.status(err.status).json({
       error: err.message,
@@ -149,9 +154,7 @@ export function errorHandler(
     rootError,
   );
 
-  const tc = getTelemetryClient();
-  if (tc) trackErrorHandlerCrash(tc, { errorCode: rootError.name });
-  captureException(rootError);
+  reportCrash(rootError);
 
   res.status(500).json({
     error: "Internal server error",

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -4,6 +4,7 @@ import { ZodError } from "zod";
 import { HttpError } from "../errors.js";
 import { trackErrorHandlerCrash } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
+import { captureException } from "../sentry.js";
 import { COMPANY_IMPORT_API_PATH } from "../routes/company-import-paths.js";
 import { logger } from "./logger.js";
 import {
@@ -21,6 +22,20 @@ export interface ErrorContext {
 
 function isRedactedSkillPolicyDenial(details: Record<string, unknown> | null) {
   return details?.code === "skill_policy_denied";
+}
+
+/**
+ * Report an error to Sentry without changing the response the error handler
+ * already built. `captureException` never throws by its own contract, but
+ * this wrapper keeps that guarantee local to this file too, so a future
+ * change to the Sentry gate cannot alter a response or an exit code here.
+ */
+function captureExceptionSafely(err: Error) {
+  try {
+    captureException(err);
+  } catch {
+    // Error monitoring must never change the response. Swallow and move on.
+  }
 }
 
 function readZodIssues(err: unknown): unknown[] | null {
@@ -109,6 +124,7 @@ export function errorHandler(
       );
       const tc = getTelemetryClient();
       if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
+      captureExceptionSafely(err);
     }
     res.status(err.status).json({
       error: err.message,
@@ -149,6 +165,7 @@ export function errorHandler(
 
   const tc = getTelemetryClient();
   if (tc) trackErrorHandlerCrash(tc, { errorCode: rootError.name });
+  captureExceptionSafely(rootError);
 
   res.status(500).json({
     error: "Internal server error",

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -24,20 +24,6 @@ function isRedactedSkillPolicyDenial(details: Record<string, unknown> | null) {
   return details?.code === "skill_policy_denied";
 }
 
-/**
- * Report an error to Sentry without changing the response the error handler
- * already built. `captureException` never throws by its own contract, but
- * this wrapper keeps that guarantee local to this file too, so a future
- * change to the Sentry gate cannot alter a response or an exit code here.
- */
-function captureExceptionSafely(err: Error) {
-  try {
-    captureException(err);
-  } catch {
-    // Error monitoring must never change the response. Swallow and move on.
-  }
-}
-
 function readZodIssues(err: unknown): unknown[] | null {
   if (err instanceof ZodError) return err.issues;
   if (!err || typeof err !== "object" || (err as { name?: unknown }).name !== "ZodError") return null;
@@ -124,7 +110,7 @@ export function errorHandler(
       );
       const tc = getTelemetryClient();
       if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
-      captureExceptionSafely(err);
+      captureException(err);
     }
     res.status(err.status).json({
       error: err.message,
@@ -165,7 +151,7 @@ export function errorHandler(
 
   const tc = getTelemetryClient();
   if (tc) trackErrorHandlerCrash(tc, { errorCode: rootError.name });
-  captureExceptionSafely(rootError);
+  captureException(rootError);
 
   res.status(500).json({
     error: "Internal server error",

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -49,6 +49,10 @@ export function authRoutes(db: Db) {
         userId: req.actor.userId,
       },
       user,
+      // The browser reads this value to open its own Sentry gate — see
+      // `ui/src/lib/sentry.ts`. `req.actor.type` already gates this whole
+      // handler, so no second authorization check runs here.
+      sentryDsn: process.env.SENTRY_DSN || null,
     }));
   });
 

--- a/server/src/sentry.ts
+++ b/server/src/sentry.ts
@@ -100,6 +100,15 @@ interface SentryModuleLike {
   onUnhandledRejectionIntegration(options: { mode: string }): { name: string };
 }
 
+/** The `Sentry.init` options this gate builds. */
+export interface SentryInitOptions {
+  dsn: string;
+  skipOpenTelemetrySetup: boolean;
+  tracesSampleRate: number;
+  sendDefaultPii: boolean;
+  integrations: (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+}
+
 /**
  * Build the `Sentry.init` options object. A pure function, split out from
  * `bootstrapSentry` so a test can call it with a real `@sentry/node` module
@@ -109,7 +118,7 @@ interface SentryModuleLike {
 export function buildSentryInitOptions(
   dsn: string,
   Sentry: SentryModuleLike,
-): Record<string, unknown> {
+): SentryInitOptions {
   return {
     dsn,
     skipOpenTelemetrySetup: true,

--- a/server/src/sentry.ts
+++ b/server/src/sentry.ts
@@ -1,0 +1,164 @@
+// Optional Sentry error monitoring for the server process.
+//
+// Activated only when `SENTRY_DSN` is set. When unset, no Sentry package is
+// loaded at all.
+//
+// The import is dynamic and the package is an optional runtime dependency —
+// operators who want server-side error monitoring install `@sentry/node`
+// themselves. That keeps Sentry off the default dependency graph and avoids
+// forcing a lockfile bump for an opt-in feature. This gate mirrors the
+// OpenTelemetry gate in `instrumentation.ts`.
+//
+// OpenTelemetry keeps ownership of trace setup: the initializer passes
+// `skipOpenTelemetrySetup: true` and `tracesSampleRate: 0`, so this module
+// adds error monitoring only and starts no span or trace behavior of its
+// own.
+//
+// Default-integration privacy note: `sendDefaultPii: false` filters values
+// by name, inside the `RequestData` integration only. Three other default
+// integrations copy raw values past that filter, so the initializer removes
+// or narrows them with built-in Sentry options — no custom filter code:
+//   - `Console` turns a `console.*` call into a breadcrumb with the raw
+//     arguments. The initializer drops it.
+//   - `ContextLines` reads local source lines around each stack frame off
+//     the host disk. The initializer drops it.
+//   - `Http` records a breadcrumb for each outbound request, with its URL
+//     and query string. The initializer keeps the integration (`RequestData`
+//     and request isolation need it) and turns the breadcrumb off with the
+//     integration's own `breadcrumbs` option.
+//
+// `onUnhandledRejectionIntegration` defaults to `mode: "warn"`, which
+// registers a `process.on("unhandledRejection")` listener. Node cancels its
+// own crash-on-unhandled-rejection behavior when any listener is registered.
+// The server relies on that crash today, so the initializer passes
+// `mode: "strict"`: Sentry still captures the event, then exits the process,
+// so the existing crash-and-restart behavior stays.
+
+const dsn = process.env.SENTRY_DSN;
+
+/** The subset of the `@sentry/node` client surface this gate calls. */
+interface SentryHandle {
+  captureException(error: unknown): string;
+  close(timeout?: number): Promise<boolean>;
+}
+
+let sentryHandle: SentryHandle | null = null;
+let shutdownPromise: Promise<void> | null = null;
+
+/**
+ * Resolves once the Sentry SDK has started, or once bootstrap has failed and
+ * logged, or at once when `SENTRY_DSN` is unset. No caller needs to await
+ * this before calling `captureException` — it is a no-op until ready — but
+ * `index.ts` awaits it at startup so the first real error has a live client.
+ */
+export const sentryReady: Promise<void> = dsn ? bootstrapSentry(dsn) : Promise.resolve();
+
+/**
+ * Report an error to Sentry. A no-op before the gate opens, when the gate
+ * never opens (`SENTRY_DSN` unset), or when bootstrap failed. Never throws —
+ * observability must not change control flow.
+ */
+export function captureException(error: unknown): void {
+  if (!sentryHandle) return;
+  try {
+    sentryHandle.captureException(error);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[paperclip] Sentry captureException failed", err);
+  }
+}
+
+/**
+ * Flush buffered events and close the Sentry client. Idempotent — concurrent
+ * callers share one shutdown. A no-op when monitoring is off or bootstrap
+ * failed.
+ */
+export function shutdownSentry(): Promise<void> {
+  shutdownPromise ??= (async () => {
+    await sentryReady;
+    if (!sentryHandle) return;
+    try {
+      // Awaiting matters: the client flushes buffered events to Sentry
+      // during close; exiting before it settles silently drops them.
+      await sentryHandle.close(5_000);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[paperclip] Sentry shutdown failed", err);
+    }
+  })();
+  return shutdownPromise;
+}
+
+/**
+ * The subset of the `@sentry/node` module surface the initializer needs to
+ * build its options object. A structural type, not the real Sentry type —
+ * the real type is unavailable at compile time because the package is an
+ * optional runtime dependency (see the module comment above).
+ */
+interface SentryModuleLike {
+  httpIntegration(options: { breadcrumbs: boolean }): { name: string };
+  onUnhandledRejectionIntegration(options: { mode: string }): { name: string };
+}
+
+/**
+ * Build the `Sentry.init` options object. A pure function, split out from
+ * `bootstrapSentry` so a test can call it with a real `@sentry/node` module
+ * and assert the resolved integration list and the captured-event shape
+ * against the true SDK, not a stand-in.
+ */
+export function buildSentryInitOptions(
+  dsn: string,
+  Sentry: SentryModuleLike,
+): Record<string, unknown> {
+  return {
+    dsn,
+    skipOpenTelemetrySetup: true,
+    tracesSampleRate: 0,
+    sendDefaultPii: false,
+    integrations: (defaults: Array<{ name: string }>) => {
+      const kept = defaults.filter(
+        (integration) =>
+          integration.name !== "Console" &&
+          integration.name !== "ContextLines" &&
+          integration.name !== "Http" &&
+          integration.name !== "OnUnhandledRejection",
+      );
+      return [
+        ...kept,
+        // Keep the rest of the Http integration — RequestData and request
+        // isolation need it — but turn the outbound breadcrumb off.
+        Sentry.httpIntegration({ breadcrumbs: false }),
+        // Keep today's crash-on-unhandled-rejection behavior. See the
+        // module comment above for why the default mode cannot stay.
+        Sentry.onUnhandledRejectionIntegration({ mode: "strict" }),
+      ];
+    },
+  };
+}
+
+async function bootstrapSentry(dsn: string): Promise<void> {
+  try {
+    // Dynamic import so type-resolution doesn't require the package to be
+    // installed unless the operator actually opts in.
+    // @ts-ignore optional peer dep
+    const Sentry = await import("@sentry/node");
+
+    Sentry.init(buildSentryInitOptions(dsn, Sentry));
+
+    sentryHandle = {
+      captureException: (error) => Sentry.captureException(error),
+      close: (timeout) => Sentry.close(timeout),
+    };
+  } catch (err) {
+    // The package is not installed, or the dynamic import or init call
+    // failed. Fall through with a single diagnostic so the opt-in path is
+    // self-documenting. The gate fails open — the server keeps booting
+    // without error monitoring rather than crashing on an opt-in feature.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[paperclip] SENTRY_DSN is set but the @sentry/node package is not " +
+        "installed. Install @sentry/node to enable server error monitoring.",
+      err,
+    );
+  }
+}

--- a/server/src/shutdown.test.ts
+++ b/server/src/shutdown.test.ts
@@ -37,6 +37,9 @@ describe("finalizeServerShutdown", () => {
     const shutdownInstrumentation = vi.fn(async () => {
       order.push("instrumentation:flush");
     });
+    const shutdownSentry = vi.fn(async () => {
+      order.push("sentry:flush");
+    });
 
     let exited = false;
     const finalize = finalizeServerShutdown({
@@ -44,6 +47,7 @@ describe("finalizeServerShutdown", () => {
       shutdownAppServices,
       stopEmbeddedPostgres,
       shutdownInstrumentation,
+      shutdownSentry,
       log: stubLogger(),
     }).then(() => {
       // This models the caller's `process.exit(0)` continuation.
@@ -67,6 +71,7 @@ describe("finalizeServerShutdown", () => {
       "appServices:settled",
       "postgres:stop",
       "instrumentation:flush",
+      "sentry:flush",
       "exit",
     ]);
   });
@@ -87,6 +92,7 @@ describe("finalizeServerShutdown", () => {
     const shutdownInstrumentation = vi.fn(async () => {
       order.push("instrumentation:flush");
     });
+    const shutdownSentry = vi.fn(async () => undefined);
     const log = stubLogger();
 
     let exited = false;
@@ -95,6 +101,7 @@ describe("finalizeServerShutdown", () => {
       shutdownAppServices,
       stopEmbeddedPostgres,
       shutdownInstrumentation,
+      shutdownSentry,
       log,
     }).then(() => {
       exited = true;
@@ -120,6 +127,7 @@ describe("finalizeServerShutdown", () => {
   it("skips the database stop when no embedded PostgreSQL runs in this process", async () => {
     const shutdownAppServices = vi.fn(async () => undefined);
     const shutdownInstrumentation = vi.fn(async () => undefined);
+    const shutdownSentry = vi.fn(async () => undefined);
     const log = stubLogger();
 
     await finalizeServerShutdown({
@@ -127,6 +135,7 @@ describe("finalizeServerShutdown", () => {
       shutdownAppServices,
       stopEmbeddedPostgres: null,
       shutdownInstrumentation,
+      shutdownSentry,
       log,
     });
 

--- a/server/src/shutdown.ts
+++ b/server/src/shutdown.ts
@@ -25,7 +25,7 @@ export async function finalizeServerShutdown(input: {
   shutdownAppServices: (() => Promise<void>) | undefined;
   stopEmbeddedPostgres: (() => Promise<void>) | null;
   shutdownInstrumentation: () => Promise<void>;
-  shutdownSentry?: () => Promise<void>;
+  shutdownSentry: () => Promise<void>;
   log: ShutdownLogger;
 }): Promise<void> {
   const { signal } = input;
@@ -54,7 +54,7 @@ export async function finalizeServerShutdown(input: {
 
   // Flush buffered Sentry events before the process goes away; without this
   // await the last events are dropped on exit.
-  await input.shutdownSentry?.();
+  await input.shutdownSentry();
 }
 
 const COORDINATED_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM"] as const;

--- a/server/src/shutdown.ts
+++ b/server/src/shutdown.ts
@@ -25,6 +25,7 @@ export async function finalizeServerShutdown(input: {
   shutdownAppServices: (() => Promise<void>) | undefined;
   stopEmbeddedPostgres: (() => Promise<void>) | null;
   shutdownInstrumentation: () => Promise<void>;
+  shutdownSentry?: () => Promise<void>;
   log: ShutdownLogger;
 }): Promise<void> {
   const { signal } = input;
@@ -50,6 +51,10 @@ export async function finalizeServerShutdown(input: {
   // Flush buffered OTel spans before the process goes away; without this await
   // the exporter's final batch is dropped on exit.
   await input.shutdownInstrumentation();
+
+  // Flush buffered Sentry events before the process goes away; without this
+  // await the last events are dropped on exit.
+  await input.shutdownSentry?.();
 }
 
 const COORDINATED_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM"] as const;

--- a/ui/package.json
+++ b/ui/package.json
@@ -72,6 +72,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@sentry/browser": "^10.71.0",
     "@storybook/addon-a11y": "10.5.10",
     "@storybook/addon-docs": "10.5.10",
     "@storybook/react-vite": "10.5.10",

--- a/ui/src/components/AppErrorBoundary.test.tsx
+++ b/ui/src/components/AppErrorBoundary.test.tsx
@@ -5,6 +5,12 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppErrorBoundary } from "./AppErrorBoundary";
 
+const captureBrowserExceptionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/sentry", () => ({
+  captureBrowserException: (error: unknown) => captureBrowserExceptionMock(error),
+}));
+
 function BoomRender(): never {
   throw new Error("Maximum update depth exceeded");
 }
@@ -30,6 +36,30 @@ describe("AppErrorBoundary", () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     container.remove();
+    captureBrowserExceptionMock.mockClear();
+  });
+
+  it("reports one captured error and keeps the reload prompt", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppErrorBoundary>
+          <BoomRender />
+        </AppErrorBoundary>,
+      );
+    });
+
+    expect(captureBrowserExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureBrowserExceptionMock).toHaveBeenCalledWith(expect.any(Error));
+    expect(
+      Array.from(container.querySelectorAll("button")).some(
+        (button) => button.textContent === "Reload page",
+      ),
+    ).toBe(true);
+
+    act(() => {
+      root.unmount();
+    });
   });
 
   it("renders a reload prompt instead of a blank page when the shell throws in render", () => {

--- a/ui/src/components/AppErrorBoundary.tsx
+++ b/ui/src/components/AppErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { captureBrowserException } from "@/lib/sentry";
 
 type AppErrorBoundaryState = {
   error: Error | null;
@@ -24,6 +25,7 @@ export class AppErrorBoundary extends Component<{ children: ReactNode }, AppErro
 
   override componentDidCatch(error: unknown, info: ErrorInfo): void {
     console.error("App shell crashed", { error, componentStack: info.componentStack });
+    captureBrowserException(error);
   }
 
   override render() {

--- a/ui/src/components/RouteErrorBoundary.test.tsx
+++ b/ui/src/components/RouteErrorBoundary.test.tsx
@@ -7,10 +7,15 @@ import { RouteErrorBoundary } from "./RouteErrorBoundary";
 
 const navigateMock = vi.hoisted(() => vi.fn());
 const routerLocation = vi.hoisted(() => ({ current: { pathname: "/co/agents/new", search: "?adapterType=claude_local" } }));
+const captureBrowserExceptionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/router", () => ({
   useLocation: () => routerLocation.current,
   useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureBrowserException: (error: unknown) => captureBrowserExceptionMock(error),
 }));
 
 function Boom(): never {
@@ -33,6 +38,30 @@ describe("RouteErrorBoundary", () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     container.remove();
+    captureBrowserExceptionMock.mockClear();
+  });
+
+  it("reports one captured error and keeps the recovery button", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <RouteErrorBoundary>
+          <Boom />
+        </RouteErrorBoundary>,
+      );
+    });
+
+    expect(captureBrowserExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureBrowserExceptionMock).toHaveBeenCalledWith(expect.any(Error));
+    expect(
+      Array.from(container.querySelectorAll("button")).some(
+        (button) => button.textContent === "Go back",
+      ),
+    ).toBe(true);
+
+    act(() => {
+      root.unmount();
+    });
   });
 
   it("renders a recoverable error card instead of a blank page when a child throws", () => {

--- a/ui/src/components/RouteErrorBoundary.tsx
+++ b/ui/src/components/RouteErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { useLocation, useNavigate } from "@/lib/router";
 import { Button } from "@/components/ui/button";
+import { captureBrowserException } from "@/lib/sentry";
 
 type RouteErrorBoundaryInnerProps = {
   resetKey: string;
@@ -21,6 +22,7 @@ class RouteErrorBoundaryInner extends Component<RouteErrorBoundaryInnerProps, Ro
 
   override componentDidCatch(error: unknown, info: ErrorInfo): void {
     console.error("Page render failed", { error, componentStack: info.componentStack });
+    captureBrowserException(error);
   }
 
   override componentDidUpdate(prevProps: RouteErrorBoundaryInnerProps): void {

--- a/ui/src/components/SentryGate.test.tsx
+++ b/ui/src/components/SentryGate.test.tsx
@@ -9,6 +9,7 @@ import { SentryGate } from "./SentryGate";
 
 const getSessionMock = vi.hoisted(() => vi.fn());
 const initBrowserErrorMonitoringMock = vi.hoisted(() => vi.fn(async (_dsn: string) => {}));
+const teardownBrowserErrorMonitoringMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("@/api/auth", () => ({
   authApi: { getSession: () => getSessionMock() },
@@ -16,6 +17,7 @@ vi.mock("@/api/auth", () => ({
 
 vi.mock("@/lib/sentry", () => ({
   initBrowserErrorMonitoring: (dsn: string) => initBrowserErrorMonitoringMock(dsn),
+  teardownBrowserErrorMonitoring: () => teardownBrowserErrorMonitoringMock(),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -113,5 +115,43 @@ describe("SentryGate", () => {
     expect(initBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
     expect(initBrowserErrorMonitoringMock).toHaveBeenCalledWith("https://public@o0.ingest.sentry.io/1");
     root.unmount();
+  });
+
+  it("closes browser monitoring when sign-out clears the session's DSN", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: "https://public@o0.ingest.sentry.io/1",
+    });
+    const root = await renderGate();
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
+    expect(teardownBrowserErrorMonitoringMock).not.toHaveBeenCalled();
+
+    // `useSignOut` resets the session query on sign-out; a mounted observer
+    // (this component) sees its data drop to `undefined` immediately.
+    getSessionMock.mockResolvedValue(null);
+    await act(async () => {
+      queryClient.resetQueries({ queryKey: queryKeys.auth.session });
+    });
+    await flushReact();
+
+    expect(teardownBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
+    // Signing back in must start a fresh client, not skip re-init.
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
+    root.unmount();
+  });
+
+  it("closes browser monitoring when the gate unmounts while a session DSN is set", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: "https://public@o0.ingest.sentry.io/1",
+    });
+    const root = await renderGate();
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
+
+    root.unmount();
+
+    expect(teardownBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/components/SentryGate.test.tsx
+++ b/ui/src/components/SentryGate.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/lib/queryKeys";
+import { SentryGate } from "./SentryGate";
+
+const getSessionMock = vi.hoisted(() => vi.fn());
+const initBrowserErrorMonitoringMock = vi.hoisted(() => vi.fn(async (_dsn: string) => {}));
+
+vi.mock("@/api/auth", () => ({
+  authApi: { getSession: () => getSessionMock() },
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  initBrowserErrorMonitoring: (dsn: string) => initBrowserErrorMonitoringMock(dsn),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("SentryGate", () => {
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  async function renderGate() {
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <SentryGate />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+    return root;
+  }
+
+  it("loads no SDK when the session query answers null", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const root = await renderGate();
+
+    expect(initBrowserErrorMonitoringMock).not.toHaveBeenCalled();
+    expect(container.textContent).toBe("");
+    root.unmount();
+  });
+
+  it("loads no SDK when the session sentryDsn is null", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: null,
+    });
+
+    const root = await renderGate();
+
+    expect(initBrowserErrorMonitoringMock).not.toHaveBeenCalled();
+    root.unmount();
+  });
+
+  it("opens the gate once when the session carries a DSN", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: "https://public@o0.ingest.sentry.io/1",
+    });
+
+    const root = await renderGate();
+
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledWith("https://public@o0.ingest.sentry.io/1");
+    root.unmount();
+  });
+
+  it("opens the gate after a signed-out session query refetches with a DSN", async () => {
+    getSessionMock.mockResolvedValue(null);
+    const root = await renderGate();
+    expect(initBrowserErrorMonitoringMock).not.toHaveBeenCalled();
+
+    getSessionMock.mockResolvedValue({
+      session: { id: "s1", userId: "u1" },
+      user: { id: "u1", email: "a@b.com", name: "Jane", image: null },
+      sentryDsn: "https://public@o0.ingest.sentry.io/1",
+    });
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: queryKeys.auth.session });
+    });
+    await flushReact();
+
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledTimes(1);
+    expect(initBrowserErrorMonitoringMock).toHaveBeenCalledWith("https://public@o0.ingest.sentry.io/1");
+    root.unmount();
+  });
+});

--- a/ui/src/components/SentryGate.tsx
+++ b/ui/src/components/SentryGate.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { authApi } from "@/api/auth";
+import { queryKeys } from "@/lib/queryKeys";
+import { initBrowserErrorMonitoring } from "@/lib/sentry";
+
+/**
+ * Opens the browser Sentry gate for an authorized board actor. Reads the
+ * signed-in session and starts browser error monitoring only when the
+ * session carries a Sentry DSN. Renders nothing.
+ *
+ * Sets no `enabled` option on the session query, so this also runs in
+ * `local_trusted` mode — the actor middleware fabricates a board actor
+ * there, so `/api/auth/get-session` still answers 200 with a session.
+ */
+export function SentryGate() {
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    retry: false,
+  });
+
+  const dsn = session?.sentryDsn;
+
+  useEffect(() => {
+    if (!dsn) return;
+    void initBrowserErrorMonitoring(dsn);
+  }, [dsn]);
+
+  return null;
+}

--- a/ui/src/components/SentryGate.tsx
+++ b/ui/src/components/SentryGate.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { authApi } from "@/api/auth";
 import { queryKeys } from "@/lib/queryKeys";
-import { initBrowserErrorMonitoring } from "@/lib/sentry";
+import { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring } from "@/lib/sentry";
 
 /**
  * Opens the browser Sentry gate for an authorized board actor. Reads the
@@ -12,6 +12,11 @@ import { initBrowserErrorMonitoring } from "@/lib/sentry";
  * Sets no `enabled` option on the session query, so this also runs in
  * `local_trusted` mode — the actor middleware fabricates a board actor
  * there, so `/api/auth/get-session` still answers 200 with a session.
+ *
+ * Sign-out clears the session query (`useSignOut`), so `dsn` goes back to
+ * falsy on the same render pass that drops the session. That change tears
+ * down monitoring through the effect cleanup below, closing the running
+ * client, so a signed-out browser sends Sentry no more events.
  */
 export function SentryGate() {
   const { data: session } = useQuery({
@@ -25,6 +30,9 @@ export function SentryGate() {
   useEffect(() => {
     if (!dsn) return;
     void initBrowserErrorMonitoring(dsn);
+    return () => {
+      void teardownBrowserErrorMonitoring();
+    };
   }, [dsn]);
 
   return null;

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -33,24 +33,30 @@ async function importFreshSentry() {
  */
 function mockSentryPackage() {
   let nextClientId = 0;
-  let attachedClient: { id: string } | null = null;
+  let attachedClient: { id: string; close: (timeout?: number) => Promise<boolean> } | null = null;
 
+  // One shared `close` mock, attached to every client `init` creates. The
+  // fix reads the client with `getClient()` and calls `client.close()`
+  // directly, so the mocked client — not the mocked module — needs the
+  // `close` method a test can hold open or reject.
+  const close = vi.fn(async () => true);
   const init = vi.fn((_options: Record<string, unknown>) => {
-    attachedClient = { id: `client-${nextClientId++}` };
+    attachedClient = { id: `client-${nextClientId++}`, close };
   });
   const captureException = vi.fn(() => (attachedClient ? "event-id" : undefined));
-  const close = vi.fn(async () => true);
-  const setClient = vi.fn((client: { id: string } | undefined) => {
+  const getClient = vi.fn(() => attachedClient ?? undefined);
+  const setClient = vi.fn((client: typeof attachedClient | undefined) => {
     attachedClient = client ?? null;
   });
   const getCurrentScope = vi.fn(() => ({ setClient }));
 
-  vi.doMock("@sentry/browser", () => ({ init, captureException, close, getCurrentScope }));
+  vi.doMock("@sentry/browser", () => ({ init, captureException, close, getClient, getCurrentScope }));
 
   return {
     init,
     captureException,
     close,
+    getClient,
     getCurrentScope,
     setClient,
     /** The `id` of whichever client `init`/`setClient` last attached, or `null` if none is. */
@@ -139,6 +145,30 @@ describe("teardownBrowserErrorMonitoring", () => {
 
     expect(mocks.close).toHaveBeenCalledTimes(1);
     expect(mocks.setClient).toHaveBeenCalledWith(undefined);
+  });
+
+  it("detaches the client from the current scope before close() settles", async () => {
+    // The client stays attached, and stays enabled, for the whole `close()`
+    // call — a signed-out page can still reach it until detach runs. Hold
+    // `close()` open and assert the detach already ran while it is still
+    // pending, so a regression back to close-then-detach fails this test.
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring } = await importFreshSentry();
+    await initBrowserErrorMonitoring(DSN);
+    const releaseClose = holdCloseOpen(mocks);
+
+    const teardownDone = teardownBrowserErrorMonitoring();
+    // Give the queued teardown operation a few turns of the microtask queue
+    // to run up to its `await client.close()` call, without waiting for
+    // `close()` itself to settle — the gate above holds that call open.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.setClient).toHaveBeenCalledWith(undefined);
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+
+    releaseClose();
+    await expect(teardownDone).resolves.toBeUndefined();
   });
 
   it("detaches the client from the current scope even when close() rejects, and still resolves", async () => {

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -233,6 +233,22 @@ describe("captureBrowserException", () => {
   });
 });
 
+/**
+ * Call the `integrations` option with the given default list. The real
+ * `@sentry/browser` option type allows `integrations` to be an array instead
+ * of a function, so this guard narrows it before the call — this gate always
+ * builds a function, never an array, but the type does not know that.
+ */
+function resolveIntegrations(
+  options: ReturnType<typeof import("./sentry")["buildBrowserSentryInitOptions"]>,
+  defaults: Array<{ name: string }>,
+) {
+  if (typeof options.integrations !== "function") {
+    throw new Error("expected buildBrowserSentryInitOptions to set a function, not an array");
+  }
+  return options.integrations(defaults);
+}
+
 describe("buildBrowserSentryInitOptions", () => {
   it("sets the recorded built-in privacy options", async () => {
     const { buildBrowserSentryInitOptions } = await importFreshSentry();
@@ -256,10 +272,7 @@ describe("buildBrowserSentryInitOptions", () => {
     const { buildBrowserSentryInitOptions } = await importFreshSentry();
 
     const options = buildBrowserSentryInitOptions(DSN);
-    const integrationsFn = options.integrations as (
-      defaults: Array<{ name: string }>,
-    ) => Array<{ name: string }>;
-    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const resolved = resolveIntegrations(options, DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
     const names = resolved.map((i) => i.name);
 
     expect(names).not.toContain("HttpContext");
@@ -270,10 +283,7 @@ describe("buildBrowserSentryInitOptions", () => {
     const { buildBrowserSentryInitOptions } = await importFreshSentry();
 
     const options = buildBrowserSentryInitOptions(DSN);
-    const integrationsFn = options.integrations as (
-      defaults: Array<{ name: string }>,
-    ) => Array<{ name: string }>;
-    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const resolved = resolveIntegrations(options, DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
     const names = resolved.map((i) => i.name);
 
     expect(names).toEqual(

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -141,14 +141,17 @@ describe("teardownBrowserErrorMonitoring", () => {
     expect(mocks.setClient).toHaveBeenCalledWith(undefined);
   });
 
-  it("detaches the client from the current scope even when close() rejects", async () => {
+  it("detaches the client from the current scope even when close() rejects, and still resolves", async () => {
     const mocks = mockSentryPackage();
     mocks.close.mockRejectedValueOnce(new Error("close timed out"));
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring } = await importFreshSentry();
     await initBrowserErrorMonitoring(DSN);
 
-    await teardownBrowserErrorMonitoring();
+    // The returned promise must resolve, not reject: SentryGate.tsx discards
+    // it with a bare `void` call, so a rejection would surface as an
+    // unhandled promise rejection in the browser.
+    await expect(teardownBrowserErrorMonitoring()).resolves.toBeUndefined();
 
     expect(mocks.setClient).toHaveBeenCalledWith(undefined);
     expect(consoleErrorSpy).toHaveBeenCalled();

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -141,6 +141,19 @@ describe("teardownBrowserErrorMonitoring", () => {
     expect(mocks.setClient).toHaveBeenCalledWith(undefined);
   });
 
+  it("detaches the client from the current scope even when close() rejects", async () => {
+    const mocks = mockSentryPackage();
+    mocks.close.mockRejectedValueOnce(new Error("close timed out"));
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring } = await importFreshSentry();
+    await initBrowserErrorMonitoring(DSN);
+
+    await teardownBrowserErrorMonitoring();
+
+    expect(mocks.setClient).toHaveBeenCalledWith(undefined);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
   it("stops captureBrowserException from reaching the client", async () => {
     const mocks = mockSentryPackage();
     const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring, captureBrowserException } =

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -23,17 +23,39 @@ async function importFreshSentry() {
  * Register a fake `@sentry/browser` module for the next dynamic import. Used
  * by the tests that only care about the call the module makes into the SDK,
  * not the shape of a captured event.
+ *
+ * `init` and `setClient` both write one shared `attachedClient` variable —
+ * the real SDK's `Sentry.init` and `Sentry.getCurrentScope().setClient` both
+ * mutate the same module-global scope, not a value scoped to one caller. A
+ * race that lets a stale `setClient(undefined)` land after a newer
+ * `Sentry.init` needs a mock that tracks this shared state to catch it —
+ * two mocks that record calls independently cannot see the clobber.
  */
 function mockSentryPackage() {
-  const init = vi.fn();
-  const captureException = vi.fn(() => "event-id");
+  let nextClientId = 0;
+  let attachedClient: { id: string } | null = null;
+
+  const init = vi.fn((_options: Record<string, unknown>) => {
+    attachedClient = { id: `client-${nextClientId++}` };
+  });
+  const captureException = vi.fn(() => (attachedClient ? "event-id" : undefined));
   const close = vi.fn(async () => true);
-  const setClient = vi.fn();
+  const setClient = vi.fn((client: { id: string } | undefined) => {
+    attachedClient = client ?? null;
+  });
   const getCurrentScope = vi.fn(() => ({ setClient }));
 
   vi.doMock("@sentry/browser", () => ({ init, captureException, close, getCurrentScope }));
 
-  return { init, captureException, close, getCurrentScope, setClient };
+  return {
+    init,
+    captureException,
+    close,
+    getCurrentScope,
+    setClient,
+    /** The `id` of whichever client `init`/`setClient` last attached, or `null` if none is. */
+    attachedClientId: () => attachedClient?.id ?? null,
+  };
 }
 
 /**
@@ -144,29 +166,42 @@ describe("teardownBrowserErrorMonitoring", () => {
     expect(mocks.init).toHaveBeenCalledTimes(2);
   });
 
-  it("a sign-back-in that overlaps a still-in-flight teardown ends up monitored", async () => {
+  it("a sign-back-in that overlaps a still-in-flight teardown ends up monitored, not silently disabled", async () => {
     // A sign-out whose `Sentry.close()` call is still in flight when the
-    // browser signs back in. The still-running teardown must not stop the
-    // new sign-in from starting its own client, and `captureBrowserException`
-    // must reach the NEW client once it is up, not the one being torn down.
+    // browser signs back in. `Sentry.init` and `Sentry.getCurrentScope().
+    // setClient` both mutate ONE shared scope, so the old teardown's
+    // `setClient(undefined)` call, if it lands after the new sign-in's
+    // `Sentry.init`, would detach the NEW client rather than the old one —
+    // silently disabling monitoring for the session that just signed in.
+    // The fix serializes the two: the old teardown's close-and-detach must
+    // finish in full before the new sign-in's `Sentry.init` runs.
     const mocks = mockSentryPackage();
     const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring, captureBrowserException } =
       await importFreshSentry();
     await initBrowserErrorMonitoring(DSN);
     expect(mocks.init).toHaveBeenCalledTimes(1);
+    const clientAId = mocks.attachedClientId();
+    expect(clientAId).not.toBeNull();
 
     const releaseClose = holdCloseOpen(mocks);
     const teardownDone = teardownBrowserErrorMonitoring();
-    // teardownBrowserErrorMonitoring is now stuck awaiting close(). A sign-in
-    // right now must not reuse the session being torn down.
-    await initBrowserErrorMonitoring(DSN);
-
-    expect(mocks.init).toHaveBeenCalledTimes(2);
+    // The sign-back-in's own `Sentry.init` is now queued behind the
+    // in-flight teardown, so its returned promise settles only once the
+    // gate below releases — await it after releasing, not before.
+    const signInBDone = initBrowserErrorMonitoring(DSN);
 
     releaseClose();
     await teardownDone;
+    await signInBDone;
 
     expect(mocks.close).toHaveBeenCalledTimes(1);
+    expect(mocks.init).toHaveBeenCalledTimes(2);
+    // The old teardown's close-and-detach ran to completion BEFORE the new
+    // sign-in's `Sentry.init`, so the client left attached is the new one —
+    // not `undefined`, and not the old client A ever reused.
+    const clientBId = mocks.attachedClientId();
+    expect(clientBId).not.toBeNull();
+    expect(clientBId).not.toBe(clientAId);
 
     captureBrowserException(new Error("boom after the race"));
     await Promise.resolve();

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -36,6 +36,26 @@ function mockSentryPackage() {
   return { init, captureException, close, getCurrentScope, setClient };
 }
 
+/**
+ * Hold a mocked `close()` call open until the test releases it. Returns the
+ * release function. Used to put a teardown mid-flight without a second,
+ * truly concurrent dynamic `import()` of the mocked `@sentry/browser` module
+ * — Vitest does not guarantee two in-flight `import()` calls for one mocked
+ * specifier both resolve against the same mock instance, so a test must
+ * never rely on that to race two sign-ins.
+ */
+function holdCloseOpen(mocks: ReturnType<typeof mockSentryPackage>): () => void {
+  let release = () => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  mocks.close.mockImplementationOnce(async () => {
+    await gate;
+    return true;
+  });
+  return release;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.doUnmock("@sentry/browser");
@@ -124,23 +144,28 @@ describe("teardownBrowserErrorMonitoring", () => {
     expect(mocks.init).toHaveBeenCalledTimes(2);
   });
 
-  it("a sign-back-in that races teardown ends up monitored, not stuck on the closed client", async () => {
-    // A sign-out followed at once by a sign-in, both before the first
-    // client's dynamic import settles. The first client must close itself
-    // once it notices the second sign-in superseded it, and the second
-    // client must end up the one `captureBrowserException` reaches.
+  it("a sign-back-in that overlaps a still-in-flight teardown ends up monitored", async () => {
+    // A sign-out whose `Sentry.close()` call is still in flight when the
+    // browser signs back in. The still-running teardown must not stop the
+    // new sign-in from starting its own client, and `captureBrowserException`
+    // must reach the NEW client once it is up, not the one being torn down.
     const mocks = mockSentryPackage();
     const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring, captureBrowserException } =
       await importFreshSentry();
+    await initBrowserErrorMonitoring(DSN);
+    expect(mocks.init).toHaveBeenCalledTimes(1);
 
-    const firstReady = initBrowserErrorMonitoring(DSN);
+    const releaseClose = holdCloseOpen(mocks);
     const teardownDone = teardownBrowserErrorMonitoring();
-    const secondReady = initBrowserErrorMonitoring(DSN);
-    await Promise.all([firstReady, teardownDone, secondReady]);
+    // teardownBrowserErrorMonitoring is now stuck awaiting close(). A sign-in
+    // right now must not reuse the session being torn down.
+    await initBrowserErrorMonitoring(DSN);
 
     expect(mocks.init).toHaveBeenCalledTimes(2);
-    // The superseded first client closes itself; the still-in-flight
-    // teardown finds nothing left to close, so `close` runs once, not twice.
+
+    releaseClose();
+    await teardownDone;
+
     expect(mocks.close).toHaveBeenCalledTimes(1);
 
     captureBrowserException(new Error("boom after the race"));

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -123,6 +123,32 @@ describe("teardownBrowserErrorMonitoring", () => {
 
     expect(mocks.init).toHaveBeenCalledTimes(2);
   });
+
+  it("a sign-back-in that races teardown ends up monitored, not stuck on the closed client", async () => {
+    // A sign-out followed at once by a sign-in, both before the first
+    // client's dynamic import settles. The first client must close itself
+    // once it notices the second sign-in superseded it, and the second
+    // client must end up the one `captureBrowserException` reaches.
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring, captureBrowserException } =
+      await importFreshSentry();
+
+    const firstReady = initBrowserErrorMonitoring(DSN);
+    const teardownDone = teardownBrowserErrorMonitoring();
+    const secondReady = initBrowserErrorMonitoring(DSN);
+    await Promise.all([firstReady, teardownDone, secondReady]);
+
+    expect(mocks.init).toHaveBeenCalledTimes(2);
+    // The superseded first client closes itself; the still-in-flight
+    // teardown finds nothing left to close, so `close` runs once, not twice.
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+
+    captureBrowserException(new Error("boom after the race"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.captureException).toHaveBeenCalledWith(expect.any(Error));
+  });
 });
 
 describe("captureBrowserException", () => {

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -27,10 +27,13 @@ async function importFreshSentry() {
 function mockSentryPackage() {
   const init = vi.fn();
   const captureException = vi.fn(() => "event-id");
+  const close = vi.fn(async () => true);
+  const setClient = vi.fn();
+  const getCurrentScope = vi.fn(() => ({ setClient }));
 
-  vi.doMock("@sentry/browser", () => ({ init, captureException }));
+  vi.doMock("@sentry/browser", () => ({ init, captureException, close, getCurrentScope }));
 
-  return { init, captureException };
+  return { init, captureException, close, getCurrentScope, setClient };
 }
 
 afterEach(() => {
@@ -75,6 +78,50 @@ describe("initBrowserErrorMonitoring", () => {
     await initBrowserErrorMonitoring(DSN);
 
     expect(mocks.init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("teardownBrowserErrorMonitoring", () => {
+  it("is a no-op when monitoring never started", async () => {
+    const { teardownBrowserErrorMonitoring } = await importFreshSentry();
+
+    await expect(teardownBrowserErrorMonitoring()).resolves.toBeUndefined();
+  });
+
+  it("closes the running client and detaches it from the current scope", async () => {
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring } = await importFreshSentry();
+    await initBrowserErrorMonitoring(DSN);
+
+    await teardownBrowserErrorMonitoring();
+
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+    expect(mocks.setClient).toHaveBeenCalledWith(undefined);
+  });
+
+  it("stops captureBrowserException from reaching the client", async () => {
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring, captureBrowserException } =
+      await importFreshSentry();
+    await initBrowserErrorMonitoring(DSN);
+    await teardownBrowserErrorMonitoring();
+
+    captureBrowserException(new Error("boom after sign-out"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it("a call to initBrowserErrorMonitoring after teardown starts a fresh client", async () => {
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring, teardownBrowserErrorMonitoring } = await importFreshSentry();
+    await initBrowserErrorMonitoring(DSN);
+    await teardownBrowserErrorMonitoring();
+
+    await initBrowserErrorMonitoring(DSN);
+
+    expect(mocks.init).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/ui/src/lib/sentry.test.ts
+++ b/ui/src/lib/sentry.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for the browser Sentry gate. Unlike the server gate,
+ * `@sentry/browser` is a real development dependency of this package (see
+ * the constraint in the plan), so most tests here run against the true SDK
+ * instead of a stand-in.
+ *
+ * The module holds module-scoped state (the readiness promise, the client
+ * handle), so each test resets the module registry and imports a fresh copy.
+ */
+
+const DSN = "https://public@o0.ingest.sentry.io/1";
+
+async function importFreshSentry() {
+  vi.resetModules();
+  return await import("./sentry");
+}
+
+/**
+ * Register a fake `@sentry/browser` module for the next dynamic import. Used
+ * by the tests that only care about the call the module makes into the SDK,
+ * not the shape of a captured event.
+ */
+function mockSentryPackage() {
+  const init = vi.fn();
+  const captureException = vi.fn(() => "event-id");
+
+  vi.doMock("@sentry/browser", () => ({ init, captureException }));
+
+  return { init, captureException };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock("@sentry/browser");
+});
+
+// A representative default-integration list, shaped like the array
+// `@sentry/browser@10.71.0`'s `getDefaultIntegrations()` returns. Recorded
+// 2026-08-25 with `node -e` against the published package.
+const DEFAULT_INTEGRATION_NAMES = [
+  "InboundFilters",
+  "FunctionToString",
+  "ConversationId",
+  "BrowserApiErrors",
+  "Breadcrumbs",
+  "GlobalHandlers",
+  "LinkedErrors",
+  "Dedupe",
+  "HttpContext",
+  "CultureContext",
+  "BrowserSession",
+];
+
+describe("initBrowserErrorMonitoring", () => {
+  it("initializes with the DSN it receives", async () => {
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring } = await importFreshSentry();
+
+    await initBrowserErrorMonitoring(DSN);
+
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+    const initOptions = mocks.init.mock.calls[0][0] as { dsn: string };
+    expect(initOptions.dsn).toBe(DSN);
+  });
+
+  it("a second call starts no second client", async () => {
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring } = await importFreshSentry();
+
+    await initBrowserErrorMonitoring(DSN);
+    await initBrowserErrorMonitoring(DSN);
+
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("captureBrowserException", () => {
+  it("does not throw when the gate is closed", async () => {
+    const { captureBrowserException } = await importFreshSentry();
+
+    expect(() => captureBrowserException(new Error("boom"))).not.toThrow();
+  });
+
+  it("reaches the client once the gate opens", async () => {
+    const mocks = mockSentryPackage();
+    const { initBrowserErrorMonitoring, captureBrowserException } = await importFreshSentry();
+
+    await initBrowserErrorMonitoring(DSN);
+    captureBrowserException(new Error("boom"));
+    // captureBrowserException resolves asynchronously; give its internal
+    // promise a turn to settle before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.captureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe("buildBrowserSentryInitOptions", () => {
+  it("sets the recorded built-in privacy options", async () => {
+    const { buildBrowserSentryInitOptions } = await importFreshSentry();
+
+    const options = buildBrowserSentryInitOptions(DSN);
+
+    expect(options.sendDefaultPii).toBe(false);
+    expect(options.tracesSampleRate).toBe(0);
+  });
+
+  it("holds no beforeSend hook and no custom filter function", async () => {
+    const { buildBrowserSentryInitOptions } = await importFreshSentry();
+
+    const options = buildBrowserSentryInitOptions(DSN);
+
+    expect(options.beforeSend).toBeUndefined();
+    expect(options.beforeSendTransaction).toBeUndefined();
+  });
+
+  it("the resolved integration list holds no HttpContext integration and no Breadcrumbs integration", async () => {
+    const { buildBrowserSentryInitOptions } = await importFreshSentry();
+
+    const options = buildBrowserSentryInitOptions(DSN);
+    const integrationsFn = options.integrations as (
+      defaults: Array<{ name: string }>,
+    ) => Array<{ name: string }>;
+    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const names = resolved.map((i) => i.name);
+
+    expect(names).not.toContain("HttpContext");
+    expect(names).not.toContain("Breadcrumbs");
+  });
+
+  it("the resolved integration list keeps GlobalHandlers, BrowserApiErrors, Dedupe, and LinkedErrors", async () => {
+    const { buildBrowserSentryInitOptions } = await importFreshSentry();
+
+    const options = buildBrowserSentryInitOptions(DSN);
+    const integrationsFn = options.integrations as (
+      defaults: Array<{ name: string }>,
+    ) => Array<{ name: string }>;
+    const resolved = integrationsFn(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+    const names = resolved.map((i) => i.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining(["GlobalHandlers", "BrowserApiErrors", "Dedupe", "LinkedErrors"]),
+    );
+  });
+});
+
+/**
+ * Tests against the real `@sentry/browser` SDK. `@sentry/browser` is not an
+ * optional dependency here — it is a real, always-installed development
+ * dependency of this package (see the module comment in `sentry.ts`) — so
+ * these tests run unconditionally.
+ */
+describe("captured event shape against the real @sentry/browser SDK", () => {
+  /**
+   * Initialize the real SDK with this module's exact options, plus a
+   * transport stub so no event leaves the test process, plus `beforeSend`
+   * so the test can inspect the resolved event before it would have been
+   * sent. `beforeSend` here is test-only introspection — the shipped module
+   * adds no `beforeSend` of its own (see the "holds no beforeSend hook"
+   * test above).
+   */
+  async function initRealSentryForTest(onEvent: (event: Record<string, unknown>) => void) {
+    const { buildBrowserSentryInitOptions } = await importFreshSentry();
+    const Sentry = await import("@sentry/browser");
+    Sentry.init({
+      ...buildBrowserSentryInitOptions(DSN),
+      transport: () => ({ send: async () => ({}), flush: async () => true }),
+      beforeSend: (event) => {
+        onEvent(event as unknown as Record<string, unknown>);
+        return event;
+      },
+    });
+    return Sentry;
+  }
+
+  it("an event from a page URL that holds a test capability value carries no request URL, no query string, and no referrer", async () => {
+    window.history.pushState({}, "", "/dashboard?token=test-capability-value");
+    Object.defineProperty(document, "referrer", {
+      value: "https://from.example/previous-page",
+      configurable: true,
+    });
+    let captured: Record<string, unknown> | null = null;
+    const Sentry = await initRealSentryForTest((event) => {
+      captured = event;
+    });
+
+    Sentry.captureException(new Error("boom"));
+    await Sentry.flush(2000);
+
+    expect(captured).not.toBeNull();
+    // `HttpContext` is the only default integration that writes
+    // `event.request`. With it removed, the field never appears.
+    expect((captured as unknown as Record<string, unknown>).request).toBeUndefined();
+  });
+
+  it("an event captured after a console call and a fetch call carries no breadcrumb", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => new Response("ok")) as unknown as typeof fetch;
+    let captured: Record<string, unknown> | null = null;
+    const Sentry = await initRealSentryForTest((event) => {
+      captured = event;
+    });
+
+    // eslint-disable-next-line no-console
+    console.warn("a console call the Breadcrumbs integration would otherwise record");
+    await fetch("/api/probe?token=test-capability-value");
+    Sentry.captureException(new Error("boom"));
+    await Sentry.flush(2000);
+
+    globalThis.fetch = originalFetch;
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as Record<string, unknown>).breadcrumbs).toBeUndefined();
+  });
+});

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -95,8 +95,19 @@ export function teardownBrowserErrorMonitoring(): Promise<void> {
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
-    } finally {
+    }
+    // Detach even when the close rejects. An attached client keeps the
+    // global handlers that Sentry.init installed, so a signed-out page
+    // would keep reporting errors. A separate guarded try keeps this
+    // operation unable to reject, unlike a bare finally block: a thrown
+    // error here would still reach the caller, and SentryGate.tsx discards
+    // this promise with a bare `void` call, so a rejection would surface
+    // as an unhandled promise rejection in the browser.
+    try {
       Sentry.getCurrentScope().setClient(undefined);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[paperclip] Sentry client detach failed", err);
     }
   });
 }

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -6,11 +6,15 @@
 // no DSN, calls this module never — see `SentryGate.tsx`.
 //
 // Sign-out must stop monitoring, not just stop starting it: `SentryGate`
-// calls `teardownBrowserErrorMonitoring` when the session's DSN goes away,
-// which closes the running client (`Sentry.close`) and detaches it from the
-// current scope (`Sentry.getCurrentScope().setClient(undefined)`), so the
-// global handlers `Sentry.init` installed send no more events. Both are
-// built-in Sentry client calls — no custom filter code.
+// calls `teardownBrowserErrorMonitoring` when the session's DSN goes away.
+// The function detaches the client from the current scope first
+// (`Sentry.getCurrentScope().setClient(undefined)`), then closes that same
+// client (`client.close()`), so a signed-out page's global handlers find no
+// attached client at any point. Detach runs first because a client stays
+// attached, and stays enabled, for the whole close call — closing first
+// would leave the signed-out page able to send one more event to Sentry for
+// as long as the close call takes. Both calls are built-in Sentry client
+// calls — no custom filter code.
 //
 // `initBrowserErrorMonitoring`, `teardownBrowserErrorMonitoring`, and
 // `captureBrowserException` each queue their work on one shared promise
@@ -82,32 +86,46 @@ export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
  * Stop browser error monitoring and forget the started client. Call this on
  * sign-out, so the browser sends Sentry no more events and no more
  * breadcrumbs after the session ends. A no-op when monitoring never started.
+ *
+ * Detaches the client from the current scope, then closes that same client.
+ * A client stays attached, and stays enabled, for the whole close call — a
+ * signed-out page's `window.onerror` or `window.onunhandledrejection`
+ * handler would still reach it for as long as the close call takes.
+ * Detaching first removes that window instead of leaving it open.
  */
 export function teardownBrowserErrorMonitoring(): Promise<void> {
   return enqueue(async () => {
     const Sentry = sentry;
     sentry = null;
     if (!Sentry) return;
-    try {
-      // Awaiting matters: the client flushes buffered events to Sentry
-      // during close; detaching before it settles silently drops them.
-      await Sentry.close(2_000);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
-    }
-    // Detach even when the close rejects. An attached client keeps the
-    // global handlers that Sentry.init installed, so a signed-out page
-    // would keep reporting errors. A separate guarded try keeps this
-    // operation unable to reject, unlike a bare finally block: a thrown
-    // error here would still reach the caller, and SentryGate.tsx discards
-    // this promise with a bare `void` call, so a rejection would surface
-    // as an unhandled promise rejection in the browser.
+    // Read the client before detaching it. The scope holds no client after
+    // detach, so the close step below needs this reference to flush and
+    // close the right client.
+    const client = Sentry.getClient();
+    // Detach first, close second — the opposite order from a plain
+    // `Sentry.close()` call, which reads the client off the current scope
+    // and would find nothing to close if detach ran first. A separate
+    // guarded try keeps this step unable to reject, unlike a bare finally
+    // block: a thrown error here would still reach the caller, and
+    // `SentryGate.tsx` discards this function's returned promise with a
+    // bare `void` call, so a rejection would surface as an unhandled
+    // promise rejection in the browser.
     try {
       Sentry.getCurrentScope().setClient(undefined);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("[paperclip] Sentry client detach failed", err);
+    }
+    // A second, separate guarded try, for the same reason as the one
+    // above: this step must never reject the returned promise.
+    try {
+      // Awaiting matters: the client flushes buffered events to Sentry
+      // during close; a caller that does not wait may navigate away, or
+      // the page may unload, before the flush finishes.
+      await client?.close(2_000);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
     }
   });
 }

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -92,10 +92,11 @@ export function teardownBrowserErrorMonitoring(): Promise<void> {
       // Awaiting matters: the client flushes buffered events to Sentry
       // during close; detaching before it settles silently drops them.
       await Sentry.close(2_000);
-      Sentry.getCurrentScope().setClient(undefined);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
+    } finally {
+      Sentry.getCurrentScope().setClient(undefined);
     }
   });
 }

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -38,13 +38,21 @@ let queue: Promise<void> = Promise.resolve();
 
 /** Run gate operations one at a time, in call order. */
 function enqueue(op: () => Promise<void>): Promise<void> {
-  const next = queue.then(op, op);
+  const next = queue.then(op);
   queue = next.catch(() => {});
   return next;
 }
 
 /** The `@sentry/browser` module shape, resolved once. */
 type SentryBrowserModule = typeof import("@sentry/browser");
+
+/**
+ * The `Sentry.init` options this gate builds. `Sentry.init`'s parameter is
+ * optional, so `Parameters<...>[0]` alone carries an `| undefined` arm this
+ * gate never returns. `NonNullable` removes only that arm — the object shape
+ * underneath stays the true `@sentry/browser` option type.
+ */
+type BrowserSentryInitOptions = NonNullable<Parameters<SentryBrowserModule["init"]>[0]>;
 
 let sentry: SentryBrowserModule | null = null;
 
@@ -114,12 +122,12 @@ export function captureBrowserException(error: unknown): void {
  * `@sentry/browser` module and assert the resolved integration list and the
  * captured-event shape against the true SDK, not a stand-in.
  */
-export function buildBrowserSentryInitOptions(dsn: string): Record<string, unknown> {
+export function buildBrowserSentryInitOptions(dsn: string): BrowserSentryInitOptions {
   return {
     dsn,
     tracesSampleRate: 0,
     sendDefaultPii: false,
-    integrations: (defaults: Array<{ name: string }>) =>
+    integrations: (defaults) =>
       defaults.filter(
         (integration) => integration.name !== "HttpContext" && integration.name !== "Breadcrumbs",
       ),

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -12,6 +12,15 @@
 // global handlers `Sentry.init` installed send no more events. Both are
 // built-in Sentry client calls — no custom filter code.
 //
+// State lives in one `current` session record, not in separate module
+// variables, so a sign-out that races a fast sign-back-in cannot mix up the
+// two sessions. `teardownBrowserErrorMonitoring` swaps `current` to `null`
+// before it awaits anything, so the next `initBrowserErrorMonitoring` call
+// starts its own session record right away. A bootstrap still in flight for
+// the old session checks, once the dynamic import resolves, whether it is
+// still `current`; a superseded bootstrap closes the client it just started
+// instead of publishing it, so it can never leak into the new session.
+//
 // `@sentry/browser` loads through a dynamic import, so Vite puts it in a
 // separate chunk that a browser with no DSN never fetches.
 //
@@ -38,9 +47,14 @@ interface SentryModuleHandle {
   getCurrentScope(): { setClient(client: undefined): void };
 }
 
-let sentryHandle: SentryHandle | null = null;
-let sentryModule: SentryModuleHandle | null = null;
-let readyPromise: Promise<void> | null = null;
+/** One sign-in's worth of browser Sentry state. */
+interface SentrySession {
+  ready: Promise<void>;
+  handle: SentryHandle | null;
+  sentryModule: SentryModuleHandle | null;
+}
+
+let current: SentrySession | null = null;
 
 /**
  * Load `@sentry/browser` and start the client with the given DSN. Idempotent
@@ -48,8 +62,11 @@ let readyPromise: Promise<void> | null = null;
  * returns the first call's promise instead of starting a second client.
  */
 export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
-  readyPromise ??= bootstrapBrowserSentry(dsn);
-  return readyPromise;
+  if (current) return current.ready;
+  const session: SentrySession = { ready: Promise.resolve(), handle: null, sentryModule: null };
+  session.ready = bootstrapBrowserSentry(dsn, session);
+  current = session;
+  return session.ready;
 }
 
 /**
@@ -57,26 +74,22 @@ export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
  * sign-out, so the browser sends Sentry no more events and no more
  * breadcrumbs after the session ends.
  *
- * A no-op when monitoring never started. Waits for a bootstrap already in
- * flight first, so a teardown that races `initBrowserErrorMonitoring` still
- * wins — the client ends up closed even when the dynamic import lands after
- * this call starts.
- *
- * Resets the ready state, so the next `initBrowserErrorMonitoring` call (the
- * next sign-in) starts a fresh client instead of reusing the closed one.
+ * A no-op when monitoring never started. Detaches `current` from the module
+ * before it awaits anything, so a sign-back-in that races this call starts
+ * its own session record right away instead of reusing this one's promise.
+ * See `bootstrapBrowserSentry` for the other half of that guard: a bootstrap
+ * still in flight for the session torn down here closes the client it just
+ * started rather than publish it once it notices it is no longer `current`.
  */
 export async function teardownBrowserErrorMonitoring(): Promise<void> {
-  if (readyPromise) {
-    await readyPromise;
-  }
-  readyPromise = null;
-  sentryHandle = null;
-  const Sentry = sentryModule;
-  sentryModule = null;
-  if (!Sentry) return;
+  const session = current;
+  current = null;
+  if (!session) return;
+  await session.ready;
+  if (!session.sentryModule) return;
   try {
-    await Sentry.close(2_000);
-    Sentry.getCurrentScope().setClient(undefined);
+    await session.sentryModule.close(2_000);
+    session.sentryModule.getCurrentScope().setClient(undefined);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
@@ -87,20 +100,21 @@ export async function teardownBrowserErrorMonitoring(): Promise<void> {
  * Report an error to Sentry. Waits for `initBrowserErrorMonitoring` to
  * settle, so a call that races the dynamic import still reaches the client.
  * A no-op before the gate opens, when the gate never opens (no DSN on the
- * session), or when bootstrap failed. Never throws — observability must not
- * change control flow.
+ * session), when bootstrap failed, or when a teardown superseded the session
+ * this call started against. Never throws — observability must not change
+ * control flow.
  */
 export function captureBrowserException(error: unknown): void {
   void reportWhenReady(error);
 }
 
 async function reportWhenReady(error: unknown): Promise<void> {
-  if (readyPromise) {
-    await readyPromise;
-  }
-  if (!sentryHandle) return;
+  const session = current;
+  if (!session) return;
+  await session.ready;
+  if (current !== session || !session.handle) return;
   try {
-    sentryHandle.captureException(error);
+    session.handle.captureException(error);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error("[paperclip] Sentry captureBrowserException failed", err);
@@ -125,12 +139,21 @@ export function buildBrowserSentryInitOptions(dsn: string): Record<string, unkno
   };
 }
 
-async function bootstrapBrowserSentry(dsn: string): Promise<void> {
+async function bootstrapBrowserSentry(dsn: string, session: SentrySession): Promise<void> {
   try {
     const Sentry = await import("@sentry/browser");
     Sentry.init(buildBrowserSentryInitOptions(dsn));
-    sentryHandle = { captureException: (error) => Sentry.captureException(error) };
-    sentryModule = Sentry;
+    if (current !== session) {
+      // A teardown (and maybe a new sign-in after it) ran while the dynamic
+      // import was in flight. This client belongs to no session anymore —
+      // close it now instead of publishing it onto `session`, so it cannot
+      // outlive the sign-out that should have stopped it.
+      await Sentry.close(2_000).catch(() => {});
+      Sentry.getCurrentScope().setClient(undefined);
+      return;
+    }
+    session.handle = { captureException: (error) => Sentry.captureException(error) };
+    session.sentryModule = Sentry;
   } catch (err) {
     // The dynamic import or the init call failed. Fall through with a
     // single diagnostic. The gate fails open — the app keeps running

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -22,7 +22,11 @@
 // instead of publishing it, so it can never leak into the new session.
 //
 // `@sentry/browser` loads through a dynamic import, so Vite puts it in a
-// separate chunk that a browser with no DSN never fetches.
+// separate chunk that a browser with no DSN never fetches. `loadSentryModule`
+// caches that import's promise at module scope, so a sign-out followed at
+// once by a sign-back-in issues one dynamic import call, not two — two
+// concurrent calls for the same not-yet-loaded chunk is also the shape a
+// test needs a stand-in module to resolve deterministically.
 //
 // Default-integration privacy note: two default integrations copy values
 // this app does not want inside a Sentry event, so the initializer removes
@@ -55,6 +59,28 @@ interface SentrySession {
 }
 
 let current: SentrySession | null = null;
+
+/** The `@sentry/browser` module shape, resolved once. */
+type SentryBrowserModule = typeof import("@sentry/browser");
+
+let sentryModuleImport: Promise<SentryBrowserModule> | null = null;
+
+/**
+ * Load `@sentry/browser`, caching the dynamic import's promise so a second
+ * call — even one issued before the first import settles — reuses it
+ * instead of starting a second fetch of the same chunk. Clears the cache on
+ * a rejected import, so a later sign-in retries the fetch instead of
+ * repeating a stale network failure for the rest of the browser tab's life.
+ */
+function loadSentryModule(): Promise<SentryBrowserModule> {
+  if (!sentryModuleImport) {
+    sentryModuleImport = import("@sentry/browser").catch((err: unknown) => {
+      sentryModuleImport = null;
+      throw err;
+    });
+  }
+  return sentryModuleImport;
+}
 
 /**
  * Load `@sentry/browser` and start the client with the given DSN. Idempotent
@@ -141,7 +167,7 @@ export function buildBrowserSentryInitOptions(dsn: string): Record<string, unkno
 
 async function bootstrapBrowserSentry(dsn: string, session: SentrySession): Promise<void> {
   try {
-    const Sentry = await import("@sentry/browser");
+    const Sentry = await loadSentryModule();
     Sentry.init(buildBrowserSentryInitOptions(dsn));
     if (current !== session) {
       // A teardown (and maybe a new sign-in after it) ran while the dynamic

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -12,31 +12,15 @@
 // global handlers `Sentry.init` installed send no more events. Both are
 // built-in Sentry client calls — no custom filter code.
 //
-// State lives in one `current` session record, not in separate module
-// variables, so a sign-out that races a fast sign-back-in cannot mix up the
-// two sessions. `teardownBrowserErrorMonitoring` swaps `current` to `null`
-// before it awaits anything, so the next `initBrowserErrorMonitoring` call
-// starts its own session record right away. A bootstrap still in flight for
-// the old session checks, once the dynamic import resolves, whether it is
-// still `current`; a superseded bootstrap closes the client it just started
-// instead of publishing it, so it can never leak into the new session.
-//
-// A fast sign-back-in must also never start ahead of a still-running
-// teardown: `Sentry.init` and `Sentry.getCurrentScope().setClient` both act
-// on ONE shared scope, so if the new sign-in's `Sentry.init()` ran before the
-// old teardown's `close()`-then-`setClient(undefined)` finished, that stale
-// `setClient(undefined)` would detach the NEW client instead of the old one
-// — silently disabling monitoring for the session that just signed in.
-// `teardownInFlight` tracks the running teardown's promise, so
-// `initBrowserErrorMonitoring` can wait for it to finish in full before it
-// calls `Sentry.init()` for the new session. The two never interleave.
+// `initBrowserErrorMonitoring`, `teardownBrowserErrorMonitoring`, and
+// `captureBrowserException` each queue their work on one shared promise
+// chain (`enqueue`) instead of running at once. One operation runs at a
+// time, in call order, so no operation can ever observe another one
+// part-finished — a sign-out always closes the client a sign-in already
+// finished starting, never one still starting.
 //
 // `@sentry/browser` loads through a dynamic import, so Vite puts it in a
-// separate chunk that a browser with no DSN never fetches. `loadSentryModule`
-// caches that import's promise at module scope, so a sign-out followed at
-// once by a sign-back-in issues one dynamic import call, not two — two
-// concurrent calls for the same not-yet-loaded chunk is also the shape a
-// test needs a stand-in module to resolve deterministically.
+// separate chunk that a browser with no DSN never fetches.
 //
 // Default-integration privacy note: two default integrations copy values
 // this app does not want inside a Sentry event, so the initializer removes
@@ -50,143 +34,83 @@
 // (`GlobalHandlers`), the two React error boundaries, deduplicates a repeat
 // event (`Dedupe`), and links a caused-by chain (`LinkedErrors`).
 
-/** The subset of the `@sentry/browser` client surface this gate calls. */
-interface SentryHandle {
-  captureException(error: unknown): string;
+let queue: Promise<void> = Promise.resolve();
+
+/** Run gate operations one at a time, in call order. */
+function enqueue(op: () => Promise<void>): Promise<void> {
+  const next = queue.then(op, op);
+  queue = next.catch(() => {});
+  return next;
 }
-
-/** The subset of the `@sentry/browser` module surface teardown calls. */
-interface SentryModuleHandle {
-  close(timeout?: number): Promise<boolean>;
-  getCurrentScope(): { setClient(client: undefined): void };
-}
-
-/** One sign-in's worth of browser Sentry state. */
-interface SentrySession {
-  ready: Promise<void>;
-  handle: SentryHandle | null;
-  sentryModule: SentryModuleHandle | null;
-}
-
-let current: SentrySession | null = null;
-
-/**
- * The running teardown's promise, or `null` when no teardown is in flight.
- * `initBrowserErrorMonitoring` awaits this before it starts a new client, so
- * a sign-back-in never runs `Sentry.init()` ahead of a still-running
- * teardown's close-and-detach.
- */
-let teardownInFlight: Promise<void> | null = null;
 
 /** The `@sentry/browser` module shape, resolved once. */
 type SentryBrowserModule = typeof import("@sentry/browser");
 
-let sentryModuleImport: Promise<SentryBrowserModule> | null = null;
-
-/**
- * Load `@sentry/browser`, caching the dynamic import's promise so a second
- * call — even one issued before the first import settles — reuses it
- * instead of starting a second fetch of the same chunk. Clears the cache on
- * a rejected import, so a later sign-in retries the fetch instead of
- * repeating a stale network failure for the rest of the browser tab's life.
- */
-function loadSentryModule(): Promise<SentryBrowserModule> {
-  if (!sentryModuleImport) {
-    sentryModuleImport = import("@sentry/browser").catch((err: unknown) => {
-      sentryModuleImport = null;
-      throw err;
-    });
-  }
-  return sentryModuleImport;
-}
+let sentry: SentryBrowserModule | null = null;
 
 /**
  * Load `@sentry/browser` and start the client with the given DSN. Idempotent
- * — the session query can refetch and call this again, and a second call
- * returns the first call's promise instead of starting a second client.
- *
- * Waits for any in-flight teardown to finish before it calls
- * `bootstrapBrowserSentry`, so this session's `Sentry.init()` never races
- * that teardown's close-and-detach — see the module comment.
+ * — the session query can refetch and call this again, and a second call is
+ * a no-op because a client is already started.
  */
 export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
-  if (current) return current.ready;
-  const session: SentrySession = { ready: Promise.resolve(), handle: null, sentryModule: null };
-  const afterTeardown = teardownInFlight ?? Promise.resolve();
-  session.ready = afterTeardown.then(() => bootstrapBrowserSentry(dsn, session));
-  current = session;
-  return session.ready;
+  return enqueue(async () => {
+    if (sentry) return;
+    try {
+      const Sentry = await import("@sentry/browser");
+      Sentry.init(buildBrowserSentryInitOptions(dsn));
+      sentry = Sentry;
+    } catch (err) {
+      // The dynamic import or the init call failed. Fall through with a
+      // single diagnostic. The gate fails open — the app keeps running
+      // without error monitoring rather than crashing on an opt-in feature.
+      // eslint-disable-next-line no-console
+      console.error("[paperclip] Sentry browser bootstrap failed", err);
+    }
+  });
 }
 
 /**
  * Stop browser error monitoring and forget the started client. Call this on
  * sign-out, so the browser sends Sentry no more events and no more
- * breadcrumbs after the session ends.
- *
- * A no-op when monitoring never started. Detaches `current` from the module
- * before it awaits anything, so a sign-back-in that races this call starts
- * its own session record right away instead of reusing this one's promise.
- * See `bootstrapBrowserSentry` for the other half of that guard: a bootstrap
- * still in flight for the session torn down here closes the client it just
- * started rather than publish it once it notices it is no longer `current`.
- *
- * Publishes its own promise onto `teardownInFlight` before it awaits
- * anything, so a sign-back-in issued in the same tick already sees it and
- * waits its turn — see `initBrowserErrorMonitoring`.
+ * breadcrumbs after the session ends. A no-op when monitoring never started.
  */
-export async function teardownBrowserErrorMonitoring(): Promise<void> {
-  const session = current;
-  current = null;
-  if (!session) return;
-  const work = closeSession(session);
-  teardownInFlight = work;
-  try {
-    await work;
-  } finally {
-    if (teardownInFlight === work) teardownInFlight = null;
-  }
-}
-
-async function closeSession(session: SentrySession): Promise<void> {
-  await session.ready;
-  if (!session.sentryModule) return;
-  try {
-    await session.sentryModule.close(2_000);
-    session.sentryModule.getCurrentScope().setClient(undefined);
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
-  }
+export function teardownBrowserErrorMonitoring(): Promise<void> {
+  return enqueue(async () => {
+    const Sentry = sentry;
+    sentry = null;
+    if (!Sentry) return;
+    try {
+      // Awaiting matters: the client flushes buffered events to Sentry
+      // during close; detaching before it settles silently drops them.
+      await Sentry.close(2_000);
+      Sentry.getCurrentScope().setClient(undefined);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
+    }
+  });
 }
 
 /**
- * Report an error to Sentry. Waits for `initBrowserErrorMonitoring` to
- * settle, so a call that races the dynamic import still reaches the client.
- * A no-op before the gate opens, when the gate never opens (no DSN on the
- * session), when bootstrap failed, or when a teardown superseded the session
- * this call started against. Never throws — observability must not change
- * control flow.
+ * Report an error to Sentry. Never throws — observability must not change
+ * control flow. A no-op before the gate opens, when the gate never opens (no
+ * DSN on the session), or when bootstrap failed.
  */
 export function captureBrowserException(error: unknown): void {
-  void reportWhenReady(error);
-}
-
-async function reportWhenReady(error: unknown): Promise<void> {
-  const session = current;
-  if (!session) return;
-  await session.ready;
-  if (current !== session || !session.handle) return;
-  try {
-    session.handle.captureException(error);
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error("[paperclip] Sentry captureBrowserException failed", err);
-  }
+  void enqueue(async () => {
+    try {
+      sentry?.captureException(error);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[paperclip] Sentry captureBrowserException failed", err);
+    }
+  });
 }
 
 /**
  * Build the `Sentry.init` options object. A pure function, split out from
- * `bootstrapBrowserSentry` so a test can call it with the real
+ * `initBrowserErrorMonitoring` so a test can call it with the real
  * `@sentry/browser` module and assert the resolved integration list and the
  * captured-event shape against the true SDK, not a stand-in.
  */
@@ -200,28 +124,4 @@ export function buildBrowserSentryInitOptions(dsn: string): Record<string, unkno
         (integration) => integration.name !== "HttpContext" && integration.name !== "Breadcrumbs",
       ),
   };
-}
-
-async function bootstrapBrowserSentry(dsn: string, session: SentrySession): Promise<void> {
-  try {
-    const Sentry = await loadSentryModule();
-    Sentry.init(buildBrowserSentryInitOptions(dsn));
-    if (current !== session) {
-      // A teardown (and maybe a new sign-in after it) ran while the dynamic
-      // import was in flight. This client belongs to no session anymore —
-      // close it now instead of publishing it onto `session`, so it cannot
-      // outlive the sign-out that should have stopped it.
-      await Sentry.close(2_000).catch(() => {});
-      Sentry.getCurrentScope().setClient(undefined);
-      return;
-    }
-    session.handle = { captureException: (error) => Sentry.captureException(error) };
-    session.sentryModule = Sentry;
-  } catch (err) {
-    // The dynamic import or the init call failed. Fall through with a
-    // single diagnostic. The gate fails open — the app keeps running
-    // without error monitoring rather than crashing on an opt-in feature.
-    // eslint-disable-next-line no-console
-    console.error("[paperclip] Sentry browser bootstrap failed", err);
-  }
 }

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -5,6 +5,13 @@
 // `initBrowserErrorMonitoring` once. A signed-out browser, or a browser with
 // no DSN, calls this module never — see `SentryGate.tsx`.
 //
+// Sign-out must stop monitoring, not just stop starting it: `SentryGate`
+// calls `teardownBrowserErrorMonitoring` when the session's DSN goes away,
+// which closes the running client (`Sentry.close`) and detaches it from the
+// current scope (`Sentry.getCurrentScope().setClient(undefined)`), so the
+// global handlers `Sentry.init` installed send no more events. Both are
+// built-in Sentry client calls — no custom filter code.
+//
 // `@sentry/browser` loads through a dynamic import, so Vite puts it in a
 // separate chunk that a browser with no DSN never fetches.
 //
@@ -25,7 +32,14 @@ interface SentryHandle {
   captureException(error: unknown): string;
 }
 
+/** The subset of the `@sentry/browser` module surface teardown calls. */
+interface SentryModuleHandle {
+  close(timeout?: number): Promise<boolean>;
+  getCurrentScope(): { setClient(client: undefined): void };
+}
+
 let sentryHandle: SentryHandle | null = null;
+let sentryModule: SentryModuleHandle | null = null;
 let readyPromise: Promise<void> | null = null;
 
 /**
@@ -36,6 +50,37 @@ let readyPromise: Promise<void> | null = null;
 export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
   readyPromise ??= bootstrapBrowserSentry(dsn);
   return readyPromise;
+}
+
+/**
+ * Stop browser error monitoring and forget the started client. Call this on
+ * sign-out, so the browser sends Sentry no more events and no more
+ * breadcrumbs after the session ends.
+ *
+ * A no-op when monitoring never started. Waits for a bootstrap already in
+ * flight first, so a teardown that races `initBrowserErrorMonitoring` still
+ * wins — the client ends up closed even when the dynamic import lands after
+ * this call starts.
+ *
+ * Resets the ready state, so the next `initBrowserErrorMonitoring` call (the
+ * next sign-in) starts a fresh client instead of reusing the closed one.
+ */
+export async function teardownBrowserErrorMonitoring(): Promise<void> {
+  if (readyPromise) {
+    await readyPromise;
+  }
+  readyPromise = null;
+  sentryHandle = null;
+  const Sentry = sentryModule;
+  sentryModule = null;
+  if (!Sentry) return;
+  try {
+    await Sentry.close(2_000);
+    Sentry.getCurrentScope().setClient(undefined);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[paperclip] Sentry teardownBrowserErrorMonitoring failed", err);
+  }
 }
 
 /**
@@ -85,6 +130,7 @@ async function bootstrapBrowserSentry(dsn: string): Promise<void> {
     const Sentry = await import("@sentry/browser");
     Sentry.init(buildBrowserSentryInitOptions(dsn));
     sentryHandle = { captureException: (error) => Sentry.captureException(error) };
+    sentryModule = Sentry;
   } catch (err) {
     // The dynamic import or the init call failed. Fall through with a
     // single diagnostic. The gate fails open — the app keeps running

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -21,6 +21,16 @@
 // still `current`; a superseded bootstrap closes the client it just started
 // instead of publishing it, so it can never leak into the new session.
 //
+// A fast sign-back-in must also never start ahead of a still-running
+// teardown: `Sentry.init` and `Sentry.getCurrentScope().setClient` both act
+// on ONE shared scope, so if the new sign-in's `Sentry.init()` ran before the
+// old teardown's `close()`-then-`setClient(undefined)` finished, that stale
+// `setClient(undefined)` would detach the NEW client instead of the old one
+// — silently disabling monitoring for the session that just signed in.
+// `teardownInFlight` tracks the running teardown's promise, so
+// `initBrowserErrorMonitoring` can wait for it to finish in full before it
+// calls `Sentry.init()` for the new session. The two never interleave.
+//
 // `@sentry/browser` loads through a dynamic import, so Vite puts it in a
 // separate chunk that a browser with no DSN never fetches. `loadSentryModule`
 // caches that import's promise at module scope, so a sign-out followed at
@@ -60,6 +70,14 @@ interface SentrySession {
 
 let current: SentrySession | null = null;
 
+/**
+ * The running teardown's promise, or `null` when no teardown is in flight.
+ * `initBrowserErrorMonitoring` awaits this before it starts a new client, so
+ * a sign-back-in never runs `Sentry.init()` ahead of a still-running
+ * teardown's close-and-detach.
+ */
+let teardownInFlight: Promise<void> | null = null;
+
 /** The `@sentry/browser` module shape, resolved once. */
 type SentryBrowserModule = typeof import("@sentry/browser");
 
@@ -86,11 +104,16 @@ function loadSentryModule(): Promise<SentryBrowserModule> {
  * Load `@sentry/browser` and start the client with the given DSN. Idempotent
  * — the session query can refetch and call this again, and a second call
  * returns the first call's promise instead of starting a second client.
+ *
+ * Waits for any in-flight teardown to finish before it calls
+ * `bootstrapBrowserSentry`, so this session's `Sentry.init()` never races
+ * that teardown's close-and-detach — see the module comment.
  */
 export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
   if (current) return current.ready;
   const session: SentrySession = { ready: Promise.resolve(), handle: null, sentryModule: null };
-  session.ready = bootstrapBrowserSentry(dsn, session);
+  const afterTeardown = teardownInFlight ?? Promise.resolve();
+  session.ready = afterTeardown.then(() => bootstrapBrowserSentry(dsn, session));
   current = session;
   return session.ready;
 }
@@ -106,11 +129,25 @@ export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
  * See `bootstrapBrowserSentry` for the other half of that guard: a bootstrap
  * still in flight for the session torn down here closes the client it just
  * started rather than publish it once it notices it is no longer `current`.
+ *
+ * Publishes its own promise onto `teardownInFlight` before it awaits
+ * anything, so a sign-back-in issued in the same tick already sees it and
+ * waits its turn — see `initBrowserErrorMonitoring`.
  */
 export async function teardownBrowserErrorMonitoring(): Promise<void> {
   const session = current;
   current = null;
   if (!session) return;
+  const work = closeSession(session);
+  teardownInFlight = work;
+  try {
+    await work;
+  } finally {
+    if (teardownInFlight === work) teardownInFlight = null;
+  }
+}
+
+async function closeSession(session: SentrySession): Promise<void> {
   await session.ready;
   if (!session.sentryModule) return;
   try {

--- a/ui/src/lib/sentry.ts
+++ b/ui/src/lib/sentry.ts
@@ -1,0 +1,95 @@
+// Optional Sentry error monitoring for the browser.
+//
+// Activated only when the signed-in session carries a Sentry DSN. `SentryGate`
+// reads the DSN off `GET /api/auth/get-session` and calls
+// `initBrowserErrorMonitoring` once. A signed-out browser, or a browser with
+// no DSN, calls this module never — see `SentryGate.tsx`.
+//
+// `@sentry/browser` loads through a dynamic import, so Vite puts it in a
+// separate chunk that a browser with no DSN never fetches.
+//
+// Default-integration privacy note: two default integrations copy values
+// this app does not want inside a Sentry event, so the initializer removes
+// them with a built-in Sentry option — no custom filter code:
+//   - `Breadcrumbs` turns a console call, a click, and a fetch call into a
+//     breadcrumb with the raw arguments and the raw request URL.
+//   - `HttpContext` copies the page URL, the query string, and the referrer
+//     onto every event.
+// The initializer keeps every other default integration, so the browser
+// still captures `window.onerror` and `window.onunhandledrejection`
+// (`GlobalHandlers`), the two React error boundaries, deduplicates a repeat
+// event (`Dedupe`), and links a caused-by chain (`LinkedErrors`).
+
+/** The subset of the `@sentry/browser` client surface this gate calls. */
+interface SentryHandle {
+  captureException(error: unknown): string;
+}
+
+let sentryHandle: SentryHandle | null = null;
+let readyPromise: Promise<void> | null = null;
+
+/**
+ * Load `@sentry/browser` and start the client with the given DSN. Idempotent
+ * — the session query can refetch and call this again, and a second call
+ * returns the first call's promise instead of starting a second client.
+ */
+export function initBrowserErrorMonitoring(dsn: string): Promise<void> {
+  readyPromise ??= bootstrapBrowserSentry(dsn);
+  return readyPromise;
+}
+
+/**
+ * Report an error to Sentry. Waits for `initBrowserErrorMonitoring` to
+ * settle, so a call that races the dynamic import still reaches the client.
+ * A no-op before the gate opens, when the gate never opens (no DSN on the
+ * session), or when bootstrap failed. Never throws — observability must not
+ * change control flow.
+ */
+export function captureBrowserException(error: unknown): void {
+  void reportWhenReady(error);
+}
+
+async function reportWhenReady(error: unknown): Promise<void> {
+  if (readyPromise) {
+    await readyPromise;
+  }
+  if (!sentryHandle) return;
+  try {
+    sentryHandle.captureException(error);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[paperclip] Sentry captureBrowserException failed", err);
+  }
+}
+
+/**
+ * Build the `Sentry.init` options object. A pure function, split out from
+ * `bootstrapBrowserSentry` so a test can call it with the real
+ * `@sentry/browser` module and assert the resolved integration list and the
+ * captured-event shape against the true SDK, not a stand-in.
+ */
+export function buildBrowserSentryInitOptions(dsn: string): Record<string, unknown> {
+  return {
+    dsn,
+    tracesSampleRate: 0,
+    sendDefaultPii: false,
+    integrations: (defaults: Array<{ name: string }>) =>
+      defaults.filter(
+        (integration) => integration.name !== "HttpContext" && integration.name !== "Breadcrumbs",
+      ),
+  };
+}
+
+async function bootstrapBrowserSentry(dsn: string): Promise<void> {
+  try {
+    const Sentry = await import("@sentry/browser");
+    Sentry.init(buildBrowserSentryInitOptions(dsn));
+    sentryHandle = { captureException: (error) => Sentry.captureException(error) };
+  } catch (err) {
+    // The dynamic import or the init call failed. Fall through with a
+    // single diagnostic. The gate fails open — the app keeps running
+    // without error monitoring rather than crashing on an opt-in feature.
+    // eslint-disable-next-line no-console
+    console.error("[paperclip] Sentry browser bootstrap failed", err);
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from "@/lib/router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
 import { AppErrorBoundary } from "./components/AppErrorBoundary";
+import { SentryGate } from "./components/SentryGate";
 import { CompanyProvider, useCompany } from "./context/CompanyContext";
 import { LiveUpdatesProvider } from "./context/LiveUpdatesProvider";
 import { BreadcrumbProvider } from "./context/BreadcrumbContext";
@@ -57,6 +58,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <AppErrorBoundary>
       <QueryClientProvider client={queryClient}>
+        <SentryGate />
         <ThemeProvider>
           <BrowserRouter>
             <CompanyProvider>

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -119,6 +119,7 @@ export const storybookAuthSession: AuthSession = {
     email: "riley@paperclip.local",
     image: null,
   },
+  sentryDsn: null,
 };
 
 export const storybookAgents: Agent[] = [


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server and the browser need clear error reports when an operator enables external monitoring.
> - Paperclip already uses an opt-in OpenTelemetry pattern for server traces.
> - Sentry can provide error reports for both runtime paths when the operator sets one data source name.
> - This pull request adds one opt-in Sentry gate for the server and the browser.
> - The benefit is faster diagnosis while the default setup sends no Sentry data.

## Linked Issues or Issue Description

**What is improved?**

Paperclip gains optional error monitoring for server and browser failures.

**Subsystem affected**

Cross-cutting (server, UI, and shared authentication data).

**Current behavior**

Paperclip has no built-in Sentry error capture for server failures or browser boundary failures. Operators must inspect local logs and browser tools.

**Proposed behavior**

When the operator sets `SENTRY_DSN`, the server and authenticated browser use the same Sentry project. When the variable is absent, both paths stay inactive. The server loads Sentry dynamically and fails open when the optional package is absent.

**Reason and benefit**

Operators can inspect runtime errors in one Sentry project. The default setup remains local and sends no monitoring data.

**Breaking changes**

None when `SENTRY_DSN` remains unset. Authenticated session responses add the optional `sentryDsn` field.

**Additional context**

The implementation uses built-in Sentry privacy options. It disables default HTTP context and breadcrumb integrations and keeps `sendDefaultPii` false.

## What Changed

- Add an opt-in server Sentry gate with dynamic package loading and fail-open behavior.
- Add the Sentry data source name to the authenticated session response.
- Add an authenticated browser Sentry gate and React error boundary capture.
- Add tests for server, browser, route, and application error paths.
- Document activation, installation, privacy settings, capture behavior, and operator controls.

## Verification

- Run `npx vitest run server/src/__tests__/sentry.test.ts`.
- Run `npx vitest run ui/src/lib/sentry.test.ts`.
- Run `npx vitest run server/src/__tests__/auth-routes.test.ts server/src/__tests__/shutdown.test.ts`.
- Confirm that the full continuous integration suite passes on this pull request.
- Leave `SENTRY_DSN` unset and confirm that the server and browser gates stay inactive.
- Set `SENTRY_DSN` and install the optional Sentry packages before a manual capture check.

## Risks

The operator controls the Sentry project and accepts the data risk when the operator enables the feature. Error objects can contain messages, stacks, or cause chains with private values. The default configuration sends no data because the feature stays off without `SENTRY_DSN`. A missing optional server package does not stop server boot.

## Model Used

OpenAI Codex, GPT-5, with tool use, repository inspection, GitHub CLI operations, and code review support.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge