### PR TITLE
feat(approvals): add idempotencyKey to POST /approvals to prevent duplicate cards (INUA-6294)

### DIFF
--- a/packages/db/src/migrations/0221_approvals_idempotency_key.sql
+++ b/packages/db/src/migrations/0221_approvals_idempotency_key.sql
@@ -1,0 +1,3 @@
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: Drizzle migrations run transactionally, so CONCURRENTLY is unavailable. The idempotency_key column is new and NULL for all existing rows, so the partial unique index (WHERE idempotency_key IS NOT NULL) covers an empty set on all deployed databases and is safe to create atomically.
+ALTER TABLE "approvals" ADD COLUMN "idempotency_key" text;
+CREATE UNIQUE INDEX IF NOT EXISTS "approvals_company_idempotency_uq" ON "approvals" USING btree ("company_id","idempotency_key") WHERE "approvals"."idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1534,6 +1534,13 @@
       "when": 1786711898731,
       "tag": "0220_execution_workspace_runtime_leases",
       "breakpoints": true
+    },
+    {
+      "idx": 221,
+      "version": "7",
+      "when": 1787400000000,
+      "tag": "0221_approvals_idempotency_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/approvals.ts
+++ b/packages/db/src/schema/approvals.ts
@@ -1,4 +1,5 @@
-import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
 
@@ -15,6 +16,7 @@ export const approvals = pgTable(
     decisionNote: text("decision_note"),
     decidedByUserId: text("decided_by_user_id"),
     decidedAt: timestamp("decided_at", { withTimezone: true }),
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -24,5 +26,8 @@ export const approvals = pgTable(
       table.status,
       table.type,
     ),
+    companyIdempotencyUq: uniqueIndex("approvals_company_idempotency_uq")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
   }),
 );

--- a/packages/shared/src/validators/approval.ts
+++ b/packages/shared/src/validators/approval.ts
@@ -7,6 +7,7 @@ export const createApprovalSchema = z.object({
   requestedByAgentId: z.string().uuid().optional().nullable(),
   payload: z.record(z.string(), z.unknown()),
   issueIds: z.array(z.string().uuid()).optional(),
+  idempotencyKey: z.string().min(1).max(512).optional().nullable(),
 });
 
 export type CreateApproval = z.infer<typeof createApprovalSchema>;

--- a/server/src/__tests__/agents-pending-approval-config.test.ts
+++ b/server/src/__tests__/agents-pending-approval-config.test.ts
@@ -81,7 +81,7 @@ describeEmbeddedPostgres("pending approval agent config integrity", () => {
       permissions: {},
       lastHeartbeatAt: null,
     });
-    const approval = await approvalSvc.create(companyId, {
+    const { approval } = await approvalSvc.create(companyId, {
       type: "hire_agent",
       requestedByAgentId: null,
       requestedByUserId: "board-user",

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -32,6 +32,10 @@ const mockAccessService = vi.hoisted(() => ({
   decide: vi.fn(),
 }));
 
+const mockIssueService = vi.hoisted(() => ({
+  listReviewAttention: vi.fn(),
+}));
+
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     accessService: () => mockAccessService,
@@ -40,6 +44,9 @@ function registerModuleMocks() {
     issueApprovalService: () => mockIssueApprovalService,
     logActivity: mockLogActivity,
     secretService: () => mockSecretService,
+  }));
+  vi.doMock("../services/issues.js", () => ({
+    issueService: () => mockIssueService,
   }));
 }
 
@@ -116,8 +123,10 @@ describe("approval routes idempotent retries", () => {
     vi.doUnmock("../routes/approvals.js");
     vi.doUnmock("../routes/authz.js");
     vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("../services/issues.js");
     registerModuleMocks();
     vi.clearAllMocks();
+    mockIssueService.listReviewAttention.mockResolvedValue(new Map());
     mockApprovalService.list.mockReset();
     mockApprovalService.getById.mockReset();
     mockApprovalService.create.mockReset();
@@ -324,29 +333,32 @@ describe("approval routes idempotent retries", () => {
 
   it("lets agents create generic issue-linked board approval requests", async () => {
     mockApprovalService.create.mockResolvedValue({
-      id: "approval-1",
-      companyId: "company-1",
-      type: "request_board_approval",
-      requestedByAgentId: "agent-1",
-      requestedByUserId: null,
-      status: "pending",
-      payload: { title: "Approve hosting spend" },
-      decisionNote: null,
-      decidedByUserId: null,
-      decidedAt: null,
-      createdAt: new Date("2026-04-06T00:00:00.000Z"),
-      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+      approval: {
+        id: "approval-1",
+        companyId: "company-1",
+        type: "request_board_approval",
+        requestedByAgentId: "agent-1",
+        requestedByUserId: null,
+        status: "pending",
+        payload: { title: "Approve hosting spend" },
+        decisionNote: null,
+        decidedByUserId: null,
+        decidedAt: null,
+        createdAt: new Date("2026-04-06T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+      },
+      created: true,
     });
 
     const res = await request(await createAgentApp())
       .post("/api/companies/company-1/approvals")
       .send({
         type: "request_board_approval",
-        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        issueIds: ["00000000-0000-0000-0000-000000000000"],
         payload: { title: "Approve hosting spend" },
       });
 
-    expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
     expect(res.body).toMatchObject({
       companyId: "company-1",
       type: "request_board_approval",
@@ -357,7 +369,7 @@ describe("approval routes idempotent retries", () => {
     expect(mockSecretService.normalizeHireApprovalPayloadForPersistence).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.linkManyForApproval).toHaveBeenCalledWith(
       "approval-1",
-      ["00000000-0000-0000-0000-000000000001"],
+      ["00000000-0000-0000-0000-000000000000"],
       { agentId: "agent-1", userId: null },
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
@@ -369,6 +381,38 @@ describe("approval routes idempotent retries", () => {
         action: "approval.created",
       }),
     );
+  });
+
+  it("returns 200 and skips logActivity when idempotencyKey matches an existing approval", async () => {
+    mockApprovalService.create.mockResolvedValue({
+      approval: {
+        id: "approval-1",
+        companyId: "company-1",
+        type: "request_board_approval",
+        requestedByAgentId: "agent-1",
+        requestedByUserId: null,
+        status: "pending",
+        payload: { title: "Approve hosting spend" },
+        decisionNote: null,
+        decidedByUserId: null,
+        decidedAt: null,
+        createdAt: new Date("2026-04-06T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+      },
+      created: false,
+    });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        idempotencyKey: "key-already-used",
+        payload: { title: "Approve hosting spend" },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ id: "approval-1", companyId: "company-1", status: "pending" });
+    expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
   it("blocks status-only recovery runs from creating approvals", async () => {

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -136,6 +136,82 @@ describe("approvalService resolution idempotency", () => {
   });
 });
 
+function createDbStubForCreate(
+  selectResults: (ApprovalRecord | null)[][],
+  insertRows: ApprovalRecord[],
+  insertError?: unknown,
+) {
+  const pendingSelectResults = [...selectResults];
+  const selectWhere = vi.fn(() => Promise.resolve(pendingSelectResults.shift() ?? []));
+  const from = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from }));
+
+  const returning = vi.fn(() =>
+    insertError ? Promise.reject(insertError) : Promise.resolve(insertRows),
+  );
+  const values = vi.fn(() => ({ returning }));
+  const insert = vi.fn(() => ({ values }));
+
+  return { db: { select, insert }, selectWhere, returning };
+}
+
+describe("approvalService.create idempotency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns created:true and the new approval when no matching idempotencyKey exists", async () => {
+    const newApproval = createApproval("pending");
+    const stub = createDbStubForCreate([[]], [newApproval]);
+    const svc = approvalService(stub.db as any);
+
+    const result = await svc.create("company-1", {
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      idempotencyKey: "key-new",
+    } as any);
+
+    expect(result.created).toBe(true);
+    expect(result.approval.id).toBe("approval-1");
+    expect(stub.returning).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns created:false and the existing approval when idempotencyKey already exists", async () => {
+    const existing = createApproval("pending");
+    const stub = createDbStubForCreate([[existing]], []);
+    const svc = approvalService(stub.db as any);
+
+    const result = await svc.create("company-1", {
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      idempotencyKey: "key-already-used",
+    } as any);
+
+    expect(result.created).toBe(false);
+    expect(result.approval.id).toBe("approval-1");
+    expect(stub.returning).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the existing approval on concurrent-insert constraint conflict", async () => {
+    const existing = createApproval("pending");
+    const conflictError = { code: "23505", constraint: "approvals_company_idempotency_uq" };
+    const stub = createDbStubForCreate([[], [existing]], [], conflictError);
+    const svc = approvalService(stub.db as any);
+
+    const result = await svc.create("company-1", {
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      idempotencyKey: "key-race",
+    } as any);
+
+    expect(result.created).toBe(false);
+    expect(result.approval.id).toBe("approval-1");
+  });
+});
+
 describe("approvalService.findOpenHireApprovalForAgent", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -953,7 +953,7 @@ describeEmbeddedPostgres("built-in agents", () => {
         metadata: withBuiltInAgentMarker({}, { key: "briefs", featureKeys: ["briefs"] }),
       },
     ]);
-    const approval = await approvalService(db).create(companyId, {
+    const { approval } = await approvalService(db).create(companyId, {
       type: "hire_agent",
       requestedByAgentId: null,
       requestedByUserId: null,
@@ -964,7 +964,7 @@ describeEmbeddedPostgres("built-in agents", () => {
       decidedAt: null,
       updatedAt: new Date(),
     });
-    return { olderId, newerId, approvalId: approval!.id };
+    return { olderId, newerId, approvalId: approval.id };
   }
 
   it("self-heals duplicate active instances, keeping the oldest and cancelling the newer's approval", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3058,7 +3058,7 @@ export function agentRoutes(
         redactEventPayload(
           ((normalizedHireInput.metadata ?? agent.metadata ?? {}) as Record<string, unknown>),
         ) ?? {};
-      approval = await approvalsSvc.create(companyId, {
+      ({ approval } = await approvalsSvc.create(companyId, {
         type: "hire_agent",
         requestedByAgentId: actor.actorType === "agent" ? actor.actorId : null,
         requestedByUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -3092,7 +3092,7 @@ export function agentRoutes(
         decidedByUserId: null,
         decidedAt: null,
         updatedAt: new Date(),
-      });
+      }));
 
       if (sourceIssueIds.length > 0) {
         await issueApprovalsSvc.linkManyForApproval(approval.id, sourceIssueIds, {

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -242,7 +242,7 @@ export function approvalRoutes(
         : approvalInput.payload;
 
     const actor = getActorInfo(req);
-    const approval = await svc.create(companyId, {
+    const { approval, created } = await svc.create(companyId, {
       ...approvalInput,
       payload: normalizedPayload,
       requestedByUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -262,18 +262,20 @@ export function approvalRoutes(
       });
     }
 
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "approval.created",
-      entityType: "approval",
-      entityId: approval.id,
-      details: { type: approval.type, issueIds: uniqueIssueIds },
-    });
+    if (created) {
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "approval.created",
+        entityType: "approval",
+        entityId: approval.id,
+        details: { type: approval.type, issueIds: uniqueIssueIds },
+      });
+    }
 
-    res.status(201).json(redactApprovalPayload(approval));
+    res.status(created ? 201 : 200).json(redactApprovalPayload(approval));
   });
 
   router.get("/approvals/:id/issues", async (req, res) => {

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -8,6 +8,15 @@ import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
 
+const APPROVAL_IDEMPOTENCY_CONSTRAINT = "approvals_company_idempotency_uq";
+
+function isApprovalIdempotencyConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const err = error as { code?: string; constraint?: string; constraint_name?: string };
+  const constraint = err.constraint ?? err.constraint_name;
+  return err.code === "23505" && constraint === APPROVAL_IDEMPOTENCY_CONSTRAINT;
+}
+
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
   const budgets = budgetService(db);
@@ -114,12 +123,50 @@ export function approvalService(db: Db) {
       return rows[0] ?? null;
     },
 
-    create: (companyId: string, data: Omit<typeof approvals.$inferInsert, "companyId">) =>
-      db
-        .insert(approvals)
-        .values({ ...data, companyId })
-        .returning()
-        .then((rows) => rows[0]),
+    create: async (
+      companyId: string,
+      data: Omit<typeof approvals.$inferInsert, "companyId">,
+    ): Promise<{ approval: typeof approvals.$inferSelect; created: boolean }> => {
+      const idempotencyKey = data.idempotencyKey ?? null;
+
+      if (idempotencyKey) {
+        const existing = await db
+          .select()
+          .from(approvals)
+          .where(
+            and(
+              eq(approvals.companyId, companyId),
+              eq(approvals.idempotencyKey, idempotencyKey),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (existing) return { approval: existing, created: false };
+      }
+
+      try {
+        const approval = await db
+          .insert(approvals)
+          .values({ ...data, companyId, idempotencyKey })
+          .returning()
+          .then((rows) => rows[0]);
+        return { approval, created: true };
+      } catch (error) {
+        if (idempotencyKey && isApprovalIdempotencyConflict(error)) {
+          const existing = await db
+            .select()
+            .from(approvals)
+            .where(
+              and(
+                eq(approvals.companyId, companyId),
+                eq(approvals.idempotencyKey, idempotencyKey),
+              ),
+            )
+            .then((rows) => rows[0] ?? null);
+          if (existing) return { approval: existing, created: false };
+        }
+        throw error;
+      }
+    },
 
     // Cancel an open (pending/revision_requested) approval without a board
     // decision — e.g. when its paired agent is terminated during duplicate

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -1789,7 +1789,7 @@ export function builtInAgentService(db: Db) {
       throw error;
     }
 
-    const approval = await approvalSvc.create(companyId, {
+    const { approval } = await approvalSvc.create(companyId, {
       type: "hire_agent",
       requestedByAgentId: actor.requestedByAgentId ?? null,
       requestedByUserId: actor.requestedByUserId ?? null,
@@ -1815,9 +1815,9 @@ export function builtInAgentService(db: Db) {
       decidedByUserId: null,
       decidedAt: null,
       updatedAt: new Date(),
-    }) as Approval;
+    });
 
-    return { state: await state(definition, pending), approval };
+    return { state: await state(definition, pending), approval: approval as Approval };
   }
 
   async function list(companyId: string) {

--- a/server/src/services/plugin-managed-agents.ts
+++ b/server/src/services/plugin-managed-agents.ts
@@ -427,7 +427,7 @@ export function pluginManagedAgentService(
 
     let approvalId: string | null = null;
     if (requiresApproval) {
-      const approval = await approvalSvc.create(companyId, {
+      const { approval } = await approvalSvc.create(companyId, {
         type: "hire_agent",
         requestedByAgentId: null,
         requestedByUserId: null,


### PR DESCRIPTION
## Thinking Path

\`POST /api/companies/:companyId/approvals\` had no idempotency protection. The [BAND-AID] dedup check in OPERATIONS.md §3 has a race window: two runs starting within ~100ms both find no match in \`GET /approvals?status=pending\` and both insert, creating duplicate Slack cards. A sweep on 2026-08-27 found 7 duplicates out of 24 pending cards.

The fix adds an \`idempotency_key\` column with a partial unique index so the DB enforces "one card per key", eliminating the race regardless of how many concurrent runs fire.

Closes INUA-6294

## What Changed

- **Migration 0221** (\`packages/db/src/migrations/0221_approvals_idempotency_key.sql\`): \`ALTER TABLE approvals ADD COLUMN idempotency_key text\` + partial unique index \`(company_id, idempotency_key) WHERE idempotency_key IS NOT NULL\`
- **DB schema** (\`packages/db/src/schema/approvals.ts\`): \`idempotencyKey\` field + index
- **Shared validator** (\`packages/shared/src/validators/approval.ts\`): optional \`idempotencyKey\` in \`createApprovalSchema\`
- **Service** (\`server/src/services/approvals.ts\`): \`create()\` returns \`{ approval, created }\` — pre-check on key, conflict fallback to lookup on unique constraint violation
- **Route** (\`server/src/routes/approvals.ts\`): skips \`logActivity\` on idempotent response; returns \`200\` vs \`201\`
- **Callers updated**: \`agents.ts\`, \`built-in-agents.ts\`, \`plugin-managed-agents.ts\`, two test files

## Verification

- Unit tests: \`server/src/__tests__/approvals-service.test.ts\` — new \`describe("approvalService.create idempotency")\` covering fresh insert (\`created:true\`), second call same key (\`created:false\`), and concurrent-insert conflict-fallback path — all pass (verified by CodeReviewer INUA-6296 at SHA \`045e08f3e\`)
- Behavior with no \`idempotencyKey\`: unchanged (existing tests pass)

## Risks

- **Low** — \`idempotencyKey\` is optional; existing callers that don't send it get identical behavior
- **Migration** is additive only (new nullable column + index) — safe on existing DBs with empty key set
- **Return type change** (\`{ approval, created }\` instead of bare approval) — only internal callers, all updated in this PR

## Model Used

claude-sonnet-4-6

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — [INUA-6294](/INUA/issues/INUA-6294)