### PR TITLE
Ride out a cold auth stack in the release smoke bootstrap

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Test standalone package build concurrency
         run: node --test ./scripts/__tests__/build-standalone-concurrency.test.mjs
 
+      - name: Test release smoke admin bootstrap
+        run: node --test ./scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs
+
       - name: Validate release package manifest
         run: node ./scripts/release-package-map.mjs check
 

--- a/scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs
+++ b/scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const script = new URL("../docker-onboard-smoke.sh", import.meta.url).pathname;
+
+/**
+ * The admin bootstrap in `docker-onboard-smoke.sh`, exercised without Docker.
+ *
+ * `/api/health` answering 200 is not a promise that auth can serve a write: the
+ * container cold-installs paperclipai and brings up embedded postgres, and there
+ * is a window where health answers while a sign-up still fails. A single
+ * un-retried attempt in that window is what made the nightly release smoke flake
+ * — it failed on 2026-08-21, -23, -24, -26 and -27 while passing on the days
+ * between, on identical inputs.
+ *
+ * These tests drive the real functions out of the shipped script with a stubbed
+ * request helper. Extracting them rather than restating them keeps the test
+ * honest: a copy would drift from what actually runs in CI.
+ */
+
+const source = fs.readFileSync(script, "utf8");
+
+function extractFunction(name) {
+  // Anchored to the start of a line: a bare indexOf for `sign_up_or_sign_in() {`
+  // also matches inside `try_sign_up_or_sign_in() {`, which is defined first.
+  const marker = `\n${name}() {`;
+  const at = source.indexOf(marker);
+  assert.notEqual(at, -1, `${name} not found at column 0 in docker-onboard-smoke.sh`);
+  const start = at + 1;
+  const end = source.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `${name} has no closing brace at column 0`);
+  return source.slice(start, end + 3);
+}
+
+/**
+ * Runs the bootstrap against a scripted sequence of responses.
+ *
+ * Each entry in `attempts` is `[signUpStatus, signInStatus]` for one pass of the
+ * loop; "000" stands for curl failing to connect at all, which is what the
+ * server returns while it is still coming up — and which produces the empty
+ * body the real failures showed.
+ */
+function runBootstrap(attempts, { retrySeconds = 6 } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "smoke-bootstrap-"));
+  try {
+    const table = attempts.map((pair) => pair.join(" ")).join("\n");
+    fs.writeFileSync(path.join(dir, "responses"), `${table}\n`);
+
+    // The helper is called as `$(...)`, so a counter held in a shell variable
+    // would die with that subshell. It lives in a file for the same reason.
+    const harness = `
+set -uo pipefail
+TMP_DIR=${JSON.stringify(dir)}
+COUNTER="$TMP_DIR/attempt"
+echo 0 > "$COUNTER"
+PAPERCLIP_PUBLIC_URL="http://stub"
+SMOKE_ADMIN_NAME="Smoke Admin"
+SMOKE_ADMIN_EMAIL="smoke-admin@paperclip.local"
+SMOKE_ADMIN_PASSWORD="pw"
+SMOKE_BOOTSTRAP_RETRY_SECONDS=${retrySeconds}
+
+post_json_with_cookies() {
+  local url="$1" body="$2" out="$3"
+  local idx line code
+  idx="$(cat "$COUNTER")"
+  line="$(sed -n "$((idx + 1))p" "$TMP_DIR/responses")"
+  [[ -z "$line" ]] && line="000 000"
+  if [[ "$url" == *sign-up* ]]; then
+    code="\${line%% *}"
+    [[ "$code" =~ ^2 ]] && echo $((idx + 1)) > "$COUNTER"
+  else
+    code="\${line##* }"
+    echo $((idx + 1)) > "$COUNTER"
+  fi
+  if [[ "$code" == "000" ]]; then : > "$out"; else echo "{\\"stub\\":$code}" > "$out"; fi
+  printf '%s' "$code"
+}
+
+${extractFunction("try_sign_up_or_sign_in")}
+${extractFunction("sign_up_or_sign_in")}
+
+sign_up_or_sign_in
+`;
+    const started = Date.now();
+    const res = spawnSync("bash", ["-c", harness], { encoding: "utf8" });
+    return {
+      code: res.status,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+      elapsedMs: Date.now() - started,
+    };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("succeeds when sign-up works on the first attempt", () => {
+  const r = runBootstrap([["200", "000"]]);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /created admin user/);
+});
+
+test("falls back to sign-in for a data dir that already holds the admin", () => {
+  const r = runBootstrap([["409", "200"]]);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /signed in existing admin user/);
+});
+
+test("retries past an auth stack that is not up yet", () => {
+  // The flake: health answers, the first sign-ups cannot connect, and the
+  // stack is serving moments later. One attempt failed here; the loop rides it out.
+  const r = runBootstrap([
+    ["000", "000"],
+    ["000", "000"],
+    ["200", "000"],
+  ]);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /created admin user/);
+});
+
+test("retries a 5xx and then signs in", () => {
+  const r = runBootstrap([
+    ["000", "000"],
+    ["500", "500"],
+    ["409", "200"],
+  ]);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /signed in existing admin user/);
+});
+
+test("gives up at the deadline rather than hanging", () => {
+  const r = runBootstrap([["000", "000"]], { retrySeconds: 4 });
+  assert.equal(r.code, 1);
+  // Bounded on both sides: it must actually wait, and must not run away.
+  assert.ok(r.elapsedMs >= 4000, `gave up too early: ${r.elapsedMs}ms`);
+  assert.ok(r.elapsedMs < 30000, `overran the deadline: ${r.elapsedMs}ms`);
+});
+
+test("reports the HTTP status it saw, not just an empty body", () => {
+  // The reason this flake went a week without a diagnosis: the failure printed
+  // the response body, and a sign-up that never connected has none. The status
+  // was in hand the whole time and was not being surfaced.
+  const r = runBootstrap([["000", "000"]], { retrySeconds: 4 });
+  assert.match(r.stderr, /Sign-up HTTP 000/);
+  assert.match(r.stderr, /Sign-in HTTP 000/);
+  assert.match(r.stderr, /attempts over 4s/);
+});

--- a/scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs
+++ b/scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs
@@ -140,6 +140,17 @@ test("gives up at the deadline rather than hanging", () => {
   assert.ok(r.elapsedMs < 30000, `overran the deadline: ${r.elapsedMs}ms`);
 });
 
+test("bounds every request so the deadline can actually be reached", () => {
+  // The retry loop only checks its deadline between attempts. An unbounded curl
+  // that connects and then stalls never returns to be checked, so the job would
+  // run to its own 45-minute timeout printing nothing — strictly worse than the
+  // single-attempt failure this change replaced. Asserted on the script text
+  // because the harness above stubs the helper out.
+  const helper = extractFunction("post_json_with_cookies");
+  assert.match(helper, /--max-time/, "post_json_with_cookies must cap request duration");
+  assert.match(helper, /--connect-timeout/, "post_json_with_cookies must cap connect time");
+});
+
 test("reports the HTTP status it saw, not just an empty body", () => {
   // The reason this flake went a week without a diagnosis: the failure printed
   // the response body, and a sign-up that never connected has none. The status

--- a/scripts/docker-onboard-smoke.sh
+++ b/scripts/docker-onboard-smoke.sh
@@ -135,11 +135,19 @@ generate_bootstrap_invite_url() {
   printf '%s\n' "$invite_url"
 }
 
+# Seconds any single bootstrap request may take. Without this a connection that
+# is accepted and then stalls hangs curl forever: the retry loop below only
+# checks its deadline between attempts, so an unbounded call never returns to be
+# checked and the job runs to its own timeout printing nothing.
+SMOKE_REQUEST_TIMEOUT_SECONDS="${SMOKE_REQUEST_TIMEOUT_SECONDS:-20}"
+
 post_json_with_cookies() {
   local url="$1"
   local body="$2"
   local output_file="$3"
   curl -sS \
+    --connect-timeout 5 \
+    --max-time "$SMOKE_REQUEST_TIMEOUT_SECONDS" \
     -o "$output_file" \
     -w "%{http_code}" \
     -c "$COOKIE_JAR" \

--- a/scripts/docker-onboard-smoke.sh
+++ b/scripts/docker-onboard-smoke.sh
@@ -160,9 +160,24 @@ get_with_cookies() {
     "$url"
 }
 
-sign_up_or_sign_in() {
-  local signup_response="$TMP_DIR/signup.json"
-  local signup_status
+# Seconds to keep retrying the admin bootstrap after /api/health first answers.
+# `/api/health` returning 200 is not a promise that auth can serve a write: the
+# container cold-installs paperclipai and brings up embedded postgres, and there
+# is a window where health answers while a sign-up still fails. One un-retried
+# attempt in that window is what made the nightly smoke flake — it failed on
+# 2026-08-21, -23, -24, -26 and -27 while passing on the days in between, with
+# identical inputs.
+SMOKE_BOOTSTRAP_RETRY_SECONDS="${SMOKE_BOOTSTRAP_RETRY_SECONDS:-90}"
+
+# One sign-up, then one sign-in, reporting the status of each. Sign-in is the
+# path for a container whose data dir already holds the admin — including one
+# created by an earlier pass of the retry loop below, which is what makes the
+# pair safe to repeat.
+try_sign_up_or_sign_in() {
+  local signup_response="$1"
+  local signin_response="$2"
+  local signup_status signin_status
+
   signup_status="$(post_json_with_cookies \
     "$PAPERCLIP_PUBLIC_URL/api/auth/sign-up/email" \
     "{\"name\":\"$SMOKE_ADMIN_NAME\",\"email\":\"$SMOKE_ADMIN_EMAIL\",\"password\":\"$SMOKE_ADMIN_PASSWORD\"}" \
@@ -172,8 +187,6 @@ sign_up_or_sign_in() {
     return 0
   fi
 
-  local signin_response="$TMP_DIR/signin.json"
-  local signin_status
   signin_status="$(post_json_with_cookies \
     "$PAPERCLIP_PUBLIC_URL/api/auth/sign-in/email" \
     "{\"email\":\"$SMOKE_ADMIN_EMAIL\",\"password\":\"$SMOKE_ADMIN_PASSWORD\"}" \
@@ -183,11 +196,38 @@ sign_up_or_sign_in() {
     return 0
   fi
 
+  LAST_SIGNUP_STATUS="$signup_status"
+  LAST_SIGNIN_STATUS="$signin_status"
+  return 1
+}
+
+sign_up_or_sign_in() {
+  local signup_response="$TMP_DIR/signup.json"
+  local signin_response="$TMP_DIR/signin.json"
+  local deadline=$((SECONDS + SMOKE_BOOTSTRAP_RETRY_SECONDS))
+  local attempts=0
+
+  while :; do
+    attempts=$((attempts + 1))
+    if try_sign_up_or_sign_in "$signup_response" "$signin_response"; then
+      return 0
+    fi
+    if ((SECONDS >= deadline)); then
+      break
+    fi
+    sleep 2
+  done
+
+  # The statuses, not just the bodies. A failing sign-up here has historically
+  # returned an empty body — 000 when curl could not connect at all — so
+  # printing the body alone said nothing about what went wrong, which is why
+  # this flake went a week without a diagnosis.
   echo "Smoke bootstrap failed: could not sign up or sign in admin user" >&2
-  echo "Sign-up response:" >&2
+  echo "Gave up after $attempts attempts over ${SMOKE_BOOTSTRAP_RETRY_SECONDS}s." >&2
+  echo "Sign-up HTTP ${LAST_SIGNUP_STATUS:-<none>}, body:" >&2
   cat "$signup_response" >&2 || true
   echo >&2
-  echo "Sign-in response:" >&2
+  echo "Sign-in HTTP ${LAST_SIGNIN_STATUS:-<none>}, body:" >&2
   cat "$signin_response" >&2 || true
   echo >&2
   return 1


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - It ships as a versioned tenant image, promoted along a release train: canary → nightly → beta → stable
> - `publish_nightly` requires `smoke_nightly`, a job that starts the image in a container and bootstraps an admin over HTTP
> - That bootstrap has been failing about half the time for a week, on identical inputs, so the train stalled on every failing day
> - The cause is a race: `/api/health` answering 200 does not mean auth can serve a write yet, and the bootstrap made exactly one attempt inside that window
> - This pull request retries the attempt to a deadline, bounds each request, and prints the HTTP status the failure already knew
> - The benefit is that nightly images publish again, and the next failure says what went wrong

## Linked Issues or Issue Description

No existing issue. Describing it inline, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

The `smoke_nightly / smoke` job fails intermittently with `Smoke bootstrap failed: could not sign up or sign in admin user`. Because `publish_nightly` declares `needs: smoke_nightly`, each failure skips the publish and no nightly image is produced that day.

Observed on the scheduled nightly cuts:

| Aug 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 |
|---|---|---|---|---|---|---|---|
| pass | **fail** | pass | **fail** | **fail** | pass | **fail** | **fail** |

**Expected behavior**

The admin bootstrap succeeds, the smoke suite runs, and the nightly publishes.

**Paperclip version or commit**

`2026.827.0-canary.0`, built from `d785b1921`. The same failure occurs on earlier canaries; it is not specific to one build.

**Deployment mode**

`authenticated` / `private` — the mode `smoke_nightly` runs the container in, and the only mode in which the bootstrap runs at all.

**Steps to reproduce**

1. Run the `Release` workflow on `master` (scheduled, or dispatched with `channel=nightly`).
2. Observe `smoke_nightly / smoke`.
3. It fails on roughly half of runs with the same message and no further detail.

**Relevant logs or output**

```
Sign-up response:
Sign-in response: {"message":"Invalid email or password","code":"INVALID_EMAIL_OR_PASSWORD"}
Smoke bootstrap failed: could not sign up or sign in admin user
```

The sign-up body is empty because the request never connected. The sign-in that follows then correctly reports that no such user exists.

**Root cause**

`scripts/docker-onboard-smoke.sh` waits for `/api/health` and then calls `sign_up_or_sign_in`, which makes one sign-up attempt and one sign-in attempt. Health returning 200 is not a promise that auth can serve a write: the container cold-installs `paperclipai` from npm and brings up embedded postgres. A single attempt landing inside that window fails, and the script gives up.

`bootstrapStatus` in the health payload is not a usable readiness signal here. It is `ready` / `bootstrap_pending` and reports whether an instance admin exists, which on a fresh container is the state the bootstrap is trying to leave.

## What Changed

- `sign_up_or_sign_in` retries the sign-up/sign-in pair until `SMOKE_BOOTSTRAP_RETRY_SECONDS` (default 90) elapses. The pair is idempotent: sign-in already covers a data dir that holds the admin, including one created by an earlier pass.
- `post_json_with_cookies` bounds each request with `--max-time` and `--connect-timeout`. Without this, a connection that is accepted and then stalls hangs forever, because the loop only checks its deadline between attempts.
- The failure now prints the HTTP status of each call. The status was in hand the whole time and was never shown, so a week of failures printed `Sign-up response:` and a blank line.
- `scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs` — seven cases.
- `pr.yml` runs that suite. This repository lists its script-level `node:test` files one by one, so a new file does not run until it is added.

## Verification

- `node --test scripts/__tests__/docker-onboard-smoke-bootstrap.test.mjs` — 7/7 pass.
- `bash -n scripts/docker-onboard-smoke.sh` — clean.
- Fault injection, each reverted afterwards:
  - Remove the retry loop (the behaviour before this change): 3 tests fail.
  - Remove the status from the failure message: 1 test fails.
  - Remove the curl timeouts: 1 test fails.
  - Restore: 7 pass.
- The tests drive the real functions extracted from the shipped script with a stubbed request helper. They are extracted, not restated, so they cannot drift from what CI runs.
- **Not run against a real container.** This machine has no Docker. The logic is covered; the integration is not. CI is the first real exercise of the container path.

## Risks

Low. The change is limited to a bootstrap helper in a CI-only script. No product code reads it.

Two deliberate trade-offs:

- A real auth regression now takes up to 90 seconds to surface instead of failing at once. That is the cost of riding out a gate that has been wrong more often than right.
- Each request is capped at 20 seconds. A genuinely slow but working auth stack could now time out where it previously waited. 20 seconds is far above the normal response time for these endpoints.

Rollback is a straight revert. The smoke returns to failing about half the time.

Two other failures on the `Release` workflow are independent of this and remain: `verify_canary / General tests (server (2/3))` exits 1 on a leaked postgres connection whose write lands after teardown, with all 141 test files passing, and `Serialized tests (1/5)` fails on `spawn npm ENOENT`.

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking, with tool use: shell, file editing, and the GitHub CLI for the run-history analysis that identified the flake pattern.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
