### PR TITLE
fix(heartbeat): gate same-issue queued run claims

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -12,6 +12,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueRecoveryActions,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
@@ -685,6 +686,189 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
         }),
       ]),
     );
+  });
+
+  it.each([
+    ["checkout ownership", { checkoutRunId: true, executionRunId: false }],
+    ["execution ownership", { checkoutRunId: false, executionRunId: true }],
+    ["checkout and execution ownership", { checkoutRunId: true, executionRunId: true }],
+  ])("keeps a queued same-issue run dormant while a sibling holds %s", async (_label, locks) => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ maxConcurrentRuns: 2 });
+    const issueId = randomUUID();
+    const ownerRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: ownerRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Sibling-owned issue",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: locks.checkoutRunId ? ownerRunId : null,
+      executionRunId: locks.executionRunId ? ownerRunId : null,
+      executionLockedAt: locks.executionRunId ? new Date() : null,
+    });
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_assigned",
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    await heartbeat.drainActiveRunExecutions();
+
+    const [queuedRun, lockedIssue] = await Promise.all([
+      db.select({ status: heartbeatRuns.status }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db.select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+        .from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null),
+    ]);
+    expect(queuedRun?.status).toBe("queued");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+    expect(lockedIssue?.checkoutRunId).toBe(locks.checkoutRunId ? ownerRunId : null);
+    expect(lockedIssue?.executionRunId).toBe(locks.executionRunId ? ownerRunId : null);
+
+    await heartbeat.cancelRun(ownerRunId, "Release sibling ownership for queued wake");
+    await heartbeat.drainActiveRunExecutions();
+
+    const [completedRun, releasedIssue] = await Promise.all([
+      db.select({ status: heartbeatRuns.status }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db.select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+        .from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null),
+    ]);
+    expect(completedRun?.status).toBe("succeeded");
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+    expect(releasedIssue).toMatchObject({ checkoutRunId: null, executionRunId: null });
+  });
+
+  it("lets an authorized source-scoped recovery action run without taking source issue ownership", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ maxConcurrentRuns: 2 });
+    const issueId = randomUUID();
+    const ownerRunId = randomUUID();
+    const recoveryActionId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: ownerRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Source issue under recovery",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: ownerRunId,
+      executionRunId: ownerRunId,
+      executionLockedAt: new Date(),
+    });
+    await db.insert(issueRecoveryActions).values({
+      id: recoveryActionId,
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      cause: "process_lost",
+      fingerprint: `test:${recoveryActionId}`,
+      evidence: {},
+      nextAction: "Repair source issue liveness.",
+    });
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "source_scoped_recovery_action",
+      contextExtras: { recoveryActionId },
+      invocationSource: "automation",
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    await heartbeat.drainActiveRunExecutions();
+
+    const [recoveryRun, issue] = await Promise.all([
+      db.select({ status: heartbeatRuns.status }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db.select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+        .from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null),
+    ]);
+    expect(recoveryRun?.status).toBe("succeeded");
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+    expect(issue).toMatchObject({ checkoutRunId: ownerRunId, executionRunId: ownerRunId });
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "cancelled", finishedAt: new Date() })
+      .where(eq(heartbeatRuns.id, ownerRunId));
+  });
+
+  it("does not let an invalid source-scoped recovery label bypass sibling ownership", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ maxConcurrentRuns: 2 });
+    const issueId = randomUUID();
+    const ownerRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: ownerRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Source issue with malformed recovery wake",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: ownerRunId,
+      executionRunId: ownerRunId,
+      executionLockedAt: new Date(),
+    });
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "source_scoped_recovery_action",
+      contextExtras: { recoveryActionId: randomUUID() },
+      invocationSource: "automation",
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    await heartbeat.drainActiveRunExecutions();
+
+    const [queuedRun, issue] = await Promise.all([
+      db.select({ status: heartbeatRuns.status }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db.select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+        .from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null),
+    ]);
+    expect(queuedRun?.status).toBe("queued");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+    expect(issue).toMatchObject({ checkoutRunId: ownerRunId, executionRunId: ownerRunId });
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "cancelled", finishedAt: new Date() })
+      .where(eq(heartbeatRuns.id, ownerRunId));
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "cancelled", finishedAt: new Date() })
+      .where(eq(heartbeatRuns.id, runId));
   });
 
   it("skips wakes before queueing when per-agent daily cost cap is reached", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12740,17 +12740,146 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueContext: issueId ? await getIssueExecutionContext(run.companyId, issueId) : null,
       routineEnvContext: { routineId: null, env: null, responsibleUserId: null },
     });
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        responsibleUserId,
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
+    const recoveryActionId = readNonEmptyString(context.recoveryActionId);
+    const claimed = issueId
+      ? await db.transaction(async (tx) => {
+        await tx.execute(sql`
+          select id from issues
+          where id = ${issueId} and company_id = ${run.companyId}
+          for update
+        `);
+        const issue = await tx
+          .select({
+            id: issues.id,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+          .then((rows) => rows[0] ?? null);
+        if (!issue) return null;
+
+        const authorizedSourceScopedRecovery =
+          readNonEmptyString(context.wakeReason) === "source_scoped_recovery_action" &&
+          recoveryActionId
+            ? await tx
+              .select({ id: issueRecoveryActions.id })
+              .from(issueRecoveryActions)
+              .where(and(
+                eq(issueRecoveryActions.id, recoveryActionId),
+                eq(issueRecoveryActions.companyId, run.companyId),
+                eq(issueRecoveryActions.sourceIssueId, issue.id),
+                eq(issueRecoveryActions.ownerAgentId, run.agentId),
+                inArray(issueRecoveryActions.status, ["active", "escalated"]),
+              ))
+              .limit(1)
+              .then((rows) => Boolean(rows[0]))
+            : false;
+
+        const mustAcquireIssueExecutionAuthority =
+          !authorizedSourceScopedRecovery && issue.assigneeAgentId === run.agentId;
+        if (mustAcquireIssueExecutionAuthority) {
+          // A normal issue-bound run must acquire the source issue's execution
+          // authority before it can become running. Recovery-action runs are a
+          // separate authority contract and intentionally do not claim these fields.
+          const ownerIds = [...new Set(
+            [issue.checkoutRunId, issue.executionRunId]
+              .filter((ownerId): ownerId is string => Boolean(ownerId && ownerId !== run.id)),
+          )];
+          const ownerStatusById = new Map<string, string>();
+          if (ownerIds.length > 0) {
+            await tx.execute(sql`
+              select id from heartbeat_runs
+              where ${inArray(heartbeatRuns.id, ownerIds)}
+              order by id
+              for update
+            `);
+            const owners = await tx
+              .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+              .from(heartbeatRuns)
+              .where(inArray(heartbeatRuns.id, ownerIds));
+            for (const owner of owners) ownerStatusById.set(owner.id, owner.status);
+          }
+
+          const hasLiveSiblingOwner = ownerIds.some((ownerId) => {
+            const status = ownerStatusById.get(ownerId);
+            return status !== undefined && !isHeartbeatRunTerminalStatus(status);
+          });
+          if (hasLiveSiblingOwner) return null;
+
+          const checkoutOwnerIsStale = Boolean(
+            issue.checkoutRunId &&
+            issue.checkoutRunId !== run.id &&
+            (
+              !ownerStatusById.has(issue.checkoutRunId) ||
+              isHeartbeatRunTerminalStatus(ownerStatusById.get(issue.checkoutRunId))
+            ),
+          );
+          const executionOwnerIsStale = Boolean(
+            issue.executionRunId &&
+            issue.executionRunId !== run.id &&
+            (
+              !ownerStatusById.has(issue.executionRunId) ||
+              isHeartbeatRunTerminalStatus(ownerStatusById.get(issue.executionRunId))
+            ),
+          );
+          if (checkoutOwnerIsStale || executionOwnerIsStale) {
+            await tx
+              .update(issues)
+              .set({
+                ...(checkoutOwnerIsStale ? { checkoutRunId: null } : {}),
+                ...(executionOwnerIsStale
+                  ? {
+                    executionRunId: null,
+                    executionAgentNameKey: null,
+                    executionLockedAt: null,
+                  }
+                  : {}),
+                updatedAt: claimedAt,
+              })
+              .where(and(eq(issues.id, issue.id), eq(issues.companyId, run.companyId)));
+          }
+        }
+
+        const claimedRun = await tx
+          .update(heartbeatRuns)
+          .set({
+            status: "running",
+            responsibleUserId,
+            startedAt: run.startedAt ?? claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!claimedRun) return null;
+
+        if (mustAcquireIssueExecutionAuthority) {
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: claimedRun.id,
+              executionAgentNameKey: normalizeAgentNameKey(agent.name),
+              executionLockedAt: claimedAt,
+              updatedAt: claimedAt,
+            })
+            .where(and(eq(issues.id, issue.id), eq(issues.companyId, run.companyId)));
+        }
+
+        return claimedRun;
       })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+      : await db
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          responsibleUserId,
+          startedAt: run.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
     if (!claimed) return null;
 
     publishLiveEvent({
@@ -12771,33 +12900,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     publishRunLifecyclePluginEvent(claimed);
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
-
-    // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedContext = parseObject(claimed.contextSnapshot);
-    const claimedIssueId = readNonEmptyString(claimedContext.issueId);
-    const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
-    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
-      const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, claimedIssueId),
-            eq(issues.companyId, claimed.companyId),
-            // Mention/context runs can touch an issue, but only the current assignee
-            // owns the issue execution lock shown as the active run.
-            eq(issues.assigneeAgentId, claimed.agentId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
-        );
-    }
 
     return claimed;
   }


### PR DESCRIPTION
## Thinking Path

- Paperclip can run more than one heartbeat for an agent at the same time
- Different runs can work on different issues concurrently
- An issue uses checkout and execution ownership to prevent conflicting active work
- A queued run could still become running while another live run already owned the same issue
- The later execution ownership update could fail without stopping the new run
- This pull request makes issue ownership part of the queued-run claim transaction
- The benefit is that concurrent agent runs can still work on different issues without starting conflicting execution on the same issue

## Linked Issues or Issue Description

Fixes: #10694

## What Changed

- Added a claim-time ownership gate for queued issue-bound heartbeat runs
- Lock the issue and inspect both `checkoutRunId` and `executionRunId` before a normal queued run becomes running
- Leave the queued run unchanged when another non-terminal run owns the issue
- Clear terminal or missing ownership references inside the same transaction before a valid claim
- Establish `executionRunId` in the same transaction as a successful normal claim
- Preserve the existing `source_scoped_recovery_action` exception when the recovery action is fully authorized
- Do not let an invalid recovery label bypass issue ownership

## Verification

Tested with Node 24.11.0 in Docker.

Targeted regression suite:

`server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`

- 29 tests passed
- 0 failed

New coverage verifies:

- a live sibling that owns only `checkoutRunId`
- a live sibling that owns only `executionRunId`
- a live sibling that owns both ownership fields
- an authorized source-scoped recovery action can run without taking source issue ownership
- an invalid recovery label cannot bypass sibling ownership

Adjacent heartbeat regression suites:

- `heartbeat-stale-queue-invalidation.test.ts`
- `heartbeat-lock-release-on-reassignment.test.ts`
- `heartbeat-dependency-scheduling.test.ts`

Result:

- 3 test files passed
- 37 tests passed
- 0 failed

Server TypeScript compilation also passed after building the required TypeScript workspace dependencies.

The full server `typecheck` preparation was not completed locally because it also builds the Rust runner binary and the validation container does not include Cargo. CI can run the complete repository toolchain.

`git diff --check` passed.

## Risks

- The change adds issue-row and owner-run locking to the queued-run claim transaction
- A blocked same-issue run remains queued instead of being cancelled
- This preserves the wake and allows it to run after the current owner releases the issue
- The gate is issue-scoped and does not reduce concurrency across different issues
- Authorized source-scoped recovery actions keep their existing separate ownership semantics

## Model Used

OpenAI Codex with Terra medium reasoning mode and repository inspection/edit tools.

The Codex client did not expose the exact backend model ID or context window size, so those values are not available to report accurately.

The implementation was reviewed in a separate Terra medium review pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge