### PR TITLE
fix(cli): supervise Windows listener loss

### DIFF
--- a/cli/src/__tests__/listener-watchdog.test.ts
+++ b/cli/src/__tests__/listener-watchdog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { startListenerWatchdog } from "../services/listener-watchdog.js";
+
+describe("listener watchdog", () => {
+  it("does not restart while probes are healthy", async () => {
+    vi.useFakeTimers();
+    const onFailure = vi.fn();
+    const watchdog = startListenerWatchdog({
+      probe: vi.fn(async () => ({ ok: true })),
+      intervalMs: 10,
+      onFailure,
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    watchdog.stop();
+    expect(onFailure).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("reports one restart after a live process loses its listener", async () => {
+    vi.useFakeTimers();
+    const onFailure = vi.fn();
+    const watchdog = startListenerWatchdog({
+      probe: vi.fn(async () => ({ ok: false, error: "fetch failed" })),
+      intervalMs: 10,
+      failureThreshold: 3,
+      onFailure,
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    watchdog.stop();
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledWith({ failures: 3, error: "fetch failed" });
+    vi.useRealTimers();
+  });
+});

--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -7,8 +7,10 @@ import {
   detectServiceManager,
   LaunchdServiceManager,
   renderLaunchdPlist,
+  renderWindowsTaskXml,
   renderSystemdUnit,
   SystemdServiceManager,
+  WindowsTaskServiceManager,
   type CommandRunner,
   type ServiceManager,
 } from "../services/service-manager.js";
@@ -112,6 +114,24 @@ describe("service adapter dispatch", () => {
     const detection = await detectServiceManager({ platform: "linux", instanceId: "default", runner });
     expect(detection.supported).toBe(true);
     if (detection.supported) expect(detection.manager).toBeInstanceOf(SystemdServiceManager);
+  });
+
+  it("selects Task Scheduler on Windows", async () => {
+    const detection = await detectServiceManager({ platform: "win32", instanceId: "default" });
+    expect(detection.supported).toBe(true);
+    if (detection.supported) expect(detection.manager).toBeInstanceOf(WindowsTaskServiceManager);
+  });
+
+  it("renders a singleton Windows task with restart-on-failure", () => {
+    const xml = renderWindowsTaskXml({
+      instanceId: "default",
+      shimPath: "C:\\Program Files\\Paperclip\\paperclipai.cmd",
+      homeDir: "C:\\Users\\Jane\\.paperclip",
+      stdoutPath: "C:\\Users\\Jane\\.paperclip\\service.log",
+    });
+    expect(xml).toContain("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>");
+    expect(xml).toContain("<RestartOnFailure><Interval>PT1M</Interval><Count>999</Count></RestartOnFailure>");
+    expect(xml).toContain("PAPERCLIP_SERVICE_MANAGED");
   });
 
   it("returns a foreground-run skip on unsupported hosts", async () => {

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -20,6 +20,8 @@ import { assertForegroundRunAllowed } from "../services/service-manager.js";
 import { removeRuntimeInfoForPid, writeRuntimeInfo } from "../runtime-info.js";
 import { printUpdateNotice } from "../update-notice.js";
 import { ensureWorktreeSeeded } from "./worktree.js";
+import { buildLocalHealthUrl } from "../utils/health-url.js";
+import { startListenerWatchdog } from "../services/listener-watchdog.js";
 
 interface RunOptions {
   config?: string;
@@ -104,6 +106,37 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     startedAt: new Date().toISOString(),
   });
   process.once("exit", () => removeRuntimeInfoForPid(process.pid, instanceId));
+
+  // A supervisor can only restart a process which actually exits.  On Windows
+  // a rare listener-loss failure used to leave this Node process alive forever,
+  // so Task Scheduler (and any other supported service manager) saw it as
+  // running.  Probe the listener from inside the managed process and request
+  // the server's existing ordered SIGTERM shutdown after three failures.  That
+  // shutdown drains/reconciles heartbeat work and stops embedded PostgreSQL
+  // before the service manager starts the replacement process.
+  if (process.env.PAPERCLIP_SERVICE_MANAGED === "1") {
+    const healthUrl = buildLocalHealthUrl(startedServer.host, startedServer.listenPort);
+    const watchdog = startListenerWatchdog({
+      probe: async () => {
+        try {
+          const response = await fetch(healthUrl, { signal: AbortSignal.timeout(2_000) });
+          const body = await response.json() as { status?: unknown };
+          return response.ok && body.status === "ok"
+            ? { ok: true }
+            : { ok: false, error: `health returned ${response.status}` };
+        } catch (error) {
+          return { ok: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+      onFailure: ({ failures, error }) => {
+        console.error(
+          `[paperclip] listener-watchdog restart: reason=listener_unhealthy oldPid=${process.pid} failures=${failures} error=${error ?? "unknown"} outcome=ordered_shutdown_requested`,
+        );
+        process.kill(process.pid, "SIGTERM");
+      },
+    });
+    process.once("exit", () => watchdog.stop());
+  }
 
   if (shouldGenerateBootstrapInviteAfterStart(config)) {
     p.log.step("Generating bootstrap CEO invite");

--- a/cli/src/services/listener-watchdog.ts
+++ b/cli/src/services/listener-watchdog.ts
@@ -1,0 +1,50 @@
+export type ListenerWatchdogProbe = () => Promise<{ ok: boolean; error?: string }>;
+
+export type ListenerWatchdogOptions = {
+  probe: ListenerWatchdogProbe;
+  intervalMs?: number;
+  failureThreshold?: number;
+  onFailure: (details: { failures: number; error?: string }) => void;
+};
+
+/**
+ * Detect a server process which is still alive but no longer owns a healthy
+ * HTTP listener.  The caller owns restart policy; this deliberately only
+ * raises one failure after consecutive failed probes.
+ */
+export function startListenerWatchdog(options: ListenerWatchdogOptions): { stop(): void } {
+  const intervalMs = options.intervalMs ?? 5_000;
+  const failureThreshold = options.failureThreshold ?? 3;
+  let failures = 0;
+  let stopped = false;
+  let restarting = false;
+
+  const check = async () => {
+    if (stopped || restarting) return;
+    try {
+      const result = await options.probe();
+      if (result.ok) {
+        failures = 0;
+        return;
+      }
+      failures += 1;
+      if (failures >= failureThreshold) {
+        restarting = true;
+        options.onFailure({ failures, error: result.error });
+      }
+    } catch (error) {
+      failures += 1;
+      if (failures >= failureThreshold) {
+        restarting = true;
+        options.onFailure({
+          failures,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  };
+
+  const timer = setInterval(() => { void check(); }, intervalMs);
+  timer.unref();
+  return { stop: () => { stopped = true; clearInterval(timer); } };
+}

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -5,10 +5,11 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
+import { readRuntimeInfo } from "../runtime-info.js";
 
 const execFileAsync = promisify(execFile);
 
-export type ServicePlatform = "systemd" | "launchd";
+export type ServicePlatform = "systemd" | "launchd" | "windows-task";
 export type ServiceStatus = {
   platform: ServicePlatform;
   serviceName: string;
@@ -69,6 +70,11 @@ function escapeXml(value: string): string {
   return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;");
 }
 
+function escapePowerShellLiteral(value: string): string {
+  if (/\r|\n/.test(value)) throw new Error("Windows service values must not contain line breaks");
+  return value.replaceAll("'", "''");
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -124,6 +130,10 @@ export function launchdServiceName(instanceId: string): string {
   return instanceId === "default" ? "ing.paperclip.paperclipai" : `ing.paperclip.paperclipai.${instanceId}`;
 }
 
+export function windowsTaskServiceName(instanceId: string): string {
+  return instanceId === "default" ? "PaperclipAI" : `PaperclipAI-${instanceId}`;
+}
+
 export function renderSystemdUnit(input: { instanceId: string; shimPath: string; homeDir: string }): string {
   return `[Unit]
 Description=Paperclip AI (${escapeSystemd(input.instanceId)})
@@ -173,6 +183,26 @@ export function renderLaunchdPlist(input: { instanceId: string; shimPath: string
   <key>StandardErrorPath</key><string>${escapeXml(input.stderrPath)}</string>
 </dict>
 </plist>
+`;
+}
+
+/** Task Scheduler is the native per-user supervisor on Windows. */
+export function renderWindowsTaskXml(input: { instanceId: string; shimPath: string; homeDir: string; stdoutPath: string }): string {
+  const script = [
+    `$env:PAPERCLIP_SERVICE_MANAGED = '1'`,
+    `$env:PAPERCLIP_INSTANCE_ID = '${escapePowerShellLiteral(input.instanceId)}'`,
+    `$env:PAPERCLIP_HOME = '${escapePowerShellLiteral(input.homeDir)}'`,
+    `& '${escapePowerShellLiteral(input.shimPath)}' 'run' '--instance' '${escapePowerShellLiteral(input.instanceId)}' *>> '${escapePowerShellLiteral(input.stdoutPath)}'`,
+    "exit $LASTEXITCODE",
+  ].join("; ");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo><Description>Paperclip AI (${escapeXml(input.instanceId)})</Description></RegistrationInfo>
+  <Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers>
+  <Principals><Principal id="Author"><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>
+  <Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries><StopIfGoingOnBatteries>false</StopIfGoingOnBatteries><AllowHardTerminate>true</AllowHardTerminate><StartWhenAvailable>true</StartWhenAvailable><AllowStartOnDemand>true</AllowStartOnDemand><Enabled>true</Enabled><ExecutionTimeLimit>PT0S</ExecutionTimeLimit><RestartOnFailure><Interval>PT1M</Interval><Count>999</Count></RestartOnFailure></Settings>
+  <Actions Context="Author"><Exec><Command>powershell.exe</Command><Arguments>-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command &quot;&amp; { ${escapeXml(script)} }&quot;</Arguments><WorkingDirectory>${escapeXml(input.homeDir)}</WorkingDirectory></Exec></Actions>
+</Task>
 `;
 }
 
@@ -343,6 +373,83 @@ export class LaunchdServiceManager implements ServiceManager {
   async logs(follow: boolean, lines: number): Promise<void> { await this.runner("tail", ["-n", String(lines), ...(follow ? ["-F"] : []), this.stdoutPath, this.stderrPath], { inherit: true }); }
 }
 
+export class WindowsTaskServiceManager implements ServiceManager {
+  readonly platform = "windows-task" as const;
+  readonly serviceName: string;
+  readonly definitionPath: string;
+  private readonly stdoutPath: string;
+
+  constructor(
+    readonly instanceId: string,
+    private readonly runner: CommandRunner = defaultCommandRunner,
+    private readonly homeDir = resolvePaperclipHomeDir(),
+    private readonly shimPath = resolveServiceShimPath(),
+  ) {
+    this.serviceName = windowsTaskServiceName(instanceId);
+    this.definitionPath = path.join(homeDir, "instances", instanceId, "paperclip-service.xml");
+    this.stdoutPath = path.join(homeDir, "instances", instanceId, "logs", "service.log");
+  }
+
+  renderDefinition(): string {
+    return renderWindowsTaskXml({ instanceId: this.instanceId, shimPath: this.shimPath, homeDir: this.homeDir, stdoutPath: this.stdoutPath });
+  }
+
+  async installedExecutablePath(): Promise<string | null> {
+    try {
+      const content = (await fs.readFile(this.definitionPath, "utf8")).replaceAll("&amp;", "&");
+      const match = content.match(/& '([^']*(?:''[^']*)*)' 'run'/);
+      return match ? match[1].replaceAll("''", "'") : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async ensureCurrent(): Promise<boolean> {
+    await fs.mkdir(path.dirname(this.stdoutPath), { recursive: true });
+    const changed = await writeIfChanged(this.definitionPath, this.renderDefinition());
+    await this.runner("schtasks.exe", ["/create", "/tn", this.serviceName, "/xml", this.definitionPath, "/f"]);
+    return changed;
+  }
+
+  async install(options: ServiceInstallOptions): Promise<{ changed: boolean }> {
+    const changed = await this.ensureCurrent();
+    if (!options.startOnLogin) await this.runner("schtasks.exe", ["/change", "/tn", this.serviceName, "/disable"]);
+    if (options.startNow) await this.start();
+    return { changed };
+  }
+
+  async uninstall(): Promise<void> {
+    await this.runner("schtasks.exe", ["/end", "/tn", this.serviceName]).catch(() => undefined);
+    await this.runner("schtasks.exe", ["/delete", "/tn", this.serviceName, "/f"]).catch(() => undefined);
+    await fs.rm(this.definitionPath, { force: true });
+  }
+
+  async start(): Promise<void> { await this.ensureCurrent(); await this.runner("schtasks.exe", ["/run", "/tn", this.serviceName]); }
+  async stop(): Promise<void> { await this.runner("schtasks.exe", ["/end", "/tn", this.serviceName]); }
+  async restart(): Promise<void> { await this.stop().catch(() => undefined); await this.start(); }
+
+  async status(): Promise<ServiceStatus> {
+    const script = [
+      `$task = Get-ScheduledTask -TaskName '${escapePowerShellLiteral(this.serviceName)}' -ErrorAction SilentlyContinue`,
+      "if ($null -eq $task) { @{ installed = $false } | ConvertTo-Json -Compress; exit 0 }",
+      "@{ installed = $true; enabled = [bool]$task.Settings.Enabled; state = [string]$task.State } | ConvertTo-Json -Compress",
+    ].join("; ");
+    try {
+      const { stdout } = await this.runner("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script]);
+      const task = JSON.parse(stdout) as { installed?: boolean; enabled?: boolean; state?: string };
+      const runtime = readRuntimeInfo(this.instanceId);
+      const active = task.state === "Running";
+      return { platform: this.platform, serviceName: this.serviceName, installed: task.installed === true, active, enabled: task.enabled === true, pid: active && runtime ? runtime.pid : null, detail: task.state };
+    } catch {
+      return { platform: this.platform, serviceName: this.serviceName, installed: false, active: false, enabled: false, pid: null };
+    }
+  }
+
+  async logs(follow: boolean, lines: number): Promise<void> {
+    await this.runner("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", `Get-Content -LiteralPath '${escapePowerShellLiteral(this.stdoutPath)}' -Tail ${lines}${follow ? " -Wait" : ""}`], { inherit: true });
+  }
+}
+
 export type ServiceManagerDetection = { supported: true; manager: ServiceManager } | { supported: false; reason: string };
 
 export async function detectServiceManager(input: { instanceId?: string; platform?: NodeJS.Platform; runner?: CommandRunner } = {}): Promise<ServiceManagerDetection> {
@@ -350,6 +457,7 @@ export async function detectServiceManager(input: { instanceId?: string; platfor
   const platform = input.platform ?? process.platform;
   const runner = input.runner ?? defaultCommandRunner;
   if (platform === "darwin") return { supported: true, manager: new LaunchdServiceManager(instanceId, runner) };
+  if (platform === "win32") return { supported: true, manager: new WindowsTaskServiceManager(instanceId, runner) };
   if (platform !== "linux") return { supported: false, reason: `Service management is not supported on ${platform}. Use paperclipai run instead.` };
   try {
     await runner("systemctl", ["--user", "show-environment"]);


### PR DESCRIPTION
## Summary\n- add a native Windows Task Scheduler service manager\n- run a managed listener watchdog that requests existing graceful shutdown after three failed health probes\n- add unit coverage for Windows task rendering/detection and listener loss\n\n## Validation\n- git diff --check passed.\n- Test/typecheck execution is blocked locally: upstream requires Node >=24.11.0, while this host has Node 22.23.2; dependency installation did not complete inside the runner time limit.\n\n## Scope\nThis addresses a live Node process that has lost its HTTP listener. The shutdown path remains the existing ordered server shutdown, so embedded PostgreSQL and heartbeat-run reconciliation remain owned by the server.