### PR TITLE
build(docker): fix workspace manifest drift and add a healthcheck

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,22 @@ coverage
 data
 tmp
 *.log
+
+# Host build outputs. The build stage produces its own (ui/dist is what the
+# server serves from at runtime — see server/src/app.ts), and copying a stale
+# host build into the context would shadow the fresh one.
+dist
+**/dist
+ui/storybook-static
+server/ui-dist
+
+# Docs, screenshots and test fixtures are not read at runtime; keeping them out
+# shrinks both the build context and the final image (COPY . . ships the whole
+# tree into the runtime stage).
+docs
+doc
+screenshots
+evals
+report
+releases
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,36 +15,27 @@ RUN usermod -u $USER_UID --non-unique node \
 FROM base AS deps
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
-COPY cli/package.json cli/
-COPY server/package.json server/
-COPY ui/package.json ui/
-COPY packages/shared/package.json packages/shared/
-COPY packages/db/package.json packages/db/
-COPY packages/adapter-utils/package.json packages/adapter-utils/
-COPY packages/google-sheets-mcp-server/package.json packages/google-sheets-mcp-server/
-COPY packages/kv-demo-mcp-server/package.json packages/kv-demo-mcp-server/
-COPY packages/mcp-server/package.json packages/mcp-server/
-COPY packages/paperclip-runner/package.json packages/paperclip-runner/
-COPY packages/skills-catalog/package.json packages/skills-catalog/
-COPY packages/tailscale-https-broker/package.json packages/tailscale-https-broker/
-COPY packages/teams-catalog/package.json packages/teams-catalog/
-COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
-COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
-COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/
-COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
-COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
-COPY packages/adapters/grok-local/package.json packages/adapters/grok-local/
-COPY packages/adapters/kimi-local/package.json packages/adapters/kimi-local/
-COPY packages/adapters/hermes/package.json packages/adapters/hermes/
-COPY packages/adapters/hermes-gateway/package.json packages/adapters/hermes-gateway/
-COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
-COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
-COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
-COPY packages/plugins/sdk/package.json packages/plugins/sdk/
-COPY --parents packages/plugins/sandbox-providers/./*/package.json packages/plugins/sandbox-providers/
-COPY packages/plugins/paperclip-plugin-fake-sandbox/package.json packages/plugins/paperclip-plugin-fake-sandbox/
-COPY packages/plugins/plugin-llm-wiki/package.json packages/plugins/plugin-llm-wiki/
-COPY packages/plugins/plugin-workspace-diff/package.json packages/plugins/plugin-workspace-diff/
+# One glob per workspace root in pnpm-workspace.yaml, instead of a hand-listed
+# COPY per package. The hand-listed form silently drifted from the workspace
+# (packages/plugins/create-paperclip-plugin and the four
+# packages/plugins/examples/* members were in pnpm-lock.yaml but never copied
+# here), which leaves this stage installing a different importer set than the
+# lockfile describes. Globs cannot drift: adding a package to the workspace
+# adds it here automatically.
+#
+# sandbox-providers and plugin-orchestration-smoke-example are deliberately NOT
+# workspace members (see pnpm-workspace.yaml), so pnpm ignores their manifests
+# — but the root postinstall (scripts/link-plugin-dev-sdk.mjs) walks those
+# directories to link the in-repo plugin SDK into them, so their package.json
+# files still have to be present.
+COPY --parents \
+  ./*/package.json \
+  ./packages/*/package.json \
+  ./packages/adapters/*/package.json \
+  ./packages/plugins/*/package.json \
+  ./packages/plugins/examples/*/package.json \
+  ./packages/plugins/sandbox-providers/*/package.json \
+  ./
 COPY patches/ patches/
 COPY scripts/link-plugin-dev-sdk.mjs scripts/
 
@@ -118,6 +109,17 @@ ENV NODE_ENV=production \
   GEMINI_SANDBOX=false
 
 EXPOSE 3100
+
+# GET /api/health needs no auth and answers 200 while the database probe
+# succeeds, 503 on `database_unreachable` — so it distinguishes "process is up"
+# from "actually serving", which is what a rolling deploy has to gate on.
+# 127.0.0.1 is always allowed past the private-hostname guard regardless of
+# PAPERCLIP_ALLOWED_HOSTNAMES, so this never needs updating per deployment.
+# The start period is generous: a first boot applies the bundled migrations
+# (and initialises the embedded cluster when DATABASE_URL is unset) before the
+# listener comes up.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${PORT}/api/health" >/dev/null || exit 1
 
 # tini, not node, is PID 1. The entrypoint ends in `exec`, so without an init
 # node inherits PID 1 and never wait()s the orphans the kernel re-parents onto


### PR DESCRIPTION
The deps stage listed one COPY per workspace package by hand, and that list had drifted from pnpm-workspace.yaml: packages/plugins/create-paperclip-plugin and the four packages/plugins/examples/* members are importers in pnpm-lock.yaml but were never copied, so the stage installed a different importer set than the lockfile describes. Replace the list with one glob per workspace root. Globs cannot drift. The sandbox-provider manifests stay copied: those packages are excluded from the workspace, but the root postinstall (scripts/link-plugin-dev-sdk.mjs) walks their directories to link the in-repo plugin SDK and needs the manifests present.

Add a HEALTHCHECK. Orchestrators that gate a deploy on container health had nothing to read from this image. GET /api/health needs no auth, answers 200 while its database probe succeeds and 503 on database_unreachable, so it separates "the process is up" from "it is serving". 127.0.0.1 always passes the private-hostname guard, so the probe needs no per-deployment configuration. The start period covers a first boot, which applies the bundled migrations before the listener opens.

Ignore host build outputs in the build context. A stale ui/dist from the host was copied in and shadowed the fresh one the build stage produces, which is what the server serves from at runtime. Ignore docs, screenshots and test fixtures too: COPY . . ships the whole tree into the runtime stage. skills/ and skills-releases/ stay in the context because company-skills.ts reads them at runtime.

<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip is the open source app people use to manage AI agents for work
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## Linked Issues or Issue Description

<!--
  Required. Pick ONE of the two paths below.

  (A) Issue exists — replace the placeholder below with your issue links.
      Tag each linked issue with `Fixes: #123`, `Closes #123`, or `Refs #123`.
      Include duplicates and closely related issues too.

  Only reference PUBLIC GitHub issues/PRs here. Do NOT paste internal,
  instance-local Paperclip references — ticket ids like PAPA-123 / PAP-224,
  /PAP/issues/... or agent://... links, or localhost/tailnet URLs. Other
  contributors cannot open them. See CONTRIBUTING.md → "No Internal Issue
  References".

  (B) No issue exists — describe the underlying problem here. Follow the issue
      template that fits your change. Open the matching file and copy its field
      labels into your description:
        • Bug:         .github/ISSUE_TEMPLATE/bug_report.yml
        • Feature:     .github/ISSUE_TEMPLATE/feature_request.yml
        • Adapter:     .github/ISSUE_TEMPLATE/adapter_request.yml
        • Enhancement: .github/ISSUE_TEMPLATE/enhancement.yml
        • Docs:        .github/ISSUE_TEMPLATE/docs_issue.yml
      An automated check reads the literal bold labels AND the content under
      each label. Keep at least three of these labels, each alone on its own
      line, and write real content under each. A label with only the bare "-"
      placeholder does not count, and the check fails.

  See CONTRIBUTING.md → "Link Issues or Describe Them In-PR".
-->

-

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
