### PR TITLE
Add inherited company governance policy overlay

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -32,6 +32,7 @@ import {
 } from "@paperclipai/adapter-utils/execution-target";
 import {
   asString,
+  asStringArray,
   asNumber,
   parseObject,
   buildPaperclipEnv,
@@ -1202,8 +1203,28 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     const runAttempt = async (resumeSessionId: string | null) => {
+      const governancePolicy = context.companyGovernancePolicy;
+      const governanceBody = governancePolicy
+        && typeof governancePolicy === "object"
+        && !Array.isArray(governancePolicy)
+        && typeof (governancePolicy as Record<string, unknown>).body === "string"
+        ? (governancePolicy as Record<string, unknown>).body
+        : null;
+      const configWithGovernanceOverlay = governanceBody
+        ? {
+            ...config,
+            // This is intentionally appended after operator args: policy delivery
+            // uses Codex's developer-level channel and cannot be shadowed by a
+            // role prompt or ordinary adapter extraArgs.
+            extraArgs: [
+              ...asStringArray((config as Record<string, unknown>).extraArgs),
+              "-c",
+              `developer_instructions=${JSON.stringify(governanceBody)}`,
+            ],
+          }
+        : config;
       const execArgs = buildCodexExecArgs(
-        forceSaferInvocation ? { ...config, fastMode: false } : config,
+        forceSaferInvocation ? { ...configWithGovernanceOverlay, fastMode: false } : configWithGovernanceOverlay,
         {
           resumeSessionId,
           skipGitRepoCheck: executionTargetIsSandbox,

--- a/packages/db/src/migrations/0228_company_governance_policies.sql
+++ b/packages/db/src/migrations/0228_company_governance_policies.sql
@@ -1,0 +1,62 @@
+CREATE TABLE "company_governance_policies" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE CASCADE,
+  "active_revision_id" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "company_governance_policies_company_unique" ON "company_governance_policies" USING btree ("company_id");
+--> statement-breakpoint
+CREATE TABLE "company_governance_policy_revisions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE CASCADE,
+  "policy_id" uuid NOT NULL REFERENCES "company_governance_policies"("id") ON DELETE CASCADE,
+  "revision" integer NOT NULL,
+  "schema_version" integer DEFAULT 1 NOT NULL,
+  "body" text NOT NULL,
+  "bindings" jsonb NOT NULL,
+  "sha256" text NOT NULL,
+  "created_by_agent_id" uuid,
+  "created_by_user_id" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "company_governance_policy_revisions_policy_revision_unique" ON "company_governance_policy_revisions" USING btree ("policy_id","revision");
+--> statement-breakpoint
+WITH created_policies AS (
+  INSERT INTO "company_governance_policies" ("id", "company_id")
+  SELECT gen_random_uuid(), "id"
+  FROM "companies"
+  ON CONFLICT ("company_id") DO NOTHING
+  RETURNING "id", "company_id"
+), created_revisions AS (
+  INSERT INTO "company_governance_policy_revisions" (
+    "id", "company_id", "policy_id", "revision", "schema_version", "body", "bindings", "sha256"
+  )
+  SELECT
+    gen_random_uuid(),
+    "company_id",
+    "id",
+    1,
+    1,
+    $policy$# Company governance policy
+
+- Keep one machine-visible next path: a live or queued run, assigned todo, real blocker, active review, or done with evidence.
+- Route work to the responsible role. Do not assign technical, QA, recovery, or operational work to the founder; use a single explicit interaction only for a non-delegable founder decision.
+- After two equivalent scope-mismatch outcomes, do not start a third run for the same executor; route to CTO/QA or create one non-duplicating corrective issue.
+- Before validation record original scope, changed surfaces, affected contracts, blocking tests, diagnostic tests, external failures, and dependency decision. Review comments must include validation_scope.
+- Every substantive review uses gpt-5.6-luna with fastMode=false and reasoningEffort=medium; reviewer records a machine decision before CTO approval.
+- Before reopening a done or blocked issue validate its execution workspace. Clear stale workspace linkage through the API; never recreate a vanished worktree or erase changes to mask a problem.
+- Send text JSON from Windows PowerShell as UTF-8 bytes with application/json; charset=utf-8, then read it back and compare it. A mismatch or four question marks is a failed mutation.
+- Never set done manually to mask infrastructure, recovery, encoding, sandbox, setup, or cleanup failures.
+$policy$,
+    $json$[{"id":"all-codex-heartbeats","priority":100,"effect":"include","subject":{"type":"all_agents"},"scopes":["heartbeat"],"adapterTypes":["codex_local"],"delivery":"required"}]$json$::jsonb,
+    'a6e65ae99def75347c38e609521412384199da4c0c5690966f385854da1c0057'
+  FROM created_policies
+  RETURNING "id", "policy_id"
+)
+UPDATE "company_governance_policies" AS policy
+SET "active_revision_id" = revision."id", "updated_at" = now()
+FROM created_revisions AS revision
+WHERE policy."id" = revision."policy_id";

--- a/packages/db/src/migrations/0228_company_governance_policies.sql
+++ b/packages/db/src/migrations/0228_company_governance_policies.sql
@@ -51,8 +51,8 @@ WITH created_policies AS (
 - Send text JSON from Windows PowerShell as UTF-8 bytes with application/json; charset=utf-8, then read it back and compare it. A mismatch or four question marks is a failed mutation.
 - Never set done manually to mask infrastructure, recovery, encoding, sandbox, setup, or cleanup failures.
 $policy$,
-    $json$[{"id":"all-codex-heartbeats","priority":100,"effect":"include","subject":{"type":"all_agents"},"scopes":["heartbeat"],"adapterTypes":["codex_local"],"delivery":"required"}]$json$::jsonb,
-    'a6e65ae99def75347c38e609521412384199da4c0c5690966f385854da1c0057'
+    $json$[{"id":"all-codex-heartbeats","priority":100,"effect":"include","subject":{"type":"all_agents"},"scopes":["heartbeat"],"adapterTypes":["codex_local","paperclip_runner"],"delivery":"required"}]$json$::jsonb,
+    'fda8127cc899c459594052ab1d89282daa88f923010c655b2738f8d600e3623f'
   FROM created_policies
   RETURNING "id", "policy_id"
 )

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1583,6 +1583,13 @@
       "when": 1787668790923,
       "tag": "0227_modern_pandemic",
       "breakpoints": true
+    },
+    {
+      "idx": 228,
+      "version": "7",
+      "when": 1787668791923,
+      "tag": "0228_company_governance_policies",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/company_governance_policies.ts
+++ b/packages/db/src/schema/company_governance_policies.ts
@@ -1,0 +1,40 @@
+import { integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+
+/**
+ * A company-owned pointer to an immutable governance policy revision.  The
+ * policy is deliberately independent from agent instruction bundles: replacing
+ * an AGENTS.md bundle must never change this row or its revision history.
+ */
+export const companyGovernancePolicies = pgTable("company_governance_policies", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+  activeRevisionId: uuid("active_revision_id"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  companyUnique: uniqueIndex("company_governance_policies_company_unique").on(table.companyId),
+}));
+
+/**
+ * Revision bodies are never updated or deleted by the governance API. Restore
+ * creates a new row, preserving the exact revision an earlier run loaded.
+ */
+export const companyGovernancePolicyRevisions = pgTable("company_governance_policy_revisions", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+  policyId: uuid("policy_id").notNull().references(() => companyGovernancePolicies.id, { onDelete: "cascade" }),
+  revision: integer("revision").notNull(),
+  schemaVersion: integer("schema_version").notNull().default(1),
+  body: text("body").notNull(),
+  bindings: jsonb("bindings").$type<Array<Record<string, unknown>>>().notNull(),
+  sha256: text("sha256").notNull(),
+  createdByAgentId: uuid("created_by_agent_id"),
+  createdByUserId: text("created_by_user_id"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  policyRevisionUnique: uniqueIndex("company_governance_policy_revisions_policy_revision_unique").on(
+    table.policyId,
+    table.revision,
+  ),
+}));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -15,6 +15,7 @@ export { companyMemberships } from "./company_memberships.js";
 export { companyUserSidebarPreferences } from "./company_user_sidebar_preferences.js";
 export { principalPermissionGrants } from "./principal_permission_grants.js";
 export { companySkillPolicies } from "./company_skill_policies.js";
+export { companyGovernancePolicies, companyGovernancePolicyRevisions } from "./company_governance_policies.js";
 export { invites } from "./invites.js";
 export { joinRequests } from "./join_requests.js";
 export { budgetPolicies } from "./budget_policies.js";

--- a/packages/paperclip-runner/protocol/manifest.json
+++ b/packages/paperclip-runner/protocol/manifest.json
@@ -10,276 +10,276 @@
     {
       "path": "schemas/capabilities.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/capabilities.schema.json",
-      "sha256": "e62a80328e5edde136b35463033280922ac2220575a83046b07fe034d233db88"
+      "sha256": "ec307893c72ca349a8efa98c0b2267058b6b359464510c16e7d787398e16ab41"
     },
     {
       "path": "schemas/command.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/command.schema.json",
-      "sha256": "fc813e6b4d5b7e6890b496bd69848ada25dba58adbf7cf04163ca9e9bf2bcb79"
+      "sha256": "7d535d5e5b8c27d6fb512bbc2185d895b7366668a86d082ef7d9290804385422"
     },
     {
       "path": "schemas/conformance-fixture.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/conformance-fixture.schema.json",
-      "sha256": "0febc66d128da1f251f9e932d78353a67f47ee60b7427e0a347c287bb6b7ea79"
+      "sha256": "76be2089344bf785b44fefe200a5db817b9dfec0bda95376dbcf730c267047e2"
     },
     {
       "path": "schemas/conformance-output.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/conformance-output.schema.json",
-      "sha256": "96f78846dffc4a8300184751b9943214506f32ee1f393c6c0c453b666cf12d59"
+      "sha256": "823c24c4fd0bc85ac02ac39a214dd05016885e8b4ffe72a328cfd1793712190c"
     },
     {
       "path": "schemas/event.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/event.schema.json",
-      "sha256": "d69ac4acfd9cd265f9dcb6a6580e949a67a50347093d0a7c12c2000a2da6d482"
+      "sha256": "ef559c6cd59c8bdeead38c65a41162b16684a88aeb00a8e3d946ac754847781c"
     },
     {
       "path": "schemas/fixture.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/fixture.schema.json",
-      "sha256": "8ac87c2d8c639981277b5f72b9757a95badf85ff482d11596e4c63e01c616cba"
+      "sha256": "544e073f3cf3545311772f5037f1316fbb2acecfc23a80e5e4963eccd88f1bfb"
     },
     {
       "path": "schemas/identity.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/identity.schema.json",
-      "sha256": "8a8a1943f14c739284daa241c5189f3b8026c050472c4f9909897456da506f48"
+      "sha256": "dadec498197bce09955bfc21d5d8177aeb533c9f1843f4c80a26fcb0b610b146"
     },
     {
       "path": "schemas/provider-descriptor.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/provider-descriptor.schema.json",
-      "sha256": "26e8af9314f1ca49578bfbacdcc111332225b422ea4ff68918a25ddac59129a6"
+      "sha256": "dc812bf6b357e0709108c302c1b7f73c4f43c9cdce1e9bc99f5c77869f0ad3cf"
     },
     {
       "path": "schemas/provider-event.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/provider-event.schema.json",
-      "sha256": "84521ea87ae782a7c07d1ef68b70f87fc4c436e79951a8076b7ba55e923fa88b"
+      "sha256": "dd0dca29464a889785019c276a482679a3ee4b6f12d1258f3a509488e768e371"
     },
     {
       "path": "schemas/question-adapter-fixture.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/question-adapter-fixture.schema.json",
-      "sha256": "002062abb4df9a98c92003eb4af43afbe8bdedd15d08b8697ad221fcc28ad9c7"
+      "sha256": "2e0203420890429aa711a0dc7bfa62837b2a99a85d99ab593d7281e2c74d7ba1"
     },
     {
       "path": "schemas/question-response.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/question-response.schema.json",
-      "sha256": "dec308b0daa4d882deb3878a1ad6ae5360f3342060f63ca636d65d1d9af1e055"
+      "sha256": "2bb1ba028dd7a944b2411a8cf0fb1ea660f70a2285cb6f4b9aa0e365c091a9f5"
     },
     {
       "path": "schemas/question-set.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/question-set.schema.json",
-      "sha256": "3bda40311ae3153bbf9d4a8c59f716680e17d711a4db3570193963918359751c"
+      "sha256": "9c47d1fe36e7b9ca1ed399e8755bfbc19238f317ac5df34427ae04a2941936bc"
     },
     {
       "path": "schemas/request.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/request.schema.json",
-      "sha256": "bd41f01c00eddc1b635d3131a7183ddb616ff8fe68d5e348ddd9593a674c8d8e"
+      "sha256": "0a401c9f129d23180390b578da325d31eea18a5d2ce91c331117a6864358b32a"
     },
     {
       "path": "schemas/result.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/result.schema.json",
-      "sha256": "90f02c0a96e8ab9f75970fd788b61c18ccbd9abbd005bedfba280701729adce0"
+      "sha256": "d7e37041b467d162dfa00e6b876184f392c8289e89f9c19106745cb0cb4fc2f6"
     },
     {
       "path": "schemas/semantic-tool.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/semantic-tool.schema.json",
-      "sha256": "f53f6832c0d65caaccf540662fdb08cf62d9bab45a18def7b559c4068ef54efc"
+      "sha256": "2f00dd2522082be0ea0604700c44070f085ab63b38114926aa40facca959e998"
     },
     {
       "path": "schemas/stop-reason.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/stop-reason.schema.json",
-      "sha256": "ed0c0807904ff1198273458057e1a565e828dba499372c0c80e2c69a1d600a13"
+      "sha256": "393ad2e2cc7df9effca0efecb784dff0d250c118c656c9ed9f3449379b117a35"
     },
     {
       "path": "schemas/terminal.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/terminal.schema.json",
-      "sha256": "e9093399ac6422e77b060269910ffaba9a3d574ed578832821e310a0582edffd"
+      "sha256": "ab24cc1e7aa1fece06efe27a6959ea8bea340b3c1a3663c62b7e36a147e09168"
     },
     {
       "path": "schemas/usage.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/usage.schema.json",
-      "sha256": "28fdbb3202095144649dddc438e6270c66d599c6f7e86838687f58d644726456"
+      "sha256": "26bdd79a1f910f714ef6d6548e07d9f7a5b8e33941fd3a30abde3e78cda17f18"
     },
     {
       "path": "schemas/workspace-diff.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/workspace-diff.schema.json",
-      "sha256": "f71b21f41cfc4c40aeaa503d1981d29355b4dd8b15036fcf3d8df5c35f8b8f6f"
+      "sha256": "948ea963f365a16987b415439af3402276483adc90bca745286ab72e7932f1dd"
     },
     {
       "path": "schemas/workspace-file-reference.schema.json",
       "id": "https://paperclip.dev/schemas/prp/v1/workspace-file-reference.schema.json",
-      "sha256": "0ab57e76c9710f520ed9d15cc5d0f25c68176beff3aff556ad62dba9b922eb23"
+      "sha256": "2137e4511effffd5d57336967b03cab17613fa0a6be8200d2ed35b2e59e10bd8"
     }
   ],
   "fixtures": [
     {
       "path": "fixtures/conformance-expected-output.json",
-      "sha256": "5a643639c9df0a2925ba95c5c5dfa2217605018bfa0dd3954ab4aca5fcfdc2c6",
+      "sha256": "fa0148c0a3bc83d386e77543d84ac94f3e4f53db6d2b2338fb9cd8b63201f410",
       "expectation": "accept",
       "compatibilityCase": "cross-language-output"
     },
     {
       "path": "fixtures/conformance-minimal-run.json",
-      "sha256": "1e4304bcb51c3d7aa0575cf47b1ff3901700a254a60cf7432003ce9af0175e3a",
+      "sha256": "6bc0cdf8ac4939b25f5c7734eccdf90f674aa06eb14b9ca4d6acb9fcbb955e3f",
       "expectation": "accept",
       "compatibilityCase": "cross-language-input"
     },
     {
       "path": "fixtures/local-runner/scripts/duplicate-terminal.json",
-      "sha256": "56928a21318ea4b390c65fb34f0d3114760619d79301f4d535391a8566b693ab",
+      "sha256": "37aa1861d31cf0388af1cd25293ed1dddf84ee59b4265f82c5bbde78c86440f7",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/local-runner/scripts/error.json",
-      "sha256": "a4c74f8a85f8ab25adb13e83ae753fcac1a9cb289bad44d49be05df8f3170edb",
+      "sha256": "8e2bf68358cc756dfdeb97326f873833d1ec1cfbbbc628e99dafdb3049bd9d21",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/local-runner/scripts/happy-path.json",
-      "sha256": "ccdeef3df1e2020b692da3bd361958643f2f3d5ec6e1e0b16cca9e0d9890da2f",
+      "sha256": "11a0633d2868d902efe2e68d013001ce1434ac257349b794039e45cdbf276a44",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/local-runner/scripts/interrupted.json",
-      "sha256": "36dc94dc1a67d320a48921f2ed10f0e7ab760c518eea84d5f224e1e6ab8fa57c",
+      "sha256": "494797be9be552f1787816a88da94aac4bb6c2c967473a69e45e32571679f2ad",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/local-runner/scripts/linger.json",
-      "sha256": "ac6fed60bea22b22c16501c03388828ccaae6e9ec44ceb2ec0e8b145ab590bb8",
+      "sha256": "a029c982b09e9c2fb0fce7fd377db1e478272f933c35e1f25a919e13bc95d208",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/local-runner/scripts/oversized-line.json",
-      "sha256": "485b03653a2e41351f155b787a406f903e018b3c29b19c4ddf2dfc7c031552b7",
+      "sha256": "3dc563124be9326aa2841b6d0ed8389ad9527bc804190c78eee625b5a9e49c1a",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/local-runner/scripts/permission-input.json",
-      "sha256": "9b64b78ed75006b9190c80fd88c5ab555ef458f7ad023e8ebfdac8de373e1f9c",
+      "sha256": "0af0fe9baaee691d4711c989d1b073ed504af57eb768cacf077eb8d9d5ae63ef",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/questions/codex.json",
-      "sha256": "ad673b6f9d70b74b53656e622d15fad1a66430f39d62b9ef71479d194a198bd6",
+      "sha256": "dff1484cc5bc58e6875db6fa8eceff9825e99b6593d6b0b38a9bc0a1646c5e48",
       "expectation": "accept",
       "compatibilityCase": "codex-structured-input"
     },
     {
       "path": "fixtures/replay/duplicate-event.json",
-      "sha256": "779c146966d2825ffcde88bfff8b1fb238c162d40c578980ad3bd1a7def405d7",
+      "sha256": "ba3165091a77a5312a125064148e96d4b0dfd28375fb42b548db973e735222d2",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/replay/failed-run.json",
-      "sha256": "59281021b6ff11e4765213043580fc91eca8a02bedb3fe0c012bef9ad807da12",
+      "sha256": "6a8f5a554d36364c799eba818fcce528368defe1b7d976cd24de877ae78547f9",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/replay/golden/duplicate-event.snapshot.json",
-      "sha256": "24a6c221f9d46824128cde009b277dae2ea8672a608cf7fa2d7e4a714e38bc92",
+      "sha256": "b79c7b698123f70a406774f3295111091894453f9727dd76a6ea5451ff0a2193",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/duplicate-event.summary.json",
-      "sha256": "dcbb2dae5810649cc59c6c0fe136e1033131d9510ebcbcc5f3435bfa998b95c9",
+      "sha256": "2d89ea724f7c64a49f64fee50d0e182a316e4f4b255127c391b6c2582e73aa97",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/failed-run.snapshot.json",
-      "sha256": "a2bb468e3ca94b092a86afb8a57d2d05e0ce3cd6e9f87927dea81aef5aa32dd1",
+      "sha256": "5d0cae094fa1fe6081976e8c07cdaa34354c064519e72d62c4043057d98105ce",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/failed-run.summary.json",
-      "sha256": "d7ac19d40b5d1d6106e2232cd2436ba1c4232bc6daa8a71957f12300ba851f65",
+      "sha256": "225ca4382f001e43dafcc4b163dfd61ad2f2b3ecab34930b0d85074fe8ad125b",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/happy-path.snapshot.json",
-      "sha256": "037c114df8f205a13fa9070b07e6f9707218b8249bd196925246b054a7690853",
+      "sha256": "31558ad231bafe051720ee404fb0198c10e4202de8d6868d272715deeb8fc237",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/happy-path.summary.json",
-      "sha256": "00d2a033518c7b3f51ecb10aa64f7456922f6b3f930d853b3db35e72eaf55325",
+      "sha256": "23feeb0f877d871e3f81e8338f3fbf6e6378ecec5a18d9f4b374e9483032b6bb",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/interrupted-run.snapshot.json",
-      "sha256": "dc216831c437cc8fd2c37cee6f40f342767b21e01a511f2235a443be0d0b7b0c",
+      "sha256": "c744697f98ed3b6498fac888fc7fade348b80f31cbb1a0ac454dc832768fc101",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/interrupted-run.summary.json",
-      "sha256": "753f226607b2d97301736d7f54b281ab7157397f3f32015c644787d370526332",
+      "sha256": "7e262233c2718ffb5d371e28a19b2509754a9ad2f4fd7306fbc09cc23dfc6881",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/source-gap.snapshot.json",
-      "sha256": "7db7f25e423a721e60adfcdfee02db6d5e6fcd4a644ee180f5e29810ebbc0d78",
+      "sha256": "a796b8cc9fcc02edb7ad29d0566766837372b291c63810162df383541c936286",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/source-gap.summary.json",
-      "sha256": "861d0ee3fafe13bf8bf0fb71b7c1ef9a62cb26efba4dc8db889f36d27a14a813",
+      "sha256": "8129578e06caefe22551a1ea910227302f3041f540bc7e2e239052b711956e2c",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/unknown-optional-fields.snapshot.json",
-      "sha256": "cf5b13a4b8d7ae73d1632e0539ec50d2ebcee8fbb6a2f33b28db7ff786fa90ff",
+      "sha256": "6776553f7036aaff54dc63ef21d57304fccc8fae2d7a5ae0af22c94eba12fc8c",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/golden/unknown-optional-fields.summary.json",
-      "sha256": "7d983bcad0439b7884e70d07f8070b53ed594fba2da3e8ac6998570e238e84dc",
+      "sha256": "e3468d985f448d7b120c85265da6d58b553122fcd52399ab277d995fa867df46",
       "expectation": "accept",
       "compatibilityCase": "deterministic-replay-oracle"
     },
     {
       "path": "fixtures/replay/happy-path.json",
-      "sha256": "dfe0aeb4e7a217f8d375afe6e6d1ab0151bb8e81921b07ae0aaa6c4d0b8f8a1d",
+      "sha256": "3f51df916acf52aeeeb01491ae42527731d520567a472a3105c5a5ac6def930a",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/replay/interrupted-run.json",
-      "sha256": "2056789605ffde847b3272e751226ce4be61527f6aaa4fe3f5557a621af0ad5c",
+      "sha256": "d750c1d51fe84dc281e2541f12bd49472d0d647dbec61f61089103b676d272db",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/replay/source-gap.json",
-      "sha256": "d8a3eb2861e8198226360e666e5296ff5d7215f81d255a273b21d2bfe7dcc2ef",
+      "sha256": "aa1ea35153361422240a509383f9c5f1c1987194e8693646f6a260a5ebdcca9d",
       "expectation": "accept",
       "compatibilityCase": "canonical"
     },
     {
       "path": "fixtures/replay/unknown-optional-fields.json",
-      "sha256": "4dbc4b70c299fe21791ca66949f3cb189c8f76514b62c52f5f40a489a84515c4",
+      "sha256": "43c04132038295fe283b36b500ff75984c1a84d224e2126c2dc87cfa81d1726e",
       "expectation": "accept",
       "compatibilityCase": "additive-optional-fields"
     },
     {
       "path": "fixtures/replay/unsupported-required-version.json",
-      "sha256": "60ac964d2cf49dc80ada0cb9c946b25952f3e2be10719801d3f2f8bd98d27699",
+      "sha256": "214a9ebdebb3d7c574d32ced6b8e45d792fe616caa5951e90e5a96b5097e321d",
       "expectation": "reject",
       "compatibilityCase": "unknown-required-version"
     }

--- a/packages/paperclip-runner/runner/crates/runner-core/src/bin/fake-codex-app-server.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/bin/fake-codex-app-server.rs
@@ -47,6 +47,13 @@ fn log_call(path: Option<&Path>, method: &str) -> io::Result<()> {
     writeln!(file, "{method}")
 }
 
+fn log_thread_params(path: Option<&Path>, params: &Value) -> io::Result<()> {
+    let Some(path) = path else { return Ok(()) };
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    serde_json::to_writer(&mut file, params)?;
+    writeln!(file)
+}
+
 fn finish_turn(state_path: &Path, state: &mut FakeState, status: &str) -> io::Result<()> {
     let turn_id = state
         .active_turn_id
@@ -84,6 +91,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let state_path =
         PathBuf::from(argument(&args, "--state-file").ok_or("--state-file is required")?);
     let call_log = argument(&args, "--call-log").map(PathBuf::from);
+    let thread_params_log = argument(&args, "--thread-params-log").map(PathBuf::from);
     let emit_question = args.iter().any(|value| value == "--emit-question");
     let hold_turn = args.iter().any(|value| value == "--hold-turn");
     let exit_after_turn_start = args.iter().any(|value| value == "--exit-after-turn-start");
@@ -104,6 +112,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         };
         log_call(call_log.as_deref(), method)?;
         let id = message.get("id").cloned();
+        if matches!(method, "thread/start" | "thread/resume") {
+            log_thread_params(thread_params_log.as_deref(), message.get("params").unwrap_or(&Value::Null))?;
+        }
         match method {
             "initialize" => send(json!({
                 "id": id,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,9 +18,11 @@ export {
   governancePolicyBindingSchema,
   governancePolicyDocumentSchema,
   replaceGovernancePolicySchema,
+  restoreGovernancePolicyRevisionSchema,
   type GovernancePolicyBinding,
   type GovernancePolicyDocument,
   type ReplaceGovernancePolicy,
+  type RestoreGovernancePolicyRevision,
 } from "./validators/company-governance-policy.js";
 export {
   decisionEffectStalenessSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,14 @@ export {
   type NativeRunTerminalState,
 } from "./types/native-finalization.js";
 export {
+  governancePolicyBindingSchema,
+  governancePolicyDocumentSchema,
+  replaceGovernancePolicySchema,
+  type GovernancePolicyBinding,
+  type GovernancePolicyDocument,
+  type ReplaceGovernancePolicy,
+} from "./validators/company-governance-policy.js";
+export {
   decisionEffectStalenessSchema,
   decisionOptionStyleSchema,
   commentOnIssueDecisionEffectSchema,

--- a/packages/shared/src/validators/company-governance-policy.test.ts
+++ b/packages/shared/src/validators/company-governance-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  governancePolicyDocumentSchema,
+  restoreGovernancePolicyRevisionSchema,
+} from "./company-governance-policy.js";
+
+const binding = {
+  id: "all-protected-runners",
+  priority: 100,
+  effect: "include",
+  subject: { type: "all_agents" },
+  scopes: ["heartbeat"],
+  delivery: "required",
+} as const;
+
+describe("company governance policy validation", () => {
+  it("accepts each adapter with a protected policy delivery implementation", () => {
+    for (const adapterType of ["codex_local", "paperclip_runner"] as const) {
+      expect(governancePolicyDocumentSchema.parse({
+        schemaVersion: 1,
+        body: "# Policy",
+        bindings: [{ ...binding, adapterTypes: [adapterType] }],
+      }).bindings[0]?.adapterTypes).toEqual([adapterType]);
+    }
+  });
+
+  it("rejects duplicate adapter bindings and unsupported delivery targets", () => {
+    expect(() => governancePolicyDocumentSchema.parse({
+      schemaVersion: 1,
+      body: "# Policy",
+      bindings: [{ ...binding, adapterTypes: ["paperclip_runner", "paperclip_runner"] }],
+    })).toThrow(/unique/i);
+    expect(() => governancePolicyDocumentSchema.parse({
+      schemaVersion: 1,
+      body: "# Policy",
+      bindings: [{ ...binding, adapterTypes: ["claude_local"] }],
+    })).toThrow();
+  });
+
+  it("requires a positive active revision for immutable restore", () => {
+    expect(restoreGovernancePolicyRevisionSchema.parse({ expectedRevision: 1 }))
+      .toEqual({ expectedRevision: 1 });
+    expect(() => restoreGovernancePolicyRevisionSchema.parse({ expectedRevision: 0 })).toThrow();
+  });
+});

--- a/packages/shared/src/validators/company-governance-policy.ts
+++ b/packages/shared/src/validators/company-governance-policy.ts
@@ -7,7 +7,10 @@ const nonEmptyUniqueStrings = z.array(z.string().trim().min(1).max(256)).min(1).
 // Do not accept a binding that looks applicable but would silently omit the
 // overlay for another adapter. Additional adapters must add an explicit,
 // tested protected delivery implementation before joining this allowlist.
-const protectedGovernanceAdapterTypes = z.array(z.literal("codex_local")).min(1).max(1);
+const protectedGovernanceAdapterTypes = z.array(z.enum(["codex_local", "paperclip_runner"]))
+  .min(1)
+  .max(2)
+  .refine((values) => new Set(values).size === values.length, "Adapter types must be unique");
 
 export const governancePolicyBindingSchema = z.object({
   id: z.string().trim().min(1).max(128).regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/),
@@ -34,6 +37,11 @@ export const replaceGovernancePolicySchema = governancePolicyDocumentSchema.exte
   expectedRevision: z.number().int().nonnegative(),
 }).strict();
 
+export const restoreGovernancePolicyRevisionSchema = z.object({
+  expectedRevision: z.number().int().positive(),
+}).strict();
+
 export type GovernancePolicyBinding = z.infer<typeof governancePolicyBindingSchema>;
 export type GovernancePolicyDocument = z.infer<typeof governancePolicyDocumentSchema>;
 export type ReplaceGovernancePolicy = z.infer<typeof replaceGovernancePolicySchema>;
+export type RestoreGovernancePolicyRevision = z.infer<typeof restoreGovernancePolicyRevisionSchema>;

--- a/packages/shared/src/validators/company-governance-policy.ts
+++ b/packages/shared/src/validators/company-governance-policy.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+const nonEmptyUniqueStrings = z.array(z.string().trim().min(1).max(256)).min(1).max(500)
+  .refine((values) => new Set(values).size === values.length, "Values must be unique");
+
+// Codex is the first adapter with a protected developer-instruction channel.
+// Do not accept a binding that looks applicable but would silently omit the
+// overlay for another adapter. Additional adapters must add an explicit,
+// tested protected delivery implementation before joining this allowlist.
+const protectedGovernanceAdapterTypes = z.array(z.literal("codex_local")).min(1).max(1);
+
+export const governancePolicyBindingSchema = z.object({
+  id: z.string().trim().min(1).max(128).regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/),
+  priority: z.number().int().min(-1_000_000).max(1_000_000),
+  effect: z.enum(["include", "exclude"]),
+  subject: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("all_agents") }).strict(),
+    z.object({ type: z.literal("agents"), agentIds: z.array(z.string().uuid()).min(1).max(500) }).strict(),
+    z.object({ type: z.literal("roles"), roles: nonEmptyUniqueStrings }).strict(),
+  ]),
+  scopes: z.array(z.literal("heartbeat")).min(1).max(1),
+  adapterTypes: protectedGovernanceAdapterTypes,
+  delivery: z.literal("required"),
+}).strict();
+
+export const governancePolicyDocumentSchema = z.object({
+  schemaVersion: z.literal(1),
+  body: z.string().min(1).max(200_000),
+  bindings: z.array(governancePolicyBindingSchema).min(1).max(1_000)
+    .refine((bindings) => new Set(bindings.map((binding) => binding.id)).size === bindings.length, "Binding IDs must be unique"),
+}).strict();
+
+export const replaceGovernancePolicySchema = governancePolicyDocumentSchema.extend({
+  expectedRevision: z.number().int().nonnegative(),
+}).strict();
+
+export type GovernancePolicyBinding = z.infer<typeof governancePolicyBindingSchema>;
+export type GovernancePolicyDocument = z.infer<typeof governancePolicyDocumentSchema>;
+export type ReplaceGovernancePolicy = z.infer<typeof replaceGovernancePolicySchema>;

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -1322,6 +1322,73 @@ process.exit(1);
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("keeps the governance overlay after the managed role instructions are replaced", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-governance-overlay-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const instructionsPath = path.join(root, "AGENTS.md");
+    const explicitCodexHome = path.join(root, "explicit-codex-home");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(explicitCodexHome, { recursive: true });
+    // Use an explicitly owned test home: Windows runners may prohibit the
+    // managed home's credential symlink, which is unrelated to overlay
+    // delivery and must not turn this regression into an EPERM skip.
+    await fs.writeFile(path.join(explicitCodexHome, "auth.json"), `${fakeCodexAuthJson}\n`, "utf8");
+    // This simulates the managed-revision overwrite which previously removed a
+    // policy copied into AGENTS.md. The policy now comes from run context.
+    await fs.writeFile(instructionsPath, "Replacement role instructions.\n", "utf8");
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      const result = await execute({
+        runId: "run-governance-overlay",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: { sessionId: null, sessionParams: {}, sessionDisplayId: null, taskKey: null },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          instructionsFilePath: instructionsPath,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            CODEX_HOME: explicitCodexHome,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          companyGovernancePolicy: {
+            revision: 7,
+            sha256: "a".repeat(64),
+            body: "# Company policy\nThis instruction is inherited.",
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.argv).toEqual(expect.arrayContaining([
+        "-c",
+        'developer_instructions="# Company policy\\nThis instruction is inherited."',
+      ]));
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("uses a worktree-isolated CODEX_HOME while preserving shared auth and config", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/companies-service.test.ts
+++ b/server/src/__tests__/companies-service.test.ts
@@ -11,6 +11,8 @@ import {
   companySkillVersions,
   companySkills,
   companyMemberships,
+  companyGovernancePolicies,
+  companyGovernancePolicyRevisions,
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -50,6 +52,8 @@ describeEmbeddedPostgres("companyService", () => {
     await db.delete(builtInManagedResources);
     await db.delete(companySkillVersions);
     await db.delete(companySkills);
+    await db.delete(companyGovernancePolicyRevisions);
+    await db.delete(companyGovernancePolicies);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -79,6 +83,36 @@ describeEmbeddedPostgres("companyService", () => {
 
     const rows = await db.select({ issuePrefix: companies.issuePrefix }).from(companies);
     expect(rows.map((row) => row.issuePrefix).sort()).toEqual(["ARO", "AROA"]);
+  });
+
+  it("backfills one immutable governance revision and makes company provisioning idempotent", async () => {
+    const created = await companyService(db).create({ name: "Governed Company" });
+
+    const first = await db
+      .select()
+      .from(companyGovernancePolicies)
+      .where(eq(companyGovernancePolicies.companyId, created.id));
+    const firstRevisions = await db
+      .select()
+      .from(companyGovernancePolicyRevisions)
+      .where(eq(companyGovernancePolicyRevisions.companyId, created.id));
+    expect(first).toHaveLength(1);
+    expect(firstRevisions).toHaveLength(1);
+    expect(first[0]?.activeRevisionId).toBe(firstRevisions[0]?.id);
+    expect(firstRevisions[0]).toMatchObject({ revision: 1, sha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
+
+    // Cloud provisioning and startup repair call the same public service. A
+    // repeated seed must retain the active immutable row rather than append a
+    // second default revision.
+    const { companyGovernancePolicyService } = await import("../services/company-governance-policy.js");
+    await companyGovernancePolicyService(db).ensureDefault(created.id);
+    const repeated = await db
+      .select()
+      .from(companyGovernancePolicyRevisions)
+      .where(eq(companyGovernancePolicyRevisions.companyId, created.id));
+    expect(repeated).toHaveLength(1);
+    expect(repeated[0]?.id).toBe(firstRevisions[0]?.id);
+    expect(repeated[0]?.sha256).toBe(firstRevisions[0]?.sha256);
   });
 
   it("does not auto-provision bundled built-in agents for a freshly created company", async () => {

--- a/server/src/__tests__/company-governance-policy-routes.test.ts
+++ b/server/src/__tests__/company-governance-policy-routes.test.ts
@@ -123,5 +123,32 @@ describeEmbeddedPostgres("company governance policy routes", () => {
     expect(await db.select().from(activityLog)).toEqual(expect.arrayContaining([
       expect.objectContaining({ action: "company.governance_policy_replaced", entityType: "company_governance_policy" }),
     ]));
+
+    await request(app)
+      .post(`/companies/${companyId}/governance-policy/revisions/${(await db.select().from(companyGovernancePolicyRevisions))[0]!.id}/restore`)
+      .set("x-test-actor", "board")
+      .send({ expectedRevision: 1 })
+      .expect(200)
+      .expect(({ body }) => expect(body).toMatchObject({ revision: 2, body: policy.body }));
+    const readback = await request(app)
+      .get(`/companies/${companyId}/governance-policy`)
+      .set("x-test-actor", "board")
+      .expect(200);
+    expect(readback.body.history.map((revision: { revision: number }) => revision.revision)).toEqual([2, 1]);
+  });
+
+  it("serializes concurrent revision CAS writes into one success and one 409", async () => {
+    const app = await setupApp();
+    await request(app).put(`/companies/${companyId}/governance-policy`)
+      .set("x-test-actor", "board").send(policy).expect(200);
+    const [left, right] = await Promise.all([
+      request(app).put(`/companies/${companyId}/governance-policy`).set("x-test-actor", "board")
+        .send({ ...policy, expectedRevision: 1, body: "# Left policy" }),
+      request(app).put(`/companies/${companyId}/governance-policy`).set("x-test-actor", "board")
+        .send({ ...policy, expectedRevision: 1, body: "# Right policy" }),
+    ]);
+    expect([left.status, right.status].sort()).toEqual([200, 409]);
+    expect([left.body, right.body].find((body) => body.code === "governance_policy_revision_conflict"))
+      .toMatchObject({ currentRevision: 2 });
   });
 });

--- a/server/src/__tests__/company-governance-policy-routes.test.ts
+++ b/server/src/__tests__/company-governance-policy-routes.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  companyGovernancePolicies,
+  companyGovernancePolicyRevisions,
+  createDb,
+} from "@paperclipai/db";
+import { errorHandler } from "../middleware/error-handler.js";
+import { companyGovernancePolicyRoutes } from "../routes/company-governance-policy.js";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("company governance policy routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId: string;
+  let agentId: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-governance-policy-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(companyGovernancePolicyRevisions);
+    await db.delete(companyGovernancePolicies);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function setupApp() {
+    companyId = randomUUID();
+    agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Governance Co",
+      issuePrefix: `G${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Developer",
+      role: "developer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      status: "idle",
+    });
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = req.header("x-test-actor") === "board"
+        ? { type: "board", source: "local_implicit", userId: "board", companyIds: [], isInstanceAdmin: true }
+        : { type: "agent", source: "agent_key", agentId, companyId, runId: null };
+      next();
+    });
+    app.use(companyGovernancePolicyRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
+
+  const policy = {
+    schemaVersion: 1,
+    expectedRevision: 0,
+    body: "# Company Policy\nThis is loaded outside role instructions.",
+    bindings: [{
+      id: "all-codex",
+      priority: 1,
+      effect: "include",
+      subject: { type: "all_agents" },
+      scopes: ["heartbeat"],
+      adapterTypes: ["codex_local"],
+      delivery: "required",
+    }],
+  } as const;
+
+  it("is board-managed, revisioned, and exposes hash, targets, and drift readback", async () => {
+    const app = await setupApp();
+    await request(app)
+      .put(`/companies/${companyId}/governance-policy`)
+      .send(policy)
+      .expect(403)
+      .expect(({ body }) => expect(body.code).toBe("governance_policy_board_required"));
+    await request(app)
+      .put(`/companies/${companyId}/governance-policy`)
+      .set("x-test-actor", "board")
+      .send(policy)
+      .expect(200)
+      .expect(({ body }) => expect(body).toMatchObject({ revision: 1 }));
+
+    await request(app)
+      .get(`/companies/${companyId}/governance-policy`)
+      .set("x-test-actor", "board")
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.active).toMatchObject({ revision: 1, sha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
+        expect(body.drift).toEqual({ detected: false, reason: null });
+        expect(body.targets).toEqual(expect.arrayContaining([
+          expect.objectContaining({ agentId, bindingId: "all-codex", delivery: "required", included: true }),
+        ]));
+      });
+    await request(app)
+      .get(`/companies/${companyId}/governance-policy`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.active).toMatchObject({ revision: 1, sha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
+        expect(body.active.body).toBeUndefined();
+        expect(body.history[0].bindings).toBeUndefined();
+        expect(body.targets).toHaveLength(1);
+      });
+    expect(await db.select().from(activityLog)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: "company.governance_policy_replaced", entityType: "company_governance_policy" }),
+    ]));
+  });
+});

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -26,6 +26,7 @@ const apiPrefixes: Record<string, string> = {
   "companies.ts": "/api/companies",
   "company-skills.ts": "/api",
   "company-skill-policy.ts": "/api",
+  "company-governance-policy.ts": "/api",
   "costs.ts": "/api",
   "dashboard.ts": "/api",
   "decision-queues.ts": "/api",
@@ -203,6 +204,9 @@ describe("openapi routes", () => {
       },
       required: expect.arrayContaining(["candidates"]),
     });
+    expect(res.body.paths["/api/companies/{companyId}/governance-policy"].put.requestBody.content[
+      "application/json"
+    ].schema.required).toEqual(expect.arrayContaining(["expectedRevision", "body", "bindings"]));
     expect(res.body.paths["/api/agents/{id}/keys"].post.requestBody.content["application/json"].schema).toMatchObject({
       type: "object",
       properties: {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -23,6 +23,7 @@ import { cloudRoutes } from "./routes/cloud.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
 import { companySkillPolicyRoutes } from "./routes/company-skill-policy.js";
+import { companyGovernancePolicyRoutes } from "./routes/company-governance-policy.js";
 import { inboxAgentPolicyRoutes } from "./routes/inbox-agent-policy.js";
 import { builtInAgentRoutes } from "./routes/built-in-agents.js";
 import { folderRoutes } from "./routes/folders.js";
@@ -419,6 +420,7 @@ export async function createApp(
   api.use(folderRoutes(db));
   api.use(companySkillRoutes(db));
   api.use(companySkillPolicyRoutes(db));
+  api.use(companyGovernancePolicyRoutes(db));
   api.use(inboxAgentPolicyRoutes(db));
   api.use(builtInAgentRoutes(db));
   api.use(summarySlotRoutes(db));

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -17,6 +17,7 @@ import { isUuidLike, normalizeAgentApiKeyScope, type DeploymentMode } from "@pap
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
+import { companyGovernancePolicyService } from "../services/company-governance-policy.js";
 
 const CLOUD_TENANT_WRITE_DEBOUNCE_MS = 5_000;
 const CLOUD_TENANT_WRITE_DEBOUNCE_MAX = 1_000;
@@ -567,6 +568,11 @@ export async function resolveCloudTenantActor(
     .onConflictDoNothing({
       target: companies.id,
     });
+
+  // Cloud tenant provisioning bypasses companyService.create. Seed the same
+  // immutable revision here so no newly materialized tenant can run agents
+  // without the company overlay.
+  if (shouldSync) await companyGovernancePolicyService(db).ensureDefault(companyId);
 
   if (shouldSync && paperclipCompanyName) {
     await repairCloudTenantCompanyName(db, {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -555,24 +555,27 @@ export async function resolveCloudTenantActor(
     .delete(instanceUserRoles)
     .where(and(eq(instanceUserRoles.userId, userId), eq(instanceUserRoles.role, "instance_admin")));
 
-  if (shouldSync) await db
-    .insert(companies)
-    .values({
-      id: companyId,
-      name: companyName,
-      description: `Provisioned by Paperclip Cloud for stack ${stackId}.`,
-      status: "active",
-      issuePrefix: issuePrefixForCloudStack(stackId),
-      updatedAt: now,
-    })
-    .onConflictDoNothing({
-      target: companies.id,
-    });
+  if (shouldSync) await db.transaction(async (tx) => {
+    await tx
+      .insert(companies)
+      .values({
+        id: companyId,
+        name: companyName,
+        description: `Provisioned by Paperclip Cloud for stack ${stackId}.`,
+        status: "active",
+        issuePrefix: issuePrefixForCloudStack(stackId),
+        updatedAt: now,
+      })
+      .onConflictDoNothing({
+        target: companies.id,
+      });
 
-  // Cloud tenant provisioning bypasses companyService.create. Seed the same
-  // immutable revision here so no newly materialized tenant can run agents
-  // without the company overlay.
-  if (shouldSync) await companyGovernancePolicyService(db).ensureDefault(companyId);
+    // Cloud tenant provisioning bypasses companyService.create. The company
+    // row and its first policy become visible together, so a failed seed
+    // cannot leave a heartbeat-capable company without required policy.
+    await companyGovernancePolicyService(tx as unknown as Db)
+      .ensureDefaultInTransaction(tx as unknown as Db, companyId);
+  });
 
   if (shouldSync && paperclipCompanyName) {
     await repairCloudTenantCompanyName(db, {

--- a/server/src/middleware/cloud-tenant-actor.test.ts
+++ b/server/src/middleware/cloud-tenant-actor.test.ts
@@ -2,7 +2,15 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Request } from "express";
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { authUsers, companies, companyMemberships, instanceSettings, instanceUserRoles } from "@paperclipai/db";
+import {
+  authUsers,
+  companies,
+  companyGovernancePolicies,
+  companyGovernancePolicyRevisions,
+  companyMemberships,
+  instanceSettings,
+  instanceUserRoles,
+} from "@paperclipai/db";
 import { cloudActorHeaderSourceFromHeaders, resolveCloudTenantActor } from "./auth.js";
 
 // Minimal fake Drizzle Db: records every table passed to .insert() / .delete() and
@@ -36,26 +44,62 @@ function createFakeDb(options: {
   const insertedTables: unknown[] = [];
   const deletedTables: unknown[] = [];
   const selectWheres: Array<{ table: unknown; condition: unknown }> = [];
-  const chain: Record<string, unknown> = {};
-  chain.values = () => chain;
-  chain.onConflictDoUpdate = () => chain;
-  chain.onConflictDoNothing = () => chain;
-  chain.where = () => chain;
-  chain.returning = async () => [membershipRow];
-  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(undefined).then(resolve);
+  let transactionCalls = 0;
+  let cloudPolicySeedCommitted = false;
+  let policyRow: { id: string; activeRevisionId: string | null } | null = null;
+  let revisionRow: { id: string; policyId: string; revision: number } | null = null;
+  function mutationChain(table: unknown): Record<string, unknown> {
+    const chain: Record<string, unknown> = {};
+    chain.values = () => chain;
+    chain.onConflictDoUpdate = () => chain;
+    chain.onConflictDoNothing = () => chain;
+    chain.where = () => chain;
+    chain.for = () => chain;
+    chain.returning = async () => table === companyGovernancePolicyRevisions
+      ? [{
+          id: revisionRow!.id,
+          policyId: revisionRow!.policyId,
+          revision: revisionRow!.revision,
+          sha256: "a".repeat(64),
+        }]
+      : [membershipRow];
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(undefined).then(resolve);
+    return chain;
+  }
   const db = {
     insert: (table: unknown) => {
       insertedTables.push(table);
+      if (table === companyGovernancePolicies) policyRow = { id: "policy-1", activeRevisionId: null };
+      if (table === companyGovernancePolicyRevisions) {
+        revisionRow = { id: "revision-1", policyId: policyRow?.id ?? "policy-1", revision: 1 };
+      }
+      return mutationChain(table);
+    },
+    update: (table: unknown) => {
+      const chain = mutationChain(table);
+      chain.set = (values: { activeRevisionId?: string }) => {
+        if (table === companyGovernancePolicies && policyRow && values.activeRevisionId) {
+          policyRow.activeRevisionId = values.activeRevisionId;
+        }
+        return chain;
+      };
       return chain;
     },
     delete: (table: unknown) => {
       deletedTables.push(table);
-      return chain;
+      return mutationChain(table);
     },
     select: () => {
-      if (options.selectThrows) throw new Error("select unavailable");
       return {
-        from: (table: unknown) => ({
+        from: (table: unknown) => {
+          // The failure-mode tests model reads made after the transactional
+          // tenant seed. Required policy reads must remain available within
+          // that seed; membership/settings reads below still exercise the
+          // fail-closed/degraded actor paths.
+          if (options.selectThrows && cloudPolicySeedCommitted && (table === companyMemberships || table === instanceSettings)) {
+            throw new Error("select unavailable");
+          }
+          return {
           where: (condition: unknown) => {
             selectWheres.push({ table, condition });
             const rows =
@@ -63,16 +107,25 @@ function createFakeDb(options: {
                 ? [settingsRow]
                 : table === companyMemberships
                   ? (options.membershipQueryRows ?? [])
+                  : table === companyGovernancePolicies
+                    ? (policyRow ? [policyRow] : [])
+                    : table === companyGovernancePolicyRevisions
+                      ? (revisionRow ? [revisionRow] : [])
                   : [];
-            return {
-              then: (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve),
-            };
+            return { for: () => ({ then: (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve) }), then: (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve) };
           },
-        }),
+          };
+        },
       };
     },
+    transaction: async (callback: (tx: Db) => Promise<unknown>) => {
+      transactionCalls += 1;
+      const result = await callback(db as unknown as Db);
+      cloudPolicySeedCommitted = true;
+      return result;
+    },
   } as unknown as Db;
-  return { db, insertedTables, deletedTables, selectWheres };
+  return { db, insertedTables, deletedTables, selectWheres, transactionCalls: () => transactionCalls };
 }
 
 function settingsRowWith(experimental: Record<string, unknown>) {
@@ -157,6 +210,15 @@ describe("resolveCloudTenantActor (shared-pool hardening)", () => {
     expect(insertedTables).toContain(authUsers);
     expect(insertedTables).toContain(companies);
     expect(insertedTables).toContain(companyMemberships);
+  });
+
+  it("creates the cloud tenant and required governance seed in one transaction", async () => {
+    const { db, insertedTables, transactionCalls } = createFakeDb();
+    await resolveCloudTenantActor(db, fakeReq(VALID_HEADERS));
+    expect(transactionCalls()).toBe(1);
+    expect(insertedTables).toContain(companies);
+    expect(insertedTables).toContain(companyGovernancePolicies);
+    expect(insertedTables).toContain(companyGovernancePolicyRevisions);
   });
 
   it("resyncs an A to B to A context transition inside the debounce window", async () => {

--- a/server/src/routes/company-governance-policy.ts
+++ b/server/src/routes/company-governance-policy.ts
@@ -85,5 +85,23 @@ export function companyGovernancePolicyRoutes(db: Db) {
     }));
   });
 
+  router.post("/companies/:companyId/governance-policy/revisions/:revisionId/restore", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    await assertBoardAdmin(req, companyId);
+    const expectedRevision = typeof req.body?.expectedRevision === "number" ? req.body.expectedRevision : NaN;
+    if (!Number.isInteger(expectedRevision) || expectedRevision < 1) {
+      throw unprocessable("expectedRevision must be a positive integer", {
+        code: "governance_policy_validation_failed",
+      });
+    }
+    const actor = getActorInfo(req);
+    res.json(await policies.restore({
+      companyId,
+      revisionId: req.params.revisionId as string,
+      expectedRevision,
+      activity: { actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId },
+    }));
+  });
+
   return router;
 }

--- a/server/src/routes/company-governance-policy.ts
+++ b/server/src/routes/company-governance-policy.ts
@@ -1,6 +1,6 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
 import type { Db } from "@paperclipai/db";
-import { replaceGovernancePolicySchema } from "@paperclipai/shared";
+import { replaceGovernancePolicySchema, restoreGovernancePolicyRevisionSchema } from "@paperclipai/shared";
 import { ZodError } from "zod";
 import { forbidden, HttpError, unprocessable } from "../errors.js";
 import { accessService } from "../services/access.js";
@@ -88,17 +88,17 @@ export function companyGovernancePolicyRoutes(db: Db) {
   router.post("/companies/:companyId/governance-policy/revisions/:revisionId/restore", async (req, res) => {
     const companyId = req.params.companyId as string;
     await assertBoardAdmin(req, companyId);
-    const expectedRevision = typeof req.body?.expectedRevision === "number" ? req.body.expectedRevision : NaN;
-    if (!Number.isInteger(expectedRevision) || expectedRevision < 1) {
+    const parsed = restoreGovernancePolicyRevisionSchema.safeParse(req.body);
+    if (!parsed.success) {
       throw unprocessable("expectedRevision must be a positive integer", {
-        code: "governance_policy_validation_failed",
+        code: "governance_policy_validation_failed", issues: parsed.error.issues,
       });
     }
     const actor = getActorInfo(req);
     res.json(await policies.restore({
       companyId,
       revisionId: req.params.revisionId as string,
-      expectedRevision,
+      expectedRevision: parsed.data.expectedRevision,
       activity: { actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId },
     }));
   });

--- a/server/src/routes/company-governance-policy.ts
+++ b/server/src/routes/company-governance-policy.ts
@@ -1,0 +1,89 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import type { Db } from "@paperclipai/db";
+import { replaceGovernancePolicySchema } from "@paperclipai/shared";
+import { ZodError } from "zod";
+import { forbidden, HttpError, unprocessable } from "../errors.js";
+import { accessService } from "../services/access.js";
+import { companyGovernancePolicyService } from "../services/company-governance-policy.js";
+import { assertCompanyAccess, getActorInfo } from "./authz.js";
+
+/** Board-only configuration surface. Agent credentials may read their company
+ * policy metadata but never create, replace, or restore an overlay. */
+export function companyGovernancePolicyRoutes(db: Db) {
+  const router = Router();
+  const access = accessService(db);
+  const policies = companyGovernancePolicyService(db);
+
+  function assertRead(req: Request, companyId: string) {
+    if (req.actor.type === "none") throw new HttpError(401, "Authentication required");
+    if (req.actor.type === "agent" && req.actor.companyId !== companyId) {
+      throw forbidden("Agent key cannot access another company", { code: "governance_policy_company_boundary_denied" });
+    }
+    assertCompanyAccess(req, companyId);
+  }
+
+  async function assertBoardAdmin(req: Request, companyId: string) {
+    assertRead(req, companyId);
+    if (req.actor.type !== "board") {
+      throw forbidden("Board governance authority required", { code: "governance_policy_board_required" });
+    }
+    if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
+    if (await access.canUser(companyId, req.actor.userId, "users:manage_permissions")) return;
+    throw forbidden("Board governance authority required", { code: "governance_policy_board_required" });
+  }
+
+  function validate(req: Request, _res: Response, next: NextFunction) {
+    try {
+      req.body = replaceGovernancePolicySchema.parse(req.body);
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        next(unprocessable("Invalid governance policy document", {
+          code: "governance_policy_validation_failed", issues: error.issues,
+        }));
+        return;
+      }
+      next(error);
+    }
+  }
+
+  router.get("/companies/:companyId/governance-policy", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertRead(req, companyId);
+    const readback = await policies.get(companyId);
+    if (req.actor.type === "agent") {
+      // An agent needs provenance for its own run, not the board's complete
+      // policy text or historical configuration. Keep policy content and peer
+      // bindings board-visible only.
+      const metadata = (revision: typeof readback.active) => revision && ({
+        id: revision.id,
+        revision: revision.revision,
+        sha256: revision.sha256,
+        createdAt: revision.createdAt,
+      });
+      res.json({
+        active: metadata(readback.active),
+        history: readback.history.map(metadata),
+        targets: readback.targets.filter((target) => target.agentId === req.actor.agentId),
+        drift: readback.drift,
+      });
+      return;
+    }
+    res.json(readback);
+  });
+
+  router.put("/companies/:companyId/governance-policy", validate, async (req, res) => {
+    const companyId = req.params.companyId as string;
+    await assertBoardAdmin(req, companyId);
+    const actor = getActorInfo(req);
+    const { expectedRevision, ...policy } = req.body;
+    res.json(await policies.replace({
+      companyId,
+      expectedRevision,
+      policy,
+      activity: { actorType: actor.actorType, actorId: actor.actorId, agentId: actor.agentId, runId: actor.runId },
+    }));
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,6 +2,7 @@ export { healthRoutes } from "./health.js";
 export { companyRoutes } from "./companies.js";
 export { companySkillRoutes } from "./company-skills.js";
 export { companySkillPolicyRoutes } from "./company-skill-policy.js";
+export { companyGovernancePolicyRoutes } from "./company-governance-policy.js";
 export { inboxAgentPolicyRoutes } from "./inbox-agent-policy.js";
 export { builtInAgentRoutes } from "./built-in-agents.js";
 export { folderRoutes } from "./folders.js";

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -134,6 +134,7 @@ import {
   companySkillTestRunTemplateCreateSchema,
   companySkillTestRunTemplateUpdateSchema,
   evaluateSkillPolicySchema,
+  replaceGovernancePolicySchema,
   replaceSkillPolicySchema,
   updateInboxAgentPolicySchema,
   // Issue tree
@@ -5241,6 +5242,33 @@ registry.registerPath({
   summary: "Get the effective company skill policy",
   request: { params: z.object({ companyId: z.string() }) },
   responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/companies/{companyId}/governance-policy",
+  tags: ["companies"],
+  summary: "Get the active company governance policy readback",
+  request: { params: z.object({ companyId: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/api/companies/{companyId}/governance-policy",
+  tags: ["companies"],
+  summary: "Create a new active company governance policy revision",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    body: jsonBody(replaceGovernancePolicySchema),
+  },
+  responses: {
+    200: r.ok(),
+    401: r.unauthorized,
+    403: r.forbidden,
+    409: r.conflict,
+    422: r.unprocessable,
+  },
 });
 
 registry.registerPath({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -135,6 +135,7 @@ import {
   companySkillTestRunTemplateUpdateSchema,
   evaluateSkillPolicySchema,
   replaceGovernancePolicySchema,
+  restoreGovernancePolicyRevisionSchema,
   replaceSkillPolicySchema,
   updateInboxAgentPolicySchema,
   // Issue tree
@@ -5266,6 +5267,25 @@ registry.registerPath({
     200: r.ok(),
     401: r.unauthorized,
     403: r.forbidden,
+    409: r.conflict,
+    422: r.unprocessable,
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/companies/{companyId}/governance-policy/revisions/{revisionId}/restore",
+  tags: ["companies"],
+  summary: "Restore a prior governance policy as a new immutable revision",
+  request: {
+    params: z.object({ companyId: z.string(), revisionId: z.string().uuid() }),
+    body: jsonBody(restoreGovernancePolicyRevisionSchema),
+  },
+  responses: {
+    200: r.ok(),
+    401: r.unauthorized,
+    403: r.forbidden,
+    404: r.notFound,
     409: r.conflict,
     422: r.unprocessable,
   },

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -236,13 +236,13 @@ export function companyService(db: Db) {
     return false;
   }
 
-  async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {
+  async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert, database: Db = db) {
     const base = deriveIssuePrefixBase(data.name);
     let suffix = 1;
     while (suffix < 10000) {
       const candidate = `${base}${suffixForAttempt(suffix)}`;
       try {
-        const rows = await db
+        const rows = await database
           .insert(companies)
           .values({ ...data, issuePrefix: candidate })
           .returning();
@@ -277,8 +277,14 @@ export function companyService(db: Db) {
     },
 
     create: async (data: typeof companies.$inferInsert) => {
-      const created = await createCompanyWithUniquePrefix(data);
-      await governancePolicies.ensureDefault(created.id);
+      // A company is not runnable until its required policy pointer and first
+      // immutable revision exist. Keep the seed in the same transaction as the
+      // company row so a failed seed cannot leave a heartbeat-capable tenant.
+      const created = await db.transaction(async (tx) => {
+        const company = await createCompanyWithUniquePrefix(data, tx as unknown as Db);
+        await governancePolicies.ensureDefaultInTransaction(tx as unknown as Db, company!.id);
+        return company!;
+      });
       await environmentsSvc.ensureLocalEnvironment(created.id);
       await builtInAgents.autoProvisionBundledAgents(created.id);
       const row = await getCompanyQuery(db)

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -38,6 +38,7 @@ import { environmentService } from "./environments.js";
 import { heartbeatService } from "./heartbeat.js";
 import { logActivity } from "./activity-log.js";
 import { builtInAgentService } from "./built-in-agents.js";
+import { companyGovernancePolicyService } from "./company-governance-policy.js";
 
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -60,6 +61,7 @@ export function companyService(db: Db) {
   const environmentsSvc = environmentService(db);
   const heartbeat = heartbeatService(db);
   const builtInAgents = builtInAgentService(db);
+  const governancePolicies = companyGovernancePolicyService(db);
 
   type CompanyTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -276,6 +278,7 @@ export function companyService(db: Db) {
 
     create: async (data: typeof companies.$inferInsert) => {
       const created = await createCompanyWithUniquePrefix(data);
+      await governancePolicies.ensureDefault(created.id);
       await environmentsSvc.ensureLocalEnvironment(created.id);
       await builtInAgents.autoProvisionBundledAgents(created.id);
       const row = await getCompanyQuery(db)

--- a/server/src/services/company-governance-policy.test.ts
+++ b/server/src/services/company-governance-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveGovernancePolicyBinding,
+  type GovernancePolicyTarget,
+} from "./company-governance-policy.js";
+
+const target: GovernancePolicyTarget = {
+  agentId: "11111111-1111-4111-8111-111111111111",
+  role: "Developer",
+  adapterType: "codex_local",
+};
+
+describe("resolveGovernancePolicyBinding", () => {
+  it("uses deterministic priority and preserves an explicit exclusion", () => {
+    const binding = resolveGovernancePolicyBinding([
+      {
+        id: "include-all",
+        priority: 20,
+        effect: "include",
+        subject: { type: "all_agents" },
+        scopes: ["heartbeat"],
+        adapterTypes: ["codex_local"],
+        delivery: "required",
+      },
+      {
+        id: "exclude-developer",
+        priority: 10,
+        effect: "exclude",
+        subject: { type: "roles", roles: ["developer"] },
+        scopes: ["heartbeat"],
+        adapterTypes: ["codex_local"],
+        delivery: "required",
+      },
+    ], target);
+
+    expect(binding).toMatchObject({ id: "exclude-developer", effect: "exclude" });
+  });
+
+  it("only resolves a compatible delivery target", () => {
+    const binding = resolveGovernancePolicyBinding([{
+      id: "codex-only",
+      priority: 1,
+      effect: "include",
+      subject: { type: "all_agents" },
+      scopes: ["heartbeat"],
+      adapterTypes: ["codex_local"],
+      delivery: "required",
+    }], target);
+
+    expect(binding?.id).toBe("codex-only");
+    expect(resolveGovernancePolicyBinding([{
+      id: "codex-only",
+      priority: 1,
+      effect: "include",
+      subject: { type: "all_agents" },
+      scopes: ["heartbeat"],
+      adapterTypes: ["codex_local"],
+      delivery: "required",
+    }], { ...target, adapterType: "process" })).toBeNull();
+  });
+});

--- a/server/src/services/company-governance-policy.ts
+++ b/server/src/services/company-governance-policy.ts
@@ -1,0 +1,274 @@
+import { createHash, randomUUID } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, companyGovernancePolicies, companyGovernancePolicyRevisions } from "@paperclipai/db";
+import {
+  governancePolicyDocumentSchema,
+  type GovernancePolicyBinding,
+  type GovernancePolicyDocument,
+} from "@paperclipai/shared";
+import { conflict, notFound } from "../errors.js";
+import { logActivity, type LogActivityInput } from "./activity-log.js";
+
+export type GovernancePolicyTarget = {
+  agentId: string;
+  role: string | null;
+  adapterType: string | null;
+};
+
+export type LoadedGovernancePolicy = {
+  policyId: string;
+  revisionId: string;
+  revision: number;
+  sha256: string;
+  body: string;
+  bindingId: string;
+  delivery: "required" | "best_effort";
+};
+
+/** The delivery contract is fixed by Paperclip, not by editable role prompts.
+ * A policy may constrain a run but cannot be weakened by task context or a
+ * skill. Adapters map this to their strongest available instruction channel. */
+export const GOVERNANCE_POLICY_PRECEDENCE = [
+  "company_policy",
+  "role_instructions",
+  "task_context",
+  "skills",
+] as const;
+
+export const DEFAULT_COMPANY_GOVERNANCE_POLICY: GovernancePolicyDocument = {
+  schemaVersion: 1,
+  body: `# Company governance policy
+
+- Keep one machine-visible next path: a live or queued run, assigned todo, real blocker, active review, or done with evidence.
+- Route work to the responsible role. Do not assign technical, QA, recovery, or operational work to the founder; use a single explicit interaction only for a non-delegable founder decision.
+- After two equivalent scope-mismatch outcomes, do not start a third run for the same executor; route to CTO/QA or create one non-duplicating corrective issue.
+- Before validation record original scope, changed surfaces, affected contracts, blocking tests, diagnostic tests, external failures, and dependency decision. Review comments must include validation_scope.
+- Every substantive review uses gpt-5.6-luna with fastMode=false and reasoningEffort=medium; reviewer records a machine decision before CTO approval.
+- Before reopening a done or blocked issue validate its execution workspace. Clear stale workspace linkage through the API; never recreate a vanished worktree or erase changes to mask a problem.
+- Send text JSON from Windows PowerShell as UTF-8 bytes with application/json; charset=utf-8, then read it back and compare it. A mismatch or four question marks is a failed mutation.
+- Never set done manually to mask infrastructure, recovery, encoding, sandbox, setup, or cleanup failures.
+`,
+  bindings: [{
+    id: "all-codex-heartbeats",
+    priority: 100,
+    effect: "include",
+    subject: { type: "all_agents" },
+    scopes: ["heartbeat"],
+    adapterTypes: ["codex_local"],
+    delivery: "required",
+  }],
+};
+
+export type GovernancePolicyReadback = {
+  active: (typeof companyGovernancePolicyRevisions.$inferSelect) | null;
+  history: Array<typeof companyGovernancePolicyRevisions.$inferSelect>;
+  /** Current resolution for every agent. This is intentionally computed at
+   * read time so binding changes and newly hired agents are visible without a
+   * write-side cache that could drift from the immutable revision. */
+  targets: Array<{
+    agentId: string;
+    name: string;
+    role: string | null;
+    adapterType: string | null;
+    bindingId: string | null;
+    delivery: "required" | "best_effort" | null;
+    included: boolean;
+  }>;
+  /** A non-null status is operational evidence that the stored revision has
+   * not been altered out-of-band. */
+  drift: { detected: boolean; reason: "sha256_mismatch" | null } | null;
+};
+
+function roleMatches(candidate: string | null, roles: string[]) {
+  const normalized = candidate?.trim().toLocaleLowerCase();
+  return Boolean(normalized && roles.some((role) => role.trim().toLocaleLowerCase() === normalized));
+}
+
+export function resolveGovernancePolicyBinding(
+  bindings: GovernancePolicyBinding[],
+  target: GovernancePolicyTarget,
+): GovernancePolicyBinding | null {
+  return [...bindings]
+    .sort((left, right) => left.priority - right.priority || left.id.localeCompare(right.id))
+    .find((binding) => {
+      if (!binding.scopes.includes("heartbeat")) return false;
+      if (binding.adapterTypes && (!target.adapterType || !binding.adapterTypes.includes(target.adapterType))) return false;
+      if (binding.subject.type === "all_agents") return true;
+      if (binding.subject.type === "agents") return binding.subject.agentIds.includes(target.agentId);
+      return roleMatches(target.role, binding.subject.roles);
+    }) ?? null;
+}
+
+function sha256(body: string) {
+  return createHash("sha256").update(Buffer.from(body, "utf8")).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`).join(",")}}`;
+}
+
+function policyHash(policy: GovernancePolicyDocument): string {
+  return sha256(stableJson({
+    schemaVersion: policy.schemaVersion,
+    body: policy.body,
+    bindings: policy.bindings,
+  }));
+}
+
+export function companyGovernancePolicyService(db: Db) {
+  async function active(companyId: string) {
+    const policy = await db.select().from(companyGovernancePolicies)
+      .where(eq(companyGovernancePolicies.companyId, companyId)).then((rows) => rows[0] ?? null);
+    if (!policy?.activeRevisionId) return null;
+    return db.select().from(companyGovernancePolicyRevisions)
+      .where(and(
+        eq(companyGovernancePolicyRevisions.companyId, companyId),
+        eq(companyGovernancePolicyRevisions.id, policy.activeRevisionId),
+      )).then((rows) => rows[0] ?? null);
+  }
+
+  async function get(companyId: string): Promise<GovernancePolicyReadback> {
+    const revision = await active(companyId);
+    if (!revision) return { active: null, history: [], targets: [], drift: null };
+    const history = await db.select().from(companyGovernancePolicyRevisions)
+      .where(eq(companyGovernancePolicyRevisions.companyId, companyId))
+      .orderBy(desc(companyGovernancePolicyRevisions.revision));
+    const document = governancePolicyDocumentSchema.parse({
+      schemaVersion: revision.schemaVersion,
+      body: revision.body,
+      bindings: revision.bindings,
+    });
+    const companyAgents = await db.select({
+      id: agents.id,
+      name: agents.name,
+      role: agents.role,
+      adapterType: agents.adapterType,
+    }).from(agents).where(eq(agents.companyId, companyId));
+    const targets = companyAgents.map((agent) => {
+      const binding = resolveGovernancePolicyBinding(document.bindings, agent);
+      const included = Boolean(binding && binding.effect === "include");
+      return {
+        agentId: agent.id,
+        name: agent.name,
+        role: agent.role,
+        adapterType: agent.adapterType,
+        bindingId: binding?.id ?? null,
+        delivery: included ? binding!.delivery : null,
+        included,
+      };
+    });
+    const storedPolicyHash = policyHash(document);
+    return {
+      active: revision,
+      history,
+      targets,
+      drift: {
+        detected: storedPolicyHash !== revision.sha256,
+        reason: storedPolicyHash === revision.sha256 ? null : "sha256_mismatch",
+      },
+    };
+  }
+
+  async function resolveForHeartbeat(companyId: string, agentId: string): Promise<LoadedGovernancePolicy | null> {
+    const revision = await active(companyId);
+    if (!revision) return null;
+    const agent = await db.select({ id: agents.id, role: agents.role, adapterType: agents.adapterType })
+      .from(agents).where(and(eq(agents.companyId, companyId), eq(agents.id, agentId)))
+      .then((rows) => rows[0] ?? null);
+    if (!agent) throw notFound("Agent not found");
+    const document = governancePolicyDocumentSchema.parse({
+      schemaVersion: revision.schemaVersion,
+      body: revision.body,
+      bindings: revision.bindings,
+    });
+    const binding = resolveGovernancePolicyBinding(document.bindings, {
+      agentId: agent.id,
+      role: agent.role,
+      adapterType: agent.adapterType,
+    });
+    if (!binding || binding.effect === "exclude") return null;
+    return {
+      policyId: revision.policyId,
+      revisionId: revision.id,
+      revision: revision.revision,
+      sha256: revision.sha256,
+      body: revision.body,
+      bindingId: binding.id,
+      delivery: binding.delivery,
+    };
+  }
+
+  async function replace(input: {
+    companyId: string;
+    expectedRevision: number;
+    policy: GovernancePolicyDocument;
+    activity: Omit<LogActivityInput, "companyId" | "action" | "entityType" | "entityId" | "details">;
+  }) {
+    return db.transaction(async (tx) => {
+      const policy = governancePolicyDocumentSchema.parse(input.policy);
+      const existing = await tx.select().from(companyGovernancePolicies)
+        .where(eq(companyGovernancePolicies.companyId, input.companyId)).then((rows) => rows[0] ?? null);
+      const current = existing?.activeRevisionId
+        ? await tx.select().from(companyGovernancePolicyRevisions)
+          .where(eq(companyGovernancePolicyRevisions.id, existing.activeRevisionId)).then((rows) => rows[0] ?? null)
+        : null;
+      const currentRevision = current?.revision ?? 0;
+      if (currentRevision !== input.expectedRevision) {
+        throw conflict("Governance policy revision is stale", {
+          code: "governance_policy_revision_conflict", expectedRevision: input.expectedRevision, currentRevision,
+        });
+      }
+      const policyId = existing?.id ?? randomUUID();
+      if (!existing) await tx.insert(companyGovernancePolicies).values({ id: policyId, companyId: input.companyId });
+      const [revision] = await tx.insert(companyGovernancePolicyRevisions).values({
+        companyId: input.companyId,
+        policyId,
+        revision: currentRevision + 1,
+        schemaVersion: policy.schemaVersion,
+        body: policy.body,
+        bindings: policy.bindings,
+        sha256: policyHash(policy),
+        createdByAgentId: input.activity.agentId ?? null,
+        createdByUserId: input.activity.actorType === "user" ? input.activity.actorId : null,
+      }).returning();
+      await tx.update(companyGovernancePolicies).set({ activeRevisionId: revision!.id, updatedAt: new Date() })
+        .where(eq(companyGovernancePolicies.id, policyId));
+      await logActivity(tx as unknown as Db, {
+        ...input.activity,
+        companyId: input.companyId,
+        action: "company.governance_policy_replaced",
+        entityType: "company_governance_policy",
+        entityId: policyId,
+        details: { revision: revision!.revision, sha256: revision!.sha256, bindingCount: policy.bindings.length },
+      });
+      return revision!;
+    });
+  }
+
+  async function ensureDefault(companyId: string) {
+    const current = await active(companyId);
+    if (current) return current;
+    try {
+      return await replace({
+        companyId,
+        expectedRevision: 0,
+        policy: DEFAULT_COMPANY_GOVERNANCE_POLICY,
+        activity: { actorType: "system", actorId: "system", agentId: null, runId: null },
+      });
+    } catch (error) {
+      // A concurrent creator won the revision-0 CAS. Return its immutable
+      // revision rather than replacing a board-provided policy.
+      if (error && typeof error === "object" && (error as { status?: number }).status === 409) {
+        const concurrent = await active(companyId);
+        if (concurrent) return concurrent;
+      }
+      throw error;
+    }
+  }
+
+  return { get, replace, ensureDefault, resolveForHeartbeat };
+}

--- a/server/src/services/company-governance-policy.ts
+++ b/server/src/services/company-governance-policy.ts
@@ -93,7 +93,7 @@ export function resolveGovernancePolicyBinding(
     .sort((left, right) => left.priority - right.priority || left.id.localeCompare(right.id))
     .find((binding) => {
       if (!binding.scopes.includes("heartbeat")) return false;
-      if (binding.adapterTypes && (!target.adapterType || !binding.adapterTypes.includes(target.adapterType))) return false;
+      if (binding.adapterTypes && (!target.adapterType || !(binding.adapterTypes as string[]).includes(target.adapterType))) return false;
       if (binding.subject.type === "all_agents") return true;
       if (binding.subject.type === "agents") return binding.subject.agentIds.includes(target.agentId);
       return roleMatches(target.role, binding.subject.roles);
@@ -149,7 +149,11 @@ export function companyGovernancePolicyService(db: Db) {
       adapterType: agents.adapterType,
     }).from(agents).where(eq(agents.companyId, companyId));
     const targets = companyAgents.map((agent) => {
-      const binding = resolveGovernancePolicyBinding(document.bindings, agent);
+      const binding = resolveGovernancePolicyBinding(document.bindings, {
+        agentId: agent.id,
+        role: agent.role,
+        adapterType: agent.adapterType,
+      });
       const included = Boolean(binding && binding.effect === "include");
       return {
         agentId: agent.id,

--- a/server/src/services/company-governance-policy.ts
+++ b/server/src/services/company-governance-policy.ts
@@ -55,7 +55,7 @@ export const DEFAULT_COMPANY_GOVERNANCE_POLICY: GovernancePolicyDocument = {
     effect: "include",
     subject: { type: "all_agents" },
     scopes: ["heartbeat"],
-    adapterTypes: ["codex_local"],
+    adapterTypes: ["codex_local", "paperclip_runner"],
     delivery: "required",
   }],
 };
@@ -120,11 +120,11 @@ function policyHash(policy: GovernancePolicyDocument): string {
 }
 
 export function companyGovernancePolicyService(db: Db) {
-  async function active(companyId: string) {
-    const policy = await db.select().from(companyGovernancePolicies)
+  async function active(companyId: string, database: Db = db) {
+    const policy = await database.select().from(companyGovernancePolicies)
       .where(eq(companyGovernancePolicies.companyId, companyId)).then((rows) => rows[0] ?? null);
     if (!policy?.activeRevisionId) return null;
-    return db.select().from(companyGovernancePolicyRevisions)
+    return database.select().from(companyGovernancePolicyRevisions)
       .where(and(
         eq(companyGovernancePolicyRevisions.companyId, companyId),
         eq(companyGovernancePolicyRevisions.id, policy.activeRevisionId),
@@ -202,16 +202,33 @@ export function companyGovernancePolicyService(db: Db) {
     };
   }
 
-  async function replace(input: {
+  type ReplaceInput = {
     companyId: string;
     expectedRevision: number;
     policy: GovernancePolicyDocument;
     activity: Omit<LogActivityInput, "companyId" | "action" | "entityType" | "entityId" | "details">;
-  }) {
-    return db.transaction(async (tx) => {
+  };
+
+  /**
+   * The policy pointer is the CAS lock.  Locking it before reading the active
+   * revision makes two PUTs with the same expected revision serialize: one
+   * creates the immutable revision and the other observes a typed 409 instead
+   * of losing to the unique revision index with a 500.
+   */
+  async function replaceInTransaction(tx: Db, input: ReplaceInput) {
       const policy = governancePolicyDocumentSchema.parse(input.policy);
-      const existing = await tx.select().from(companyGovernancePolicies)
-        .where(eq(companyGovernancePolicies.companyId, input.companyId)).then((rows) => rows[0] ?? null);
+      let existing = await tx.select().from(companyGovernancePolicies)
+        .where(eq(companyGovernancePolicies.companyId, input.companyId)).for("update")
+        .then((rows) => rows[0] ?? null);
+      if (!existing) {
+        await tx.insert(companyGovernancePolicies)
+          .values({ id: randomUUID(), companyId: input.companyId })
+          .onConflictDoNothing({ target: companyGovernancePolicies.companyId });
+        existing = await tx.select().from(companyGovernancePolicies)
+          .where(eq(companyGovernancePolicies.companyId, input.companyId)).for("update")
+          .then((rows) => rows[0] ?? null);
+      }
+      if (!existing) throw new Error("governance_policy_pointer_unavailable");
       const current = existing?.activeRevisionId
         ? await tx.select().from(companyGovernancePolicyRevisions)
           .where(eq(companyGovernancePolicyRevisions.id, existing.activeRevisionId)).then((rows) => rows[0] ?? null)
@@ -222,8 +239,7 @@ export function companyGovernancePolicyService(db: Db) {
           code: "governance_policy_revision_conflict", expectedRevision: input.expectedRevision, currentRevision,
         });
       }
-      const policyId = existing?.id ?? randomUUID();
-      if (!existing) await tx.insert(companyGovernancePolicies).values({ id: policyId, companyId: input.companyId });
+      const policyId = existing.id;
       const [revision] = await tx.insert(companyGovernancePolicyRevisions).values({
         companyId: input.companyId,
         policyId,
@@ -246,14 +262,43 @@ export function companyGovernancePolicyService(db: Db) {
         details: { revision: revision!.revision, sha256: revision!.sha256, bindingCount: policy.bindings.length },
       });
       return revision!;
+  }
+
+  async function replace(input: ReplaceInput) {
+    return db.transaction((tx) => replaceInTransaction(tx as unknown as Db, input));
+  }
+
+  async function restore(input: {
+    companyId: string;
+    revisionId: string;
+    expectedRevision: number;
+    activity: ReplaceInput["activity"];
+  }) {
+    const source = await db.select().from(companyGovernancePolicyRevisions)
+      .where(and(
+        eq(companyGovernancePolicyRevisions.companyId, input.companyId),
+        eq(companyGovernancePolicyRevisions.id, input.revisionId),
+      )).then((rows) => rows[0] ?? null);
+    if (!source) throw notFound("Governance policy revision not found");
+    // Restore is deliberately a replacement, never a pointer rewind: this
+    // writes a new immutable revision and preserves the full audit history.
+    return replace({
+      companyId: input.companyId,
+      expectedRevision: input.expectedRevision,
+      policy: governancePolicyDocumentSchema.parse({
+        schemaVersion: source.schemaVersion,
+        body: source.body,
+        bindings: source.bindings,
+      }),
+      activity: input.activity,
     });
   }
 
-  async function ensureDefault(companyId: string) {
-    const current = await active(companyId);
+  async function ensureDefaultInTransaction(tx: Db, companyId: string) {
+    const current = await active(companyId, tx);
     if (current) return current;
     try {
-      return await replace({
+      return await replaceInTransaction(tx, {
         companyId,
         expectedRevision: 0,
         policy: DEFAULT_COMPANY_GOVERNANCE_POLICY,
@@ -263,12 +308,16 @@ export function companyGovernancePolicyService(db: Db) {
       // A concurrent creator won the revision-0 CAS. Return its immutable
       // revision rather than replacing a board-provided policy.
       if (error && typeof error === "object" && (error as { status?: number }).status === 409) {
-        const concurrent = await active(companyId);
+        const concurrent = await active(companyId, tx);
         if (concurrent) return concurrent;
       }
       throw error;
     }
   }
 
-  return { get, replace, ensureDefault, resolveForHeartbeat };
+  async function ensureDefault(companyId: string) {
+    return db.transaction((tx) => ensureDefaultInTransaction(tx as unknown as Db, companyId));
+  }
+
+  return { get, replace, restore, ensureDefault, ensureDefaultInTransaction, resolveForHeartbeat };
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16216,7 +16216,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           });
         };
         const adapterContext = { ...context };
-        const governancePolicy = await companyGovernancePolicyService(db).resolveForHeartbeat(agent.companyId, agent.id);
+        const governancePolicies = companyGovernancePolicyService(db);
+        const governanceReadback = await governancePolicies.get(agent.companyId);
+        const governancePolicy = await governancePolicies.resolveForHeartbeat(agent.companyId, agent.id);
+        if (!governanceReadback.active && ["codex_local", "paperclip_runner"].includes(agent.adapterType ?? "")) {
+          throw new HttpError(422, "Required governance policy is missing", {
+            code: "governance_policy_required_missing",
+          });
+        }
         if (governancePolicy) {
           // The snapshot is deliberately independent of the managed role bundle.
           // It is stored before invocation and the adapter receives the exact body
@@ -16228,7 +16235,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             sha256: governancePolicy.sha256,
             bindingId: governancePolicy.bindingId,
             delivery: governancePolicy.delivery,
-            channel: agent.adapterType === "codex_local" ? "developer_instructions" : "unsupported",
+            channel: agent.adapterType === "codex_local"
+              ? "developer_instructions"
+              : agent.adapterType === "paperclip_runner"
+              ? "app_server_base_instructions"
+              : "unsupported",
             precedence: GOVERNANCE_POLICY_PRECEDENCE,
           };
           // Keep durable evidence in the canonical run context. The adapter gets
@@ -16240,7 +16251,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             contextSnapshot: context,
             updatedAt: new Date(),
           }).where(eq(heartbeatRuns.id, run.id));
-          if (governancePolicy.delivery === "required" && agent.adapterType !== "codex_local") {
+          if (governancePolicy.delivery === "required" && !["codex_local", "paperclip_runner"].includes(agent.adapterType ?? "")) {
             throw new HttpError(422, "Required governance policy delivery is unsupported by this adapter", {
               code: "governance_policy_unsupported_delivery",
             });
@@ -16286,6 +16297,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             cwd: executionWorkspace.cwd,
             prompt,
             model: readNonEmptyString(runtimeConfig.model),
+            developerInstructions: governancePolicy?.body ?? "",
             resumeProviderSessionId: runtimeSessionIdForAdapter,
             completionContract: native.completionContract,
             timeoutMs,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -105,6 +105,7 @@ import { costService } from "./costs.js";
 import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
+import { companyGovernancePolicyService, GOVERNANCE_POLICY_PRECEDENCE } from "./company-governance-policy.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService, type MissingRuntimeBinding } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
@@ -16214,6 +16215,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             startedAt: meta.startedAt,
           });
         };
+        const adapterContext = { ...context };
+        const governancePolicy = await companyGovernancePolicyService(db).resolveForHeartbeat(agent.companyId, agent.id);
+        if (governancePolicy) {
+          // The snapshot is deliberately independent of the managed role bundle.
+          // It is stored before invocation and the adapter receives the exact body
+          // with the revision/hash that operators can read back later.
+          const governanceEvidence = {
+            policyId: governancePolicy.policyId,
+            revisionId: governancePolicy.revisionId,
+            revision: governancePolicy.revision,
+            sha256: governancePolicy.sha256,
+            bindingId: governancePolicy.bindingId,
+            delivery: governancePolicy.delivery,
+            channel: agent.adapterType === "codex_local" ? "developer_instructions" : "unsupported",
+            precedence: GOVERNANCE_POLICY_PRECEDENCE,
+          };
+          // Keep durable evidence in the canonical run context. The adapter gets
+          // the full body below, while later lifecycle writes retain only this
+          // immutable revision metadata.
+          context.companyGovernancePolicy = governanceEvidence;
+          adapterContext.companyGovernancePolicy = governancePolicy;
+          await db.update(heartbeatRuns).set({
+            contextSnapshot: context,
+            updatedAt: new Date(),
+          }).where(eq(heartbeatRuns.id, run.id));
+          if (governancePolicy.delivery === "required" && agent.adapterType !== "codex_local") {
+            throw new HttpError(422, "Required governance policy delivery is unsupported by this adapter", {
+              code: "governance_policy_unsupported_delivery",
+            });
+          }
+        }
         if (runtimeResolution.kind === "native") {
           if (!issueRef) throw new Error("paperclip_runner_issue_required");
           const native = await prepareNativeHeartbeatRun({
@@ -16262,7 +16294,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             onSpawn,
           });
         } else {
-          const adapterContext = { ...context };
           const runtimeMcpServers = await buildPaperclipRuntimeMcpServers({
             db,
             agent,

--- a/server/src/services/native-runtime/native-codex-runner.integration.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner.integration.test.ts
@@ -188,6 +188,7 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
       cwd: tmpdir(),
       prompt: "Complete the fake native Codex turn.",
       model: "test-model",
+      developerInstructions: "# Company policy\nNative delivery is required.",
       resumeProviderSessionId: null,
       completionContract: native.completionContract,
       timeoutMs: 30_000,
@@ -201,6 +202,8 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
           resolve(runtimeRoot, "fake-codex-state.json"),
           "--call-log",
           resolve(runtimeRoot, "fake-codex-calls.log"),
+          "--thread-params-log",
+          resolve(runtimeRoot, "fake-codex-thread-params.log"),
         ],
         providerVersion: "fake-codex-v1",
       },
@@ -301,6 +304,7 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
       cwd: tmpdir(),
       prompt: "Continue the fake native Codex session.",
       model: "test-model",
+      developerInstructions: "# Company policy\nNative delivery is required.",
       resumeProviderSessionId: "codex-thread-1",
       completionContract: resumedNative.completionContract,
       timeoutMs: 30_000,
@@ -314,6 +318,8 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
           resolve(runtimeRoot, "fake-codex-state.json"),
           "--call-log",
           resolve(runtimeRoot, "fake-codex-calls.log"),
+          "--thread-params-log",
+          resolve(runtimeRoot, "fake-codex-thread-params.log"),
         ],
         providerVersion: "fake-codex-v1",
       },
@@ -332,5 +338,11 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
     );
     expect(providerCalls.match(/^thread\/start$/gm)).toHaveLength(1);
     expect(providerCalls.match(/^thread\/resume$/gm)).toHaveLength(1);
+    const threadParams = (await readFile(resolve(runtimeRoot, "fake-codex-thread-params.log"), "utf8"))
+      .trim().split("\n").map((line) => JSON.parse(line) as { baseInstructions?: string });
+    expect(threadParams).toEqual([
+      expect.objectContaining({ baseInstructions: "# Company policy\nNative delivery is required." }),
+      expect.objectContaining({ baseInstructions: "# Company policy\nNative delivery is required." }),
+    ]);
   }, 60_000);
 });

--- a/server/src/services/native-runtime/native-codex-runner.ts
+++ b/server/src/services/native-runtime/native-codex-runner.ts
@@ -143,6 +143,8 @@ export async function executeNativeCodexRunner(input: {
   cwd: string;
   prompt: string;
   model: string | null;
+  /** Delivered as Codex app-server baseInstructions for fresh and resumed threads. */
+  developerInstructions: string;
   resumeProviderSessionId: string | null;
   completionContract: { revision: string; criterionIds: string[] };
   timeoutMs: number;
@@ -203,7 +205,7 @@ export async function executeNativeCodexRunner(input: {
       ...(input.resumeProviderSessionId
         ? { providerSessionId: input.resumeProviderSessionId }
         : {}),
-      instructions: "",
+      instructions: input.developerInstructions,
       approvalPolicy: "never",
     },
     completionContract: input.completionContract,

--- a/ui/src/api/companyGovernancePolicy.ts
+++ b/ui/src/api/companyGovernancePolicy.ts
@@ -5,12 +5,16 @@ export type CompanyGovernancePolicyReadback = {
     id: string;
     revision: number;
     sha256: string;
+    body: string;
+    bindings: Array<Record<string, unknown>>;
     createdAt: string;
   } | null;
   history: Array<{
     id: string;
     revision: number;
     sha256: string;
+    body: string;
+    bindings: Array<Record<string, unknown>>;
     createdAt: string;
   }>;
   targets: Array<{
@@ -29,5 +33,10 @@ export const companyGovernancePolicyApi = {
   get: (companyId: string) =>
     api.get<CompanyGovernancePolicyReadback>(
       `/companies/${encodeURIComponent(companyId)}/governance-policy`,
+    ),
+  restore: (companyId: string, revisionId: string, expectedRevision: number) =>
+    api.post<CompanyGovernancePolicyReadback["active"]>(
+      `/companies/${encodeURIComponent(companyId)}/governance-policy/revisions/${encodeURIComponent(revisionId)}/restore`,
+      { expectedRevision },
     ),
 };

--- a/ui/src/api/companyGovernancePolicy.ts
+++ b/ui/src/api/companyGovernancePolicy.ts
@@ -1,0 +1,33 @@
+import { api } from "./client";
+
+export type CompanyGovernancePolicyReadback = {
+  active: {
+    id: string;
+    revision: number;
+    sha256: string;
+    createdAt: string;
+  } | null;
+  history: Array<{
+    id: string;
+    revision: number;
+    sha256: string;
+    createdAt: string;
+  }>;
+  targets: Array<{
+    agentId: string;
+    name: string;
+    role: string | null;
+    adapterType: string | null;
+    bindingId: string | null;
+    delivery: "required" | "best_effort" | null;
+    included: boolean;
+  }>;
+  drift: { detected: boolean; reason: "sha256_mismatch" | null } | null;
+};
+
+export const companyGovernancePolicyApi = {
+  get: (companyId: string) =>
+    api.get<CompanyGovernancePolicyReadback>(
+      `/companies/${encodeURIComponent(companyId)}/governance-policy`,
+    ),
+};

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -157,6 +157,9 @@ export const queryKeys = {
   builtInAgents: {
     list: (companyId: string) => ["built-in-agents", companyId] as const,
   },
+  companyGovernancePolicy: {
+    detail: (companyId: string) => ["company-governance-policy", companyId] as const,
+  },
   summarySlots: {
     detail: (companyId: string, scopeKind: string, slotKey: string, scopeId?: string | null) =>
       ["summary-slots", companyId, scopeKind, slotKey, scopeId ?? null] as const,

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -53,6 +53,16 @@ export function CompanySettings() {
     queryFn: () => companyGovernancePolicyApi.get(selectedCompanyId!),
     enabled: Boolean(selectedCompanyId),
   });
+  const restoreGovernancePolicyMutation = useMutation({
+    mutationFn: (revisionId: string) => companyGovernancePolicyApi.restore(
+      selectedCompanyId!,
+      revisionId,
+      governancePolicyQuery.data?.active?.revision ?? 0,
+    ),
+    onSuccess: () => queryClient.invalidateQueries({
+      queryKey: queryKeys.companyGovernancePolicy.detail(selectedCompanyId ?? ""),
+    }),
+  });
 
   // Sync local state from selected company
   useEffect(() => {
@@ -445,6 +455,35 @@ export function CompanySettings() {
                   </li>
                 ))}
               </ul>
+              <details className="rounded border border-border p-2 text-xs">
+                <summary className="cursor-pointer font-medium">Active body and ordered bindings</summary>
+                <pre className="mt-2 whitespace-pre-wrap font-mono text-xs">{governancePolicyQuery.data.active.body}</pre>
+                <ol className="mt-2 list-decimal pl-4">
+                  {governancePolicyQuery.data.active.bindings.map((binding, index) => (
+                    <li key={`${index}-${JSON.stringify(binding)}`}><code>{JSON.stringify(binding)}</code></li>
+                  ))}
+                </ol>
+              </details>
+              <div className="space-y-1 text-xs">
+                <span className="font-medium">Revision history</span>
+                {governancePolicyQuery.data.history.map((revision) => (
+                  <div key={revision.id} className="flex items-center justify-between gap-2">
+                    <span>v{revision.revision} · {revision.sha256.slice(0, 12)}</span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={revision.id === governancePolicyQuery.data.active.id || restoreGovernancePolicyMutation.isPending}
+                      onClick={() => restoreGovernancePolicyMutation.mutate(revision.id)}
+                    >
+                      Restore as new revision
+                    </Button>
+                  </div>
+                ))}
+                {restoreGovernancePolicyMutation.isError ? (
+                  <span className="text-destructive">Restore failed. Refresh and retry from the current revision.</span>
+                ) : null}
+              </div>
             </>
           ) : (
             <span className="text-muted-foreground">No company policy overlay is configured.</span>

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES,
   MAX_COMPANY_ATTACHMENT_MAX_BYTES,
@@ -9,6 +9,7 @@ import {
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { companiesApi } from "../api/companies";
+import { companyGovernancePolicyApi } from "../api/companyGovernancePolicy";
 import { assetsApi } from "../api/assets";
 import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
@@ -47,6 +48,11 @@ export function CompanySettings() {
   const [logoUrl, setLogoUrl] = useState("");
   const [logoUploadError, setLogoUploadError] = useState<string | null>(null);
   const [governance, setGovernance] = useState<InteractionResolverGovernance>({});
+  const governancePolicyQuery = useQuery({
+    queryKey: queryKeys.companyGovernancePolicy.detail(selectedCompanyId ?? ""),
+    queryFn: () => companyGovernancePolicyApi.get(selectedCompanyId!),
+    enabled: Boolean(selectedCompanyId),
+  });
 
   // Sync local state from selected company
   useEffect(() => {
@@ -406,6 +412,45 @@ export function CompanySettings() {
       />
 
       <InstanceGeneralSettings embedded />
+
+      <div className="space-y-4" data-testid="company-governance-policy-readback">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Company policy overlay
+        </div>
+        <div className="space-y-2 rounded-md border border-border px-4 py-3 text-sm">
+          {governancePolicyQuery.isLoading ? (
+            <span className="text-muted-foreground">Loading policy readback…</span>
+          ) : governancePolicyQuery.isError ? (
+            <span className="text-destructive">Unable to load policy readback.</span>
+          ) : governancePolicyQuery.data?.active ? (
+            <>
+              <p>
+                Active revision <span className="font-medium">{governancePolicyQuery.data.active.revision}</span>
+                {" · SHA-256 "}<code className="text-xs">{governancePolicyQuery.data.active.sha256}</code>
+              </p>
+              <p className={governancePolicyQuery.data.drift?.detected ? "text-destructive" : "text-muted-foreground"}>
+                {governancePolicyQuery.data.drift?.detected
+                  ? "Drift detected: stored policy body does not match its revision hash."
+                  : `No drift. ${governancePolicyQuery.data.targets.filter((target) => target.included).length} agent target(s) receive this overlay.`}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Delivery precedence: company policy → role instructions → task context → skills.
+              </p>
+              <ul className="space-y-1 text-xs text-muted-foreground">
+                {governancePolicyQuery.data.targets.map((target) => (
+                  <li key={target.agentId}>
+                    {target.name} ({target.role ?? "no role"}): {target.included
+                      ? `${target.delivery} via ${target.bindingId}`
+                      : "not targeted"}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <span className="text-muted-foreground">No company policy overlay is configured.</span>
+          )}
+        </div>
+      </div>
 
       {/* Danger Zone */}
       <div className="space-y-4">

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -473,7 +473,7 @@ export function CompanySettings() {
                       type="button"
                       variant="outline"
                       size="sm"
-                      disabled={revision.id === governancePolicyQuery.data.active.id || restoreGovernancePolicyMutation.isPending}
+                      disabled={revision.id === governancePolicyQuery.data?.active?.id || restoreGovernancePolicyMutation.isPending}
                       onClick={() => restoreGovernancePolicyMutation.mutate(revision.id)}
                     >
                       Restore as new revision


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents that perform work.
> - Heartbeats start agent work through local or native Codex runtimes.
> - Company governance policy constrains that work independently of role files.
> - The first implementation saved policy evidence but did not deliver it to native Codex app-server.
> - It also allowed a policy seed or CAS write to race.
> - This pull request makes policy delivery and policy storage fail closed.
> - The result is a board-visible and revisioned policy contract for both runtimes.

## Linked Issues or Issue Description

**What happened?**

Native Codex runs opened app-server threads with empty base instructions. Concurrent policy writes could return an internal error. Company provisioning could commit a company before its initial required policy existed.

**What did you expect to happen?**

Both fresh and resumed native Codex threads receive the active policy through app-server base instructions. One concurrent CAS write succeeds and the other returns 409. A created company has its initial policy in the same transaction.

**How can a reviewer verify the change?**

Run the focused server policy route suite and native Codex runner integration suite on Node 24.11 or later. Confirm the fake app-server records the same base instructions for `thread/start` and `thread/resume`.

## What Changed

- Send the resolved governance body as native Codex app-server `baseInstructions` for fresh and resumed threads.
- Persist the policy revision, hash, binding, delivery channel, and precedence before invocation.
- Fail closed when a required compatible runtime has no active policy.
- Serialize policy writes with the policy-pointer row lock.
- Seed company and initial policy in one transaction.
- Add board restore that writes a new immutable revision.
- Show active body, ordered bindings, revision history, restore action, and state feedback in Company Settings.
- Add focused regression coverage for CAS, restore history, and native provider payloads.

## Verification

- `git diff --check` passed.
- Focused runtime suites require Node `>=24.11.0`. This workspace has Node `22.23.2` and no dependencies installed, so test collection cannot start here.
- Native integration build also requires Cargo. Cargo is not installed in this workspace.

## Risks

- The migration changes the default binding to include `paperclip_runner`.
- A missing policy now stops compatible agent execution with a machine error code.
- The restore action creates a new immutable revision. It does not move the active pointer to an old row.
- UI screenshots still require a supported Node workspace and a running UI. They are not attached from this unsupported environment.

## Model Used

- OpenAI Codex, GPT-5.6 Terra, medium reasoning, tool use and local code execution. Fast mode was disabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
