### PR TITLE
docs(release): reconcile v2026.824.1 release notes to master

### DIFF
--- a/releases/v2026.824.1.md
+++ b/releases/v2026.824.1.md
@@ -1,0 +1,21 @@
+# Paperclip v2026.824.1
+
+> Released: 2026-08-25
+
+Paperclip v2026.824.1 is a patch release on v2026.824.0 that repairs the background-service leg of onboarding end to end: the service now actually starts from an `npx` onboard, onboarding no longer steers you into a safety-check error afterward, and it finishes by handing you the dashboard in your browser.
+
+## Fixes
+
+- **Accepting the background-service prompt during an `npx` onboard no longer installs a broken service.** The service definition targets the managed command shim, but an ephemeral run never installs it — the service crash-looped on a missing binary while onboarding, believing the service was handling things, skipped its own foreground start: a first run that ended with nothing serving. The service step now materializes the managed install (payload and command shim, pinned to the version being onboarded) before registering the service, and when it cannot — a custom `PAPERCLIP_SHIM_PATH`, or a failed install — it declines with the repair commands instead. ([#12148](https://github.com/paperclipai/paperclip/pull/12148))
+- **Onboarding no longer offers a foreground start the service already covers.** After a successful service install, interactive onboarding still asked "Start Paperclip now?" — accepting ran a second server into the already-running instance guard, ending a successful onboard with an error. The prompt is skipped once the service is running. ([#12153](https://github.com/paperclipai/paperclip/pull/12153))
+- **Onboarding ends at the dashboard instead of a dead stop.** After the service starts, onboarding now waits for it to report the endpoint it actually bound (including a fallback port when the configured one is busy), prints the dashboard URL, and opens it in the browser on interactive terminals. Headless runs print the URL; `PAPERCLIP_NO_BROWSER=1` disables the browser open. If the service does not become ready, onboarding says so and points at `paperclipai service logs` instead of claiming success. ([#12164](https://github.com/paperclipai/paperclip/pull/12164))
+- **`paperclipai doctor` diagnoses a missing service binary as exactly that.** The service-runtime check no longer suggests stopping a nonexistent conflicting process when the service's binary is missing (it names the missing path and points at `paperclipai install`), and the health check attributes a healthy responder that is not the managed service instead of reporting a plain "Healthy". ([#12148](https://github.com/paperclipai/paperclip/pull/12148))
+
+## Upgrade Guide
+
+- No migrations and no configuration changes.
+- If a previous onboard left a crash-looping background service behind: run `paperclipai install`, then `paperclipai service start`. The dead service definition is reused once its binary exists.
+
+## Contributors
+
+This release has 3 commits from the core team.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Release notes live in releases/ on master as the permanent record
> - v2026.824.1 shipped from a candidate branch, so its notes exist only on that branch and the release tag
> - Master would otherwise skip from v2026.824.0 to the next stable with a gap
> - This pull request copies the published v2026.824.1 notes to master
> - The benefit is a complete releases/ record

## Linked Issues or Issue Description

Refs #12148, #12153, #12164 — the fixes the patch carried. Same reconcile pattern as the v2026.817.0 and v2026.824.0 notes canonicalization.

## What Changed

- Adds releases/v2026.824.1.md, byte-identical to the notes published with the v2026.824.1 GitHub Release.

## Verification

- diff against the v2026.824.1 tag: identical.

## Risks

- None; docs only.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), extended thinking, agentic tool use via Claude Code.
