### PR TITLE
fix(llm-wiki): index extensionless wikilinks

### DIFF
--- a/packages/plugins/plugin-llm-wiki/src/wiki/core.ts
+++ b/packages/plugins/plugin-llm-wiki/src/wiki/core.ts
@@ -1669,6 +1669,16 @@ function extractWikiLinks(contents: string): string[] {
       links.add(target);
     }
   }
+  const wikiLinkPattern = /\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]/g;
+  for (const match of contents.matchAll(wikiLinkPattern)) {
+    const target = match[1]?.trim();
+    if (!target) continue;
+    if (target.startsWith("wiki/")) {
+      links.add(target.endsWith(".md") ? target : `${target}.md`);
+    } else if (["index.md", "log.md", "AGENTS.md", "IDEA.md"].includes(target)) {
+      links.add(target);
+    }
+  }
   const wikiTokenPattern = /\bwiki\/[A-Za-z0-9._/-]+\.md\b/g;
   for (const match of contents.matchAll(wikiTokenPattern)) {
     links.add(match[0]);

--- a/packages/plugins/plugin-llm-wiki/src/wiki/core.ts
+++ b/packages/plugins/plugin-llm-wiki/src/wiki/core.ts
@@ -1675,7 +1675,7 @@ function extractWikiLinks(contents: string): string[] {
     if (!target) continue;
     if (target.startsWith("wiki/")) {
       links.add(target.endsWith(".md") ? target : `${target}.md`);
-    } else if (["index.md", "log.md", "AGENTS.md", "IDEA.md"].includes(target)) {
+    } else if (["index.md", "log.md", "WIKI.md", "AGENTS.md", "IDEA.md"].includes(target)) {
       links.add(target);
     }
   }

--- a/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
@@ -3493,6 +3493,54 @@ Duplicate headings receive stable suffixes.
     expect(harness.dbExecutes.some((execute) => execute.sql.includes("wiki_page_revisions"))).toBe(true);
   });
 
+  it("indexes extensionless project wikilinks as canonical markdown page backlinks", async () => {
+    const harness = createTestHarness({ manifest });
+    const files = new Map<string, string>();
+    harness.ctx.localFolders.readText = async (_companyId, _folderKey, relativePath) => {
+      const value = files.get(relativePath);
+      if (value == null) throw new Error("missing");
+      return value;
+    };
+    harness.ctx.localFolders.writeTextAtomic = async (_companyId, _folderKey, relativePath, contents) => {
+      files.set(relativePath, contents);
+      return harness.ctx.localFolders.status(COMPANY_ID, "wiki-root");
+    };
+
+    await plugin.definition.setup(harness.ctx);
+    await harness.executeTool("wiki_write_page", {
+      companyId: COMPANY_ID,
+      wikiId: "default",
+      path: "wiki/projects/bounceless-v2/index.md",
+      contents: [
+        "# Bounceless v2",
+        "",
+        "See [[wiki/entities/paperclip]] and [[wiki/concepts/dependency-gated-delivery|dependency gates]].",
+        "",
+        "- Current standup: [[wiki/projects/bounceless-v2/standup#next-actions]]",
+      ].join("\n"),
+    });
+    await harness.executeTool("wiki_write_page", {
+      companyId: COMPANY_ID,
+      wikiId: "default",
+      path: "wiki/projects/bounceless-v2/standup.md",
+      contents: "# Bounceless v2 Standup\n\n- [[wiki/projects/bounceless-v2/index]]\n",
+    });
+
+    const pageWrites = harness.dbExecutes.filter((execute) =>
+      execute.sql.includes("INSERT INTO")
+      && execute.sql.includes("wiki_pages")
+      && !execute.sql.includes("wiki_page_revisions"),
+    );
+    expect(pageWrites.at(-2)?.params).toContain(JSON.stringify([
+      "wiki/concepts/dependency-gated-delivery.md",
+      "wiki/entities/paperclip.md",
+      "wiki/projects/bounceless-v2/standup.md",
+    ]));
+    expect(pageWrites.at(-1)?.params).toContain(JSON.stringify([
+      "wiki/projects/bounceless-v2/index.md",
+    ]));
+  });
+
   it("blocks agent-tool writes to AGENTS.md but allows explicit board edits", async () => {
     const harness = createTestHarness({ manifest });
     const files = new Map<string, string>([

--- a/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
@@ -3517,6 +3517,7 @@ Duplicate headings receive stable suffixes.
         "See [[wiki/entities/paperclip]] and [[wiki/concepts/dependency-gated-delivery|dependency gates]].",
         "",
         "- Current standup: [[wiki/projects/bounceless-v2/standup#next-actions]]",
+        "- Wiki root: [[WIKI.md]]",
       ].join("\n"),
     });
     await harness.executeTool("wiki_write_page", {
@@ -3532,6 +3533,7 @@ Duplicate headings receive stable suffixes.
       && !execute.sql.includes("wiki_page_revisions"),
     );
     expect(pageWrites.at(-2)?.params).toContain(JSON.stringify([
+      "WIKI.md",
       "wiki/concepts/dependency-gated-delivery.md",
       "wiki/entities/paperclip.md",
       "wiki/projects/bounceless-v2/standup.md",


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their company knowledge.
> - The LLM Wiki plugin stores page link metadata for backlink queries.
> - Project pages use extensionless wiki links such as `[[wiki/projects/example/standup]]`.
> - The metadata extractor only indexed wiki paths that ended in `.md`.
> - The backlink query therefore omitted valid inbound links after project page writes.
> - This pull request normalizes extensionless wiki links to canonical `.md` page paths.
> - The benefit is complete backlink metadata for project, standup, entity, and concept pages.

## Linked Issues or Issue Description

**What happened?**

The LLM Wiki plugin wrote project pages with extensionless `[[wiki/...]]` links. The page metadata did not index those links. `wiki_list_backlinks` then omitted the corresponding inbound edges.

**Expected behavior**

The plugin should store extensionless wiki links under the canonical `.md` page path. Backlink queries should return pages that use these links.

**Steps to reproduce**

1. Write `wiki/projects/example/index.md` with `[[wiki/entities/paperclip]]` and `[[wiki/projects/example/standup]]`.
2. Write `wiki/projects/example/standup.md` with `[[wiki/projects/example/index]]`.
3. Query backlink metadata for these target pages.
4. Observe that the inbound edges are missing before this change.

**Paperclip version or commit**

`d785b19213a572bff9f92204dc7b8922217ef979`

**Deployment mode**

Self-hosted server.

## What Changed

- Parse Obsidian-style wiki links with optional aliases and heading fragments.
- Add `.md` to extensionless `wiki/` targets before metadata storage.
- Add a regression test for project overview, standup, entity, and concept links.

## Verification

- `pnpm --filter @paperclipai/plugin-llm-wiki test` — 102 tests passed.
- `pnpm --filter @paperclipai/plugin-llm-wiki typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Low risk. The change only adds valid wiki-link targets to existing metadata.
- Explicit `.md` targets keep their current value.
- External links and non-wiki tokens remain excluded.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5, with reasoning, repository tools, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
