### PR TITLE
fix(codex-local): write http_headers so codex sends the MCP gateway bearer token

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -877,7 +877,11 @@ describe("evaluateCodexCredentialReadiness", () => {
       const alpha = await fs.readFile(path.join(alphaHome, "config.toml"), "utf8");
       const zero = await fs.readFile(path.join(zeroHome, "config.toml"), "utf8");
       expect(alpha).toContain('[mcp_servers."alpha"]');
-      expect(alpha).toContain('Authorization = "Bearer alpha-token"');
+      // Codex's MCP server config key is `http_headers` (its TOML schema has no
+      // plain `headers`); writing `headers` makes codex silently ignore the
+      // server, so every governed gateway vanishes from the agent's toolset.
+      expect(alpha).toContain('http_headers = { Authorization = "Bearer alpha-token" }');
+      expect(alpha).not.toMatch(/\n\s*headers = /);
       expect(zero).not.toContain("mcp_servers.");
       expect(zero).not.toContain("stale-token");
       expect(alphaHome).not.toBe(zeroHome);

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -293,7 +293,7 @@ function buildManagedMcpBlock(input: {
       "",
       `[mcp_servers.${tomlString(managedName)}]`,
       `url = ${tomlString(url)}`,
-      `headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
+      `http_headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
     );
   });
   lines.push(MANAGED_MCP_BLOCK_END);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The codex-local adapter provisions a managed `CODEX_HOME` for each agent, including a managed MCP block in `config.toml` for Paperclip-governed tool gateways
> - Codex reads MCP HTTP headers from the `http_headers` key; its config schema has no plain `headers` key
> - `buildManagedMcpBlock` writes `headers = { Authorization = ... }`, so codex drops the Authorization header and the gateway rejects the connection
> - Every codex agent with governed MCP connections therefore reports zero gateway tools
> - This pull request renames the emitted key to `http_headers`
> - The benefit is that codex agents can use Paperclip-governed MCP gateways again

## Linked Issues or Issue Description

No open issue exists. Related PR: #11957 by @Oldrich333 carries the identical fix but has stalled on the required PR checks since 2026-08-22 — full credit to them for finding the same root cause first; this PR exists to carry the fix over the line. Description below follows the bug report template.

**What happened?**

A codex-local agent with Paperclip-governed MCP gateways starts with zero gateway tools. The generated `codex-home/config.toml` contains `headers = { Authorization = "Bearer ..." }` in each `[mcp_servers.*]` block. Codex does not read that key, so it dials the gateway without the Authorization header (or shows the server with `Auth: Unknown`). Minted gateway tokens are never used.

**Expected behavior**

Codex sends the gateway bearer token and lists the gateway's tools.

**Steps to reproduce**

1. Configure a codex-local agent with at least one governed MCP gateway connection.
2. Start a run and inspect the generated `codex-home/config.toml`: the managed block contains `headers = ...`.
3. Run `codex mcp list` against that config: the server shows `Auth: Unknown` and no Authorization header reaches the gateway.
4. Change the key to `http_headers`: `codex mcp list` shows `Auth: Bearer token` and the header reaches the gateway.

**Paperclip version or commit**

Reproduced on release 2026.817.0 and on `master` (d785b1921).

**Agent adapter(s) involved**

Codex (codex-cli 0.147–0.149 verified; the binary only contains `http_headers`).

## What Changed

- `buildManagedMcpBlock` now emits `http_headers = { Authorization = ... }` instead of `headers = ...` in the managed MCP block.
- The config-generation test asserts the exact `http_headers` line and asserts that no plain `headers` key is emitted.

## Verification

- `pnpm exec vitest run` in `packages/adapters/codex-local`: 327 passed, 1 skipped. `pnpm typecheck` is clean.
- Manual, against the real codex binary (0.149.1): two scratch `CODEX_HOME`s pointed at a local HTTP server that logs request headers. With `headers = ...` codex sends no Authorization header. With `http_headers = ...` codex sends `Authorization: Bearer alpha-token`. `codex mcp list` shows `Auth: Unknown` vs `Auth: Bearer token` respectively.

## Risks

Low risk. One emitted key renamed inside the Paperclip-managed block, which Paperclip rewrites on each run. Codex versions in support read `http_headers`; no supported version reads `headers`.

## Model Used

- Claude (Anthropic), model ID `claude-fable-5` (Claude Fable 5), extended thinking and tool use, driven interactively through Claude Code by a human operator. The fix was independently verified against the codex 0.149.1 binary as described above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
