### PR TITLE
KOMAA-147 P0 runtime port: provider schema preflight + scoped MCP tool-surface narrowing

### DIFF
--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -140,3 +140,14 @@ Notes:
   runtime config with \`permission.external_directory=allow\` so headless runs do \
   not stall on approval prompts.
 `;
+
+export {
+  resolveOpenCodeMcpToolSurfaceFilter,
+  applyOpenCodeMcpToolSurface,
+} from "./server/runtime-config.js";
+export { validateProviderSchemaContract, ProviderSchemaContractError } from "./server/provider-schema.js";
+export type {
+  OpenCodeRuntimeDiagnostics,
+  OpenCodeMcpToolSurfaceFilter,
+  AppliedOpenCodeMcpToolSurfaceResult,
+} from "./server/runtime-config.js";

--- a/packages/adapters/opencode-local/src/server/provider-schema.test.ts
+++ b/packages/adapters/opencode-local/src/server/provider-schema.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  ProviderSchemaContractError,
+  validateProviderSchemaContract,
+} from "./provider-schema.js";
+
+describe("validateProviderSchemaContract", () => {
+  it("accepts an empty surface", () => {
+    expect(() => validateProviderSchemaContract({ providers: {}, mcp: {} })).not.toThrow();
+    expect(() => validateProviderSchemaContract({})).not.toThrow();
+  });
+
+  it("accepts legal boundary names at exactly the 64-char limit", () => {
+    const atLimit = "a".repeat(64);
+    expect(() =>
+      validateProviderSchemaContract({
+        providers: { [atLimit]: { models: { [atLimit]: {} } } },
+        mcp: { [atLimit]: {} },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a tool/function name of 75 chars with a specific PROVIDER_SCHEMA_CONTRACT error", () => {
+    const tooLong = "a".repeat(75);
+    let caught: unknown;
+    try {
+      validateProviderSchemaContract({
+        providers: {
+          gateway: {
+            tools: [{ name: tooLong, description: "x" }],
+          },
+        },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderSchemaContractError);
+    const error = caught as ProviderSchemaContractError;
+    expect(error.code).toBe("PROVIDER_SCHEMA_CONTRACT");
+    expect(error.tool).toBe(tooLong);
+    expect(error.connection).toBe("gateway");
+    expect(error.length).toBe(75);
+    expect(error.maxLength).toBe(64);
+    expect(error.message).toContain("tool/function name");
+    expect(error.message).toContain("gateway");
+  });
+
+  it("rejects a nested function.name shape", () => {
+    const tooLong = "b".repeat(70);
+    expect(() =>
+      validateProviderSchemaContract({
+        providers: { gw: { tools: [{ function: { name: tooLong } }] } },
+      }),
+    ).toThrow(ProviderSchemaContractError);
+  });
+
+  it("rejects an over-long provider connection id", () => {
+    const tooLong = "c".repeat(65);
+    expect(() =>
+      validateProviderSchemaContract({ providers: { [tooLong]: { models: { m: {} } } } }),
+    ).toThrow(/provider connection name/);
+  });
+
+  it("rejects an over-long model id", () => {
+    const tooLong = "d".repeat(66);
+    expect(() =>
+      validateProviderSchemaContract({ providers: { gw: { models: { [tooLong]: {} } } } }),
+    ).toThrow(/model id/);
+  });
+
+  it("rejects an over-long MCP server id", () => {
+    const tooLong = "e".repeat(67);
+    expect(() => validateProviderSchemaContract({ mcp: { [tooLong]: {} } })).toThrow(/MCP server name/);
+  });
+
+  it("honours a custom maxNameLength", () => {
+    const name = "f".repeat(20);
+    expect(() =>
+      validateProviderSchemaContract({ providers: { gw: { tools: [{ name }] } }, maxNameLength: 10 }),
+    ).toThrow(ProviderSchemaContractError);
+    expect(() =>
+      validateProviderSchemaContract({ providers: { gw: { tools: [{ name }] } }, maxNameLength: 64 }),
+    ).not.toThrow();
+  });
+});

--- a/packages/adapters/opencode-local/src/server/provider-schema.ts
+++ b/packages/adapters/opencode-local/src/server/provider-schema.ts
@@ -1,0 +1,160 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Thrown when a generated provider/tool/function name violates the contract
+ * the upstream OpenAI-compatible (or Console Go) provider enforces before a
+ * model call. The runtime fails fast with a specific connection/tool so the
+ * harness can surface the offending surface instead of letting the provider
+ * reject the whole request mid-inference.
+ *
+ * Canonical tool identity is preserved: we never silently rename an ambiguous
+ * tool, we only refuse to spawn the model until the surface is corrected.
+ */
+export class ProviderSchemaContractError extends Error {
+  readonly code = "PROVIDER_SCHEMA_CONTRACT" as const;
+  readonly connection?: string;
+  readonly tool?: string;
+  readonly length: number;
+  readonly maxLength: number;
+
+  constructor(offense: {
+    kind: "provider" | "model" | "mcp_server" | "tool_function";
+    name: string;
+    connection?: string;
+    length: number;
+    maxLength: number;
+  }) {
+    const where = offense.connection ? ` on connection "${offense.connection}"` : "";
+    const label =
+      offense.kind === "provider"
+        ? `provider connection name "${offense.name}"`
+        : offense.kind === "model"
+          ? `model id "${offense.name}"`
+          : offense.kind === "mcp_server"
+            ? `MCP server name "${offense.name}"`
+            : `tool/function name "${offense.name}"`;
+    super(
+      `PROVIDER_SCHEMA_CONTRACT: ${label}${where} is ${offense.length} chars, exceeding the provider limit of ${offense.maxLength}. Refusing model inference until the tool surface is corrected.`,
+    );
+    this.name = "ProviderSchemaContractError";
+    this.connection = offense.connection;
+    this.tool = offense.kind === "tool_function" ? offense.name : undefined;
+    this.length = offense.length;
+    this.maxLength = offense.maxLength;
+  }
+}
+
+function collectToolFunctionNames(node: unknown, out: Array<{ name: string; connection?: string }>): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectToolFunctionNames(item, out);
+    return;
+  }
+  if (!isPlainObject(node)) return;
+
+  // OpenAI-compatible tool shape: { tools: [ { name?, function?: { name? } } ] }
+  // or function-calling shape: { functions: [ { name? } ] }.
+  for (const key of ["tools", "functions", "tool", "function"]) {
+    const value = node[key];
+    if (value === undefined || value === null) continue;
+    const entries = Array.isArray(value) ? value : [value];
+    for (const entry of entries) {
+      if (!isPlainObject(entry)) continue;
+      if (typeof entry.name === "string" && entry.name.length > 0) {
+        out.push({ name: entry.name, connection: node.__connection as string | undefined });
+      }
+      // function.name nested shape
+      if (isPlainObject(entry.function) && typeof entry.function.name === "string" && entry.function.name.length > 0) {
+        out.push({ name: entry.function.name, connection: node.__connection as string | undefined });
+      }
+      collectToolFunctionNames(entry, out);
+    }
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "tools" || key === "functions" || key === "tool" || key === "function") continue;
+    collectToolFunctionNames(value, out);
+  }
+}
+
+export interface ValidateProviderSchemaContractInput {
+  /** Resolved provider map (connection id -> provider definition). */
+  providers?: Record<string, unknown> | null;
+  /** Resolved MCP server map (server id -> server definition). */
+  mcp?: Record<string, unknown> | null;
+  /** Provider/tool name length ceiling. Defaults to 64 (OpenAI-compatible/Console Go). */
+  maxNameLength?: number;
+}
+
+/**
+ * Validate the generated tool surface against provider name-length limits
+ * BEFORE model inference. Throws {@link ProviderSchemaContractError} naming the
+ * first offending connection/tool.
+ */
+export function validateProviderSchemaContract(input: ValidateProviderSchemaContractInput): void {
+  const maxLength = input.maxNameLength && input.maxNameLength > 0 ? input.maxNameLength : 64;
+  const providers = isPlainObject(input.providers) ? input.providers : {};
+  const mcp = isPlainObject(input.mcp) ? input.mcp : {};
+
+  // 1. Provider connection ids are the tool/function namespace for --model provider/model.
+  for (const connectionId of Object.keys(providers)) {
+    if (connectionId.length > maxLength) {
+      throw new ProviderSchemaContractError({
+        kind: "provider",
+        name: connectionId,
+        length: connectionId.length,
+        maxLength,
+      });
+    }
+  }
+
+  // 2. Model ids are passed verbatim to the provider and become function routing keys.
+  for (const [connectionId, provider] of Object.entries(providers)) {
+    if (!isPlainObject(provider)) continue;
+    const models = isPlainObject(provider.models) ? provider.models : {};
+    for (const modelId of Object.keys(models)) {
+      if (modelId.length > maxLength) {
+        throw new ProviderSchemaContractError({
+          kind: "model",
+          name: modelId,
+          connection: connectionId,
+          length: modelId.length,
+          maxLength,
+        });
+      }
+    }
+  }
+
+  // 3. MCP server ids become tool-name prefixes for the model.
+  for (const serverId of Object.keys(mcp)) {
+    if (serverId.length > maxLength) {
+      throw new ProviderSchemaContractError({
+        kind: "mcp_server",
+        name: serverId,
+        length: serverId.length,
+        maxLength,
+      });
+    }
+  }
+
+  // 4. Recursively scan for tool/function names anywhere in the provider or MCP surface.
+  const toolNames: Array<{ name: string; connection?: string }> = [];
+  for (const [connectionId, provider] of Object.entries(providers)) {
+    collectToolFunctionNames({ ...(isPlainObject(provider) ? provider : {}), __connection: connectionId }, toolNames);
+  }
+  for (const [serverId, server] of Object.entries(mcp)) {
+    collectToolFunctionNames({ ...(isPlainObject(server) ? server : {}), __connection: serverId }, toolNames);
+  }
+  for (const tool of toolNames) {
+    if (tool.name.length > maxLength) {
+      throw new ProviderSchemaContractError({
+        kind: "tool_function",
+        name: tool.name,
+        connection: tool.connection,
+        length: tool.name.length,
+        maxLength,
+      });
+    }
+  }
+}

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
+import { ProviderSchemaContractError } from "./provider-schema.js";
 
 const cleanupPaths = new Set<string>();
 
@@ -321,4 +322,129 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     expect(prepared.notes).toEqual([]);
     await prepared.cleanup();
   });
+
+  describe("MCP tool-surface narrowing", () => {
+    const mcpSurface = {
+      git: { command: "opencode-git" },
+      filesystem: { command: "opencode-fs" },
+      cloudflare: { command: "mcp-cloudflare" },
+      playwright: { command: "mcp-playwright" },
+      shadcn: { command: "mcp-shadcn" },
+      storybook: { command: "mcp-storybook" },
+    };
+
+    it("keeps the full surface when no filter is configured and reports BEFORE/AFTER", async () => {
+      const configHome = await makeConfigHome({ mcp: mcpSurface });
+      const prepared = await prepareOpenCodeRuntimeConfig({
+        env: { XDG_CONFIG_HOME: configHome },
+        config: {},
+      });
+      cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+      const runtimeConfig = JSON.parse(
+        await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+      ) as { mcp?: Record<string, unknown> };
+      expect(Object.keys(runtimeConfig.mcp ?? {})).toHaveLength(6);
+      expect(prepared.runtimeDiagnostics.mcp?.serverNames.before).toHaveLength(6);
+      expect(prepared.runtimeDiagnostics.mcp?.serverNames.after).toHaveLength(6);
+      expect(prepared.notes.some((n) => n.startsWith("MCP tool surface:"))).toBe(true);
+      await prepared.cleanup();
+    });
+
+    it("defers irrelevant Cloudflare/Playwright/Shadcn/Storybook connections via denylist before inference", async () => {
+      const configHome = await makeConfigHome({ mcp: mcpSurface });
+      const prepared = await prepareOpenCodeRuntimeConfig({
+        env: { XDG_CONFIG_HOME: configHome },
+        config: { toolSurface: { mcpDenylist: ["cloudflare", "playwright", "shadcn", "storybook"] } },
+      });
+      cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+      const runtimeConfig = JSON.parse(
+        await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+      ) as { mcp?: Record<string, unknown> };
+      expect(Object.keys(runtimeConfig.mcp ?? {})).toEqual(["git", "filesystem"]);
+      expect(prepared.runtimeDiagnostics.mcp?.removedByDenylist.sort()).toEqual([
+        "cloudflare",
+        "playwright",
+        "shadcn",
+        "storybook",
+      ]);
+      expect(prepared.runtimeDiagnostics.mcp?.serverNames.after).toEqual(["git", "filesystem"]);
+      await prepared.cleanup();
+    });
+
+    it("keeps only an explicit allowlist (git/filesystem) for a scoped Engineer Paperclip Ops run", async () => {
+      const configHome = await makeConfigHome({ mcp: mcpSurface });
+      const prepared = await prepareOpenCodeRuntimeConfig({
+        env: { XDG_CONFIG_HOME: configHome, PAPERCLIP_OPENCODE_MCP_ALLOWLIST: "git,filesystem" },
+        config: {},
+      });
+      cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+      const runtimeConfig = JSON.parse(
+        await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+      ) as { mcp?: Record<string, unknown> };
+      expect(Object.keys(runtimeConfig.mcp ?? {}).sort()).toEqual(["filesystem", "git"]);
+      expect(prepared.runtimeDiagnostics.mcp?.removedByAllowlist.sort()).toEqual([
+        "cloudflare",
+        "playwright",
+        "shadcn",
+        "storybook",
+      ]);
+      await prepared.cleanup();
+    });
+
+    it("collapses duplicate alias definitions to one canonical entry", async () => {
+      const configHome = await makeConfigHome({
+        mcp: {
+          srv: { command: "dup", args: ["--a"] },
+          srv_alias: { command: "dup", args: ["--a"] },
+        },
+      });
+      const prepared = await prepareOpenCodeRuntimeConfig({
+        env: { XDG_CONFIG_HOME: configHome },
+        config: { toolSurface: { mcpAllowlist: "srv,srv_alias" } },
+      });
+      cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+      const runtimeConfig = JSON.parse(
+        await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+      ) as { mcp?: Record<string, unknown> };
+      expect(Object.keys(runtimeConfig.mcp ?? {})).toEqual(["srv"]);
+      expect(prepared.runtimeDiagnostics.mcp?.removedAsAliases).toEqual(["srv_alias (= srv)"]);
+      await prepared.cleanup();
+    });
+  });
+
+  describe("provider schema preflight", () => {
+    it("fails fast with PROVIDER_SCHEMA_CONTRACT when a generated tool name exceeds 64 chars", async () => {
+      const configHome = await makeConfigHome();
+      const providers = {
+        bifrost: {
+          npm: "@ai-sdk/openai-compatible",
+          options: { baseURL: "http://gateway/v1" },
+          tools: [{ name: "a".repeat(75), description: "oversized" }],
+          models: { "example/model-a": {} },
+        },
+      };
+      await expect(
+        prepareOpenCodeRuntimeConfig({
+          env: { XDG_CONFIG_HOME: configHome, PAPERCLIP_OPENCODE_PROVIDERS: JSON.stringify(providers) },
+          config: {},
+        }),
+      ).rejects.toThrow(ProviderSchemaContractError);
+    });
+
+    it("still writes and returns diagnostics for a legal provider surface", async () => {
+      const configHome = await makeConfigHome();
+      const providers = {
+        bifrost: { npm: "@ai-sdk/openai-compatible", models: { "example/model-a": {} } },
+      };
+      const prepared = await prepareOpenCodeRuntimeConfig({
+        env: { XDG_CONFIG_HOME: configHome, PAPERCLIP_OPENCODE_PROVIDERS: JSON.stringify(providers) },
+        config: {},
+      });
+      cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+      expect(prepared.runtimeDiagnostics).toBeDefined();
+      expect(prepared.runtimeDiagnostics.mcp).toBeUndefined();
+      await prepared.cleanup();
+    });
+  });
+
 });

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -2,12 +2,184 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+import { validateProviderSchemaContract } from "./provider-schema.js";
 
 type PreparedOpenCodeRuntimeConfig = {
   env: Record<string, string>;
   notes: string[];
+  /**
+   * Per-run runtime diagnostics for cost review: BEFORE/AFTER tool-surface
+   * measurement (and removals) surfaced with the invocation meta as
+   * `runtimeDiagnostics.mcp.serverNames`. Empty when no MCP map is configured.
+   */
+  runtimeDiagnostics: OpenCodeRuntimeDiagnostics;
   cleanup: () => Promise<void>;
 };
+
+export interface OpenCodeRuntimeDiagnostics {
+  mcp?: {
+    serverNames: {
+      before: string[];
+      after: string[];
+    };
+    removedByAllowlist: string[];
+    removedByDenylist: string[];
+    removedAsAliases: string[];
+  };
+}
+
+export interface OpenCodeMcpToolSurfaceFilter {
+  /** When set, only these MCP server keys stay enabled for the run. */
+  allowlist: ReadonlySet<string> | null;
+  /** MCP server keys dropped even when no allowlist is configured. */
+  denylist: ReadonlySet<string>;
+  active: boolean;
+}
+
+function parseNameList(value: unknown): string[] | null {
+  let entries: unknown[];
+  if (typeof value === "string") {
+    entries = value.split(",");
+  } else if (Array.isArray(value)) {
+    entries = value;
+  } else {
+    return null;
+  }
+  const names = entries
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  return names.length > 0 ? Array.from(new Set(names)) : null;
+}
+
+/**
+ * Resolve the per-run MCP tool-surface filter from agent config
+ * (`toolSurface.mcpAllowlist` / `toolSurface.mcpDenylist`) or run env
+ * (`PAPERCLIP_OPENCODE_MCP_ALLOWLIST` / `PAPERCLIP_OPENCODE_MCP_DENYLIST`).
+ * Unset on both sides means "no filtering": every configured server stays
+ * enabled, preserving existing behavior. A scoped Engineer Paperclip Ops run
+ * uses this to keep unrelated Cloudflare/Playwright/Shadcn/Storybook
+ * connections out of the generated runtime surface.
+ */
+export function resolveOpenCodeMcpToolSurfaceFilter(input: {
+  config: Record<string, unknown>;
+  env: Record<string, string | undefined>;
+}): OpenCodeMcpToolSurfaceFilter {
+  const resolveEnv = (name: string): string | undefined => input.env[name] ?? process.env[name];
+  const rawToolSurface = isPlainObject(input.config.toolSurface) ? input.config.toolSurface : {};
+  const rawAllowlist =
+    parseNameList(rawToolSurface.mcpAllowlist) ?? parseNameList(resolveEnv("PAPERCLIP_OPENCODE_MCP_ALLOWLIST"));
+  const rawDenylist =
+    parseNameList(rawToolSurface.mcpDenylist) ?? parseNameList(resolveEnv("PAPERCLIP_OPENCODE_MCP_DENYLIST"));
+  const denylist = new Set(rawDenylist ?? []);
+  const allowlist = rawAllowlist ? new Set(rawAllowlist) : null;
+  return { allowlist, denylist, active: allowlist !== null || denylist.size > 0 };
+}
+
+/** Stable identity of an MCP server definition used to collapse duplicates. */
+function mcpServerSignature(entry: unknown): string {
+  if (!isPlainObject(entry)) return typeof entry === "string" ? `raw:${entry}` : "unknown";
+  if (typeof entry.url === "string" && entry.url.trim()) {
+    return `remote:${entry.type === "string" ? entry.type : ""}:${entry.url.trim()}`;
+  }
+  if (typeof entry.command === "string" && entry.command.trim()) {
+    return `local:${entry.command.trim()}:${JSON.stringify(Array.isArray(entry.args) ? entry.args : [])}`;
+  }
+  return `json:${JSON.stringify(entry)}`;
+}
+
+export interface AppliedOpenCodeMcpToolSurfaceResult {
+  next: Record<string, unknown> | null;
+  beforeCount: number;
+  afterCount: number;
+  beforeServerNames: string[];
+  afterServerNames: string[];
+  removedByAllowlist: string[];
+  removedByDenylist: string[];
+  removedAsAliases: string[];
+}
+
+/**
+ * Apply the resolved filter to an opencode.json `mcp` map and collapse
+ * compatibility aliases: multiple keys pointing at the identical server
+ * definition keep only one canonical entry (the lexicographically first key),
+ * so the model sees a single execution path instead of duplicated tools.
+ * Alias collapsing only happens when a filter is explicitly configured.
+ */
+export function applyOpenCodeMcpToolSurface(
+  mcp: unknown,
+  filter: OpenCodeMcpToolSurfaceFilter,
+): AppliedOpenCodeMcpToolSurfaceResult {
+  const result: AppliedOpenCodeMcpToolSurfaceResult = {
+    next: null,
+    beforeCount: 0,
+    afterCount: 0,
+    beforeServerNames: [],
+    afterServerNames: [],
+    removedByAllowlist: [],
+    removedByDenylist: [],
+    removedAsAliases: [],
+  };
+  if (!isPlainObject(mcp)) return result;
+
+  const entries = Object.entries(mcp).filter(([, value]) => value !== null && value !== undefined);
+  result.beforeCount = entries.length;
+  result.beforeServerNames = entries.map(([key]) => key);
+
+  const filtered = entries.filter(([key]) => {
+    if (filter.allowlist && !filter.allowlist.has(key)) {
+      result.removedByAllowlist.push(key);
+      return false;
+    }
+    if (filter.denylist.has(key)) {
+      result.removedByDenylist.push(key);
+      return false;
+    }
+    return true;
+  });
+
+  const kept = [...filtered];
+  if (filter.active && filtered.length > 1) {
+    const canonicalByKey = new Map<string, string>();
+    const sortedKeys = filtered.map(([key]) => key).sort();
+    const entryByKey = new Map(filtered);
+    for (const key of sortedKeys) {
+      const signature = mcpServerSignature(entryByKey.get(key));
+      const canonical = canonicalByKey.get(signature);
+      if (canonical === undefined) {
+        canonicalByKey.set(signature, key);
+        continue;
+      }
+      result.removedAsAliases.push(`${key} (= ${canonical})`);
+    }
+    const aliased = new Set(result.removedAsAliases.map((alias) => alias.split(" ")[0]));
+    const nextEntries = filtered.filter(([key]) => !aliased.has(key));
+    kept.length = 0;
+    kept.push(...nextEntries);
+  }
+
+  // Null means "no change": callers leave the configured mcp map untouched.
+  result.next = kept.length !== entries.length ? Object.fromEntries(kept) : null;
+  result.afterCount = kept.length;
+  result.afterServerNames = kept.map(([key]) => key);
+  return result;
+}
+
+function openCodeRuntimeDiagnosticsFromToolSurface(
+  toolSurfaceResult: AppliedOpenCodeMcpToolSurfaceResult,
+): OpenCodeRuntimeDiagnostics {
+  if (toolSurfaceResult.beforeCount === 0) return {};
+  return {
+    mcp: {
+      serverNames: {
+        before: [...toolSurfaceResult.beforeServerNames],
+        after: [...toolSurfaceResult.afterServerNames],
+      },
+      removedByAllowlist: [...toolSurfaceResult.removedByAllowlist],
+      removedByDenylist: [...toolSurfaceResult.removedByDenylist],
+      removedAsAliases: [...toolSurfaceResult.removedAsAliases],
+    },
+  };
+}
 
 function resolveXdgConfigHome(env: Record<string, string>): string {
   return (
@@ -112,6 +284,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     return {
       env: input.env,
       notes: [],
+      runtimeDiagnostics: {},
       cleanup: async () => {},
     };
   }
@@ -125,6 +298,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     return {
       env: input.env,
       notes: [],
+      runtimeDiagnostics: {},
       cleanup: async () => {},
     };
   }
@@ -216,6 +390,36 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     nextConfig.provider = nextProvider;
   }
 
+  // Measure and optionally constrain the per-run MCP tool surface. Without an
+  // explicit allow/deny configuration every configured server stays enabled
+  // (unchanged behavior); the measurement note is always emitted so runs carry
+  // BEFORE/AFTER tool-surface metrics for cost review. A scoped Engineer
+  // Paperclip Ops run uses the filter to keep unrelated Cloudflare/Playwright/
+  // Shadcn/Storybook connections out of the generated runtime surface.
+  const toolSurfaceFilter = resolveOpenCodeMcpToolSurfaceFilter({ config: input.config, env: input.env });
+  const toolSurfaceResult = applyOpenCodeMcpToolSurface(existingConfig.mcp, toolSurfaceFilter);
+  if (toolSurfaceResult.beforeCount > 0 || toolSurfaceFilter.active) {
+    notes.push(
+      `MCP tool surface: ${toolSurfaceResult.beforeCount} server(s) configured -> ${toolSurfaceResult.afterCount} enabled` +
+        `${toolSurfaceResult.removedByAllowlist.length ? `; allowlist removed: ${toolSurfaceResult.removedByAllowlist.join(", ")}` : ""}` +
+        `${toolSurfaceResult.removedByDenylist.length ? `; denylist removed: ${toolSurfaceResult.removedByDenylist.join(", ")}` : ""}` +
+        `${toolSurfaceResult.removedAsAliases.length ? `; duplicate aliases collapsed: ${toolSurfaceResult.removedAsAliases.join(", ")}` : ""}` +
+        `.`,
+    );
+    if (toolSurfaceResult.next !== null) {
+      nextConfig.mcp = toolSurfaceResult.next;
+    }
+  }
+
+  // PROVIDER SCHEMA PREFLIGHT (P0): validate every generated tool/function name
+  // against the provider length limit BEFORE the model is inferred. The upstream
+  // OpenAI-compatible/Console Go path rejects tool names >64 chars; we fail fast
+  // with a specific PROVIDER_SCHEMA_CONTRACT error naming the offending
+  // connection/tool instead of letting the provider reject mid-inference.
+  // Canonical tool identity is preserved — we never silently rename.
+  const finalMcp = toolSurfaceResult.next ?? (isPlainObject(existingConfig.mcp) ? existingConfig.mcp : null);
+  validateProviderSchemaContract({ providers: nextProvider, mcp: finalMcp });
+
   // Pin OpenCode's auxiliary "small" model (used for session-title generation and
   // other helper tasks) via PAPERCLIP_OPENCODE_SMALL_MODEL. OpenCode otherwise
   // defaults the small model to a built-in provider default (e.g. a claude-* model
@@ -235,6 +439,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
       XDG_CONFIG_HOME: runtimeConfigHome,
     },
     notes,
+    runtimeDiagnostics: openCodeRuntimeDiagnosticsFromToolSurface(toolSurfaceResult),
     cleanup: async () => {
       await fs.rm(runtimeConfigHome, { recursive: true, force: true });
     },


### PR DESCRIPTION
Recover KOMAA-147: deliverable from commit 35116edfa (branch issueKey) pushed to fork after upstream push was 403-blocked for miloszspyrka-code.

Provider schema preflight (<=64 char tool names, fail-fast PROVIDER_SCHEMA_CONTRACT) + scoped MCP tool-surface narrowing for Paperclip Ops runs. 28/28 adapter tests pass, tsc clean.

Needs independent CTO review per DOD before merge.