### PR TITLE
Fix explicit execution workspace updates during project remaps

### DIFF
--- a/server/src/__tests__/issue-execution-workspace-remap-routes.test.ts
+++ b/server/src/__tests__/issue-execution-workspace-remap-routes.test.ts
@@ -1,0 +1,395 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  companies,
+  companyMemberships,
+  createDb,
+  executionWorkspaces,
+  issueComments,
+  issues,
+  projectWorkspaces,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { instanceSettingsService } from "../services/instance-settings.js";
+import type { StorageService } from "../storage/types.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping execution workspace remap route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue execution workspace remap routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-workspace-remap-");
+    db = createDb(tempDb.connectionString);
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createStorage(): StorageService {
+    return {
+      provider: "local_disk",
+      putFile: vi.fn(async () => {
+        throw new Error("Unexpected storage.putFile call in issue workspace remap route test");
+      }),
+      getObject: vi.fn(async () => {
+        throw new Error("Unexpected storage.getObject call in issue workspace remap route test");
+      }),
+      headObject: vi.fn(async () => ({ exists: false })),
+      deleteObject: vi.fn(async () => undefined),
+    };
+  }
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, createStorage()));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedFixture() {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const sourceProjectId = randomUUID();
+    const destinationProjectId = randomUUID();
+    const otherProjectId = randomUUID();
+    const sourceProjectWorkspaceId = randomUUID();
+    const destinationProjectWorkspaceId = randomUUID();
+    const otherProjectWorkspaceId = randomUUID();
+    const sourceExecutionWorkspaceId = randomUUID();
+    const destinationExecutionWorkspaceId = randomUUID();
+    const otherExecutionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    const historyId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Workspace remap company",
+        issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Other workspace company",
+        issuePrefix: `O${otherCompanyId.replace(/-/g, "").slice(0, 7).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await db.insert(projects).values([
+      { id: sourceProjectId, companyId, name: "Source project", status: "in_progress" },
+      { id: destinationProjectId, companyId, name: "Destination project", status: "in_progress" },
+      { id: otherProjectId, companyId: otherCompanyId, name: "Other project", status: "in_progress" },
+    ]);
+    await db.insert(projectWorkspaces).values([
+      {
+        id: sourceProjectWorkspaceId,
+        companyId,
+        projectId: sourceProjectId,
+        name: "Source primary workspace",
+        isPrimary: true,
+      },
+      {
+        id: destinationProjectWorkspaceId,
+        companyId,
+        projectId: destinationProjectId,
+        name: "Destination primary workspace",
+        isPrimary: true,
+      },
+      {
+        id: otherProjectWorkspaceId,
+        companyId: otherCompanyId,
+        projectId: otherProjectId,
+        name: "Other primary workspace",
+        isPrimary: true,
+      },
+    ]);
+    await db.insert(executionWorkspaces).values([
+      {
+        id: sourceExecutionWorkspaceId,
+        companyId,
+        projectId: sourceProjectId,
+        projectWorkspaceId: sourceProjectWorkspaceId,
+        mode: "shared_workspace",
+        strategyType: "project_primary",
+        name: "Source execution workspace",
+        status: "archived",
+        providerType: "local_fs",
+      },
+      {
+        id: destinationExecutionWorkspaceId,
+        companyId,
+        projectId: destinationProjectId,
+        projectWorkspaceId: destinationProjectWorkspaceId,
+        mode: "shared_workspace",
+        strategyType: "project_primary",
+        name: "Destination execution workspace",
+        status: "archived",
+        providerType: "local_fs",
+      },
+      {
+        id: otherExecutionWorkspaceId,
+        companyId: otherCompanyId,
+        projectId: otherProjectId,
+        projectWorkspaceId: otherProjectWorkspaceId,
+        mode: "shared_workspace",
+        strategyType: "project_primary",
+        name: "Other execution workspace",
+        status: "archived",
+        providerType: "local_fs",
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId: sourceProjectId,
+      title: "Original issue title",
+      description: "Keep this description unchanged.",
+      status: "todo",
+      priority: "high",
+      assigneeUserId: "cloud-user-1",
+      createdByUserId: "cloud-user-1",
+      billingCode: "portfolio-remap",
+      executionWorkspaceId: sourceExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+    });
+    await db.insert(issueComments).values({
+      id: commentId,
+      companyId,
+      issueId,
+      authorUserId: "cloud-user-1",
+      authorType: "user",
+      body: "Preserve this comment and its history.",
+    });
+    await db.insert(activityLog).values({
+      id: historyId,
+      companyId,
+      actorType: "user",
+      actorId: "cloud-user-1",
+      action: "issue.seed_history",
+      entityType: "issue",
+      entityId: issueId,
+      details: { marker: "preserve" },
+      createdAt: new Date("2026-08-01T10:00:00.000Z"),
+    });
+
+    return {
+      app: createApp(companyId),
+      companyId,
+      sourceProjectId,
+      destinationProjectId,
+      sourceExecutionWorkspaceId,
+      destinationExecutionWorkspaceId,
+      otherExecutionWorkspaceId,
+      issueId,
+      commentId,
+      historyId,
+    };
+  }
+
+  it("honors explicit null before a later project and title remap when isolated workspaces are disabled", async () => {
+    const fixture = await seedFixture();
+
+    const detach = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({ executionWorkspaceId: null });
+
+    expect(detach.status, JSON.stringify(detach.body)).toBe(200);
+    expect(detach.body.executionWorkspaceId).toBeNull();
+
+    const remap = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({
+        projectId: fixture.destinationProjectId,
+        title: "Remapped issue title",
+      });
+
+    expect(remap.status, JSON.stringify(remap.body)).toBe(200);
+    expect(remap.body).toMatchObject({
+      projectId: fixture.destinationProjectId,
+      title: "Remapped issue title",
+      executionWorkspaceId: null,
+    });
+
+    const retry = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({
+        projectId: fixture.destinationProjectId,
+        title: "Remapped issue title",
+      });
+    expect(retry.status, JSON.stringify(retry.body)).toBe(200);
+
+    const storedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0]);
+    const storedComment = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.id, fixture.commentId))
+      .then((rows) => rows[0]);
+    const storedHistory = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.id, fixture.historyId))
+      .then((rows) => rows[0]);
+
+    expect(storedIssue).toMatchObject({
+      projectId: fixture.destinationProjectId,
+      title: "Remapped issue title",
+      description: "Keep this description unchanged.",
+      status: "todo",
+      priority: "high",
+      assigneeUserId: "cloud-user-1",
+      billingCode: "portfolio-remap",
+      executionWorkspaceId: null,
+      executionWorkspacePreference: "reuse_existing",
+    });
+    expect(storedComment).toMatchObject({
+      issueId: fixture.issueId,
+      authorUserId: "cloud-user-1",
+      body: "Preserve this comment and its history.",
+      deletedAt: null,
+    });
+    expect(storedHistory).toMatchObject({
+      id: fixture.historyId,
+      companyId: fixture.companyId,
+      action: "issue.seed_history",
+      entityType: "issue",
+      entityId: fixture.issueId,
+      details: { marker: "preserve" },
+      createdAt: new Date("2026-08-01T10:00:00.000Z"),
+    });
+  });
+
+  it("atomically accepts a destination workspace and rejects wrong-project or cross-company pointers", async () => {
+    const fixture = await seedFixture();
+
+    const remap = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({
+        projectId: fixture.destinationProjectId,
+        title: "Atomic destination remap",
+        executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+      });
+
+    expect(remap.status, JSON.stringify(remap.body)).toBe(200);
+    expect(remap.body).toMatchObject({
+      projectId: fixture.destinationProjectId,
+      title: "Atomic destination remap",
+      executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+    });
+
+    const retry = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({
+        projectId: fixture.destinationProjectId,
+        title: "Atomic destination remap",
+        executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+      });
+    expect(retry.status, JSON.stringify(retry.body)).toBe(200);
+
+    const wrongProject = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({
+        projectId: fixture.sourceProjectId,
+        title: "Must not persist",
+        executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+      });
+    expect(wrongProject.status, JSON.stringify(wrongProject.body)).toBe(422);
+    expect(wrongProject.body.error).toBe("Execution workspace must belong to the selected project");
+
+    const crossCompany = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({ executionWorkspaceId: fixture.otherExecutionWorkspaceId });
+    expect(crossCompany.status, JSON.stringify(crossCompany.body)).toBe(422);
+    expect(crossCompany.body.error).toBe("Execution workspace must belong to same company");
+
+    const storedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0]);
+    expect(storedIssue).toMatchObject({
+      projectId: fixture.destinationProjectId,
+      title: "Atomic destination remap",
+      executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+    });
+  });
+
+  it("preserves an omitted pointer and rejects an incompatible project move without a partial update", async () => {
+    const fixture = await seedFixture();
+
+    const titleOnly = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({ title: "Pointer remains attached" });
+    expect(titleOnly.status, JSON.stringify(titleOnly.body)).toBe(200);
+    expect(titleOnly.body.executionWorkspaceId).toBe(fixture.sourceExecutionWorkspaceId);
+
+    const incompatibleMove = await request(fixture.app)
+      .patch(`/api/issues/${fixture.issueId}`)
+      .send({
+        projectId: fixture.destinationProjectId,
+        title: "Must not persist",
+      });
+    expect(incompatibleMove.status, JSON.stringify(incompatibleMove.body)).toBe(422);
+    expect(incompatibleMove.body.error).toBe("Execution workspace must belong to the selected project");
+
+    const storedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0]);
+    expect(storedIssue).toMatchObject({
+      projectId: fixture.sourceProjectId,
+      title: "Pointer remains attached",
+      description: "Keep this description unchanged.",
+      status: "todo",
+      priority: "high",
+      billingCode: "portfolio-remap",
+      executionWorkspaceId: fixture.sourceExecutionWorkspaceId,
+    });
+  });
+});

--- a/server/src/__tests__/issue-execution-workspace-remap-routes.test.ts
+++ b/server/src/__tests__/issue-execution-workspace-remap-routes.test.ts
@@ -359,6 +359,66 @@ describeEmbeddedPostgres("issue execution workspace remap routes", () => {
     });
   });
 
+  it("rejects a stale workspace patch after a concurrent project remap", async () => {
+    const fixture = await seedFixture();
+    const originalTransaction = db.transaction.bind(db);
+    let pauseFirstTransaction = true;
+    let signalFirstTransaction!: () => void;
+    let releaseFirstTransaction!: () => void;
+    const firstTransactionReached = new Promise<void>((resolve) => {
+      signalFirstTransaction = resolve;
+    });
+    const firstTransactionReleased = new Promise<void>((resolve) => {
+      releaseFirstTransaction = resolve;
+    });
+    const transactionSpy = vi.spyOn(db, "transaction").mockImplementation(
+      (async (...args: Parameters<typeof db.transaction>) => {
+        if (pauseFirstTransaction) {
+          pauseFirstTransaction = false;
+          signalFirstTransaction();
+          await firstTransactionReleased;
+        }
+        return originalTransaction(...args);
+      }) as typeof db.transaction,
+    );
+    let stalePatch: Promise<request.Response> | null = null;
+
+    try {
+      stalePatch = request(fixture.app)
+        .patch(`/api/issues/${fixture.issueId}`)
+        .send({ executionWorkspaceId: fixture.sourceExecutionWorkspaceId })
+        .then((response) => response);
+      await firstTransactionReached;
+
+      const concurrentRemap = await request(fixture.app)
+        .patch(`/api/issues/${fixture.issueId}`)
+        .send({
+          projectId: fixture.destinationProjectId,
+          executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+        });
+      expect(concurrentRemap.status, JSON.stringify(concurrentRemap.body)).toBe(200);
+
+      releaseFirstTransaction();
+      const staleResult = await stalePatch;
+      expect(staleResult.status, JSON.stringify(staleResult.body)).toBe(422);
+      expect(staleResult.body.error).toBe("Execution workspace must belong to the selected project");
+    } finally {
+      releaseFirstTransaction();
+      await stalePatch?.catch(() => undefined);
+      transactionSpy.mockRestore();
+    }
+
+    const storedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, fixture.issueId))
+      .then((rows) => rows[0]);
+    expect(storedIssue).toMatchObject({
+      projectId: fixture.destinationProjectId,
+      executionWorkspaceId: fixture.destinationExecutionWorkspaceId,
+    });
+  });
+
   it("preserves an omitted pointer and rejects an incompatible project move without a partial update", async () => {
     const fixture = await seedFixture();
 

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -186,6 +186,10 @@ describe("openapi routes", () => {
     expect(res.body.paths["/mcp/gateways/{gatewayPublicId}"].post.security).toEqual([]);
     expect(res.body.paths["/api/mcp/gateways/{gatewayPublicId}"]).toBeUndefined();
     expect(res.body.paths["/api/companies"].post.responses["201"]).toBeDefined();
+    expect(
+      res.body.paths["/api/issues/{id}"].patch.requestBody.content["application/json"].schema.properties
+        .executionWorkspaceId,
+    ).toMatchObject({ type: "string", format: "uuid", nullable: true });
     expect(res.body.paths["/api/companies"].post.requestBody.content["application/json"].schema).toMatchObject({
       type: "object",
       properties: {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7664,7 +7664,6 @@ export function issueService(db: Db) {
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
-        delete issueData.executionWorkspaceId;
         delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7803,6 +7803,11 @@ export function issueService(db: Db) {
         patch.executionLockedAt = null;
       }
 
+      const workspaceBindingChanged =
+        issueData.projectId !== undefined ||
+        issueData.projectWorkspaceId !== undefined ||
+        issueData.executionWorkspaceId !== undefined;
+
       const runUpdate = async (tx: any) => {
         // The receipt baseline must be read under the same row lock as the
         // write. Otherwise a concurrent update can be mistaken for a change
@@ -7814,6 +7819,59 @@ export function issueService(db: Db) {
           .for("update")
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!receiptExisting) return null;
+        if (workspaceBindingChanged) {
+          let lockedNextProjectId =
+            issueData.projectId !== undefined ? issueData.projectId : receiptExisting.projectId;
+          const lockedNextProjectWorkspaceId =
+            issueData.projectWorkspaceId !== undefined
+              ? issueData.projectWorkspaceId
+              : receiptExisting.projectWorkspaceId;
+          const lockedNextExecutionWorkspaceId =
+            issueData.executionWorkspaceId !== undefined
+              ? issueData.executionWorkspaceId
+              : receiptExisting.executionWorkspaceId;
+          let lockedValidatedProjectWorkspace: { projectId: string } | null = null;
+          let lockedValidatedExecutionWorkspace: { projectId: string } | null = null;
+
+          if (!lockedNextProjectId && lockedNextProjectWorkspaceId) {
+            const workspace = await assertValidProjectWorkspace(
+              receiptExisting.companyId,
+              null,
+              lockedNextProjectWorkspaceId,
+              tx,
+            );
+            lockedValidatedProjectWorkspace = workspace;
+            lockedNextProjectId = workspace.projectId;
+            patch.projectId = workspace.projectId;
+          }
+          if (!lockedNextProjectId && lockedNextExecutionWorkspaceId) {
+            const workspace = await assertValidExecutionWorkspace(
+              receiptExisting.companyId,
+              null,
+              lockedNextExecutionWorkspaceId,
+              tx,
+            );
+            lockedValidatedExecutionWorkspace = workspace;
+            lockedNextProjectId = workspace.projectId;
+            patch.projectId = workspace.projectId;
+          }
+          if (lockedNextProjectWorkspaceId && !lockedValidatedProjectWorkspace) {
+            await assertValidProjectWorkspace(
+              receiptExisting.companyId,
+              lockedNextProjectId,
+              lockedNextProjectWorkspaceId,
+              tx,
+            );
+          }
+          if (lockedNextExecutionWorkspaceId && !lockedValidatedExecutionWorkspace) {
+            await assertValidExecutionWorkspace(
+              receiptExisting.companyId,
+              lockedNextProjectId,
+              lockedNextExecutionWorkspaceId,
+              tx,
+            );
+          }
+        }
         const [previousLabelsByIssueId, previousRelationSummaries] = await Promise.all([
           nextLabelIds !== undefined
             ? labelMapForIssues(tx, [id])


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI agents for work.
> - The issue service stores the project and execution workspace for each issue.
> - The API accepts an optional and nullable execution workspace ID during an issue update.
> - The service removed this field when isolated workspaces were off.
> - The service then used the old workspace ID to validate a requested project change.
> - This pull request keeps an explicit workspace ID update and validates the requested next state.
> - It also validates the effective project and workspace state again after the issue row lock.
> - The benefit is that an operator can detach or replace a stale workspace pointer without a database edit or a concurrent request creating an invalid link.

## Linked Issues or Issue Description

**What happened?**

When isolated workspaces were off, `PATCH /api/issues/{id}` removed an explicit `executionWorkspaceId` from the update. An explicit `null` returned 200 but did not clear the pointer. A project move with a destination workspace failed because the service validated the old pointer against the new project.

The first candidate also validated the requested pointer before the issue transaction. A concurrent project move could make that result stale before the row lock and write.

**Expected behavior**

An explicit `null` must clear the pointer. An explicit workspace ID must be validated as the requested next pointer. An omitted field must preserve the current pointer. Company and project checks must remain in force at the locked write boundary.

**Steps to reproduce**

1. Turn off `enableIsolatedWorkspaces`.
2. Create an issue in project A with an execution workspace from project A.
3. Patch the issue with `executionWorkspaceId: null`.
4. Observe that the old pointer remains.
5. Patch the issue with project B and an execution workspace from project B.
6. Observe the 422 response for the old project A pointer.

**Paperclip version or commit**

The installed reproduction used version `2026.824.0`. The source baseline is `9c57c0f11900faef6e5498c3b11c066539a1b6b4`.

## What Changed

- Keep `executionWorkspaceId` in the issue update payload when isolated workspaces are off.
- Validate an effective non-null project/workspace binding again against the locked issue row before the write.
- Add route tests for null detach, destination replacement, omission, rejection, rollback, retry, data preservation, and a concurrent stale-pointer race.
- Add an OpenAPI assertion for the nullable UUID contract.

## Verification

- `./node_modules/.bin/vitest run server/src/__tests__/issue-execution-workspace-remap-routes.test.ts server/src/__tests__/openapi-routes.test.ts packages/shared/src/validators/issue.test.ts` — 41 tests passed.
- `./server/node_modules/.bin/tsc --noEmit -p server/tsconfig.json` — passed.
- `git diff --cached --check` — passed before each commit.
- A controlled pre-fix run restored the old feature gate. Two route tests failed on null detach and destination replacement. The final candidate then passed the same tests.
- A second controlled run removed only the locked-state repair while keeping the concurrency test. The stale request returned 200 and wrote the project A workspace after the project B remap. The final candidate rejects that request with 422 and preserves the project B workspace.

## Risks

- Risk is limited to issue updates that include a project, project workspace, or execution workspace field.
- Such updates now repeat the same company and project checks after the existing issue row lock.
- Existing same-company and selected-project checks still reject invalid non-null pointers.
- The change has no migration, dependency, deployment, runtime activation, credential, or external service effect.
- The package typecheck wrapper did not run because this host has Node 22 and no bare `pnpm` command. The direct server TypeScript compiler passed.

> This bug fix does not duplicate an item in `ROADMAP.md`.

## Model Used

- OpenAI Codex, GPT-5. The run used reasoning, tool use, local code execution, Git, and GitHub CLI. The exact context window was not exposed to the run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
