### PR TITLE
fix(plugins): log activity when a plugin pauses or resumes an agent

### DIFF
--- a/server/src/__tests__/plugin-access-authorization-host-services.test.ts
+++ b/server/src/__tests__/plugin-access-authorization-host-services.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   activityLog,
   agents,
@@ -319,6 +320,54 @@ describeEmbeddedPostgres("plugin access and authorization host services", () => 
     });
     expect(JSON.stringify(rows[0]!.details)).not.toContain("sk-test-secret");
     expect(JSON.stringify(rows[0]!.details)).not.toContain("should-not-persist");
+    services.dispose();
+  });
+
+  it("records an attributable activity entry when a plugin pauses or resumes an agent", async () => {
+    // agents.pause/resume previously mutated the agent row with no
+    // logPluginActivity call, so a plugin-triggered pause left zero audit trail.
+    const company = await createCompany(db, "PBQ");
+    const targetAgent = await db
+      .insert(agents)
+      .values({
+        companyId: company.id,
+        name: "Pause target",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+        permissions: {},
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const services = buildHostServices(db, pluginId, "permissions-extension", createEventBusStub());
+
+    const paused = await services.agents.pause({ companyId: company.id, agentId: targetAgent.id });
+    expect(paused.status).toBe("paused");
+
+    const resumed = await services.agents.resume({ companyId: company.id, agentId: targetAgent.id });
+    expect(resumed.status).toBe("idle");
+
+    const rows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, targetAgent.id));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      companyId: company.id,
+      actorType: "plugin",
+      actorId: pluginId,
+      action: "agent.paused",
+      entityType: "agent",
+      entityId: targetAgent.id,
+    });
+    expect(rows[1]).toMatchObject({
+      companyId: company.id,
+      actorType: "plugin",
+      actorId: pluginId,
+      action: "agent.resumed",
+      entityType: "agent",
+      entityId: targetAgent.id,
+    });
     services.dispose();
   });
 });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2797,14 +2797,28 @@ export function buildHostServices(
         await ensurePluginAvailableForCompany(companyId);
         const agent = await agents.getById(params.agentId);
         requireInCompany("Agent", agent, companyId);
-        return (await agents.pause(params.agentId)) as Agent;
+        const paused = (await agents.pause(params.agentId)) as Agent;
+        await logPluginActivity({
+          companyId,
+          action: "agent.paused",
+          entityType: "agent",
+          entityId: paused.id,
+        });
+        return paused;
       },
       async resume(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
         const agent = await agents.getById(params.agentId);
         requireInCompany("Agent", agent, companyId);
-        return (await agents.resume(params.agentId)) as Agent;
+        const resumed = (await agents.resume(params.agentId)) as Agent;
+        await logPluginActivity({
+          companyId,
+          action: "agent.resumed",
+          entityType: "agent",
+          entityId: resumed.id,
+        });
+        return resumed;
       },
       async invoke(params) {
         const companyId = ensureCompanyId(params.companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The plugin system lets installed plugins directly manage agent lifecycle — `plugins.agents.pause` / `plugins.agents.resume` are host-service methods any plugin can call
> - Every other mutating action exposed to plugins in `plugin-host-services.ts` (creating/updating issues, upserting documents, updating projects, updating members, updating authorization policies) calls `logPluginActivity(...)` right after the mutation, so the activity feed always attributes the change to `actorType: "plugin"` plus the plugin's id
> - `agents.pause` and `agents.resume` are the only two mutating methods in that file that skip this call — they mutate the `agents` row and return, with nothing written to `activity_log`
> - That means a plugin can pause or resume any agent in a company and there is zero record of which plugin did it or when, so an operator investigating an unexplained agent pause has no way to rule "a plugin did this" in or out
> - This pull request adds the same `logPluginActivity` call already used by every neighboring method to `agents.pause` and `agents.resume`
> - The benefit is that plugin-triggered pause/resume now shows up in `GET /companies/:id/activity` like every other plugin action, closing a real attribution gap with no behavior change to the pause/resume mutation itself

## Linked Issues or Issue Description

No existing public issue captures this specific gap, so per the bug report template:

**What happened?** `services/plugin-host-services.ts`'s `agents.pause(params)` and `agents.resume(params)` methods (used by any installed plugin via the host SDK) call `agents.pause(params.agentId)` / `agents.resume(params.agentId)` and return the result, but never call `logPluginActivity`. Every other agent-adjacent or entity-mutating method in the same file (`issues.create`, `issues.update`, `issueDocuments.upsert`, `issueDocuments.delete`, `projects.update`, `access.updateMember`, `authorization.updatePolicy`, etc.) calls `logPluginActivity` right after mutating. Pause/resume are the outliers.

**Expected behavior:** A plugin pausing or resuming an agent should produce an `activity_log` row with `actorType: "plugin"` and `actorId: <pluginId>`, matching the pattern every other plugin-mutating action already follows.

**Steps to reproduce:**
1. Register a plugin and grant it the `agents` host-service capability.
2. From the plugin, call `ctx.agents.pause({ companyId, agentId })` (or `resume`) against an existing agent.
3. Query `GET /api/companies/:companyId/activity?entityType=agent&entityId=<agentId>`.
4. Observe: the agent's `status` changed, but no `agent.paused` (or `agent.resumed`) row appears anywhere in the activity log — the mutation is silent.

**Paperclip version/commit:** reproduced against `master` @ `eb86fcd` (also present on earlier commits going back to at least #403, which introduced these two methods).

Related prior PRs (linking per CONTRIBUTING.md, no duplicates found, both address different-but-adjacent problems):
- Refs #403 — introduced `agents.pause`/`agents.resume` to the plugin SDK originally; this PR closes an audit-logging gap in that original implementation.
- Refs #6689 — closed, unmerged. That PR fixed the *plugin event-bus translation table* so `agent.paused`/`agent.resumed`/`agent.terminated` activity actions correctly forward to the `agent.status_changed` plugin event. It assumed `logActivity` already fires for these actions (true for the board-facing `POST /agents/:id/pause` HTTP route) and did not touch `plugin-host-services.ts`. It does not fix this gap: a plugin calling the host-service `agents.pause`/`resume` directly still produces no `activity_log` row at all, so there's nothing for that translation table to forward in this specific path.

## What Changed

- `server/src/services/plugin-host-services.ts`: `agents.pause` and `agents.resume` now call `logPluginActivity` (action `agent.paused` / `agent.resumed`, `entityType: "agent"`, `entityId: <agent.id>`) after mutating, matching the pattern used by every other method in this file. No change to the underlying `agents.pause()` / `agents.resume()` service calls or their return values.
- `server/src/__tests__/plugin-access-authorization-host-services.test.ts`: new test asserting that calling `services.agents.pause` then `services.agents.resume` against a real agent produces two ordered `activity_log` rows with `actorType: "plugin"`, `actorId: <pluginId>`, and the expected `agent.paused` / `agent.resumed` actions.

## Verification

- `cd server && pnpm vitest run src/__tests__/plugin-access-authorization-host-services.test.ts` — 6 tests pass (5 pre-existing + 1 new), against the embedded Postgres test harness.
- `cd server && pnpm exec tsc --noEmit -p tsconfig.json` — no new errors; the touched files (`plugin-host-services.ts`, the test file) report zero errors. (The full run shows pre-existing, unrelated errors in `native-runtime`/`paperclip-runner` vendor code on `master` before this change.)

## Risks

- **Low risk.** Purely additive: one extra `INSERT` into `activity_log` per plugin pause/resume call, using the exact same helper and shape every neighboring method already uses. No schema, migration, or plugin-API change. No change to what `agents.pause`/`agents.resume` return to the calling plugin.
- Plugins that pause/resume agents at high frequency will now write proportionally more activity-log rows — same cost profile as the identical pattern already accepted for issues/documents/projects/members/policies in this file.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), extended reasoning enabled, with read/bash/edit tooling. Investigated via source audit + running the project's own test/typecheck tooling; PR description drafted by the model under human/agent operator direction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — n/a, this brings pause/resume in line with documented behavior of every other plugin action; no doc claimed pause/resume were silent
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending CI run
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending review
- [x] I will address all Greptile and reviewer comments before requesting merge
