### PR TITLE
fix(issues): allow blocked assignee comment acknowledgements

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -606,6 +606,18 @@ rollout mode, and fails closed with the cap in the error once enforcement is
 active. Writes to the run's own source issue are not counted. Assignee self-comments do not
 wake the assignee, and a non-assignee comment cannot mint a mention grant.
 
+A valid persisted heartbeat run without a source issue may post a comment to an
+already-blocked issue with unresolved first-class blockers assigned to that
+same authenticated agent when the request is comment-only and leaves the issue
+blocked. This covers unscoped timer heartbeats acknowledging new evidence while
+those blockers prevent checkout. The route revalidates the assignment, blocked
+status, and dependency readiness under the same issue-row lock used for comment
+persistence. The write is treated as self-scoped and does not consume the
+cross-issue counter. Peer-issue comments, non-blocked targets, issue updates,
+and requests that resume or reopen the issue continue to fail closed without a
+source-issue run context. The normal checkout and unresolved-blocker rules are
+unchanged.
+
 Agent-authored issue comments persist the responsible user derived from the
 authenticated actor; clients cannot choose that attribution. Each comment also
 records the write-policy reason, and spoof attempts fail with an audited 422.

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -162,6 +162,66 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
+  it("allows an assigned blocked-issue comment from a valid unscoped heartbeat run", async () => {
+    const fake = counterDb(0, { contextSnapshot: {} });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueStatus: "blocked",
+      allowUnscopedAssignedBlockedComment: true,
+      kind: "comment",
+    })).resolves.toMatchObject({
+      allowed: true,
+      exemption: "unscoped_assigned_blocked_comment",
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("rejects an unscoped blocked-issue comment when the route did not prove it is comment-only", async () => {
+    const fake = counterDb(0, { contextSnapshot: {} });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueStatus: "blocked",
+      allowUnscopedAssignedBlockedComment: false,
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it.each([
+    ["a peer's blocked issue", "44444444-4444-4444-8444-444444444444", "blocked"],
+    ["the assignee's non-blocked issue", "33333333-3333-4333-8333-333333333333", "todo"],
+  ] as const)("keeps an unscoped heartbeat from commenting on %s", async (_label, assigneeAgentId, status) => {
+    const fake = counterDb(0, { contextSnapshot: {} });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueAssigneeAgentId: assigneeAgentId,
+      targetIssueStatus: status,
+      allowUnscopedAssignedBlockedComment: true,
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
   it.each([
     ["missing", null],
     ["wrong-agent", { agentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }],
@@ -174,6 +234,9 @@ describe("cross-issue influence limit rollout", () => {
       runId: "11111111-1111-4111-8111-111111111111",
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueStatus: "blocked",
+      allowUnscopedAssignedBlockedComment: true,
       kind: "comment",
     })).rejects.toMatchObject({
       status: 403,

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1326,6 +1326,104 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
+  it("attributes an assignee's blocked-issue comment as self-scoped for an unscoped heartbeat", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockObserveCrossIssueInfluence.mockResolvedValue({
+      allowed: true,
+      exemption: "unscoped_assigned_blocked_comment",
+    });
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: false,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Evidence acknowledged; blockers remain." });
+
+    expect(res.status).toBe(201);
+    expect(mockObserveCrossIssueInfluence).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        agentId: "22222222-2222-4222-8222-222222222222",
+        targetIssueId: "11111111-1111-4111-8111-111111111111",
+        targetIssueAssigneeAgentId: "22222222-2222-4222-8222-222222222222",
+        targetIssueStatus: "blocked",
+        allowUnscopedAssignedBlockedComment: true,
+        kind: "comment",
+      }),
+    );
+    expect(mockIssueService.getByIdForUpdate).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      mockTx,
+    );
+    expect(mockIssueService.getDependencyReadiness).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      mockTx,
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "Evidence acknowledged; blockers remain.",
+      expect.anything(),
+      expect.anything(),
+      mockTx,
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["reassigned", { ...makeIssue("blocked"), assigneeAgentId: "44444444-4444-4444-8444-444444444444" }],
+    ["no longer blocked", makeIssue("todo")],
+  ])("fails closed when an unscoped comment target is concurrently %s", async (_label, lockedIssue) => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getByIdForUpdate.mockResolvedValue(lockedIssue);
+    mockObserveCrossIssueInfluence.mockResolvedValue({
+      allowed: true,
+      exemption: "unscoped_assigned_blocked_comment",
+    });
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerIssueIds: ["33333333-3333-4333-8333-333333333333"],
+      unresolvedBlockerCount: 1,
+      allBlockersDone: false,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Evidence acknowledged; blockers remain." });
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("does not grant the unscoped comment path when a blocked issue has no unresolved blockers", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "11111111-1111-4111-8111-111111111111",
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "This issue can be checked out now." });
+
+    expect(res.status).toBe(201);
+    expect(mockObserveCrossIssueInfluence).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ allowUnscopedAssignedBlockedComment: false }),
+    );
+  });
+
   it("does not implicitly reopen a blocked issue via PATCH when the same request wires blockers", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2909,10 +2909,17 @@ export function issueRoutes(
   async function assertCrossIssueInfluenceWithinRunCap(
     req: Request,
     res: Response,
-    issue: { id: string; identifier?: string | null; companyId: string },
+    issue: {
+      id: string;
+      identifier?: string | null;
+      companyId: string;
+      assigneeAgentId?: string | null;
+      status?: string | null;
+    },
     kind: CrossIssueInfluenceKind,
+    options: { allowUnscopedAssignedBlockedComment?: boolean } = {},
   ) {
-    if (req.actor.type !== "agent") return true;
+    if (req.actor.type !== "agent") return { exemption: null };
     if (!req.actor.agentId || !req.actor.runId) throw crossIssueInfluenceRunContextError();
 
     // The counter transaction locks and validates the persisted run before it
@@ -2924,9 +2931,14 @@ export function issueRoutes(
       responsibleUserId: req.actor.onBehalfOfUserId ?? null,
       targetIssueId: issue.id,
       targetIssueIdentifier: issue.identifier ?? null,
+      targetIssueAssigneeAgentId: issue.assigneeAgentId ?? null,
+      targetIssueStatus: issue.status ?? null,
+      allowUnscopedAssignedBlockedComment: options.allowUnscopedAssignedBlockedComment === true,
       kind,
     });
-    if (!decision || decision.allowed) return true;
+    if (!decision) return { exemption: null };
+    if ("exemption" in decision) return { exemption: decision.exemption };
+    if (decision.allowed) return { exemption: null };
 
     const labels = await issueWriteDenialLabels(req, {
       identifier: issue.identifier ?? null,
@@ -12224,14 +12236,20 @@ export function issueRoutes(
         }) ||
         shouldResumeInProgressScheduledRetry);
     const hasUnresolvedFirstClassBlockers =
-      isBlocked && effectiveMoveToTodoRequested
+      isBlocked
         ? (await svc.getDependencyReadiness(issue.id)).unresolvedBlockerCount > 0
         : false;
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;
     }
-    if (!(await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "comment"))) return;
+    const influence = await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "comment", {
+      allowUnscopedAssignedBlockedComment:
+        isBlocked && hasUnresolvedFirstClassBlockers && !effectiveMoveToTodoRequested,
+    });
+    if (!influence) return;
+    const requiresUnscopedBlockedCommentFence =
+      influence.exemption === "unscoped_assigned_blocked_comment";
     // Reopen the closed isolated workspace only after every access, resume-intent,
     // blocker, and run-cap gate passes. A rejected comment must not rebuild and
     // republish the workspace as active, because the issue stays terminal and the
@@ -12497,18 +12515,38 @@ export function issueRoutes(
         requestedByActorId: actor.actorId,
       });
     } else {
-      comment = await svc.addComment(id, req.body.body, {
+      const commentActor = {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
         runId: actor.runId,
         onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
-      }, {
+      };
+      const commentOptions = {
         authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
         presentation: commentPresentation,
         metadata: req.body.metadata ?? null,
         authorizationReason: commentAuthorizationReason,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
-      });
+      };
+      if (requiresUnscopedBlockedCommentFence) {
+        comment = await db.transaction(async (tx) => {
+          const lockedIssue = await svc.getByIdForUpdate(id, tx);
+          if (
+            !lockedIssue ||
+            lockedIssue.status !== "blocked" ||
+            lockedIssue.assigneeAgentId !== actor.agentId
+          ) {
+            throw crossIssueInfluenceRunContextError();
+          }
+          const lockedReadiness = await svc.getDependencyReadiness(id, tx);
+          if (lockedReadiness.unresolvedBlockerCount < 1) {
+            throw crossIssueInfluenceRunContextError();
+          }
+          return svc.addComment(id, req.body.body, commentActor, commentOptions, tx);
+        });
+      } else {
+        comment = await svc.addComment(id, req.body.body, commentActor, commentOptions);
+      }
     }
 
     await issueReferencesSvc.syncComment(comment.id);

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -27,6 +27,11 @@ export type CrossIssueInfluenceDecision = {
   enforceAt: string;
 };
 
+export type CrossIssueInfluenceExemption = {
+  allowed: true;
+  exemption: "unscoped_assigned_blocked_comment";
+};
+
 export function crossIssueInfluenceRunContextError() {
   // Copy comes from the shared issue-write denial contract (the open cross-task write design (failure UX))
   // so the agent reading this 403 is told the fix, not just the refusal.
@@ -76,10 +81,13 @@ export async function observeCrossIssueInfluence(
     responsibleUserId?: string | null;
     targetIssueId: string;
     targetIssueIdentifier?: string | null;
+    targetIssueAssigneeAgentId?: string | null;
+    targetIssueStatus?: string | null;
+    allowUnscopedAssignedBlockedComment?: boolean;
     kind: CrossIssueInfluenceKind;
     now?: Date;
   },
-): Promise<CrossIssueInfluenceDecision | null> {
+): Promise<CrossIssueInfluenceDecision | CrossIssueInfluenceExemption | null> {
   // API-key callers control the run header. Reject malformed UUIDs before the
   // database can turn an untrusted identifier into a PostgreSQL cast error.
   if (!isUuidLike(input.runId)) throw crossIssueInfluenceRunContextError();
@@ -110,7 +118,20 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
+    if (!sourceIssueId) {
+      // Timer heartbeats have no source issue. Permit only the assignee's
+      // comment-only acknowledgement on an issue that stays blocked by an
+      // unresolved first-class dependency; the route proves both conditions.
+      const isAssignedBlockedIssueComment =
+        input.allowUnscopedAssignedBlockedComment === true &&
+        input.kind === "comment" &&
+        input.targetIssueStatus === "blocked" &&
+        input.targetIssueAssigneeAgentId === input.agentId;
+      if (isAssignedBlockedIssueComment) {
+        return { allowed: true, exemption: "unscoped_assigned_blocked_comment" };
+      }
+      throw crossIssueInfluenceRunContextError();
+    }
     if (
       sourceIssueId === input.targetIssueId ||
       (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -67,6 +67,23 @@ Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLI
 
 If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**
 
+**Assigned blocked-issue acknowledgment.** Checkout correctly rejects an issue
+that still has unresolved first-class blockers. When new evidence wakes you on
+an issue that is already `blocked`, assigned to you, and must remain blocked,
+acknowledge or triage it with a direct comment instead of retrying checkout:
+
+```
+POST /api/issues/{issueId}/comments
+Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+{ "body": "What the new evidence changes; the unresolved blocker and owner." }
+```
+
+This is a narrow comment-only path. Omit `resume`, `reopen`, status changes, and
+other issue mutation fields; the issue remains blocked. It is not authorization
+to resume deliverable work. Peer-issue comments and non-blocked targets still
+require a source-issue run context, and the normal checkout/blocker rules remain
+in force.
+
 **Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
 
 If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling the API. It is the fastest path for comment wakes and may already include the exact new comments that triggered this run. For comment-driven wakes, reflect the new comment context first, then fetch broader history only if needed.


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip uses heartbeat runs to attribute agent issue writes.
> - Timer heartbeats can start without a source issue in their persisted context.
> - An issue with unresolved first-class blockers correctly rejects checkout.
> - The assigned agent must still acknowledge new evidence while the issue stays blocked.
> - The cross-issue guard rejected that comment because the run had no source issue.
> - This pull request adds one comment-only exemption for the assigned blocked issue.
> - The benefit is correct attribution without weakening blocker, checkout, or cross-issue controls.

## Linked Issues or Issue Description

Refs #12118.
Refs #11852.
Refs #11975.

This change complements #12305 and #11466. Those changes require a successful checkout. Unresolved blockers correctly prevent checkout, so they do not cover this case.

**What happened?**

An unscoped timer heartbeat could not comment on an assigned issue that had unresolved first-class blockers. Checkout returned the correct blocker error. A direct comment then returned `403 cross_issue_influence_run_context_required` even with the valid current run header.

**Expected behavior**

The assignee can post a comment-only acknowledgment while the issue stays blocked. Peer comments, non-blocked targets, issue updates, and resume or reopen requests still fail closed.

**Steps to reproduce**

1. Start a timer heartbeat run with no `contextSnapshot.issueId` or `taskId`.
2. Assign a blocked issue with an unresolved first-class blocker to that agent.
3. Confirm that checkout rejects the issue because the blocker is unresolved.
4. Post a plain comment with the valid run header.
5. Observe `403 cross_issue_influence_run_context_required` on the base commit.

**Paperclip version or commit**

Reproduced on `master` at `4d82f5eae`.

**Deployment mode**

Self-hosted source deployment. The server path is deployment-mode independent.

## What Changed

- Allow a valid unscoped run to post a plain comment only when the target is assigned to that agent, is blocked, and has an unresolved first-class blocker.
- Return an explicit exemption classification and revalidate the issue under a row lock.
- Insert the comment in the same transaction as the final assignment, status, and readiness checks.
- Keep peer issues, non-blocked issues, invalid runs, updates, resume requests, reopen requests, and stale blocked issues fail-closed.
- Document the API path in the implementation specification and the Paperclip runtime skill.

## Verification

- `pnpm exec vitest run server/src/__tests__/cross-issue-influence-limit.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts` — 114 passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.
- Paperclip skill validation — passed.
- Independent code review — no remaining Critical or Important findings.
- The packaged server typecheck stops before TypeScript in this local environment because Rust `cargo` is not installed. The direct server TypeScript check passes. CI provides the complete toolchain.

## Risks

- Low authorization risk. The exemption is comment-only and requires the same authenticated agent, a blocked target, and an unresolved first-class blocker.
- The final state checks and comment insert use one transaction. A concurrent reassignment or status change fails closed before persistence.
- The route performs one additional dependency-readiness read for blocked comments.
- This pull request touches the same containment files as #12305. The behavior is complementary, but a rebase can require a small conflict resolution.

> This bug fix does not duplicate planned core work in `ROADMAP.md`.

## Model Used

- OpenAI Codex, GPT-5 family. The runtime did not expose the exact deployment ID or context-window size. High-reasoning mode, repository tools, shell execution, tests, and independent subagent review were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
