### PR TITLE
fix: separate aggregate child work from blockers

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -394,6 +394,7 @@ export type IssueBlockerAttentionState = "none" | "covered" | "stalled" | "needs
 
 export type IssueBlockerAttentionReason =
   | "active_child"
+  | "human_owned_child"
   | "active_dependency"
   | "stalled_review"
   | "attention_required"

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -179,6 +179,32 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("does not project a human-owned aggregate child as active execution", async () => {
+    const { companyId } = await createCompany("PBH");
+    const parentId = await insertIssue({ companyId, identifier: "PBH-1", title: "Parent", status: "blocked" });
+    const childId = await insertIssue({
+      companyId,
+      identifier: "PBH-2",
+      title: "Human-owned child",
+      status: "todo",
+      parentId,
+      assigneeUserId: "board-user-1",
+    });
+    await block({ companyId, blockerIssueId: childId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "human_owned_child",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBH-2",
+      blockingTreeLive: false,
+    });
+  });
+
   it("does not let active aggregate child work hide an unattended direct blocker", async () => {
     const { companyId, agentId } = await createCompany("PBA");
     const parentId = await insertIssue({ companyId, identifier: "PBA-1", title: "Parent", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -154,7 +154,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     return runId;
   }
 
-  it("classifies a blocked parent as covered when its child has a running execution path", async () => {
+  it("classifies a blocked aggregate parent as covered when its child has a running execution path without a direct blocker edge", async () => {
     const { companyId, agentId } = await createCompany("PBC");
     const parentId = await insertIssue({ companyId, identifier: "PBC-1", title: "Parent", status: "blocked" });
     const childId = await insertIssue({
@@ -165,7 +165,6 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       parentId,
       assigneeAgentId: agentId,
     });
-    await block({ companyId, blockerIssueId: childId, blockedIssueId: parentId });
     await activeRun({ companyId, agentId, issueId: childId });
 
     const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
@@ -173,10 +172,42 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention).toMatchObject({
       state: "covered",
       reason: "active_child",
-      unresolvedBlockerCount: 1,
+      unresolvedBlockerCount: 0,
       coveredBlockerCount: 1,
       attentionBlockerCount: 0,
       sampleBlockerIdentifier: "PBC-2",
+    });
+  });
+
+  it("does not let active aggregate child work hide an unattended direct blocker", async () => {
+    const { companyId, agentId } = await createCompany("PBA");
+    const parentId = await insertIssue({ companyId, identifier: "PBA-1", title: "Parent", status: "blocked" });
+    const childId = await insertIssue({
+      companyId,
+      identifier: "PBA-2",
+      title: "Running child",
+      status: "todo",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    const directBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBA-3",
+      title: "Unassigned direct blocker",
+      status: "todo",
+    });
+    await block({ companyId, blockerIssueId: directBlockerId, blockedIssueId: parentId });
+    await activeRun({ companyId, agentId, issueId: childId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 0,
+      attentionBlockerCount: 1,
+      sampleBlockerIdentifier: "PBA-3",
     });
   });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2162,6 +2162,20 @@ function appendBlockerAttentionEdges(
   }
 }
 
+function appendBlockerAttentionChildren(
+  childrenByIssueId: Map<string, string[]>,
+  rows: IssueBlockerAttentionQueryRow[],
+) {
+  for (const row of rows) {
+    if (!row.issueId) continue;
+    const existing = childrenByIssueId.get(row.issueId) ?? [];
+    if (!existing.includes(row.blockerIssueId)) {
+      existing.push(row.blockerIssueId);
+      childrenByIssueId.set(row.issueId, existing);
+    }
+  }
+}
+
 type IssueRelationSummaryRow = {
   relatedId: string;
   identifier: string | null;
@@ -2391,6 +2405,7 @@ async function listIssueBlockerAttentionMap(
 
   const nodesById = new Map<string, IssueBlockerAttentionNode>();
   const edgesByIssueId = new Map<string, IssueBlockerAttentionEdge[]>();
+  const childrenByIssueId = new Map<string, string[]>();
   for (const root of roots) nodesById.set(root.id, { ...root });
 
   let frontier = roots.map((root) => root.id);
@@ -2464,10 +2479,8 @@ async function listIssueBlockerAttentionMap(
         ...unresolvedExplicitBlockerRows
           .filter((row): row is IssueBlockerAttentionQueryRow & { issueId: string } => row.issueId !== null)
           .map((row) => ({ issueId: row.issueId, blockerIssueId: row.blockerIssueId })),
-        ...childRows
-          .filter((row): row is IssueBlockerAttentionQueryRow & { issueId: string } => row.issueId !== null)
-          .map((row) => ({ issueId: row.issueId, blockerIssueId: row.blockerIssueId })),
       ]);
+      appendBlockerAttentionChildren(childrenByIssueId, childRows);
 
       for (const row of [...unresolvedExplicitBlockerRows, ...childRows]) {
         if (!row.issueId || nodesById.has(row.blockerIssueId)) continue;
@@ -2821,12 +2834,39 @@ async function listIssueBlockerAttentionMap(
     return null;
   };
 
+  const activeChildrenFor = (issueId: string, seen = new Set<string>()): IssueBlockerAttentionNode[] => {
+    if (seen.has(issueId)) return [];
+    const nextSeen = new Set(seen);
+    nextSeen.add(issueId);
+    const activeChildren: IssueBlockerAttentionNode[] = [];
+    for (const childId of childrenByIssueId.get(issueId) ?? []) {
+      const child = nodesById.get(childId);
+      if (!child || child.companyId !== companyId) continue;
+      if (activeIssueIds.has(child.id)) {
+        activeChildren.push(child);
+        continue;
+      }
+      activeChildren.push(...activeChildrenFor(child.id, nextSeen));
+    }
+    return activeChildren;
+  };
+
   for (const root of roots) {
     const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => {
       const blocker = nodesById.get(edge.blockerIssueId);
       return blocker?.status !== "done" || pendingFinalizeBlockerIssueIds.has(edge.blockerIssueId);
     });
+    const activeChildren = activeChildrenFor(root.id);
     if (topLevelEdges.length === 0) {
+      if (activeChildren.length > 0) {
+        attentionMap.set(root.id, createIssueBlockerAttention({
+          state: "covered",
+          reason: "active_child",
+          coveredBlockerCount: activeChildren.length,
+          sampleBlockerIdentifier: blockerSampleIdentifier(activeChildren[0]),
+        }));
+        continue;
+      }
       attentionMap.set(root.id, createIssueBlockerAttention({
         state: "needs_attention",
         reason: "attention_required",

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2813,8 +2813,7 @@ async function listIssueBlockerAttentionMap(
     if (
       node.status === "in_progress" ||
       activeIssueIds.has(node.id) ||
-      explicitWaitingIssueIds.has(node.id) ||
-      Boolean(node.assigneeUserId)
+      explicitWaitingIssueIds.has(node.id)
     ) return true;
 
     const nextSeen = new Set(seen);
@@ -2911,9 +2910,17 @@ async function listIssueBlockerAttentionMap(
       reason = "stalled_review";
     } else {
       state = "covered";
-      reason = topLevelEdges.every((edge) => nodesById.get(edge.blockerIssueId)?.parentId === root.id)
+      const directChildrenOnly = topLevelEdges.every(
+        (edge) => nodesById.get(edge.blockerIssueId)?.parentId === root.id,
+      );
+      const allDirectChildrenHumanOwned = directChildrenOnly && topLevelEdges.every(
+        (edge) => Boolean(nodesById.get(edge.blockerIssueId)?.assigneeUserId),
+      );
+      reason = activeChildren.length > 0
         ? "active_child"
-        : "active_dependency";
+        : allDirectChildrenHumanOwned
+          ? "human_owned_child"
+          : "active_dependency";
     }
 
     attentionMap.set(root.id, createIssueBlockerAttention({

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -431,6 +431,30 @@ describe("IssueBlockedNotice", () => {
     expect(node.textContent).toContain("A message won’t restart this task yet");
   });
 
+  it("renders aggregate child coverage without telling operators to move the parent back to todo", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        blockerAttention={{
+          state: "covered",
+          reason: "active_child",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 1,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          sampleBlockerIdentifier: "TASK-2",
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+
+    expect(node.querySelector('[data-testid="issue-blocked-notice-active-child"]')).not.toBeNull();
+    expect(node.textContent).toContain("Active sub-task work is in progress");
+    expect(node.textContent).toContain("no direct blocker");
+    expect(node.textContent).not.toContain("moved back to todo");
+  });
+
   it("sorts same-status live-work steps with numeric identifier ordering", () => {
     const node = render(
       <IssueBlockedNotice

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -490,6 +490,30 @@ describe("IssueBlockedNotice", () => {
     expect(node.textContent).not.toContain("Work on this task is blocked by the linked task");
   });
 
+  it("renders human-owned aggregate child coverage without claiming work is in progress", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        blockerAttention={{
+          state: "covered",
+          reason: "human_owned_child",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 1,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          sampleBlockerIdentifier: "TASK-4",
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+
+    expect(node.querySelector('[data-testid="issue-blocked-notice-human-owned-child"]')).not.toBeNull();
+    expect(node.textContent).toContain("Waiting on a human-owned sub-task");
+    expect(node.textContent).toContain("assigned person updates or completes the sub-task");
+    expect(node.textContent).not.toContain("Active sub-task work is in progress");
+  });
+
   it("sorts same-status live-work steps with numeric identifier ordering", () => {
     const node = render(
       <IssueBlockedNotice

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -485,6 +485,8 @@ describe("IssueBlockedNotice", () => {
 
     expect(node.querySelector('[data-testid="issue-blocked-notice-active-child"]')).not.toBeNull();
     expect(node.textContent).toContain("Active sub-task work is in progress");
+    expect(node.textContent).toContain("also has a direct blocker");
+    expect(node.textContent).not.toContain("no direct blocker");
     expect(node.textContent).not.toContain("Work on this task is blocked by the linked task");
   });
 

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -455,6 +455,39 @@ describe("IssueBlockedNotice", () => {
     expect(node.textContent).not.toContain("moved back to todo");
   });
 
+  it("renders aggregate-child coverage when the API retains covered relationship summaries", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[
+          {
+            id: "covered-child-edge",
+            identifier: "TASK-3",
+            title: "Active sub-task",
+            status: "in_progress",
+            priority: "medium",
+            assigneeAgentId: "agent-1",
+            assigneeUserId: null,
+          },
+        ]}
+        blockerAttention={{
+          state: "covered",
+          reason: "active_child",
+          unresolvedBlockerCount: 1,
+          coveredBlockerCount: 1,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          sampleBlockerIdentifier: "TASK-3",
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+
+    expect(node.querySelector('[data-testid="issue-blocked-notice-active-child"]')).not.toBeNull();
+    expect(node.textContent).toContain("Active sub-task work is in progress");
+    expect(node.textContent).not.toContain("Work on this task is blocked by the linked task");
+  });
+
   it("sorts same-status live-work steps with numeric identifier ordering", () => {
     const node = render(
       <IssueBlockedNotice

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -612,6 +612,35 @@ export function IssueBlockedNotice({
     );
   }
 
+  const aggregateChildIsHumanOwned =
+    !showSuccessfulRunHandoff
+    && issueStatus === "blocked"
+    && blockerAttention?.reason === "human_owned_child";
+
+  if (aggregateChildIsHumanOwned) {
+    return (
+      <div
+        data-blocker-attention-state={blockerAttention?.state}
+        data-testid="issue-blocked-notice-human-owned-child"
+        className="mb-3 rounded-md border border-border bg-card px-3 py-2.5 text-sm text-foreground shadow-sm"
+      >
+        <div className="flex items-start gap-2">
+          <span className="mt-1.5 flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>
+            <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+          </span>
+          <div className="min-w-0 space-y-1">
+            <p className="font-medium leading-5">Waiting on a human-owned sub-task</p>
+            <p className="leading-5">
+              {blockers.length === 0
+                ? "This aggregate task has no direct blocker. It remains blocked until the assigned person updates or completes the sub-task."
+                : `This aggregate task also has ${blockers.length === 1 ? "a direct blocker" : `${blockers.length} direct blockers`}.`}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (waitingOnLiveWork) {
     return (
       <WaitingOnLiveWorkNotice

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -602,7 +602,9 @@ export function IssueBlockedNotice({
           <div className="min-w-0 space-y-1">
             <p className="font-medium leading-5">Active sub-task work is in progress</p>
             <p className="leading-5">
-              This aggregate task has no direct blocker. Do not move it back to todo while its sub-task work is active.
+              {blockers.length === 0
+                ? "This aggregate task has no direct blocker. Do not move it back to todo while its sub-task work is active."
+                : `This aggregate task also has ${blockers.length === 1 ? "a direct blocker" : `${blockers.length} direct blockers`}.`}
             </p>
           </div>
         </div>

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -586,19 +586,18 @@ export function IssueBlockedNotice({
   const aggregateChildWorkIsLive =
     !showSuccessfulRunHandoff
     && issueStatus === "blocked"
-    && blockerAttention?.reason === "active_child"
-    && blockers.length === 0;
+    && blockerAttention?.reason === "active_child";
 
   if (aggregateChildWorkIsLive) {
     return (
       <div
         data-blocker-attention-state={blockerAttention?.state}
         data-testid="issue-blocked-notice-active-child"
-        className="mb-3 rounded-md border border-blue-300/70 bg-blue-50/90 px-3 py-2.5 text-sm text-blue-950 shadow-sm dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-100"
+        className="mb-3 rounded-md border border-border bg-card px-3 py-2.5 text-sm text-foreground shadow-sm"
       >
         <div className="flex items-start gap-2">
           <span className="mt-1.5 flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>
-            <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-blue-400" />
+            <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-primary" />
           </span>
           <div className="min-w-0 space-y-1">
             <p className="font-medium leading-5">Active sub-task work is in progress</p>

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -583,6 +583,34 @@ export function IssueBlockedNotice({
     && chainBlockers.length > 0
     && hasLiveWaitingBlocker;
 
+  const aggregateChildWorkIsLive =
+    !showSuccessfulRunHandoff
+    && issueStatus === "blocked"
+    && blockerAttention?.reason === "active_child"
+    && blockers.length === 0;
+
+  if (aggregateChildWorkIsLive) {
+    return (
+      <div
+        data-blocker-attention-state={blockerAttention?.state}
+        data-testid="issue-blocked-notice-active-child"
+        className="mb-3 rounded-md border border-blue-300/70 bg-blue-50/90 px-3 py-2.5 text-sm text-blue-950 shadow-sm dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-100"
+      >
+        <div className="flex items-start gap-2">
+          <span className="mt-1.5 flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>
+            <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-blue-400" />
+          </span>
+          <div className="min-w-0 space-y-1">
+            <p className="font-medium leading-5">Active sub-task work is in progress</p>
+            <p className="leading-5">
+              This aggregate task has no direct blocker. Do not move it back to todo while its sub-task work is active.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (waitingOnLiveWork) {
     return (
       <WaitingOnLiveWorkNotice


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work through issues, direct blocker edges, and liveness projections.
> - Aggregate issues can have active child execution without a direct dependency edge.
> - Treating that hierarchy as a blockerless blocked defect causes false operator remediation prompts.
> - The server now projects this state as `active_child` while preserving real direct blockers.
> - The board notice must honor that authoritative projection even when relationship summaries remain in the response.
> - This PR keeps aggregate-child execution distinct from dependency blocking and makes the UI state consistent with the API.

## Linked Issues or Issue Description

Closes #47

Tracked in WEI-7402 and WEI-7416.

## What Changed

- Separate aggregate child traversal from explicit `blocks` edges in blocker-attention classification.
- Project active child execution as covered `active_child` work without fabricating a direct blocker edge.
- Render the aggregate-child notice for every server-emitted `active_child` shape, including responses that retain covered relationship summaries.
- Use semantic UI tokens for the aggregate-child notice and add a focused regression test.

## Verification

- `pnpm exec vitest run ui/src/components/IssueBlockedNotice.test.tsx` — 11 passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- Original PR verification: focused server blocker-attention tests and server/UI typechecks passed before review; no migration.

## Risks

Low. This is a read-only UI projection change backed by the server reason field; it neither mutates issue relations nor changes persistence. A malformed server response with `active_child` still presents the safe aggregate-child notice rather than encouraging a false status transition.

## Model Used

OpenAI Codex `gpt-5.6-terra`, tool-assisted source review, targeted test execution, and typechecking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes (not needed: no user-facing documentation changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (rerunning after follow-up commit)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (rerunning after follow-up commit)
- [x] I will address all Greptile and reviewer comments before requesting merge
