### PR TITLE
fix(test): run Vitest without a shell so the runner starts on Windows

### DIFF
--- a/scripts/__tests__/vitest-cli.test.mjs
+++ b/scripts/__tests__/vitest-cli.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { resolveVitestCli } from "../vitest-cli.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const runnerSource = readFileSync(path.join(repoRoot, "scripts", "run-vitest-stable.mjs"), "utf8");
+
+test("resolves an existing Vitest JS entry point", () => {
+  const cli = resolveVitestCli();
+
+  assert.ok(path.isAbsolute(cli), `expected an absolute path, got ${cli}`);
+  assert.equal(path.basename(cli), "vitest.mjs");
+  assert.ok(existsSync(cli), `expected ${cli} to exist`);
+});
+
+test("caches the resolved path", () => {
+  assert.equal(resolveVitestCli(), resolveVitestCli());
+});
+
+test("the entry point is directly executable by Node, not a shell shim", () => {
+  // A .cmd/.bat/.ps1 shim cannot be spawned without a shell on Windows, which
+  // is the defect this module exists to avoid.
+  const cli = resolveVitestCli();
+
+  assert.ok(
+    !/\.(cmd|bat|ps1)$/i.test(cli),
+    `expected a JS entry point rather than a shell shim, got ${cli}`,
+  );
+});
+
+test("the runner spawns Node with the resolved entry point and never spawns pnpm", () => {
+  assert.match(
+    runnerSource,
+    /spawnSync\(\s*process\.execPath,\s*\[\s*resolveVitestCli\(\)/,
+    "expected the runner to spawn Node with the resolved Vitest entry point",
+  );
+  assert.doesNotMatch(
+    runnerSource,
+    /spawnSync\(\s*"pnpm"/,
+    "expected the runner not to spawn the pnpm shim, which fails on Windows",
+  );
+  assert.doesNotMatch(
+    runnerSource,
+    /shell:\s*true/,
+    "expected the runner not to use a shell, which overruns the cmd.exe command-line limit",
+  );
+});

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { createRequire } from "node:module";
 import { mkdirSync, mkdtempSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadShardDurations, selectGeneralServerShard } from "./general-server-shard.mjs";
+import { resolveVitestCli } from "./vitest-cli.mjs";
 
 const repoRoot = process.cwd();
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -82,14 +82,6 @@ const sourceOnlyVitestArgs = ["--exclude", "**/dist/**"];
 // the general-server invocation passes one --exclude per serialized suite, which
 // overruns the 8191-character cmd.exe command line. Node is invoked directly, so
 // no shell parses the arguments on any platform.
-const require = createRequire(import.meta.url);
-let cachedVitestCli = null;
-function resolveVitestCli() {
-  // Resolved lazily: --dry-run never spawns Vitest, and some jobs run this
-  // script without the Vitest package installed.
-  cachedVitestCli ??= path.join(path.dirname(require.resolve("vitest/package.json")), "vitest.mjs");
-  return cachedVitestCli;
-}
 
 function walk(dir) {
   const entries = readdirSync(dir);

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -83,7 +83,13 @@ const sourceOnlyVitestArgs = ["--exclude", "**/dist/**"];
 // overruns the 8191-character cmd.exe command line. Node is invoked directly, so
 // no shell parses the arguments on any platform.
 const require = createRequire(import.meta.url);
-const vitestCli = path.join(path.dirname(require.resolve("vitest/package.json")), "vitest.mjs");
+let cachedVitestCli = null;
+function resolveVitestCli() {
+  // Resolved lazily: --dry-run never spawns Vitest, and some jobs run this
+  // script without the Vitest package installed.
+  cachedVitestCli ??= path.join(path.dirname(require.resolve("vitest/package.json")), "vitest.mjs");
+  return cachedVitestCli;
+}
 
 function walk(dir) {
   const entries = readdirSync(dir);
@@ -294,7 +300,7 @@ function runVitest(args, label) {
   };
   mkdirSync(env.PAPERCLIP_HOME, { recursive: true });
   mkdirSync(env.TMPDIR, { recursive: true });
-  const result = spawnSync(process.execPath, [vitestCli, "run", ...sourceOnlyVitestArgs, ...args], {
+  const result = spawnSync(process.execPath, [resolveVitestCli(), "run", ...sourceOnlyVitestArgs, ...args], {
     cwd: repoRoot,
     env,
     stdio: "inherit",

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { mkdirSync, mkdtempSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -74,6 +75,15 @@ const serializedServerVitestArgs = [
   "--maxWorkers=1",
 ];
 const sourceOnlyVitestArgs = ["--exclude", "**/dist/**"];
+
+// Run Vitest through its own JS entry point rather than `pnpm exec vitest`.
+// Spawning `pnpm` fails on Windows, where it is a .cmd shim that Node cannot
+// execute without a shell, and routing through a shell is not an option here:
+// the general-server invocation passes one --exclude per serialized suite, which
+// overruns the 8191-character cmd.exe command line. Node is invoked directly, so
+// no shell parses the arguments on any platform.
+const require = createRequire(import.meta.url);
+const vitestCli = path.join(path.dirname(require.resolve("vitest/package.json")), "vitest.mjs");
 
 function walk(dir) {
   const entries = readdirSync(dir);
@@ -284,7 +294,7 @@ function runVitest(args, label) {
   };
   mkdirSync(env.PAPERCLIP_HOME, { recursive: true });
   mkdirSync(env.TMPDIR, { recursive: true });
-  const result = spawnSync("pnpm", ["exec", "vitest", "run", ...sourceOnlyVitestArgs, ...args], {
+  const result = spawnSync(process.execPath, [vitestCli, "run", ...sourceOnlyVitestArgs, ...args], {
     cwd: repoRoot,
     env,
     stdio: "inherit",

--- a/scripts/vitest-cli.mjs
+++ b/scripts/vitest-cli.mjs
@@ -1,0 +1,22 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+let cachedVitestCli = null;
+
+// Resolve Vitest's own JS entry point so callers can spawn it with Node.
+//
+// Spawning `pnpm exec vitest` fails on Windows, where `pnpm` is a .cmd shim
+// that Node cannot execute without a shell. A shell is not an acceptable
+// workaround here: the general-server invocation passes one --exclude argument
+// per serialized suite, which overruns the 8191-character cmd.exe command line,
+// and a POSIX shell would expand glob arguments such as **/dist/** before Vitest
+// received them. Spawning Node with this path avoids a shell on every platform.
+//
+// Resolution is lazy because callers such as --dry-run never spawn Vitest, and
+// some CI jobs run those paths without the Vitest package installed.
+export function resolveVitestCli() {
+  cachedVitestCli ??= path.join(path.dirname(require.resolve("vitest/package.json")), "vitest.mjs");
+  return cachedVitestCli;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - `AGENTS.md` section 7 makes `pnpm test` the default verification path before hand-off
> - On Windows that command cannot start Vitest at all, so it runs no tests
> - A Windows contributor therefore cannot verify any change locally before opening a pull request
> - This pull request makes the runner start Vitest without a shell
> - The benefit is that `pnpm test` executes suites on Windows, as it already does on Linux and macOS

## Linked Issues or Issue Description

Refs #11864 — this pull request fixes section 1 of that issue. Sections 2 and later describe separate POSIX assumptions inside `server/src/__tests__/workspace-runtime.test.ts`, which this pull request does not change.

A search found no other open pull request that changes `scripts/run-vitest-stable.mjs` for this problem.

**Issue type**

Bug.

**What happened?**

`pnpm test` exits immediately on Windows and runs no tests:

```
[test:run] general-server server suites excluding 138 serialized suites
[test:run] Failed to start Vitest: spawnSync pnpm ENOENT
 ELIFECYCLE  Command failed with exit code 1.
```

`scripts/run-vitest-stable.mjs` spawned `pnpm`. On Windows `pnpm` is a `.cmd` shim. Node cannot execute a `.cmd` file without a shell, so `spawnSync` fails with `ENOENT` before Vitest loads.

**Expected behavior**

`pnpm test` runs the Vitest suites on Windows, as it does on Linux and macOS.

**Steps to reproduce**

1. Clone the repository on Windows.
2. Run `pnpm install`.
3. Run `pnpm test`.

**Paperclip version / environment**

- Windows 11 Pro 10.0.26220
- Node v26.4.0, pnpm 9.15.4
- vitest 4.1.10
- Branch: current `master`

## What Changed

- `scripts/run-vitest-stable.mjs`: resolve Vitest's own JS entry point through `createRequire`, then spawn it with `process.execPath` instead of spawning `pnpm exec vitest`
- Added a comment recording why a shell is not used on any platform

## Verification

`shell: true` looks like the obvious fix, but it is wrong here. Two problems:

1. The general-server invocation passes one `--exclude` argument per serialized suite. There are currently 138, so roughly 276 arguments. Through `cmd.exe` this overruns the 8191-character command line and fails differently:

```
[test:run] general-server server suites excluding 138 serialized suites
The syntax of the command is incorrect.
 ELIFECYCLE  Command failed with exit code 255.
```

2. `sourceOnlyVitestArgs` contains the glob `**/dist/**`. A POSIX shell expands that glob before Vitest receives it, which changes behavior on Linux and macOS.

Spawning Node directly avoids both. No shell parses the arguments on any platform, and Node's process creation limit is far above the argument count this script generates.

Before this change, on Windows:

```
[test:run] Failed to start Vitest: spawnSync pnpm ENOENT
```

After this change, on the same machine, Vitest starts and executes suites:

```
❯ |@paperclipai/server| src/__tests__/tool-access-service.test.ts (126 tests | 119 skipped) 20063ms
```

Individual `workspace-runtime` tests still fail on Windows. Those failures are section 2 of #11864 and are not addressed here. The point of this change is that the runner starts and executes suites at all, which it previously could not do.

On Linux and macOS the behavior is unchanged: the same Vitest CLI runs with the same arguments, and no shell is involved before or after.

## Risks

Low risk. The change affects the test runner script only. No product code, schema, or behavior changes.

The one behavioral difference is that Vitest no longer runs through `pnpm exec`. `pnpm exec` adds the workspace `node_modules/.bin` directory to `PATH` for the child process. This script passes an explicit argument list to a resolved absolute entry point and does not depend on `PATH` lookup for Vitest itself. CI on Linux exercises this path on every pull request, so a regression there would be visible immediately.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5[1m]`, 1M context window. Used through Claude Code with extended thinking and tool use. The model reproduced the failure, tested the `shell: true` approach and found it insufficient, implemented the Node-spawn fix, and confirmed that Vitest then executes suites on Windows. A human reviewed the result.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass — the runner now starts and executes suites on Windows, but unrelated `workspace-runtime` tests still fail there (#11864 section 2). CI on Linux is the passing signal for this change.
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
