### PR TITLE
test(adapter-utils): restore ignore fixture metadata

### DIFF
--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -2281,7 +2281,11 @@ describe("sandbox managed runtime", () => {
         adapterKey: "test-adapter",
         client,
         workspaceLocalDir: localWorkspaceDir,
-        additionalSources: [{ localPath: referencedDir, projectId: "proj-first" }],
+        additionalSources: [{
+          localPath: referencedDir,
+          projectId: "proj-first",
+          ignoreResolution: { kind: "other" },
+        }],
         onProgress: (line) => { lines.push(line); },
       });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Adapter utilities prepare referenced project sources for sandbox execution.
> - Each source now carries an explicit ignore-resolution result.
> - One new transfer test omitted that required result.
> - The omission breaks typecheck and build on current master.
> - This pull request restores the fixture metadata.
> - The benefit is a green build with no production behavior change.

## Linked Issues or Issue Description

**What happened?**

Current master fails adapter-utils typecheck and build. A new sandbox transfer fixture constructs `SandboxAdditionalSource` without its required `ignoreResolution` field.

**Expected behavior**

All adapter-utils fixtures must provide the same explicit ignore-resolution metadata as production construction sites.

**Steps to reproduce**

1. Check out current master at `802f2af15`.
2. Run `pnpm --filter @paperclipai/adapter-utils typecheck`.
3. Observe TS2741 at `sandbox-managed-runtime.test.ts:2284`.

**Paperclip version or commit**

`802f2af15`

## What Changed

- Add `ignoreResolution: { kind: "other" }` to the transfer-byte test fixture.
- Keep production code and build configuration unchanged.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm -r typecheck`
- `pnpm exec vitest run packages/adapter-utils/src/sandbox-managed-runtime.test.ts`: 58 passed. Three unrelated macOS realpath cases fail because temporary paths use `/var` while `realpath` returns `/private/var`. The Linux CI job is the authoritative test gate.
- GitHub build, typecheck, canary, unit/server, and browser-test matrices pass.
- Greptile: 5/5 with no actionable comments.
- Socket, Snyk, Superagent, dependency review, and contributor-trust checks pass.

## Risks

Low risk. This change only completes a typed test fixture. It does not change production behavior, dependencies, workflows, or lockfiles.

## Model Used

OpenAI Codex, GPT-5 family. The client does not expose the exact deployment ID or context window. Agentic reasoning, tool use, and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run the affected typecheck locally and it passes
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
