### PR TITLE
fix(auth): reject malformed local authorization

### DIFF
--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -102,6 +102,9 @@ function createApp(db: any, deploymentMode: "authenticated" | "local_trusted" = 
   app.get("/actor", (req, res) => {
     res.json(req.actor);
   });
+  app.post("/actor", (req, res) => {
+    res.json(req.actor);
+  });
   app.get("/companies/:companyId/protected", (req, res) => {
     assertCompanyAccess(req, req.params.companyId);
     res.json({ ok: true });
@@ -184,9 +187,23 @@ describe("agent auth middleware", () => {
     expect(res.body).toMatchObject({ type: "board", userId: "local-board", runId });
   });
 
+  it("keeps header-less local writes as the implicit board actor", async () => {
+    const { db } = createDbState({ agent: { id: randomUUID(), companyId: randomUUID() } });
+
+    const res = await request(createApp(db, "local_trusted"))
+      .post("/actor")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "board", userId: "local-board", source: "local_implicit" });
+  });
+
   it.each([
     ["empty bearer token", "Bearer   ", "Empty bearer token"],
     ["unverified token", "Bearer not-a-token", "Agent token did not verify"],
+    ["Basic authorization", "Basic credentials", "Authorization header must use Bearer credentials"],
+    ["malformed Bearer-like authorization", "BearerXYZ", "Authorization header must use Bearer credentials"],
+    ["whitespace-only authorization", "   ", "Authorization header must use Bearer credentials"],
   ])("rejects %s instead of retaining the implicit local-board actor", async (_label, authorization, error) => {
     const { db } = createDbState({ agent: { id: randomUUID(), companyId: randomUUID() } });
     let commentWrites = 0;
@@ -201,6 +218,17 @@ describe("agent auth middleware", () => {
     expect(res.status).toBe(401);
     expect(res.body.error).toContain(error);
     expect(commentWrites).toBe(0);
+  });
+
+  it("rejects malformed authorization on a local read instead of retaining local-board", async () => {
+    const { db } = createDbState({ agent: { id: randomUUID(), companyId: randomUUID() } });
+
+    const res = await request(createApp(db, "local_trusted"))
+      .get("/actor")
+      .set("Authorization", "Basic credentials");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("Authorization header must use Bearer credentials");
   });
 
   it.each([
@@ -430,6 +458,35 @@ describe("agent auth middleware", () => {
       onBehalfOfUserId: "user-key",
       source: "agent_key",
     });
+  });
+
+  it("uses valid explicit bearer authentication instead of the implicit local-board actor", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const token = "pcp_test_local_trusted_agent_key";
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      agentKey: {
+        id: randomUUID(),
+        agentId,
+        companyId,
+        keyHash: hashToken(token),
+        responsibleUserId: "user-key",
+      },
+    });
+
+    const res = await request(createApp(db, "local_trusted"))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+    });
+    expect(res.body.userId).toBeUndefined();
   });
 
   it("rejects agent keys that lack a responsible user binding and audits the denial", async () => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -223,6 +223,10 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     const authHeader = req.header("authorization");
     const hasBearerCredentials = /^bearer(?:\s|$)/i.test(authHeader ?? "");
     if (!hasBearerCredentials) {
+      if (opts.deploymentMode === "local_trusted" && authHeader !== undefined) {
+        next(unauthorized("Authorization header must use Bearer credentials"));
+        return;
+      }
       if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
         const cloudTenantActor = await resolveCloudTenantActor(db, req);
         if (cloudTenantActor) {


### PR DESCRIPTION
## Thinking Path

> * Paperclip is an open source app for managing AI agents and their work
> * The authentication middleware assigns an actor to each request
> * In `local_trusted` mode, a request without an `Authorization` header can use the implicit `local-board` actor
> * A request with a malformed `Authorization` header could also keep the implicit `local-board` actor
> * This behavior could replace an explicit failed authentication attempt with a different actor identity
> * This pull request rejects a supplied malformed or non-Bearer authorization value
> * The change keeps the existing header-less `local-board` behavior
> * The benefit is more reliable authentication and actor attribution

## Linked Issues or Issue Description

Fixes: #8019

## What Changed

* Reject a supplied non-Bearer `Authorization` header in `local_trusted` mode
* Keep implicit `local-board` access when the `Authorization` header is absent
* Keep the existing handling for empty, invalid, and valid Bearer credentials
* Add regression tests for malformed authorization on read and write requests
* Add tests for header-less local writes and valid explicit agent authentication

## Verification

I ran the affected server tests with Node 24.11.0 in Docker.

```bash
pnpm exec vitest run \
  server/src/__tests__/agent-auth-middleware.test.ts \
  server/src/__tests__/board-mutation-guard.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       30 passed (30)
```

I also ran:

```bash
git diff --check
```

It completed without errors.

## Risks

Low risk.

The change affects only `local_trusted` requests that supply an `Authorization` header that does not use the recognized Bearer form.

Requests without an `Authorization` header still use the existing implicit `local-board` behavior.

Valid Bearer authentication is unchanged.

The `authenticated` deployment mode is unchanged.

## Model Used

OpenAI Codex with Terra high reasoning mode.

The Codex session used repository inspection and code editing tools.

The exact backend model ID and context window were not exposed in the Codex session.

I ran the verification tests separately in Docker with Node 24.11.0.

## Checklist

* [x] I have included a thinking path that traces from project context to this change
* [x] I have specified the model used (with version and capability details)
* [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
* [x] I have searched GitHub for duplicate or related PRs and linked them above
* [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
* [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
* [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
* [x] I have run tests locally and they pass
* [x] I have added or updated tests where applicable
* [ ] I have updated relevant documentation to reflect my changes
* [x] I have considered and documented any risks above
* [ ] All Paperclip CI gates are green
* [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
* [x] I will address all Greptile and reviewer comments before requesting merge
