### PR TITLE
fix(adapter-utils): make SSH env-lab fixture teardown deterministic

### DIFF
--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -194,6 +194,56 @@ describe("ssh env-lab fixture", () => {
     expect(stopped.running).toBe(false);
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
+  it("resolves a relative statePath to the same absolute state across start, status, and stop", async () => {
+    const rootDir = await createFixtureRootDir();
+    const absoluteStatePath = path.join(rootDir, "state.json");
+    // A path relative to the test process's own working directory. This is
+    // the shape a caller outside this file's own resolveEnvLabSshStatePath
+    // helper can pass; startSshEnvLabFixture must resolve it up front so the
+    // persisted state and every derived path stay absolute.
+    const relativeStatePath = path.relative(process.cwd(), absoluteStatePath);
+
+    if (sshEnvLabUnsupportedReason) {
+      console.warn(`Skipping relative statePath test: ${sshEnvLabUnsupportedReason}`);
+      return;
+    }
+    const support = await getSshEnvLabSupport();
+    if (!support.supported) {
+      sshEnvLabUnsupportedReason = support.reason ?? "unsupported environment";
+      console.warn(`Skipping relative statePath test: ${sshEnvLabUnsupportedReason}`);
+      return;
+    }
+
+    const entry = fixtureTeardowns.find((candidate) => candidate.rootDir === rootDir);
+    if (!entry) {
+      throw new Error(`No fixture teardown entry for ${rootDir}.`);
+    }
+
+    let state: SshEnvLabFixtureState;
+    try {
+      state = await startSshEnvLabFixture({ statePath: relativeStatePath });
+    } catch (error) {
+      sshEnvLabUnsupportedReason = error instanceof Error ? error.message : String(error);
+      console.warn(`Skipping relative statePath test: ${sshEnvLabUnsupportedReason}`);
+      return;
+    }
+    entry.state = state;
+
+    expect(state.statePath).toBe(absoluteStatePath);
+    expect(state.rootDir).toBe(rootDir);
+
+    const running = await readSshEnvLabFixtureStatus(relativeStatePath);
+    expect(running.running).toBe(true);
+    expect(running.state?.statePath).toBe(absoluteStatePath);
+
+    const stopped = await stopSshEnvLabFixture(relativeStatePath);
+    expect(stopped).toBe(true);
+    entry.state = null;
+
+    const afterStop = await readSshEnvLabFixtureStatus(relativeStatePath);
+    expect(afterStop.running).toBe(false);
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
   it("forwards stdin to remote SSH commands", async () => {
     const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -1,8 +1,9 @@
 import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import {
   buildSshSpawnTarget,
   buildSshEnvLabFixtureConfig,
@@ -15,11 +16,35 @@ import {
   syncDirectoryToSsh,
   startSshEnvLabFixture,
   stopSshEnvLabFixture,
+  type SshEnvLabFixtureState,
 } from "./ssh.js";
 import { prepareRemoteManagedRuntime } from "./remote-managed-runtime.js";
 
 const SSH_FIXTURE_TEST_TIMEOUT_MS = 30_000;
 let sshEnvLabUnsupportedReason: string | null = null;
+
+// One entry per fixture-start attempt, registered at start time so teardown
+// survives an assertion failure, a thrown error, or an early return on skip.
+// `state` stays null until the fixture actually starts; a caller that stops
+// the fixture itself still leaves the entry in the stack, so the drain below
+// must be idempotent (stopSshEnvLabFixture is).
+interface FixtureTeardownEntry {
+  rootDir: string;
+  state: SshEnvLabFixtureState | null;
+}
+
+const fixtureTeardowns: FixtureTeardownEntry[] = [];
+
+async function drainFixtureTeardowns(): Promise<void> {
+  while (fixtureTeardowns.length > 0) {
+    const entry = fixtureTeardowns.pop();
+    if (!entry) continue;
+    if (entry.state) {
+      await stopSshEnvLabFixture(entry.state).catch(() => undefined);
+    }
+    await rm(entry.rootDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
 
 async function git(cwd: string, args: string[]): Promise<string> {
   return await new Promise((resolve, reject) => {
@@ -34,6 +59,12 @@ async function git(cwd: string, args: string[]): Promise<string> {
 }
 
 async function startSshEnvLabFixtureOrSkip(statePath: string, label: string) {
+  // Register the teardown entry before the first await, so a fixture that
+  // starts and then throws later in the calling test still gets its root
+  // directory removed.
+  const entry: FixtureTeardownEntry = { rootDir: path.dirname(statePath), state: null };
+  fixtureTeardowns.push(entry);
+
   if (sshEnvLabUnsupportedReason) {
     console.warn(`Skipping ${label}: ${sshEnvLabUnsupportedReason}`);
     return null;
@@ -47,7 +78,9 @@ async function startSshEnvLabFixtureOrSkip(statePath: string, label: string) {
   }
 
   try {
-    return await startSshEnvLabFixture({ statePath });
+    const state = await startSshEnvLabFixture({ statePath });
+    entry.state = state;
+    return state;
   } catch (error) {
     sshEnvLabUnsupportedReason = error instanceof Error ? error.message : String(error);
     console.warn(`Skipping ${label}: ${sshEnvLabUnsupportedReason}`);
@@ -81,19 +114,13 @@ function parseProgressLine(line: string): ParsedProgressLine {
 }
 
 describe("ssh env-lab fixture", () => {
-  const cleanupDirs: string[] = [];
-
-  afterEach(async () => {
-    while (cleanupDirs.length > 0) {
-      const dir = cleanupDirs.pop();
-      if (!dir) continue;
-      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
-    }
-  });
+  afterEach(drainFixtureTeardowns);
+  // Backstop: if a throw inside afterEach ever leaves an entry on the stack,
+  // this drains it too instead of stranding a listener until the process exits.
+  afterAll(drainFixtureTeardowns);
 
   it("starts an isolated sshd fixture and executes commands through it", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
@@ -109,7 +136,7 @@ describe("ssh env-lab fixture", () => {
     const status = await readSshEnvLabFixtureStatus(statePath);
     expect(status.running).toBe(true);
 
-    await stopSshEnvLabFixture(statePath);
+    await stopSshEnvLabFixture(started);
 
     const stopped = await readSshEnvLabFixtureStatus(statePath);
     expect(stopped.running).toBe(false);
@@ -117,7 +144,6 @@ describe("ssh env-lab fixture", () => {
 
   it("forwards stdin to remote SSH commands", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH stdin forwarding test");
@@ -146,12 +172,11 @@ describe("ssh env-lab fixture", () => {
 
   it("does not treat an unrelated reused pid as the running fixture", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
     if (!started) return;
-    await stopSshEnvLabFixture(statePath);
+    await stopSshEnvLabFixture(started);
     await mkdir(path.dirname(statePath), { recursive: true });
 
     await writeFile(
@@ -167,7 +192,36 @@ describe("ssh env-lab fixture", () => {
     if (!restarted) return;
     expect(restarted.pid).not.toBe(process.pid);
 
-    await stopSshEnvLabFixture(statePath);
+    await stopSshEnvLabFixture(restarted);
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  it("stops the fixture listener and frees its loopback port", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const statePath = path.join(rootDir, "state.json");
+
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH teardown regression test");
+    if (!started) return;
+    const { pid, port, bindHost } = started;
+
+    await stopSshEnvLabFixture(started);
+
+    let pidStillRunning = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      pidStillRunning = false;
+    }
+    expect(pidStillRunning).toBe(false);
+
+    // Bind the exact port to prove it is free; a stopped process is not
+    // proof the OS released the socket.
+    await new Promise<void>((resolve, reject) => {
+      const probe = net.createServer();
+      probe.once("error", reject);
+      probe.listen(port, bindHost, () => {
+        probe.close((closeError) => (closeError ? reject(closeError) : resolve()));
+      });
+    });
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("builds a remote script that sources login profiles but no nvm", async () => {
@@ -237,7 +291,6 @@ describe("ssh env-lab fixture", () => {
 
   it("syncs a local directory into the remote fixture workspace", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localDir = path.join(rootDir, "local-overlay");
 
@@ -270,7 +323,6 @@ describe("ssh env-lab fixture", () => {
 
   it("reports throttled upload progress with a clamped percent and terminal 100% line", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localDir = path.join(rootDir, "local-overlay");
 
@@ -318,7 +370,6 @@ describe("ssh env-lab fixture", () => {
 
   it("reports restore progress with a terminal completion line", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localDir = path.join(rootDir, "local-overlay");
     const restoreDir = path.join(rootDir, "restore-target");
@@ -364,7 +415,6 @@ describe("ssh env-lab fixture", () => {
 
   it("reports exact git-history import percentage from the known bundle size", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -406,7 +456,6 @@ describe("ssh env-lab fixture", () => {
 
   it("can dereference local symlinks while syncing to the remote fixture", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const sourceDir = path.join(rootDir, "source");
     const localDir = path.join(rootDir, "local-overlay");
@@ -442,7 +491,6 @@ describe("ssh env-lab fixture", () => {
 
   it("round-trips a git workspace through the SSH fixture", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -502,7 +550,6 @@ describe("ssh env-lab fixture", () => {
 
   it("preserves both concurrent SSH restores in a shared git workspace", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -560,7 +607,6 @@ describe("ssh env-lab fixture", () => {
 
   it("preserves nested per-run files across sequential SSH restores with stale baselines", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -616,7 +662,6 @@ describe("ssh env-lab fixture", () => {
 
   it("round-trips remote git commits through the managed runtime restore path", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -662,7 +707,6 @@ describe("ssh env-lab fixture", () => {
     // the local execution-workspace cwd is the only persistence boundary
     // across runs. No adapter may depend on a git remote for cross-run state.
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -720,7 +764,6 @@ describe("ssh env-lab fixture", () => {
 
   it("merges concurrent remote commits through the managed runtime restore path", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
-    cleanupDirs.push(rootDir);
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
@@ -245,6 +245,73 @@ describe("ssh env-lab fixture", () => {
     expect(restarted.pid).not.toBe(process.pid);
 
     await stopSshEnvLabFixture(restarted);
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  it("rejects a forged state file and cannot signal an unrelated local process", async () => {
+    const rootDir = await createFixtureRootDir();
+    const statePath = path.join(rootDir, "state.json");
+
+    // A process this test does not own. A forged state must never be able
+    // to target it for SIGTERM or SIGKILL.
+    const bystander = spawn("sleep", ["30"], { stdio: "ignore" });
+    const bystanderPid = bystander.pid;
+    if (!bystanderPid) {
+      throw new Error("Failed to spawn the bystander process for this regression test.");
+    }
+
+    try {
+      const baseState = {
+        kind: "ssh_openbsd" as const,
+        bindHost: "127.0.0.1",
+        host: "127.0.0.1",
+        port: 0,
+        username: os.userInfo().username,
+        rootDir,
+        workspaceDir: path.join(rootDir, "workspace"),
+        statePath,
+        createdAt: new Date().toISOString(),
+        clientPrivateKeyPath: path.join(rootDir, "client_key"),
+        clientPublicKeyPath: path.join(rootDir, "client_key.pub"),
+        hostPrivateKeyPath: path.join(rootDir, "host_key"),
+        hostPublicKeyPath: path.join(rootDir, "host_key.pub"),
+        authorizedKeysPath: path.join(rootDir, "authorized_keys"),
+        knownHostsPath: path.join(rootDir, "known_hosts"),
+        sshdConfigPath: path.join(rootDir, "sshd_config"),
+        sshdLogPath: path.join(rootDir, "sshd.log"),
+      };
+
+      const forgedVariants = [
+        // An empty sshdConfigPath used to defeat the identity check: an
+        // empty string is a substring of every command line.
+        { ...baseState, pid: bystanderPid, sshdConfigPath: "" },
+        // A sshdConfigPath outside the fixture root.
+        { ...baseState, pid: bystanderPid, sshdConfigPath: "/etc/ssh/sshd_config" },
+        // A non-positive pid.
+        { ...baseState, pid: 0 },
+        { ...baseState, pid: -1 },
+      ];
+
+      for (const forged of forgedVariants) {
+        await writeFile(statePath, JSON.stringify(forged, null, 2), { mode: 0o600 });
+
+        const status = await readSshEnvLabFixtureStatus(statePath);
+        expect(status.running).toBe(false);
+        expect(status.state).toBeNull();
+
+        const stopped = await stopSshEnvLabFixture(statePath);
+        expect(stopped).toBe(false);
+      }
+
+      // No forged state ever reached the identity check or a signal call,
+      // so the bystander process is still alive.
+      expect(() => process.kill(bystanderPid, 0)).not.toThrow();
+    } finally {
+      try {
+        process.kill(bystanderPid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("stops the fixture listener and frees its loopback port", async () => {

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -23,11 +23,12 @@ import { prepareRemoteManagedRuntime } from "./remote-managed-runtime.js";
 const SSH_FIXTURE_TEST_TIMEOUT_MS = 30_000;
 let sshEnvLabUnsupportedReason: string | null = null;
 
-// One entry per fixture-start attempt, registered at start time so teardown
-// survives an assertion failure, a thrown error, or an early return on skip.
-// `state` stays null until the fixture actually starts; a caller that stops
-// the fixture itself still leaves the entry in the stack, so the drain below
-// must be idempotent (stopSshEnvLabFixture is).
+// One entry per fixture root directory, registered at creation time so
+// teardown survives a setup call that throws before the fixture starts, an
+// assertion failure, or an early return on skip. `state` stays null until
+// the fixture actually starts; a caller that stops the fixture itself still
+// leaves the entry in the stack, so the drain below must be idempotent
+// (stopSshEnvLabFixture is).
 interface FixtureTeardownEntry {
   rootDir: string;
   state: SshEnvLabFixtureState | null;
@@ -35,12 +36,36 @@ interface FixtureTeardownEntry {
 
 const fixtureTeardowns: FixtureTeardownEntry[] = [];
 
+// Creates the fixture root directory and registers its teardown entry in
+// the same step, so a setup call that throws between here and the fixture
+// start (mkdir, writeFile, git init) still leaves the root directory queued
+// for removal.
+async function createFixtureRootDir(): Promise<string> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+  fixtureTeardowns.push({ rootDir, state: null });
+  return rootDir;
+}
+
 async function drainFixtureTeardowns(): Promise<void> {
   while (fixtureTeardowns.length > 0) {
     const entry = fixtureTeardowns.pop();
     if (!entry) continue;
     if (entry.state) {
-      await stopSshEnvLabFixture(entry.state).catch(() => undefined);
+      try {
+        await stopSshEnvLabFixture(entry.state);
+      } catch (error) {
+        // stopSshEnvLabFixture throws only when the listener survives
+        // SIGKILL, and it deliberately keeps the root directory so a later
+        // stop call can still find and signal it through the state file.
+        // Report the failure but keep the root directory; do not remove it,
+        // and do not rethrow, so a throw here cannot strand the entries
+        // still left on the stack.
+        console.error(
+          `SSH env-lab fixture teardown failed for pid ${entry.state.pid} on port ${entry.state.port}:`,
+          error,
+        );
+        continue;
+      }
     }
     await rm(entry.rootDir, { recursive: true, force: true }).catch(() => undefined);
   }
@@ -58,12 +83,39 @@ async function git(cwd: string, args: string[]): Promise<string> {
   });
 }
 
+// Finds the pid of a running sshd process by its config file path, the same
+// way isSshEnvLabFixtureProcess identifies a fixture internally. Used by the
+// readiness-failure regression test, which needs the pid of a fixture that
+// startSshEnvLabFixture never returns because it throws before returning it.
+async function findSshdPidByConfigPath(sshdConfigPath: string): Promise<number | null> {
+  const stdout = await new Promise<string>((resolve) => {
+    execFile("ps", ["-eo", "pid=,args="], (error, out) => resolve(error ? "" : out));
+  });
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    const spaceIndex = trimmed.indexOf(" ");
+    if (spaceIndex === -1) continue;
+    const pid = Number.parseInt(trimmed.slice(0, spaceIndex), 10);
+    const args = trimmed.slice(spaceIndex + 1);
+    if (Number.isFinite(pid) && args.includes(sshdConfigPath)) {
+      return pid;
+    }
+  }
+  return null;
+}
+
 async function startSshEnvLabFixtureOrSkip(statePath: string, label: string) {
-  // Register the teardown entry before the first await, so a fixture that
-  // starts and then throws later in the calling test still gets its root
-  // directory removed.
-  const entry: FixtureTeardownEntry = { rootDir: path.dirname(statePath), state: null };
-  fixtureTeardowns.push(entry);
+  // The teardown entry for this root directory must already exist: callers
+  // create it with createFixtureRootDir() before they derive statePath, so
+  // this only attaches the state to that entry instead of pushing a new
+  // one (a root directory must never get two entries).
+  const rootDir = path.dirname(statePath);
+  const entry = fixtureTeardowns.find((candidate) => candidate.rootDir === rootDir);
+  if (!entry) {
+    throw new Error(
+      `No fixture teardown entry for ${rootDir}. Call createFixtureRootDir() before starting a fixture.`,
+    );
+  }
 
   if (sshEnvLabUnsupportedReason) {
     console.warn(`Skipping ${label}: ${sshEnvLabUnsupportedReason}`);
@@ -120,7 +172,7 @@ describe("ssh env-lab fixture", () => {
   afterAll(drainFixtureTeardowns);
 
   it("starts an isolated sshd fixture and executes commands through it", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
@@ -143,7 +195,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("forwards stdin to remote SSH commands", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH stdin forwarding test");
@@ -171,7 +223,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("does not treat an unrelated reused pid as the running fixture", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
@@ -196,7 +248,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("stops the fixture listener and frees its loopback port", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
 
     const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH teardown regression test");
@@ -222,6 +274,60 @@ describe("ssh env-lab fixture", () => {
         probe.close((closeError) => (closeError ? reject(closeError) : resolve()));
       });
     });
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  it("leaves no live listener and no root directory when the fixture fails readiness", async () => {
+    if (sshEnvLabUnsupportedReason) {
+      console.warn(`Skipping SSH readiness-failure cleanup test: ${sshEnvLabUnsupportedReason}`);
+      return;
+    }
+    const support = await getSshEnvLabSupport();
+    if (!support.supported) {
+      sshEnvLabUnsupportedReason = support.reason ?? "unsupported environment";
+      console.warn(`Skipping SSH readiness-failure cleanup test: ${sshEnvLabUnsupportedReason}`);
+      return;
+    }
+
+    const rootDir = await createFixtureRootDir();
+    const statePath = path.join(rootDir, "state.json");
+    const sshdConfigPath = path.join(rootDir, "sshd_config");
+
+    // sshd binds through bindHost (127.0.0.1) and stays alive; the readiness
+    // check targets an unreachable RFC 5737 TEST-NET-3 address instead, so it
+    // fails on every attempt without ever reaching a real host. Poll for the
+    // resulting sshd process concurrently, since startSshEnvLabFixture never
+    // returns a state on this path (it throws before writing one).
+    let capturedPid: number | null = null;
+    const pollDeadline = Date.now() + 5_000;
+    const pollForPid = (async () => {
+      while (capturedPid === null && Date.now() < pollDeadline) {
+        capturedPid = await findSshdPidByConfigPath(sshdConfigPath);
+        if (capturedPid === null) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      }
+    })();
+
+    await expect(
+      startSshEnvLabFixture({
+        statePath,
+        host: "203.0.113.1",
+        readinessTimeoutMs: 1_000,
+      }),
+    ).rejects.toThrow();
+
+    await pollForPid;
+    expect(capturedPid).not.toBeNull();
+
+    let pidStillRunning = true;
+    try {
+      process.kill(capturedPid!, 0);
+    } catch {
+      pidStillRunning = false;
+    }
+    expect(pidStillRunning).toBe(false);
+
+    await expect(stat(rootDir)).rejects.toThrow();
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("builds a remote script that sources login profiles but no nvm", async () => {
@@ -290,7 +396,7 @@ describe("ssh env-lab fixture", () => {
   });
 
   it("syncs a local directory into the remote fixture workspace", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localDir = path.join(rootDir, "local-overlay");
 
@@ -322,7 +428,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("reports throttled upload progress with a clamped percent and terminal 100% line", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localDir = path.join(rootDir, "local-overlay");
 
@@ -369,7 +475,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("reports restore progress with a terminal completion line", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localDir = path.join(rootDir, "local-overlay");
     const restoreDir = path.join(rootDir, "restore-target");
@@ -414,7 +520,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("reports exact git-history import percentage from the known bundle size", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -455,7 +561,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("can dereference local symlinks while syncing to the remote fixture", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const sourceDir = path.join(rootDir, "source");
     const localDir = path.join(rootDir, "local-overlay");
@@ -490,7 +596,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("round-trips a git workspace through the SSH fixture", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -549,7 +655,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("preserves both concurrent SSH restores in a shared git workspace", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -606,7 +712,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("preserves nested per-run files across sequential SSH restores with stale baselines", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -661,7 +767,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("round-trips remote git commits through the managed runtime restore path", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -706,7 +812,7 @@ describe("ssh env-lab fixture", () => {
     // packages/adapter-utils/README.md and packages/adapters/AUTHORING.md:
     // the local execution-workspace cwd is the only persistence boundary
     // across runs. No adapter may depend on a git remote for cross-run state.
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 
@@ -763,7 +869,7 @@ describe("ssh env-lab fixture", () => {
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("merges concurrent remote commits through the managed runtime restore path", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    const rootDir = await createFixtureRootDir();
     const statePath = path.join(rootDir, "state.json");
     const localRepo = path.join(rootDir, "local-workspace");
 

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1716,19 +1716,51 @@ export async function readSshEnvLabFixtureState(
   }
 }
 
-export async function stopSshEnvLabFixture(statePath: string): Promise<boolean> {
-  const state = await readSshEnvLabFixtureState(statePath);
+async function waitUntilFixtureProcessExits(
+  state: Pick<SshEnvLabFixtureState, "pid" | "sshdConfigPath">,
+  timeoutMs: number,
+  intervalMs = 100,
+): Promise<boolean> {
+  const timeoutAt = Date.now() + timeoutMs;
+  while (true) {
+    if (!(await isSshEnvLabFixtureProcess(state))) return true;
+    if (Date.now() >= timeoutAt) return false;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+// Accepts a state path or an already-read state so a caller that already
+// holds the fixture state in memory does not have to depend on the state
+// file, which a teardown step may have already removed.
+export async function stopSshEnvLabFixture(
+  stateOrPath: string | SshEnvLabFixtureState,
+): Promise<boolean> {
+  const state = typeof stateOrPath === "string"
+    ? await readSshEnvLabFixtureState(stateOrPath)
+    : stateOrPath;
   if (!state) return false;
 
   if (await isSshEnvLabFixtureProcess(state)) {
     process.kill(state.pid, "SIGTERM");
-    await waitForCondition(async () => {
+    if (!(await waitUntilFixtureProcessExits(state, 5_000))) {
+      // Re-check identity immediately before SIGKILL: the pid can be reused
+      // in the gap between the two signals.
       if (await isSshEnvLabFixtureProcess(state)) {
-        throw new Error("SSH fixture process is still running.");
+        process.kill(state.pid, "SIGKILL");
+        if (!(await waitUntilFixtureProcessExits(state, 2_000))) {
+          if (await isSshEnvLabFixtureProcess(state)) {
+            throw new Error(
+              `SSH env-lab fixture did not stop: pid ${state.pid} on port ${state.port} is still running after SIGKILL.`,
+            );
+          }
+        }
       }
-    }, { timeoutMs: 5_000, intervalMs: 100 });
+    }
   }
 
+  // Remove the root directory only after the listener process is confirmed
+  // gone. Removing it earlier would delete the state file the process needs
+  // for a later stop attempt to find and signal it.
   await fs.rm(state.rootDir, { recursive: true, force: true }).catch(() => undefined);
   return true;
 }

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1729,6 +1729,25 @@ async function waitUntilFixtureProcessExits(
   }
 }
 
+// Sends a signal to a pid and treats an already-dead process as success.
+// The identity check that runs before this call is not free: it spawns
+// `ps`, which opens a real gap between the check and the signal. If the
+// process exits inside that gap, `process.kill` throws ESRCH even though
+// the outcome the caller wants (the process is gone) already holds. Any
+// other error, such as EPERM for a pid that belongs to another user, must
+// still propagate.
+function signalFixtureProcess(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
 // Bounded shutdown escalation shared by every caller that must stop a
 // fixture process: send SIGTERM, wait, re-check process identity (the pid
 // can be reused in the gap between two signals), then SIGKILL, then wait
@@ -1738,11 +1757,11 @@ async function escalateSshEnvLabFixtureShutdown(
 ): Promise<boolean> {
   if (!(await isSshEnvLabFixtureProcess(state))) return true;
 
-  process.kill(state.pid, "SIGTERM");
+  if (!signalFixtureProcess(state.pid, "SIGTERM")) return true;
   if (await waitUntilFixtureProcessExits(state, 5_000)) return true;
 
   if (!(await isSshEnvLabFixtureProcess(state))) return true;
-  process.kill(state.pid, "SIGKILL");
+  if (!signalFixtureProcess(state.pid, "SIGKILL")) return true;
   if (await waitUntilFixtureProcessExits(state, 2_000)) return true;
 
   return !(await isSshEnvLabFixtureProcess(state));

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1704,12 +1704,70 @@ export async function ensureSshWorkspaceReady(
   };
 }
 
+const SSH_ENV_LAB_FIXTURE_PATH_FIELDS = [
+  "rootDir",
+  "workspaceDir",
+  "statePath",
+  "clientPrivateKeyPath",
+  "clientPublicKeyPath",
+  "hostPrivateKeyPath",
+  "hostPublicKeyPath",
+  "authorizedKeysPath",
+  "knownHostsPath",
+  "sshdConfigPath",
+  "sshdLogPath",
+] as const satisfies readonly (keyof SshEnvLabFixtureState)[];
+
+// True when candidate is an absolute path equal to rootDir or nested under
+// it. Used to reject a state file whose paths point outside the fixture
+// root it was read from.
+function isPathRootedAt(candidate: string, rootDir: string): boolean {
+  if (!path.isAbsolute(candidate)) return false;
+  if (candidate === rootDir) return true;
+  const relative = path.relative(rootDir, candidate);
+  return (
+    relative.length > 0 &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+// The state file is untrusted input: any local process running as the same
+// user can write one. A forged pid or an empty sshdConfigPath would weaken
+// isSshEnvLabFixtureProcess's identity check — an empty string is a
+// substring of every command line, so it would match any running process.
+// Reject a state file that fails this check before any identity check or
+// signal runs against it.
+function isValidSshEnvLabFixtureState(
+  raw: SshEnvLabFixtureState,
+  expectedRootDir: string,
+): boolean {
+  if (!Number.isSafeInteger(raw.pid) || raw.pid <= 0) return false;
+  if (raw.rootDir !== expectedRootDir) return false;
+
+  for (const field of SSH_ENV_LAB_FIXTURE_PATH_FIELDS) {
+    const value = raw[field];
+    if (typeof value !== "string" || !isPathRootedAt(value, expectedRootDir)) {
+      return false;
+    }
+  }
+
+  const expectedSshdConfigPath = path.join(expectedRootDir, "sshd_config");
+  if (raw.sshdConfigPath.length === 0 || raw.sshdConfigPath !== expectedSshdConfigPath) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function readSshEnvLabFixtureState(
   statePath: string,
 ): Promise<SshEnvLabFixtureState | null> {
   try {
     const raw = JSON.parse(await fs.readFile(statePath, "utf8")) as SshEnvLabFixtureState;
     if (!raw || raw.kind !== "ssh_openbsd") return null;
+    if (!isValidSshEnvLabFixtureState(raw, path.dirname(statePath))) return null;
     return raw;
   } catch {
     return null;

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1765,9 +1765,14 @@ export async function readSshEnvLabFixtureState(
   statePath: string,
 ): Promise<SshEnvLabFixtureState | null> {
   try {
-    const raw = JSON.parse(await fs.readFile(statePath, "utf8")) as SshEnvLabFixtureState;
+    // Resolve a relative statePath against the current working directory
+    // before use. The state validator below only accepts absolute paths, and
+    // a relative statePath must resolve to the same absolute directory every
+    // time a caller reads it, no matter the process working directory.
+    const resolvedStatePath = path.resolve(statePath);
+    const raw = JSON.parse(await fs.readFile(resolvedStatePath, "utf8")) as SshEnvLabFixtureState;
     if (!raw || raw.kind !== "ssh_openbsd") return null;
-    if (!isValidSshEnvLabFixtureState(raw, path.dirname(statePath))) return null;
+    if (!isValidSshEnvLabFixtureState(raw, path.dirname(resolvedStatePath))) return null;
     return raw;
   } catch {
     return null;
@@ -1858,7 +1863,12 @@ export async function startSshEnvLabFixture(input: {
   // real 10 second wait.
   readinessTimeoutMs?: number;
 }): Promise<SshEnvLabFixtureState> {
-  const existing = await readSshEnvLabFixtureState(input.statePath);
+  // Resolve a relative statePath against the current working directory once,
+  // up front. Every derived path (rootDir and the persisted statePath field)
+  // must be absolute, so the state validator in readSshEnvLabFixtureState
+  // accepts the file that this function writes.
+  const statePath = path.resolve(input.statePath);
+  const existing = await readSshEnvLabFixtureState(statePath);
   if (existing && await isSshEnvLabFixtureProcess(existing)) {
     return existing;
   }
@@ -1877,7 +1887,7 @@ export async function startSshEnvLabFixture(input: {
 
   const bindHost = input.bindHost ?? "127.0.0.1";
   const host = input.host ?? bindHost;
-  const rootDir = path.dirname(input.statePath);
+  const rootDir = path.dirname(statePath);
   await fs.mkdir(rootDir, { recursive: true });
 
   const username = os.userInfo().username;
@@ -1949,7 +1959,7 @@ export async function startSshEnvLabFixture(input: {
     username,
     rootDir,
     workspaceDir,
-    statePath: input.statePath,
+    statePath,
     pid: child.pid ?? 0,
     createdAt: new Date().toISOString(),
     clientPrivateKeyPath,
@@ -1975,7 +1985,7 @@ export async function startSshEnvLabFixture(input: {
       const config = await buildSshEnvLabFixtureConfig(state);
       await ensureSshWorkspaceReady(config);
     }, { timeoutMs: input.readinessTimeoutMs ?? 10_000, intervalMs: 250 });
-    await fs.writeFile(input.statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
+    await fs.writeFile(statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
     return state;
   } catch (error) {
     // No state file exists on this path yet, so a later stopSshEnvLabFixture

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1729,6 +1729,25 @@ async function waitUntilFixtureProcessExits(
   }
 }
 
+// Bounded shutdown escalation shared by every caller that must stop a
+// fixture process: send SIGTERM, wait, re-check process identity (the pid
+// can be reused in the gap between two signals), then SIGKILL, then wait
+// again. Returns true only when the listener is confirmed gone.
+async function escalateSshEnvLabFixtureShutdown(
+  state: Pick<SshEnvLabFixtureState, "pid" | "sshdConfigPath">,
+): Promise<boolean> {
+  if (!(await isSshEnvLabFixtureProcess(state))) return true;
+
+  process.kill(state.pid, "SIGTERM");
+  if (await waitUntilFixtureProcessExits(state, 5_000)) return true;
+
+  if (!(await isSshEnvLabFixtureProcess(state))) return true;
+  process.kill(state.pid, "SIGKILL");
+  if (await waitUntilFixtureProcessExits(state, 2_000)) return true;
+
+  return !(await isSshEnvLabFixtureProcess(state));
+}
+
 // Accepts a state path or an already-read state so a caller that already
 // holds the fixture state in memory does not have to depend on the state
 // file, which a teardown step may have already removed.
@@ -1740,22 +1759,10 @@ export async function stopSshEnvLabFixture(
     : stateOrPath;
   if (!state) return false;
 
-  if (await isSshEnvLabFixtureProcess(state)) {
-    process.kill(state.pid, "SIGTERM");
-    if (!(await waitUntilFixtureProcessExits(state, 5_000))) {
-      // Re-check identity immediately before SIGKILL: the pid can be reused
-      // in the gap between the two signals.
-      if (await isSshEnvLabFixtureProcess(state)) {
-        process.kill(state.pid, "SIGKILL");
-        if (!(await waitUntilFixtureProcessExits(state, 2_000))) {
-          if (await isSshEnvLabFixtureProcess(state)) {
-            throw new Error(
-              `SSH env-lab fixture did not stop: pid ${state.pid} on port ${state.port} is still running after SIGKILL.`,
-            );
-          }
-        }
-      }
-    }
+  if (!(await escalateSshEnvLabFixtureShutdown(state))) {
+    throw new Error(
+      `SSH env-lab fixture did not stop: pid ${state.pid} on port ${state.port} is still running after SIGKILL.`,
+    );
   }
 
   // Remove the root directory only after the listener process is confirmed
@@ -1769,6 +1776,10 @@ export async function startSshEnvLabFixture(input: {
   statePath: string;
   bindHost?: string;
   host?: string;
+  // Test-only. Shortens the readiness wait below its 10 second default, so
+  // a regression test can force the start-failure cleanup path without a
+  // real 10 second wait.
+  readinessTimeoutMs?: number;
 }): Promise<SshEnvLabFixtureState> {
   const existing = await readSshEnvLabFixtureState(input.statePath);
   if (existing && await isSshEnvLabFixtureProcess(existing)) {
@@ -1886,14 +1897,28 @@ export async function startSshEnvLabFixture(input: {
       }
       const config = await buildSshEnvLabFixtureConfig(state);
       await ensureSshWorkspaceReady(config);
-    }, { timeoutMs: 10_000, intervalMs: 250 });
+    }, { timeoutMs: input.readinessTimeoutMs ?? 10_000, intervalMs: 250 });
     await fs.writeFile(input.statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
     return state;
   } catch (error) {
-    if (await isPidRunning(state.pid)) {
-      process.kill(state.pid, "SIGTERM");
+    // No state file exists on this path yet, so a later stopSshEnvLabFixture
+    // call can never find this pid. Escalate and wait for exit here, the
+    // same way stopSshEnvLabFixture does, before the root directory goes
+    // away — otherwise a slow-to-exit sshd survives as an orphan with its
+    // root directory already gone.
+    const stopped = await escalateSshEnvLabFixtureShutdown(state);
+    if (stopped) {
+      await fs.rm(rootDir, { recursive: true, force: true }).catch(() => undefined);
+    } else {
+      const survivalNote =
+        `SSH env-lab fixture pid ${state.pid} on port ${state.port} is still running after SIGKILL. ` +
+        `Kept ${rootDir} for inspection; no state file exists to target it with a later stop call.`;
+      if (error instanceof Error) {
+        error.message = `${error.message}\n${survivalNote}`;
+      } else {
+        console.error(survivalNote);
+      }
     }
-    await fs.rm(rootDir, { recursive: true, force: true }).catch(() => undefined);
     throw error;
   }
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent adapters use SSH environment fixtures to test process behavior
> - The SSH fixture detached its listener process from the test process
> - Teardown removed the fixture directory without stopping and awaiting that listener
> - This pull request validates fixture state, stops the listener with bounded escalation, and waits before directory removal
> - The benefit is deterministic test cleanup without orphan listeners or unsafe signals

## Linked Issues or Issue Description

**What happened?**

The SSH environment fixture detached its listener process. Test teardown removed the temporary fixture directory without stopping and awaiting the listener. Repeated test runs left orphan listeners that held loopback ports.

**Expected behavior**

The fixture teardown stops its listener, waits for exit, and then removes the fixture directory. A forged state file must not signal an unrelated process.

**Steps to reproduce**

1. Run the SSH fixture test repeatedly.
2. Inspect listener processes after each run.
3. Observe orphan listeners or ports that remain held.

**Paperclip version or commit**

Commit 324e1331f8701ac57334f8404d3c613e99ddb4d9.

**Deployment mode**

Not deployment-related.

**Installation method**

Built from source.

**Agent adapter(s) involved**

Custom / external plugin adapter.

**Database mode**

Not database-related.

**Access context**

Unclear / not applicable.

**Node.js version**

Node.js 24.

**Operating system**

Linux.

**Relevant logs or output**

A diagnostic found orphan listeners with parent process ID 1. Each orphan held a loopback port.

**Relevant config (if applicable)**

Not applicable.

**Additional context**

The change keeps the process identifier reuse check and limits signals to fixture-owned processes.

## What Changed

- Add one teardown owner for each SSH fixture.
- Stop the detached listener and wait for exit before removing the fixture root.
- Add bounded SIGTERM and SIGKILL escalation with ESRCH guards.
- Validate the state file before any signal call.
- Require a positive safe-integer PID and safe absolute paths rooted at the fixture directory.
- Require sshdConfigPath to equal the fixture root sshd_config path.
- Add regression coverage for listener cleanup and forged state files.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm exec vitest run packages/adapter-utils/src/ssh-fixture.test.ts`
- Confirm the fixture listener count stays at zero before and after the test run.

## Risks

The teardown now sends signals to a fixture-owned process. State validation and the existing PID reuse check limit the target. The escalation has bounded waits.

## Model Used

OpenAI GPT-5 Codex. Exact model ID: GPT-5 Codex. Context window: not exposed in this run. Capabilities used: tool use, repository inspection, GitHub operations, and code review workflow management.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I have addressed all Greptile and reviewer comments before requesting merge