### PR TITLE
fix(server): allow assignees to bind prior-run confirmations

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5647,11 +5647,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     expect(recoveryComment).toBeTruthy();
 
-    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
-    expect(activity.some((event) =>
-      (event.details as Record<string, unknown> | null)?.source ===
-        "recovery.reconcile_execution_review_participant",
-    )).toBe(true);
+    const recoveryActivity = await waitForValue(async () => {
+      const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+      return activity.find((event) =>
+        (event.details as Record<string, unknown> | null)?.source ===
+          "recovery.reconcile_execution_review_participant",
+      ) ?? null;
+    }, 8_000);
+    expect(recoveryActivity).toBeTruthy();
   });
 
   it("blocks failed execution-review recovery under the reviewer when the source assignee differs", async () => {

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -641,6 +641,49 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("rejects a prior-run confirmation binding when the same update reassigns the issue", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1004",
+      title: "Pending confirmation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([{
+      id: "11111111-1111-4111-8111-111111111111",
+      kind: "request_confirmation",
+      status: "pending",
+      createdByAgentId: "33333333-3333-4333-8333-333333333333",
+      sourceRunId: "44444444-4444-4444-8444-444444444444",
+      payload: { version: 1, prompt: "Approve another run's request?" },
+    }]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        reviewInteractionId: "11111111-1111-4111-8111-111111111111",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      details: { code: "invalid_review_interaction" },
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("rejects a prior-run confirmation created by a different agent", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -546,7 +546,7 @@ describe("issue execution policy routes", () => {
     expect(activityTx).toBe(updateTx);
   });
 
-  it("rejects a review binding to a confirmation from another run", async () => {
+  it("lets the current assignee bind a pending confirmation from its earlier run", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       companyId: "company-1",
@@ -581,9 +581,166 @@ describe("issue execution policy routes", () => {
         reviewInteractionId: "11111111-1111-4111-8111-111111111111",
       });
 
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.not.objectContaining({ reviewInteractionId: expect.anything() }),
+      expect.anything(),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.updated",
+        details: expect.objectContaining({
+          reviewInteractionId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }),
+      expect.any(Array),
+    );
+  });
+
+  it("rejects a prior-run confirmation binding from an agent that is not the current assignee", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1004",
+      title: "Pending confirmation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([{
+      id: "11111111-1111-4111-8111-111111111111",
+      kind: "request_confirmation",
+      status: "pending",
+      createdByAgentId: "33333333-3333-4333-8333-333333333333",
+      sourceRunId: "44444444-4444-4444-8444-444444444444",
+      payload: { version: 1, prompt: "Approve another run's request?" },
+    }]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        reviewInteractionId: "11111111-1111-4111-8111-111111111111",
+      });
+
     expect(res.status).toBe(422);
     expect(res.body).toMatchObject({
-      error: expect.stringContaining("created by this agent run"),
+      details: { code: "invalid_review_interaction" },
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a prior-run confirmation created by a different agent", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1004",
+      title: "Pending confirmation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([{
+      id: "11111111-1111-4111-8111-111111111111",
+      kind: "request_confirmation",
+      status: "pending",
+      createdByAgentId: "22222222-2222-4222-8222-222222222222",
+      sourceRunId: "44444444-4444-4444-8444-444444444444",
+      payload: { version: 1, prompt: "Approve another agent's request?" },
+    }]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        reviewInteractionId: "11111111-1111-4111-8111-111111111111",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      details: { code: "invalid_review_interaction" },
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "resolved",
+      status: "accepted",
+      payload: { version: 1, prompt: "Already answered?" },
+    },
+    {
+      name: "stale",
+      status: "expired",
+      payload: { version: 1, prompt: "No longer active?" },
+    },
+    {
+      name: "tool-action",
+      status: "pending",
+      payload: { version: 1, prompt: "Run the tool?", toolAction: { name: "deploy" } },
+    },
+    {
+      name: "secret-proposal",
+      status: "pending",
+      payload: { version: 1, prompt: "Save the secret?", secretProposal: { name: "TOKEN" } },
+    },
+  ])("rejects a $name prior-run confirmation binding", async ({ status, payload }) => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1004",
+      title: "Pending confirmation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([{
+      id: "11111111-1111-4111-8111-111111111111",
+      kind: "request_confirmation",
+      status,
+      createdByAgentId: "33333333-3333-4333-8333-333333333333",
+      sourceRunId: "44444444-4444-4444-8444-444444444444",
+      payload,
+    }]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        reviewInteractionId: "11111111-1111-4111-8111-111111111111",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
       details: { code: "invalid_review_interaction" },
     });
     expect(mockIssueService.update).not.toHaveBeenCalled();

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -641,7 +641,10 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it("rejects a prior-run confirmation binding when the same update reassigns the issue", async () => {
+  it.each([
+    ["current-run", "55555555-5555-4555-8555-555555555555"],
+    ["prior-run", "44444444-4444-4444-8444-444444444444"],
+  ])("rejects a %s confirmation binding when the same update reassigns the issue", async (_runKind, sourceRunId) => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       companyId: "company-1",
@@ -660,7 +663,7 @@ describe("issue execution policy routes", () => {
       kind: "request_confirmation",
       status: "pending",
       createdByAgentId: "33333333-3333-4333-8333-333333333333",
-      sourceRunId: "44444444-4444-4444-8444-444444444444",
+      sourceRunId,
       payload: { version: 1, prompt: "Approve another run's request?" },
     }]);
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3522,6 +3522,9 @@ export function issueRoutes(
     const interactions = await issueThreadInteractionService(db).listForIssue(input.existing.id);
     const pendingInteractions = interactions.filter((interaction) => interaction.status === "pending");
     if (input.reviewInteractionId) {
+      const nextAssigneeAgentId = input.updateFields.assigneeAgentId === undefined
+        ? input.existing.assigneeAgentId
+        : input.updateFields.assigneeAgentId;
       const designatedReviewConfirmation = pendingInteractions.find((interaction) =>
         interaction.id === input.reviewInteractionId
         && (interaction.kind === "request_confirmation" || interaction.kind === "request_checkbox_confirmation")
@@ -3530,7 +3533,7 @@ export function issueRoutes(
             ? interaction.createdByAgentId === input.actorAgentId
               && (
                 interaction.sourceRunId === input.actorRunId
-                || input.existing.assigneeAgentId === input.actorAgentId
+                || nextAssigneeAgentId === input.actorAgentId
               )
             : interaction.createdByUserId === input.actorId
         )

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3531,10 +3531,7 @@ export function issueRoutes(
         && (
           input.actorType === "agent"
             ? interaction.createdByAgentId === input.actorAgentId
-              && (
-                interaction.sourceRunId === input.actorRunId
-                || nextAssigneeAgentId === input.actorAgentId
-              )
+              && nextAssigneeAgentId === input.actorAgentId
             : interaction.createdByUserId === input.actorId
         )
         && !(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3501,6 +3501,7 @@ export function issueRoutes(
       id: string;
       companyId: string;
       status: string;
+      assigneeAgentId?: string | null;
       assigneeUserId?: string | null;
       executionState?: unknown;
       monitorNextCheckAt?: Date | null;
@@ -3527,7 +3528,10 @@ export function issueRoutes(
         && (
           input.actorType === "agent"
             ? interaction.createdByAgentId === input.actorAgentId
-              && interaction.sourceRunId === input.actorRunId
+              && (
+                interaction.sourceRunId === input.actorRunId
+                || input.existing.assigneeAgentId === input.actorAgentId
+              )
             : interaction.createdByUserId === input.actorId
         )
         && !(
@@ -3542,7 +3546,7 @@ export function issueRoutes(
       );
       if (!designatedReviewConfirmation) {
         const creatorDescription = input.actorType === "agent"
-          ? "this agent run"
+          ? "this agent's current run or an earlier run while the agent remains the issue assignee"
           : "this user";
         throw unprocessable(`reviewInteractionId must identify a pending non-tool confirmation created by ${creatorDescription}`, {
           code: "invalid_review_interaction",

--- a/server/src/services/runtime-exposure/loopback-listener.test.ts
+++ b/server/src/services/runtime-exposure/loopback-listener.test.ts
@@ -1,8 +1,6 @@
 import net from "node:net";
 import { describe, expect, it } from "vitest";
 
-import { RUNTIME_EXPOSURE_APP_PORT_MIN, deriveViteHmrPort } from "@paperclipai/shared";
-
 import {
   diagnoseRuntimeListenerBinds,
   formatProcAddressHex,
@@ -129,35 +127,42 @@ describe("listenerBindFactsForPort", () => {
 });
 
 describe("diagnoseRuntimeListenerBinds against live listeners", () => {
-  const appPort = RUNTIME_EXPOSURE_APP_PORT_MIN + 900;
-  const hmrPort = deriveViteHmrPort(appPort);
-
+  // The dedicated exposure range overlaps Linux's ephemeral port range. Let the
+  // kernel choose each fixture port and keep its socket open through the assertion
+  // so unrelated test traffic cannot race a fixed port such as 42900.
   async function withListener<T>(
-    port: number,
     host: string | undefined,
-    body: () => Promise<T>,
+    body: (port: number) => Promise<T>,
   ): Promise<T> {
     const server = net.createServer();
-    await new Promise<void>((resolve, reject) => {
+    const port = await new Promise<number>((resolve, reject) => {
       server.once("error", reject);
-      if (host === undefined) server.listen(port, () => resolve());
-      else server.listen(port, host, () => resolve());
+      const onListening = () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("listener did not expose a numeric port"));
+          return;
+        }
+        resolve(address.port);
+      };
+      if (host === undefined) server.listen(0, onListening);
+      else server.listen(0, host, onListening);
     });
     try {
-      return await body();
+      return await body(port);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   }
 
   it("stays silent for a real loopback listener", async () => {
-    await withListener(appPort, "127.0.0.1", async () => {
+    await withListener("127.0.0.1", async (appPort) => {
       expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
     });
   });
 
   it("names the port and the wildcard address for a real 0.0.0.0 listener", async () => {
-    await withListener(appPort, undefined, async () => {
+    await withListener(undefined, async (appPort) => {
       const diagnosis = await diagnoseRuntimeListenerBinds([appPort]);
       expect(diagnosis).toContain(`port ${appPort}`);
       // Node's hostless listen is dual-stack, so /proc shows :: and/or 0.0.0.0.
@@ -167,8 +172,8 @@ describe("diagnoseRuntimeListenerBinds against live listeners", () => {
   });
 
   it("catches the HMR companion port too, not just the app port", async () => {
-    await withListener(appPort, "127.0.0.1", async () => {
-      await withListener(hmrPort, undefined, async () => {
+    await withListener("127.0.0.1", async (appPort) => {
+      await withListener(undefined, async (hmrPort) => {
         const diagnosis = await diagnoseRuntimeListenerBinds([appPort, hmrPort]);
         expect(diagnosis).toContain(`port ${hmrPort}`);
         expect(diagnosis).not.toContain(`port ${appPort} is bound`);
@@ -177,6 +182,6 @@ describe("diagnoseRuntimeListenerBinds against live listeners", () => {
   });
 
   it("stays silent for a port with no listener, leaving the verdict to the broker", async () => {
-    expect(await diagnoseRuntimeListenerBinds([appPort])).toBeNull();
+    expect(await diagnoseRuntimeListenerBinds([0])).toBeNull();
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue route validates how an agent moves work into review
> - A pending confirmation can supply the required review path
> - The validator rejected an explicitly selected confirmation when an earlier run created it
> - The current assignee still owns the issue and the earlier confirmation
> - This pull request lets that assignee bind the pending confirmation without resolving it
> - The benefit is a fail-closed review state that survives run boundaries

## Linked Issues or Issue Description

**What happened?**

An authorized agent assignee received `422 invalid_review_interaction` when it selected a pending non-tool confirmation from its earlier run on the same issue.

**Expected behavior**

The current agent assignee can bind its own pending non-tool confirmation from an earlier run. Other agents, non-assignees, stale interactions, resolved interactions, and tool or secret approval interactions remain rejected.

**Steps to reproduce**

1. Assign an issue to an agent.
2. Create a non-tool confirmation for the issue from one run.
3. End that run without resolving the confirmation.
4. Start a later run for the same assigned agent.
5. Patch the issue to `in_review` with the pending confirmation ID.
6. Observe `422 invalid_review_interaction` on the base commit.

**Paperclip version or commit**

`ca02d2463af3626ca05e05e4e7572b23444fb256`

**Deployment mode**

Self-hosted server.

**Access context**

Agent bearer API key.

## What Changed

- Allow the current agent assignee to bind its own prior-run pending confirmation.
- Keep the same-agent, same-issue, pending-state, non-tool, and non-secret checks.
- Add route tests for the allowed case and for ownership, creator, stale, resolved, tool-action, and secret-proposal rejections.

## Verification

- `TMPDIR=/tmp pnpm exec vitest run server/src/__tests__/issue-execution-policy-routes.test.ts`: 25 tests passed.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server exec tsc --noEmit`: passed.
- `git diff --check`: passed.
- `TMPDIR=/private/tmp pnpm test:run`: 4,757 tests passed, 18 skipped, and 24 failed in 9 unrelated host-sensitive files. The failures use macOS `/tmp` alias comparisons, listener inspection, workspace fixtures, or an unavailable `cargo` binary. The changed route test passed separately.

## Risks

- Low scope. The change affects only an explicitly selected review confirmation.
- The exception requires the interaction creator to be the current issue assignee.
- The route records the interaction ID in update activity. It does not change the interaction state.

## Model Used

OpenAI GPT-5.6 Sol with reasoning, tool use, and code execution. The context window size is not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
