### PR TITLE
fix(recovery): classify ACPX quota failures

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -36,6 +36,7 @@ import {
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
+const ACPX_QUOTA_SUMMARY_TEST_ADAPTER = "acpx_quota_summary_test";
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -89,6 +90,27 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         testedAt: new Date().toISOString(),
       }),
     });
+    registerServerAdapter({
+      type: ACPX_QUOTA_SUMMARY_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "Internal error",
+        errorCode: "acpx_turn_failed",
+        resultJson: {
+          status: "failed",
+          stopReason: "adapter_failed",
+        },
+        summary: "You've hit your usage limit.",
+      }),
+      testEnvironment: async () => ({
+        adapterType: ACPX_QUOTA_SUMMARY_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
   }, 20_000);
 
   afterEach(async () => {
@@ -104,6 +126,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
   afterAll(async () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
+    unregisterServerAdapter(ACPX_QUOTA_SUMMARY_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
 
@@ -281,6 +304,89 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       "2030-04-22T21:00:00.000Z",
     );
     expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.codexTransientFallbackMode ?? null).toBeNull();
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ status: agents.status, errorReason: agents.errorReason })
+            .from(agents)
+            .where(eq(agents.id, agentId))
+            .then((rows) => rows[0] ?? null),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toEqual({ status: "idle", errorReason: null });
+  });
+
+  it("normalizes ACPX usage-limit summaries before scheduling the bounded quota retry", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ACPX Quota Test",
+      role: "engineer",
+      status: "idle",
+      adapterType: ACPX_QUOTA_SUMMARY_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("provider_quota");
+    expect(failedRun?.resultJson).toMatchObject({
+      errorFamily: "provider_quota",
+      summary: "You've hit your usage limit.",
+    });
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+            .then((rows) => rows.length),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(1);
+
+    const retryRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        scheduledRetryAt: heartbeatRuns.scheduledRetryAt,
+        scheduledRetryReason: heartbeatRuns.scheduledRetryReason,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun?.status).toBe("scheduled_retry");
+    expect(retryRun?.scheduledRetryReason).toBe("transient_failure");
+    expect(retryRun?.scheduledRetryAt?.getTime()).toBeGreaterThan(Date.now());
+    expect(retryRun?.contextSnapshot).toMatchObject({
+      errorFamily: "provider_quota",
+      wakeReason: "transient_failure_retry",
+    });
 
     await expect
       .poll(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -248,7 +248,11 @@ import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
-import { ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS as RECOVERY_ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS, recoveryService } from "./recovery/service.js";
+import {
+  ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS as RECOVERY_ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
+  classifyAdapterFailureForRecovery,
+  recoveryService,
+} from "./recovery/service.js";
 import { collectDispositionRepairSourceState } from "./recovery/disposition-repair.js";
 import {
   buildIssueReviewPathLostIdempotencyKey,
@@ -16466,7 +16470,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               );
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode(latestRun?.errorCode);
-      const runErrorCode =
+      const adapterResultErrorCode =
         outcome === "timed_out"
           ? "timeout"
           : outcome === "cancelled"
@@ -16474,6 +16478,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             : outcome === "failed"
               ? (adapterResult.errorCode ?? recordedResponsibleUserDenialCode ?? "adapter_failed")
               : null;
+      const adapterFailureRecoveryClassification = outcome === "failed"
+        ? classifyAdapterFailureForRecovery({
+            errorCode: adapterResultErrorCode,
+            error: runErrorMessage,
+            resultJson: {
+              ...parseObject(adapterResult.resultJson),
+              ...(adapterResult.summary ? { summary: adapterResult.summary } : {}),
+            },
+          })
+        : null;
+      const runErrorCode = adapterFailureRecoveryClassification?.kind ?? adapterResultErrorCode;
+      const runErrorFamily = adapterFailureRecoveryClassification?.kind ?? adapterResult.errorFamily ?? null;
+      const runRetryNotBefore = adapterFailureRecoveryClassification?.kind === "provider_quota"
+        ? adapterFailureRecoveryClassification.retryAt.toISOString()
+        : adapterResult.retryNotBefore ?? null;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -16541,8 +16560,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 ...parseObject(adapterResult.resultJson),
                 configFreshness: configFreshnessResultMetadata,
               },
-              errorFamily: adapterResult.errorFamily ?? null,
-              retryNotBefore: adapterResult.retryNotBefore ?? null,
+              errorFamily: runErrorFamily,
+              retryNotBefore: runRetryNotBefore,
             }),
             modelProfileApplication,
           ),

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -35,6 +35,25 @@ describe("classifyAdapterFailureForRecovery", () => {
     });
   });
 
+  it("classifies ACPX turn failures from the persisted assistant summary", () => {
+    const now = new Date("2026-08-26T07:00:00.000Z");
+    const classification = classifyAdapterFailureForRecovery({
+      errorCode: "acpx_turn_failed",
+      error: "Internal error",
+      resultJson: {
+        status: "failed",
+        stopReason: "adapter_failed",
+        summary: "You've hit your usage limit. Try again at 8:20 AM.",
+      },
+    }, now);
+
+    expect(classification).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date("2026-08-26T08:20:00.000Z"),
+      parsedResetTime: true,
+    });
+  });
+
   it("treats timezone-less provider reset clocks as UTC", () => {
     const now = new Date("2026-07-15T20:00:00.000Z");
     const classification = classifyAdapterFailureForRecovery({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -470,6 +470,7 @@ export function classifyAdapterFailureForRecovery(
 ): AdapterFailureRecoveryClassification {
   if (
     latestRun.errorCode !== "adapter_failed" &&
+    latestRun.errorCode !== "acpx_turn_failed" &&
     latestRun.errorCode !== "provider_quota" &&
     latestRun.errorCode !== "configuration_incomplete"
   ) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for teams of AI agents.
> - The recovery service classifies provider failures and schedules bounded retries.
> - ACPX reports provider quota failures with the `acpx_turn_failed` error code.
> - The quota message can exist only in the adapter summary.
> - The recovery classifier did not inspect that error code or summary during heartbeat finalization.
> - This pull request normalizes this ACPX failure before retry scheduling.
> - The benefit is that quota failures wait for the provider reset instead of entering generic recovery.

## Linked Issues or Issue Description

Refs: #9634

Refs: #11961

**What happened?**

An ACPX run returned `acpx_turn_failed` with an internal error. Its assistant summary said that the provider usage limit was reached. Paperclip stored a generic adapter failure and did not use the provider quota retry path.

**Expected behavior**

Paperclip must classify the run as `provider_quota`. It must store the reset hint, schedule one bounded retry, and leave the agent idle until the retry is due.

**Steps to reproduce**

1. Run an ACPX adapter when the provider quota is exhausted.
2. Return `acpx_turn_failed` and place the usage-limit message in the adapter summary.
3. Inspect the completed run and its scheduled retry.

**Paperclip version or commit**

`ca02d2463`

**Deployment mode**

Self-hosted server.

## What Changed

- Allow the recovery classifier to inspect `acpx_turn_failed` failures.
- Classify adapter failures during heartbeat finalization with both result JSON and the adapter summary.
- Persist normalized `provider_quota` metadata before the existing bounded retry scheduler runs.
- Add unit and database-backed integration coverage for the ACPX response shape.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/provider-failure-classification.test.ts` — 10 passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-retry-scheduling.test.ts --reporter=verbose` — 31 passed.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.
- `git diff --check` — passed.

## Risks

- Low risk. The new classification applies only to failed runs with a recognized recovery error code and a known quota or configuration message.
- Existing non-quota ACPX failures keep the `acpx_turn_failed` code.
- No schema, telemetry, observability, or run-log event contract changes are included.

## Model Used

OpenAI Codex based on GPT-5. The model used reasoning, repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
