### PR TITLE
fix(heartbeat): bound stdout/stderr in persisted result_json

### DIFF
--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -3,6 +3,8 @@ import {
   summarizeHeartbeatRunResultJson,
   buildHeartbeatRunIssueComment,
   mergeHeartbeatRunResultJson,
+  boundHeartbeatRunResultJson,
+  HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
 } from "../services/heartbeat-run-summary.js";
 
 describe("summarizeHeartbeatRunResultJson", () => {
@@ -159,5 +161,35 @@ describe("mergeHeartbeatRunResultJson", () => {
       summary: "adapter result",
       stdout: "raw stdout",
     });
+  });
+});
+
+describe("boundHeartbeatRunResultJson", () => {
+  it("caps oversized stdout/stderr to the tail and records what was dropped", () => {
+    const stdout = "x".repeat(HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS + 500) + "LAST";
+    const bounded = boundHeartbeatRunResultJson({ stdout, stderr: "short", summary: "done" });
+
+    expect(bounded).not.toBeNull();
+    expect((bounded!.stdout as string).length).toBe(HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS);
+    // the tail is what a failing run explains itself with
+    expect(bounded!.stdout as string).toMatch(/LAST$/);
+    expect(bounded!.stdoutTruncated).toBe(true);
+    expect(bounded!.stdoutFullChars).toBe(stdout.length);
+    // untouched fields survive, and a short stream gains no truncation marker
+    expect(bounded!.stderr).toBe("short");
+    expect(bounded!.summary).toBe("done");
+    expect("stderrTruncated" in bounded!).toBe(false);
+  });
+
+  it("returns the original object untouched when nothing exceeds the cap", () => {
+    const input = { stdout: "small", stderr: "small", result: "ok" };
+    expect(boundHeartbeatRunResultJson(input)).toBe(input);
+  });
+
+  it("ignores non-string and absent streams", () => {
+    const input = { stdout: 42, summary: "no streams" };
+    expect(boundHeartbeatRunResultJson(input)).toBe(input);
+    expect(boundHeartbeatRunResultJson(null)).toBeNull();
+    expect(boundHeartbeatRunResultJson(undefined)).toBeNull();
   });
 });

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -17,6 +17,38 @@ function readCommentText(value: unknown) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+// Write-side counterpart of heartbeatRunSafeResultJsonColumn. That read guard
+// already decided that once result_json passes HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES
+// only the first HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS of stdout/stderr are ever
+// projected — so anything past that was stored, dumped hourly and never read back.
+// Adapters return the whole stream (the full log already goes to the out-of-band
+// log store: log_store/log_ref/log_bytes/log_sha256), which is why heartbeat_runs
+// grew to 7.9 GB with result_json alone accounting for 7.0 GB of it. Bound it here,
+// at the single point where every adapter's result is persisted, rather than in each
+// of the dozen adapter execute.ts files where a new adapter would silently regress it.
+export function boundHeartbeatRunResultJson(
+  resultJson: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) {
+    return null;
+  }
+
+  let bounded: Record<string, unknown> | null = null;
+  for (const key of ["stdout", "stderr"] as const) {
+    const value = resultJson[key];
+    if (typeof value !== "string" || value.length <= HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS) {
+      continue;
+    }
+    bounded ??= { ...resultJson };
+    // Keep the tail: a failing run says why it failed at the end, not the start.
+    bounded[key] = value.slice(value.length - HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS);
+    bounded[`${key}Truncated`] = true;
+    bounded[`${key}FullChars`] = value.length;
+  }
+
+  return bounded ?? resultJson;
+}
+
 export function mergeHeartbeatRunResultJson(
   resultJson: Record<string, unknown> | null | undefined,
   summary: string | null | undefined,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -113,6 +113,7 @@ import {
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
   HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS,
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
+  boundHeartbeatRunResultJson,
   mergeHeartbeatRunResultJson,
 } from "./heartbeat-run-summary.js";
 import {
@@ -16533,7 +16534,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             } as Record<string, unknown>)
           : null;
 
-      const persistedResultJson = mergeHeartbeatRunResultJson(
+      const persistedResultJson = boundHeartbeatRunResultJson(mergeHeartbeatRunResultJson(
         mergeRunStopMetadataForAgent(agent, outcome, {
           resultJson: mergeModelProfileRunMetadata(
             mergeAdapterRecoveryMetadata({
@@ -16550,7 +16551,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           errorMessage: runErrorMessage,
         }),
         adapterResult.summary ?? null,
-      );
+      ));
 
       const persistedRunWrite = await setRunStatusIfRunning(run.id, status, {
         finishedAt: new Date(),


### PR DESCRIPTION
## Problem

`heartbeat_runs.result_json` stores the full adapter `stdout`/`stderr` verbatim. On one production instance that table reached **7.9 GB, of which `result_json` alone is 7.0 GB** — 24,657 rows averaging 291 KB, largest 10.9 MB. Every hourly database backup copies all of it.

It is already stored twice: 18,539 of those rows carry `log_store=local_file` with `log_ref`/`log_bytes`/`log_sha256` pointing at the complete log on disk (6.4 GB), and the row still keeps the whole stream inline.

## Why this is a bug rather than a tuning question

The intended bound already exists on the read side. `heartbeatRunSafeResultJsonColumn` projects only the first `HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS` of `stdout`/`stderr` once a row passes `HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES`. So everything beyond that cap is written, backed up, and never read back.

## Change

Apply the same bound at write time, at the single point where every adapter's result is persisted — not in each of the twelve adapter `execute.ts` files, where a new adapter would silently regress it.

- keeps the **tail**, not the head: a failing run explains itself at the end
- returns the original object unchanged when nothing exceeds the cap (no allocation on the common path)
- records `stdoutTruncated` / `stdoutFullChars` so the truncation is visible rather than silent
- no new dependencies; the module stays free of Node globals

## Tests

Three cases added to `heartbeat-run-summary.test.ts` (truncation + tail + markers, no-op identity, non-string/absent streams). Full file: 11 passed.