### PR TITLE
fix(adapter-utils): contain child stdin errors

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -486,6 +486,106 @@ describe("runChildProcess", () => {
     expect(finishedAt - startedAt).toBeGreaterThanOrEqual(spawnDelayMs);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "contains adapter stdin EPIPE when the child closes its pipe before a deferred write",
+    async () => {
+      let resolvePipeClosed!: () => void;
+      const pipeClosed = new Promise<void>((resolve) => {
+        resolvePipeClosed = resolve;
+      });
+      let resolveStdinError!: (code: string | undefined) => void;
+      const stdinError = new Promise<string | undefined>((resolve) => {
+        resolveStdinError = resolve;
+      });
+      let listenerCountBeforeObserver = -1;
+      const runId = randomUUID();
+      const result = await runChildProcess(
+        runId,
+        process.execPath,
+        [
+          "-e",
+          [
+            "process.stdin.once('close', () => {",
+            "  process.stdout.write('stdin-closed\\n');",
+            "  setTimeout(() => process.exit(0), 500);",
+            "});",
+            "process.stdin.destroy();",
+          ].join("\n"),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          stdin: "x".repeat(16 * 1024 * 1024),
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async (_stream, chunk) => {
+            if (chunk.includes("stdin-closed")) resolvePipeClosed();
+          },
+          onSpawn: async () => {
+            await pipeClosed;
+            const running = runningProcesses.get(runId);
+            const stdin = running?.child.stdin;
+            expect(stdin).toBeTruthy();
+            listenerCountBeforeObserver = stdin!.listenerCount("error");
+            stdin!.once("error", (err: NodeJS.ErrnoException) => {
+              resolveStdinError(err.code);
+            });
+          },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.timedOut).toBe(false);
+      expect(listenerCountBeforeObserver).toBeGreaterThan(0);
+      expect(await stdinError).toBe("EPIPE");
+    },
+  );
+
+  it("reports an unexpected adapter stdin error without throwing from the event handler", async () => {
+    const runId = randomUUID();
+    const loggedErrors: Array<{ err: unknown; id: string; message: string }> = [];
+    const expectedError = Object.assign(new Error("synthetic stdin failure"), { code: "EIO" });
+
+    const result = await runChildProcess(
+      runId,
+      process.execPath,
+      [
+        "-e",
+        "process.stdin.resume(); process.stdin.on('end', () => process.exit(0));",
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        stdin: "done",
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        onLogError: (err, id, message) => {
+          loggedErrors.push({ err, id, message });
+        },
+        onSpawn: async () => {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          const running = runningProcesses.get(runId);
+          const stdin = running?.child.stdin;
+          expect(stdin).toBeTruthy();
+          try {
+            stdin!.emit("error", expectedError);
+          } catch {
+            // The pre-fix implementation has no listener. Its synchronous throw
+            // is converted into the onSpawn rejection that this assertion catches.
+          }
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(loggedErrors).toContainEqual({
+      err: expectedError,
+      id: runId,
+      message: "adapter child stdin stream error",
+    });
+  });
+
   it.skipIf(process.platform === "win32")("kills descendant processes on timeout via the process group", async () => {
     let descendantPid: number | null = null;
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3386,6 +3386,16 @@ export async function runChildProcess(
           shell: false,
           stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
         }) as ChildProcessWithEvents;
+        const stdin = child.stdin;
+        if (opts.stdin != null && stdin) {
+          // Attach before onSpawn can await persistence. The child may close its
+          // pipe during that gap, and an unhandled stream error would terminate
+          // the control plane instead of failing only this adapter run.
+          stdin.on("error", (err: NodeJS.ErrnoException) => {
+            if (err.code === "EPIPE") return;
+            onLogError(err, runId, "adapter child stdin stream error");
+          });
+        }
         const startedAt = new Date().toISOString();
         const processGroupId = resolveProcessGroupId(child);
 
@@ -3500,10 +3510,9 @@ export async function runChildProcess(
             });
         });
 
-        const stdin = child.stdin;
         if (opts.stdin != null && stdin) {
           void spawnPersistPromise.finally(() => {
-            if (child.killed || stdin.destroyed) return;
+            if (child.killed || stdin.destroyed || !stdin.writable) return;
             stdin.write(opts.stdin as string);
             stdin.end();
           });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Adapter processes receive their prompt through a child stdin stream.
> - A child can close the stream before Paperclip writes the prompt.
> - Node emits `EPIPE` when Paperclip writes to the closed stream.
> - The stream had no early error listener, so Node could stop the full Paperclip server.
> - This pull request contains the stream error inside one adapter run.
> - The benefit is that one failed adapter process cannot stop other active runs.

## Linked Issues or Issue Description

- Fixes: #7755
- Refs: #6434
- Refs: #11943
- Refs: #7757

PR #7757 found the correct failure area. Its head branch is no longer available, so it cannot receive corrective commits. This replacement gives credit to that diagnosis and corrects the listener timing, non-`EPIPE` behavior, and test coverage.

## What Changed

- Attach the child stdin error listener immediately after `spawn()`.
- Ignore `EPIPE` as an expected closed-pipe lifecycle event.
- Send other stdin errors to the existing `onLogError` callback.
- Skip a deferred write when stdin is destroyed or is not writable.
- Add a causal regression test that closes the child pipe before the write and observes a real `EPIPE`.
- Add a regression test for a non-`EPIPE` stdin error.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts --testNamePattern 'adapter stdin EPIPE|unexpected adapter stdin error'`
  - Result: 2 passed.
- Deterministic RED/GREEN check.
  - Result without the implementation: exit 1. The test found zero existing stdin error listeners.
  - Result with the implementation: 2 passed. The test observed `EPIPE`.
- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts`
  - Result: 98 passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck`
  - Result: passed.
- `pnpm -r typecheck`
  - Result: passed.
- `pnpm build`
  - Result: passed.
- `pnpm test:run`
  - Result: 4,864 passed, 5 failed, and 9 skipped in 421 files.
  - All five failures are in `server/src/__tests__/workspace-runtime.test.ts`.
  - A clean `origin/master` worktree reproduced the same five failures.
  - The clean baseline failures are caused by generated `.paperclip/config.json` files that do not include newly required schema fields.
- Independent review.
  - Initial result: one P2 test-fidelity finding.
  - Final result after correction: PASS with no open finding.

## Risks

- Low risk. The change is limited to one child stdin stream and its tests.
- `EPIPE` no longer stops the server. The child exit status still determines the adapter result.
- Other stdin errors no longer stop the server. Paperclip reports them through the existing error callback.
- The real `EPIPE` test is skipped on Windows. The non-`EPIPE` containment test is platform neutral.
- No database, migration, API, telemetry, observability, or run-log contract changes are present.

## Model Used

- Provider: OpenAI Codex.
- Model: `gpt-5.6-sol`.
- Context window: the runtime did not expose the numeric size to this session.
- Reasoning mode: high reasoning effort.
- Capabilities: repository tools, GitHub CLI, terminal code execution, test execution, and independent read-only agent review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge