### PR TITLE
fix(cli): supervise Windows run listener loss

### DIFF
--- a/cli/src/__tests__/windows-run-supervisor.test.ts
+++ b/cli/src/__tests__/windows-run-supervisor.test.ts
@@ -253,6 +253,23 @@ describe("Windows foreground run supervision", () => {
     expect(calls).toBe(1);
   });
 
+  it("retains shutdown ownership after a failed stop and allows a later retry", async () => {
+    let stopAttempts = 0;
+    let releaseCalls = 0;
+    const shutdown = createIdempotentShutdown(async () => {
+      stopAttempts += 1;
+      if (stopAttempts === 1) throw new Error("child process tree is still alive");
+      releaseCalls += 1;
+    });
+
+    await expect(shutdown()).rejects.toThrow("child process tree is still alive");
+    expect(releaseCalls).toBe(0);
+
+    await expect(shutdown()).resolves.toBeUndefined();
+    expect(stopAttempts).toBe(2);
+    expect(releaseCalls).toBe(1);
+  });
+
   it("retries a failed child stop without starting a second server", async () => {
     const children = [new FakeChild(101), new FakeChild(202)];
     let nextChild = 0;

--- a/cli/src/__tests__/windows-run-supervisor.test.ts
+++ b/cli/src/__tests__/windows-run-supervisor.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   acquireWindowsRunSupervisorLock,
+  supervisedRunChildArgs,
   stopWindowsServerChild,
   WindowsRunSupervisor,
   type WindowsRunHealth,
@@ -177,6 +178,59 @@ describe("Windows foreground run supervision", () => {
     releaseProbe();
     await Promise.all([first, second]);
     expect(supervisor.childPid).toBe(101);
+  });
+
+  it("uses an explicit run child invocation when onboarding calls runCommand programmatically", () => {
+    const args = supervisedRunChildArgs({
+      config: "C:/Paperclip/config.json",
+      instance: "team-a",
+      bind: "loopback",
+      repair: false,
+      force: true,
+    });
+
+    expect(args.slice(1)).toEqual([
+      "run",
+      "--config", "C:/Paperclip/config.json",
+      "--instance", "team-a",
+      "--bind", "loopback",
+      "--no-repair",
+      "--force",
+      "--supervised-child",
+    ]);
+  });
+
+  it("waits for an in-flight listener-loss restart before releasing shutdown ownership", async () => {
+    const children = [new FakeChild(101), new FakeChild(202)];
+    let nextChild = 0;
+    let releaseStop!: () => void;
+    const oldChildStop = new Promise<void>((resolve) => { releaseStop = resolve; });
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      failureThreshold: 1,
+      startupGraceMs: 0,
+      startChild: () => children[nextChild++]!,
+      stopChild: async (child) => {
+        if (child.pid === 101) {
+          await oldChildStop;
+          child.kill("SIGTERM");
+          return;
+        }
+        child.kill("SIGTERM");
+      },
+      probeHealth: async () => ({ listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null }),
+      log: () => undefined,
+    });
+
+    supervisor.start();
+    const restart = supervisor.tick();
+    const shutdown = supervisor.stop();
+    releaseStop();
+    await Promise.all([restart, shutdown]);
+
+    expect(nextChild).toBe(1);
+    expect(supervisor.childPid).toBeNull();
+    expect(children[0]!.killed).toBe(true);
   });
 
   it("retries a failed child stop without starting a second server", async () => {

--- a/cli/src/__tests__/windows-run-supervisor.test.ts
+++ b/cli/src/__tests__/windows-run-supervisor.test.ts
@@ -1,0 +1,257 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireWindowsRunSupervisorLock,
+  stopWindowsServerChild,
+  WindowsRunSupervisor,
+  type WindowsRunHealth,
+} from "../commands/windows-run-supervisor.js";
+
+class FakeChild extends EventEmitter {
+  killed = false;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  send?: (message: unknown, callback?: (error: Error | null) => void) => boolean;
+  constructor(readonly pid: number) { super(); }
+  kill() { this.killed = true; this.signalCode = "SIGTERM"; this.emit("exit", null, "SIGTERM"); return true; }
+}
+
+let temporaryHome: string | undefined;
+let previousHome: string | undefined;
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.PAPERCLIP_HOME;
+  else process.env.PAPERCLIP_HOME = previousHome;
+  if (temporaryHome) fs.rmSync(temporaryHome, { recursive: true, force: true });
+  temporaryHome = undefined;
+  previousHome = undefined;
+});
+
+function healthy(databaseBackupStatus: string | null = "ok"): WindowsRunHealth {
+  return { listenerOk: true, databaseBackupOk: databaseBackupStatus === "ok", databaseBackupStatus };
+}
+
+async function freePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  if (!address || typeof address === "string") throw new Error("Could not allocate a test port");
+  return address.port;
+}
+
+async function waitFor(check: () => Promise<boolean>, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("Timed out waiting for test condition");
+}
+
+describe("Windows foreground run supervision", () => {
+  it("replaces a real node process whose HTTP listener closes while the process stays alive", async () => {
+    const port = await freePort();
+    const script = [
+      "const http = require('node:http');",
+      "const server = http.createServer((req, res) => {",
+      "  if (req.url === '/drop') { res.end('dropping'); setTimeout(() => server.close(), 0); return; }",
+      "  res.end('ok');",
+      "});",
+      "server.listen(Number(process.argv[1]), '127.0.0.1');",
+      "setInterval(() => {}, 1_000);",
+      "process.on('SIGTERM', () => server.close(() => process.exit(0)));",
+    ].join("\n");
+    const children: ReturnType<typeof spawn>[] = [];
+    const probe = async (): Promise<WindowsRunHealth> => {
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/health`);
+        return { listenerOk: response.ok, databaseBackupOk: response.ok, databaseBackupStatus: "ok" };
+      } catch {
+        return { listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null };
+      }
+    };
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      failureThreshold: 1,
+      startChild: () => {
+        const child = spawn(process.execPath, ["-e", script, String(port)], { stdio: "ignore" });
+        children.push(child);
+        return child;
+      },
+      stopChild: async (child) => {
+        await new Promise<void>((resolve) => {
+          child.once("exit", () => resolve());
+          child.kill("SIGTERM");
+        });
+      },
+      probeHealth: async () => probe(),
+      log: () => undefined,
+    });
+
+    try {
+      supervisor.start();
+      await waitFor(async () => (await probe()).listenerOk);
+      await supervisor.tick();
+      const firstPid = supervisor.childPid;
+      await fetch(`http://127.0.0.1:${port}/drop`);
+      await waitFor(async () => !(await probe()).listenerOk);
+      expect(children[0]!.exitCode).toBeNull();
+
+      await supervisor.tick();
+      expect(supervisor.childPid).not.toBe(firstPid);
+      await waitFor(async () => (await probe()).listenerOk);
+    } finally {
+      await supervisor.stop();
+    }
+  }, 15_000);
+
+  it("restarts a live node child after its listener disappears", async () => {
+    const children = [new FakeChild(101), new FakeChild(202)];
+    const logs: string[] = [];
+    let nextChild = 0;
+    let probeCount = 0;
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      startChild: () => children[nextChild++]!,
+      stopChild: async (child) => { child.kill("SIGTERM"); },
+      log: (message) => logs.push(message),
+      probeHealth: async () => {
+        probeCount += 1;
+        // The first node process remains alive, but its listener is gone.
+        return probeCount === 1 ? healthy() : { listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null };
+      },
+    });
+
+    supervisor.start();
+    await supervisor.tick();
+    await supervisor.tick();
+    await supervisor.tick();
+    await supervisor.tick();
+
+    expect(children[0]!.killed).toBe(true);
+    expect(supervisor.childPid).toBe(202);
+    expect(logs).toContainEqual(expect.stringContaining("reason=listener_loss oldPid=101"));
+  });
+
+  it("allows a bounded startup window before treating a missing listener as a fault", async () => {
+    const child = new FakeChild(101);
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      failureThreshold: 1,
+      startupGraceMs: 60_000,
+      now: () => 1_000,
+      startChild: () => child,
+      stopChild: async () => undefined,
+      probeHealth: async () => ({ listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null }),
+      log: () => undefined,
+    });
+
+    supervisor.start();
+    await supervisor.tick();
+    expect(child.killed).toBe(false);
+  });
+
+  it("serializes overlapping health ticks so an old probe cannot restart a replacement child", async () => {
+    const child = new FakeChild(101);
+    let probeCount = 0;
+    let releaseProbe!: () => void;
+    const pendingProbe = new Promise<WindowsRunHealth>((resolve) => { releaseProbe = () => resolve(healthy()); });
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      startChild: () => child,
+      stopChild: async () => undefined,
+      probeHealth: async () => { probeCount += 1; return pendingProbe; },
+      log: () => undefined,
+    });
+
+    supervisor.start();
+    const first = supervisor.tick();
+    const second = supervisor.tick();
+    expect(probeCount).toBe(1);
+    releaseProbe();
+    await Promise.all([first, second]);
+    expect(supervisor.childPid).toBe(101);
+  });
+
+  it("retries a failed child stop without starting a second server", async () => {
+    const children = [new FakeChild(101), new FakeChild(202)];
+    let nextChild = 0;
+    let stopAttempts = 0;
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      failureThreshold: 1,
+      startupGraceMs: 0,
+      startChild: () => children[nextChild++]!,
+      stopChild: async (child) => {
+        stopAttempts += 1;
+        if (stopAttempts === 1) throw new Error("first stop timed out");
+        child.kill("SIGTERM");
+      },
+      probeHealth: async () => ({ listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null }),
+      log: () => undefined,
+    });
+
+    supervisor.start();
+    await supervisor.tick();
+    expect(supervisor.childPid).toBe(101);
+    expect(nextChild).toBe(1);
+    await supervisor.tick();
+    expect(supervisor.childPid).toBe(202);
+  });
+
+  it("uses the child IPC channel for ordered shutdown before force-killing the process tree", async () => {
+    const child = new FakeChild(101);
+    let message: unknown;
+    child.send = (sent) => {
+      message = sent;
+      child.exitCode = 0;
+      child.emit("exit", 0, null);
+      return true;
+    };
+
+    await stopWindowsServerChild(child);
+    expect(message).toEqual({ type: "paperclip:graceful-shutdown" });
+    expect(child.killed).toBe(false);
+  });
+
+  it("does not allow a second Windows supervisor for the same instance", () => {
+    previousHome = process.env.PAPERCLIP_HOME;
+    temporaryHome = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-windows-supervisor-"));
+    process.env.PAPERCLIP_HOME = temporaryHome;
+    const release = acquireWindowsRunSupervisorLock("default");
+    expect(() => acquireWindowsRunSupervisorLock("default")).toThrow("already supervised");
+    release();
+    expect(() => acquireWindowsRunSupervisorLock("default")).not.toThrow();
+  });
+
+  it("reports recovery only after the replacement listener and backup health return", async () => {
+    const children = [new FakeChild(101), new FakeChild(202)];
+    const logs: string[] = [];
+    let nextChild = 0;
+    let probeCount = 0;
+    const supervisor = new WindowsRunSupervisor({
+      instanceId: "default",
+      startChild: () => children[nextChild++]!,
+      stopChild: async (child) => { child.kill("SIGTERM"); },
+      log: (message) => logs.push(message),
+      probeHealth: async () => {
+        probeCount += 1;
+        if (probeCount === 1 || probeCount >= 6) return healthy("ok");
+        if (probeCount === 5) return healthy("stale");
+        return { listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null };
+      },
+    });
+
+    supervisor.start();
+    for (let index = 0; index < 6; index += 1) await supervisor.tick();
+
+    expect(logs).toContainEqual(expect.stringContaining("database backup is not healthy"));
+    expect(logs).toContainEqual(expect.stringContaining("oldPid=101 newPid=202 health=ok databaseBackup=ok"));
+  });
+});

--- a/cli/src/__tests__/windows-run-supervisor.test.ts
+++ b/cli/src/__tests__/windows-run-supervisor.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   acquireWindowsRunSupervisorLock,
+  createIdempotentShutdown,
   supervisedRunChildArgs,
   stopWindowsServerChild,
   WindowsRunSupervisor,
@@ -231,6 +232,25 @@ describe("Windows foreground run supervision", () => {
     expect(nextChild).toBe(1);
     expect(supervisor.childPid).toBeNull();
     expect(children[0]!.killed).toBe(true);
+  });
+
+  it("coalesces repeated termination signals into one shutdown transaction", async () => {
+    let calls = 0;
+    let releaseShutdown!: () => void;
+    const pendingShutdown = new Promise<void>((resolve) => { releaseShutdown = resolve; });
+    const shutdown = createIdempotentShutdown(async () => {
+      calls += 1;
+      await pendingShutdown;
+    });
+
+    const firstSignal = shutdown();
+    const repeatedSignal = shutdown();
+    expect(repeatedSignal).toBe(firstSignal);
+    expect(calls).toBe(1);
+
+    releaseShutdown();
+    await Promise.all([firstSignal, repeatedSignal]);
+    expect(calls).toBe(1);
   });
 
   it("retries a failed child stop without starting a second server", async () => {

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -20,6 +20,7 @@ import { assertForegroundRunAllowed } from "../services/service-manager.js";
 import { removeRuntimeInfoForPid, writeRuntimeInfo } from "../runtime-info.js";
 import { printUpdateNotice } from "../update-notice.js";
 import { ensureWorktreeSeeded } from "./worktree.js";
+import { runWithWindowsSupervisor } from "./windows-run-supervisor.js";
 
 interface RunOptions {
   config?: string;
@@ -28,6 +29,7 @@ interface RunOptions {
   yes?: boolean;
   bind?: "loopback" | "lan" | "tailnet";
   force?: boolean;
+  supervisedChild?: boolean;
 }
 
 interface StartedServer {
@@ -40,6 +42,14 @@ interface StartedServer {
 export async function runCommand(opts: RunOptions): Promise<void> {
   const instanceId = resolvePaperclipInstanceId(opts.instance);
   process.env.PAPERCLIP_INSTANCE_ID = instanceId;
+  if (
+    process.platform === "win32"
+    && !opts.supervisedChild
+    && process.env.PAPERCLIP_SERVICE_MANAGED !== "1"
+  ) {
+    await runWithWindowsSupervisor(instanceId);
+    return;
+  }
   await assertForegroundRunAllowed(instanceId, opts.force);
 
   const homeDir = resolvePaperclipHomeDir();
@@ -104,6 +114,19 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     startedAt: new Date().toISOString(),
   });
   process.once("exit", () => removeRuntimeInfoForPid(process.pid, instanceId));
+  // Windows parent supervision uses IPC rather than SIGTERM so the child
+  // reaches the server's ordered shutdown path before any forced fallback.
+  if (process.send) {
+    process.on("message", (message: unknown) => {
+      if (
+        message
+        && typeof message === "object"
+        && (message as { type?: unknown }).type === "paperclip:graceful-shutdown"
+      ) {
+        process.emit("SIGTERM");
+      }
+    });
+  }
 
   if (shouldGenerateBootstrapInviteAfterStart(config)) {
     p.log.step("Generating bootstrap CEO invite");

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -47,7 +47,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     && !opts.supervisedChild
     && process.env.PAPERCLIP_SERVICE_MANAGED !== "1"
   ) {
-    await runWithWindowsSupervisor(instanceId);
+    await runWithWindowsSupervisor(instanceId, opts);
     return;
   }
   await assertForegroundRunAllowed(instanceId, opts.force);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import type { Server as HttpServer } from "node:http";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
@@ -20,7 +21,11 @@ import { assertForegroundRunAllowed } from "../services/service-manager.js";
 import { removeRuntimeInfoForPid, writeRuntimeInfo } from "../runtime-info.js";
 import { printUpdateNotice } from "../update-notice.js";
 import { ensureWorktreeSeeded } from "./worktree.js";
-import { runWithWindowsSupervisor } from "./windows-run-supervisor.js";
+import {
+  runWithWindowsSupervisor,
+  WINDOWS_RUN_ACCEPTANCE_CLOSE_LISTENER,
+  WINDOWS_RUN_ACCEPTANCE_HARNESS_ENV,
+} from "./windows-run-supervisor.js";
 
 interface RunOptions {
   config?: string;
@@ -33,6 +38,7 @@ interface RunOptions {
 }
 
 interface StartedServer {
+  server: HttpServer;
   apiUrl: string;
   databaseUrl: string;
   host: string;
@@ -124,6 +130,32 @@ export async function runCommand(opts: RunOptions): Promise<void> {
         && (message as { type?: unknown }).type === "paperclip:graceful-shutdown"
       ) {
         process.emit("SIGTERM");
+        return;
+      }
+      if (
+        process.env[WINDOWS_RUN_ACCEPTANCE_HARNESS_ENV] === "1"
+        && message
+        && typeof message === "object"
+        && (message as { type?: unknown }).type === WINDOWS_RUN_ACCEPTANCE_CLOSE_LISTENER
+      ) {
+        try {
+          // Failure injection is reachable only from the explicitly enabled
+          // Windows acceptance harness over the inherited private IPC channel.
+          // close() removes the listener while this Node child and embedded
+          // PostgreSQL stay alive, reproducing the field failure deterministically.
+          startedServer.server.close();
+          startedServer.server.closeAllConnections();
+          process.send?.({
+            type: "paperclip:acceptance:listener-closed",
+            pid: process.pid,
+            at: new Date().toISOString(),
+          });
+        } catch (error) {
+          process.send?.({
+            type: "paperclip:acceptance:error",
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
     });
   }

--- a/cli/src/commands/windows-run-supervisor.ts
+++ b/cli/src/commands/windows-run-supervisor.ts
@@ -1,0 +1,324 @@
+import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { resolvePaperclipInstanceRoot } from "../config/home.js";
+import {
+  readRuntimeInfo,
+  removeRuntimeInfoForPid,
+  type PaperclipRuntimeInfo,
+} from "../runtime-info.js";
+import { buildLocalHealthUrl } from "../utils/health-url.js";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_FAILURE_THRESHOLD = 3;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const DEFAULT_CHILD_STOP_TIMEOUT_MS = 30_000;
+const DEFAULT_STARTUP_GRACE_MS = 60_000;
+
+export type WindowsRunHealth = {
+  listenerOk: boolean;
+  databaseBackupOk: boolean;
+  databaseBackupStatus: string | null;
+};
+
+type SupervisedChild = {
+  pid?: number;
+  exitCode?: number | null;
+  signalCode?: NodeJS.Signals | number | null;
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+  once: (event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void) => unknown;
+  send?: ChildProcess["send"];
+};
+
+type WindowsRunSupervisorOptions = {
+  instanceId: string;
+  startChild: () => SupervisedChild;
+  probeHealth: (childPid: number) => Promise<WindowsRunHealth>;
+  stopChild: (child: SupervisedChild) => Promise<void>;
+  log: (message: string) => void;
+  failureThreshold?: number;
+  startupGraceMs?: number;
+  now?: () => number;
+};
+
+/**
+ * Supervises the child that owns a Windows foreground `paperclipai run`.
+ *
+ * Windows has no supported service manager in the CLI today. Keeping the
+ * server in a child lets the foreground command retain a single owner while
+ * replacing a node process whose HTTP listener disappeared without exiting.
+ */
+export class WindowsRunSupervisor {
+  private child: SupervisedChild | null = null;
+  private failures = 0;
+  private stopping = false;
+  private restarting: Promise<void> | null = null;
+  private restartFromPid: number | null = null;
+  private readonly failureThreshold: number;
+  private readonly startupGraceMs: number;
+  private readonly now: () => number;
+  private childStartedAt = 0;
+  private childHasBeenHealthy = false;
+  private backupWarningLogged = false;
+  private tickInFlight: Promise<void> | null = null;
+
+  constructor(private readonly options: WindowsRunSupervisorOptions) {
+    this.failureThreshold = options.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+    this.startupGraceMs = options.startupGraceMs ?? DEFAULT_STARTUP_GRACE_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  get childPid(): number | null {
+    return this.child?.pid ?? null;
+  }
+
+  start(): void {
+    if (this.child) return;
+    const child = this.options.startChild();
+    if (!child.pid) throw new Error("Paperclip Windows supervisor failed to start a server child.");
+    this.child = child;
+    this.failures = 0;
+    this.childStartedAt = this.now();
+    this.childHasBeenHealthy = false;
+    const childPid = child.pid;
+    child.once("exit", () => {
+      if (this.stopping || this.restarting) return;
+      void this.restart(`server_child_exit`, childPid);
+    });
+    this.options.log(`[paperclipai run] Windows supervisor started server child pid=${childPid}.`);
+  }
+
+  async tick(): Promise<void> {
+    if (this.tickInFlight) return this.tickInFlight;
+    this.tickInFlight = this.tickOnce().finally(() => { this.tickInFlight = null; });
+    return this.tickInFlight;
+  }
+
+  private async tickOnce(): Promise<void> {
+    const child = this.child;
+    if (!child?.pid || this.stopping || this.restarting) return;
+
+    const health = await this.options.probeHealth(child.pid);
+    if (this.child !== child || this.stopping || this.restarting) return;
+    if (health.listenerOk) {
+      this.childHasBeenHealthy = true;
+      this.failures = 0;
+      if (this.restartFromPid !== null) {
+        if (health.databaseBackupOk) {
+          if (this.restartFromPid === child.pid) {
+            this.options.log(
+              `[paperclipai run] Windows supervisor observed listener recovery without replacement: pid=${child.pid} health=ok databaseBackup=${health.databaseBackupStatus ?? "disabled"}.`,
+            );
+          } else {
+            this.options.log(
+              `[paperclipai run] Windows supervisor restored listener: oldPid=${this.restartFromPid} newPid=${child.pid} health=ok databaseBackup=${health.databaseBackupStatus ?? "disabled"}.`,
+            );
+          }
+          this.restartFromPid = null;
+          this.backupWarningLogged = false;
+        } else if (!this.backupWarningLogged) {
+          this.options.log(
+            `[paperclipai run] Windows supervisor restored listener but database backup is not healthy: oldPid=${this.restartFromPid} newPid=${child.pid} databaseBackup=${health.databaseBackupStatus ?? "unknown"}.`,
+          );
+          this.backupWarningLogged = true;
+        }
+      }
+      return;
+    }
+
+    if (!this.childHasBeenHealthy && this.now() - this.childStartedAt < this.startupGraceMs) return;
+    this.failures += 1;
+    if (this.failures >= this.failureThreshold) {
+      await this.restart("listener_loss", child.pid);
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    const child = this.child;
+    this.child = null;
+    if (child) await this.options.stopChild(child);
+  }
+
+  private async restart(reason: "listener_loss" | "server_child_exit", oldPid: number): Promise<void> {
+    if (this.restarting || this.stopping) return this.restarting ?? undefined;
+    this.restarting = (async () => {
+      this.options.log(`[paperclipai run] Windows supervisor restarting instance=${this.options.instanceId} reason=${reason} oldPid=${oldPid}.`);
+      const previousChild = this.child;
+      this.child = null;
+      this.failures = 0;
+      this.restartFromPid = oldPid;
+      this.backupWarningLogged = false;
+      if (previousChild && reason === "listener_loss") {
+        try {
+          await this.options.stopChild(previousChild);
+        } catch (error) {
+          // Do not launch a second child while the previous process may still
+          // own the port. Keep it as the sole owner and retry this restart on
+          // the next failed probe instead of leaving the supervisor empty.
+          this.child = previousChild;
+          this.options.log(
+            `[paperclipai run] Windows supervisor could not stop oldPid=${oldPid}; will retry listener recovery without starting another server: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return;
+        }
+      }
+      removeRuntimeInfoForPid(oldPid, this.options.instanceId);
+      this.start();
+    })().finally(() => {
+      this.restarting = null;
+    });
+    return this.restarting;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function supervisorLockPath(instanceId: string): string {
+  return path.join(resolvePaperclipInstanceRoot(instanceId), "windows-run-supervisor.lock");
+}
+
+/** Acquire a per-instance, crash-safe lock for the foreground Windows supervisor. */
+export function acquireWindowsRunSupervisorLock(instanceId: string): () => void {
+  const lockPath = supervisorLockPath(instanceId);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true, mode: 0o700 });
+  const token = `${process.pid}:${randomUUID()}`;
+
+  for (;;) {
+    try {
+      fs.writeFileSync(lockPath, `${token}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      return () => {
+        try {
+          if (fs.readFileSync(lockPath, "utf8").trim() === token) fs.rmSync(lockPath, { force: true });
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+
+    let existing: string;
+    try {
+      existing = fs.readFileSync(lockPath, "utf8").trim();
+    } catch (readError) {
+      if ((readError as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw readError;
+    }
+    const ownerPid = Number.parseInt(existing.split(":", 1)[0] ?? "", 10);
+    if (Number.isInteger(ownerPid) && ownerPid > 0 && isProcessAlive(ownerPid)) {
+      throw new Error(`Paperclip instance '${instanceId}' is already supervised by foreground process ${ownerPid}.`);
+    }
+    try {
+      if (fs.readFileSync(lockPath, "utf8").trim() === existing) fs.rmSync(lockPath, { force: true });
+    } catch (readError) {
+      if ((readError as NodeJS.ErrnoException).code !== "ENOENT") throw readError;
+    }
+  }
+}
+
+function runtimeHealthUrl(runtime: PaperclipRuntimeInfo): string {
+  return buildLocalHealthUrl(runtime.host, runtime.port);
+}
+
+export async function probeRuntimeHealth(instanceId: string, expectedPid: number): Promise<WindowsRunHealth> {
+  const runtime = readRuntimeInfo(instanceId);
+  if (!runtime || runtime.pid !== expectedPid) return { listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null };
+  try {
+    const response = await fetch(runtimeHealthUrl(runtime), { signal: AbortSignal.timeout(DEFAULT_PROBE_TIMEOUT_MS) });
+    const body = await response.json() as { status?: unknown; databaseBackup?: { enabled?: unknown; status?: unknown } };
+    const databaseBackupStatus = typeof body.databaseBackup?.status === "string" ? body.databaseBackup.status : null;
+    const databaseBackupOk = body.databaseBackup?.enabled !== true || databaseBackupStatus === "ok";
+    return {
+      listenerOk: response.ok && body.status === "ok",
+      databaseBackupOk,
+      databaseBackupStatus,
+    };
+  } catch {
+    return { listenerOk: false, databaseBackupOk: false, databaseBackupStatus: null };
+  }
+}
+
+async function waitForChildExit(child: SupervisedChild, timeoutMs = DEFAULT_CHILD_STOP_TIMEOUT_MS): Promise<boolean> {
+  if (!child.pid) return true;
+  if (child.exitCode !== null && child.exitCode !== undefined) return true;
+  if (child.signalCode !== null && child.signalCode !== undefined) return true;
+  return await new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => resolve(false), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
+
+export async function stopWindowsServerChild(child: SupervisedChild): Promise<void> {
+  if (!child.pid) return;
+  const gracefulExit = waitForChildExit(child);
+  try {
+    if (child.send) child.send({ type: "paperclip:graceful-shutdown" });
+    else child.kill("SIGTERM");
+  } catch {
+    // The child may have exited between the health failure and the restart.
+  }
+  if (await gracefulExit) return;
+  await execFileAsync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"]).catch(() => undefined);
+  if (!(await waitForChildExit(child, 5_000))) {
+    throw new Error(`Timed out stopping Paperclip server child ${child.pid}.`);
+  }
+}
+
+function supervisedChildArgs(): string[] {
+  const args = process.argv.slice(1);
+  if (args.includes("--supervised-child")) return args;
+  return [...args, "--supervised-child"];
+}
+
+/**
+ * Runs the Windows-only parent watchdog until the operator terminates it.
+ * The child receives the original CLI argv plus a hidden recursion guard.
+ */
+export async function runWithWindowsSupervisor(instanceId: string): Promise<void> {
+  const releaseLock = acquireWindowsRunSupervisorLock(instanceId);
+  const supervisor = new WindowsRunSupervisor({
+    instanceId,
+    startChild: () => spawn(process.execPath, supervisedChildArgs(), {
+      cwd: process.cwd(),
+      env: { ...process.env, PAPERCLIP_WINDOWS_RUN_SUPERVISED_CHILD: "1" },
+      stdio: ["inherit", "inherit", "inherit", "ipc"],
+    }),
+    probeHealth: (pid) => probeRuntimeHealth(instanceId, pid),
+    stopChild: stopWindowsServerChild,
+    log: (message) => console.error(message),
+  });
+
+  let interval: NodeJS.Timeout | null = null;
+  const shutdown = async () => {
+    if (interval) clearInterval(interval);
+    try {
+      await supervisor.stop();
+    } finally {
+      releaseLock();
+    }
+  };
+  const onSignal = () => { void shutdown().finally(() => process.exit(0)); };
+
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  try {
+    supervisor.start();
+    interval = setInterval(() => { void supervisor.tick(); }, 2_000);
+  } catch (error) {
+    await shutdown();
+    throw error;
+  }
+}

--- a/cli/src/commands/windows-run-supervisor.ts
+++ b/cli/src/commands/windows-run-supervisor.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -29,7 +29,7 @@ type SupervisedChild = {
   signalCode?: NodeJS.Signals | number | null;
   kill: (signal?: NodeJS.Signals | number) => boolean;
   once: (event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void) => unknown;
-  send?: ChildProcess["send"];
+  send?: (message: { type: string }) => unknown;
 };
 
 type WindowsRunSupervisorOptions = {
@@ -41,6 +41,15 @@ type WindowsRunSupervisorOptions = {
   failureThreshold?: number;
   startupGraceMs?: number;
   now?: () => number;
+};
+
+/** The run options that must be preserved when a parent starts its child. */
+export type SupervisedRunOptions = {
+  config?: string;
+  instance?: string;
+  repair?: boolean;
+  bind?: "loopback" | "lan" | "tailnet";
+  force?: boolean;
 };
 
 /**
@@ -137,6 +146,10 @@ export class WindowsRunSupervisor {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    // A listener-loss restart can be paused while it waits for the old child
+    // to exit. Do not release the owning parent until that transaction has
+    // observed `stopping`; otherwise it can launch an orphan after shutdown.
+    if (this.restarting) await this.restarting;
     const child = this.child;
     this.child = null;
     if (child) await this.options.stopChild(child);
@@ -165,6 +178,7 @@ export class WindowsRunSupervisor {
           return;
         }
       }
+      if (this.stopping) return;
       removeRuntimeInfoForPid(oldPid, this.options.instanceId);
       this.start();
     })().finally(() => {
@@ -277,21 +291,34 @@ export async function stopWindowsServerChild(child: SupervisedChild): Promise<vo
   }
 }
 
-function supervisedChildArgs(): string[] {
-  const args = process.argv.slice(1);
-  if (args.includes("--supervised-child")) return args;
-  return [...args, "--supervised-child"];
+/**
+ * Constructs a `run` invocation instead of copying the parent's argv. This
+ * matters when onboarding invokes runCommand() programmatically: its argv is
+ * still `onboard`, which must never be restarted by the watchdog.
+ */
+export function supervisedRunChildArgs(options: SupervisedRunOptions): string[] {
+  const entrypoint = process.argv[1];
+  if (!entrypoint) throw new Error("Paperclip Windows supervisor could not locate the CLI entrypoint.");
+  const args = [entrypoint, "run"];
+  if (options.config) args.push("--config", options.config);
+  if (options.instance) args.push("--instance", options.instance);
+  if (options.bind) args.push("--bind", options.bind);
+  if (options.repair === false) args.push("--no-repair");
+  if (options.force) args.push("--force");
+  args.push("--supervised-child");
+  return args;
 }
 
 /**
  * Runs the Windows-only parent watchdog until the operator terminates it.
- * The child receives the original CLI argv plus a hidden recursion guard.
+ * The child always receives an explicit `run` invocation plus a hidden
+ * recursion guard, including when onboarding called runCommand directly.
  */
-export async function runWithWindowsSupervisor(instanceId: string): Promise<void> {
+export async function runWithWindowsSupervisor(instanceId: string, options: SupervisedRunOptions): Promise<void> {
   const releaseLock = acquireWindowsRunSupervisorLock(instanceId);
   const supervisor = new WindowsRunSupervisor({
     instanceId,
-    startChild: () => spawn(process.execPath, supervisedChildArgs(), {
+    startChild: () => spawn(process.execPath, supervisedRunChildArgs(options), {
       cwd: process.cwd(),
       env: { ...process.env, PAPERCLIP_WINDOWS_RUN_SUPERVISED_CHILD: "1" },
       stdio: ["inherit", "inherit", "inherit", "ipc"],

--- a/cli/src/commands/windows-run-supervisor.ts
+++ b/cli/src/commands/windows-run-supervisor.ts
@@ -32,6 +32,10 @@ type SupervisedChild = {
   send?: (message: { type: string }) => unknown;
 };
 
+export const WINDOWS_RUN_ACCEPTANCE_HARNESS_ENV = "PAPERCLIP_WINDOWS_RUN_ACCEPTANCE_HARNESS";
+export const WINDOWS_RUN_ACCEPTANCE_CLOSE_LISTENER = "paperclip:acceptance:close-listener";
+export const WINDOWS_RUN_ACCEPTANCE_SHUTDOWN = "paperclip:acceptance:shutdown";
+
 type WindowsRunSupervisorOptions = {
   instanceId: string;
   startChild: () => SupervisedChild;
@@ -151,8 +155,17 @@ export class WindowsRunSupervisor {
     // observed `stopping`; otherwise it can launch an orphan after shutdown.
     if (this.restarting) await this.restarting;
     const child = this.child;
-    this.child = null;
-    if (child) await this.options.stopChild(child);
+    if (!child) return;
+    // Keep the child reference until termination is proven. If stopping the
+    // process tree fails, the foreground owner must retain both the child and
+    // its instance lock so a later invocation cannot start a competing server.
+    await this.options.stopChild(child);
+    if (this.child === child) this.child = null;
+  }
+
+  sendToChild(message: { type: string }): boolean {
+    if (!this.child?.send) return false;
+    return this.child.send(message) !== false;
   }
 
   private async restart(reason: "listener_loss" | "server_child_exit", oldPid: number): Promise<void> {
@@ -275,6 +288,61 @@ async function waitForChildExit(child: SupervisedChild, timeoutMs = DEFAULT_CHIL
   });
 }
 
+async function listWindowsOwnedProcessPids(rootPid: number, instanceRoot: string): Promise<number[]> {
+  const command = [
+    "$ErrorActionPreference = 'Stop'",
+    "$rows = Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine",
+    "$rows | ConvertTo-Json -Compress",
+  ].join("; ");
+  const { stdout } = await execFileAsync("powershell.exe", [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    command,
+  ], { windowsHide: true, timeout: 30_000 });
+  const parsed = JSON.parse(stdout.replace(/^\uFEFF/, "").trim() || "[]") as
+    | { ProcessId: number; ParentProcessId: number; Name?: string; CommandLine?: string }
+    | Array<{ ProcessId: number; ParentProcessId: number; Name?: string; CommandLine?: string }>;
+  const rows = Array.isArray(parsed) ? parsed : [parsed];
+  const descendants: number[] = [];
+  const parents = [rootPid];
+  for (let index = 0; index < parents.length; index += 1) {
+    const parentPid = parents[index];
+    for (const row of rows) {
+      const pid = Number(row.ProcessId);
+      if (Number(row.ParentProcessId) !== parentPid || !Number.isInteger(pid) || pid <= 0) continue;
+      if (descendants.includes(pid)) continue;
+      descendants.push(pid);
+      parents.push(pid);
+    }
+  }
+  const instanceNeedle = instanceRoot.toLowerCase();
+  for (const row of rows) {
+    const pid = Number(row.ProcessId);
+    if (
+      String(row.Name ?? "").toLowerCase() === "postgres.exe"
+      && String(row.CommandLine ?? "").toLowerCase().includes(instanceNeedle)
+      && Number.isInteger(pid)
+      && pid > 0
+      && !descendants.includes(pid)
+    ) {
+      descendants.push(pid);
+    }
+  }
+  return descendants;
+}
+
+async function waitForPidsExit(pids: readonly number[], timeoutMs: number): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let survivors = pids.filter(isProcessAlive);
+  while (survivors.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    survivors = survivors.filter(isProcessAlive);
+  }
+  return survivors;
+}
+
 export async function stopWindowsServerChild(child: SupervisedChild): Promise<void> {
   if (!child.pid) return;
   const gracefulExit = waitForChildExit(child);
@@ -288,6 +356,23 @@ export async function stopWindowsServerChild(child: SupervisedChild): Promise<vo
   await execFileAsync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"]).catch(() => undefined);
   if (!(await waitForChildExit(child, 5_000))) {
     throw new Error(`Timed out stopping Paperclip server child ${child.pid}.`);
+  }
+}
+
+/** Stop the server and prove that every process it owned has exited. */
+export async function stopWindowsServerTree(child: SupervisedChild, instanceId: string): Promise<void> {
+  const descendants = child.pid
+    ? await listWindowsOwnedProcessPids(child.pid, resolvePaperclipInstanceRoot(instanceId))
+    : [];
+  await stopWindowsServerChild(child);
+
+  let survivors = await waitForPidsExit(descendants, 10_000);
+  for (const pid of survivors) {
+    await execFileAsync("taskkill.exe", ["/pid", String(pid), "/t", "/f"]).catch(() => undefined);
+  }
+  survivors = await waitForPidsExit(survivors, 5_000);
+  if (survivors.length > 0) {
+    throw new Error(`Timed out stopping Paperclip server descendants: ${survivors.join(", ")}.`);
   }
 }
 
@@ -313,7 +398,17 @@ export function supervisedRunChildArgs(options: SupervisedRunOptions): string[] 
 export function createIdempotentShutdown(action: () => Promise<void>): () => Promise<void> {
   let shutdownPromise: Promise<void> | null = null;
   return () => {
-    if (!shutdownPromise) shutdownPromise = action();
+    if (!shutdownPromise) {
+      let attempt: Promise<void>;
+      attempt = action().catch((error) => {
+        // A failed stop retains ownership and may be retried by a later signal.
+        // Clear only the cached transaction; concurrent signals still share the
+        // same attempt and can never release the lock independently.
+        if (shutdownPromise === attempt) shutdownPromise = null;
+        throw error;
+      });
+      shutdownPromise = attempt;
+    }
     return shutdownPromise;
   };
 }
@@ -325,34 +420,72 @@ export function createIdempotentShutdown(action: () => Promise<void>): () => Pro
  */
 export async function runWithWindowsSupervisor(instanceId: string, options: SupervisedRunOptions): Promise<void> {
   const releaseLock = acquireWindowsRunSupervisorLock(instanceId);
+  const acceptanceHarnessEnabled = process.env[WINDOWS_RUN_ACCEPTANCE_HARNESS_ENV] === "1";
   const supervisor = new WindowsRunSupervisor({
     instanceId,
-    startChild: () => spawn(process.execPath, supervisedRunChildArgs(options), {
-      cwd: process.cwd(),
-      env: { ...process.env, PAPERCLIP_WINDOWS_RUN_SUPERVISED_CHILD: "1" },
-      stdio: ["inherit", "inherit", "inherit", "ipc"],
-    }),
+    startChild: () => {
+      // The native acceptance harness executes the TypeScript CLI through
+      // Node's loader. Preserve those Node arguments for its real supervised
+      // child without changing packaged production invocations.
+      const nodeArgs = acceptanceHarnessEnabled
+        ? [...process.execArgv, ...supervisedRunChildArgs(options)]
+        : supervisedRunChildArgs(options);
+      const child = spawn(process.execPath, nodeArgs, {
+        cwd: process.cwd(),
+        env: { ...process.env, PAPERCLIP_WINDOWS_RUN_SUPERVISED_CHILD: "1" },
+        stdio: ["inherit", "inherit", "inherit", "ipc"],
+      });
+      if (acceptanceHarnessEnabled && process.send) {
+        child.on("message", (message) => process.send?.(message));
+        child.on("exit", (code, signal) => {
+          process.send?.({ type: "paperclip:acceptance:child-exit", code, signal });
+        });
+      }
+      return child;
+    },
     probeHealth: (pid) => probeRuntimeHealth(instanceId, pid),
-    stopChild: stopWindowsServerChild,
+    stopChild: (child) => stopWindowsServerTree(child, instanceId),
     log: (message) => console.error(message),
+    // First-run migrations in a source checkout can exceed the production
+    // startup grace. The acceptance harness must observe that same child
+    // becoming healthy before it injects listener loss.
+    startupGraceMs: acceptanceHarnessEnabled ? 240_000 : undefined,
   });
 
   let interval: NodeJS.Timeout | null = null;
   const shutdown = createIdempotentShutdown(async () => {
     if (interval) clearInterval(interval);
-    try {
-      await supervisor.stop();
-    } finally {
-      releaseLock();
-    }
+    await supervisor.stop();
+    releaseLock();
   });
-  const onSignal = () => { void shutdown().finally(() => process.exit(0)); };
+  const onSignal = () => {
+    void shutdown().then(
+      () => process.exit(0),
+      (error) => {
+        console.error(
+          `[paperclipai run] Windows supervisor shutdown failed; retaining instance ownership: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    );
+  };
+  const onParentMessage = (message: unknown) => {
+    if (!acceptanceHarnessEnabled || !message || typeof message !== "object") return;
+    const type = (message as { type?: unknown }).type;
+    if (type === WINDOWS_RUN_ACCEPTANCE_CLOSE_LISTENER) {
+      if (!supervisor.sendToChild({ type: WINDOWS_RUN_ACCEPTANCE_CLOSE_LISTENER })) {
+        process.send?.({ type: "paperclip:acceptance:error", message: "server child has no IPC channel" });
+      }
+      return;
+    }
+    if (type === WINDOWS_RUN_ACCEPTANCE_SHUTDOWN) onSignal();
+  };
 
   // Keep both handlers installed until the one idempotent shutdown transaction
   // completes. A repeated signal must not restore Node's default termination
   // behavior while the supervised child may still own the instance port.
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
+  if (acceptanceHarnessEnabled) process.on("message", onParentMessage);
   try {
     supervisor.start();
     interval = setInterval(() => { void supervisor.tick(); }, 2_000);

--- a/cli/src/commands/windows-run-supervisor.ts
+++ b/cli/src/commands/windows-run-supervisor.ts
@@ -309,6 +309,15 @@ export function supervisedRunChildArgs(options: SupervisedRunOptions): string[] 
   return args;
 }
 
+/** Coalesce repeated operator signals into one ownership-preserving shutdown. */
+export function createIdempotentShutdown(action: () => Promise<void>): () => Promise<void> {
+  let shutdownPromise: Promise<void> | null = null;
+  return () => {
+    if (!shutdownPromise) shutdownPromise = action();
+    return shutdownPromise;
+  };
+}
+
 /**
  * Runs the Windows-only parent watchdog until the operator terminates it.
  * The child always receives an explicit `run` invocation plus a hidden
@@ -329,18 +338,21 @@ export async function runWithWindowsSupervisor(instanceId: string, options: Supe
   });
 
   let interval: NodeJS.Timeout | null = null;
-  const shutdown = async () => {
+  const shutdown = createIdempotentShutdown(async () => {
     if (interval) clearInterval(interval);
     try {
       await supervisor.stop();
     } finally {
       releaseLock();
     }
-  };
+  });
   const onSignal = () => { void shutdown().finally(() => process.exit(0)); };
 
-  process.once("SIGINT", onSignal);
-  process.once("SIGTERM", onSignal);
+  // Keep both handlers installed until the one idempotent shutdown transaction
+  // completes. A repeated signal must not restore Node's default termination
+  // behavior while the supervised child may still own the instance port.
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
   try {
     supervisor.start();
     interval = setInterval(() => { void supervisor.tick(); }, 2_000);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { warnIfUnsupportedNodeVersion } from "@paperclipai/shared/node-version";
 import { onboard } from "./commands/onboard.js";
 import { doctor } from "./commands/doctor.js";
@@ -179,6 +179,7 @@ const run = program
   .option("--repair", "Attempt automatic repairs during doctor", true)
   .option("--no-repair", "Disable automatic repairs during doctor")
   .option("--force", "Run even when the same instance is active under the service manager")
+  .addOption(new Option("--supervised-child").hideHelp())
   .action(runCommand);
 
 registerRunCommands(run);

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -202,8 +202,12 @@ paperclipai service logs [-f]
 ```
 
 Every service verb supports `--instance <id>` and `--json`. Linux and WSL2 use
-a systemd user unit when available; macOS uses a LaunchAgent. Unsupported
-environments receive foreground `paperclipai run` guidance.
+a systemd user unit when available; macOS uses a LaunchAgent. Windows does not
+yet install an OS service, but foreground `paperclipai run` is supervised: it
+holds one instance lock, starts the server in a child process, and replaces that
+child after three failed listener-health probes. This detects a lost HTTP listener even
+when the old Node process remains alive. Other unsupported environments receive
+foreground `paperclipai run` guidance.
 
 `paperclipai doctor` includes managed-install and service-health diagnostics in
 addition to configuration, storage, database, logging, and port checks.

--- a/doc/INSTALLING.md
+++ b/doc/INSTALLING.md
@@ -156,9 +156,11 @@ paperclipai service uninstall
 ```
 
 Paperclip uses a systemd user service on Linux and WSL2 systems with user
-systemd, and a LaunchAgent on macOS. Containers, WSL1, and systems without a
-supported user service manager receive foreground `paperclipai run` guidance
-instead of a hard failure.
+systemd, and a LaunchAgent on macOS. Windows does not yet install an OS service;
+its foreground `paperclipai run` command uses a per-instance watchdog that
+owns one server child and restarts it after a lost listener-health check. Containers,
+WSL1, and other systems without a supported user service manager receive
+foreground `paperclipai run` guidance instead of a hard failure.
 
 The service uses the stable managed-install shim, restarts after crashes, and
 can start on login. On Linux, service installation may offer to enable user

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "smoke:openclaw-docker-ui": "./scripts/smoke/openclaw-docker-ui.sh",
     "smoke:openclaw-sse-standalone": "./scripts/smoke/openclaw-sse-standalone.sh",
     "smoke:mcp-fixtures": "node scripts/smoke/mcp-fixture-harness.mjs",
+    "smoke:windows-run-listener-recovery": "node scripts/smoke/windows-run-listener-recovery.mjs",
     "smoke:pipelines-tutorial": "./scripts/smoke/pipelines-tutorial-smoke.sh",
     "smoke:terminal-bench-loop-skill": "node scripts/smoke/terminal-bench-loop-skill-smoke.mjs",
     "test:release-registry": "node --test scripts/verify-release-registry-state.test.mjs scripts/release-package-map.test.mjs scripts/check-release-package-bootstrap.test.mjs scripts/check-no-git-push.test.mjs scripts/release-lib.test.mjs scripts/release-registry-versions.test.mjs scripts/link-plugin-dev-sdk.test.js scripts/acpx-patch-packaging.test.mjs scripts/service-onboard-smoke.test.mjs",

--- a/scripts/smoke/windows-run-listener-recovery.mjs
+++ b/scripts/smoke/windows-run-listener-recovery.mjs
@@ -1,0 +1,506 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+
+const ACCEPTANCE_CLOSE_LISTENER = "paperclip:acceptance:close-listener";
+const ACCEPTANCE_LISTENER_CLOSED = "paperclip:acceptance:listener-closed";
+const ACCEPTANCE_SHUTDOWN = "paperclip:acceptance:shutdown";
+const ACCEPTANCE_ERROR = "paperclip:acceptance:error";
+const ACCEPTANCE_CHILD_EXIT = "paperclip:acceptance:child-exit";
+const WORKING_LISTENER_PORT = 3100;
+const STARTUP_TIMEOUT_MS = 240_000;
+const RECOVERY_TIMEOUT_MS = 120_000;
+
+class FatalSmokeError extends Error {}
+
+function assertWindowsNodeVersion() {
+  assert.equal(process.platform, "win32", "This smoke harness must run on native Windows.");
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  assert.ok(major > 24 || (major === 24 && minor >= 11), `Node 24.11+ is required; found ${process.version}.`);
+}
+
+function assertUnderWindowsTemp(candidate) {
+  const resolved = path.resolve(candidate);
+  const requiredRoot = path.resolve("C:\\temp");
+  assert.ok(
+    resolved.toLowerCase() === requiredRoot.toLowerCase()
+      || resolved.toLowerCase().startsWith(`${requiredRoot.toLowerCase()}${path.sep}`),
+    `Smoke paths must stay under ${requiredRoot}; received ${resolved}.`,
+  );
+  return resolved;
+}
+
+async function allocatePort(excluded = new Set()) {
+  for (;;) {
+    const server = net.createServer();
+    const port = await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+    });
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    if (!excluded.has(port)) return port;
+  }
+}
+
+async function waitFor(description, check, timeoutMs, intervalMs = 200) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const value = await check();
+      if (value) return value;
+    } catch (error) {
+      if (error instanceof FatalSmokeError) throw error;
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${description}.${lastError ? ` Last error: ${lastError.message}` : ""}`);
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function windowsProcessSnapshot() {
+  const command = [
+    "$ErrorActionPreference = 'Stop'",
+    "$rows = Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine",
+    "$rows | ConvertTo-Json -Compress",
+  ].join("; ");
+  const output = execFileSync("powershell.exe", [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    command,
+  ], { encoding: "utf8", timeout: 30_000, windowsHide: true }).replace(/^\uFEFF/, "").trim();
+  if (!output) return [];
+  const parsed = JSON.parse(output);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function listeningPids(port) {
+  const output = execFileSync("netstat.exe", ["-ano", "-p", "tcp"], {
+    encoding: "utf8",
+    timeout: 15_000,
+    windowsHide: true,
+  });
+  const pids = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^\s*TCP\s+(\S+)\s+\S+\s+LISTENING\s+(\d+)\s*$/i);
+    if (!match) continue;
+    const localAddress = match[1];
+    if (localAddress.endsWith(`:${port}`)) pids.push(Number(match[2]));
+  }
+  return [...new Set(pids)];
+}
+
+function directServerChildren(snapshot, supervisorPid) {
+  return snapshot.filter((row) =>
+    Number(row.ParentProcessId) === supervisorPid
+    && String(row.Name ?? "").toLowerCase() === "node.exe"
+    && String(row.CommandLine ?? "").includes("--supervised-child"),
+  );
+}
+
+function instancePostmasters(snapshot, databaseDir) {
+  const needle = databaseDir.toLowerCase();
+  return snapshot.filter((row) =>
+    String(row.Name ?? "").toLowerCase() === "postgres.exe"
+    && String(row.CommandLine ?? "").toLowerCase().includes(needle),
+  );
+}
+
+function writeConfig({ configPath, instanceRoot, appPort, databasePort }) {
+  const config = {
+    $meta: { version: 1, updatedAt: new Date().toISOString(), source: "onboard" },
+    database: {
+      mode: "embedded-postgres",
+      embeddedPostgresDataDir: path.join(instanceRoot, "db"),
+      embeddedPostgresPort: databasePort,
+      backup: {
+        enabled: true,
+        intervalMinutes: 60,
+        retentionDays: 7,
+        dir: path.join(instanceRoot, "data", "backups"),
+      },
+    },
+    logging: { mode: "file", logDir: path.join(instanceRoot, "logs") },
+    server: {
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      bind: "loopback",
+      host: "127.0.0.1",
+      port: appPort,
+      allowedHostnames: [],
+      serveUi: false,
+    },
+    auth: { baseUrlMode: "auto", disableSignUp: false },
+    storage: {
+      provider: "local_disk",
+      localDisk: { baseDir: path.join(instanceRoot, "data", "storage") },
+      s3: { bucket: "paperclip", region: "us-east-1", prefix: "", forcePathStyle: false },
+    },
+    secrets: {
+      provider: "local_encrypted",
+      strictMode: false,
+      localEncrypted: { keyFilePath: path.join(instanceRoot, "secrets", "master.key") },
+    },
+    telemetry: { enabled: false },
+    updates: { checkEnabled: false },
+  };
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+}
+
+function buildIsolatedEnvironment({ taskRoot, homeRoot, instanceId, configPath }) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("PAPERCLIP_")) delete env[key];
+  }
+  for (const key of ["DATABASE_URL", "DATABASE_MIGRATION_URL", "HOST", "PORT"]) delete env[key];
+  const tempDir = path.join(taskRoot, "tmp");
+  fs.mkdirSync(tempDir, { recursive: true });
+  return {
+    ...env,
+    TEMP: tempDir,
+    TMP: tempDir,
+    TMPDIR: tempDir,
+    PAPERCLIP_HOME: homeRoot,
+    PAPERCLIP_INSTANCE_ID: instanceId,
+    PAPERCLIP_CONFIG: configPath,
+    PAPERCLIP_WINDOWS_RUN_ACCEPTANCE_HARNESS: "1",
+    PAPERCLIP_DB_BACKUP_ENABLED: "true",
+    PAPERCLIP_DB_BACKUP_MAX_AGE_HOURS: "24",
+    PAPERCLIP_OPEN_ON_LISTEN: "false",
+    PAPERCLIP_UI_DEV_MIDDLEWARE: "false",
+    SERVE_UI: "false",
+  };
+}
+
+function createApi(baseUrl) {
+  return async function api(method, pathname, body) {
+    const response = await fetch(`${baseUrl}${pathname}`, {
+      method,
+      headers: body === undefined ? undefined : { "content-type": "application/json; charset=utf-8" },
+      body: body === undefined ? undefined : Buffer.from(JSON.stringify(body), "utf8"),
+      signal: AbortSignal.timeout(30_000),
+    });
+    const text = await response.text();
+    let value = null;
+    if (text) {
+      try { value = JSON.parse(text); } catch { value = text; }
+    }
+    if (!response.ok) {
+      throw new Error(`${method} ${pathname} returned ${response.status}: ${text.slice(0, 1000)}`);
+    }
+    return value;
+  };
+}
+
+function tail(value, limit = 16_000) {
+  return value.length <= limit ? value : value.slice(value.length - limit);
+}
+
+async function main() {
+  assertWindowsNodeVersion();
+  const repoRoot = path.resolve(import.meta.dirname, "../..");
+  const cliEntrypoint = path.join(repoRoot, "cli", "src", "index.ts");
+  const tsxLoader = path.join(repoRoot, "cli", "node_modules", "tsx", "dist", "loader.mjs");
+  assert.ok(fs.existsSync(cliEntrypoint), `Missing CLI entrypoint: ${cliEntrypoint}`);
+  assert.ok(fs.existsSync(tsxLoader), "Install workspace dependencies before running the smoke harness.");
+
+  const tempBase = assertUnderWindowsTemp(process.env.PAPERCLIP_WINDOWS_SMOKE_ROOT ?? "C:\\temp");
+  fs.mkdirSync(tempBase, { recursive: true });
+  const taskRoot = fs.mkdtempSync(path.join(tempBase, "paperclip-win-listener-recovery-"));
+  const instanceId = `win-listener-recovery-${process.pid}-${Date.now()}`;
+  const homeRoot = path.join(taskRoot, "home");
+  const instanceRoot = path.join(homeRoot, "instances", instanceId);
+  const configPath = path.join(instanceRoot, "config.json");
+  const runtimeInfoPath = path.join(instanceRoot, "runtime-info.json");
+  const databaseDir = path.join(instanceRoot, "db");
+  const appPort = await allocatePort(new Set([WORKING_LISTENER_PORT]));
+  const databasePort = await allocatePort(new Set([WORKING_LISTENER_PORT, appPort]));
+  assert.notEqual(appPort, WORKING_LISTENER_PORT);
+  writeConfig({ configPath, instanceRoot, appPort, databasePort });
+
+  const childEnv = buildIsolatedEnvironment({ taskRoot, homeRoot, instanceId, configPath });
+  let output = "";
+  const messages = [];
+  let supervisor;
+  let success = false;
+
+  try {
+    supervisor = spawn(process.execPath, [
+      "--import", pathToFileURL(tsxLoader).href,
+      cliEntrypoint,
+      "run",
+      "--config", configPath,
+      "--instance", instanceId,
+      "--force",
+    ], {
+      cwd: repoRoot,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      windowsHide: true,
+    });
+    assert.ok(supervisor.pid, "Failed to start the paperclipai run supervisor.");
+    supervisor.stdout.on("data", (chunk) => { output = tail(output + chunk.toString("utf8"), 2_000_000); });
+    supervisor.stderr.on("data", (chunk) => { output = tail(output + chunk.toString("utf8"), 2_000_000); });
+    supervisor.on("message", (message) => messages.push(message));
+
+    const baseUrl = `http://127.0.0.1:${appPort}`;
+    const api = createApi(baseUrl);
+    const initialHealth = await waitFor("initial Paperclip health", async () => {
+      if (supervisor.exitCode !== null) {
+        throw new FatalSmokeError(`paperclipai run exited before health became ready (exit=${supervisor.exitCode}).\n${tail(output)}`);
+      }
+      const earlyChildExit = messages.find((message) => message?.type === ACCEPTANCE_CHILD_EXIT);
+      if (earlyChildExit) {
+        throw new FatalSmokeError(`supervised child exited before health became ready (${JSON.stringify(earlyChildExit)}).\n${tail(output)}`);
+      }
+      const response = await fetch(`${baseUrl}/api/health`, { signal: AbortSignal.timeout(2_000) });
+      if (!response.ok) return null;
+      const health = await response.json();
+      return health.status === "ok" ? health : null;
+    }, STARTUP_TIMEOUT_MS, 500);
+    assert.equal(initialHealth.status, "ok");
+
+    const initialRuntime = readJson(runtimeInfoPath);
+    const oldServerPid = initialRuntime.pid;
+    assert.ok(isPidAlive(oldServerPid), `Initial server child ${oldServerPid} is not alive.`);
+    const initialSnapshot = windowsProcessSnapshot();
+    const initialServerChildren = directServerChildren(initialSnapshot, supervisor.pid);
+    const oldPostmasters = instancePostmasters(initialSnapshot, databaseDir);
+    assert.equal(initialServerChildren.length, 1, "Expected exactly one initial supervised server child.");
+    assert.equal(initialServerChildren[0].ProcessId, oldServerPid);
+    assert.equal(oldPostmasters.length, 1, "Expected exactly one initial embedded PostgreSQL postmaster.");
+
+    await api("POST", "/api/instance/database-backups", {});
+    const backedUpHealth = await api("GET", "/api/health");
+    assert.equal(backedUpHealth.status, "ok");
+    assert.equal(backedUpHealth.databaseBackup?.status, "ok");
+
+    const company = await api("POST", "/api/companies", { name: `Windows Recovery Smoke ${Date.now()}` });
+    const goal = await api("POST", `/api/companies/${company.id}/goals`, {
+      title: "Verify listener process-loss recovery",
+      level: "company",
+      status: "active",
+    });
+    const terminalAgent = await api("POST", `/api/companies/${company.id}/agents`, {
+      name: "Terminal Recovery Fixture",
+      role: "qa",
+      adapterType: "process",
+      adapterConfig: { command: process.execPath, args: ["-e", "process.exit(0)"], graceSec: 5 },
+    });
+    const activeAgent = await api("POST", `/api/companies/${company.id}/agents`, {
+      name: "Active Recovery Fixture",
+      role: "qa",
+      adapterType: "process",
+      adapterConfig: {
+        command: process.execPath,
+        args: ["-e", "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)"],
+        graceSec: 5,
+      },
+    });
+    const terminalIssue = await api("POST", `/api/companies/${company.id}/issues`, {
+      title: "Terminal run must not replay",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: terminalAgent.id,
+      goalId: goal.id,
+    });
+    const activeIssue = await api("POST", `/api/companies/${company.id}/issues`, {
+      title: "Active run must retry exactly once",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: activeAgent.id,
+      goalId: goal.id,
+    });
+
+    const terminalRun = await api("POST", `/api/agents/${terminalAgent.id}/heartbeat/invoke`, {
+      reason: "windows_listener_recovery_terminal_fixture",
+    });
+    await waitFor("terminal fixture run", async () => {
+      const run = await api("GET", `/api/heartbeat-runs/${terminalRun.id}`);
+      if (["failed", "cancelled", "timed_out", "interrupted"].includes(run.status)) {
+        throw new FatalSmokeError(`Terminal fixture entered ${run.status}: ${JSON.stringify(run)}`);
+      }
+      return run.status === "succeeded" ? run : null;
+    }, 60_000);
+    await api("PATCH", `/api/issues/${terminalIssue.id}`, {
+      status: "done",
+      comment: "Windows recovery terminal fixture completed.",
+    });
+    await waitFor("terminal fixture issue", async () => {
+      const issue = await api("GET", `/api/issues/${terminalIssue.id}`);
+      return issue.status === "done" ? issue : null;
+    }, 30_000);
+    const terminalRunsBefore = await api("GET", `/api/companies/${company.id}/heartbeat-runs?agentId=${terminalAgent.id}&limit=100`);
+
+    const activeRun = await api("POST", `/api/agents/${activeAgent.id}/heartbeat/invoke`, {
+      reason: "windows_listener_recovery_active_fixture",
+    });
+    const runningActive = await waitFor("active fixture process", async () => {
+      const run = await api("GET", `/api/heartbeat-runs/${activeRun.id}`);
+      return run.status === "running" && Number.isInteger(run.processPid) ? run : null;
+    }, 60_000);
+    assert.ok(isPidAlive(runningActive.processPid), `Active fixture process ${runningActive.processPid} is not alive.`);
+
+    const recoveryStartedAt = performance.now();
+    supervisor.send({ type: ACCEPTANCE_CLOSE_LISTENER });
+    const closeAck = await waitFor("listener close acknowledgement", async () => {
+      const failure = messages.find((message) => message?.type === ACCEPTANCE_ERROR);
+      if (failure) throw new Error(failure.message);
+      return messages.find((message) => message?.type === ACCEPTANCE_LISTENER_CLOSED) ?? null;
+    }, 15_000);
+    assert.equal(closeAck.pid, oldServerPid);
+    assert.ok(isPidAlive(oldServerPid), "The old Node child exited before listener loss was observed.");
+    await waitFor("listener loss", async () => listeningPids(appPort).length === 0, 15_000);
+    assert.ok(isPidAlive(oldServerPid), "The old Node child did not remain alive after its listener closed.");
+
+    const recovered = await waitFor("bounded listener recovery", async () => {
+      if (!fs.existsSync(runtimeInfoPath)) return null;
+      const runtime = readJson(runtimeInfoPath);
+      if (runtime.pid === oldServerPid) return null;
+      try {
+        const response = await fetch(`${baseUrl}/api/health`, { signal: AbortSignal.timeout(2_000) });
+        if (!response.ok) return null;
+        const health = await response.json();
+        if (health.status !== "ok" || health.databaseBackup?.status !== "ok") return null;
+        return { runtime, health };
+      } catch {
+        return null;
+      }
+    }, RECOVERY_TIMEOUT_MS, 500);
+    const recoveryMs = Math.round(performance.now() - recoveryStartedAt);
+    const newServerPid = recovered.runtime.pid;
+    assert.notEqual(newServerPid, oldServerPid);
+    await waitFor("old server child exit", async () => !isPidAlive(oldServerPid), 30_000);
+
+    const finalSnapshot = windowsProcessSnapshot();
+    const finalServerChildren = directServerChildren(finalSnapshot, supervisor.pid);
+    const finalPostmasters = instancePostmasters(finalSnapshot, databaseDir);
+    const finalListeners = listeningPids(appPort);
+    assert.equal(finalServerChildren.length, 1, "Expected exactly one final supervised server child.");
+    assert.equal(finalServerChildren[0].ProcessId, newServerPid);
+    assert.deepEqual(finalListeners, [newServerPid], "Expected exactly one final listener owned by the replacement child.");
+    assert.equal(finalPostmasters.length, 1, "Expected exactly one final embedded PostgreSQL postmaster.");
+    for (const oldPostmaster of oldPostmasters) {
+      assert.ok(!isPidAlive(oldPostmaster.ProcessId), `Old postmaster ${oldPostmaster.ProcessId} is orphaned.`);
+    }
+
+    const activeRunsAfter = await waitFor("exactly one process-loss retry", async () => {
+      const runs = await api("GET", `/api/companies/${company.id}/heartbeat-runs?agentId=${activeAgent.id}&limit=100`);
+      const original = runs.find((run) => run.id === activeRun.id);
+      const retries = runs.filter((run) => run.retryOfRunId === activeRun.id);
+      return original?.status === "interrupted" && retries.length === 1 ? { runs, original, retry: retries[0] } : null;
+    }, 60_000);
+    assert.equal(
+      activeRunsAfter.original.errorCode,
+      "server_shutdown_interrupted",
+      `Unexpected original run recovery state: ${JSON.stringify(activeRunsAfter.original)}`,
+    );
+    assert.equal(
+      activeRunsAfter.retry.processLossRetryCount,
+      1,
+      `Unexpected retry accounting: ${JSON.stringify(activeRunsAfter.retry)}`,
+    );
+    assert.ok(
+      ["queued", "running", "failed"].includes(activeRunsAfter.retry.status),
+      `Unexpected retry status: ${JSON.stringify(activeRunsAfter.retry)}`,
+    );
+    if (activeRunsAfter.retry.status === "failed") {
+      assert.equal(activeRunsAfter.retry.errorCode, "process_lost");
+    }
+
+    const terminalRunsAfter = await api("GET", `/api/companies/${company.id}/heartbeat-runs?agentId=${terminalAgent.id}&limit=100`);
+    const terminalIssueAfter = await api("GET", `/api/issues/${terminalIssue.id}`);
+    assert.equal(terminalIssueAfter.status, "done");
+    assert.equal(terminalRunsAfter.length, terminalRunsBefore.length, "Terminal agent unexpectedly ran again.");
+    assert.equal(terminalRunsAfter.filter((run) => run.retryOfRunId === terminalRun.id).length, 0);
+
+    const restoredMarker = `oldPid=${oldServerPid} newPid=${newServerPid} health=ok databaseBackup=ok`;
+    await waitFor("ordered recovery success log", async () => output.includes(restoredMarker), 10_000);
+    const reasonIndex = output.indexOf(`reason=listener_loss oldPid=${oldServerPid}`);
+    const newChildIndex = output.indexOf(`started server child pid=${newServerPid}`);
+    const restoredIndex = output.indexOf(restoredMarker);
+    assert.ok(reasonIndex >= 0, "Recovery log is missing listener_loss reason and old PID.");
+    assert.ok(newChildIndex > reasonIndex, "Replacement child started before the listener-loss restart was logged.");
+    assert.ok(restoredIndex > newChildIndex, "Recovery success was logged before the replacement child started.");
+
+    const lockPath = path.join(instanceRoot, "windows-run-supervisor.lock");
+    assert.equal(fs.readFileSync(lockPath, "utf8").trim().split(":", 1)[0], String(supervisor.pid));
+
+    const summary = {
+      status: "passed",
+      platform: process.platform,
+      node: process.version,
+      instanceId,
+      appPort,
+      workingListener3100Used: false,
+      oldServerPid,
+      newServerPid,
+      oldPostmasterPids: oldPostmasters.map((row) => row.ProcessId),
+      newPostmasterPids: finalPostmasters.map((row) => row.ProcessId),
+      finalListenerPids: finalListeners,
+      finalServerChildCount: finalServerChildren.length,
+      recoveryMs,
+      recoveryBoundMs: RECOVERY_TIMEOUT_MS,
+      health: recovered.health.status,
+      databaseBackup: recovered.health.databaseBackup.status,
+      restartReason: "listener_loss",
+      activeRun: {
+        oldRunId: activeRun.id,
+        oldStatus: activeRunsAfter.original.status,
+        retryRunId: activeRunsAfter.retry.id,
+        retryCount: activeRunsAfter.retry.processLossRetryCount,
+        retryStatus: activeRunsAfter.retry.status,
+        retryErrorCode: activeRunsAfter.retry.errorCode,
+      },
+      terminalRun: {
+        issueId: terminalIssue.id,
+        runId: terminalRun.id,
+        status: terminalIssueAfter.status,
+        replayCount: 0,
+      },
+    };
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    success = true;
+  } finally {
+    if (supervisor && supervisor.exitCode === null) {
+      try { supervisor.send({ type: ACCEPTANCE_SHUTDOWN }); } catch {}
+      await waitFor("acceptance supervisor shutdown", async () => supervisor.exitCode !== null, 45_000).catch(() => null);
+    }
+    if (supervisor?.pid && isPidAlive(supervisor.pid)) {
+      try {
+        execFileSync("taskkill.exe", ["/pid", String(supervisor.pid), "/t", "/f"], {
+          stdio: "ignore",
+          timeout: 30_000,
+          windowsHide: true,
+        });
+      } catch {}
+    }
+    if (!success) process.stderr.write(`\n--- paperclipai run output tail ---\n${tail(output, 4_000)}\n`);
+    fs.rmSync(taskRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The CLI starts the local control plane with `paperclipai run`.
> - Windows has no supported Paperclip service manager.
> - A live Node process can lose its HTTP listener and look alive to an outside process watcher.
> - The foreground CLI must own one server and replace it after listener loss.
> - The replacement must wait until the old Node child and embedded PostgreSQL tree stop.
> - This pull request adds a Windows parent watchdog and a native recovery smoke test.
> - The benefit is bounded local recovery without an external watcher or an orphaned postmaster.

## Linked Issues or Issue Description

**What happened?**

On Windows, `paperclipai service` reports that service management is unsupported. A live `paperclipai run` Node process can also lose its HTTP listener while it stays alive. A replacement can start before the detached embedded PostgreSQL postmaster has stopped.

**Expected behavior**

The foreground command must keep one owner for an instance. It must detect listener loss, stop the old child and its owned process tree, and start one replacement child. The control plane must queue one process-loss retry for active work and must not replay terminal work.

**Steps to reproduce**

1. Start `paperclipai run` on native Windows with embedded PostgreSQL.
2. Close its HTTP listener while its Node process remains alive.
3. Observe the listener recovery and the process tree.

**Paperclip version or commit**

`v2026.824.0` reproduces the issue. This pull request targets current `master`.

**Deployment mode**

Local dev.

**Operating system**

Windows 11.

**Agent adapter(s) involved**

Not adapter-specific. This is a core CLI lifecycle bug.

## What Changed

- Add a per-instance Windows foreground watchdog for `paperclipai run`.
- Run the Paperclip server in one supervised child process.
- Restart only after three failed listener-health probes.
- Use IPC to route shutdown through the existing SIGTERM drain and embedded PostgreSQL cleanup.
- Keep the instance lock when child or process-tree shutdown fails.
- Wait for the old Node descendants and instance-owned PostgreSQL processes before a replacement starts.
- Construct an explicit `run` child invocation for programmatic onboarding.
- Add singleton locking, stale runtime-info protection, restart logs, and backup-health reporting.
- Add an environment-gated listener-loss injection over the private parent-child IPC channel.
- Add a native Windows smoke harness with isolated paths and ports under `C:\temp`.
- Verify active process-loss retry and terminal run no-replay behavior through the real HTTP control plane.
- Add regression tests for listener loss, concurrent probes, retry safety, startup grace, onboarding child arguments, and shutdown ownership.

## Verification

- Node: `v24.11.0` on native Windows 11.
- `pnpm smoke:windows-run-listener-recovery` passed.
- The native smoke used app port `62394`. It did not use port `3100`.
- Listener recovery took `25405 ms` with a `120000 ms` bound.
- The server changed from PID `13968` to PID `19312`.
- The old postmaster PID `11468` exited. One new postmaster PID `4268` remained.
- One server child and one listener remained. Health and database backup both reported `ok`.
- The active run became `interrupted` and received one retry with `processLossRetryCount=1`.
- The terminal issue stayed `done`. Its successful run received no retry and no replay.
- `pnpm --filter paperclipai exec vitest run src/__tests__/windows-run-supervisor.test.ts` passed: 12 tests.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` passed: 109 tests, 2 skipped.
- `pnpm --filter paperclipai typecheck` passed.
- `node --check scripts/smoke/windows-run-listener-recovery.mjs` passed.
- Re-verification on 2026-08-26 at head `593c416d65270966a2e6d218718dfb1907ba26db` (native Windows 11, Node `v24.11.0`): supervisor `12/12`; process recovery `109 passed, 2 skipped`; CLI typecheck and syntax check passed; native smoke passed on isolated port `63547` in `25415 ms` with old/new server PIDs `18544`/`18180`, old/new postmasters `21696`/`21576`, one final listener/server, `health=ok`, `databaseBackup=ok`, exactly one active-run retry, and zero terminal replay.

## Risks

- Windows does not yet have an OS-managed service. The foreground parent must remain running.
- The listener-loss injection is disabled unless the smoke-only environment gate is set. It is reachable only through inherited IPC.
- Process ownership enumeration uses native Windows CIM. An enumeration or stop failure keeps the instance lock and prevents a competing server.
- The harness creates one unique instance and two free ports under `C:\temp`. It removes that instance after the run.

## Model Used

- OpenAI Codex, GPT-5.6 family. Tool use and code execution. Medium reasoning. Context window size was not exposed by the platform.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub for duplicate or related PRs and linked them above (no duplicate public item was found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented risks
- [ ] All Paperclip CI gates are green — upstream approval is still required for the `PR` and `Storybook Visual` workflow runs.
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
