### PR TITLE
docs(deploy): clarify persisted Tailnet config

### DIFF
--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -88,7 +88,7 @@ Examples:
 ```sh
 pnpm paperclipai onboard --yes
 npx paperclipai onboard --yes --bind lan
-npx paperclipai run --bind tailnet
+npx paperclipai configure --section server
 ```
 
 The reachability and authentication choices made during onboarding are saved in the instance `config.json`. A later `paperclipai run` reads that saved configuration, including when a background service starts Paperclip without reachability flags. You do not need to repeat a Tailnet or authenticated/private selection on every start. Use `configure --section server` when you want to reconfigure the saved setting.

--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -91,7 +91,9 @@ npx paperclipai onboard --yes --bind lan
 npx paperclipai run --bind tailnet
 ```
 
-`configure --section server` follows the same interactive behavior.
+The reachability and authentication choices made during onboarding are saved in the instance `config.json`. A later `paperclipai run` reads that saved configuration, including when a background service starts Paperclip without reachability flags. You do not need to repeat a Tailnet or authenticated/private selection on every start. Use a flag again only when you want to override or reconfigure the saved setting.
+
+`configure --section server` follows the same interactive behavior and saves the updated server configuration.
 
 ## 5. Doctor UX Contract
 

--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -91,7 +91,7 @@ npx paperclipai onboard --yes --bind lan
 npx paperclipai run --bind tailnet
 ```
 
-The reachability and authentication choices made during onboarding are saved in the instance `config.json`. A later `paperclipai run` reads that saved configuration, including when a background service starts Paperclip without reachability flags. You do not need to repeat a Tailnet or authenticated/private selection on every start. Use a flag again only when you want to override or reconfigure the saved setting.
+The reachability and authentication choices made during onboarding are saved in the instance `config.json`. A later `paperclipai run` reads that saved configuration, including when a background service starts Paperclip without reachability flags. You do not need to repeat a Tailnet or authenticated/private selection on every start. Use `configure --section server` when you want to reconfigure the saved setting.
 
 `configure --section server` follows the same interactive behavior and saves the updated server configuration.
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip supports local and authenticated deployment modes.
> - Server reachability and authentication settings are configured during onboarding.
> - Paperclip saves these settings in the instance configuration.
> - Later foreground and background starts reuse the saved configuration.
> - The deployment guide did not state this persistence clearly.
> - This pull request documents the saved behavior and supported reconfiguration path.
> - The benefit is clearer Tailnet and managed-service startup guidance.

## Linked Issues or Issue Description

Fixes: #11856

## What Changed

- Clarified that onboarding saves reachability and authentication choices in `config.json`.
- Clarified that later foreground and background starts reuse the saved configuration.
- Clarified that `configure --section server` changes the saved server setting.

## Verification

- Compared the documentation against current onboarding and server configuration behavior.
- Corrected the misleading `run --bind` guidance identified during review.
- No executable tests were run because this change only updates documentation.

## Risks

Low risk. This change only updates documentation.

## Model Used

OpenAI GPT-5.6 Sol with reasoning and GitHub tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
