### PR TITLE
fix(heartbeat): recognize routine_execution issues as active routine continuations

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -41,6 +41,7 @@ import {
   plugins,
   projects,
   projectWorkspaces,
+  routines,
   workspaceOperations,
 } from "@paperclipai/db";
 import {
@@ -401,6 +402,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(issueRecoveryActions);
     await db.delete(issueTreeHoldMembers);
     await db.delete(issueTreeHolds);
+    await db.delete(routines);
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(issueComments);
       await db.delete(issueDocuments);
@@ -3725,6 +3727,69 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(activityLog)
       .where(eq(activityLog.entityId, issueId));
     expect(activity.some((event) => event.action === "issue.successful_run_handoff_required")).toBe(true);
+  });
+
+  it("AGE-1766: skips the missing-disposition handoff for a recurring routine_execution issue whose own routine is still active", async () => {
+    const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
+    const routineId = randomUUID();
+
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "Chief of Agents \u2014 board unstick watchdog",
+      assigneeAgentId: agentId,
+      status: "active",
+      // skip_if_active is the whole point: the routine intentionally reuses
+      // this same execution issue in_progress across future 15-min triggers
+      // instead of creating a new one each time.
+      concurrencyPolicy: "skip_if_active",
+    });
+
+    await db
+      .update(issues)
+      .set({ originKind: "routine_execution", originId: routineId })
+      .where(eq(issues.id, issueId));
+
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { runId: string }) => {
+      await db.insert(issueComments).values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: ctx.runId,
+        body: "Swept the board; nothing to unstick. Leaving in_progress per spec for the next 15-min trigger.",
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Swept the board; nothing to unstick. Leaving in_progress per spec for the next 15-min trigger.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+
+    // The synchronous, durable side effect of the missing-disposition handoff
+    // firing is this activity-log entry, written in the same post-run pipeline
+    // step that computes the decision. Poll for it the same way the sibling
+    // "queues one finish-handoff wake" test polls for the wakeup row, since the
+    // activity write lands slightly after the source run itself reaches a
+    // terminal status.
+    await waitForHeartbeatIdle(db, 5_000);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity.some((event) => event.action === "issue.successful_run_handoff_required")).toBe(false);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
   });
 
   it("requeues a missing-disposition handoff when the previous corrective wake was cancelled", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9431,6 +9431,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         monitorNextCheckAt: issues.monitorNextCheckAt,
         projectId: issues.projectId,
         originKind: issues.originKind,
+        originId: issues.originId,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -9602,10 +9603,31 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .select({ id: routines.id })
           .from(routines)
           .where(
-            and(
-              eq(routines.companyId, issue.companyId),
-              eq(routines.parentIssueId, issue.id),
-              eq(routines.status, "active"),
+            or(
+              // A routine explicitly anchored to this issue as its static parent container.
+              and(
+                eq(routines.companyId, issue.companyId),
+                eq(routines.parentIssueId, issue.id),
+                eq(routines.status, "active"),
+              ),
+              // AGE-1766: this issue IS a routine_execution instance, and its own
+              // origin routine is still active with a concurrency policy
+              // (coalesce_if_active/skip_if_active) that intentionally reuses this
+              // same execution issue across future triggers instead of creating a
+              // new one. Without this branch, every recurring routine execution
+              // issue that finishes and (by design) stays in_progress waiting for
+              // its next scheduled trigger falsely tripped the missing-disposition
+              // handoff, because `routines.parentIssueId` only ever matches a
+              // routine's configured parent container issue, never the per-firing
+              // execution issue id.
+              issue.originKind === "routine_execution" && issue.originId
+                ? and(
+                  eq(routines.companyId, issue.companyId),
+                  eq(routines.id, issue.originId),
+                  eq(routines.status, "active"),
+                  notInArray(routines.concurrencyPolicy, ["always_enqueue"]),
+                )
+                : sql`false`,
             ),
           )
           .limit(1)


### PR DESCRIPTION
## Problem
The missing-disposition liveness check (`successful_run_missing_state`, aka `missing_disposition`) is supposed to skip recurring routine execution issues via `hasActiveRoutineContinuation`, but the underlying query in `handleSuccessfulRunHandoff` only matched routines whose `parentIssueId` equals the current issue's id:

```ts
eq(routines.parentIssueId, issue.id)
```

`routines.parentIssueId` is a routine's optional *static parent container* issue, set once at routine creation — it is never the id of the per-firing execution issue created each time the routine fires (`originKind = "routine_execution"`, `originId = <routine id>`).

Every routine with `concurrencyPolicy = skip_if_active` / `coalesce_if_active` intentionally leaves its execution issue `in_progress` between scheduled triggers, so the next trigger finds it active and skips creating a duplicate. Because that pattern never satisfies the old query, every such routine tripped a false-positive missing-disposition handoff on every successful run, forcing a human to manually re-comment/unstick the same recurring ticket. Observed 4x in a row on one "Chief of Agents — board unstick watchdog" routine.

## Fix
Also treat the issue as covered by an active routine continuation when the issue is itself a `routine_execution` instance whose origin routine is still `active` and not using `always_enqueue` (i.e. the routine is designed to reuse this same issue rather than spawn a new one each time).

## Tests
Added an integration test in `heartbeat-process-recovery.test.ts` that:
- seeds a routine with `concurrencyPolicy: "skip_if_active"` and links the issue to it via `originKind`/`originId`,
- runs a successful adapter execution that posts a comment but leaves the issue `in_progress`,
- asserts no `issue.successful_run_handoff_required` activity is recorded.

Verified the test fails (reproduces the bug) with the query reverted to the old `parentIssueId`-only check, and passes with the fix. Full `heartbeat-process-recovery.test.ts` suite: 112/112 passing.