### PR TITLE
fix(db): recognize ALTER COLUMN SET DEFAULT as migration evidence

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -411,6 +411,31 @@ async function columnExists(
   return rows[0]?.exists ?? false;
 }
 
+// Postgres reports column defaults with an explicit cast appended, for example
+// 'on_demand'::text, while the migration statement writes the bare literal.
+// Compare the literal without the cast so both forms match.
+function normalizeColumnDefault(value: string): string {
+  return value.replace(/::[\w\s"\[\]().]+$/, "").trim().toLowerCase();
+}
+
+async function columnHasDefault(
+  sql: ReturnType<typeof postgres>,
+  tableName: string,
+  columnName: string,
+  expectedDefault: string,
+): Promise<boolean> {
+  const rows = await sql<{ columnDefault: string | null }[]>`
+    SELECT column_default AS "columnDefault"
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = ${tableName}
+      AND column_name = ${columnName}
+  `;
+  const actual = normalizeColumnDefault(rows[0]?.columnDefault ?? "");
+  if (actual.length === 0) return false;
+  return actual === normalizeColumnDefault(expectedDefault);
+}
+
 async function columnHasDataType(
   sql: ReturnType<typeof postgres>,
   tableName: string,
@@ -544,6 +569,18 @@ async function migrationStatementAlreadyApplied(
       alterColumnTypeMatch[1],
       alterColumnTypeMatch[2],
       alterColumnTypeMatch[3],
+    );
+  }
+
+  const alterColumnDefaultMatch = normalized.match(
+    /^ALTER TABLE "([^"]+)" ALTER COLUMN "([^"]+)" SET DEFAULT (.+?);?$/i,
+  );
+  if (alterColumnDefaultMatch) {
+    return columnHasDefault(
+      sql,
+      alterColumnDefaultMatch[1],
+      alterColumnDefaultMatch[2],
+      alterColumnDefaultMatch[3],
     );
   }
 

--- a/packages/db/src/migration-evidence-set-default.test.ts
+++ b/packages/db/src/migration-evidence-set-default.test.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { reconcilePendingMigrationHistory } from "./client.js";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./test-embedded-postgres.js";
+
+// 0001 is the earliest migration whose body contains an
+// `ALTER COLUMN ... SET DEFAULT` statement, which the migration-evidence
+// detector previously could not reason about.
+const MIGRATION_FILE = "0001_fast_northstar.sql";
+const cleanups: Array<() => Promise<void>> = [];
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function migrationHash() {
+  const content = await fs.promises.readFile(new URL(`./migrations/${MIGRATION_FILE}`, import.meta.url), "utf8");
+  return createHash("sha256").update(content).digest("hex");
+}
+
+describeEmbeddedPostgres("migration history reconcile: SET DEFAULT evidence", () => {
+  afterEach(async () => Promise.all(cleanups.splice(0).map((cleanup) => cleanup())));
+
+  it("records a migration whose only unrecognized statement is ALTER COLUMN SET DEFAULT", async () => {
+    const database = await startEmbeddedPostgresTestDatabase("paperclip-set-default-evidence-");
+    cleanups.push(database.cleanup);
+    const sql = postgres(database.connectionString, { max: 1 });
+    cleanups.push(async () => sql.end());
+
+    // The schema is fully migrated. Drop only this migration's history row so
+    // it looks pending while every statement in it is already applied.
+    await sql`DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = ${await migrationHash()}`;
+
+    const defaultBefore = await sql<{ columnDefault: string | null }[]>`
+      SELECT column_default AS "columnDefault"
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'heartbeat_runs'
+        AND column_name = 'invocation_source'
+    `;
+    expect(defaultBefore[0]?.columnDefault ?? "").toContain("on_demand");
+
+    const result = await reconcilePendingMigrationHistory(database.connectionString);
+
+    // Before the fix this returned an empty list: the SET DEFAULT statement was
+    // unrecognized, so the migration was treated as unapplied and the reconcile
+    // loop stopped, leaving every later migration unrecorded too.
+    expect(result.repairedMigrations).toContain(MIGRATION_FILE);
+
+    const rows = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count
+      FROM "drizzle"."__drizzle_migrations"
+      WHERE "hash" = ${await migrationHash()}
+    `;
+    expect(Number(rows[0]?.count ?? 0)).toBe(1);
+  }, 60_000);
+
+  it("does not record a migration whose SET DEFAULT is absent from the schema", async () => {
+    const database = await startEmbeddedPostgresTestDatabase("paperclip-set-default-missing-");
+    cleanups.push(database.cleanup);
+    const sql = postgres(database.connectionString, { max: 1 });
+    cleanups.push(async () => sql.end());
+
+    await sql`DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = ${await migrationHash()}`;
+    await sql`ALTER TABLE "heartbeat_runs" ALTER COLUMN "invocation_source" DROP DEFAULT`;
+
+    const result = await reconcilePendingMigrationHistory(database.connectionString);
+
+    // The evidence is genuinely missing, so the migration must stay pending
+    // rather than be silently marked as applied.
+    expect(result.repairedMigrations).not.toContain(MIGRATION_FILE);
+  }, 60_000);
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server reconciles migration history at startup when a database's history has drifted
> - Reconciliation proves a pending migration is already applied by checking each statement against the schema
> - It cannot reason about `ALTER COLUMN ... SET DEFAULT`, so a migration containing one is treated as unapplied
> - The reconcile loop stops at the first migration it cannot prove, so one unreadable statement leaves every later migration unrecorded
> - Startup then replays an old migration against existing tables and the server does not start
> - This pull request teaches the checker to verify a column default
> - The benefit is that a drifted database reconciles fully instead of stopping at the first `SET DEFAULT`

## Linked Issues or Issue Description

Refs #11864. That issue is about Windows test tooling; this fix comes from the same investigation but is platform independent.

A search found no other open pull request that changes the migration-evidence checks in `packages/db/src/client.ts`.

**Issue type**

Bug.

**What happened?**

On a database whose migration history had drifted, the server reconciled one migration and then failed to start:

```
WARN: Embedded PostgreSQL had drifted migration history; repaired migration journal entries
      from existing schema state. {"repairedMigrations":["0000_mature_masked_marvel.sql"]}
INFO: Applying 211 pending migrations for Embedded PostgreSQL
Paperclip server failed to start.
relation "agent_runtime_state" already exists
```

The schema was complete. Only the history rows were missing.

`reconcilePendingMigrationHistory` walks pending migrations in order and records each one whose statements are all provably applied. `migrationStatementAlreadyApplied` recognizes `CREATE TABLE`, `ADD COLUMN`, `ALTER COLUMN ... SET DATA TYPE`, `CREATE INDEX`, `ADD CONSTRAINT`, `CREATE OR REPLACE FUNCTION`, and `CREATE TRIGGER`. Anything else returns `false`, and one `false` marks the whole migration unapplied.

`0001_fast_northstar.sql` line 55 is:

```sql
ALTER TABLE "heartbeat_runs" ALTER COLUMN "invocation_source" SET DEFAULT 'on_demand';
```

That shape was not recognized. `0001` was therefore treated as unapplied, the loop broke, and the 210 migrations behind it stayed unrecorded. Startup then replayed `0001`, whose first statement creates `agent_runtime_state`, which already existed.

**Expected behavior**

A migration whose only unrecognized statement is `ALTER COLUMN ... SET DEFAULT` is recognized as already applied when the column carries that default, so reconciliation continues past it.

**Steps to reproduce**

1. Use a fully migrated database.
2. Delete the `drizzle.__drizzle_migrations` row for `0001_fast_northstar.sql`.
3. Call `reconcilePendingMigrationHistory`.
4. Before this change the result is empty. The migration stays pending even though every statement in it is applied.

## What Changed

- `packages/db/src/client.ts`: recognize `ALTER TABLE ... ALTER COLUMN ... SET DEFAULT` and verify it with a new `columnHasDefault` check against `information_schema.columns`
- `packages/db/src/client.ts`: add `normalizeColumnDefault`, because Postgres reports defaults with a cast appended (`'on_demand'::text`) while the migration statement writes the bare literal
- `packages/db/src/migration-evidence-set-default.test.ts`: new test covering both directions

The reconcile loop still breaks at the first migration it cannot prove. That behavior is correct and is unchanged: recording a later migration while an earlier one is missing would leave a gap that the migrator then fails on.

## Verification

```sh
cd packages/db && npx vitest run src/migration-evidence-set-default.test.ts
```

```
Test Files  1 passed (1)
     Tests  2 passed (2)
  Duration  36.09s
```

The test uses a real embedded PostgreSQL database:

- Positive case: with a fully migrated schema and only `0001`'s history row deleted, `reconcilePendingMigrationHistory` now records `0001_fast_northstar.sql`. Without this change the returned list is empty.
- Negative case: the same setup, but the column default is dropped first with `ALTER COLUMN ... DROP DEFAULT`. The migration must stay pending. This guards against the checker rubber-stamping the statement instead of verifying it.

## Risks

Low risk. The change adds one statement shape to a read-only evidence check. It records history rows; it never executes migration SQL, and it never relaxes an existing check.

The failure mode to consider is a false positive: recording a migration as applied when it is not, which would skip real schema changes. The check reads the actual column default and compares it to the literal in the statement, so a column without that default still returns `false`. The negative test covers exactly this.

Cast normalization is deliberately narrow. It strips a trailing `::type` before comparing, so `'on_demand'` matches `'on_demand'::text`. Defaults that differ in value still do not match.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5[1m]`, 1M context window. Used through Claude Code with extended thinking and tool use. The model diagnosed the failure from a real database, traced it to the unrecognized statement shape, implemented the check, and verified both directions against embedded PostgreSQL. A human reviewed the result.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
