### PR TITLE
fix(heartbeat): pre-dispatch fingerprint-continuity gate for grok-* adapters

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -30,6 +30,7 @@ import {
   resolveExecutionWorkspaceConfigFreshness,
   resolveExecutionWorkspaceReuseRequestForIssue,
   resolveExecutionWorkspaceReuseProvisioningPolicy,
+  resolveFingerprintContinuityGateDecision,
   resolveNextSessionState,
   resolveTaskSessionConfigFreshness,
   isWorkspaceSyncConflictFailure,
@@ -2474,6 +2475,111 @@ describe("effective run session config freshness", () => {
     expect(canonical).not.toContain("plain-value");
     expect(canonical).not.toContain("enabled");
     expect(canonical).not.toContain("openai-api-key");
+  });
+});
+
+describe("resolveFingerprintContinuityGateDecision", () => {
+  const FINGERPRINT_MISSING_RESET = {
+    reset: true,
+    reasons: ["effective run configuration fingerprint metadata is missing"],
+  };
+
+  it("never gates adapters outside the grok family", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "codex_local",
+      taskSessionParams: { __paperclipConfigFingerprintMissingStreak: 10 },
+      sessionConfigFreshness: FINGERPRINT_MISSING_RESET,
+    });
+
+    expect(decision).toEqual({
+      blocked: false,
+      consecutiveFingerprintMissingResets: 0,
+      reason: null,
+    });
+  });
+
+  it("does not gate a grok dispatch whose reset is for an unrelated reason", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "grok_local",
+      taskSessionParams: { __paperclipConfigFingerprintMissingStreak: 5 },
+      sessionConfigFreshness: {
+        reset: true,
+        reasons: ['configured model changed from "grok-4" to "grok-4.5"'],
+      },
+    });
+
+    expect(decision).toEqual({
+      blocked: false,
+      consecutiveFingerprintMissingResets: 0,
+      reason: null,
+    });
+  });
+
+  it("does not gate the first fingerprint-missing reset for a fresh grok task session", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "grok_local",
+      taskSessionParams: null,
+      sessionConfigFreshness: FINGERPRINT_MISSING_RESET,
+    });
+
+    expect(decision).toEqual({
+      blocked: false,
+      consecutiveFingerprintMissingResets: 1,
+      reason: null,
+    });
+  });
+
+  it("tolerates the bounded number of consecutive resets before gating", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "grok_local",
+      taskSessionParams: { __paperclipConfigFingerprintMissingStreak: 1 },
+      sessionConfigFreshness: FINGERPRINT_MISSING_RESET,
+    });
+
+    expect(decision).toEqual({
+      blocked: false,
+      consecutiveFingerprintMissingResets: 2,
+      reason: null,
+    });
+  });
+
+  it("blocks dispatch once the same-reason streak exceeds the bound", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "grok_local",
+      taskSessionParams: { __paperclipConfigFingerprintMissingStreak: 2 },
+      sessionConfigFreshness: FINGERPRINT_MISSING_RESET,
+    });
+
+    expect(decision).toEqual({
+      blocked: true,
+      consecutiveFingerprintMissingResets: 3,
+      reason: "effective run configuration fingerprint metadata is missing",
+    });
+  });
+
+  it("honors a caller-supplied bound", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "grok_local",
+      taskSessionParams: { __paperclipConfigFingerprintMissingStreak: 0 },
+      sessionConfigFreshness: FINGERPRINT_MISSING_RESET,
+      maxConsecutiveResets: 0,
+    });
+
+    expect(decision).toEqual({
+      blocked: true,
+      consecutiveFingerprintMissingResets: 1,
+      reason: "effective run configuration fingerprint metadata is missing",
+    });
+  });
+
+  it("matches other grok-* adapter type variants by prefix", () => {
+    const decision = resolveFingerprintContinuityGateDecision({
+      adapterType: "grok_cloud",
+      taskSessionParams: { __paperclipConfigFingerprintMissingStreak: 2 },
+      sessionConfigFreshness: FINGERPRINT_MISSING_RESET,
+    });
+
+    expect(decision.blocked).toBe(true);
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1976,6 +1976,13 @@ export function isConfigurationIncompleteFailedRun(
   return run?.errorCode === CONFIGURATION_INCOMPLETE_FAILURE_CODE || run?.errorCode === "model_not_found";
 }
 
+function readConfigurationIncompleteReasonFromRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "resultJson"> | null | undefined,
+) {
+  const resultJson = parseObject(run?.resultJson);
+  return readNonEmptyString(parseObject(resultJson.configurationIncomplete).reason);
+}
+
 async function hasGitMetadata(cwd: string | null | undefined) {
   const normalized = readNonEmptyString(cwd);
   if (!normalized) return false;
@@ -4373,13 +4380,29 @@ const SESSION_CONFIG_FINGERPRINT_KEY = "__paperclipConfigFingerprint";
 const SESSION_CONFIG_FINGERPRINT_VERSION_KEY = "__paperclipConfigFingerprintVersion";
 const SESSION_CONFIG_CATEGORIES_KEY = "__paperclipConfigCategories";
 const SESSION_CONFIG_CATEGORY_FINGERPRINTS_KEY = "__paperclipConfigCategoryFingerprints";
+const SESSION_CONFIG_FINGERPRINT_MISSING_STREAK_KEY = "__paperclipConfigFingerprintMissingStreak";
 const PAPERCLIP_SESSION_METADATA_KEYS = new Set([
   SESSION_CONFIGURED_MODEL_KEY,
   SESSION_CONFIG_FINGERPRINT_KEY,
   SESSION_CONFIG_FINGERPRINT_VERSION_KEY,
   SESSION_CONFIG_CATEGORIES_KEY,
   SESSION_CONFIG_CATEGORY_FINGERPRINTS_KEY,
+  SESSION_CONFIG_FINGERPRINT_MISSING_STREAK_KEY,
 ]);
+// SPC-35033: adapters whose session/config continuity is fingerprint-backed but that
+// have shown they can get stuck permanently re-triggering the "fingerprint metadata is
+// missing" reset (grok-4.5 on grok_local never converges — see SPC-31006). A pre-dispatch
+// gate below counts consecutive same-reason resets per task session and, once the streak
+// is durably unresolvable, surfaces a configuration-incomplete blocker instead of
+// dispatching another doomed 0-token run.
+const FINGERPRINT_CONTINUITY_GATED_ADAPTER_TYPE_RE = /^grok/i;
+const FINGERPRINT_CONTINUITY_GATE_MAX_CONSECUTIVE_RESETS = 2;
+const EFFECTIVE_RUN_CONFIG_FINGERPRINT_MISSING_RESET_REASON =
+  "effective run configuration fingerprint metadata is missing";
+
+function isFingerprintContinuityGatedAdapterType(adapterType: string) {
+  return FINGERPRINT_CONTINUITY_GATED_ADAPTER_TYPE_RE.test(adapterType);
+}
 const WORKSPACE_CONFIG_FINGERPRINT_METADATA_KEY = "configFingerprint";
 const EFFECTIVE_RUN_SESSION_CONFIG_CATEGORIES = [
   "adapter",
@@ -4422,6 +4445,12 @@ type TaskSessionConfigFreshnessDecision = {
   changedCategories: EffectiveRunSessionConfigCategory[];
   storedFingerprint: string | null;
   nextFingerprint: string | null;
+};
+
+export type FingerprintContinuityGateDecision = {
+  blocked: boolean;
+  consecutiveFingerprintMissingResets: number;
+  reason: string | null;
 };
 
 export type EffectiveRunWorkspaceConfigMetadata = {
@@ -5244,8 +5273,9 @@ function attachPaperclipSessionMetadataToSessionParams(
   sessionParams: Record<string, unknown> | null | undefined,
   configuredModel: string | null,
   configMetadata?: EffectiveRunSessionConfigMetadata | null,
+  fingerprintMissingResetStreak?: number | null,
 ) {
-  if (!configuredModel && !configMetadata) return sessionParams ?? null;
+  if (!configuredModel && !configMetadata && !fingerprintMissingResetStreak) return sessionParams ?? null;
   const next = { ...(sessionParams ?? {}) };
   if (configuredModel) next[SESSION_CONFIGURED_MODEL_KEY] = configuredModel;
   if (configMetadata) {
@@ -5253,6 +5283,11 @@ function attachPaperclipSessionMetadataToSessionParams(
     next[SESSION_CONFIG_FINGERPRINT_VERSION_KEY] = configMetadata.version;
     next[SESSION_CONFIG_CATEGORIES_KEY] = configMetadata.categories;
     next[SESSION_CONFIG_CATEGORY_FINGERPRINTS_KEY] = configMetadata.categoryFingerprints;
+  }
+  if (fingerprintMissingResetStreak && fingerprintMissingResetStreak > 0) {
+    next[SESSION_CONFIG_FINGERPRINT_MISSING_STREAK_KEY] = fingerprintMissingResetStreak;
+  } else {
+    delete next[SESSION_CONFIG_FINGERPRINT_MISSING_STREAK_KEY];
   }
   return next;
 }
@@ -5326,7 +5361,7 @@ export function resolveTaskSessionConfigFreshness(input: {
   if (input.configMetadata) {
     if (!storedConfig && !input.preserveLegacySessionWithoutConfigMetadata) {
       changedCategories = [...input.configMetadata.categories];
-      reasons.push("effective run configuration fingerprint metadata is missing");
+      reasons.push(EFFECTIVE_RUN_CONFIG_FINGERPRINT_MISSING_RESET_REASON);
     } else if (storedConfig && storedConfig.version !== input.configMetadata.version) {
       changedCategories = [...input.configMetadata.categories];
       reasons.push(
@@ -5351,6 +5386,44 @@ export function resolveTaskSessionConfigFreshness(input: {
     changedCategories,
     storedFingerprint: storedConfig?.fingerprint ?? null,
     nextFingerprint: input.configMetadata?.fingerprint ?? null,
+  };
+}
+
+// SPC-35033 pre-dispatch gate: grok-* dispatches whose task session keeps resetting for
+// the exact same "fingerprint metadata is missing" reason are not converging — each
+// dispatch tears the session down again instead of persisting the fingerprint it just
+// computed. Dispatching another run only buys another 0-token reset. Once the streak of
+// consecutive same-reason resets exceeds the bound, this is a durable pre-dispatch
+// configuration gap, not a runtime failure, so the caller must surface a
+// configuration-incomplete blocker instead of dispatching.
+export function resolveFingerprintContinuityGateDecision(input: {
+  adapterType: string;
+  taskSessionParams: Record<string, unknown> | null | undefined;
+  sessionConfigFreshness: Pick<TaskSessionConfigFreshnessDecision, "reset" | "reasons">;
+  maxConsecutiveResets?: number;
+}): FingerprintContinuityGateDecision {
+  if (!isFingerprintContinuityGatedAdapterType(input.adapterType)) {
+    return { blocked: false, consecutiveFingerprintMissingResets: 0, reason: null };
+  }
+
+  const isFingerprintMissingReset =
+    input.sessionConfigFreshness.reset &&
+    input.sessionConfigFreshness.reasons.includes(EFFECTIVE_RUN_CONFIG_FINGERPRINT_MISSING_RESET_REASON);
+  if (!isFingerprintMissingReset) {
+    return { blocked: false, consecutiveFingerprintMissingResets: 0, reason: null };
+  }
+
+  const previousStreak = asNumber(
+    input.taskSessionParams?.[SESSION_CONFIG_FINGERPRINT_MISSING_STREAK_KEY],
+    0,
+  );
+  const consecutiveFingerprintMissingResets = previousStreak + 1;
+  const maxConsecutiveResets = input.maxConsecutiveResets ?? FINGERPRINT_CONTINUITY_GATE_MAX_CONSECUTIVE_RESETS;
+  const blocked = previousStreak >= maxConsecutiveResets;
+  return {
+    blocked,
+    consecutiveFingerprintMissingResets,
+    reason: blocked ? EFFECTIVE_RUN_CONFIG_FINGERPRINT_MISSING_RESET_REASON : null,
   };
 }
 
@@ -14886,6 +14959,31 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       wakeResetReason: wakeSessionResetReason,
       preserveLegacySessionWithoutConfigMetadata: acceptedPlanContinuationWake && !acceptedPlanWakeRoutingDecision,
     });
+    // SPC-35033 pre-dispatch gate: grok-* (or equivalent adapter-backed) dispatches must
+    // not keep re-dispatching once the effective run configuration fingerprint has proven
+    // durably unresolvable. Surface configuration-incomplete instead of another 0-token run.
+    const fingerprintContinuityGate = resolveFingerprintContinuityGateDecision({
+      adapterType: agent.adapterType,
+      taskSessionParams: taskSession?.sessionParamsJson ?? taskSessionDecodedParams,
+      sessionConfigFreshness,
+    });
+    if (fingerprintContinuityGate.blocked) {
+      throw new ConfigurationIncompleteFailure(
+        `configuration incomplete: adapter "${agent.adapterType}" run configuration fingerprint metadata has not ` +
+          `become durable after ${fingerprintContinuityGate.consecutiveFingerprintMissingResets} consecutive resets`,
+        {
+          configurationIncomplete: {
+            reason: "adapter_fingerprint_continuity_unresolvable",
+            companyId: agent.companyId,
+            agentId: agent.id,
+            issueId: issueRef?.id ?? null,
+            adapterType: agent.adapterType,
+            consecutiveFingerprintMissingResets: fingerprintContinuityGate.consecutiveFingerprintMissingResets,
+            missingBindings: [],
+          },
+        },
+      );
+    }
     const resetTaskSession = shouldResetTaskSessionForWake(context) || sessionConfigFreshness.reset;
     const sessionResetReason = sessionConfigFreshness.reasons.join("; ") || null;
     const taskSessionForRun = resetTaskSession ? null : taskSession;
@@ -16747,6 +16845,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 nextSessionState.params,
                 configuredModel,
                 sessionConfigMetadata,
+                fingerprintContinuityGate.consecutiveFingerprintMissingResets,
               ),
               sessionDisplayId: nextSessionState.displayId,
               lastRunId: finalizedRun.id,
@@ -16892,6 +16991,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               previousSessionParams,
               configuredModel,
               sessionConfigMetadata,
+              fingerprintContinuityGate.consecutiveFingerprintMissingResets,
             ),
             sessionDisplayId: previousSessionDisplayId,
             lastRunId: failedRun.id,
@@ -17251,7 +17351,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           issue,
           previousStatus: issue.status,
           notice: configurationIncomplete
-            ? buildConfigurationIncompleteRecoveryNoticeSeed()
+            ? buildConfigurationIncompleteRecoveryNoticeSeed({
+                reason: readConfigurationIncompleteReasonFromRun(run),
+              })
             : buildWorkspaceValidationRecoveryNoticeSeed(),
           recoveryCause: configurationIncomplete
             ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
@@ -17726,7 +17828,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const notice = workspaceValidationFailure
           ? buildWorkspaceValidationRecoveryNoticeSeed()
           : configurationIncompleteFailure
-            ? buildConfigurationIncompleteRecoveryNoticeSeed()
+            ? buildConfigurationIncompleteRecoveryNoticeSeed({
+                reason: readConfigurationIncompleteReasonFromRun(run),
+              })
             : buildImmediateExecutionPathRecoveryNoticeSeed({
                 status: issue.status as "todo" | "in_progress",
               });

--- a/server/src/services/recovery/stranded-notice.ts
+++ b/server/src/services/recovery/stranded-notice.ts
@@ -60,7 +60,20 @@ export function buildWorkspaceValidationRecoveryNoticeSeed(): StrandedRecoveryNo
   };
 }
 
-export function buildConfigurationIncompleteRecoveryNoticeSeed(): StrandedRecoveryNoticeSeed {
+export function buildConfigurationIncompleteRecoveryNoticeSeed(input?: {
+  reason?: string | null;
+}): StrandedRecoveryNoticeSeed {
+  if (input?.reason === "adapter_fingerprint_continuity_unresolvable") {
+    return {
+      body:
+        "Paperclip stopped dispatching this adapter because its run configuration fingerprint metadata kept " +
+        "resetting for the same reason on every attempt instead of becoming durable. Dispatching again would " +
+        "only produce another zero-token run. Moving it to `blocked` so an operator can repair the adapter's " +
+        "session/config continuity (or clear the task session) before resuming.",
+      title: "Configuration incomplete",
+      tone: "danger",
+    };
+  }
   return {
     body:
       "Paperclip stopped before dispatching the adapter because required secret/env bindings are missing. " +


### PR DESCRIPTION
## Summary

- `grok_local` (grok-4.5) run dispatches on an assigned issue could loop indefinitely: `resolveTaskSessionConfigFreshness` reset the task session for the same `"effective run configuration fingerprint metadata is missing"` reason on every dispatch — the fingerprint it just computed never became durable across runs — producing repeated 0-token runs. Diagnosed in SPC-31006 (14 runs / 6h, ~$10.93, zero productive output blocking SPC-30704).
- Adds `resolveFingerprintContinuityGateDecision`, a pre-dispatch gate for grok-* adapters that tracks a per-task-session streak of consecutive same-reason resets (persisted via a new `__paperclipConfigFingerprintMissingStreak` session-param key). Once the streak exceeds the bound (default 2), the dispatch path throws `ConfigurationIncompleteFailure` instead of starting another doomed run.
- This reuses the existing `configuration_incomplete` pre-dispatch contract (doc/execution-semantics.md §5) rather than inventing a new one: the run is marked `failed`/`configuration_incomplete`, the issue moves to `blocked` with a source-scoped recovery action, exactly like the existing missing-secret-binding gate.
- `buildConfigurationIncompleteRecoveryNoticeSeed` is now reason-aware so the operator-facing comment names the actual condition (fingerprint/session continuity unresolvable) instead of the generic "required secret/env bindings are missing" text, which would have been misleading for this failure mode.

## Why not fix the underlying persistence bug directly?

The specific reason grok's session write-back never durably retains the fingerprint metadata wasn't root-caused in SPC-31006 (diagnosis-only, gated by board/CTO approval before implementation — see the `diagnose-why-work-stopped` skill contract). This change ships the general product-rule gate asked for in SPC-35033 so the platform fails safe (surfaced blocker, named owner action) regardless of the exact underlying cause, and preserves the three loop-prevention invariants: productive work continues once the gate passes, only real blockers stop work, and there's no infinite re-dispatch loop.

## Test plan

- [x] `npx tsc --noEmit` in `server/` — zero new errors (pre-existing errors are all `@paperclipai/plugin-sdk` module-resolution / unrelated `unknown`-type errors in plugin files untouched by this change; confirmed by grep — none reference `heartbeat.ts` or `stranded-notice.ts`)
- [x] New unit tests for `resolveFingerprintContinuityGateDecision` in `server/src/__tests__/heartbeat-workspace-session.test.ts` (adapter-type scoping, unrelated-reason resets, bounded tolerance, gating, custom bound, `grok-*` prefix matching) — 151/151 tests pass in that file
- [x] `heartbeat-process-recovery.test.ts` — 110/111 pass; the one failure (`reaps orphaned descendant process groups when the parent pid is already gone`) reproduces identically on unmodified `master` in this sandbox (confirmed via `git stash`) — a pre-existing OS process/signal-handling flake unrelated to this change, not a regression
- [ ] `pnpm run typecheck` full workspace / Rust `build:binary` — sandbox has no `cargo`, so the full `prepare:runner-vendor` build couldn't run locally; ran `tsc --noEmit` directly instead (see above)

Refs SPC-35033, SPC-31006.