### PR TITLE
fix(control): cancel queued runs when agents pause

### DIFF
--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -439,6 +439,32 @@ describe.sequential("agent cross-tenant route authorization", () => {
     expect(mockAgentService.clearError).not.toHaveBeenCalled();
   });
 
+  it("cancels queued and running work after an API pause", async () => {
+    const pausedAgent = {
+      ...baseAgent,
+      status: "paused",
+      pauseReason: "manual",
+      pausedAt: new Date("2026-04-11T00:06:00.000Z"),
+    };
+    mockAgentService.pause.mockResolvedValue(pausedAgent);
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: true,
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("paused");
+    expect(mockAgentService.pause).toHaveBeenCalledWith(agentId);
+    expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith(agentId);
+  });
+
   it("preserves board resume access", async () => {
     const pausedAgent = { ...baseAgent, status: "paused", pauseReason: "manual", pausedAt: new Date() };
     mockAgentService.getById.mockResolvedValue(pausedAgent);

--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -462,7 +462,11 @@ describe.sequential("agent cross-tenant route authorization", () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("paused");
     expect(mockAgentService.pause).toHaveBeenCalledWith(agentId);
-    expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith(agentId);
+    expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith(
+      agentId,
+      undefined,
+      pausedAgent.pausedAt,
+    );
   });
 
   it("preserves board resume access", async () => {

--- a/server/src/__tests__/agent-invokability.test.ts
+++ b/server/src/__tests__/agent-invokability.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   evaluateAgentInvokability,
   listInvalidOrgChainDescendantIds,
+  shouldCancelRunsForNonInvokableAgent,
   type AgentOrgRow,
 } from "../services/agent-invokability.ts";
 
@@ -65,5 +66,17 @@ describe("agent invokability", () => {
     ];
 
     expect(listInvalidOrgChainDescendantIds("ceo", rows).sort()).toEqual(["coder", "cto"]);
+  });
+
+  it("treats pause as a cancellation boundary instead of a deferred queue", () => {
+    const paused = [agent({ id: "coder", status: "paused" })];
+    const pendingApproval = [agent({ id: "candidate", status: "pending_approval" })];
+
+    expect(shouldCancelRunsForNonInvokableAgent(
+      evaluateAgentInvokability(paused[0], paused),
+    )).toBe(true);
+    expect(shouldCancelRunsForNonInvokableAgent(
+      evaluateAgentInvokability(pendingApproval[0], pendingApproval),
+    )).toBe(false);
   });
 });

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -221,6 +221,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     contextExtras?: Record<string, unknown>;
     invocationSource?: "assignment" | "automation";
     scheduledRetryReason?: string | null;
+    createdAt?: Date;
   }) {
     const wakeupRequestId = randomUUID();
     const runId = randomUUID();
@@ -233,6 +234,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       reason: input.wakeReason,
       payload: { issueId: input.issueId },
       status: "queued",
+      ...(input.createdAt ? { createdAt: input.createdAt, updatedAt: input.createdAt } : {}),
     });
     await db.insert(heartbeatRuns).values({
       id: runId,
@@ -248,6 +250,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
         wakeReason: input.wakeReason,
         ...(input.contextExtras ?? {}),
       },
+      ...(input.createdAt ? { createdAt: input.createdAt, updatedAt: input.createdAt } : {}),
     });
     await db
       .update(agentWakeupRequests)
@@ -1229,6 +1232,94 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       .then((rows) => rows[0] ?? null);
     expect(runAfterUnpause).toEqual({ status: "cancelled", errorCode: "agent_paused" });
     expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("does not let a stale paused-state cancellation drop work accepted after resume", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const staleIssueId = randomUUID();
+    const resumedIssueId = randomUUID();
+    const pauseBoundary = new Date("2026-08-27T18:00:00.000Z");
+    await db.insert(issues).values([
+      {
+        id: staleIssueId,
+        companyId,
+        title: "Pre-pause queued work",
+        status: "in_progress",
+        priority: "critical",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: resumedIssueId,
+        companyId,
+        title: "Post-resume queued work",
+        status: "in_progress",
+        priority: "critical",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    const stale = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId: staleIssueId,
+      wakeReason: "issue_continuation_needed",
+      invocationSource: "automation",
+      contextExtras: { retryReason: "issue_continuation_needed" },
+      createdAt: new Date(pauseBoundary.getTime() - 1_000),
+    });
+    await db
+      .update(agents)
+      .set({ status: "paused", pausedAt: pauseBoundary })
+      .where(eq(agents.id, agentId));
+    await db
+      .update(agents)
+      .set({ status: "idle", pausedAt: null })
+      .where(eq(agents.id, agentId));
+    const resumed = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId: resumedIssueId,
+      wakeReason: "issue_assigned",
+      createdAt: new Date(pauseBoundary.getTime() + 1_000),
+    });
+
+    await heartbeat.cancelActiveForAgent(agentId, undefined, pauseBoundary);
+
+    const [staleRun, staleWakeup, resumedRun, resumedWakeup] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, stale.runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, stale.wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, resumed.runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, resumed.wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+    expect(staleRun).toEqual({ status: "cancelled", errorCode: "agent_paused" });
+    expect(staleWakeup?.status).toBe("cancelled");
+    expect(resumedRun).toEqual({ status: "queued", errorCode: null });
+    expect(resumedWakeup?.status).toBe("queued");
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, resumed.runId))
+      .then((rows) => rows[0]?.status === "succeeded"));
+
+    expect(countExecuteCallsForRun(stale.runId)).toBe(0);
+    expect(countExecuteCallsForRun(resumed.runId)).toBe(1);
   });
 
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1169,6 +1169,68 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels a queued continuation while paused so a later unpause cannot revive it", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Paused owner continuation",
+      status: "in_progress",
+      priority: "critical",
+      assigneeAgentId: agentId,
+    });
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_continuation_needed",
+      invocationSource: "automation",
+      contextExtras: { retryReason: "issue_continuation_needed" },
+    });
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, agentId));
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]?.status === "cancelled"));
+
+    const [run, wakeup, issue] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ executionRunId: issues.executionRunId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+    expect(run).toEqual({ status: "cancelled", errorCode: "agent_paused" });
+    expect(wakeup?.status).toBe("cancelled");
+    expect(issue?.executionRunId).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+
+    await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agentId));
+    await heartbeat.resumeQueuedRuns();
+
+    const runAfterUnpause = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(runAfterUnpause).toEqual({ status: "cancelled", errorCode: "agent_paused" });
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4279,7 +4279,7 @@ export function agentRoutes(
       return;
     }
 
-    await heartbeat.cancelActiveForAgent(id);
+    await heartbeat.cancelActiveForAgent(id, undefined, agent.pausedAt ?? undefined);
 
     await logActivity(db, {
       companyId: agent.companyId,

--- a/server/src/services/agent-invokability.ts
+++ b/server/src/services/agent-invokability.ts
@@ -160,5 +160,11 @@ export function listInvalidOrgChainDescendantIds(
 }
 
 export function shouldCancelRunsForNonInvokableAgent(result: AgentInvokability) {
-  return !result.invokable && (result.reason === "terminated" || result.invalidOrgChain);
+  // A pause is a cancellation boundary, not a deferred queue. Keeping queued
+  // runs while paused would let stale work start silently after a later resume.
+  return !result.invokable && (
+    result.reason === "paused" ||
+    result.reason === "terminated" ||
+    result.invalidOrgChain
+  );
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14018,7 +14018,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const invokability = await getAgentInvokability(agent);
       if (!invokability.invokable) {
         if (shouldCancelRunsForNonInvokableAgent(invokability)) {
-          await cancelActiveForAgentInternal(agentId, `Cancelled because the agent is not invokable: ${invokability.reason}`);
+          await cancelActiveForAgentInternal(
+            agentId,
+            `Cancelled because the agent is not invokable: ${invokability.reason}`,
+            invokability.reason === "paused" ? "agent_paused" : "cancelled",
+          );
         }
         return [];
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14022,6 +14022,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             agentId,
             `Cancelled because the agent is not invokable: ${invokability.reason}`,
             invokability.reason === "paused" ? "agent_paused" : "cancelled",
+            invokability.reason === "paused" ? agent.pausedAt ?? undefined : undefined,
           );
         }
         return [];
@@ -19319,12 +19320,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return cancelled;
   }
 
-  async function cancelActiveForAgentInternal(agentId: string, reason = "Cancelled due to agent pause", errorCode = "cancelled") {
+  async function cancelActiveForAgentInternal(
+    agentId: string,
+    reason = "Cancelled due to agent pause",
+    errorCode = "cancelled",
+    createdAtLte?: Date,
+  ) {
+    // A pause cancellation can finish after the agent has resumed. Restrict it
+    // to work that existed at the observed pause boundary so it cannot cancel a
+    // newly valid run that was accepted after resume.
     const agent = await getAgent(agentId);
     const runs = await db
       .select()
       .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.agentId, agentId), inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES])));
+      .where(and(
+        eq(heartbeatRuns.agentId, agentId),
+        inArray(heartbeatRuns.status, [...CANCELLABLE_HEARTBEAT_RUN_STATUSES]),
+        createdAtLte ? lte(heartbeatRuns.createdAt, createdAtLte) : undefined,
+      ));
 
     for (const run of runs) {
       await setRunStatus(run.id, "cancelled", {
@@ -19834,7 +19847,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
      * agent pause route. For non-pause cancellations use cancelRun, or call the internal
      * cancelActiveForAgentInternal(agentId, reason, errorCode) with an explicit errorCode.
      */
-    cancelActiveForAgent: (agentId: string, reason?: string) => cancelActiveForAgentInternal(agentId, reason, "agent_paused"),
+    cancelActiveForAgent: (agentId: string, reason?: string, pauseBoundary?: Date) =>
+      cancelActiveForAgentInternal(agentId, reason, "agent_paused", pauseBoundary),
 
     cancelInvocationsForAgents: (agentIds: string[], reason: string) =>
       cancelInvocationsForAgentsInternal(agentIds, reason),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that manages AI-agent work.
> - The heartbeat service queues and starts agent runs.
> - A paused agent can still have queued or running work from before the pause.
> - That stale work must not start silently after the agent resumes.
> - A pause can race with a later resume, so cancellation must stop old work without dropping new work.
> - This pull request makes pause a cancellation boundary.
> - The benefit is explicit operator control and non-vacuous regression coverage.

## Linked Issues or Issue Description

**What happened?**

Pausing an agent did not cancel all queued runs. A later resume could make stale queued work eligible to start. The first revision then exposed a pause/resume race, because a stale paused-state observation could cancel newly valid work accepted after resume.

**Expected behavior**

Pausing an agent must cancel queued and running runs that existed at the pause boundary. The cancelled run and wake request must stay cancelled after resume. Work accepted after resume must stay eligible to run.

**Steps to reproduce**

1. Queue a continuation run for an active agent.
2. Pause the agent before the run starts.
3. Resume the agent and accept new queued work.
4. Let the earlier paused-state cancellation finish.
5. Confirm the pre-pause run remains cancelled and the post-resume run executes.

**Paperclip version or commit**

Reproduced before this change. This PR was replayed onto `origin/master` commit `a3b78f9d3494179a929570aca141edd503748bf7`. Current PR head is `e314fe65590a0959bdba2e59bafb89f19dcd6fdd`.

**Deployment mode**

Not deployment-specific. The behavior is in the server heartbeat control path.

## What Changed

- Treat a paused agent as a cancellation boundary for active and queued runs.
- Record `agent_paused` when pause causes cancellation.
- Pass the persisted pause timestamp into pause-route cancellation.
- Limit pause cancellation to runs created on or before the pause boundary.
- Preserve post-resume queued work when a stale pause cancellation finishes late.
- Add regression coverage for invokability, authorized API pause, queued-run cancellation, wake cancellation, lock release, post-resume durability, and the pause/resume interleaving.

## Verification

- Local Node `v24.20.0`: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-invokability.test.ts src/__tests__/agent-cross-tenant-authz-routes.test.ts src/__tests__/heartbeat-stale-queue-invalidation.test.ts` passed: 3 files, 44 tests.
- Local Node `v24.20.0`: `pnpm --filter @paperclipai/server typecheck` passed.
- Local `git diff --check origin/master...HEAD` passed.
- GitHub PR run `33213151253` passed the full required matrix at head `e314fe65590a0959bdba2e59bafb89f19dcd6fdd`, including `ci / verify`.
- Greptile passed on the current head with no blocking finding.

## Risks

- Low risk. The change only affects server control paths for non-invokable agents and pause cancellation.
- Cancellation now depends on the persisted pause timestamp when it exists.
- Legacy malformed paused rows without a timestamp keep the prior broad cancellation behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-family coding agent in Codex desktop, with repository tool use, shell execution, GitHub CLI, and high-reasoning code review. The exact serving model ID and context window were not exposed in the local shell.
- OpenAI `gpt-5.6-sol` performed the earlier release integration and pause/resume race remediation that this PR refreshes.
- Kimi performed the earlier independent review of the original pause-cancellation implementation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
