### PR TITLE
feat(recovery): auto-reassign stalled issues past a priority-scaled cutoff

### DIFF
--- a/server/src/__tests__/recovery-stall-cutoff-reassignment.test.ts
+++ b/server/src/__tests__/recovery-stall-cutoff-reassignment.test.ts
@@ -1,0 +1,207 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { recoveryService } from "../services/recovery/service.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres stall-cutoff reassignment tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// BRO-2410 allowlisted assignee (Founding Engineer queue). Fixed id so the
+// reconciler's allowlist binds to the seeded issue.
+const FE_AGENT_ID = "b3b6dde7-d283-47b7-8556-9eafe7ca9b52";
+const NOW = new Date("2026-08-25T20:00:00.000Z");
+
+describeEmbeddedPostgres("recovery stall-cutoff auto-reassignment (BRO-2410)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("stall-cutoff-");
+    db = createDb(tempDb.connectionString);
+  }, 60_000);
+
+  afterEach(async () => {
+    await db.execute("TRUNCATE TABLE \"companies\" CASCADE");
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedOrg() {
+    const companyId = randomUUID();
+    const issuePrefix = `S${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const lightEngineerId = randomUUID();
+    const busyEngineerId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Stall Cutoff Co",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      { id: FE_AGENT_ID, companyId, name: "Founding Engineer", role: "engineer", status: "idle", adapterType: "process", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: lightEngineerId, companyId, name: "Light Engineer", role: "engineer", status: "idle", adapterType: "process", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: busyEngineerId, companyId, name: "Busy Engineer", role: "engineer", status: "idle", adapterType: "process", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      // A different-role teammate must never be picked up as a target.
+      { id: randomUUID(), companyId, name: "Designer", role: "designer", status: "idle", adapterType: "process", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+
+    // Differing open loads so the least-loaded sibling wins the pickup.
+    await db.insert(issues).values([
+      { id: randomUUID(), companyId, title: "busy1", status: "in_progress", priority: "medium", assigneeAgentId: busyEngineerId },
+      { id: randomUUID(), companyId, title: "busy2", status: "todo", priority: "low", assigneeAgentId: busyEngineerId },
+      { id: randomUUID(), companyId, title: "light1", status: "todo", priority: "low", assigneeAgentId: lightEngineerId },
+    ]);
+
+    return { companyId, lightEngineerId, busyEngineerId };
+  }
+
+  async function seedStallIssue(companyId: string, overrides: Record<string, unknown> = {}) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stalled FE issue",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: FE_AGENT_ID,
+      ...overrides,
+    });
+    return issueId;
+  }
+
+  it("reassigns a priority-stale FE issue to the least-loaded same-role engineer, posts a comment, and wakes it", async () => {
+    const { companyId, lightEngineerId, busyEngineerId } = await seedOrg();
+    const issueId = await seedStallIssue(companyId, { updatedAt: new Date(NOW.getTime() - 40 * 60 * 1000) });
+
+    const wakeup = vi.fn().mockResolvedValue({ id: randomUUID() });
+    const recovery = recoveryService(db as any, { enqueueWakeup: wakeup });
+
+    const result = await recovery.reconcileStallCutoffReassignments(NOW);
+
+    expect(result.reassigned).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    // Least-loaded same-role sibling wins; FE and the busy sibling lose out.
+    expect(issue.assigneeAgentId).toBe(lightEngineerId);
+    expect(issue.assigneeAgentId).not.toBe(busyEngineerId);
+    expect(issue.assigneeAgentId).not.toBe(FE_AGENT_ID);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments.some((c) => c.body.includes("Auto-reassigned"))).toBe(true);
+
+    expect(wakeup).toHaveBeenCalledTimes(1);
+    const [targetAgentId, opts] = wakeup.mock.calls[0];
+    expect(targetAgentId).toBe(lightEngineerId);
+    expect(opts.reason).toBe("issue_assigned");
+  });
+
+  it("leaves an issue untouched while it is still inside its priority cutoff", async () => {
+    const { companyId } = await seedOrg();
+    const issueId = await seedStallIssue(companyId, { updatedAt: new Date(NOW.getTime() - 10 * 60 * 1000) });
+
+    const wakeup = vi.fn().mockResolvedValue({ id: randomUUID() });
+    const recovery = recoveryService(db as any, { enqueueWakeup: wakeup });
+
+    const result = await recovery.reconcileStallCutoffReassignments(NOW);
+
+    expect(result.reassigned).toBe(0);
+    expect(result.skippedStaleWithinCutoff).toBeGreaterThan(0);
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue.assigneeAgentId).toBe(FE_AGENT_ID);
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reassign an issue that has a live scheduled monitor", async () => {
+    const { companyId } = await seedOrg();
+    const issueId = await seedStallIssue(companyId, {
+      updatedAt: new Date(NOW.getTime() - 40 * 60 * 1000),
+      monitorNextCheckAt: new Date(NOW.getTime() + 5 * 60 * 1000),
+    });
+
+    const wakeup = vi.fn().mockResolvedValue({ id: randomUUID() });
+    const recovery = recoveryService(db as any, { enqueueWakeup: wakeup });
+
+    const result = await recovery.reconcileStallCutoffReassignments(NOW);
+
+    expect(result.reassigned).toBe(0);
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue.assigneeAgentId).toBe(FE_AGENT_ID);
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("leaves an issue alone when a live execution path is deferred for it", async () => {
+    const { companyId } = await seedOrg();
+    const issueId = await seedStallIssue(companyId, { updatedAt: new Date(NOW.getTime() - 40 * 60 * 1000) });
+
+    // A deferred_issue_execution wake counts as a live execution path.
+    await db.insert(agentWakeupRequests).values({
+      id: randomUUID(),
+      companyId,
+      agentId: FE_AGENT_ID,
+      source: "system",
+      status: "deferred_issue_execution",
+      payload: { issueId },
+    });
+
+    const wakeup = vi.fn().mockResolvedValue({ id: randomUUID() });
+    const recovery = recoveryService(db as any, { enqueueWakeup: wakeup });
+
+    const result = await recovery.reconcileStallCutoffReassignments(NOW);
+
+    expect(result.reassigned).toBe(0);
+    expect(result.skippedActivePath).toBeGreaterThan(0);
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue.assigneeAgentId).toBe(FE_AGENT_ID);
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("skips the issue when no invokable same-role sibling is available", async () => {
+    const companyId = randomUUID();
+    const issuePrefix = `S${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Lone Engineer Co",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      { id: FE_AGENT_ID, companyId, name: "Founding Engineer", role: "engineer", status: "idle", adapterType: "process", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: randomUUID(), companyId, name: "Designer", role: "designer", status: "idle", adapterType: "process", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    const issueId = await seedStallIssue(companyId, { updatedAt: new Date(NOW.getTime() - 40 * 60 * 1000) });
+
+    const wakeup = vi.fn().mockResolvedValue({ id: randomUUID() });
+    const recovery = recoveryService(db as any, { enqueueWakeup: wakeup });
+
+    const result = await recovery.reconcileStallCutoffReassignments(NOW);
+
+    expect(result.reassigned).toBe(0);
+    expect(result.skippedNoTarget).toBeGreaterThan(0);
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue.assigneeAgentId).toBe(FE_AGENT_ID);
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13891,6 +13891,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileStrandedAssignedIssues({ issueCreatedAtGte: await getWorktreeExecutionCutoff() });
   }
 
+  async function reconcileStallCutoffReassignments() {
+    return recovery.reconcileStallCutoffReassignments(new Date());
+  }
+
   async function sweepStaleIssueLocks() {
     return recovery.sweepStaleIssueLocks();
   }
@@ -19815,6 +19819,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const issueMonitors = await tickDueIssueMonitors(now);
+
+      const stallCutoff = await reconcileStallCutoffReassignments();
+      if (stallCutoff.reassigned > 0) {
+        logger.warn({ ...stallCutoff }, "stall-cutoff sweep auto-reassigned stalled issues");
+      }
 
       return {
         checked: checked + issueMonitors.checked,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, gte, inArray, isNull, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -116,6 +116,23 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+
+// BRO-2410 — Priority-scaled stall cutoff: auto-reassign an issue whose assignee
+// has not picked it up (no active run, no queued wake, no live monitor) past a
+// priority-scaled cutoff. v1 is scoped to an allowlist of assignee agents whose
+// queue is overloaded; generalizing company-wide later means broadening the
+// allowlist (or swapping it for a role/company scope).
+const STALL_CUTOFF_ASSIGNEE_AGENT_IDS = new Set<string>([
+  // Founding Engineer queue (overloaded; BRO-2410 field-tested here).
+  "b3b6dde7-d283-47b7-8556-9eafe7ca9b52",
+]);
+const STALL_CUTOFF_PRIORITY_MS: Record<string, number> = {
+  critical: 30 * 60 * 1000,
+  high: 30 * 60 * 1000,
+  medium: 2 * 60 * 60 * 1000,
+  low: 4 * 60 * 60 * 1000,
+};
+const STALL_CUTOFF_RECONCILE_SOURCE = "recovery.reconcile_stall_cutoff_reassignment";
 
 // GGU-809: when a stranded `in_progress` issue would otherwise hit the
 // `isRepeatedProductiveContinuationRecovery` escalation path, exempt the
@@ -4834,6 +4851,188 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return result;
   }
 
+  // BRO-2410 — Pick the least-loaded invokable agent in the same company+role as
+  // the current assignee (excluding the current assignee) to take over a stalled
+  // issue. Returns null when no sibling in the same role is available to take it.
+  async function pickStallCutoffReassignee(
+    issue: typeof issues.$inferSelect,
+    currentAssignee: typeof agents.$inferSelect,
+  ) {
+    const siblingRows = await db
+      .select()
+      .from(agents)
+      .where(and(
+        eq(agents.companyId, issue.companyId),
+        eq(agents.role, currentAssignee.role),
+        ne(agents.id, currentAssignee.id),
+      ));
+
+    const invokable: Array<typeof agents.$inferSelect> = [];
+    for (const agent of siblingRows) {
+      if (await isAgentInvokable(agent)) invokable.push(agent);
+    }
+    if (invokable.length === 0) return null;
+
+    const candidateIds = invokable.map((agent) => agent.id);
+    const openLoadRows = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId, openCount: count() })
+      .from(issues)
+      .where(and(
+        inArray(issues.assigneeAgentId, candidateIds),
+        inArray(issues.status, ["todo", "in_progress", "in_review"]),
+        isNull(issues.hiddenAt),
+      ))
+      .groupBy(issues.assigneeAgentId);
+
+    const openByAgent = new Map(openLoadRows.map((row) => [row.assigneeAgentId, Number(row.openCount)]));
+    invokable.sort((left, right) => {
+      const loadDiff = (openByAgent.get(left.id) ?? 0) - (openByAgent.get(right.id) ?? 0);
+      if (loadDiff !== 0) return loadDiff;
+      // Stable tie-break so the same sibling is not thrashed across sweeps.
+      return left.id.localeCompare(right.id);
+    });
+    return invokable[0] ?? null;
+  }
+
+  // BRO-2410 — Priority-scaled stall cutoff: an issue sitting `todo`/`in_progress`
+  // with no active run, no queued wake, and no live monitor gets auto-reassigned
+  // to the least-loaded invokable agent in the same role once it has been
+  // untouched past its priority cutoff. Legitimate waits (an unresolved first-class
+  // blocker, a pending wake interaction/approval) are excluded on purpose. v1 is
+  // scoped to STALL_CUTOFF_ASSIGNEE_AGENT_IDS (Founding Engineer queue).
+  async function reconcileStallCutoffReassignments(now = new Date()) {
+    const formatCutoffMs = (ms: number) =>
+      ms >= 60 * 60 * 1000 ? `${Math.round(ms / (60 * 60 * 1000))} hr` : `${Math.round(ms / (60 * 1000))} min`;
+
+    const candidates = await db
+      .select()
+      .from(issues)
+      .where(and(
+        inArray(issues.assigneeAgentId, [...STALL_CUTOFF_ASSIGNEE_AGENT_IDS]),
+        isNull(issues.assigneeUserId),
+        inArray(issues.status, ["todo", "in_progress"]),
+        isNull(issues.monitorNextCheckAt),
+        isNull(issues.hiddenAt),
+      ));
+
+    const result = {
+      evaluated: 0,
+      reassigned: 0,
+      skippedStaleWithinCutoff: 0,
+      skippedActivePath: 0,
+      skippedPendingWait: 0,
+      skippedBlocked: 0,
+      skippedNoTarget: 0,
+      skippedFailed: 0,
+      issueIds: [] as string[],
+    };
+
+    for (const issue of candidates) {
+      result.evaluated += 1;
+      const cutoffMs = STALL_CUTOFF_PRIORITY_MS[issue.priority as string] ?? STALL_CUTOFF_PRIORITY_MS["medium"];
+      const idleMs = now.getTime() - new Date(issue.updatedAt).getTime();
+      // Untouched long enough? `updatedAt` moves on status change, new comment, or
+      // run activity, so it is a faithful "last touched" clock for the cutoff.
+      if (idleMs < cutoffMs) {
+        result.skippedStaleWithinCutoff += 1;
+        continue;
+      }
+
+      // Exclude legitimate waits: an active run / queued wake (live execution path).
+      if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
+        result.skippedActivePath += 1;
+        continue;
+      }
+      // Exclude a pending wake interaction or approval (someone else is deciding).
+      if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
+        result.skippedPendingWait += 1;
+        continue;
+      }
+      // Exclude issues waiting on first-class blockers.
+      const blockerIds = await existingUnresolvedBlockerIssueIds(issue.companyId, issue.id);
+      if (blockerIds.length > 0) {
+        result.skippedBlocked += 1;
+        continue;
+      }
+
+      const currentAssignee = await getAgent(issue.assigneeAgentId ?? "");
+      const target = currentAssignee && currentAssignee.companyId === issue.companyId
+        ? await pickStallCutoffReassignee(issue, currentAssignee)
+        : null;
+      if (!target) {
+        result.skippedNoTarget += 1;
+        continue;
+      }
+
+      const updated = await issuesSvc.update(issue.id, {
+        assigneeAgentId: target.id,
+        assigneeUserId: null,
+      });
+      if (!updated) {
+        result.skippedFailed += 1;
+        continue;
+      }
+
+      await issuesSvc.addComment(
+        issue.id,
+        [
+          "## Auto-reassigned: stalled past priority cutoff",
+          "",
+          `${issue.identifier} sat ${formatCutoffMs(cutoffMs)} with no active run, no queued wake, and no scheduled monitor. ` +
+            `Reassigning from ${currentAssignee?.name ?? issue.assigneeAgentId} to ${target.name} (${target.role}) so the work gets picked up.`,
+          "",
+          "- Next action: pick this issue up and drive it to done.",
+        ].join("\n"),
+        { agentId: target.id },
+        { authorType: "agent" },
+      );
+
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          identifier: issue.identifier,
+          previousAssigneeAgentId: issue.assigneeAgentId,
+          assigneeAgentId: target.id,
+          source: STALL_CUTOFF_RECONCILE_SOURCE,
+        },
+      });
+
+      const queued = await deps.enqueueWakeup(target.id, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: {
+          issueId: issue.id,
+          mutation: "stall_cutoff_reassignment",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: {
+          issueId: issue.id,
+          taskId: issue.id,
+          wakeReason: "issue_assigned",
+          source: STALL_CUTOFF_RECONCILE_SOURCE,
+        },
+      });
+
+      if (queued) {
+        result.reassigned += 1;
+        result.issueIds.push(issue.id);
+      } else {
+        result.skippedFailed += 1;
+      }
+    }
+
+    return result;
+  }
+
   async function collectIssueGraphLivenessFindings() {
     const issueRowsPromise = Promise.resolve(db
       .select({
@@ -6357,6 +6556,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recordWatchdogDecision,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
+    reconcileStallCutoffReassignments,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileResolvedDependencyWakeBackstop,


### PR DESCRIPTION
## Summary

Adds a priority-scaled stall cutoff that auto-reassigns a `todo`/`in_progress` issue with no live wake path — no active run, no queued wake, and no scheduled monitor — once its assignee has left it untouched past a per-priority cutoff. The issue is reassigned to the least-loaded invokable agent in the same role, with an explaining comment, and the new assignee is woken.

Cutoffs (configurable constants):
- `critical` / `high`: 30 min
- `medium`: 2 hr
- `low`: 4 hr

**Legitimate waits are excluded on purpose** — an issue with an unresolved first-class blocker, a pending wake interaction/approval, an active execution path, or a live scheduled monitor is never reassigned.

v1 scopes the sweep to an allowlist of assignee agents whose queues are overloaded (founded during field-testing on a production overloaded queue); widening to company-wide is a one-line allowlist change once proven.

## Why

Issues can sit `todo`/`in_progress` indefinitely with no active run and no scheduled monitor when an assignee does not pick them up. Only a monitor that wakes the *same* assignee existed before; nothing re-routed a stalled issue to a different agent. This closes that gap by re-triage that lands in the periodic heartbeat sweep alongside the existing due-monitor tick.

## Design

- `reconcileStallCutoffReassignments(now)` in `services/recovery/service.ts` selects candidate issues (allowlisted assignee, `todo`/`in_progress`, no `monitorNextCheckAt`, not hidden), skips those younger than the priority cutoff or with a live execution path / pending interaction / unresolved blocker, picks the **least-loaded invokable sibling** in the same company+role (settle te breakb), reassigns, posts a comment, logs activity, and enqueues a wake.
- Leverages existing helpers (`hasActiveExecutionPath`, `hasPendingWakeInteraction`, `existingUnresolvedBlockerIssueIds`, `isAgentInvokable`, `logActivity`) plus `issueService.addComment` / the recovery wake deps.
- Wired into `heartbeat.serv()cts tickTimers` alongside `ttickDueIssueMonitors`.

Verify repo CI, the only workflow touched is none — these are plain `services/*` and a test file.

Co-Authored-By: Paperclip <noreply@paperclip.ing>