### PR TITLE
fix(server): allow timer-run mutations on the checked-out issue

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -213,4 +213,55 @@ describe("cross-issue influence limit rollout", () => {
     });
     expect(fake.inserted).toEqual([]);
   });
+
+  it("allows a timer run with no source issue to mutate its own checked-out assigned issue", async () => {
+    const fake = counterDb(0, { contextSnapshot: { wakeReason: "heartbeat_timer" } });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueIdentifier: "TEC-7319",
+      targetCheckoutRunId: "11111111-1111-4111-8111-111111111111",
+      targetAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      kind: "update",
+    })).resolves.toBeNull();
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("still fails closed when a timer run with no source issue targets an issue it does not hold", async () => {
+    const fake = counterDb(0, { contextSnapshot: { wakeReason: "heartbeat_timer" } });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetCheckoutRunId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      targetAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      kind: "update",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("counts a third-party run with source context as cross-issue on another agent's assigned issue", async () => {
+    const fake = counterDb();
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetCheckoutRunId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      targetAssigneeAgentId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      kind: "update",
+    })).resolves.toMatchObject({ allowed: true, count: 1 });
+    expect(fake.inserted).toEqual([
+      expect.objectContaining({ action: "issue.cross_issue_influence_observed" }),
+    ]);
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5858,6 +5858,66 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       executionRunId: successorRunId,
     });
   });
+
+  it("stamps the checked-out issue onto a timer run that had no source issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "PR Coordinator",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "timer",
+      contextSnapshot: { wakeReason: "heartbeat_timer", wakeSource: "timer" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Weekly operating loop",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], runId);
+    expect(checkedOut).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      checkoutRunId: runId,
+    });
+
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+    expect(run?.contextSnapshot).toMatchObject({
+      wakeReason: "heartbeat_timer",
+      wakeSource: "timer",
+      issueId,
+      taskId: issueId,
+    });
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2909,7 +2909,13 @@ export function issueRoutes(
   async function assertCrossIssueInfluenceWithinRunCap(
     req: Request,
     res: Response,
-    issue: { id: string; identifier?: string | null; companyId: string },
+    issue: {
+      id: string;
+      identifier?: string | null;
+      companyId: string;
+      assigneeAgentId?: string | null;
+      checkoutRunId?: string | null;
+    },
     kind: CrossIssueInfluenceKind,
   ) {
     if (req.actor.type !== "agent") return true;
@@ -2924,6 +2930,8 @@ export function issueRoutes(
       responsibleUserId: req.actor.onBehalfOfUserId ?? null,
       targetIssueId: issue.id,
       targetIssueIdentifier: issue.identifier ?? null,
+      targetCheckoutRunId: issue.checkoutRunId ?? null,
+      targetAssigneeAgentId: issue.assigneeAgentId ?? null,
       kind,
     });
     if (!decision || decision.allowed) return true;

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -76,6 +76,8 @@ export async function observeCrossIssueInfluence(
     responsibleUserId?: string | null;
     targetIssueId: string;
     targetIssueIdentifier?: string | null;
+    targetCheckoutRunId?: string | null;
+    targetAssigneeAgentId?: string | null;
     kind: CrossIssueInfluenceKind;
     now?: Date;
   },
@@ -110,6 +112,15 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
+    // Timer wakes omit issueId. A checkout lock on this run's assigned issue is
+    // still same-issue influence, not a missing run.
+    if (
+      !sourceIssueId &&
+      input.targetCheckoutRunId === input.runId &&
+      input.targetAssigneeAgentId === input.agentId
+    ) {
+      return null;
+    }
     if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
       sourceIssueId === input.targetIssueId ||

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -387,6 +387,44 @@ type DerivedIssueCommentAttribution = {
  * Resolve a `created_by_run_id` safe for the heartbeat_runs FK; returns null for
  * missing/invalid ids so an unknown run id never 500s a comment insert.
  */
+
+async function bindHeartbeatRunToCheckedOutIssue(
+  db: Db,
+  input: { companyId: string; runId: string | null; agentId: string; issueId: string },
+) {
+  if (!input.runId) return;
+  const run = await db
+    .select({
+      id: heartbeatRuns.id,
+      contextSnapshot: heartbeatRuns.contextSnapshot,
+    })
+    .from(heartbeatRuns)
+    .where(and(
+      eq(heartbeatRuns.id, input.runId),
+      eq(heartbeatRuns.companyId, input.companyId),
+      eq(heartbeatRuns.agentId, input.agentId),
+    ))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return;
+  const context = run.contextSnapshot && typeof run.contextSnapshot === "object" && !Array.isArray(run.contextSnapshot)
+    ? { ...(run.contextSnapshot as Record<string, unknown>) }
+    : {};
+  const currentIssueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
+  const currentTaskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
+  if (currentIssueId === input.issueId && (currentTaskId === input.issueId || currentTaskId === "")) return;
+  await db
+    .update(heartbeatRuns)
+    .set({
+      contextSnapshot: {
+        ...context,
+        issueId: input.issueId,
+        ...(currentTaskId ? {} : { taskId: input.issueId }),
+      },
+      updatedAt: new Date(),
+    })
+    .where(eq(heartbeatRuns.id, run.id));
+}
+
 async function resolveCommentCreatedByRunId(
   dbOrTx: any,
   companyId: string,
@@ -8147,6 +8185,15 @@ export function issueService(db: Db) {
       if (!issueCompany) throw notFound("Issue not found");
       await assertAssignableAgent(db, issueCompany.companyId, agentId, { kind: "work" });
 
+      const bindCheckoutRun = async () => {
+        await bindHeartbeatRunToCheckedOutIssue(db, {
+          companyId: issueCompany.companyId,
+          runId: checkoutRunId,
+          agentId,
+          issueId: id,
+        });
+      };
+
       const now = new Date();
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issueCompany.companyId, id);
       if (
@@ -8213,6 +8260,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (updated) {
+        await bindCheckoutRun();
         const [enriched] = await withIssueLabels(db, [updated]);
         return enriched;
       }
@@ -8256,7 +8304,10 @@ export function issueService(db: Db) {
           )
           .returning()
           .then((rows) => rows[0] ?? null);
-        if (adopted) return adopted;
+        if (adopted) {
+          await bindCheckoutRun();
+          return adopted;
+        }
       }
 
       if (
@@ -8273,6 +8324,7 @@ export function issueService(db: Db) {
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (staleAdoption.adopted) {
+          await bindCheckoutRun();
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
           if (!row) throw notFound("Issue not found");
           const [enriched] = await withIssueLabels(db, [row]);
@@ -8318,6 +8370,7 @@ export function issueService(db: Db) {
             .returning()
             .then((rows) => rows[0] ?? null);
           if (adopted) {
+            await bindCheckoutRun();
             const [enriched] = await withIssueLabels(db, [adopted]);
             return enriched;
           }
@@ -8333,6 +8386,7 @@ export function issueService(db: Db) {
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
         if (!row) throw notFound("Issue not found");
         const [enriched] = await withIssueLabels(db, [row]);
+        await bindCheckoutRun();
         return enriched;
       }
 


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip manages agent work through issues and heartbeat runs.
> - Each agent write counts against a per-run cross-issue influence cap.
> - The cap needs a source issue on the persisted run snapshot.
> - Timer heartbeats start with no source issue. Checkout then binds the run to an assigned issue.
> - A later PATCH of that same issue currently fails closed with `cross_issue_influence_run_context_required`.
> - A third-party run that already has a source issue can still write to the same target as cross-issue traffic.
> - This pull request treats the run's own checkout lock as same-issue, and it stamps `issueId` onto the run at checkout.
> - The benefit is a consistent checkout-to-update path with no extra company-wide authority.

## Linked Issues or Issue Description

Supersedes #10799. That earlier change targeted a different authorization layer and is stale against current `master`.

**What happened?**

A timer-woken agent checks out its assigned issue. A later PATCH or comment on that same issue returns 403 `cross_issue_influence_run_context_required`. The run snapshot has no `issueId`. Checkout succeeds. Mutation fails.

**Expected behavior**

The same run can update and comment on the issue that it currently holds. Another issue stays under the cross-issue cap. A peer run with a source issue can still write to the target as cross-issue traffic.

**Steps to reproduce**

1. Start a timer heartbeat run whose `contextSnapshot` has `wakeReason: heartbeat_timer` and no `issueId`.
2. Check out an assigned issue with that run.
3. PATCH the same issue to `todo` with a comment.
4. Observe 403 `cross_issue_influence_run_context_required`.

**Paperclip version or commit**

Reproduced on `master` at `4d82f5eae` and on local_trusted 2026.824.0.

## What Changed

- Treat a missing source issue as same-issue when the target is assigned to the actor and `checkoutRunId` matches the current run.
- Stamp `issueId` (and `taskId` when missing) onto the heartbeat run snapshot at successful checkout.
- Add a regression for owner timer-run mutation versus peer cross-issue writes.
- Add a checkout test that stamps a timer run.

## Verification

- `pnpm exec vitest run server/src/__tests__/cross-issue-influence-limit.test.ts server/src/__tests__/cross-issue-influence-limit-postgres.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 101 passed.
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts -t "stamps the checked-out issue onto a timer run"` — 1 passed.
- This repository has no `bin/ci` script.
- `pnpm --filter @paperclipai/server exec tsc --noEmit -p tsconfig.json` — failed on missing workspace package builds (`@paperclipai/plugin-sdk`, `@paperclipai/paperclip-runner`). Those errors are outside this five-file change. Vitest compiled the changed files.

## Risks

- Low risk. The exception requires the persisted run, the assignee, and the checkout lock to match.
- Runs without a checkout still fail closed when the snapshot has no source issue.
- Checkout does not overwrite an existing `taskId`, so session keys stay stable.

> This fix does not overlap with planned core work in `ROADMAP.md`.

## Model Used

- Cursor Grok 4.6, agentic coding model, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)