### PR TITLE
Drain native runner events before disconnect

### DIFF
--- a/packages/paperclip-runner/src/control-plane/durable-prp-control-plane.test.ts
+++ b/packages/paperclip-runner/src/control-plane/durable-prp-control-plane.test.ts
@@ -615,4 +615,52 @@ describe.sequential("DurablePrpControlPlane", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("waits for in-flight committed events before disconnecting", async () => {
+    const root = mkdtempSync(resolve(tmpdir(), "paperclip-prp-disconnect-drain-"));
+    let markCommitStarted!: () => void;
+    const commitStarted = new Promise<void>((resolveStarted) => {
+      markCommitStarted = resolveStarted;
+    });
+    let finishCommit = (): void => undefined;
+    const commitBlocked = new Promise<void>((resolveCommit) => {
+      finishCommit = resolveCommit;
+    });
+    const controlPlane = new DurablePrpControlPlane({
+      stateDirectory: root,
+      identity,
+      expectedRunnerVersion,
+      expectedRunnerDigest,
+      onSemanticToolInput: async () => ({ result: { ok: true } }),
+      onCommittedEvent: async () => {
+        markCommitStarted();
+        await commitBlocked;
+      },
+    });
+    try {
+      await controlPlane.start();
+      const client = await authenticate(
+        controlPlane,
+        controlPlane.issueBootstrapTicket(),
+      );
+      sendSecure(client!, semanticInputEvent());
+      await commitStarted;
+
+      let disconnected = false;
+      const disconnecting = Promise.resolve(
+        controlPlane.disconnectActiveRunner(),
+      ).then(() => {
+        disconnected = true;
+      });
+      await new Promise<void>((resolveImmediate) => setImmediate(resolveImmediate));
+      expect(disconnected).toBe(false);
+
+      finishCommit();
+      await disconnecting;
+    } finally {
+      finishCommit();
+      await controlPlane.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/paperclip-runner/src/control-plane/durable-prp-control-plane.ts
+++ b/packages/paperclip-runner/src/control-plane/durable-prp-control-plane.ts
@@ -693,7 +693,12 @@ class PrpWebSocketConnection {
     this.#onClose();
   }
 
+  waitForProcessing(): Promise<void> {
+    return this.#processing;
+  }
+
   #consume(chunk: Buffer): void {
+    if (this.#closed) return;
     this.#buffer = Buffer.concat([this.#buffer, chunk]);
     while (this.#buffer.length >= 2) {
       const first = this.#buffer[0]!;
@@ -828,25 +833,24 @@ export class DurablePrpControlPlane {
   }
 
   async stop(): Promise<void> {
-    for (const connection of this.#connections) {
-      connection.close();
-    }
-    this.#connections.clear();
     const server = this.#server;
     this.#server = null;
     this.#port = null;
-    if (server !== null) {
-      await new Promise<void>((resolveClose) =>
+    const serverClosed = server === null
+      ? Promise.resolve()
+      : new Promise<void>((resolveClose) =>
         server.close(() => resolveClose()),
       );
-    }
+    await this.disconnectActiveRunner();
+    await serverClosed;
   }
 
   /** Forces a resumable re-authentication after an immutable run attachment rotates. */
-  disconnectActiveRunner(): void {
+  async disconnectActiveRunner(): Promise<void> {
     const connections = [...this.#connections];
     this.#connections.clear();
     for (const connection of connections) connection.close();
+    await Promise.all(connections.map((connection) => connection.waitForProcessing()));
   }
 
   activeRunnerConnectionCount(): number {
@@ -1631,7 +1635,7 @@ export class DurablePrpControlPlane {
             // A result that cannot fit the bounded durable journal cannot be
             // acknowledged as a usable tool response. Force a reconnect so
             // the caller can recover or terminate the run explicitly.
-            this.disconnectActiveRunner();
+            void this.disconnectActiveRunner();
           }
         };
         void this.#onSemanticToolInput(call)

--- a/server/src/services/native-runtime/runner-prp-coordinator.ts
+++ b/server/src/services/native-runtime/runner-prp-coordinator.ts
@@ -283,8 +283,8 @@ export function runnerPrpCoordinator(
       try {
         bootstrapTicket = authority.issueBootstrapTicket(bootstrapTtlMs);
       } catch (error) {
-        authority.disconnectActiveRunner();
         await registration.release();
+        await authority.disconnectActiveRunner();
         throw error;
       }
       let released = false;
@@ -339,8 +339,8 @@ export function runnerPrpCoordinator(
         release: async () => {
           if (released) return;
           released = true;
-          authority.disconnectActiveRunner();
           await registration.release();
+          await authority.disconnectActiveRunner();
         },
       };
     },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Native runners send durable events to the server through the PRP control plane
> - The server commits these events to PostgreSQL before it acknowledges them
> - A disconnect closed the socket but did not wait for queued frame processing
> - Test teardown could close PostgreSQL while a queued event still used it
> - This pull request drains queued frame processing before a runner session is released
> - The benefit is deterministic native runner teardown without late database writes

## Linked Issues or Issue Description

**What happened?**

The native Codex integration test could finish while a queued PRP event still wrote to PostgreSQL. Vitest then reported an unhandled TypeError from postgres/src/connection.js after all tests passed.

**Expected behavior**

Runner release must wait for all queued PRP event commits before database teardown starts.

**Steps to reproduce**

1. Run the general-server CI shard that includes native-codex-runner.integration.test.ts.
2. Let the native runner reach its terminal state.
3. Observe that a late PostgreSQL write can run after the test database closes.

**Paperclip version or commit**

ca02d2463

## What Changed

- Close PRP connections and wait for their queued frame processing before disconnect completes.
- Release the PRP registration before the coordinator drains the active connection.
- Add a regression test that blocks an event commit and verifies that disconnect waits for it.

## Verification

- pnpm --dir packages/paperclip-runner exec vitest run src/control-plane/durable-prp-control-plane.test.ts --reporter=verbose
- pnpm exec vitest run server/src/services/native-runtime/native-codex-runner.integration.test.ts --reporter=verbose
- pnpm --filter @paperclipai/server typecheck
- git diff --check

## Risks

- Low risk. Disconnect now resolves after queued frames finish.
- No database migration or public API changes are included.

> For core feature work, check ROADMAP.md first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See CONTRIBUTING.md.

## Model Used

OpenAI Codex with GPT-5. The exact deployment ID and context window are not exposed. The model used high reasoning, code execution, and GitHub tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing issue or described the issue in-PR with the relevant issue template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
