### PR TITLE
feat(adapter-utils): bound host memory on the HTTP/2 sandbox bridge

### DIFF
--- a/doc/observability.md
+++ b/doc/observability.md
@@ -630,6 +630,63 @@ names are literal constants in `duplex-observability.ts`.
 | `sandbox_duplex_aggregate_byte_reservation_rejections_total` | counter | One rejected aggregate byte reservation. The ledger increments it when a reservation would pass the aggregate ceiling. |
 | `sandbox_duplex_aggregate_byte_accounting_underflow_total` | counter | One aggregate byte accounting defect. The ledger increments it on a double release or on a transfer of a token it does not hold. |
 
+### HTTP/2 bridge admission gate
+
+The host bounds its own memory use for the sandbox HTTP/2 bridge with one
+process-wide admission gate. The code owner is
+`packages/adapter-utils/src/http2-bridge-admission.ts`. The gate holds two
+caps: a cap on parallel admitted bridge streams, and a cap on live bridge
+sessions. Each cap bounds a known per-unit byte cost, so the pair bounds the
+host's worst-case retained bytes for the bridge.
+
+The host reads two optional operator settings from the environment at
+startup:
+
+| Setting | Default | Valid range |
+| --- | --- | --- |
+| `PAPERCLIP_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS` | 64 | A safe integer from 1 to 64 |
+| `PAPERCLIP_MAX_LIVE_HTTP2_BRIDGE_SESSIONS` | 8 | A safe integer from 1 to 64 |
+
+`PAPERCLIP_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS` sets the cap on parallel
+admitted streams. A stream that arrives after the cap is full waits in a
+first-in-first-out queue for a released slot.
+
+`PAPERCLIP_MAX_LIVE_HTTP2_BRIDGE_SESSIONS` sets the cap on live bridge
+sessions. A session request never waits. When the cap is full, the host
+falls back to the file bridge at once. See "File-bridge fallback" below.
+
+An absent setting uses its default. A present invalid value — blank,
+whitespace-only, non-numeric, zero, negative, non-integer, or over 64 — does
+not stop the host from starting. The host rejects the value, logs it at
+error level, and uses the default instead.
+
+A valid range on one setting is not a bound on the pair. Each cap can pass
+its own range check, and the pair can still spend more than the host's
+reserved memory budget. So the host also checks a joint rule on the resolved
+pair before it uses either value:
+
+```text
+(maxParallel × 868,351) + (maxSessions × 16,777,216) ≤ 201,326,592
+```
+
+The host holds 201,326,592 bytes (192 MiB) in reserve out of a
+268,435,456-byte (256 MiB) memory target for the bridge. A resolved pair
+that spends the full reserved amount still leaves the remaining 25 percent
+of the target as headroom for object overhead and allocator behavior.
+
+A pair that fails the joint rule is refused as one unit: the host never
+keeps one operator value and one default from a refused pair. It logs the
+refused pair and the computed total at error level, and falls back to both
+defaults (64 parallel streams, 8 live sessions).
+
+#### File-bridge fallback
+
+When the live-session cap is full, the host closes the partial sandbox
+channel and falls back to the file bridge instead of the HTTP/2 bridge. The
+fallback event records the `host_session_capacity` reason in the
+`fallback_reason` dimension above. The sandbox request still completes; it
+uses the file bridge transport instead of a live HTTP/2 session.
+
 ### Dimension keys
 
 Counters carry no dimension labels. The guarded counter store keys each counter
@@ -644,7 +701,7 @@ key never reaches a sink by accident.
 | `provider` | string | no | `daytona`, or `other` for any other plugin key. |
 | `transport` | string | no | `duplex`, `http2`, or `file`. `duplex` names the retired bespoke frame protocol; `http2` names the Node HTTP/2 session over the sandbox channel; a fallback record uses `file`. |
 | `outcome` | string | yes | `ok` or `error`. |
-| `fallback_reason` | string | yes | `gate_off`, `capability_absent`, `route_busy`, `entrypoint_sync_failed`, `broker_construction_failed`, `channel_open_failed`, `ready_invalid`, `ready_nonce_mismatch`, `ready_timeout`, `contaminated`, `aggregate_bytes_exceeded`, or `preface_missing`. It rides only a fallback record. `route_busy` marks the process-scoped route ceiling full. `entrypoint_sync_failed` and `broker_construction_failed` mark the named build step. `channel_open_failed` marks a failed channel open. `aggregate_bytes_exceeded` marks a readiness handshake, or an `http2` post-preface pre-bind buffer, where the host fell back because the process aggregate byte ceiling had no room. `preface_missing` marks a missing or an invalid HTTP/2 client connection preface inside the bounded readiness buffer: the host found no valid preface after the accepted READY line, aborted the `http2` open, and moved the run to the file bridge (`queue_v1`) one time. |
+| `fallback_reason` | string | yes | `gate_off`, `capability_absent`, `route_busy`, `entrypoint_sync_failed`, `broker_construction_failed`, `channel_open_failed`, `ready_invalid`, `ready_nonce_mismatch`, `ready_timeout`, `contaminated`, `aggregate_bytes_exceeded`, `preface_missing`, or `host_session_capacity`. It rides only a fallback record. `route_busy` marks the process-scoped route ceiling full. `entrypoint_sync_failed` and `broker_construction_failed` mark the named build step. `channel_open_failed` marks a failed channel open. `aggregate_bytes_exceeded` marks a readiness handshake, or an `http2` post-preface pre-bind buffer, where the host fell back because the process aggregate byte ceiling had no room. `preface_missing` marks a missing or an invalid HTTP/2 client connection preface inside the bounded readiness buffer: the host found no valid preface after the accepted READY line, aborted the `http2` open, and moved the run to the file bridge (`queue_v1`) one time. `host_session_capacity` marks a full live HTTP/2 bridge session cap: every host-wide session slot was in use, so the host never bound the channel to an HTTP/2 session and moved the run to the file bridge instead. See [HTTP/2 bridge admission gate](#http2-bridge-admission-gate) above. |
 | `loss_class` | string | yes | `pre_dispatch` or `post_dispatch`, relative to the first request dispatch. It rides only a loss record. |
 | `loss_reason` | string | yes | `stdin_eof`, `provider_exit`, `heartbeat_timeout`, `rpc_failure`, `write_error`, `transport_closed`, or `other`. The host maps every loss cause to one of these values, so no raw provider text reaches a sink. `write_error` marks a rejected host-to-sandbox write. `transport_closed` marks a reason-less provider transport close with no exit data. It rides only a loss record. |
 

--- a/packages/adapter-utils/src/duplex-observability.ts
+++ b/packages/adapter-utils/src/duplex-observability.ts
@@ -108,7 +108,11 @@ export type DuplexOutcomeValue = "ok" | "error";
  * names a missing or an invalid HTTP/2 client connection preface inside the
  * bounded readiness buffer: the host found no valid preface after the
  * accepted READY line, aborted the HTTP/2 open, and moved the run to
- * `queue_v1` one time.
+ * `queue_v1` one time. The `host_session_capacity` reason names a full live
+ * HTTP/2 bridge session cap: every host-wide session slot was in use, so the
+ * host never bound the channel to an HTTP/2 session. This differs from
+ * `route_busy`, which names a full worker-manager route ceiling, a separate
+ * cap on a separate resource.
  */
 export type DuplexFallbackReason =
   | "gate_off"
@@ -122,7 +126,8 @@ export type DuplexFallbackReason =
   | "ready_timeout"
   | "contaminated"
   | "aggregate_bytes_exceeded"
-  | "preface_missing";
+  | "preface_missing"
+  | "host_session_capacity";
 
 /** The class of a terminal loss, relative to the first request dispatch. */
 export type DuplexLossClass = "pre_dispatch" | "post_dispatch";

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -25,6 +25,7 @@ import {
   formatAdapterExecutionTimeoutStartLogLine,
   parseAdapterExecutionTarget,
   postedIssueCommentLogMarker,
+  POSTED_COMMENT_MARKER_DECODE_LIMIT_BYTES,
   resolveAdapterExecutionTargetTimeout,
   resolveAdapterExecutionTargetTimeoutSec,
   runAdapterExecutionTargetProcess,
@@ -119,10 +120,46 @@ describe("sandbox adapter execution targets", () => {
   const cleanupDirs: string[] = [];
 
   it("records successful issue comment ids for attribution recovery", () => {
-    expect(postedIssueCommentLogMarker("POST", "/api/issues/issue-1/comments", 201, '{"id":"comment-1"}'))
-      .toBe("comment id: comment-1\n");
-    expect(postedIssueCommentLogMarker("POST", "/api/issues/issue-1/comments", 401, '{"id":"comment-1"}'))
-      .toBeNull();
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(postedIssueCommentLogMarker("POST", "/api/issues/issue-1/comments", 201, `{"id":"${uuid}"}`)).toBe(
+      `comment id: ${uuid}\n`,
+    );
+    expect(postedIssueCommentLogMarker("POST", "/api/issues/issue-1/comments", 401, `{"id":"${uuid}"}`)).toBeNull();
+    // The function accepts a `Buffer` body, matching the bytes the http2 path
+    // hands it after it drops the string round trip.
+    expect(
+      postedIssueCommentLogMarker(
+        "POST",
+        "/api/issues/issue-1/comments",
+        201,
+        Buffer.from(`{"id":"${uuid}"}`, "utf8"),
+      ),
+    ).toBe(`comment id: ${uuid}\n`);
+  });
+
+  it("the comment marker returns null for an identifier that is not a canonical UUID", () => {
+    expect(
+      postedIssueCommentLogMarker("POST", "/api/issues/issue-1/comments", 201, '{"id":"comment-1"}'),
+    ).toBeNull();
+    // Uppercase hex is a valid UUID, but not a canonical *lowercase* UUID.
+    expect(
+      postedIssueCommentLogMarker(
+        "POST",
+        "/api/issues/issue-1/comments",
+        201,
+        '{"id":"550E8400-E29B-41D4-A716-446655440000"}',
+      ),
+    ).toBeNull();
+  });
+
+  it("the comment marker returns null for a body past the decode limit", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const oversized = Buffer.from(
+      JSON.stringify({ id: uuid, padding: "x".repeat(POSTED_COMMENT_MARKER_DECODE_LIMIT_BYTES) }),
+      "utf8",
+    );
+    expect(oversized.length).toBeGreaterThan(POSTED_COMMENT_MARKER_DECODE_LIMIT_BYTES);
+    expect(postedIssueCommentLogMarker("POST", "/api/issues/issue-1/comments", 201, oversized)).toBeNull();
   });
 
   afterEach(async () => {
@@ -3264,10 +3301,10 @@ describe("sandbox adapter execution targets", () => {
    */
   function http2TestRequest(
     session: http2.ClientHttp2Session,
-    request: { method: string; path: string; headers?: Record<string, string>; body?: string },
-  ): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+    request: { method: string; path: string; headers?: Record<string, string>; body?: string | Buffer },
+  ): Promise<{ status: number; headers: Record<string, string>; body: string; bodyBytes: Buffer }> {
     return new Promise((resolve, reject) => {
-      const body = Buffer.from(request.body ?? "", "utf8");
+      const body = Buffer.isBuffer(request.body) ? request.body : Buffer.from(request.body ?? "", "utf8");
       const stream = session.request(
         { ":method": request.method, ":path": request.path, ...request.headers },
         { endStream: body.length === 0 },
@@ -3284,7 +3321,10 @@ describe("sandbox adapter execution targets", () => {
         }
       });
       stream.on("data", (chunk: Buffer) => chunks.push(chunk));
-      stream.once("end", () => resolve({ status, headers, body: Buffer.concat(chunks).toString("utf8") }));
+      stream.once("end", () => {
+        const bodyBytes = Buffer.concat(chunks);
+        resolve({ status, headers, body: bodyBytes.toString("utf8"), bodyBytes });
+      });
       stream.once("error", (error) => reject(error));
       if (body.length > 0) stream.end(body);
       else if (!stream.writableEnded) stream.end();
@@ -3294,7 +3334,10 @@ describe("sandbox adapter execution targets", () => {
   // Start a host API server that records each forwarded request, so a test can
   // assert the real token and the run id reach the host, or that a rejected
   // request never forwards.
-  async function startRecordingApiServer(): Promise<{
+  async function startRecordingApiServer(options?: {
+    /** Overrides the default `{ ok: true }` JSON reply with these raw bytes. */
+    responseBody?: Buffer;
+  }): Promise<{
     origin: string;
     requests: Array<{
       method: string;
@@ -3302,6 +3345,7 @@ describe("sandbox adapter execution targets", () => {
       auth: string | null;
       runId: string | null;
       headers: Record<string, string>;
+      body: Buffer;
     }>;
     close: () => Promise<void>;
   }> {
@@ -3311,21 +3355,28 @@ describe("sandbox adapter execution targets", () => {
       auth: string | null;
       runId: string | null;
       headers: Record<string, string>;
+      body: Buffer;
     }> = [];
+    const responseBody = options?.responseBody ?? Buffer.from(JSON.stringify({ ok: true }), "utf8");
     const server = createServer((req, res) => {
-      const headers: Record<string, string> = {};
-      for (const [key, value] of Object.entries(req.headers)) {
-        if (typeof value === "string") headers[key] = value;
-      }
-      requests.push({
-        method: req.method ?? "GET",
-        url: req.url ?? "/",
-        auth: req.headers.authorization ?? null,
-        runId: typeof req.headers["x-paperclip-run-id"] === "string" ? req.headers["x-paperclip-run-id"] : null,
-        headers,
+      const bodyChunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => bodyChunks.push(chunk));
+      req.on("end", () => {
+        const headers: Record<string, string> = {};
+        for (const [key, value] of Object.entries(req.headers)) {
+          if (typeof value === "string") headers[key] = value;
+        }
+        requests.push({
+          method: req.method ?? "GET",
+          url: req.url ?? "/",
+          auth: req.headers.authorization ?? null,
+          runId: typeof req.headers["x-paperclip-run-id"] === "string" ? req.headers["x-paperclip-run-id"] : null,
+          headers,
+          body: Buffer.concat(bodyChunks),
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(responseBody);
       });
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ ok: true }));
     });
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
@@ -3458,6 +3509,109 @@ describe("sandbox adapter execution targets", () => {
     // Teardown closed the channel before lease release, then stopped the child.
     expect(control.closeCount).toBeGreaterThanOrEqual(1);
     expect(control.stopCount).toBeGreaterThanOrEqual(1);
+  }, 20000);
+
+  it("the HTTP/2 path forwards malformed UTF-8 request bytes to the host API unchanged", async () => {
+    // A lone continuation byte and a truncated multi-byte sequence: bytes no
+    // UTF-8 decode-then-encode round trip preserves.
+    const malformed = Buffer.from([0x80, 0xc3, 0x28, 0xff, 0xfe, 0x00]);
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-req-bytes-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const api = await startRecordingApiServer();
+    const sessionRef: { current: http2.ClientHttp2Session | null } = { current: null };
+    let bridgeToken = "";
+    const { runner } = makeHttp2SelectionRunner((ctx) => {
+      bridgeToken = ctx.bridgeToken;
+      ctx.emitReady();
+      sessionRef.current = ctx.connectHttp2();
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-req-bytes",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    try {
+      expect(bridge?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+      await waitForCondition(() => sessionRef.current !== null, "the http2 client session to open", 4000);
+      await http2TestRequest(sessionRef.current!, {
+        method: "POST",
+        path: "/api/issues/issue-1/comments",
+        headers: { authorization: `Bearer ${bridgeToken}`, "content-type": "application/octet-stream" },
+        body: malformed,
+      });
+      await waitForCondition(() => api.requests.length >= 1, "the host to forward the http2 request", 4000);
+      expect(api.requests[0].body.equals(malformed)).toBe(true);
+    } finally {
+      sessionRef.current?.close();
+      await bridge?.stop();
+      await api.close();
+    }
+  }, 20000);
+
+  it("the HTTP/2 path returns malformed UTF-8 host response bytes to the sandbox unchanged", async () => {
+    const malformed = Buffer.from([0xff, 0xfe, 0x80, 0x81, 0x00, 0x01]);
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-resp-bytes-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const api = await startRecordingApiServer({ responseBody: malformed });
+    const sessionRef: { current: http2.ClientHttp2Session | null } = { current: null };
+    let bridgeToken = "";
+    const { runner } = makeHttp2SelectionRunner((ctx) => {
+      bridgeToken = ctx.bridgeToken;
+      ctx.emitReady();
+      sessionRef.current = ctx.connectHttp2();
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-resp-bytes",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    try {
+      expect(bridge?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+      await waitForCondition(() => sessionRef.current !== null, "the http2 client session to open", 4000);
+      const response = await http2TestRequest(sessionRef.current!, {
+        method: "GET",
+        path: "/api/agents/me",
+        headers: { authorization: `Bearer ${bridgeToken}` },
+      });
+      expect(response.status).toBe(200);
+      expect(response.bodyBytes.equals(malformed)).toBe(true);
+    } finally {
+      sessionRef.current?.close();
+      await bridge?.stop();
+      await api.close();
+    }
   }, 20000);
 
   it("falls back to the file bridge when a post-READY pre-bind flood exceeds the aggregate ceiling", async () => {

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -58,7 +58,7 @@ import {
   decodeDuplexLine,
   encodeDuplexFrame,
 } from "./duplex-frame-codec.js";
-import { DUPLEX_CHANNEL_LOST_ERROR_CODE } from "./bridge-transport-contract.js";
+import { DEFAULT_DUPLEX_BROKER_BUDGETS, DUPLEX_CHANNEL_LOST_ERROR_CODE } from "./bridge-transport-contract.js";
 import {
   configureHttp2BridgeAdmissionGate,
   getHttp2BridgeAdmissionGate,
@@ -5382,10 +5382,11 @@ describe("sandbox adapter execution targets", () => {
       effectiveCapabilities: duplexCapabilities(true),
     };
 
-    // A forward budget past the default response budget (32 s). The http2 path
-    // holds no nested-budget derivation (that budget set belonged to the retired
-    // duplex_v1 broker only), so a large forward budget must still select and
-    // serve normally.
+    // A forward budget past the default response budget (32 s). The host's
+    // own forward call may run for up to this whole budget, so the gateway's
+    // own response wait must carry headroom above it — otherwise the gateway
+    // gives up on a still-valid host response before it arrives.
+    const forwardTimeoutMs = 60_000;
     const bridge = await startAdapterExecutionTargetPaperclipBridge({
       runId: "run-budget",
       target,
@@ -5394,10 +5395,17 @@ describe("sandbox adapter execution targets", () => {
       hostApiToken: "real-run-jwt",
       hostApiUrl: api.origin,
       enableSandboxDuplexBridge: true,
-      forwardTimeoutMs: 60_000,
+      forwardTimeoutMs,
     });
     try {
       expect(bridge?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+      // The gateway response wait carries the same headroom over the forward
+      // budget that `DEFAULT_DUPLEX_BROKER_BUDGETS` reserves between
+      // `forwardTimeoutMs` and `gatewayWaitMs`, so it scales with a custom
+      // forward budget instead of staying pinned at the 30 s default.
+      const expectedHeadroomMs =
+        DEFAULT_DUPLEX_BROKER_BUDGETS.gatewayWaitMs - DEFAULT_DUPLEX_BROKER_BUDGETS.forwardTimeoutMs;
+      expect(bridge?.env.PAPERCLIP_BRIDGE_RESPONSE_TIMEOUT_MS).toBe(String(forwardTimeoutMs + expectedHeadroomMs));
       await waitForCondition(() => sessionRef.current !== null, "the http2 client session to open", 4000);
       const response = await http2TestRequest(sessionRef.current!, {
         method: "GET",
@@ -5409,6 +5417,118 @@ describe("sandbox adapter execution targets", () => {
       sessionRef.current?.close();
       await bridge?.stop();
       await api.close();
+    }
+  }, 20000);
+
+  it("gives the in-sandbox http2 gateway response wait headroom over the default forward budget", async () => {
+    // With no forward-budget override, the gateway wait must still carry
+    // headroom above the default 30 s forward budget, not collapse to the
+    // same value. A response that lands right at the forward deadline needs
+    // this gap to cross back over the stream before the gateway gives up.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-default-budget-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const api = await startRecordingApiServer();
+    const { runner } = makeHttp2SelectionRunner((ctx) => {
+      ctx.emitReady();
+      ctx.connectHttp2();
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-default-budget",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    try {
+      expect(bridge?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+      const responseTimeoutMs = Number(bridge?.env.PAPERCLIP_BRIDGE_RESPONSE_TIMEOUT_MS);
+      expect(Number.isFinite(responseTimeoutMs)).toBe(true);
+      expect(responseTimeoutMs).toBeGreaterThan(DEFAULT_DUPLEX_BROKER_BUDGETS.forwardTimeoutMs);
+    } finally {
+      await bridge?.stop();
+      await api.close();
+    }
+  }, 20000);
+
+  it("delivers a host response that lands right before the forward deadline", async () => {
+    // The host response completes near, but under, the forward deadline. The
+    // gateway must still deliver it: the headroom on its own wait, not the
+    // forward budget itself, is what this test proves.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-near-deadline-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const forwardTimeoutMs = 300;
+    const nearDeadlineDelayMs = forwardTimeoutMs - 50;
+    const api = createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      }, nearDeadlineDelayMs);
+    });
+    await new Promise<void>((resolve, reject) => {
+      api.once("error", reject);
+      api.listen(0, "127.0.0.1", () => resolve());
+    });
+    const apiAddress = api.address();
+    if (!apiAddress || typeof apiAddress === "string") {
+      throw new Error("Expected the near-deadline API server to listen on a TCP port.");
+    }
+    const sessionRef: { current: http2.ClientHttp2Session | null } = { current: null };
+    let bridgeToken = "";
+    const { runner } = makeHttp2SelectionRunner((ctx) => {
+      bridgeToken = ctx.bridgeToken;
+      ctx.emitReady();
+      sessionRef.current = ctx.connectHttp2();
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-near-deadline",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: `http://127.0.0.1:${apiAddress.port}`,
+      enableSandboxDuplexBridge: true,
+      forwardTimeoutMs,
+    });
+    try {
+      expect(bridge?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+      await waitForCondition(() => sessionRef.current !== null, "the http2 client session to open", 4000);
+      const response = await http2TestRequest(sessionRef.current!, {
+        method: "GET",
+        path: "/api/agents/me",
+        headers: { authorization: `Bearer ${bridgeToken}` },
+      });
+      expect(response.status).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ ok: true });
+    } finally {
+      sessionRef.current?.close();
+      await bridge?.stop();
+      await new Promise<void>((resolve) => api.close(() => resolve()));
     }
   }, 20000);
 

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http";
 import http2 from "node:http2";
 import net from "node:net";
-import { duplexPair, type Duplex } from "node:stream";
+import { duplexPair, Duplex } from "node:stream";
 import { execFile, spawn } from "node:child_process";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -13,6 +13,7 @@ import { getSandboxDuplexGatewayCodecSource } from "./sandbox-callback-bridge.js
 
 import {
   __duplexReadinessTesting,
+  __http2BridgeSessionAdmissionTesting,
   __http2PrefaceScanTesting,
   DEFAULT_REMOTE_SANDBOX_ADAPTER_TIMEOUT_SEC,
   adapterExecutionTargetDuplexObservabilityRecorder,
@@ -58,6 +59,12 @@ import {
   encodeDuplexFrame,
 } from "./duplex-frame-codec.js";
 import { DUPLEX_CHANNEL_LOST_ERROR_CODE } from "./bridge-transport-contract.js";
+import {
+  configureHttp2BridgeAdmissionGate,
+  getHttp2BridgeAdmissionGate,
+  Http2BridgeAdmissionGate,
+} from "./http2-bridge-admission.js";
+import type { Http2BridgeServerHandle } from "./http2-bridge-server.js";
 import {
   DUPLEX_AGGREGATE_BYTE_LEDGER_METRIC_NAMES,
   DUPLEX_COUNTER_AGGREGATE_BYTE_ACCOUNTING_UNDERFLOW_TOTAL,
@@ -169,6 +176,14 @@ describe("sandbox adapter execution targets", () => {
       if (!dir) continue;
       await rm(dir, { recursive: true, force: true }).catch(() => undefined);
     }
+  });
+
+  // The host HTTP/2 bridge admission gate is one process-wide singleton
+  // (`getHttp2BridgeAdmissionGate`). A test that configures a small session
+  // cap, or reserves a session slot directly, must not leak that state into
+  // a later test in this file.
+  afterEach(() => {
+    configureHttp2BridgeAdmissionGate({});
   });
 
   function createLocalSandboxRunner() {
@@ -5542,6 +5557,291 @@ describe("sandbox adapter execution targets", () => {
       await api.close();
     }
   }, 20000);
+
+  it("a run past the live session cap binds no HTTP/2 session and uses the file bridge", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-session-cap-mode-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const api = await startRecordingApiServer();
+    const { runner, control } = makeHttp2SelectionRunner((ctx) => {
+      ctx.emitReady();
+      // A valid client preface still arrives — the session cap, not a
+      // preface failure, is what must turn this run away.
+      ctx.connectHttp2();
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    // Fill the one live-session slot the cap allows, before the run even
+    // starts, so the run below finds no free slot.
+    configureHttp2BridgeAdmissionGate({ maxSessions: 1 });
+    const releasePreexistingSession = getHttp2BridgeAdmissionGate().tryAcquireSession();
+    expect(releasePreexistingSession).not.toBeNull();
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-session-cap-mode",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    try {
+      expect(bridge).not.toBeNull();
+      expect(control.openCount).toBe(1);
+      // The live-session cap was already full: the host never bound this
+      // channel to an HTTP/2 session, so the run serves over the file bridge.
+      expect(bridge?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("queue_v1");
+    } finally {
+      releasePreexistingSession?.();
+      await bridge?.stop();
+      await api.close();
+    }
+  }, 20000);
+
+  it("a refused session disposes the pending replay and closes the partial channel inside the cleanup budget", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-session-cap-cleanup-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const api = await startRecordingApiServer();
+    const { runner, control } = makeHttp2SelectionRunner((ctx) => {
+      ctx.emitReady();
+      ctx.connectHttp2();
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    configureHttp2BridgeAdmissionGate({ maxSessions: 1 });
+    const releasePreexistingSession = getHttp2BridgeAdmissionGate().tryAcquireSession();
+    expect(releasePreexistingSession).not.toBeNull();
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-session-cap-cleanup",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    try {
+      expect(bridge).not.toBeNull();
+      // The refused session closed the partial channel inside the bounded
+      // cleanup budget: no live provider session remains.
+      expect(control.closeCount + control.stopCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      releasePreexistingSession?.();
+      await bridge?.stop();
+      await api.close();
+    }
+  }, 20000);
+
+  it("the fallback for a full session cap reports host_session_capacity", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-session-cap-reason-"));
+    cleanupDirs.push(rootDir);
+    const remoteCwd = path.join(rootDir, "workspace");
+    await mkdir(remoteCwd, { recursive: true });
+    const api = await startRecordingApiServer();
+    const { runner } = makeHttp2SelectionRunner((ctx) => {
+      ctx.emitReady();
+      ctx.connectHttp2();
+    });
+    const { recorder, counters } = createRecordingDuplexRecorder();
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd,
+      timeoutMs: 30_000,
+      runner,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+
+    configureHttp2BridgeAdmissionGate({ maxSessions: 1 });
+    const releasePreexistingSession = getHttp2BridgeAdmissionGate().tryAcquireSession();
+    expect(releasePreexistingSession).not.toBeNull();
+
+    const bridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-session-cap-reason",
+      target,
+      runtimeRootDir: path.join(remoteCwd, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api.origin,
+      enableSandboxDuplexBridge: true,
+      duplexObservabilityRecorder: recorder,
+    });
+    try {
+      expect(bridge).not.toBeNull();
+      const fallback = counters.find((c) => c.metric === DUPLEX_COUNTER_FALLBACK_TOTAL);
+      expect(fallback?.dimensions.fallback_reason).toBe("host_session_capacity");
+    } finally {
+      releasePreexistingSession?.();
+      await bridge?.stop();
+      await api.close();
+    }
+  }, 20000);
+
+  it("a closed session frees its slot for the next run", async () => {
+    configureHttp2BridgeAdmissionGate({ maxSessions: 1 });
+
+    const rootDir1 = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-session-reuse-1-"));
+    cleanupDirs.push(rootDir1);
+    const remoteCwd1 = path.join(rootDir1, "workspace");
+    await mkdir(remoteCwd1, { recursive: true });
+    const api1 = await startRecordingApiServer();
+    const sessionRef1: { current: http2.ClientHttp2Session | null } = { current: null };
+    const { runner: runner1 } = makeHttp2SelectionRunner((ctx) => {
+      ctx.emitReady();
+      sessionRef1.current = ctx.connectHttp2();
+    });
+    const target1: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd: remoteCwd1,
+      timeoutMs: 30_000,
+      runner: runner1,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+    const bridge1 = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-session-reuse-1",
+      target: target1,
+      runtimeRootDir: path.join(remoteCwd1, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api1.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    expect(bridge1?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+    // The first run holds the one session slot the cap allows.
+    expect(getHttp2BridgeAdmissionGate().activeSessionCount).toBe(1);
+
+    await bridge1?.stop();
+    sessionRef1.current?.close();
+    await api1.close();
+    // `stop()` released the slot, either through the bound `Duplex`'s
+    // `close` event or the idempotent safety-net release inside `stop()`.
+    expect(getHttp2BridgeAdmissionGate().activeSessionCount).toBe(0);
+
+    const rootDir2 = await mkdtemp(path.join(os.tmpdir(), "paperclip-http2-session-reuse-2-"));
+    cleanupDirs.push(rootDir2);
+    const remoteCwd2 = path.join(rootDir2, "workspace");
+    await mkdir(remoteCwd2, { recursive: true });
+    const api2 = await startRecordingApiServer();
+    const sessionRef2: { current: http2.ClientHttp2Session | null } = { current: null };
+    const { runner: runner2 } = makeHttp2SelectionRunner((ctx) => {
+      ctx.emitReady();
+      sessionRef2.current = ctx.connectHttp2();
+    });
+    const target2: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "daytona",
+      remoteCwd: remoteCwd2,
+      timeoutMs: 30_000,
+      runner: runner2,
+      effectiveCapabilities: duplexCapabilities(true),
+    };
+    const bridge2 = await startAdapterExecutionTargetPaperclipBridge({
+      runId: "run-session-reuse-2",
+      target: target2,
+      runtimeRootDir: path.join(remoteCwd2, ".paperclip-runtime", "codex"),
+      adapterKey: "codex",
+      hostApiToken: "real-run-jwt",
+      hostApiUrl: api2.origin,
+      enableSandboxDuplexBridge: true,
+    });
+    try {
+      // The freed slot let a second run select the HTTP/2 transport again.
+      expect(bridge2?.env.PAPERCLIP_API_BRIDGE_MODE).toBe("http2_v1");
+    } finally {
+      sessionRef2.current?.close();
+      await bridge2?.stop();
+      await api2.close();
+    }
+  }, 20000);
+
+  describe("bindHttp2BridgeSessionWithAdmission", () => {
+    function fakeChannelForAdmissionTest(): CommandManagedDuplexChannel {
+      return {
+        write: () => {},
+        onData: () => {},
+        onExit: () => {},
+        stop: () => {},
+        close: async () => {},
+      };
+    }
+
+    it("a bind failure frees the session slot exactly one time", () => {
+      const gate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const bindError = new Error("simulated http2 bindChannel failure");
+      const fakeHandle: Http2BridgeServerHandle = {
+        server: {} as unknown as http2.Http2Server,
+        bindChannel: () => {
+          throw bindError;
+        },
+        close: async () => {},
+      };
+      expect(() =>
+        __http2BridgeSessionAdmissionTesting.bindHttp2BridgeSessionWithAdmission(
+          gate,
+          fakeHandle,
+          fakeChannelForAdmissionTest(),
+        ),
+      ).toThrow(bindError);
+      // The reservation never outlives a channel that never bound.
+      expect(gate.activeSessionCount).toBe(0);
+    });
+
+    it("the host reserves the session slot before bindChannel, not after", () => {
+      const gate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const order: string[] = [];
+      const originalTryAcquireSession = gate.tryAcquireSession.bind(gate);
+      gate.tryAcquireSession = () => {
+        order.push("reserve");
+        return originalTryAcquireSession();
+      };
+      const fakeDuplex = new Duplex({
+        read() {},
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+      });
+      const fakeHandle: Http2BridgeServerHandle = {
+        server: {} as unknown as http2.Http2Server,
+        bindChannel: () => {
+          order.push("bind");
+          return fakeDuplex;
+        },
+        close: async () => {},
+      };
+      const result = __http2BridgeSessionAdmissionTesting.bindHttp2BridgeSessionWithAdmission(
+        gate,
+        fakeHandle,
+        fakeChannelForAdmissionTest(),
+      );
+      expect(result).not.toBeNull();
+      expect(order).toEqual(["reserve", "bind"]);
+    });
+  });
 
   it("test_the_host_writes_no_byte_before_the_ready_line_is_accepted", async () => {
     // The launch wrapper gives the gateway no start acknowledgment (accepted

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -88,13 +88,36 @@ import type { LocalProcessSandboxOptions } from "./local-process-sandbox.js";
 
 export type { RuntimeProgressSink } from "./runtime-progress.js";
 
-export function postedIssueCommentLogMarker(method: string, requestPath: string, status: number, body: string) {
+/**
+ * The decode limit for {@link postedIssueCommentLogMarker}. The response body
+ * is untrusted output, so the host never decodes more than this many bytes of
+ * it to build one log line, and it never allocates a second full-size string
+ * for a body over this limit.
+ */
+export const POSTED_COMMENT_MARKER_DECODE_LIMIT_BYTES = 4096;
+
+const CANONICAL_LOWERCASE_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export function postedIssueCommentLogMarker(
+  method: string,
+  requestPath: string,
+  status: number,
+  body: Buffer | string,
+) {
   if (method !== "POST" || !/^\/api\/issues\/[^/]+\/comments$/.test(requestPath) || status < 200 || status >= 300) {
     return null;
   }
+  const bodyBytes = typeof body === "string" ? Buffer.byteLength(body, "utf8") : body.length;
+  if (bodyBytes > POSTED_COMMENT_MARKER_DECODE_LIMIT_BYTES) {
+    return null;
+  }
+  const decoded =
+    typeof body === "string" ? body : body.toString("utf8", 0, POSTED_COMMENT_MARKER_DECODE_LIMIT_BYTES);
   try {
-    const parsed = JSON.parse(body) as { id?: unknown };
-    return typeof parsed.id === "string" && parsed.id.length > 0 ? `comment id: ${parsed.id}\n` : null;
+    const parsed = JSON.parse(decoded) as { id?: unknown };
+    return typeof parsed.id === "string" && CANONICAL_LOWERCASE_UUID_PATTERN.test(parsed.id)
+      ? `comment id: ${parsed.id}\n`
+      : null;
   } catch {
     return null;
   }
@@ -1505,7 +1528,8 @@ function bridgeResponseBodyLimitError(maxBodyBytes: number): Error {
 }
 
 /**
- * Read the forward response body into a string. The reader bounds the body with
+ * Read the forward response body into one `Buffer`. The reader carries the raw
+ * bytes end to end and holds no separate string copy. It bounds the body with
  * two controls. The per-request `maxBodyBytes` limit rejects a body larger than
  * the configured per-request ceiling. The optional host aggregate byte ledger
  * bounds the retained bytes across all live routes.
@@ -1524,7 +1548,7 @@ async function readBridgeForwardResponseBody(
   response: Response,
   maxBodyBytes: number,
   ledger?: DuplexAggregateByteLedger | null,
-): Promise<string> {
+): Promise<Buffer> {
   const rawContentLength = response.headers.get("content-length");
   if (rawContentLength) {
     const contentLength = Number.parseInt(rawContentLength, 10);
@@ -1534,7 +1558,7 @@ async function readBridgeForwardResponseBody(
   }
 
   if (!response.body) {
-    return "";
+    return Buffer.alloc(0);
   }
 
   const reader = response.body.getReader();
@@ -1579,7 +1603,7 @@ async function readBridgeForwardResponseBody(
       }
       tokens.push(concatToken);
     }
-    return Buffer.concat(chunks, totalBytes).toString("utf8");
+    return Buffer.concat(chunks, totalBytes);
   } finally {
     if (ledger) {
       for (const token of tokens) {
@@ -4225,14 +4249,17 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       path: string;
       query: string;
       headers: Record<string, string>;
-      /** The file bridge passes the whole request body here as one string. */
-      body?: string;
+      /**
+       * The file bridge passes the whole request body here as one string. The
+       * http2 path passes the raw request bytes with no string round trip.
+       */
+      body?: string | Uint8Array;
     },
     signal?: AbortSignal,
     options?: {
       suppressDebugLog?: boolean;
     },
-  ): Promise<{ status: number; headers: Record<string, string>; body: string }> => {
+  ): Promise<{ status: number; headers: Record<string, string>; body: Buffer }> => {
     const method = request.method.trim().toUpperCase() || "GET";
     // The per-request debug log prints the method, the path, and the query. The
     // duplex path suppresses it, so no route or query rides a log line there. The
@@ -4257,14 +4284,22 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
     const timeoutSignal = AbortSignal.timeout(forwardTimeoutMs);
     const forwardSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
     // Build the request-body init. A GET or a HEAD carries no body. The file
-    // bridge passes the whole body as one string.
+    // bridge passes the whole body as one string; the http2 path passes the
+    // raw request bytes.
     const forwardInit: RequestInit = {
       method,
       headers,
       signal: forwardSignal,
     };
-    if (method !== "GET" && method !== "HEAD" && typeof request.body === "string") {
-      forwardInit.body = request.body;
+    if (
+      method !== "GET" &&
+      method !== "HEAD" &&
+      (typeof request.body === "string" || request.body instanceof Uint8Array)
+    ) {
+      // `fetch` accepts a `Uint8Array` body at runtime. The DOM `BodyInit` type
+      // pins the typed-array generic to a concrete `ArrayBuffer`, so a
+      // `Buffer`'s wider `ArrayBufferLike` generic needs this assertion.
+      forwardInit.body = request.body as BodyInit;
     }
     const response = await fetch(buildBridgeForwardUrl(hostApiUrl, request), forwardInit);
     if (emitDebugLog) {
@@ -4285,7 +4320,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
     // non-retryable 504 and marks the outcome indeterminate, exactly like an
     // aborted in-flight forward. The in-sandbox server maps the indeterminate 504
     // to a non-retryable 409 for both the file bridge and the duplex broker.
-    let responseBody: string;
+    let responseBody: Buffer;
     try {
       responseBody = await readBridgeForwardResponseBody(
         response,
@@ -4300,9 +4335,11 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
         return {
           status: 502,
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            error: error instanceof Error ? error.message : String(error),
-          }),
+          body: Buffer.from(
+            JSON.stringify({
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          ),
         };
       }
       return {
@@ -4311,11 +4348,13 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
           "content-type": "application/json",
           "x-paperclip-bridge-outcome": "indeterminate",
         },
-        body: JSON.stringify({
-          error: error instanceof Error ? error.message : String(error),
-          outcome: "indeterminate",
-          retryable: false,
-        }),
+        body: Buffer.from(
+          JSON.stringify({
+            error: error instanceof Error ? error.message : String(error),
+            outcome: "indeterminate",
+            retryable: false,
+          }),
+        ),
       };
     }
     const commentMarker = postedIssueCommentLogMarker(method, request.path, response.status, responseBody);
@@ -4546,7 +4585,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
                   path: request.pathname,
                   query: request.query,
                   headers: request.headers,
-                  body: request.body.toString("utf8"),
+                  body: request.body,
                 },
                 undefined,
                 { suppressDebugLog: true },
@@ -4669,7 +4708,13 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       maxBodyBytes,
       getRuntimeParentContext: input.getRuntimeParentContext,
       runtimeSpan: input.runtimeSpan,
-      handleRequest: async (request, options) => forwardBridgeRequest(request, options?.signal),
+      // The file bridge response file holds the body as a JSON string field, so
+      // this call site converts the forwarded bytes to a string here. It is the
+      // one place on the file bridge path that creates a string copy.
+      handleRequest: async (request, options) => {
+        const result = await forwardBridgeRequest(request, options?.signal);
+        return { status: result.status, headers: result.headers, body: result.body.toString("utf8") };
+      },
     });
     server = await startSandboxCallbackBridgeServer({
       runner,

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -4219,6 +4219,18 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
   // forward budget (30 s) when the caller sets no option, so current behavior
   // does not change.
   const forwardTimeoutMs = input.forwardTimeoutMs ?? DEFAULT_DUPLEX_BROKER_BUDGETS.forwardTimeoutMs;
+  // The in-sandbox HTTP/2 gateway's own wait for one response frame, passed
+  // through `PAPERCLIP_BRIDGE_RESPONSE_TIMEOUT_MS` below. It must stay above
+  // `forwardTimeoutMs`: the host bounds its own forward call at that budget,
+  // so a host response that lands right at that deadline still needs time to
+  // cross back over the stream before the gateway gives up. This mirrors the
+  // gap `DEFAULT_DUPLEX_BROKER_BUDGETS` already reserves between its
+  // `forwardTimeoutMs` (30 s) and `gatewayWaitMs` (35 s) entries. The result
+  // stays finite; the gateway never waits forever after the settings
+  // handshake.
+  const http2GatewayResponseTimeoutMs =
+    forwardTimeoutMs +
+    (DEFAULT_DUPLEX_BROKER_BUDGETS.gatewayWaitMs - DEFAULT_DUPLEX_BROKER_BUDGETS.forwardTimeoutMs);
 
   const runtimeRootDir =
     input.runtimeRootDir?.trim().length
@@ -4731,6 +4743,11 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
                 PAPERCLIP_API_URL: sandboxOrigin,
                 PAPERCLIP_API_KEY: bridgeToken,
                 PAPERCLIP_API_BRIDGE_MODE: SANDBOX_CALLBACK_BRIDGE_HTTP2_MODE,
+                // Without this, the generated gateway falls back to its own
+                // default wait, which equals the host's default forward
+                // budget and gives a near-deadline response no headroom to
+                // cross back over the stream before the gateway gives up.
+                PAPERCLIP_BRIDGE_RESPONSE_TIMEOUT_MS: String(http2GatewayResponseTimeoutMs),
               },
               runLogTail: duplexRunLogTail,
               readRunDisposition: (): DuplexBrokerRunDisposition => dispositionLatch.disposition,

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import type { Duplex } from "node:stream";
 import { randomBytes, randomUUID } from "node:crypto";
 import type { SshRemoteExecutionSpec } from "./ssh.js";
 import {
@@ -43,7 +44,9 @@ import {
 import {
   createHttp2BridgeServer,
   type Http2BridgeForwardHandler,
+  type Http2BridgeServerHandle,
 } from "./http2-bridge-server.js";
+import { getHttp2BridgeAdmissionGate, type Http2BridgeAdmissionGate } from "./http2-bridge-admission.js";
 import {
   createSandboxRunLogTailFactory,
   type SandboxRunLogTailFactory,
@@ -3541,6 +3544,45 @@ export const __http2PrefaceScanTesting = {
 };
 
 /**
+ * Reserve one live-session admission slot, then bind the channel to the
+ * HTTP/2 server. Returns `null` at once when the cap is already full; the
+ * caller must never bind the channel in that case. `bindChannel` is
+ * synchronous, so a bind failure releases the reserved slot before it
+ * re-throws the original error — the reservation never outlives a channel
+ * that never bound. On success, the returned `boundDuplex` carries a
+ * `close` listener that releases the same slot; `release` is idempotent,
+ * so a caller may also call it again on a later teardown path with no
+ * second slot freed.
+ */
+function bindHttp2BridgeSessionWithAdmission(
+  gate: Http2BridgeAdmissionGate,
+  http2Server: Http2BridgeServerHandle,
+  channel: CommandManagedDuplexChannel,
+): { boundDuplex: Duplex; release: () => void } | null {
+  const release = gate.tryAcquireSession();
+  if (!release) return null;
+  let boundDuplex: Duplex;
+  try {
+    boundDuplex = http2Server.bindChannel(channel);
+  } catch (error) {
+    release();
+    throw error;
+  }
+  boundDuplex.on("close", release);
+  return { boundDuplex, release };
+}
+
+/**
+ * Test-only surface for {@link bindHttp2BridgeSessionWithAdmission}. A test
+ * drives the reserve-then-bind-then-release cycle, including a forced bind
+ * failure, with a fake gate and a fake server handle, without the whole
+ * bridge. Production code never reads this export.
+ */
+export const __http2BridgeSessionAdmissionTesting = {
+  bindHttp2BridgeSessionWithAdmission,
+};
+
+/**
  * The terminal run disposition for the `http2_v1` path, in the same shape as
  * {@link DuplexBrokerRunDisposition}. A `failed` disposition means a terminal
  * loss ordered before an orderly completion, so the run must not report
@@ -4629,60 +4671,89 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
             stop: () => prefaceScan.scanned.stop(),
             close: () => prefaceScan.scanned.close(),
           };
-          const boundDuplex = http2Server.bindChannel(channelForHttp2Server);
-          // Also catches the `Duplex` this wrapper destroys when the bounded
-          // read backpressure queue overflows post-bind, so that loss still
-          // reaches `recordHttp2Loss` the same way any other write fault does.
-          boundDuplex.on("error", () => recordHttp2Loss("write_error"));
-
-          duplexChannelOpen.ready();
-          await onLog(
-            "stdout",
-            "[paperclip] Sandbox HTTP/2 transport ready; serving the host-assigned origin.\n",
+          // Reserve one live-session slot before the bind, not after: the
+          // host must hold the full wrapper budget for the whole session
+          // before the wrapper exists. `tryAcquireSession` never waits; a
+          // caller that waited here would hold a partly-open channel for an
+          // unbounded time.
+          const admittedSession = bindHttp2BridgeSessionWithAdmission(
+            getHttp2BridgeAdmissionGate(),
+            http2Server,
+            channelForHttp2Server,
           );
-          // Stream run logs on the http2 path with the same gate and the same
-          // log line as the file path. The http2 path starts no file-bridge
-          // worker, so create the log directory before the tail starts.
-          let duplexRunLogTail: SandboxRunLogTailFactory | null = null;
-          if (target.transport === "sandbox" && target.streamRunLogs !== false) {
-            const duplexLogsDir = sandboxCallbackBridgeDirectories(queueDir).logsDir;
-            await ensureSandboxRunLogDirectory({
-              runner,
-              remoteCwd: target.remoteCwd,
-              logsDir: duplexLogsDir,
-              shellCommand,
-              timeoutMs: bridgeTimeoutMs,
-            });
-            duplexRunLogTail = createSandboxRunLogTailFactory({
-              runner,
-              remoteCwd: target.remoteCwd,
-              logsDir: duplexLogsDir,
-              shellCommand,
-            });
-            await onLog("stdout", "[paperclip] Sandbox run log streaming enabled for this run.\n");
+          if (!admittedSession) {
+            // Fail closed, the same shape as a missing preface: close the
+            // partial channel inside the cleanup budget, then select the
+            // file bridge. The host never bound this channel to an HTTP/2
+            // session, so no request reached it or any endpoint.
+            gate.disposePendingReplay();
+            await closeDuplexChannelWithinBudget(openedChannel, DEFAULT_DUPLEX_CLEANUP_BUDGET_MS);
+            duplexChannelOpen.fallback("host_session_capacity");
+            await onLog(
+              "stderr",
+              "[paperclip] The host HTTP/2 bridge live session cap is full (host_session_capacity). Using the file bridge.\n",
+            );
+          } else {
+            const { boundDuplex, release: releaseSessionSlot } = admittedSession;
+            // Also catches the `Duplex` this wrapper destroys when the bounded
+            // read backpressure queue overflows post-bind, so that loss still
+            // reaches `recordHttp2Loss` the same way any other write fault does.
+            boundDuplex.on("error", () => recordHttp2Loss("write_error"));
+
+            duplexChannelOpen.ready();
+            await onLog(
+              "stdout",
+              "[paperclip] Sandbox HTTP/2 transport ready; serving the host-assigned origin.\n",
+            );
+            // Stream run logs on the http2 path with the same gate and the same
+            // log line as the file path. The http2 path starts no file-bridge
+            // worker, so create the log directory before the tail starts.
+            let duplexRunLogTail: SandboxRunLogTailFactory | null = null;
+            if (target.transport === "sandbox" && target.streamRunLogs !== false) {
+              const duplexLogsDir = sandboxCallbackBridgeDirectories(queueDir).logsDir;
+              await ensureSandboxRunLogDirectory({
+                runner,
+                remoteCwd: target.remoteCwd,
+                logsDir: duplexLogsDir,
+                shellCommand,
+                timeoutMs: bridgeTimeoutMs,
+              });
+              duplexRunLogTail = createSandboxRunLogTailFactory({
+                runner,
+                remoteCwd: target.remoteCwd,
+                logsDir: duplexLogsDir,
+                shellCommand,
+              });
+              await onLog("stdout", "[paperclip] Sandbox run log streaming enabled for this run.\n");
+            }
+            return {
+              env: {
+                PAPERCLIP_API_URL: sandboxOrigin,
+                PAPERCLIP_API_KEY: bridgeToken,
+                PAPERCLIP_API_BRIDGE_MODE: SANDBOX_CALLBACK_BRIDGE_HTTP2_MODE,
+              },
+              runLogTail: duplexRunLogTail,
+              readRunDisposition: (): DuplexBrokerRunDisposition => dispositionLatch.disposition,
+              // Atomically read the latch and mark the orderly completion for the
+              // ACP success-eligible terminal, so no await separates the read from
+              // the mark and a teardown loss cannot slip in between.
+              settleRunDisposition: (): DuplexBrokerRunDisposition => dispositionLatch.settleRunDisposition(),
+              markOrderlyCompletion: (): void => dispositionLatch.markOrderlyCompletion(),
+              stop: async () => {
+                // Close the HTTP/2 server's sessions, then the channel, before
+                // lease release, so no live provider session remains when the
+                // caller releases the lease.
+                await http2Server.close();
+                await closeDuplexChannelWithinBudget(openedChannel, DEFAULT_DUPLEX_CLEANUP_BUDGET_MS);
+                // Idempotent: releases the session slot here too, in case the
+                // bound `Duplex` never emits `close` on this exact teardown
+                // path. A second call from the `close` listener above frees
+                // no second slot.
+                releaseSessionSlot();
+                await bridgeAsset.cleanup();
+              },
+            };
           }
-          return {
-            env: {
-              PAPERCLIP_API_URL: sandboxOrigin,
-              PAPERCLIP_API_KEY: bridgeToken,
-              PAPERCLIP_API_BRIDGE_MODE: SANDBOX_CALLBACK_BRIDGE_HTTP2_MODE,
-            },
-            runLogTail: duplexRunLogTail,
-            readRunDisposition: (): DuplexBrokerRunDisposition => dispositionLatch.disposition,
-            // Atomically read the latch and mark the orderly completion for the
-            // ACP success-eligible terminal, so no await separates the read from
-            // the mark and a teardown loss cannot slip in between.
-            settleRunDisposition: (): DuplexBrokerRunDisposition => dispositionLatch.settleRunDisposition(),
-            markOrderlyCompletion: (): void => dispositionLatch.markOrderlyCompletion(),
-            stop: async () => {
-              // Close the HTTP/2 server's sessions, then the channel, before
-              // lease release, so no live provider session remains when the
-              // caller releases the lease.
-              await http2Server.close();
-              await closeDuplexChannelWithinBudget(openedChannel, DEFAULT_DUPLEX_CLEANUP_BUDGET_MS);
-              await bridgeAsset.cleanup();
-            },
-          };
         }
       }
     }

--- a/packages/adapter-utils/src/http2-bridge-admission.test.ts
+++ b/packages/adapter-utils/src/http2-bridge-admission.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+  DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+  HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES,
+  HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES,
+  HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES,
+  Http2BridgeAdmissionGate,
+  MAX_HTTP2_BRIDGE_ADMISSION_CAP,
+  configureHttp2BridgeAdmissionGate,
+  getHttp2BridgeAdmissionGate,
+  http2BridgeAdmissionBudgetBytes,
+  isValidHttp2BridgeAdmissionCap,
+  resolveHttp2BridgeAdmissionCaps,
+  resolveMaxLiveHttp2BridgeSessions,
+  resolveMaxParallelHttp2BridgeRequests,
+} from "./http2-bridge-admission.js";
+
+describe("Http2BridgeAdmissionGate — the stream gate", () => {
+  it("admits up to the configured parallel cap and queues the rest", async () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 2, maxSessions: 8 });
+
+    await gate.acquire();
+    await gate.acquire();
+    expect(gate.activeCount).toBe(2);
+    expect(gate.queuedCount).toBe(0);
+
+    let thirdAdmitted = false;
+    const thirdWaiter = gate.acquire().then((release) => {
+      thirdAdmitted = true;
+      return release;
+    });
+    await Promise.resolve();
+    expect(thirdAdmitted).toBe(false);
+    expect(gate.activeCount).toBe(2);
+    expect(gate.queuedCount).toBe(1);
+    void thirdWaiter;
+  });
+
+  it("releases slots to waiters in arrival order", async () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 8 });
+    const releaseFirst = await gate.acquire();
+
+    const order: number[] = [];
+    const p1 = gate.acquire().then((release) => {
+      order.push(1);
+      return release;
+    });
+    const p2 = gate.acquire().then((release) => {
+      order.push(2);
+      return release;
+    });
+    const p3 = gate.acquire().then((release) => {
+      order.push(3);
+      return release;
+    });
+
+    releaseFirst();
+    const release1 = await p1;
+    expect(order).toEqual([1]);
+
+    release1();
+    const release2 = await p2;
+    expect(order).toEqual([1, 2]);
+
+    release2();
+    const release3 = await p3;
+    expect(order).toEqual([1, 2, 3]);
+
+    release3();
+  });
+
+  it("a cancelled waiter leaves the queue and does not take a later slot", async () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 8 });
+    const releaseFirst = await gate.acquire();
+
+    const controller = new AbortController();
+    const cancelledWaiter = gate.acquire(controller.signal);
+    const cancelledAssertion = expect(cancelledWaiter).rejects.toBeInstanceOf(Error);
+
+    const secondWaiter = gate.acquire();
+    expect(gate.queuedCount).toBe(2);
+
+    controller.abort();
+    await cancelledAssertion;
+    expect(gate.queuedCount).toBe(1);
+
+    releaseFirst();
+    const releaseSecond = await secondWaiter;
+    expect(typeof releaseSecond).toBe("function");
+    expect(gate.activeCount).toBe(1);
+    expect(gate.queuedCount).toBe(0);
+    releaseSecond();
+  });
+
+  it("a second release call frees no second slot", async () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 8 });
+    const release = await gate.acquire();
+    release();
+    release();
+
+    const releaseA = await gate.acquire();
+    let secondAdmittedAtOnce = false;
+    const pendingB = gate.acquire().then((releaseB) => {
+      secondAdmittedAtOnce = true;
+      return releaseB;
+    });
+    await Promise.resolve();
+
+    // A double release must not free a second slot. If it had, both A and B
+    // would admit at once instead of B waiting behind A in the queue.
+    expect(secondAdmittedAtOnce).toBe(false);
+    expect(gate.activeCount).toBe(1);
+    expect(gate.queuedCount).toBe(1);
+
+    releaseA();
+    const releaseB = await pendingB;
+    releaseB();
+  });
+
+  it("a release after every waiter left leaves the gate idle", async () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 8 });
+    const release = await gate.acquire();
+
+    const controller = new AbortController();
+    const waiter = gate.acquire(controller.signal);
+    const rejection = expect(waiter).rejects.toBeInstanceOf(Error);
+    controller.abort();
+    await rejection;
+    expect(gate.queuedCount).toBe(0);
+
+    release();
+    expect(gate.activeCount).toBe(0);
+    expect(gate.queuedCount).toBe(0);
+  });
+});
+
+describe("Http2BridgeAdmissionGate — the session counter", () => {
+  it("a session acquire past the cap returns null and never waits", () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 64, maxSessions: 1 });
+    const release = gate.tryAcquireSession();
+    expect(typeof release).toBe("function");
+
+    const second = gate.tryAcquireSession();
+    expect(second).toBeNull();
+    expect(gate.activeSessionCount).toBe(1);
+  });
+
+  it("a released session slot goes to the next session acquire", () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 64, maxSessions: 1 });
+    const release = gate.tryAcquireSession();
+    expect(gate.tryAcquireSession()).toBeNull();
+
+    release?.();
+    expect(gate.activeSessionCount).toBe(0);
+
+    const next = gate.tryAcquireSession();
+    expect(typeof next).toBe("function");
+    expect(gate.activeSessionCount).toBe(1);
+  });
+
+  it("a second session release call frees no second slot", () => {
+    const gate = new Http2BridgeAdmissionGate({ maxParallel: 64, maxSessions: 1 });
+    const release = gate.tryAcquireSession();
+    release?.();
+    release?.();
+    expect(gate.activeSessionCount).toBe(0);
+
+    const next = gate.tryAcquireSession();
+    expect(typeof next).toBe("function");
+    const overflow = gate.tryAcquireSession();
+    expect(overflow).toBeNull();
+  });
+});
+
+describe("isValidHttp2BridgeAdmissionCap", () => {
+  it.each([0, -1, 1.5, NaN, Infinity, -Infinity, 65, "64", null, undefined, {}, []])(
+    "rejects %p",
+    (value) => {
+      expect(isValidHttp2BridgeAdmissionCap(value)).toBe(false);
+    },
+  );
+
+  it.each([1, 32, MAX_HTTP2_BRIDGE_ADMISSION_CAP])("accepts %p", (value) => {
+    expect(isValidHttp2BridgeAdmissionCap(value)).toBe(true);
+  });
+});
+
+describe("resolveMaxParallelHttp2BridgeRequests and resolveMaxLiveHttp2BridgeSessions", () => {
+  it.each([0, -1, 1.5, NaN, Infinity, -Infinity, 65])(
+    "rejects a zero, negative, non-integer, non-finite, or out-of-range override %p and returns the default",
+    (value) => {
+      const rejectedParallel: unknown[] = [];
+      expect(
+        resolveMaxParallelHttp2BridgeRequests(value, (rejected) => rejectedParallel.push(rejected)),
+      ).toBe(DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS);
+      expect(rejectedParallel).toEqual([value]);
+
+      const rejectedSessions: unknown[] = [];
+      expect(
+        resolveMaxLiveHttp2BridgeSessions(value, (rejected) => rejectedSessions.push(rejected)),
+      ).toBe(DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS);
+      expect(rejectedSessions).toEqual([value]);
+    },
+  );
+
+  it("uses the default for an absent or null override and reports nothing", () => {
+    const rejected: unknown[] = [];
+    expect(resolveMaxParallelHttp2BridgeRequests(undefined, (v) => rejected.push(v))).toBe(
+      DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+    );
+    expect(resolveMaxParallelHttp2BridgeRequests(null, (v) => rejected.push(v))).toBe(
+      DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+    );
+    expect(rejected).toEqual([]);
+  });
+
+  it("passes a valid override through unchanged and reports nothing", () => {
+    const rejected: unknown[] = [];
+    expect(resolveMaxParallelHttp2BridgeRequests(32, (v) => rejected.push(v))).toBe(32);
+    expect(resolveMaxLiveHttp2BridgeSessions(4, (v) => rejected.push(v))).toBe(4);
+    expect(rejected).toEqual([]);
+  });
+});
+
+describe("the joint budget rule", () => {
+  it("the default cap pair fits the reserved budget", () => {
+    const total = http2BridgeAdmissionBudgetBytes(
+      DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    );
+    expect(total).toBe(189_792_192);
+    expect(total).toBeLessThanOrEqual(HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES);
+  });
+
+  it("an over-budget pair of 64 parallel streams and 64 live sessions returns both defaults and reports a rejection", () => {
+    const rejections: Array<{ maxParallel: number; maxSessions: number; totalBytes: number }> = [];
+    const resolved = resolveHttp2BridgeAdmissionCaps(
+      { maxParallel: 64, maxSessions: 64 },
+      (rejection) => rejections.push(rejection),
+    );
+
+    expect(resolved).toEqual({
+      maxParallel: DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      maxSessions: DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    });
+    expect(rejections).toHaveLength(1);
+    expect(rejections[0]).toMatchObject({ maxParallel: 64, maxSessions: 64, totalBytes: 1_129_316_288 });
+    expect(rejections[0].totalBytes).toBeGreaterThan(HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES);
+  });
+
+  it("a valid over-default pair inside the reserved budget passes through unchanged", () => {
+    const rejections: unknown[] = [];
+    const resolved = resolveHttp2BridgeAdmissionCaps(
+      { maxParallel: 1, maxSessions: 9 },
+      (rejection) => rejections.push(rejection),
+    );
+
+    expect(resolved).toEqual({ maxParallel: 1, maxSessions: 9 });
+    expect(rejections).toEqual([]);
+    expect(http2BridgeAdmissionBudgetBytes(1, 9)).toBeLessThanOrEqual(HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES);
+  });
+
+  it("a pair that fails the joint rule never keeps one override and gives both defaults", () => {
+    // maxParallel=1 is a legal per-field override, but paired with maxSessions=64
+    // the total still blows the reserved budget. The failed pair must not keep
+    // the legal maxParallel override.
+    const resolved = resolveHttp2BridgeAdmissionCaps({ maxParallel: 1, maxSessions: 64 });
+    expect(resolved).toEqual({
+      maxParallel: DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      maxSessions: DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    });
+  });
+
+  it("the joint rule computes the total from the byte constants, not from a stored value", () => {
+    expect(http2BridgeAdmissionBudgetBytes(1, 0)).toBe(HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES);
+    expect(http2BridgeAdmissionBudgetBytes(0, 1)).toBe(HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES);
+    expect(http2BridgeAdmissionBudgetBytes(2, 3)).toBe(
+      2 * HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES + 3 * HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES,
+    );
+
+    const first = http2BridgeAdmissionBudgetBytes(10, 1);
+    const second = http2BridgeAdmissionBudgetBytes(20, 2);
+    expect(second).toBe(2 * first);
+  });
+});
+
+describe("the process-wide admission gate instance", () => {
+  it("returns the same gate instance across calls until reconfigured", () => {
+    const configured = configureHttp2BridgeAdmissionGate({ maxParallel: 2, maxSessions: 2 });
+    expect(getHttp2BridgeAdmissionGate()).toBe(configured);
+    expect(getHttp2BridgeAdmissionGate()).toBe(configured);
+  });
+
+  it("configureHttp2BridgeAdmissionGate replaces the instance and routes the pair through the joint resolver", () => {
+    const previous = getHttp2BridgeAdmissionGate();
+    const rejections: unknown[] = [];
+    const next = configureHttp2BridgeAdmissionGate(
+      { maxParallel: 64, maxSessions: 64 },
+      (rejection) => rejections.push(rejection),
+    );
+
+    expect(next).not.toBe(previous);
+    expect(next.maxParallel).toBe(DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS);
+    expect(next.maxSessions).toBe(DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS);
+    expect(rejections).toHaveLength(1);
+    expect(getHttp2BridgeAdmissionGate()).toBe(next);
+  });
+});

--- a/packages/adapter-utils/src/http2-bridge-admission.ts
+++ b/packages/adapter-utils/src/http2-bridge-admission.ts
@@ -1,0 +1,396 @@
+/**
+ * The process-wide admission gate for the host HTTP/2 sandbox bridge.
+ *
+ * The host holds sandbox request bytes and host response bytes in host
+ * memory for every admitted stream and every live bridge session. No
+ * per-request bound stops the host from holding an unbounded number of
+ * streams or sessions at once. This module owns two process-wide caps: a cap
+ * on parallel admitted streams, and a cap on live bridge sessions. Each cap
+ * bounds a known per-unit byte cost, so the pair of caps bounds the host's
+ * worst-case retained bytes for the bridge.
+ *
+ * A per-field cap is not a bound on the pair. The joint budget rule in
+ * {@link resolveHttp2BridgeAdmissionCaps} is the required security control:
+ * it validates the resolved pair as one policy, not as two independent
+ * fields, and it fails closed to both defaults when the pair does not fit.
+ *
+ * This module imports no other bridge module. It owns the byte budget
+ * constants so the joint rule has one home for the numbers it checks.
+ */
+
+/** The target host memory budget for the bridge admission gate. */
+export const HTTP2_BRIDGE_ADMISSION_MEMORY_TARGET_BYTES = 256 * 1024 * 1024;
+
+/**
+ * The reserved budget the joint rule checks against. The gate holds back 25
+ * percent of {@link HTTP2_BRIDGE_ADMISSION_MEMORY_TARGET_BYTES} for
+ * JavaScript object overhead and allocator behavior, so a resolved cap pair
+ * that spends the full reserved budget still leaves headroom under the
+ * target.
+ */
+export const HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES = Math.floor(
+  HTTP2_BRIDGE_ADMISSION_MEMORY_TARGET_BYTES * 0.75,
+);
+
+/**
+ * The worst-case bytes one admitted stream holds in host memory at once: the
+ * request body buffer the handler holds during the forward call
+ * (262,144 bytes), the response read chunks (262,144 bytes), the response
+ * concatenation buffer or the queued response after the read (262,144
+ * bytes), the in-flight DATA bytes on the HTTP/2 stream window (65,535
+ * bytes, the protocol default), and one decompressed header list (16,384
+ * bytes, the host's header-size limit). The three body terms each match
+ * `DEFAULT_SANDBOX_CALLBACK_BRIDGE_MAX_BODY_BYTES` in
+ * `sandbox-callback-bridge.ts`.
+ */
+export const HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES = 262_144 + 262_144 + 262_144 + 65_535 + 16_384;
+
+/**
+ * The worst-case bytes one live bridge session holds in host memory at once.
+ * This matches `DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES` in
+ * `http2-bridge-server.ts`. That file imports this constant so the wrapper
+ * cap and this reservation cannot drift apart.
+ */
+export const HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The default cap on parallel admitted streams. Paired with
+ * {@link DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS} this spends
+ * {@link HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES} times this many bytes of
+ * the reserved budget.
+ */
+export const DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS = 64;
+
+/**
+ * The default cap on live bridge sessions. Paired with
+ * {@link DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS} this spends
+ * {@link HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES} times this many bytes of the
+ * reserved budget.
+ */
+export const DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS = 8;
+
+/**
+ * The hard upper bound on either cap override, on its own. This keeps a
+ * mistyped or malicious override from removing the bound entirely. A value
+ * inside this range can still fail the joint rule below.
+ */
+export const MAX_HTTP2_BRIDGE_ADMISSION_CAP = 64;
+
+/**
+ * Report whether `value` is a valid cap override: a safe integer from 1 to
+ * {@link MAX_HTTP2_BRIDGE_ADMISSION_CAP}. Every other value is invalid,
+ * including a non-number, a non-integer, a non-finite number, zero, a
+ * negative number, and a number over the range.
+ */
+export function isValidHttp2BridgeAdmissionCap(value: unknown): boolean {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 1 &&
+    value <= MAX_HTTP2_BRIDGE_ADMISSION_CAP
+  );
+}
+
+/**
+ * A reporter the host binds to receive one invalid cap override rejection.
+ * The signal carries only the rejected value.
+ */
+export type Http2BridgeAdmissionCapOverrideRejectionReporter = (rejectedValue: unknown) => void;
+
+function resolveHttp2BridgeAdmissionCap(
+  override: number | null | undefined,
+  defaultValue: number,
+  onRejectedOverride?: Http2BridgeAdmissionCapOverrideRejectionReporter,
+): number {
+  if (override === undefined || override === null) {
+    return defaultValue;
+  }
+  if (!isValidHttp2BridgeAdmissionCap(override)) {
+    onRejectedOverride?.(override);
+    return defaultValue;
+  }
+  return override;
+}
+
+/**
+ * Resolve the parallel-stream cap from an optional operator override. A
+ * missing or `null` override uses
+ * {@link DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS}. A present invalid
+ * override does not fail host startup: the resolver rejects it, reports it
+ * through the optional `onRejectedOverride` reporter, and returns the
+ * default.
+ */
+export function resolveMaxParallelHttp2BridgeRequests(
+  override?: number | null,
+  onRejectedOverride?: Http2BridgeAdmissionCapOverrideRejectionReporter,
+): number {
+  return resolveHttp2BridgeAdmissionCap(
+    override,
+    DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+    onRejectedOverride,
+  );
+}
+
+/**
+ * Resolve the live-session cap from an optional operator override. Same
+ * fallback behavior as {@link resolveMaxParallelHttp2BridgeRequests}, with
+ * {@link DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS} as the default.
+ */
+export function resolveMaxLiveHttp2BridgeSessions(
+  override?: number | null,
+  onRejectedOverride?: Http2BridgeAdmissionCapOverrideRejectionReporter,
+): number {
+  return resolveHttp2BridgeAdmissionCap(
+    override,
+    DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    onRejectedOverride,
+  );
+}
+
+/**
+ * Compute the worst-case retained bytes for one resolved cap pair, from the
+ * byte budget constants at call time. The caller never stores this total; it
+ * always recomputes it from the current caps and the current constants.
+ */
+export function http2BridgeAdmissionBudgetBytes(maxParallel: number, maxSessions: number): number {
+  return (
+    maxParallel * HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES +
+    maxSessions * HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES
+  );
+}
+
+export interface Http2BridgeAdmissionCapOverrides {
+  maxParallel?: number | null;
+  maxSessions?: number | null;
+}
+
+export interface Http2BridgeAdmissionCaps {
+  maxParallel: number;
+  maxSessions: number;
+}
+
+/** One rejected cap pair, reported when the joint budget rule fails it. */
+export interface Http2BridgeAdmissionPairRejection extends Http2BridgeAdmissionCaps {
+  /** The worst-case retained bytes the rejected pair would have spent. */
+  totalBytes: number;
+}
+
+/**
+ * A reporter the host binds to receive one joint-rule rejection at error
+ * level. A warning is not a safety control: the pair this reporter carries
+ * already failed a required security condition, so the host must log it
+ * loud enough for an operator to act on it.
+ */
+export type Http2BridgeAdmissionPairRejectionReporter = (rejection: Http2BridgeAdmissionPairRejection) => void;
+
+/**
+ * Resolve one admission cap pair from optional operator overrides.
+ *
+ * The resolver runs each per-field check first, through
+ * {@link resolveMaxParallelHttp2BridgeRequests} and
+ * {@link resolveMaxLiveHttp2BridgeSessions}. A per-field range is not a bound
+ * on the pair: each cap alone can pass its own range and the pair can still
+ * spend far more than the reserved budget. The resolver then runs the joint
+ * rule on the resolved pair:
+ *
+ * ```text
+ * (maxParallel * HTTP2_BRIDGE_ADMITTED_STREAM_BUDGET_BYTES)
+ *   + (maxSessions * HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES)
+ *   <= HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES
+ * ```
+ *
+ * A pair that fails the joint rule returns both defaults. The resolver never
+ * keeps one override and one default: a partly-applied pair would keep an
+ * operator value the host just refused. The resolver reports a failed pair
+ * through `onRejectedPair` at error level.
+ */
+export function resolveHttp2BridgeAdmissionCaps(
+  overrides: Http2BridgeAdmissionCapOverrides,
+  onRejectedPair?: Http2BridgeAdmissionPairRejectionReporter,
+): Http2BridgeAdmissionCaps {
+  const maxParallel = resolveMaxParallelHttp2BridgeRequests(overrides.maxParallel);
+  const maxSessions = resolveMaxLiveHttp2BridgeSessions(overrides.maxSessions);
+  const totalBytes = http2BridgeAdmissionBudgetBytes(maxParallel, maxSessions);
+  if (totalBytes > HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES) {
+    onRejectedPair?.({ maxParallel, maxSessions, totalBytes });
+    return {
+      maxParallel: DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      maxSessions: DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    };
+  }
+  return { maxParallel, maxSessions };
+}
+
+/** A queued stream waiter. `settle` resolves or rejects exactly once. */
+interface Http2BridgeAdmissionStreamWaiter {
+  settle(outcome: { release: () => void } | { error: Error }): void;
+  detachAbortListener(): void;
+}
+
+function abortErrorFor(signal: AbortSignal): Error {
+  const reason = signal.reason;
+  if (reason instanceof Error) return reason;
+  return new Error(
+    typeof reason === "string" && reason.length > 0
+      ? reason
+      : "The HTTP/2 bridge stream admission wait was aborted.",
+  );
+}
+
+/**
+ * The process-owned admission gate for the host HTTP/2 sandbox bridge.
+ *
+ * The stream gate is a first-in-first-out queue. `acquire` admits a caller
+ * at once while the active count is under `maxParallel`, and otherwise
+ * queues the caller. A released slot always goes to the oldest queued
+ * waiter. A queued waiter can cancel through an `AbortSignal`; a cancelled
+ * waiter leaves the queue and never takes a later slot.
+ *
+ * The session counter never queues. `tryAcquireSession` returns a release
+ * function or `null` at once. A caller that waited for a session slot would
+ * hold a partly-open channel open for an unbounded time, so the session
+ * bound fails fast instead.
+ *
+ * Every release function this gate returns is idempotent: a second call
+ * frees no second slot.
+ */
+export class Http2BridgeAdmissionGate {
+  readonly maxParallel: number;
+  readonly maxSessions: number;
+
+  private activeStreamCount = 0;
+  private activeSessions = 0;
+  private readonly queue: Http2BridgeAdmissionStreamWaiter[] = [];
+
+  constructor(options: Http2BridgeAdmissionCaps) {
+    this.maxParallel = options.maxParallel;
+    this.maxSessions = options.maxSessions;
+  }
+
+  get activeCount(): number {
+    return this.activeStreamCount;
+  }
+
+  get queuedCount(): number {
+    return this.queue.length;
+  }
+
+  get activeSessionCount(): number {
+    return this.activeSessions;
+  }
+
+  /**
+   * Wait for one admitted stream slot. Resolves at once when a slot is free.
+   * Otherwise queues the caller in arrival order and resolves when an
+   * earlier holder releases its slot. Rejects if `signal` aborts while the
+   * caller is still queued; an already-aborted signal rejects at once
+   * without queuing.
+   */
+  acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) {
+      return Promise.reject(abortErrorFor(signal));
+    }
+    if (this.activeStreamCount < this.maxParallel) {
+      this.activeStreamCount += 1;
+      return Promise.resolve(this.createStreamRelease());
+    }
+    return new Promise<() => void>((resolve, reject) => {
+      let onAbort: (() => void) | null = null;
+      const waiter: Http2BridgeAdmissionStreamWaiter = {
+        settle: (outcome) => {
+          waiter.detachAbortListener();
+          if ("release" in outcome) {
+            resolve(outcome.release);
+          } else {
+            reject(outcome.error);
+          }
+        },
+        detachAbortListener: () => {
+          if (onAbort) {
+            signal?.removeEventListener("abort", onAbort);
+            onAbort = null;
+          }
+        },
+      };
+      if (signal) {
+        onAbort = () => {
+          const index = this.queue.indexOf(waiter);
+          if (index !== -1) {
+            this.queue.splice(index, 1);
+          }
+          waiter.settle({ error: abortErrorFor(signal) });
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+      this.queue.push(waiter);
+    });
+  }
+
+  private createStreamRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.activeStreamCount -= 1;
+      this.admitNextWaiter();
+    };
+  }
+
+  private admitNextWaiter(): void {
+    while (this.queue.length > 0 && this.activeStreamCount < this.maxParallel) {
+      const waiter = this.queue.shift();
+      if (!waiter) break;
+      this.activeStreamCount += 1;
+      waiter.settle({ release: this.createStreamRelease() });
+    }
+  }
+
+  /**
+   * Take one live-session slot if the cap allows it. Returns an idempotent
+   * release function on success, or `null` at once when the cap is already
+   * spent. Never queues.
+   */
+  tryAcquireSession(): (() => void) | null {
+    if (this.activeSessions >= this.maxSessions) {
+      return null;
+    }
+    this.activeSessions += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.activeSessions -= 1;
+    };
+  }
+}
+
+let processHttp2BridgeAdmissionGate: Http2BridgeAdmissionGate | null = null;
+
+/**
+ * Read the process-wide admission gate, creating it on first use from the
+ * default cap pair. Every host call site shares this one instance, so one
+ * pair of caps bounds the bridge's worst-case retained bytes across the
+ * whole process.
+ */
+export function getHttp2BridgeAdmissionGate(): Http2BridgeAdmissionGate {
+  if (!processHttp2BridgeAdmissionGate) {
+    processHttp2BridgeAdmissionGate = new Http2BridgeAdmissionGate(resolveHttp2BridgeAdmissionCaps({}));
+  }
+  return processHttp2BridgeAdmissionGate;
+}
+
+/**
+ * Replace the process-wide admission gate with one built from the given cap
+ * overrides. Routes the overrides through {@link resolveHttp2BridgeAdmissionCaps},
+ * so this call site and every other caller resolve a cap pair through the
+ * same per-field checks and the same joint budget rule.
+ */
+export function configureHttp2BridgeAdmissionGate(
+  overrides: Http2BridgeAdmissionCapOverrides,
+  onRejectedPair?: Http2BridgeAdmissionPairRejectionReporter,
+): Http2BridgeAdmissionGate {
+  processHttp2BridgeAdmissionGate = new Http2BridgeAdmissionGate(
+    resolveHttp2BridgeAdmissionCaps(overrides, onRejectedPair),
+  );
+  return processHttp2BridgeAdmissionGate;
+}

--- a/packages/adapter-utils/src/http2-bridge-server.test.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { duplexPair } from "node:stream";
 import type { Duplex } from "node:stream";
 import http2 from "node:http2";
@@ -8,6 +9,7 @@ import {
   buildHttp2BridgeForwardUrl,
   classifyStreamAgainstGoaway,
   createHttp2BridgeServer,
+  discardHttp2StreamBody,
   parseCanonicalBridgeRequestPath,
   wrapDuplexChannelAsNodeDuplex,
   DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES,
@@ -26,6 +28,7 @@ import {
   HTTP2_BRIDGE_SERVER_OPTIONS,
   HTTP2_BRIDGE_STREAM_RESET_BURST,
   HTTP2_BRIDGE_STREAM_RESET_RATE,
+  type Http2BridgeBodyBounds,
   type Http2BridgeForwardRequest,
   type Http2BridgeForwardResult,
   type Http2BridgeGoawayRecord,
@@ -1736,6 +1739,62 @@ describe("createHttp2BridgeServer + createSandboxHttp2BridgeGateway", () => {
       }
     });
 
+    it("denied streams never take an admission slot, even many at once across two server instances sharing a one-slot gate", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
+      const forwarderTracker = createForwarderCallTracker();
+      const forwardRequest = async (): Promise<Http2BridgeForwardResult> => {
+        forwarderTracker.markCalled();
+        return { status: 200 };
+      };
+      const serverA = bindTestServer({ admissionGate, forwardRequest });
+      const serverB = bindTestServer({ admissionGate, forwardRequest });
+      const rawClientA = connectRawClient(serverA.clientSide);
+      const rawClientB = connectRawClient(serverB.clientSide);
+      const denyOneStream = (rawClient: http2.ClientHttp2Session): Promise<number> =>
+        new Promise((resolve, reject) => {
+          // No `authorization` header: the token check denies every one of
+          // these streams before the admission gate ever runs.
+          const req = rawClient.request({ ":method": "POST", ":path": "/api/issues/abc/comments" });
+          let status = 0;
+          req.on("response", (headers) => {
+            status = Number(headers[":status"]) || 0;
+          });
+          req.on("error", reject);
+          req.on("close", () => resolve(status));
+          req.resume();
+          // A body on every one of six concurrent denied streams: if a
+          // denial ever took the one shared slot, five of the six would
+          // queue behind it instead of answering at once.
+          req.write(Buffer.alloc(200_000, "d"));
+          req.end();
+        });
+      try {
+        const startedAtMs = Date.now();
+        const statuses = await Promise.all([
+          denyOneStream(rawClientA),
+          denyOneStream(rawClientA),
+          denyOneStream(rawClientA),
+          denyOneStream(rawClientB),
+          denyOneStream(rawClientB),
+          denyOneStream(rawClientB),
+        ]);
+        // Every denied stream answered at once: none of them queued behind
+        // the one-slot gate.
+        expect(Date.now() - startedAtMs).toBeLessThan(2_000);
+        expect(statuses).toEqual([401, 401, 401, 401, 401, 401]);
+        expect(forwarderTracker.called).toBe(false);
+        // The gate count returns to its start value: a denial never moved
+        // it at all.
+        expect(admissionGate.activeCount).toBe(0);
+        expect(admissionGate.queuedCount).toBe(0);
+      } finally {
+        rawClientA.close();
+        rawClientB.close();
+        await serverA.handle.close();
+        await serverB.handle.close();
+      }
+    });
+
     it("the default caps keep the named byte total inside the reserved budget", () => {
       // 64 admitted streams x 868,351 bytes, plus 8 live sessions x
       // 16,777,216 bytes: 189,792,192 named bytes in total. This stays
@@ -1785,5 +1844,55 @@ describe("createHttp2BridgeServer + createSandboxHttp2BridgeGateway", () => {
         rawClient.close();
       }
     });
+  });
+});
+
+describe("discardHttp2StreamBody", () => {
+  /** A minimal fake `ServerHttp2Stream`: only the surface
+   * `discardHttp2StreamBody` touches — `on`/`once` for `data`, `end`,
+   * `error`, `aborted`, and `close`, plus a `destroy` a test can observe. */
+  function fakeDeniedStream(): http2.ServerHttp2Stream & { destroyCallCount: number } {
+    const emitter = new EventEmitter() as unknown as http2.ServerHttp2Stream & { destroyCallCount: number };
+    emitter.destroyCallCount = 0;
+    (emitter as unknown as { destroy: () => void }).destroy = () => {
+      emitter.destroyCallCount += 1;
+      emitter.emit("close");
+    };
+    return emitter;
+  }
+
+  it("resolves with no buffer once the body ends, however many bytes the peer delivered", async () => {
+    const stream = fakeDeniedStream();
+    const bounds: Http2BridgeBodyBounds = { maxBodyBytes: 1_000_000, idleTimeoutMs: 5_000, lifetimeCeilingMs: 60_000 };
+    const discarded = discardHttp2StreamBody(stream, bounds);
+
+    let deliveredBytes = 0;
+    const chunk = Buffer.alloc(300_000, "x");
+    for (let i = 0; i < 3; i += 1) {
+      stream.emit("data", chunk);
+      deliveredBytes += chunk.byteLength;
+    }
+    stream.emit("end");
+
+    const outcome = await discarded;
+    // The helper hands back nothing: a buffer-returning helper would
+    // instead resolve here with a 900,000-byte `Buffer`, one copy of every
+    // chunk this denied stream ever delivered.
+    expect(outcome).toBeUndefined();
+    expect(deliveredBytes).toBe(900_000);
+    expect(stream.destroyCallCount).toBe(0);
+  });
+
+  it("still destroys the stream once the running byte count passes maxBodyBytes", async () => {
+    const stream = fakeDeniedStream();
+    const bounds: Http2BridgeBodyBounds = { maxBodyBytes: 10, idleTimeoutMs: 5_000, lifetimeCeilingMs: 60_000 };
+    const rejection = discardHttp2StreamBody(stream, bounds).catch((error: unknown) => error);
+
+    stream.emit("data", Buffer.alloc(20, "y"));
+
+    const error = await rejection;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/exceeded the configured size limit/i);
+    expect(stream.destroyCallCount).toBe(1);
   });
 });

--- a/packages/adapter-utils/src/http2-bridge-server.test.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.test.ts
@@ -1085,6 +1085,84 @@ describe("createHttp2BridgeServer + createSandboxHttp2BridgeGateway", () => {
     expect(duplex.destroyed).toBe(false);
   });
 
+  it("the wrapper holds no more than the byte cap across the readable buffer and the pending queue", async () => {
+    let dataListener: ((chunk: Uint8Array) => void) | undefined;
+    let stopped = false;
+    const channel: CommandManagedDuplexChannel = {
+      write: () => undefined,
+      onData: (listener) => {
+        dataListener = listener;
+      },
+      onExit: () => undefined,
+      stop: () => {
+        stopped = true;
+      },
+      close: async () => undefined,
+    };
+    const cap = 100_000;
+    const duplex = wrapDuplexChannelAsNodeDuplex(channel, { maxBufferedReadBytes: cap });
+    const errored = new Promise<Error>((resolve) => duplex.on("error", resolve));
+
+    // Fill the readable side: this chunk passes the default 65,536-byte high
+    // water mark, so `push()` reports the readable side full, and every later
+    // chunk queues in the wrapper's own pending queue instead.
+    dataListener?.(Buffer.alloc(70_000, "a"));
+    expect(duplex.readableLength).toBe(70_000);
+
+    // Queue a chunk that brings the combined total to 99,000 of the
+    // 100,000-byte cap. The readable buffer and the pending queue are two
+    // separate buffers, so this proves their sum, not each one alone, stays
+    // under the cap.
+    dataListener?.(Buffer.alloc(29_000, "b"));
+    expect(duplex.destroyed).toBe(false);
+    expect(duplex.readableLength + 29_000).toBeLessThanOrEqual(cap);
+
+    // One more chunk brings the combined total to 100,001 bytes, one byte
+    // past the cap: the wrapper must fail closed here, not let the sum grow
+    // past what the cap allows.
+    dataListener?.(Buffer.alloc(1_001, "c"));
+    const error = await errored;
+    expect(error.message).toMatch(/backpressure/i);
+    expect(stopped).toBe(true);
+  });
+
+  it("a chunk that fits alone but passes the cap with the readable buffer fails closed", async () => {
+    let dataListener: ((chunk: Uint8Array) => void) | undefined;
+    let stopped = false;
+    const channel: CommandManagedDuplexChannel = {
+      write: () => undefined,
+      onData: (listener) => {
+        dataListener = listener;
+      },
+      onExit: () => undefined,
+      stop: () => {
+        stopped = true;
+      },
+      close: async () => undefined,
+    };
+    const cap = 80_000;
+    const duplex = wrapDuplexChannelAsNodeDuplex(channel, { maxBufferedReadBytes: cap });
+    const errored = new Promise<Error>((resolve) => duplex.on("error", resolve));
+
+    // This chunk is under the cap on its own, and it passes the default
+    // high-water mark, so it pushes directly and fills the readable side.
+    dataListener?.(Buffer.alloc(70_000, "a"));
+    expect(duplex.readableLength).toBe(70_000);
+
+    // This chunk is also under the cap on its own (20,000 < 80,000), so a
+    // check that only bounds one chunk's own size, or only the queue's own
+    // total, would let it through. Combined with the 70,000 bytes the
+    // readable side already holds, the total is 90,000 bytes: over the cap.
+    // The wrapper must fail closed with the reader message, not the
+    // oversized-chunk message, because no single chunk here passes the cap
+    // on its own.
+    dataListener?.(Buffer.alloc(20_000, "b"));
+    const error = await errored;
+    expect(error.message).toMatch(/reader could not keep up/i);
+    expect(error.message).not.toMatch(/delivered one chunk larger/i);
+    expect(stopped).toBe(true);
+  });
+
   describe("the admission gate", () => {
     it("the response drain timeout defaults to thirty seconds, and the buffered-read byte cap shares one home with the admission module's session budget", () => {
       expect(DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS).toBe(30_000);

--- a/packages/adapter-utils/src/http2-bridge-server.test.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.test.ts
@@ -10,8 +10,10 @@ import {
   createHttp2BridgeServer,
   parseCanonicalBridgeRequestPath,
   wrapDuplexChannelAsNodeDuplex,
+  DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES,
   DEFAULT_HTTP2_BRIDGE_PING_INTERVAL_MS,
   DEFAULT_HTTP2_BRIDGE_PING_STALL_MS,
+  DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS,
   HTTP2_BRIDGE_ENABLE_PUSH,
   HTTP2_BRIDGE_HEADER_TABLE_SIZE,
   HTTP2_BRIDGE_MAX_CONCURRENT_STREAMS,
@@ -30,6 +32,10 @@ import {
 } from "./http2-bridge-server.js";
 import { createSandboxHttp2BridgeGateway } from "./sandbox-callback-bridge.js";
 import type { CommandManagedDuplexChannel } from "./command-managed-runtime.js";
+import {
+  Http2BridgeAdmissionGate,
+  HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES,
+} from "./http2-bridge-admission.js";
 
 /**
  * Unit harness for the host HTTP/2 server and the sandbox HTTP/2 client
@@ -78,6 +84,9 @@ interface TestPairOptions {
   requestBodyTimeoutMs?: number;
   requestBodyLifetimeCeilingMs?: number;
   closeGraceMs?: number;
+  maxBodyBytes?: number;
+  admissionGate?: Http2BridgeAdmissionGate;
+  responseDrainTimeoutMs?: number;
   onGoaway?: (record: Http2BridgeGoawayRecord) => void;
   onSessionError?: (error: Error) => void;
   onSession?: (session: http2.ServerHttp2Session) => void;
@@ -103,6 +112,9 @@ function bindTestServer(options: TestPairOptions = {}) {
     requestBodyTimeoutMs: options.requestBodyTimeoutMs,
     requestBodyLifetimeCeilingMs: options.requestBodyLifetimeCeilingMs,
     closeGraceMs: options.closeGraceMs,
+    maxBodyBytes: options.maxBodyBytes,
+    admissionGate: options.admissionGate,
+    responseDrainTimeoutMs: options.responseDrainTimeoutMs,
     onGoaway: options.onGoaway,
     onSessionError: options.onSessionError,
     onSession: options.onSession,
@@ -1071,5 +1083,418 @@ describe("createHttp2BridgeServer + createSandboxHttp2BridgeGateway", () => {
     // empty. A timer the full drain above did not clear would fire here.
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(duplex.destroyed).toBe(false);
+  });
+
+  describe("the admission gate", () => {
+    it("the response drain timeout defaults to thirty seconds, and the buffered-read byte cap shares one home with the admission module's session budget", () => {
+      expect(DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS).toBe(30_000);
+      expect(DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES).toBe(HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES);
+    });
+
+    it("one gate caps parallel streams across two bridge server instances", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 2, maxSessions: 4 });
+      let concurrent = 0;
+      let peakConcurrent = 0;
+      const forwardRequest = async (): Promise<Http2BridgeForwardResult> => {
+        concurrent += 1;
+        peakConcurrent = Math.max(peakConcurrent, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        concurrent -= 1;
+        return { status: 200 };
+      };
+      const serverA = bindTestServer({ admissionGate, forwardRequest });
+      const serverB = bindTestServer({ admissionGate, forwardRequest });
+      const rawClientA = connectRawClient(serverA.clientSide);
+      const rawClientB = connectRawClient(serverB.clientSide);
+      try {
+        await Promise.all([
+          expectSessionStillServesARequest(rawClientA, {
+            method: "GET",
+            path: "/api/agents/me",
+            token: serverA.bridgeToken,
+          }),
+          expectSessionStillServesARequest(rawClientA, {
+            method: "GET",
+            path: "/api/companies/co1",
+            token: serverA.bridgeToken,
+          }),
+          expectSessionStillServesARequest(rawClientB, {
+            method: "GET",
+            path: "/api/agents/me",
+            token: serverB.bridgeToken,
+          }),
+          expectSessionStillServesARequest(rawClientB, {
+            method: "GET",
+            path: "/api/companies/co1",
+            token: serverB.bridgeToken,
+          }),
+        ]);
+        // The one shared gate never let more than two streams run at once,
+        // across both server instances.
+        expect(peakConcurrent).toBeLessThanOrEqual(2);
+        // Two of the four streams did run at the same time: this proves the
+        // cap is real overlap, not accidental full serialization to one.
+        expect(peakConcurrent).toBe(2);
+      } finally {
+        rawClientA.close();
+        rawClientB.close();
+        await serverA.handle.close();
+        await serverB.handle.close();
+      }
+    });
+
+    it("a queued stream starts its body read only after an earlier stream releases", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
+      const HOLD_MS = 150;
+      const IDLE_MS = 80;
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        requestBodyTimeoutMs: IDLE_MS,
+        forwardRequest: async (request) => {
+          if (request.pathname === "/api/agents/me") {
+            // Hold the only slot for HOLD_MS, so the second stream below
+            // stays queued for that whole span.
+            await new Promise((resolve) => setTimeout(resolve, HOLD_MS));
+          }
+          return { status: 200, body: JSON.stringify({ bodyLength: request.body.byteLength }) };
+        },
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const firstReq = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/agents/me",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        firstReq.resume();
+        firstReq.end();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(admissionGate.activeCount).toBe(1);
+        expect(admissionGate.queuedCount).toBe(0);
+
+        const secondResponse = new Promise<{ status: number; body: string }>((resolve, reject) => {
+          const secondReq = rawClient.request({
+            ":method": "POST",
+            ":path": "/api/issues/abc/comments",
+            authorization: `Bearer ${bridgeToken}`,
+          });
+          let status = 0;
+          let body = "";
+          secondReq.setEncoding("utf8");
+          secondReq.on("response", (headers) => {
+            status = Number(headers[":status"]) || 0;
+          });
+          secondReq.on("data", (chunk) => (body += chunk));
+          secondReq.on("end", () => resolve({ status, body }));
+          secondReq.on("error", reject);
+          // Wait almost the full hold span, sending no data, before this
+          // stream's one chunk. If the idle bound had started counting
+          // while this stream still waited in the queue, this silence alone
+          // would already exceed IDLE_MS and stall the stream.
+          setTimeout(() => {
+            secondReq.write("chunk");
+            secondReq.end();
+          }, HOLD_MS - 10);
+        });
+
+        // The second stream queues while the first holds the only slot.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(admissionGate.queuedCount).toBe(1);
+
+        const response = await secondResponse;
+        expect(response.status).toBe(200);
+        expect(JSON.parse(response.body)).toEqual({ bodyLength: "chunk".length });
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("a token, path, or route denial takes no gate slot", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
+      const { handle, bridgeToken, clientSide } = bindTestServer({ admissionGate });
+      const rawClient = connectRawClient(clientSide);
+
+      function requestAndAwaitStatus(input: { method: string; path: string; token?: string }): Promise<number> {
+        return new Promise((resolve, reject) => {
+          const headers: http2.OutgoingHttpHeaders = { ":method": input.method, ":path": input.path };
+          if (input.token !== undefined) headers.authorization = `Bearer ${input.token}`;
+          const req = rawClient.request(headers);
+          let status = 0;
+          req.on("response", (responseHeaders) => {
+            status = Number(responseHeaders[":status"]) || 0;
+          });
+          req.on("end", () => resolve(status));
+          req.on("error", reject);
+          req.resume();
+          req.end();
+        });
+      }
+
+      try {
+        // An invalid token is denied before route or body processing.
+        expect(await requestAndAwaitStatus({ method: "GET", path: "/api/agents/me" })).toBe(401);
+        expect(admissionGate.activeCount).toBe(0);
+        expect(admissionGate.queuedCount).toBe(0);
+
+        // An invalid path is denied before route processing.
+        expect(
+          await requestAndAwaitStatus({ method: "GET", path: "/api/../secrets", token: bridgeToken }),
+        ).toBe(400);
+        expect(admissionGate.activeCount).toBe(0);
+        expect(admissionGate.queuedCount).toBe(0);
+
+        // A route the allowlist does not carry is denied.
+        expect(
+          await requestAndAwaitStatus({ method: "DELETE", path: "/api/agents/me", token: bridgeToken }),
+        ).toBe(403);
+        expect(admissionGate.activeCount).toBe(0);
+        expect(admissionGate.queuedCount).toBe(0);
+
+        // None of the three denials above spent the one available slot: a
+        // legitimate request right after them still succeeds at once.
+        const survivingResponse = await expectSessionStillServesARequest(rawClient, {
+          method: "GET",
+          path: "/api/agents/me",
+          token: bridgeToken,
+        });
+        expect(survivingResponse.status).toBe(200);
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("the slot stays held until the response stream closes", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      // A body past the default HTTP/2 flow-control window, so the server
+      // cannot finish sending it, and the stream cannot close, until the
+      // client actually reads it.
+      const bigBody = Buffer.alloc(200_000, "a");
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        forwardRequest: async () => ({ status: 200, body: bigBody }),
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const req = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/agents/me",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        req.on("error", () => undefined);
+        req.end();
+        await new Promise<void>((resolve) => req.once("response", () => resolve()));
+        // The response headers arrived, but this test reads no body: the
+        // slot must still be held.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(admissionGate.activeCount).toBe(1);
+
+        const drained = new Promise<void>((resolve) => req.once("end", resolve));
+        req.resume();
+        await drained;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(admissionGate.activeCount).toBe(0);
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("a peer that never reads the response releases the slot at the drain bound", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const bigBody = Buffer.alloc(200_000, "a");
+      // Long enough that the client reliably observes the response headers
+      // before the server's own drain bound destroys the stream; short
+      // enough to keep the test fast.
+      const RESPONSE_DRAIN_TIMEOUT_MS = 150;
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        responseDrainTimeoutMs: RESPONSE_DRAIN_TIMEOUT_MS,
+        // The drain bound below force-destroys the stream while the peer
+        // never read it: a short grace bound keeps this test's own
+        // `handle.close()` call from waiting on the default five-second one.
+        closeGraceMs: 30,
+        forwardRequest: async () => ({ status: 200, body: bigBody }),
+      });
+      const rawClient = connectRawClient(clientSide);
+      const req = rawClient.request({
+        ":method": "GET",
+        ":path": "/api/agents/me",
+        authorization: `Bearer ${bridgeToken}`,
+      });
+      try {
+        req.on("error", () => undefined);
+        req.end();
+        await new Promise<void>((resolve) => req.once("response", () => resolve()));
+        // Never read the response body: the drain bound must still free the
+        // slot, instead of holding it forever.
+        await new Promise((resolve) => setTimeout(resolve, RESPONSE_DRAIN_TIMEOUT_MS + 200));
+        expect(admissionGate.activeCount).toBe(0);
+      } finally {
+        // The server destroyed its side already, at the drain bound; drop
+        // the client's own unread stream too, so the still-buffered (and
+        // now pointless) response bytes do not sit in the transport and
+        // block the session-level close below.
+        req.destroy();
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("the gate slot returns after a forward-handler error", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        forwardRequest: async () => {
+          throw new Error("forward handler failed");
+        },
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const status = await new Promise<number>((resolve, reject) => {
+          const req = rawClient.request({
+            ":method": "GET",
+            ":path": "/api/agents/me",
+            authorization: `Bearer ${bridgeToken}`,
+          });
+          req.on("response", (headers) => resolve(Number(headers[":status"]) || 0));
+          req.on("error", reject);
+          req.resume();
+          req.end();
+        });
+        expect(status).toBe(502);
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(admissionGate.activeCount).toBe(0);
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("the gate slot returns after a body size rejection", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        maxBodyBytes: 10,
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        // A body past the size limit destroys the stream at once, so the
+        // client sees an `error` or a `close`, not a clean response — the
+        // same settling pattern the idle- and lifetime-bound tests above
+        // exercise. This test's own concern is the admission slot below.
+        await new Promise<void>((resolve) => {
+          const req = rawClient.request({
+            ":method": "POST",
+            ":path": "/api/issues/abc/comments",
+            authorization: `Bearer ${bridgeToken}`,
+          });
+          req.on("error", () => resolve());
+          req.on("close", () => resolve());
+          req.resume();
+          req.write(Buffer.alloc(1_000, "a"));
+          req.end();
+        });
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(admissionGate.activeCount).toBe(0);
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("a stream that closes while it waits leaves the queue", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
+      let releaseFirst: (() => void) | undefined;
+      const firstHeld = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let forwarderCallCount = 0;
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        forwardRequest: async () => {
+          forwarderCallCount += 1;
+          if (forwarderCallCount === 1) {
+            await firstHeld;
+          }
+          return { status: 200 };
+        },
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const firstReq = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/agents/me",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        firstReq.on("error", () => undefined);
+        firstReq.resume();
+        firstReq.end();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(admissionGate.activeCount).toBe(1);
+
+        const secondReq = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/companies/co1",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        secondReq.on("error", () => undefined);
+        secondReq.end();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(admissionGate.queuedCount).toBe(1);
+
+        const secondClosed = new Promise<void>((resolve) => secondReq.once("close", resolve));
+        secondReq.close(http2.constants.NGHTTP2_CANCEL);
+        await secondClosed;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        // The cancelled stream left the queue, and never took the slot: the
+        // first stream still holds the only one.
+        expect(admissionGate.queuedCount).toBe(0);
+        expect(admissionGate.activeCount).toBe(1);
+
+        const firstClosed = new Promise<void>((resolve) => firstReq.once("close", resolve));
+        releaseFirst?.();
+        await firstClosed;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(admissionGate.activeCount).toBe(0);
+        // The cancelled stream never reached the forward handler.
+        expect(forwarderCallCount).toBe(1);
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("server close returns every held gate slot", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const bigBody = Buffer.alloc(200_000, "a");
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        // Long enough that only the server close below bounds this wait.
+        responseDrainTimeoutMs: 60_000,
+        closeGraceMs: 30,
+        forwardRequest: async () => ({ status: 200, body: bigBody }),
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const req = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/agents/me",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        req.on("error", () => undefined);
+        req.end();
+        await new Promise<void>((resolve) => req.once("response", () => resolve()));
+        // Never read the response: the stream cannot close on its own.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(admissionGate.activeCount).toBe(1);
+
+        await handle.close();
+        expect(admissionGate.activeCount).toBe(0);
+      } finally {
+        rawClient.close();
+      }
+    });
   });
 });

--- a/packages/adapter-utils/src/http2-bridge-server.test.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.test.ts
@@ -1210,6 +1210,162 @@ describe("createHttp2BridgeServer + createSandboxHttp2BridgeGateway", () => {
       }
     });
 
+    it("a queued stream reads no request body bytes until the gate admits it", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
+      let releaseFirstStream: (() => void) | undefined;
+      const firstStreamHeld = new Promise<void>((resolve) => {
+        releaseFirstStream = resolve;
+      });
+      const secondForwardTracker = createForwarderCallTracker();
+      // Count the `data` events the second stream's underlying transport
+      // delivers. A session-level listener sees the same stream object the
+      // request handler holds, so this counts real transport delivery, not
+      // a private field inside the handler.
+      let secondStreamDataEvents = 0;
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        forwardRequest: async (request) => {
+          if (request.pathname === "/api/agents/me") {
+            // Hold the only slot until the test explicitly releases it.
+            await firstStreamHeld;
+            return { status: 200 };
+          }
+          secondForwardTracker.markCalled();
+          return { status: 200, body: JSON.stringify({ bodyLength: request.body.byteLength }) };
+        },
+        onSession: (session) => {
+          session.on("stream", (stream, headers) => {
+            if (headers[":path"] === "/api/issues/abc/comments") {
+              stream.on("data", () => {
+                secondStreamDataEvents += 1;
+              });
+            }
+          });
+        },
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const firstReq = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/agents/me",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        firstReq.resume();
+        firstReq.end();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(admissionGate.activeCount).toBe(1);
+        expect(admissionGate.queuedCount).toBe(0);
+
+        const secondReq = rawClient.request({
+          ":method": "POST",
+          ":path": "/api/issues/abc/comments",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        let status = 0;
+        let responseBody = "";
+        secondReq.setEncoding("utf8");
+        secondReq.on("response", (headers) => {
+          status = Number(headers[":status"]) || 0;
+        });
+        secondReq.on("data", (chunk) => (responseBody += chunk));
+        const secondDone = new Promise<void>((resolve, reject) => {
+          secondReq.on("end", () => resolve());
+          secondReq.on("error", reject);
+        });
+        // Send the full body and end the stream while it still queues
+        // behind the first stream's held slot.
+        secondReq.write(Buffer.alloc(4096, "b"));
+        secondReq.end();
+
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(admissionGate.queuedCount).toBe(1);
+        // The second stream's body reached the transport, but the gate has
+        // not admitted it: the handler must hold none of those bytes yet.
+        expect(secondForwardTracker.called).toBe(false);
+        expect(secondStreamDataEvents).toBe(0);
+
+        releaseFirstStream?.();
+        await secondDone;
+
+        expect(status).toBe(200);
+        expect(JSON.parse(responseBody)).toEqual({ bodyLength: 4096 });
+        expect(secondForwardTracker.called).toBe(true);
+        expect(secondStreamDataEvents).toBeGreaterThan(0);
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
+    it("a body that arrives during the queue wait completes after admission", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
+      let releaseFirstStream: (() => void) | undefined;
+      const firstStreamHeld = new Promise<void>((resolve) => {
+        releaseFirstStream = resolve;
+      });
+      const { handle, bridgeToken, clientSide } = bindTestServer({
+        admissionGate,
+        forwardRequest: async (request) => {
+          if (request.pathname === "/api/agents/me") {
+            await firstStreamHeld;
+            return { status: 200 };
+          }
+          return { status: 200, body: JSON.stringify({ bodyLength: request.body.byteLength }) };
+        },
+      });
+      const rawClient = connectRawClient(clientSide);
+      try {
+        const firstReq = rawClient.request({
+          ":method": "GET",
+          ":path": "/api/agents/me",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        firstReq.resume();
+        firstReq.end();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(admissionGate.activeCount).toBe(1);
+
+        const secondReq = rawClient.request({
+          ":method": "POST",
+          ":path": "/api/issues/abc/comments",
+          authorization: `Bearer ${bridgeToken}`,
+        });
+        let status = 0;
+        let responseBody = "";
+        secondReq.setEncoding("utf8");
+        secondReq.on("response", (headers) => {
+          status = Number(headers[":status"]) || 0;
+        });
+        secondReq.on("data", (chunk) => (responseBody += chunk));
+        const secondDone = new Promise<void>((resolve, reject) => {
+          secondReq.on("end", () => resolve());
+          secondReq.on("error", reject);
+        });
+
+        // Stream the body over several writes while the stream still
+        // queues, and end it before the gate admits it.
+        const bodyParts = ["first-chunk-", "second-chunk-", "third-chunk"];
+        for (const part of bodyParts) {
+          secondReq.write(part);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        secondReq.end();
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(admissionGate.queuedCount).toBe(1);
+
+        releaseFirstStream?.();
+        await secondDone;
+
+        const expectedBody = bodyParts.join("");
+        expect(status).toBe(200);
+        expect(JSON.parse(responseBody)).toEqual({ bodyLength: expectedBody.length });
+      } finally {
+        rawClient.close();
+        await handle.close();
+      }
+    });
+
     it("a token, path, or route denial takes no gate slot", async () => {
       const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 1, maxSessions: 4 });
       const { handle, bridgeToken, clientSide } = bindTestServer({ admissionGate });

--- a/packages/adapter-utils/src/http2-bridge-server.test.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.test.ts
@@ -33,7 +33,12 @@ import {
 import { createSandboxHttp2BridgeGateway } from "./sandbox-callback-bridge.js";
 import type { CommandManagedDuplexChannel } from "./command-managed-runtime.js";
 import {
+  DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+  DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+  http2BridgeAdmissionBudgetBytes,
   Http2BridgeAdmissionGate,
+  HTTP2_BRIDGE_ADMISSION_MEMORY_TARGET_BYTES,
+  HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES,
   HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES,
 } from "./http2-bridge-admission.js";
 
@@ -1726,6 +1731,56 @@ describe("createHttp2BridgeServer + createSandboxHttp2BridgeGateway", () => {
 
         await handle.close();
         expect(admissionGate.activeCount).toBe(0);
+      } finally {
+        rawClient.close();
+      }
+    });
+
+    it("the default caps keep the named byte total inside the reserved budget", () => {
+      // 64 admitted streams x 868,351 bytes, plus 8 live sessions x
+      // 16,777,216 bytes: 189,792,192 named bytes in total. This stays
+      // inside the 201,326,592-byte reserved budget and below the
+      // 268,435,456-byte target.
+      const total = http2BridgeAdmissionBudgetBytes(
+        DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+        DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+      );
+      expect(total).toBe(189_792_192);
+      expect(total).toBeLessThanOrEqual(HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES);
+      expect(total).toBeLessThan(HTTP2_BRIDGE_ADMISSION_MEMORY_TARGET_BYTES);
+    });
+
+    it("one more live session than the default cap would pass the reserved budget", () => {
+      // 64 admitted streams x 868,351 bytes, plus 9 live sessions x
+      // 16,777,216 bytes: 206,569,408 named bytes. This passes the
+      // 201,326,592-byte reserved budget.
+      const total = http2BridgeAdmissionBudgetBytes(
+        DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+        DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS + 1,
+      );
+      expect(total).toBe(206_569_408);
+      expect(total).toBeGreaterThan(HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES);
+    });
+
+    it("bindChannel's Duplex emits close once the handle closes the session it belongs to", async () => {
+      const admissionGate = new Http2BridgeAdmissionGate({ maxParallel: 4, maxSessions: 4 });
+      const [serverSide, clientSide] = duplexPair();
+      const channel = fakeChannelFromDuplex(serverSide);
+      const handle = createHttp2BridgeServer({
+        bridgeToken: BRIDGE_TOKEN,
+        forwardRequest: async () => ({ status: 200 }),
+        admissionGate,
+      });
+      const boundDuplex = handle.bindChannel(channel);
+      const rawClient = connectRawClient(clientSide);
+      try {
+        // Wait for the session to actually establish, the same way a real
+        // sandbox client would, before the close-teardown path runs.
+        await new Promise<void>((resolve) => rawClient.once("connect", resolve));
+        const closed = new Promise<void>((resolve) => boundDuplex.once("close", resolve));
+        await handle.close();
+        await closed;
+        expect(boundDuplex.destroyed).toBe(true);
       } finally {
         rawClient.close();
       }

--- a/packages/adapter-utils/src/http2-bridge-server.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.ts
@@ -100,17 +100,17 @@ export const HTTP2_BRIDGE_SERVER_OPTIONS: http2.ServerOptions = {
 // Duplex channel adapter
 // ---------------------------------------------------------------------------
 
-/** The default cap, in bytes, on the read-side queue {@link wrapDuplexChannelAsNodeDuplex}
- * holds once `Duplex.push()` reports the readable side is full (a `false`
- * return). A sandbox-controlled channel has no upstream pause: `onData` below
- * keeps delivering bytes whether or not the HTTP/2 session keeps up with
- * them. Past this cap the wrapper treats the channel as stuck, not merely
- * slow, and fails closed: it stops the channel and destroys the `Duplex`, so
- * a producer that keeps outpacing its reader cannot grow host memory without
- * bound. This cap also bounds one single chunk: the wrapper checks a chunk's
- * own size against it before `push()` ever runs, so one oversized chunk
- * cannot cross the cap on its first delivery, before the queue holds
- * anything to compare it against.
+/** The default cap, in bytes, on the total {@link wrapDuplexChannelAsNodeDuplex}
+ * retains for one channel across both of its read buffers: the Node readable
+ * buffer (`Duplex.readableLength`) and the wrapper's own pending queue. A
+ * sandbox-controlled channel has no upstream pause: `onData` below keeps
+ * delivering bytes whether or not the HTTP/2 session keeps up with them.
+ * Past this cap the wrapper treats the channel as stuck, not merely slow,
+ * and fails closed: it stops the channel and destroys the `Duplex`, so a
+ * producer that keeps outpacing its reader cannot grow host memory without
+ * bound. One bound cap bounds the sum of both buffers, so one live session
+ * never retains more than this many bytes in total, not this many bytes in
+ * each buffer.
  *
  * This value reads {@link HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES} from the
  * admission module, so the wrapper cap and the admission gate's live-session
@@ -145,11 +145,11 @@ export const DEFAULT_HTTP2_BRIDGE_READ_BACKPRESSURE_STALL_MS = 30_000;
  * wrapper honors that signal instead: while `push()` reports room, it pushes
  * directly; once `push()` reports the readable side is full, it queues each
  * later chunk instead of pushing past that signal, and drains the queue from
- * `read()`, which Node calls again only once the consumer wants more. Every
- * chunk, on either path, first checks against
+ * `read()`, which Node calls again only once the consumer wants more. Before
+ * either path runs, every chunk checks against
  * {@link DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES} (or the caller's
- * `maxBufferedReadBytes`) on its own size, and the queue checks against the
- * same cap on its cumulative size: past either check the wrapper fails
+ * `maxBufferedReadBytes`) as one bound on the total the Node readable buffer
+ * and the pending queue hold together: past that bound the wrapper fails
  * closed instead of buffering further, because the channel has no pause to
  * fall back on. A second, independent bound —
  * {@link DEFAULT_HTTP2_BRIDGE_READ_BACKPRESSURE_STALL_MS} (or the caller's
@@ -208,6 +208,14 @@ export function wrapDuplexChannelAsNodeDuplex(
     duplex.destroy(new Error(message));
   }
 
+  /** The total bytes this channel retains right now, across both read
+   * buffers: the Node readable buffer and the wrapper's own pending queue.
+   * `channel.onData` checks this total, not each buffer alone, against
+   * `maxBufferedReadBytes`, so the cap bounds the sum the channel can hold. */
+  function retainedReadBytes(): number {
+    return duplex.readableLength + pendingReadBytes;
+  }
+
   function endReadableIfDrained(): void {
     if (!channelExited || pendingReads.length > 0 || duplex.destroyed) return;
     duplex.push(null);
@@ -264,14 +272,18 @@ export function wrapDuplexChannelAsNodeDuplex(
   channel.onData((chunk) => {
     if (duplex.destroyed) return;
     const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    // Check one chunk's own size against the cap before either path below
-    // runs. `push()` never refuses a call on its size, so a single chunk
-    // larger than the whole cap would otherwise reach Node's internal
-    // buffer unbounded on the direct-push path, before the queue this
-    // wrapper owns ever holds anything to compare a later chunk against.
-    if (bytes.byteLength > maxBufferedReadBytes) {
+    // Check this chunk against the cap as one bound on the total the Node
+    // readable buffer and the wrapper's own pending queue hold together,
+    // before either path below runs. `push()` never refuses a call on its
+    // size, so a single large chunk would otherwise reach Node's internal
+    // buffer unbounded on the direct-push path, and a check that bounds only
+    // one buffer at a time would let the two buffers together hold more
+    // than the cap allows.
+    if (retainedReadBytes() + bytes.byteLength > maxBufferedReadBytes) {
       failClosed(
-        "Sandbox HTTP/2 channel delivered one chunk larger than the bounded read backpressure buffer.",
+        bytes.byteLength > maxBufferedReadBytes
+          ? "Sandbox HTTP/2 channel delivered one chunk larger than the bounded read backpressure buffer."
+          : "Sandbox HTTP/2 channel exceeded the bounded read backpressure buffer; the reader could not keep up.",
       );
       return;
     }
@@ -281,8 +293,9 @@ export function wrapDuplexChannelAsNodeDuplex(
     }
     // The readable side already reported it is full, and the channel has no
     // pause to slow the sandbox side down: queue this chunk instead of
-    // pushing past that signal. Bound the queue, so a producer that keeps
-    // outpacing its reader cannot grow it without limit.
+    // pushing past that signal. The check above already bounds the queue as
+    // part of the shared total, so a producer that keeps outpacing its
+    // reader still cannot grow it without limit.
     if (pendingReads.length === 0) {
       // The queue was empty until this chunk: arm the stall bound, so a
       // consumer that never resumes reading still ends the channel, even
@@ -290,12 +303,6 @@ export function wrapDuplexChannelAsNodeDuplex(
       armBackpressureStallTimer();
     }
     pendingReadBytes += bytes.byteLength;
-    if (pendingReadBytes > maxBufferedReadBytes) {
-      failClosed(
-        "Sandbox HTTP/2 channel exceeded the bounded read backpressure buffer; the reader could not keep up.",
-      );
-      return;
-    }
     pendingReads.push(bytes);
   });
   channel.onExit(() => {

--- a/packages/adapter-utils/src/http2-bridge-server.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.ts
@@ -31,6 +31,11 @@ import http2 from "node:http2";
 
 import type { CommandManagedDuplexChannel } from "./command-managed-runtime.js";
 import {
+  getHttp2BridgeAdmissionGate,
+  HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES,
+  type Http2BridgeAdmissionGate,
+} from "./http2-bridge-admission.js";
+import {
   authorizeSandboxCallbackBridgeRequestWithRoutes,
   compareBridgeTokensConstantTime,
   sanitizeSandboxCallbackBridgeHeaders,
@@ -105,8 +110,12 @@ export const HTTP2_BRIDGE_SERVER_OPTIONS: http2.ServerOptions = {
  * bound. This cap also bounds one single chunk: the wrapper checks a chunk's
  * own size against it before `push()` ever runs, so one oversized chunk
  * cannot cross the cap on its first delivery, before the queue holds
- * anything to compare it against. */
-export const DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES = HTTP2_BRIDGE_MAX_SESSION_MEMORY * 1024 * 1024;
+ * anything to compare it against.
+ *
+ * This value reads {@link HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES} from the
+ * admission module, so the wrapper cap and the admission gate's live-session
+ * reservation resolve through one shared constant and cannot drift apart. */
+export const DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES = HTTP2_BRIDGE_LIVE_SESSION_BUDGET_BYTES;
 /** The default bound, in milliseconds, on how long the read-side queue
  * {@link wrapDuplexChannelAsNodeDuplex} holds can stay non-empty with no
  * chunk draining from it. The byte cap above bounds how much memory a stuck
@@ -438,6 +447,13 @@ export const DEFAULT_HTTP2_BRIDGE_REQUEST_BODY_LIFETIME_CEILING_MS = 480_000;
  * session that carries a stalled stream would otherwise hold `close()` open
  * forever, because `session.close()` waits for every open stream to end. */
 export const DEFAULT_HTTP2_BRIDGE_CLOSE_GRACE_MS = 5_000;
+/** The default bound {@link waitForStreamDrain} waits for a response stream
+ * to reach its `close` event before the server frees the admission slot the
+ * stream holds. `stream.end()` returns before the peer has read the
+ * response, so a wait with no bound would let a peer that never reads a
+ * response hold the slot open forever. Set to the same value as
+ * {@link DEFAULT_HTTP2_BRIDGE_REQUEST_BODY_TIMEOUT_MS}. */
+export const DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS = 30_000;
 
 function startHttp2BridgePingWatchdog(
   session: http2.ServerHttp2Session,
@@ -565,6 +581,16 @@ export interface CreateHttp2BridgeServerOptions {
    * chunk draining from it. The default is
    * {@link DEFAULT_HTTP2_BRIDGE_READ_BACKPRESSURE_STALL_MS}. */
   readBackpressureStallMs?: number;
+  /** The process-wide admission gate. The server takes one slot from this
+   * gate for each admitted stream, after the route check and before the
+   * request body read, and holds the slot until the stream closes (or the
+   * response drain bound fires). The default is the process-wide instance
+   * from {@link getHttp2BridgeAdmissionGate}. A test injects its own gate. */
+  admissionGate?: Http2BridgeAdmissionGate;
+  /** The bound {@link waitForStreamDrain} waits for a response stream to
+   * close before the server frees its admission slot. The default is
+   * {@link DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS}. */
+  responseDrainTimeoutMs?: number;
   /** The sink for a GOAWAY the server observed on a session (one the sandbox
    * side sent to the host). */
   onGoaway?: (record: Http2BridgeGoawayRecord) => void;
@@ -688,6 +714,141 @@ function readHttp2StreamBody(
   });
 }
 
+/** One settled body-capture result: either the concatenated body, or the
+ * error the capture settled with. */
+type Http2BridgeBodyCaptureOutcome = { ok: true; body: Buffer } | { ok: false; error: Error };
+
+/**
+ * Begin capturing one request body, ahead of the idle and lifetime timers
+ * that bound how long the capture can run. A caller that waits on the
+ * admission gate before it is ready to enforce those timers must still
+ * attach the underlying stream listeners at once, in the same synchronous
+ * turn as the `stream` event: attaching them one turn later can lose the
+ * peer's `end` (Node does not replay a body the JS layer was not yet
+ * listening for), stalling a request that already fully arrived.
+ *
+ * `awaitBody` arms the idle and lifetime timers and returns the promise the
+ * caller awaits. Call it once, when the caller is ready to enforce the
+ * bounds (after the admission wait, in this server). If the body already
+ * finished, or the stream already errored, closed, or aborted, before
+ * `awaitBody` runs, it delivers that outcome at once and arms no timer.
+ */
+function beginHttp2BridgeStreamBodyCapture(
+  stream: http2.ServerHttp2Stream,
+  maxBodyBytes: number,
+): { awaitBody(idleTimeoutMs: number, lifetimeCeilingMs: number): Promise<Buffer> } {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let settled = false;
+  let outcome: Http2BridgeBodyCaptureOutcome | undefined;
+  let onSettled: ((outcome: Http2BridgeBodyCaptureOutcome) => void) | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let lifetimeCeilingTimer: ReturnType<typeof setTimeout> | undefined;
+  let armedIdleTimeoutMs: number | undefined;
+
+  const settle = (result: Http2BridgeBodyCaptureOutcome) => {
+    if (settled) return;
+    settled = true;
+    if (idleTimer) clearTimeout(idleTimer);
+    if (lifetimeCeilingTimer) clearTimeout(lifetimeCeilingTimer);
+    outcome = result;
+    onSettled?.(result);
+  };
+
+  const armIdleTimer = () => {
+    // Before `awaitBody` runs, `armedIdleTimeoutMs` is unset: a chunk that
+    // arrives while the caller still waits on admission must not start (or
+    // restart) the idle bound, so a queue wait alone can never trip it.
+    if (armedIdleTimeoutMs === undefined) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      settle({ ok: false, error: new Error("Bridge request body stalled before it completed.") });
+      stream.destroy();
+    }, armedIdleTimeoutMs);
+    idleTimer.unref?.();
+  };
+
+  stream.on("data", (chunk: Buffer) => {
+    totalBytes += chunk.byteLength;
+    if (totalBytes > maxBodyBytes) {
+      settle({ ok: false, error: new Error("Bridge request body exceeded the configured size limit.") });
+      stream.destroy();
+      return;
+    }
+    chunks.push(chunk);
+    armIdleTimer();
+  });
+  stream.once("end", () => settle({ ok: true, body: Buffer.concat(chunks) }));
+  stream.once("error", (error) =>
+    settle({ ok: false, error: error instanceof Error ? error : new Error(String(error)) }),
+  );
+  stream.once("aborted", () => settle({ ok: false, error: new Error("Bridge request stream aborted.") }));
+  stream.once("close", () =>
+    settle({ ok: false, error: new Error("Bridge request stream closed before it completed.") }),
+  );
+
+  return {
+    awaitBody(idleTimeoutMs: number, lifetimeCeilingMs: number): Promise<Buffer> {
+      return new Promise((resolve, reject) => {
+        const deliver = (result: Http2BridgeBodyCaptureOutcome) => {
+          if (result.ok) resolve(result.body);
+          else reject(result.error);
+        };
+        if (outcome) {
+          // The body already finished (or the stream already went away)
+          // while this capture waited on admission: deliver it at once, and
+          // arm no timer for a wait that is already over.
+          deliver(outcome);
+          return;
+        }
+        onSettled = deliver;
+        armedIdleTimeoutMs = idleTimeoutMs;
+        armIdleTimer();
+        // Arms one time, from here, and never rearms on a chunk: see
+        // DEFAULT_HTTP2_BRIDGE_REQUEST_BODY_LIFETIME_CEILING_MS for why the
+        // ceiling must stay independent of progress.
+        lifetimeCeilingTimer = setTimeout(() => {
+          settle({ ok: false, error: new Error("Bridge request body passed the total lifetime ceiling.") });
+          stream.destroy();
+        }, lifetimeCeilingMs);
+        lifetimeCeilingTimer.unref?.();
+      });
+    },
+  };
+}
+
+/**
+ * Wait for `stream` to reach its `close` event, or destroy it once
+ * `timeoutMs` passes with no close. `stream.end()` returns before the peer
+ * has read the response: the response bytes, and the admission slot the
+ * stream holds, stay in host memory until the peer actually drains them.
+ * This bounds that wait, so a peer that never reads a response cannot hold
+ * the slot open forever.
+ */
+function waitForStreamDrain(stream: http2.ServerHttp2Stream, timeoutMs: number): Promise<void> {
+  if (stream.closed || stream.destroyed) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const onClose = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      stream.removeListener("close", onClose);
+      if (!stream.destroyed) stream.destroy();
+      resolve();
+    }, timeoutMs);
+    timer.unref?.();
+    stream.once("close", onClose);
+  });
+}
+
 function respondJson(stream: http2.ServerHttp2Stream, status: number, body: unknown): void {
   if (stream.destroyed || stream.closed) return;
   try {
@@ -743,6 +904,8 @@ export function createHttp2BridgeServer(options: CreateHttp2BridgeServerOptions)
   const maxBufferedReadBytes = options.maxBufferedReadBytes ?? DEFAULT_HTTP2_BRIDGE_MAX_BUFFERED_READ_BYTES;
   const readBackpressureStallMs =
     options.readBackpressureStallMs ?? DEFAULT_HTTP2_BRIDGE_READ_BACKPRESSURE_STALL_MS;
+  const admissionGate = options.admissionGate ?? getHttp2BridgeAdmissionGate();
+  const responseDrainTimeoutMs = options.responseDrainTimeoutMs ?? DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS;
   // Built one time and passed to every readHttp2StreamBody() and
   // denyRequest() call below, so every stream on this server enforces the
   // same bounds.
@@ -790,40 +953,78 @@ export function createHttp2BridgeServer(options: CreateHttp2BridgeServerOptions)
       headerAllowlist,
     );
 
-    let body: Buffer;
-    try {
-      body = await readHttp2StreamBody(stream, bodyBounds);
-    } catch (error) {
-      respondJson(stream, 413, { error: error instanceof Error ? error.message : String(error) });
-      return;
-    }
+    // Begin capturing the request body at once, in this same synchronous
+    // turn: the admission wait below can take an arbitrary time, and Node
+    // does not replay a body this handler was not yet listening for. The
+    // capture arms no timer until `awaitBody` runs, after admission.
+    const bodyCapture = beginHttp2BridgeStreamBodyCapture(stream, maxBodyBytes);
 
-    let result: Http2BridgeForwardResult;
+    // The admission gate bounds host memory across every bridge server and
+    // every session: take one slot before the body read completes, and hold
+    // it until the response leaves the host. A denial above takes no slot;
+    // only a routed, authenticated request reaches this point.
+    //
+    // Abort the queue wait if the stream closes while it still waits, so a
+    // cancelled request leaves the queue instead of taking a later slot.
+    const admissionAbortController = new AbortController();
+    const abortAdmissionWaitOnClose = () => admissionAbortController.abort();
+    stream.once("close", abortAdmissionWaitOnClose);
+    let releaseAdmissionSlot: () => void;
     try {
-      result = await options.forwardRequest({
-        method,
-        pathname: parsedPath.value.pathname,
-        query: parsedPath.value.query,
-        headers: sanitizedHeaders,
-        body,
-      });
-    } catch (error) {
-      respondJson(stream, 502, { error: error instanceof Error ? error.message : String(error) });
-      return;
-    }
-
-    if (stream.destroyed || stream.closed) return;
-    const responseHeaders: http2.OutgoingHttpHeaders = { ":status": result.status };
-    for (const [key, value] of Object.entries(result.headers ?? {})) {
-      if (key.toLowerCase() === "content-length") continue;
-      responseHeaders[key] = value;
-    }
-    try {
-      stream.respond(responseHeaders);
-      stream.end(result.body);
+      releaseAdmissionSlot = await admissionGate.acquire(admissionAbortController.signal);
     } catch {
-      // The peer reset the stream (RST_STREAM) between dispatch and response.
-      // One stream's write fault stays local to that stream.
+      // The stream closed while it waited in the queue: there is nothing
+      // left to answer.
+      stream.removeListener("close", abortAdmissionWaitOnClose);
+      return;
+    }
+    stream.removeListener("close", abortAdmissionWaitOnClose);
+
+    try {
+      let body: Buffer;
+      try {
+        body = await bodyCapture.awaitBody(requestBodyTimeoutMs, requestBodyLifetimeCeilingMs);
+      } catch (error) {
+        respondJson(stream, 413, { error: error instanceof Error ? error.message : String(error) });
+        await waitForStreamDrain(stream, responseDrainTimeoutMs);
+        return;
+      }
+
+      let result: Http2BridgeForwardResult;
+      try {
+        result = await options.forwardRequest({
+          method,
+          pathname: parsedPath.value.pathname,
+          query: parsedPath.value.query,
+          headers: sanitizedHeaders,
+          body,
+        });
+      } catch (error) {
+        respondJson(stream, 502, { error: error instanceof Error ? error.message : String(error) });
+        await waitForStreamDrain(stream, responseDrainTimeoutMs);
+        return;
+      }
+
+      if (stream.destroyed || stream.closed) return;
+      const responseHeaders: http2.OutgoingHttpHeaders = { ":status": result.status };
+      for (const [key, value] of Object.entries(result.headers ?? {})) {
+        if (key.toLowerCase() === "content-length") continue;
+        responseHeaders[key] = value;
+      }
+      try {
+        stream.respond(responseHeaders);
+        stream.end(result.body);
+        // `stream.end()` returns before the peer has read the response: wait
+        // for the stream to actually close before the outer `finally` frees
+        // the slot, so the response bytes stay accounted for in host memory
+        // until they truly leave the host.
+        await waitForStreamDrain(stream, responseDrainTimeoutMs);
+      } catch {
+        // The peer reset the stream (RST_STREAM) between dispatch and response.
+        // One stream's write fault stays local to that stream.
+      }
+    } finally {
+      releaseAdmissionSlot();
     }
   }
 

--- a/packages/adapter-utils/src/http2-bridge-server.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.ts
@@ -727,11 +727,22 @@ type Http2BridgeBodyCaptureOutcome = { ok: true; body: Buffer } | { ok: false; e
  * peer's `end` (Node does not replay a body the JS layer was not yet
  * listening for), stalling a request that already fully arrived.
  *
- * `awaitBody` arms the idle and lifetime timers and returns the promise the
- * caller awaits. Call it once, when the caller is ready to enforce the
- * bounds (after the admission wait, in this server). If the body already
- * finished, or the stream already errored, closed, or aborted, before
- * `awaitBody` runs, it delivers that outcome at once and arms no timer.
+ * The function pauses the stream right after it attaches the listeners, in
+ * that same synchronous turn. A queued stream must hold no request body
+ * bytes in host memory while it waits for admission: the pause stops the
+ * peer's flow-control window from advancing, so the peer itself stalls at
+ * the wire and the queue applies real back pressure instead of buffering
+ * the body early. `awaitBody` resumes the stream once the caller is ready
+ * to read it. Both halves are needed together: the synchronous listener
+ * attach keeps the `end` event, and the pause keeps the body out of memory
+ * until admission.
+ *
+ * `awaitBody` resumes the stream, then arms the idle and lifetime timers,
+ * and returns the promise the caller awaits. Call it once, when the caller
+ * is ready to enforce the bounds (after the admission wait, in this
+ * server). If the body already finished, or the stream already errored,
+ * closed, or aborted, before `awaitBody` runs, it delivers that outcome at
+ * once, resumes no stream, and arms no timer.
  */
 function beginHttp2BridgeStreamBodyCapture(
   stream: http2.ServerHttp2Stream,
@@ -786,6 +797,11 @@ function beginHttp2BridgeStreamBodyCapture(
   stream.once("close", () =>
     settle({ ok: false, error: new Error("Bridge request stream closed before it completed.") }),
   );
+  // Pause at once, in the same synchronous turn as the listener attach
+  // above: a queued stream then holds no request body bytes in host
+  // memory, because the peer's own flow-control window stalls it at the
+  // wire instead of the JS layer buffering the body early.
+  stream.pause();
 
   return {
     awaitBody(idleTimeoutMs: number, lifetimeCeilingMs: number): Promise<Buffer> {
@@ -803,6 +819,10 @@ function beginHttp2BridgeStreamBodyCapture(
         }
         onSettled = deliver;
         armedIdleTimeoutMs = idleTimeoutMs;
+        // The stream stayed paused for the whole admission wait: resume it
+        // here, now that the caller is ready to enforce the idle and
+        // lifetime bounds below.
+        stream.resume();
         armIdleTimer();
         // Arms one time, from here, and never rearms on a chunk: see
         // DEFAULT_HTTP2_BRIDGE_REQUEST_BODY_LIFETIME_CEILING_MS for why the

--- a/packages/adapter-utils/src/http2-bridge-server.ts
+++ b/packages/adapter-utils/src/http2-bridge-server.ts
@@ -657,23 +657,27 @@ export interface Http2BridgeBodyBounds {
 }
 
 /**
- * Read one request body, bounded on size and on two independent time
- * bounds: an idle bound and a total-lifetime ceiling. See
+ * Discard one denied request's body, bounded on size and on two independent
+ * time bounds: an idle bound and a total-lifetime ceiling. See
  * {@link DEFAULT_HTTP2_BRIDGE_REQUEST_BODY_TIMEOUT_MS} and
  * {@link DEFAULT_HTTP2_BRIDGE_REQUEST_BODY_LIFETIME_CEILING_MS} for why the
  * server enforces each one.
+ *
+ * A denial never reads its own body content, so this function keeps no
+ * chunk: it counts bytes to enforce `bounds.maxBodyBytes`, then drops each
+ * chunk at once. The host holds one running number per denied stream, not a
+ * copy of the body.
  *
  * The `close` listener is the settle-of-last-resort: it fires whenever the
  * stream ends for any reason at all — a normal end, an error, a timeout- or
  * shutdown-triggered `destroy()`, or a peer reset — so the promise always
  * settles and the caller never awaits a stream that already went away.
  */
-function readHttp2StreamBody(
+export function discardHttp2StreamBody(
   stream: http2.ServerHttp2Stream,
   bounds: Http2BridgeBodyBounds,
-): Promise<Buffer> {
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
     let totalBytes = 0;
     let settled = false;
     let idleTimer: ReturnType<typeof setTimeout>;
@@ -709,12 +713,13 @@ function readHttp2StreamBody(
         stream.destroy();
         return;
       }
-      chunks.push(chunk);
       // The chunk is real progress, so the peer is not stalled: reset the
       // idle bound. The lifetime ceiling timer above does not reset here.
+      // The chunk itself is dropped here: a denial keeps no request body
+      // byte in host memory.
       armIdleTimer();
     });
-    stream.once("end", () => settle(() => resolve(Buffer.concat(chunks))));
+    stream.once("end", () => settle(() => resolve()));
     stream.once("error", (error) => settle(() => reject(error instanceof Error ? error : new Error(String(error)))));
     stream.once("aborted", () => settle(() => reject(new Error("Bridge request stream aborted."))));
     stream.once("close", () => settle(() => reject(new Error("Bridge request stream closed before it completed."))));
@@ -889,14 +894,17 @@ function respondJson(stream: http2.ServerHttp2Stream, status: number, body: unkn
 }
 
 /**
- * Answer a denied stream, then consume and discard its request body under
- * the same bounds ({@link Http2BridgeBodyBounds}) an authenticated request
- * gets. A denied request's body content never reaches the forward handler,
- * but the inbound half of the stream still needs a bound: without one, a
- * peer that leaves the body unfinished keeps the stream open, holding one
- * of the {@link HTTP2_BRIDGE_MAX_CONCURRENT_STREAMS} slots for as long as
- * it chooses. Nothing awaits the discard; the caller has already answered
- * the request and moves on to the next stream.
+ * Answer a denied stream, then discard its request body under the same
+ * bounds ({@link Http2BridgeBodyBounds}) an authenticated request gets. A
+ * denied request's body content never reaches the forward handler, but the
+ * inbound half of the stream still needs a bound: without one, a peer that
+ * leaves the body unfinished keeps the stream open, holding one of the
+ * {@link HTTP2_BRIDGE_MAX_CONCURRENT_STREAMS} slots for as long as it
+ * chooses. This one function is every denial branch's only path to a body
+ * read, so every denial — an invalid token, a malformed path, or a denied
+ * route — discards through the same non-retaining helper and takes no
+ * admission-gate slot. Nothing awaits the discard; the caller has already
+ * answered the request and moves on to the next stream.
  */
 function denyRequest(
   stream: http2.ServerHttp2Stream,
@@ -906,7 +914,7 @@ function denyRequest(
 ): void {
   respondJson(stream, status, body);
   if (stream.destroyed || stream.closed) return;
-  readHttp2StreamBody(stream, bounds).catch(() => {
+  discardHttp2StreamBody(stream, bounds).catch(() => {
     // The idle or lifetime bound above already destroyed the stream, or the
     // peer reset it first. Either way the slot is free; the discarded body
     // content is irrelevant to a denial.
@@ -933,7 +941,7 @@ export function createHttp2BridgeServer(options: CreateHttp2BridgeServerOptions)
     options.readBackpressureStallMs ?? DEFAULT_HTTP2_BRIDGE_READ_BACKPRESSURE_STALL_MS;
   const admissionGate = options.admissionGate ?? getHttp2BridgeAdmissionGate();
   const responseDrainTimeoutMs = options.responseDrainTimeoutMs ?? DEFAULT_HTTP2_BRIDGE_RESPONSE_DRAIN_TIMEOUT_MS;
-  // Built one time and passed to every readHttp2StreamBody() and
+  // Built one time and passed to every discardHttp2StreamBody() and
   // denyRequest() call below, so every stream on this server enforces the
   // same bounds.
   const bodyBounds: Http2BridgeBodyBounds = {
@@ -1104,7 +1112,8 @@ export function createHttp2BridgeServer(options: CreateHttp2BridgeServerOptions)
       // timeout has not yet fired) would hold this wait open forever. The
       // grace timer bounds it: past `closeGraceMs`, the server force-destroys
       // the session, which ends its streams at once and settles their body
-      // reads through the `close` backstop in `readHttp2StreamBody`.
+      // reads through the `close` backstop in `discardHttp2StreamBody` and
+      // `beginHttp2BridgeStreamBodyCapture`.
       await Promise.all(
         [...activeSessions].map(
           (session) =>

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -3,7 +3,9 @@ import { createServer } from "node:http";
 import { mkdir, mkdtemp, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Duplex, duplexPair } from "node:stream";
 import { promisify } from "node:util";
+import http2 from "node:http2";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getActiveStepContext, measureStartupStep } from "./acpx-engine/startup-timing.js";
@@ -14,6 +16,7 @@ import {
   createFileSystemSandboxCallbackBridgeQueueClient,
   createSandboxCallbackBridgeAsset,
   createSandboxCallbackBridgeToken,
+  createSandboxHttp2BridgeGateway,
   getSandboxCallbackBridgeServerSource,
   sandboxCallbackBridgeDirectories,
   syncRemoteTextFileWithHashSkip,
@@ -3100,8 +3103,17 @@ describe("sandbox callback bridge", () => {
   async function startHttp2GatewayForTest(options: {
     bridgeToken: string;
     maxBodyBytes?: number;
+    responseTimeoutMs?: number;
     forwardRequest: (request: Http2BridgeForwardRequest) => Promise<Http2BridgeForwardResult>;
-  }): Promise<{ baseUrl: string; stop: () => Promise<void> }> {
+    onSession?: (session: http2.ServerHttp2Session) => void;
+    /**
+     * When true, hold every byte the host writes toward the sandbox process
+     * until a test calls the returned `releaseHostBytes`. This lets a test
+     * prove the sandbox gateway waits for the host's settings frame before
+     * it opens its first stream.
+     */
+    gateHostBytes?: boolean;
+  }): Promise<{ baseUrl: string; stop: () => Promise<void>; releaseHostBytes: () => void }> {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-http2-test-"));
     cleanupDirs.push(rootDir);
     const entrypoint = path.join(rootDir, "paperclip-bridge-server.mjs");
@@ -3129,6 +3141,9 @@ describe("sandbox callback bridge", () => {
         PAPERCLIP_BRIDGE_NONCE: "test-nonce",
         ...(options.maxBodyBytes != null
           ? { PAPERCLIP_BRIDGE_MAX_BODY_BYTES: String(options.maxBodyBytes) }
+          : {}),
+        ...(options.responseTimeoutMs != null
+          ? { PAPERCLIP_BRIDGE_RESPONSE_TIMEOUT_MS: String(options.responseTimeoutMs) }
           : {}),
       },
       stdio: ["pipe", "pipe", "pipe"],
@@ -3182,9 +3197,24 @@ describe("sandbox callback bridge", () => {
       }
     });
 
+    let hostBytesOpen = !options.gateHostBytes;
+    const bufferedHostBytes: Buffer[] = [];
+    const releaseHostBytes = () => {
+      if (hostBytesOpen) return;
+      hostBytesOpen = true;
+      for (const chunk of bufferedHostBytes.splice(0)) {
+        child.stdin.write(chunk);
+      }
+    };
+
     const channel: CommandManagedDuplexChannel = {
       write: (data) => {
-        child.stdin.write(Buffer.from(data));
+        const chunk = Buffer.from(data);
+        if (hostBytesOpen) {
+          child.stdin.write(chunk);
+        } else {
+          bufferedHostBytes.push(chunk);
+        }
       },
       onData: (listener) => {
         dataListeners.push(listener);
@@ -3205,6 +3235,7 @@ describe("sandbox callback bridge", () => {
     const handle = createHttp2BridgeServer({
       bridgeToken: options.bridgeToken,
       forwardRequest: options.forwardRequest,
+      onSession: options.onSession,
     });
     const boundDuplex = handle.bindChannel(channel);
     dispatchStarted = true;
@@ -3224,7 +3255,7 @@ describe("sandbox callback bridge", () => {
     };
     cleanupFns.push(stop);
 
-    return { baseUrl: `http://127.0.0.1:${assignedPort}`, stop };
+    return { baseUrl: `http://127.0.0.1:${assignedPort}`, stop, releaseHostBytes };
   }
 
   it("forwards the exact request body bytes to the HTTP/2 host handler, including a non-ASCII character", async () => {
@@ -3434,4 +3465,288 @@ describe("sandbox callback bridge", () => {
     expect(typeof seenRequests[0]?.body).toBe("string");
     expect(seenRequests[0]?.body).toBe(requestBodyText);
   });
+
+  /**
+   * Wrap one side of a paired in-memory `Duplex` as a minimal
+   * `CommandManagedDuplexChannel`, so the real host `createHttp2BridgeServer`
+   * can bind to it directly, with no spawned process in between.
+   */
+  function channelFromDuplex(duplex: Duplex): CommandManagedDuplexChannel {
+    const dataListeners: Array<(chunk: Uint8Array) => void> = [];
+    duplex.on("data", (chunk: Buffer) => {
+      for (const listener of dataListeners) listener(chunk);
+    });
+    return {
+      write: (data) => {
+        duplex.write(Buffer.from(data));
+      },
+      onData: (listener) => {
+        dataListeners.push(listener);
+      },
+      onExit: (listener) => {
+        duplex.once("end", () => listener({ exitCode: null, transportClosed: true }));
+      },
+      stop: () => {
+        duplex.destroy();
+      },
+      close: async () => {
+        duplex.end();
+      },
+    };
+  }
+
+  /**
+   * Hold back every chunk `source` emits until a test calls `release()`. A
+   * test uses this to delay the host's settings frame from reaching the
+   * exported sandbox HTTP/2 client gateway, so it can prove the gateway
+   * waits for that frame before it opens its first stream.
+   */
+  function createGatedDuplex(source: Duplex): { gated: Duplex; release: () => void } {
+    let open = false;
+    const buffered: Buffer[] = [];
+    const gated = new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        source.write(chunk);
+        callback();
+      },
+      final(callback) {
+        source.end();
+        callback();
+      },
+    });
+    source.on("data", (chunk: Buffer) => {
+      if (open) {
+        gated.push(chunk);
+      } else {
+        buffered.push(chunk);
+      }
+    });
+    source.on("end", () => {
+      if (open) gated.push(null);
+    });
+    return {
+      gated,
+      release: () => {
+        open = true;
+        for (const chunk of buffered.splice(0)) gated.push(chunk);
+      },
+    };
+  }
+
+  it("the gateway client opens its first stream only after the host settings frame arrives", async () => {
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const [serverSide, clientSide] = duplexPair();
+    let sawStream = false;
+    const handle = createHttp2BridgeServer({
+      bridgeToken,
+      forwardRequest: async () => ({ status: 200, headers: {}, body: "" }),
+      onSession: (session) => {
+        session.on("stream", () => {
+          sawStream = true;
+        });
+      },
+    });
+    handle.bindChannel(channelFromDuplex(serverSide));
+
+    const gate = createGatedDuplex(clientSide);
+    const gateway = createSandboxHttp2BridgeGateway({
+      bridgeToken,
+      createConnection: () => gate.gated,
+    });
+    cleanupFns.push(async () => {
+      await gateway.close();
+      serverSide.destroy();
+      clientSide.destroy();
+    });
+
+    const forwardPromise = gateway.forwardRequest({
+      method: "GET",
+      path: "/api/agents/me",
+      query: "",
+      headers: {},
+      body: Buffer.alloc(0),
+      receivedToken: bridgeToken,
+    });
+
+    // Wait before the settings frame is let through, so an early dispatch
+    // has time to open a stream if the gateway does not wait for it.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(sawStream).toBe(false);
+
+    gate.release();
+    const response = await forwardPromise;
+    expect(response.status).toBe(200);
+    expect(sawStream).toBe(true);
+  }, 15_000);
+
+  it("a host that sends no settings frame fails the first request at the bound", async () => {
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const blackHole = new Duplex({
+      read() {},
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const gateway = createSandboxHttp2BridgeGateway({
+      bridgeToken,
+      createConnection: () => blackHole,
+      responseTimeoutMs: 50,
+    });
+    // `gateway.close()` sends a graceful GOAWAY and waits for the transport
+    // to end, which a black-hole duplex never does. Destroy the transport
+    // directly instead, so teardown does not hang.
+    cleanupFns.push(async () => {
+      blackHole.destroy();
+    });
+
+    await expect(
+      gateway.forwardRequest({
+        method: "GET",
+        path: "/api/agents/me",
+        query: "",
+        headers: {},
+        body: Buffer.alloc(0),
+        receivedToken: bridgeToken,
+      }),
+    ).rejects.toThrow("Timed out waiting for the HTTP/2 bridge host settings handshake.");
+  });
+
+  it("a failed settings handshake raises no unhandled rejection when no request waits", async () => {
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const blackHole = new Duplex({
+      read() {},
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      const gateway = createSandboxHttp2BridgeGateway({
+        bridgeToken,
+        createConnection: () => blackHole,
+        responseTimeoutMs: 20,
+      });
+      // `gateway.close()` sends a graceful GOAWAY and waits for the
+      // transport to end, which a black-hole duplex never does. Destroy the
+      // transport directly instead, so teardown does not hang.
+      cleanupFns.push(async () => {
+        blackHole.destroy();
+      });
+
+      // No request is in flight while the handshake bound passes, so the
+      // stored handshake promise settles with nobody awaiting it yet.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(unhandled).toHaveLength(0);
+
+      // A request made after the bound already passed must still fail
+      // closed with the fixed handshake message. This proves the rejection
+      // was stored, not swallowed.
+      await expect(
+        gateway.forwardRequest({
+          method: "GET",
+          path: "/api/agents/me",
+          query: "",
+          headers: {},
+          body: Buffer.alloc(0),
+          receivedToken: bridgeToken,
+        }),
+      ).rejects.toThrow("Timed out waiting for the HTTP/2 bridge host settings handshake.");
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  }, 10_000);
+
+  it("the gateway client fails closed on a response body past the configured size limit", async () => {
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const maxBodyBytes = 16;
+    const [serverSide, clientSide] = duplexPair();
+    const handle = createHttp2BridgeServer({
+      bridgeToken,
+      forwardRequest: async () => ({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        body: "x".repeat(maxBodyBytes + 1),
+      }),
+    });
+    handle.bindChannel(channelFromDuplex(serverSide));
+
+    const gateway = createSandboxHttp2BridgeGateway({
+      bridgeToken,
+      createConnection: () => clientSide,
+      maxBodyBytes,
+    });
+    cleanupFns.push(async () => {
+      await gateway.close();
+      serverSide.destroy();
+      clientSide.destroy();
+    });
+
+    await expect(
+      gateway.forwardRequest({
+        method: "GET",
+        path: "/api/agents/me",
+        query: "",
+        headers: {},
+        body: Buffer.alloc(0),
+        receivedToken: bridgeToken,
+      }),
+    ).rejects.toThrow("Bridge response body exceeded the configured size limit.");
+  });
+
+  it("the generated gateway asset opens its first stream only after the host settings frame arrives", async () => {
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    let sawStream = false;
+    const gateway = await startHttp2GatewayForTest({
+      bridgeToken,
+      gateHostBytes: true,
+      onSession: (session) => {
+        session.on("stream", () => {
+          sawStream = true;
+        });
+      },
+      forwardRequest: async () => ({ status: 200, headers: {}, body: "" }),
+    });
+
+    const responsePromise = fetch(`${gateway.baseUrl}/api/agents/me`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${bridgeToken}` },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(sawStream).toBe(false);
+
+    gateway.releaseHostBytes();
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(sawStream).toBe(true);
+  }, 15_000);
+
+  it("the generated gateway asset fails closed on a response body past the configured size limit", async () => {
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const maxBodyBytes = 32;
+    const oversizedResponseBody = "x".repeat(maxBodyBytes + 1);
+    const gateway = await startHttp2GatewayForTest({
+      bridgeToken,
+      maxBodyBytes,
+      forwardRequest: async () => ({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        body: oversizedResponseBody,
+      }),
+    });
+
+    const response = await fetch(`${gateway.baseUrl}/api/agents/me`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${bridgeToken}` },
+    });
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Bridge response body exceeded the configured size limit.",
+    });
+  }, 15_000);
 });

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -3346,6 +3346,30 @@ describe("sandbox callback bridge", () => {
     expect(forwardCalls).toBe(0);
   }, 15_000);
 
+  it("the generated HTTP/2 gateway fails a request at the response bound instead of hanging when the host never finishes the stream", async () => {
+    // The host settings handshake already bounds the wait before the first
+    // stream opens. This test proves the generated gateway also bounds the
+    // rest of the response lifecycle: a host that opens a stream and then
+    // never sends a body, an error, or an abort must still fail the local
+    // request instead of leaving it pending forever.
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const gateway = await startHttp2GatewayForTest({
+      bridgeToken,
+      responseTimeoutMs: 100,
+      forwardRequest: () => new Promise(() => {}),
+    });
+
+    const start = Date.now();
+    const response = await fetch(`${gateway.baseUrl}/api/agents/me`, {
+      headers: { authorization: `Bearer ${bridgeToken}` },
+    });
+    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Timed out waiting for the HTTP/2 bridge response stream to finish.",
+    });
+  }, 15_000);
+
   it("rejects a request body over maxBodyBytes on the queue path before it writes the queue file", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-bridge-queue-maxbody-"));
     cleanupDirs.push(rootDir);
@@ -3696,6 +3720,44 @@ describe("sandbox callback bridge", () => {
         receivedToken: bridgeToken,
       }),
     ).rejects.toThrow("Bridge response body exceeded the configured size limit.");
+  });
+
+  it("fails a request at the response bound when the host opens a stream but never finishes it", async () => {
+    // The settings handshake already completed by the time this stream
+    // opens, so only the per-stream response timer can end the wait. Before
+    // this timer existed, a host that opened a stream and then went silent
+    // left `forwardRequest` pending forever.
+    const bridgeToken = createSandboxCallbackBridgeToken();
+    const [serverSide, clientSide] = duplexPair();
+    const handle = createHttp2BridgeServer({
+      bridgeToken,
+      forwardRequest: () => new Promise(() => {}),
+    });
+    handle.bindChannel(channelFromDuplex(serverSide));
+
+    const gateway = createSandboxHttp2BridgeGateway({
+      bridgeToken,
+      createConnection: () => clientSide,
+      responseTimeoutMs: 100,
+    });
+    cleanupFns.push(async () => {
+      await gateway.close();
+      serverSide.destroy();
+      clientSide.destroy();
+    });
+
+    const start = Date.now();
+    await expect(
+      gateway.forwardRequest({
+        method: "GET",
+        path: "/api/agents/me",
+        query: "",
+        headers: {},
+        body: Buffer.alloc(0),
+        receivedToken: bridgeToken,
+      }),
+    ).rejects.toThrow("Timed out waiting for the HTTP/2 bridge response stream to finish.");
+    expect(Date.now() - start).toBeLessThan(5_000);
   });
 
   it("the generated gateway asset opens its first stream only after the host settings frame arrives", async () => {

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1890,6 +1890,19 @@ export interface CreateSandboxHttp2BridgeGatewayOptions {
    * `http2-bridge-server.ts` to know which requests need a retry elsewhere.
    */
   onGoaway?: (record: { lastStreamId: number; errorCode: number }) => void;
+  /**
+   * The time bound, in milliseconds, on the wait for the host's first
+   * `remoteSettings` event. The gateway opens no stream before that event
+   * arrives or before this bound passes, whichever comes first. The default
+   * is {@link DEFAULT_BRIDGE_RESPONSE_TIMEOUT_MS}.
+   */
+  responseTimeoutMs?: number;
+  /**
+   * The response body byte limit. The gateway counts the bytes it collects
+   * from each response and fails closed, destroying the stream, past this
+   * limit. The default is {@link DEFAULT_BRIDGE_MAX_BODY_BYTES}.
+   */
+  maxBodyBytes?: number;
 }
 
 function forwardOneHttp2Request(
@@ -1902,6 +1915,7 @@ function forwardOneHttp2Request(
     headers: Record<string, string>;
     body: Buffer;
   },
+  maxBodyBytes: number,
 ): Promise<SandboxHttp2BridgeGatewayResponse> {
   return new Promise((resolve, reject) => {
     const query = request.query.trim();
@@ -1920,7 +1934,8 @@ function forwardOneHttp2Request(
       reject(error instanceof Error ? error : new Error(String(error)));
       return;
     }
-    const chunks: Buffer[] = [];
+    let chunks: Buffer[] = [];
+    let receivedBytes = 0;
     let responseHeaders: Record<string, string> = {};
     let status = 502;
     let settled = false;
@@ -1938,7 +1953,17 @@ function forwardOneHttp2Request(
         responseHeaders[key] = Array.isArray(value) ? value.join(", ") : String(value);
       }
     });
-    stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+    stream.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      receivedBytes += chunk.length;
+      if (receivedBytes > maxBodyBytes) {
+        chunks = [];
+        stream.destroy();
+        settle(() => reject(new Error("Bridge response body exceeded the configured size limit.")));
+        return;
+      }
+      chunks.push(chunk);
+    });
     stream.once("end", () => settle(() => resolve({ status, headers: responseHeaders, body: Buffer.concat(chunks) })));
     stream.once("error", (error) =>
       settle(() => reject(error instanceof Error ? error : new Error(String(error)))),
@@ -1950,6 +1975,35 @@ function forwardOneHttp2Request(
       stream.end();
     }
   });
+}
+
+/**
+ * Create the settings-handshake wait for one HTTP/2 client session. The
+ * client must wait for the host's first `remoteSettings` event before it
+ * opens its first stream (see the module-level notes on `forwardRequest`).
+ * A timer bounds the wait so a silent host never hangs a request forever.
+ * The timer is unref'd, so it never holds the process open, and the
+ * returned promise carries a no-operation rejection handler, so a rejection
+ * with no request yet in flight never raises an unhandled rejection.
+ */
+function createRemoteSettingsReadyPromise(session: http2.ClientHttp2Session, timeoutMs: number): Promise<void> {
+  let settled = false;
+  const ready = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("Timed out waiting for the HTTP/2 bridge host settings handshake."));
+    }, timeoutMs);
+    timer.unref();
+    session.once("remoteSettings", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+  ready.catch(() => undefined);
+  return ready;
 }
 
 /**
@@ -1965,6 +2019,8 @@ export function createSandboxHttp2BridgeGateway(
 ): SandboxHttp2BridgeGateway {
   const authority = options.authority?.trim() || SANDBOX_HTTP2_GATEWAY_DEFAULT_AUTHORITY;
   const headerAllowlist = options.headerAllowlist ?? DEFAULT_SANDBOX_CALLBACK_BRIDGE_HEADER_ALLOWLIST;
+  const responseTimeoutMs = options.responseTimeoutMs ?? DEFAULT_BRIDGE_RESPONSE_TIMEOUT_MS;
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_BRIDGE_MAX_BODY_BYTES;
   const session = http2.connect(`http://${authority}`, {
     createConnection: options.createConnection,
   });
@@ -1975,6 +2031,10 @@ export function createSandboxHttp2BridgeGateway(
   session.on("goaway", (errorCode: number, lastStreamId: number) => {
     options.onGoaway?.({ lastStreamId, errorCode });
   });
+  // One handshake promise for the whole session, created here before any
+  // request. Every `forwardRequest` call awaits this same stored promise, so
+  // exactly one timer is armed per session, not one per request.
+  const remoteSettingsReady = createRemoteSettingsReadyPromise(session, responseTimeoutMs);
 
   return {
     forwardRequest(request: SandboxHttp2BridgeGatewayRequest): Promise<SandboxHttp2BridgeGatewayResponse> {
@@ -1984,14 +2044,20 @@ export function createSandboxHttp2BridgeGateway(
       if (!compareBridgeTokensConstantTime(options.bridgeToken, request.receivedToken)) {
         return Promise.reject(new Error("Invalid bridge token."));
       }
-      return forwardOneHttp2Request(session, {
-        bridgeToken: options.bridgeToken,
-        method: request.method,
-        path: request.path,
-        query: request.query,
-        headers: sanitizeSandboxCallbackBridgeHeaders(request.headers, headerAllowlist),
-        body: request.body,
-      });
+      return remoteSettingsReady.then(() =>
+        forwardOneHttp2Request(
+          session,
+          {
+            bridgeToken: options.bridgeToken,
+            method: request.method,
+            path: request.path,
+            query: request.query,
+            headers: sanitizeSandboxCallbackBridgeHeaders(request.headers, headerAllowlist),
+            body: request.body,
+          },
+          maxBodyBytes,
+        ),
+      );
     },
     close(): Promise<void> {
       return new Promise((resolve) => {
@@ -2387,6 +2453,13 @@ function runHttp2Gateway() {
   const authority = "bridge.internal";
   let session = null;
   let unavailable = false;
+  // One handshake promise for the whole session, created where the session
+  // is created, before any request. Every forwarded request awaits this
+  // same stored promise, so exactly one timer is armed per session, not one
+  // per request. The catch below stops an unobserved rejection (a failed
+  // handshake with no request yet in flight) from raising an unhandled
+  // rejection warning.
+  let remoteSettingsReady = null;
 
   function openSession() {
     if (session) return session;
@@ -2403,61 +2476,92 @@ function runHttp2Gateway() {
     session.on("goaway", (errorCode, lastStreamId) => {
       diag("host sent GOAWAY (errorCode=" + errorCode + ", lastStreamId=" + lastStreamId + ")");
     });
+    const activeSession = session;
+    let handshakeSettled = false;
+    remoteSettingsReady = new Promise((resolve, reject) => {
+      const timer = setTimeout(function () {
+        if (handshakeSettled) return;
+        handshakeSettled = true;
+        reject(new Error("Timed out waiting for the HTTP/2 bridge host settings handshake."));
+      }, responseTimeoutMs);
+      timer.unref();
+      activeSession.once("remoteSettings", function () {
+        if (handshakeSettled) return;
+        handshakeSettled = true;
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+    remoteSettingsReady.catch(function () {});
     return session;
   }
 
   function forwardOverHttp2(request) {
-    return new Promise((resolve, reject) => {
-      const activeSession = openSession();
-      const query = request.query || "";
-      const pathWithQuery =
-        query.length === 0 ? request.path : request.path + (query.charAt(0) === "?" ? query : "?" + query);
-      const outboundHeaders = Object.assign(
-        {
-          ":method": request.method,
-          ":path": pathWithQuery,
-          authorization: "Bearer " + bridgeToken,
-        },
-        request.headers,
-      );
-      let stream;
-      try {
-        stream = activeSession.request(outboundHeaders, { endStream: request.body.length === 0 });
-      } catch (error) {
-        reject(error instanceof Error ? error : new Error(String(error)));
-        return;
-      }
-      const chunks = [];
-      let status = 502;
-      let responseHeaders = {};
-      let settled = false;
-      const settle = (run) => {
-        if (settled) return;
-        settled = true;
-        run();
-      };
-      stream.on("response", (headers) => {
-        const raw = headers[":status"];
-        status = typeof raw === "number" ? raw : Number(raw) || 502;
-        responseHeaders = {};
-        for (const [key, value] of Object.entries(headers)) {
-          if (key.charAt(0) === ":" || value == null) continue;
-          responseHeaders[key] = Array.isArray(value) ? value.join(", ") : String(value);
+    const activeSession = openSession();
+    const handshakeReady = remoteSettingsReady;
+    return handshakeReady.then(function () {
+      return new Promise((resolve, reject) => {
+        const query = request.query || "";
+        const pathWithQuery =
+          query.length === 0 ? request.path : request.path + (query.charAt(0) === "?" ? query : "?" + query);
+        const outboundHeaders = Object.assign(
+          {
+            ":method": request.method,
+            ":path": pathWithQuery,
+            authorization: "Bearer " + bridgeToken,
+          },
+          request.headers,
+        );
+        let stream;
+        try {
+          stream = activeSession.request(outboundHeaders, { endStream: request.body.length === 0 });
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+        let chunks = [];
+        let receivedBytes = 0;
+        let status = 502;
+        let responseHeaders = {};
+        let settled = false;
+        const settle = (run) => {
+          if (settled) return;
+          settled = true;
+          run();
+        };
+        stream.on("response", (headers) => {
+          const raw = headers[":status"];
+          status = typeof raw === "number" ? raw : Number(raw) || 502;
+          responseHeaders = {};
+          for (const [key, value] of Object.entries(headers)) {
+            if (key.charAt(0) === ":" || value == null) continue;
+            responseHeaders[key] = Array.isArray(value) ? value.join(", ") : String(value);
+          }
+        });
+        stream.on("data", (chunk) => {
+          if (settled) return;
+          receivedBytes += chunk.length;
+          if (receivedBytes > maxBodyBytes) {
+            chunks = [];
+            stream.destroy();
+            settle(() => reject(new Error("Bridge response body exceeded the configured size limit.")));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        stream.once("end", () =>
+          settle(() => resolve({ status: status, headers: responseHeaders, body: Buffer.concat(chunks) })),
+        );
+        stream.once("error", (error) =>
+          settle(() => reject(error instanceof Error ? error : new Error(String(error)))),
+        );
+        stream.once("aborted", () => settle(() => reject(new Error("Bridge HTTP/2 stream aborted."))));
+        if (request.body.length > 0) {
+          stream.end(request.body);
+        } else if (!stream.writableEnded) {
+          stream.end();
         }
       });
-      stream.on("data", (chunk) => chunks.push(chunk));
-      stream.once("end", () =>
-        settle(() => resolve({ status: status, headers: responseHeaders, body: Buffer.concat(chunks) })),
-      );
-      stream.once("error", (error) =>
-        settle(() => reject(error instanceof Error ? error : new Error(String(error)))),
-      );
-      stream.once("aborted", () => settle(() => reject(new Error("Bridge HTTP/2 stream aborted."))));
-      if (request.body.length > 0) {
-        stream.end(request.body);
-      } else if (!stream.writableEnded) {
-        stream.end();
-      }
     });
   }
 

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1891,10 +1891,13 @@ export interface CreateSandboxHttp2BridgeGatewayOptions {
    */
   onGoaway?: (record: { lastStreamId: number; errorCode: number }) => void;
   /**
-   * The time bound, in milliseconds, on the wait for the host's first
-   * `remoteSettings` event. The gateway opens no stream before that event
-   * arrives or before this bound passes, whichever comes first. The default
-   * is {@link DEFAULT_BRIDGE_RESPONSE_TIMEOUT_MS}.
+   * The time bound, in milliseconds, applied twice: once on the wait for the
+   * host's first `remoteSettings` event (the gateway opens no stream before
+   * that event arrives or before this bound passes, whichever comes first),
+   * and again, independently, on each opened stream's response lifecycle (an
+   * opened stream that never sends "end", "error", or "aborted" is destroyed
+   * and the request fails at this same bound). The default is
+   * {@link DEFAULT_BRIDGE_RESPONSE_TIMEOUT_MS}.
    */
   responseTimeoutMs?: number;
   /**
@@ -1916,6 +1919,7 @@ function forwardOneHttp2Request(
     body: Buffer;
   },
   maxBodyBytes: number,
+  responseTimeoutMs: number,
 ): Promise<SandboxHttp2BridgeGatewayResponse> {
   return new Promise((resolve, reject) => {
     const query = request.query.trim();
@@ -1942,8 +1946,22 @@ function forwardOneHttp2Request(
     const settle = (run: () => void) => {
       if (settled) return;
       settled = true;
+      clearTimeout(responseTimer);
       run();
     };
+    // The handshake before this call already bounds the wait for the host's
+    // remote settings. This timer bounds the rest of the response lifecycle:
+    // an opened stream that never sends "end", "error", or "aborted" would
+    // otherwise leave this promise pending forever, which hangs the caller.
+    // It is armed for exactly this one stream and cleared the moment the
+    // stream settles any other way.
+    const responseTimer = setTimeout(() => {
+      settle(() => {
+        stream.destroy();
+        reject(new Error("Timed out waiting for the HTTP/2 bridge response stream to finish."));
+      });
+    }, responseTimeoutMs);
+    responseTimer.unref();
     stream.on("response", (headers) => {
       const rawStatus = headers[":status"];
       status = typeof rawStatus === "number" ? rawStatus : Number(rawStatus) || 502;
@@ -2056,6 +2074,7 @@ export function createSandboxHttp2BridgeGateway(
             body: request.body,
           },
           maxBodyBytes,
+          responseTimeoutMs,
         ),
       );
     },
@@ -2527,8 +2546,22 @@ function runHttp2Gateway() {
         const settle = (run) => {
           if (settled) return;
           settled = true;
+          clearTimeout(responseTimer);
           run();
         };
+        // The handshake above already bounds the wait for the host's remote
+        // settings. This timer bounds the rest of the response lifecycle: an
+        // opened stream that never sends "end", "error", or "aborted" would
+        // otherwise leave this promise pending forever, which hangs the local
+        // gateway request. It is armed for exactly this one stream and
+        // cleared the moment the stream settles any other way.
+        const responseTimer = setTimeout(function () {
+          settle(() => {
+            stream.destroy();
+            reject(new Error("Timed out waiting for the HTTP/2 bridge response stream to finish."));
+          });
+        }, responseTimeoutMs);
+        responseTimer.unref();
         stream.on("response", (headers) => {
           const raw = headers[":status"];
           status = typeof raw === "number" ? raw : Number(raw) || 502;

--- a/server/src/http2-bridge-admission-env.test.ts
+++ b/server/src/http2-bridge-admission-env.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+  DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+} from "@paperclipai/adapter-utils/http2-bridge-admission";
+import {
+  resolveHttp2BridgeAdmissionCapsFromEnv,
+  resolveMaxLiveHttp2BridgeSessionsFromEnv,
+  resolveMaxParallelHttp2BridgeRequestsFromEnv,
+} from "./http2-bridge-admission-env.js";
+
+describe("resolveMaxParallelHttp2BridgeRequestsFromEnv", () => {
+  it("an absent variable uses the default", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxParallelHttp2BridgeRequestsFromEnv(undefined, onRejectedOverride);
+
+    expect(resolved).toBe(DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS);
+    expect(onRejectedOverride).not.toHaveBeenCalled();
+  });
+
+  it("a blank or whitespace-only value is invalid and reports a rejection", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxParallelHttp2BridgeRequestsFromEnv("   ", onRejectedOverride);
+
+    expect(resolved).toBe(DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS);
+    expect(onRejectedOverride).toHaveBeenCalledTimes(1);
+    // The reporter receives only the parsed number, never the raw string.
+    const reportedValue = onRejectedOverride.mock.calls[0]?.[0];
+    expect(typeof reportedValue).toBe("number");
+  });
+
+  it("a value above the hard range is invalid and reports a rejection", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxParallelHttp2BridgeRequestsFromEnv("65", onRejectedOverride);
+
+    expect(resolved).toBe(DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS);
+    expect(onRejectedOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("a valid positive integer inside the range passes through unchanged", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxParallelHttp2BridgeRequestsFromEnv("32", onRejectedOverride);
+
+    expect(resolved).toBe(32);
+    expect(onRejectedOverride).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveMaxLiveHttp2BridgeSessionsFromEnv", () => {
+  it("an absent variable uses the default", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxLiveHttp2BridgeSessionsFromEnv(undefined, onRejectedOverride);
+
+    expect(resolved).toBe(DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS);
+    expect(onRejectedOverride).not.toHaveBeenCalled();
+  });
+
+  it("a blank or whitespace-only value is invalid and reports a rejection", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxLiveHttp2BridgeSessionsFromEnv("", onRejectedOverride);
+
+    expect(resolved).toBe(DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS);
+    expect(onRejectedOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("a value above the hard range is invalid and reports a rejection", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxLiveHttp2BridgeSessionsFromEnv("65", onRejectedOverride);
+
+    expect(resolved).toBe(DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS);
+    expect(onRejectedOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("a valid positive integer inside the range passes through unchanged", () => {
+    const onRejectedOverride = vi.fn();
+
+    const resolved = resolveMaxLiveHttp2BridgeSessionsFromEnv("4", onRejectedOverride);
+
+    expect(resolved).toBe(4);
+    expect(onRejectedOverride).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveHttp2BridgeAdmissionCapsFromEnv", () => {
+  it("an absent pair uses both defaults", () => {
+    const onRejectedOverride = vi.fn();
+    const onRejectedPair = vi.fn();
+
+    const resolved = resolveHttp2BridgeAdmissionCapsFromEnv(
+      undefined,
+      undefined,
+      onRejectedOverride,
+      onRejectedPair,
+    );
+
+    expect(resolved).toEqual({
+      maxParallel: DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      maxSessions: DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    });
+    expect(onRejectedOverride).not.toHaveBeenCalled();
+    expect(onRejectedPair).not.toHaveBeenCalled();
+  });
+
+  it("a rejected per-field override calls the override reporter exactly once", () => {
+    const onRejectedOverride = vi.fn();
+    const onRejectedPair = vi.fn();
+
+    const resolved = resolveHttp2BridgeAdmissionCapsFromEnv(
+      "not-a-number",
+      "4",
+      onRejectedOverride,
+      onRejectedPair,
+    );
+
+    expect(resolved).toEqual({
+      maxParallel: DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      maxSessions: 4,
+    });
+    // The pair resolver reruns each per-field check with no reporter bound, so
+    // only the env helper's own per-field pass reports the rejection.
+    expect(onRejectedOverride).toHaveBeenCalledTimes(1);
+    expect(onRejectedPair).not.toHaveBeenCalled();
+  });
+
+  it("an over-budget environment pair of 64 and 64 resolves to both defaults and reports an error", () => {
+    const onRejectedOverride = vi.fn();
+    const onRejectedPair = vi.fn();
+
+    const resolved = resolveHttp2BridgeAdmissionCapsFromEnv("64", "64", onRejectedOverride, onRejectedPair);
+
+    expect(resolved).toEqual({
+      maxParallel: DEFAULT_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+      maxSessions: DEFAULT_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    });
+    expect(onRejectedOverride).not.toHaveBeenCalled();
+    expect(onRejectedPair).toHaveBeenCalledTimes(1);
+    const rejection = onRejectedPair.mock.calls[0]?.[0];
+    expect(rejection).toEqual({ maxParallel: 64, maxSessions: 64, totalBytes: expect.any(Number) });
+  });
+});

--- a/server/src/http2-bridge-admission-env.ts
+++ b/server/src/http2-bridge-admission-env.ts
@@ -1,0 +1,79 @@
+import {
+  resolveHttp2BridgeAdmissionCaps,
+  resolveMaxLiveHttp2BridgeSessions,
+  resolveMaxParallelHttp2BridgeRequests,
+  type Http2BridgeAdmissionCapOverrideRejectionReporter,
+  type Http2BridgeAdmissionCaps,
+  type Http2BridgeAdmissionPairRejectionReporter,
+} from "@paperclipai/adapter-utils/http2-bridge-admission";
+
+/**
+ * Resolve the parallel-stream admission cap from the raw operator override
+ * string. The host reads the override from
+ * PAPERCLIP_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS.
+ *
+ * This helper distinguishes an absent variable from a present blank value. An
+ * absent variable is `undefined`. The helper then uses the documented default
+ * and does not report a rejection. A present variable is a string, even when
+ * the string holds only whitespace. The helper sends every present string
+ * through `Number`, so a blank or whitespace-only value becomes `0`. The
+ * numeric validation in {@link resolveMaxParallelHttp2BridgeRequests} rejects
+ * `0`, reports it through `onRejectedOverride`, and returns the safe default.
+ * So a present blank value is visible as invalid instead of silent as absent.
+ *
+ * `Number` ignores surrounding whitespace, so a valid value with surrounding
+ * spaces still parses. The reporter receives only the parsed number, never
+ * the raw string, so no operator-supplied text reaches a log line.
+ */
+export function resolveMaxParallelHttp2BridgeRequestsFromEnv(
+  rawOverride: string | undefined,
+  onRejectedOverride?: Http2BridgeAdmissionCapOverrideRejectionReporter,
+): number {
+  return resolveMaxParallelHttp2BridgeRequests(
+    rawOverride === undefined ? undefined : Number(rawOverride),
+    onRejectedOverride,
+  );
+}
+
+/**
+ * Resolve the live-session admission cap from the raw operator override
+ * string. The host reads the override from
+ * PAPERCLIP_MAX_LIVE_HTTP2_BRIDGE_SESSIONS. Same present-versus-absent
+ * behavior as {@link resolveMaxParallelHttp2BridgeRequestsFromEnv}.
+ */
+export function resolveMaxLiveHttp2BridgeSessionsFromEnv(
+  rawOverride: string | undefined,
+  onRejectedOverride?: Http2BridgeAdmissionCapOverrideRejectionReporter,
+): number {
+  return resolveMaxLiveHttp2BridgeSessions(
+    rawOverride === undefined ? undefined : Number(rawOverride),
+    onRejectedOverride,
+  );
+}
+
+/**
+ * Resolve one admission cap pair from the two raw operator override strings.
+ *
+ * {@link resolveHttp2BridgeAdmissionCaps} runs the two per-field resolvers
+ * without a rejection reporter, so a per-field rejection would stay silent if
+ * this helper only called that function. This helper runs each per-field
+ * resolver itself first, with `onRejectedOverride` bound, so a rejected
+ * PAPERCLIP_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS or
+ * PAPERCLIP_MAX_LIVE_HTTP2_BRIDGE_SESSIONS value always reports through
+ * `onRejectedOverride` exactly once. It then passes the two resolved numbers
+ * into {@link resolveHttp2BridgeAdmissionCaps}, which reruns the same
+ * per-field checks on two already-valid numbers (harmless) and then applies
+ * the joint budget rule. A pair that fails the joint rule reports through
+ * `onRejectedPair` and returns both defaults; the host never keeps one
+ * operator value and one default from a refused pair.
+ */
+export function resolveHttp2BridgeAdmissionCapsFromEnv(
+  rawParallel: string | undefined,
+  rawSessions: string | undefined,
+  onRejectedOverride?: Http2BridgeAdmissionCapOverrideRejectionReporter,
+  onRejectedPair?: Http2BridgeAdmissionPairRejectionReporter,
+): Http2BridgeAdmissionCaps {
+  const maxParallel = resolveMaxParallelHttp2BridgeRequestsFromEnv(rawParallel, onRejectedOverride);
+  const maxSessions = resolveMaxLiveHttp2BridgeSessionsFromEnv(rawSessions, onRejectedOverride);
+  return resolveHttp2BridgeAdmissionCaps({ maxParallel, maxSessions }, onRejectedPair);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -92,6 +92,12 @@ import {
 } from "@paperclipai/adapter-utils/duplex-aggregate-byte-ledger";
 import { resolveDuplexAggregateCeilingBytesFromEnv } from "./duplex-aggregate-ceiling-env.js";
 import { DUPLEX_COUNTER_AGGREGATE_BYTE_ACCOUNTING_UNDERFLOW_TOTAL } from "@paperclipai/adapter-utils/duplex-observability";
+import {
+  configureHttp2BridgeAdmissionGate,
+  http2BridgeAdmissionBudgetBytes,
+  HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES,
+} from "@paperclipai/adapter-utils/http2-bridge-admission";
+import { resolveHttp2BridgeAdmissionCapsFromEnv } from "./http2-bridge-admission-env.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -791,6 +797,51 @@ export async function startServer(): Promise<StartedServer> {
         "duplex aggregate byte ceiling override rejected; using the safe default",
       );
     },
+  );
+  // The process-wide admission gate for the host HTTP/2 sandbox bridge. Two
+  // optional operator overrides read PAPERCLIP_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS
+  // and PAPERCLIP_MAX_LIVE_HTTP2_BRIDGE_SESSIONS. An absent variable uses the
+  // documented default. A present invalid, blank, whitespace-only, non-finite,
+  // zero, negative, non-integer, unsafe, or over-maximum value does not fail
+  // startup: the resolver rejects it, reports it at error level, and uses the
+  // safe default. Each per-field cap can pass its own range and the pair can
+  // still spend more than the reserved memory budget, so the resolver also
+  // checks the joint rule on the resolved pair. A pair that fails the joint
+  // rule gives both defaults and one error log line; the host never keeps one
+  // operator value and one default from a refused pair. Every log line carries
+  // only the parsed number, never the raw operator string.
+  const http2BridgeAdmissionCaps = resolveHttp2BridgeAdmissionCapsFromEnv(
+    process.env.PAPERCLIP_MAX_PARALLEL_HTTP2_BRIDGE_REQUESTS,
+    process.env.PAPERCLIP_MAX_LIVE_HTTP2_BRIDGE_SESSIONS,
+    (rejectedValue) => {
+      logger.error(
+        { rejectedValue },
+        "HTTP/2 bridge admission cap override rejected; using the safe default",
+      );
+    },
+    (rejection) => {
+      logger.error(
+        {
+          maxParallel: rejection.maxParallel,
+          maxSessions: rejection.maxSessions,
+          totalBytes: rejection.totalBytes,
+          reservedBudgetBytes: HTTP2_BRIDGE_ADMISSION_RESERVED_BUDGET_BYTES,
+        },
+        "HTTP/2 bridge admission cap pair refused; using the safe default pair",
+      );
+    },
+  );
+  configureHttp2BridgeAdmissionGate(http2BridgeAdmissionCaps);
+  logger.info(
+    {
+      maxParallel: http2BridgeAdmissionCaps.maxParallel,
+      maxSessions: http2BridgeAdmissionCaps.maxSessions,
+      totalBytes: http2BridgeAdmissionBudgetBytes(
+        http2BridgeAdmissionCaps.maxParallel,
+        http2BridgeAdmissionCaps.maxSessions,
+      ),
+    },
+    "HTTP/2 bridge admission gate configured",
   );
   // The server has no process metric pipeline yet, so the ledger telemetry maps to
   // the structured logger. The gauge logs at debug. A reservation rejection logs at

--- a/server/src/services/native-runtime/native-codex-runner.integration.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner.integration.test.ts
@@ -90,6 +90,7 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
   let temporary: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   let runtimeRoot: string | null = null;
   let server: Server | null = null;
+  let db: ReturnType<typeof createDb> | null = null;
 
   beforeAll(async () => {
     ensureRunnerTestBinaries();
@@ -107,13 +108,17 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
   afterAll(async () => {
     runnerPrpWebSocketInternals.resetForTests();
     await closeServer(server);
+    // Close the postgres client before the embedded database process stops.
+    // Otherwise a queued write can fire after the socket is gone and throw
+    // an unhandled TypeError from the driver's internals.
+    await db?.$client?.end?.({ timeout: 0 });
     await temporary?.cleanup();
     if (runtimeRoot) await rm(runtimeRoot, { recursive: true, force: true });
   });
 
   it("returns a durable result and resumes the provider session on the next run", async () => {
     if (!temporary || !runtimeRoot) throw new Error("Vertical-slice fixture was not initialized");
-    const db = createDb(temporary.connectionString);
+    db = createDb(temporary.connectionString);
     const companyId = randomUUID();
     const agentId = randomUUID();
     const issueId = randomUUID();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The adapter utilities connect a sandbox to the Paperclip host.
> - The HTTP/2 bridge accepts streams, sessions, request bodies, and response bodies.
> - The bridge had no shared host memory budget for these resources.
> - A sandbox could therefore grow host memory until the host failed.
> - This pull request adds admission limits and byte caps across the bridge paths.
> - The benefit is bounded host memory use with file-bridge fallback when the session cap is full.

## Linked Issues or Issue Description

No public issue tracks this change. The related public pull requests are [#12166](https://github.com/paperclipai/paperclip/pull/12166), [#12189](https://github.com/paperclipai/paperclip/pull/12189), and [#12120](https://github.com/paperclipai/paperclip/pull/12120).

**What existing behavior does this improve?**
The HTTP/2 sandbox bridge accepts streams and sessions without one shared host memory budget.

**Subsystem affected**
Cross-cutting: adapter utilities and server configuration.

**Current behavior**
The host does not cap bridge streams, live sessions, or bridge body bytes as one admission policy. A denial path can also retain request chunks.

**Proposed behavior**
The host applies a fixed admission queue, a shared byte budget, stream and session caps, response timeouts, and body caps. The denial path reads and discards the body with one running byte count.

**Reason and benefit**
The limits stop one sandbox from growing host memory without bound. The queue adds back pressure before the host reads a queued body.

**Breaking changes**
None for the sandbox-side frame limit. The host now rejects or falls back when configured bridge caps have no room.

## What Changed

- Add a first-in-first-out admission queue with a fixed parallelism cap.
- Set a 268,435,456-byte memory target and derive stream and session budgets.
- Hold one slot from route admission through body read, forward, and response drain.
- Bound live HTTP/2 sessions and use the file bridge when the session cap is full.
- Count the channel read buffers as one shared total.
- Forward response bodies as bytes instead of a UTF-8 string round trip.
- Add response timeouts and body caps to both sandbox gateway clients.
- Add operator configuration for both caps.
- Read and discard denied request bodies without retaining chunks.

## Verification

Run these commands from the repository root:

- `pnpm vitest run packages/adapter-utils/src/http2-bridge-admission.test.ts`
- `pnpm vitest run packages/adapter-utils/src/http2-bridge-server.test.ts`
- `pnpm vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts`
- `pnpm vitest run packages/adapter-utils/src/sandbox-callback-bridge.test.ts`
- `pnpm vitest run server/src/http2-bridge-admission-env.test.ts`
- `pnpm --filter @paperclip/adapter-utils exec tsc --noEmit`

The author also ran 291 adapter-utils tests, the adapter-utils typecheck, and 17 server environment tests. All reported tests passed.

## Risks

The bridge can reject a request or use the file bridge when a cap has no room. Operators can override the stream and session caps through the existing server configuration chain. The host does not read the sandbox-specific 64 KB Daytona frame limit.

## Model Used

OpenAI Codex, GPT-5, extended reasoning, tool use, and code execution. The runtime does not expose the deployment revision or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge