### PR TITLE
fix: surface owner decision at review cap

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -1246,6 +1246,15 @@ export interface RequestConfirmationSecretProposalPayload {
   expiresAt: string;
 }
 
+/** Server-owned binding for a review decision escalated at its round limit. */
+interface RequestConfirmationReviewEscalationPayload {
+  version: 1;
+  decisionId: string;
+  stageId: string;
+  reviewerAgentId: string;
+  responsibleUserId: string;
+}
+
 /**
  * Lifecycle status written back onto the resolved interaction once the operator
  * approves. `approve = run`, so the terminal states are executed/failed/expired —
@@ -1282,6 +1291,7 @@ export interface RequestConfirmationPayload {
   target?: RequestConfirmationTarget | null;
   toolAction?: RequestConfirmationToolActionPayload;
   secretProposal?: RequestConfirmationSecretProposalPayload;
+  reviewEscalation?: RequestConfirmationReviewEscalationPayload;
 }
 
 export interface RequestCheckboxConfirmationOption {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -1011,6 +1011,14 @@ export const requestConfirmationSecretProposalPayloadSchema = z.object({
   expiresAt: z.string().datetime({ offset: true }),
 });
 
+const requestConfirmationReviewEscalationPayloadSchema = z.object({
+  version: z.literal(1),
+  decisionId: z.string().guid(),
+  stageId: z.string().guid(),
+  reviewerAgentId: z.string().guid(),
+  responsibleUserId: z.string().trim().min(1).max(255),
+});
+
 export const requestConfirmationPayloadSchema = z.object({
   version: z.literal(1),
   prompt: z.string().trim().min(1).max(1000),
@@ -1025,6 +1033,7 @@ export const requestConfirmationPayloadSchema = z.object({
   target: requestConfirmationTargetSchema.nullable().optional(),
   toolAction: requestConfirmationToolActionPayloadSchema.optional(),
   secretProposal: requestConfirmationSecretProposalPayloadSchema.optional(),
+  reviewEscalation: requestConfirmationReviewEscalationPayloadSchema.optional(),
 });
 
 export const requestCheckboxConfirmationOptionSchema = z.object({

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -114,6 +114,7 @@ function registerModuleMocks() {
     }),
     issueThreadInteractionService: () => ({
       listForIssue: vi.fn(async () => []),
+      hasPendingReviewEscalationForIssue: vi.fn(async () => false),
       expirePendingInteractionsForTerminalIssue: vi.fn(async () => []),
       expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
       expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
@@ -660,7 +661,9 @@ describe("issue activity event routes", () => {
       updatedAt: new Date(),
     }));
 
-    const res = await request(await createApp())
+    const res = await request(await createApp({
+      transaction: async (callback: (tx: unknown) => Promise<unknown>) => callback({}),
+    }))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ executionPolicy: nextPolicy });
 

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -53,14 +53,18 @@ const mockDbSelectWhere = vi.hoisted(() => vi.fn(() => ({
 })));
 const mockDbSelectFrom = vi.hoisted(() => vi.fn(() => ({ where: mockDbSelectWhere })));
 const mockDbSelect = vi.hoisted(() => vi.fn(() => ({ from: mockDbSelectFrom })));
+const mockDbInsert = vi.hoisted(() => vi.fn(() => ({ values: vi.fn(async () => undefined) })));
 const mockDb = vi.hoisted(() => ({
   select: mockDbSelect,
-  transaction: vi.fn(async (callback: (tx: { select: typeof mockDbSelect }) => Promise<unknown>) =>
-    callback({ select: mockDbSelect })),
+  insert: mockDbInsert,
+  transaction: vi.fn(async (callback: (tx: { select: typeof mockDbSelect; insert: typeof mockDbInsert }) => Promise<unknown>) =>
+    callback({ select: mockDbSelect, insert: mockDbInsert })),
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  create: vi.fn(),
+  hasPendingReviewEscalationForIssue: vi.fn(async () => false),
   expirePendingInteractionsForTerminalIssue: vi.fn(async () => []),
   listForIssue: vi.fn(async () => []),
   expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
@@ -1010,6 +1014,7 @@ describe("issue execution policy routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      expect.anything(),
     );
     const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(updatePatch.status).toBeUndefined();
@@ -1137,6 +1142,281 @@ describe("issue execution policy routes", () => {
     expect(res.status).toBe(403);
     expect(res.body.error).toBe("Only the assignee agent or a board user can manage issue monitors");
     expect(mockIssueService.createChild).not.toHaveBeenCalled();
+  });
+
+  it("creates one durable owner decision interaction when a review cap is reached", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const executorAgentId = "44444444-4444-4444-8444-444444444444";
+    const policy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        participants: [{ type: "agent", agentId: reviewerAgentId }],
+      }],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: reviewerAgentId,
+      assigneeUserId: null,
+      responsibleUserId: "local-board",
+      createdByUserId: "local-board",
+      identifier: "PAP-1012",
+      title: "Capped review",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerAgentId },
+        returnAssignee: { type: "agent", agentId: executorAgentId },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockIssueThreadInteractionService.create.mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      kind: "request_confirmation",
+      status: "pending",
+    });
+    mockIssueService.addComment.mockResolvedValue({
+      id: "66666666-6666-4666-8666-666666666666",
+      body: "The migration still drops audit rows.",
+    });
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: reviewerAgentId,
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_progress", comment: "The migration still drops audit rows." });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueThreadInteractionService.create).toHaveBeenCalledTimes(1);
+    const escalatedPatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getByIdForUpdate.mockResolvedValue({ ...issue, ...escalatedPatch });
+    const stale = await request(await createApp({
+      type: "agent",
+      agentId: reviewerAgentId,
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_progress", comment: "The migration still drops audit rows." });
+    expect(stale.status).toBe(409);
+    expect(stale.body.error).toContain("active review stage changed");
+    expect(mockIssueThreadInteractionService.create).toHaveBeenCalledTimes(1);
+    expect(mockIssueThreadInteractionService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ id: issue.id, companyId: issue.companyId }),
+      expect.objectContaining({
+        kind: "request_confirmation",
+        idempotencyKey: expect.stringMatching(/^execution-review-escalation:/),
+        continuationPolicy: "wake_assignee",
+        resolverPolicy: "human_only",
+        title: "Review decision required",
+        payload: expect.objectContaining({
+          prompt: expect.stringContaining("Approve the reviewed work or return it to the executor"),
+          acceptLabel: "Approve reviewed work",
+          rejectRequiresReason: true,
+          supersedeOnUserComment: false,
+          detailsMarkdown: expect.stringContaining("The migration still drops audit rows."),
+          reviewEscalation: expect.objectContaining({
+            stageId: policy.stages[0].id,
+            reviewerAgentId,
+            responsibleUserId: "local-board",
+          }),
+        }),
+      }),
+      { allowReviewEscalationCreation: true },
+    );
+  });
+
+  it("requires the owner to resolve a capped review decision before editing its execution policy", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const executorAgentId = "44444444-4444-4444-8444-444444444444";
+    const policy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        participants: [{ type: "agent", agentId: reviewerAgentId }],
+      }],
+    })!;
+    const raisedCapPolicy = normalizeIssueExecutionPolicy({
+      ...policy,
+      maxReviewRounds: 2,
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      responsibleUserId: "local-board",
+      createdByUserId: "local-board",
+      identifier: "PAP-1013",
+      title: "Pending capped review",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: "local-board" },
+        returnAssignee: { type: "agent", agentId: executorAgentId },
+        completedStageIds: [],
+        changesRequestedCount: 1,
+        lastDecisionId: "22222222-2222-4222-8222-222222222222",
+        lastDecisionOutcome: "changes_requested",
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getByIdForUpdate.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockIssueThreadInteractionService.hasPendingReviewEscalationForIssue.mockResolvedValue(true);
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ executionPolicy: raisedCapPolicy });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("Resolve the capped review decision");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when an execution-policy edit sees a stale capped review stage", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const executorAgentId = "44444444-4444-4444-8444-444444444444";
+    const policy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [{
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "review",
+        participants: [{ type: "agent", agentId: reviewerAgentId }],
+      }],
+    })!;
+    const raisedCapPolicy = normalizeIssueExecutionPolicy({
+      ...policy,
+      maxReviewRounds: 2,
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      responsibleUserId: "local-board",
+      createdByUserId: "local-board",
+      identifier: "PAP-1014",
+      title: "Stale capped review",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: "local-board" },
+        returnAssignee: { type: "agent", agentId: executorAgentId },
+        completedStageIds: [],
+        changesRequestedCount: 1,
+        lastDecisionId: "22222222-2222-4222-8222-222222222222",
+        lastDecisionOutcome: "changes_requested",
+      },
+    };
+    const concurrentIssue = {
+      ...issue,
+      assigneeAgentId: reviewerAgentId,
+      assigneeUserId: null,
+      executionState: {
+        ...issue.executionState,
+        currentParticipant: { type: "agent" as const, agentId: reviewerAgentId },
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getByIdForUpdate.mockResolvedValue(concurrentIssue);
+    mockIssueThreadInteractionService.hasPendingReviewEscalationForIssue.mockResolvedValue(false);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ executionPolicy: raisedCapPolicy });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("active review stage changed");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a concurrent execution-policy edit changed a transitionless issue", async () => {
+    const stage = {
+      id: "11111111-1111-4111-8111-111111111111",
+      type: "review" as const,
+      participants: [{ type: "agent" as const, agentId: "33333333-3333-4333-8333-333333333333" }],
+    };
+    const existingPolicy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [stage],
+    })!;
+    const requestedPolicy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 2,
+      stages: [stage],
+    })!;
+    const concurrentPolicy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 3,
+      stages: [stage],
+    })!;
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      responsibleUserId: "local-board",
+      createdByUserId: "local-board",
+      identifier: "PAP-1015",
+      title: "Concurrent policy edit",
+      executionPolicy: existingPolicy,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getByIdForUpdate.mockResolvedValue({
+      ...issue,
+      executionPolicy: concurrentPolicy,
+    });
+    mockIssueThreadInteractionService.hasPendingReviewEscalationForIssue.mockResolvedValue(false);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ executionPolicy: requestedPolicy });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("execution policy changed");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("normalizes spoofed child monitor scheduledBy to the assignee actor", async () => {

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -1897,6 +1897,12 @@ describe("review round circuit breaker", () => {
       currentParticipant: { type: "user", userId: boardUserId },
       changesRequestedCount: 3,
     });
+    expect(result.reviewEscalation).toEqual({
+      stageId: reviewStageId,
+      reviewerAgentId: qaAgentId,
+      responsibleUserId: boardUserId,
+      reason: "Round three feedback — still not converging",
+    });
   });
 
   it("keeps the escalated hold sticky across unrelated transitions", () => {
@@ -2001,6 +2007,74 @@ describe("review round circuit breaker", () => {
       status: "changes_requested",
       changesRequestedCount: 0,
     });
+  });
+
+  it("allows a later agent review to start a new capped escalation after the human resets rounds", () => {
+    const strictPolicy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [{ type: "review", participants: [{ type: "agent", agentId: qaAgentId }] }],
+    })!;
+    const stageId = strictPolicy.stages[0].id;
+    const heldIssue = {
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: boardUserId,
+      responsibleUserId: boardUserId,
+      executionPolicy: strictPolicy,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review" as const,
+        currentParticipant: { type: "user" as const, userId: boardUserId },
+        returnAssignee: { type: "agent" as const, agentId: coderAgentId },
+        completedStageIds: [],
+        changesRequestedCount: 1,
+        lastDecisionId: null,
+        lastDecisionOutcome: "changes_requested" as const,
+      },
+    };
+    const humanReturn = applyIssueExecutionPolicyTransition({
+      issue: heldIssue,
+      policy: strictPolicy,
+      requestedStatus: "in_progress",
+      requestedAssigneePatch: {},
+      actor: { userId: boardUserId },
+      commentBody: "Make the requested correction.",
+    });
+    const afterHumanReturn = { ...heldIssue, ...humanReturn.patch };
+    expect(afterHumanReturn.executionState).toMatchObject({ changesRequestedCount: 0 });
+
+    const resubmission = applyIssueExecutionPolicyTransition({
+      issue: afterHumanReturn,
+      policy: strictPolicy,
+      requestedStatus: "done",
+      requestedAssigneePatch: {},
+      actor: { agentId: coderAgentId },
+      commentBody: "Correction completed.",
+    });
+    const nextReview = { ...afterHumanReturn, ...resubmission.patch };
+    expect(nextReview.executionState).toMatchObject({
+      changesRequestedCount: 0,
+      currentParticipant: { type: "agent", agentId: qaAgentId },
+    });
+
+    const laterEscalation = applyIssueExecutionPolicyTransition({
+      issue: nextReview,
+      policy: strictPolicy,
+      requestedStatus: "in_progress",
+      requestedAssigneePatch: {},
+      actor: { agentId: qaAgentId },
+      commentBody: "A distinct later review reason.",
+    });
+
+    expect(laterEscalation.reviewEscalation).toMatchObject({
+      stageId,
+      reviewerAgentId: qaAgentId,
+      responsibleUserId: boardUserId,
+      reason: "A distinct later review reason.",
+    });
+    expect(laterEscalation.patch.executionState).toMatchObject({ changesRequestedCount: 1 });
   });
 
   it("lets the escalated human approve the stage", () => {

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -35,6 +35,7 @@ const mockInteractionService = vi.hoisted(() => ({
   acceptSuggestedTasks: vi.fn(),
   rejectInteraction: vi.fn(),
   rejectSuggestedTasks: vi.fn(),
+  resolveReviewEscalation: vi.fn(),
   expireRequestConfirmationsSupersededByHistoricalComments: vi.fn(),
   expirePendingInteractionsForTerminalIssue: vi.fn(),
   answerQuestions: vi.fn(),
@@ -712,6 +713,30 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockInteractionService.create).not.toHaveBeenCalled();
   });
 
+  it("rejects client-supplied capped-review escalation metadata", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post(`/api/issues/${ISSUE_ID}/interactions`)
+      .send({
+        kind: "request_confirmation",
+        payload: {
+          version: 1,
+          prompt: "Approve this review?",
+          reviewEscalation: {
+            version: 1,
+            decisionId: "11111111-1111-4111-8111-111111111111",
+            stageId: "22222222-2222-4222-8222-222222222222",
+            reviewerAgentId: CREATED_AGENT_ID,
+            responsibleUserId: "local-board",
+          },
+        },
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("server-owned metadata");
+    expect(mockInteractionService.create).not.toHaveBeenCalled();
+  });
+
   it("accepts suggested tasks and wakes created assignees plus the current assignee", async () => {
     const app = await createApp();
 
@@ -1017,6 +1042,109 @@ describe.sequential("issue thread interaction routes", () => {
     );
     expect(mockHeartbeatService.wakeup.mock.calls[0]?.[1]?.payload).not.toHaveProperty("toolAction");
     expect(mockHeartbeatService.wakeup.mock.calls[0]?.[1]?.contextSnapshot).not.toHaveProperty("toolAction");
+  });
+
+  it("returns a capped review to the executor and wakes that agent", async () => {
+    const interaction = {
+      id: "interaction-review-cap",
+      companyId: "company-1",
+      issueId: ISSUE_ID,
+      kind: "request_confirmation" as const,
+      status: "pending" as const,
+      continuationPolicy: "wake_assignee" as const,
+      requestedResolverPolicy: "human_only" as const,
+      effectiveResolverPolicy: "human_only" as const,
+      payload: {
+        version: 1 as const,
+        prompt: "The review round limit was reached.",
+        rejectRequiresReason: true,
+        reviewEscalation: {
+          version: 1 as const,
+          decisionId: "11111111-1111-4111-8111-111111111111",
+          stageId: "22222222-2222-4222-8222-222222222222",
+          reviewerAgentId: CREATED_AGENT_ID,
+          responsibleUserId: "local-board",
+        },
+      },
+      result: null,
+    };
+    mockInteractionService.getForIssue.mockResolvedValue(interaction);
+    mockInteractionService.resolveReviewEscalation.mockResolvedValue({
+      interaction: {
+        ...interaction,
+        status: "rejected",
+        result: { version: 1, outcome: "rejected", reason: "Preserve audit records." },
+      },
+      issue: {
+        id: ISSUE_ID,
+        assigneeAgentId: ASSIGNEE_AGENT_ID,
+        assigneeUserId: null,
+        status: "in_progress",
+      },
+    });
+
+    const res = await request(await createApp())
+      .post(`/api/issues/${ISSUE_ID}/interactions/${interaction.id}/reject`)
+      .send({ reason: "Preserve audit records." });
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.resolveReviewEscalation).toHaveBeenCalledWith(expect.objectContaining({
+      issue: { id: ISSUE_ID, companyId: "company-1" },
+      interactionId: interaction.id,
+      outcome: "changes_requested",
+      reason: "Preserve audit records.",
+      actor: expect.objectContaining({ userId: "local-board" }),
+    }));
+    expect(mockInteractionService.rejectInteraction).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionId: interaction.id, interactionStatus: "rejected" }),
+      }),
+    );
+  });
+
+  it("approves a capped review through the real review decision resolver", async () => {
+    const interaction = {
+      id: "interaction-review-cap-approve",
+      companyId: "company-1",
+      issueId: ISSUE_ID,
+      kind: "request_confirmation" as const,
+      status: "pending" as const,
+      continuationPolicy: "wake_assignee" as const,
+      requestedResolverPolicy: "human_only" as const,
+      effectiveResolverPolicy: "human_only" as const,
+      payload: {
+        version: 1 as const,
+        prompt: "The review round limit was reached.",
+        reviewEscalation: {
+          version: 1 as const,
+          decisionId: "11111111-1111-4111-8111-111111111111",
+          stageId: "22222222-2222-4222-8222-222222222222",
+          reviewerAgentId: CREATED_AGENT_ID,
+          responsibleUserId: "local-board",
+        },
+      },
+      result: null,
+    };
+    mockInteractionService.getForIssue.mockResolvedValue(interaction);
+    mockInteractionService.resolveReviewEscalation.mockResolvedValue({
+      interaction: { ...interaction, status: "accepted", result: { version: 1, outcome: "accepted" } },
+      issue: { id: ISSUE_ID, assigneeAgentId: null, assigneeUserId: "local-board", status: "done" },
+    });
+
+    const res = await request(await createApp())
+      .post(`/api/issues/${ISSUE_ID}/interactions/${interaction.id}/accept`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.resolveReviewEscalation).toHaveBeenCalledWith(expect.objectContaining({
+      issue: { id: ISSUE_ID, companyId: "company-1" },
+      interactionId: interaction.id,
+      outcome: "approved",
+      actor: expect.objectContaining({ userId: "local-board" }),
+    }));
+    expect(mockInteractionService.acceptInteraction).not.toHaveBeenCalled();
   });
 
   it("executes an accepted tool-action confirmation through the gateway callback", async () => {

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -13,6 +13,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueExecutionDecisions,
   instanceSettings,
   issueRelations,
   issueThreadInteractions,
@@ -30,6 +31,7 @@ import { instanceSettingsService } from "../services/instance-settings.js";
 import { issueService } from "../services/issues.js";
 import { issueThreadInteractionService } from "../services/issue-thread-interactions.js";
 import { agentService } from "../services/agents.js";
+import { normalizeIssueExecutionPolicy } from "../services/issue-execution-policy.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -1288,6 +1290,77 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     expect(interactions.find((interaction) => interaction.id === otherKind.id)?.status).toBe("pending");
   });
 
+  it("keeps a capped review decision pending when the reviewer creates a newer confirmation", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Durable review escalation");
+    const reviewerAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: reviewerAgentId,
+      companyId,
+      name: "Reviewer",
+      role: "reviewer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const escalation = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      idempotencyKey: "review-escalation:decision-1",
+      resolverPolicy: "human_only",
+      payload: {
+        version: 1,
+        prompt: "Review round limit reached. Approve this review stage or request changes.",
+        reviewEscalation: {
+          version: 1,
+          decisionId: randomUUID(),
+          stageId: randomUUID(),
+          reviewerAgentId,
+          responsibleUserId: "local-board",
+        },
+      },
+    }, { agentId: reviewerAgentId, allowReviewEscalationCreation: true });
+
+    const ordinaryConfirmation = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      idempotencyKey: "reviewer:ordinary-confirmation",
+      payload: { version: 1, prompt: "Approve the ordinary request?" },
+    }, { agentId: reviewerAgentId });
+
+    expect(await interactionsSvc.hasPendingReviewEscalationForIssue({ id: issueId, companyId })).toBe(true);
+
+    const afterCreation = await interactionsSvc.listForIssue(issueId);
+    expect(afterCreation.find((interaction) => interaction.id === escalation.id)?.status).toBe("pending");
+    expect(afterCreation.find((interaction) => interaction.id === ordinaryConfirmation.id)?.status).toBe("pending");
+
+    await expect(interactionsSvc.sweepSupersededPendingRequestConfirmations())
+      .resolves.toEqual({ expired: 0 });
+    const afterSweep = await interactionsSvc.listForIssue(issueId);
+    expect(afterSweep.find((interaction) => interaction.id === escalation.id)?.status).toBe("pending");
+  });
+
+  it("rejects public creation of server-owned capped-review metadata", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Protected review escalation");
+
+    await expect(interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Forged capped review",
+        reviewEscalation: {
+          version: 1,
+          decisionId: randomUUID(),
+          stageId: randomUUID(),
+          reviewerAgentId: randomUUID(),
+          responsibleUserId: "local-board",
+        },
+      },
+    } as never, { userId: "local-board" })).rejects.toThrow("payload.reviewEscalation is server-owned metadata");
+
+    await expect(interactionsSvc.listForIssue(issueId)).resolves.toHaveLength(0);
+  });
+
   it("supersedes an agent's own older pending ask_user_questions without crossing agent, kind, or issue", async () => {
     const { companyId, goalId, issueId } = await seedConfirmationIssue("Question supersedes older sibling");
     const otherIssueId = randomUUID();
@@ -1680,6 +1753,190 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     }, requiresReason.id, {}, {
       userId: "local-board",
     })).rejects.toThrow("A decline reason is required for this confirmation");
+  });
+
+  it.each([
+    {
+      action: "approves",
+      outcome: "approved" as const,
+      reason: undefined,
+      interactionStatus: "accepted",
+      issueStatus: "done",
+      executionStatus: "completed",
+      assignee: null,
+      assigneeUserId: "local-board",
+    },
+    {
+      action: "returns work",
+      outcome: "changes_requested" as const,
+      reason: "Please preserve the audit records.",
+      interactionStatus: "rejected",
+      issueStatus: "in_progress",
+      executionStatus: "changes_requested",
+      assignee: "executor",
+      assigneeUserId: null,
+    },
+  ])("$action a capped review through its owner interaction", async ({
+    outcome,
+    reason,
+    interactionStatus,
+    issueStatus,
+    executionStatus,
+    assignee,
+    assigneeUserId,
+  }) => {
+    const { companyId, issueId } = await seedConfirmationIssue("Capped review decision");
+    const reviewerAgentId = randomUUID();
+    const executorAgentId = randomUUID();
+    const stageId = randomUUID();
+    const escalationDecisionId = randomUUID();
+    const interactionId = randomUUID();
+    const ownerUserId = "local-board";
+    const policy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [{ id: stageId, type: "review", participants: [{ type: "agent", agentId: reviewerAgentId }] }],
+    })!;
+
+    await db.insert(agents).values([
+      {
+        id: reviewerAgentId,
+        companyId,
+        name: "Reviewer",
+        role: "reviewer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: executorAgentId,
+        companyId,
+        name: "Executor",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.update(issues).set({
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: ownerUserId,
+      responsibleUserId: ownerUserId,
+      executionPolicy: policy as unknown as Record<string, unknown>,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: ownerUserId },
+        returnAssignee: { type: "agent", agentId: executorAgentId },
+        completedStageIds: [],
+        lastDecisionId: escalationDecisionId,
+        lastDecisionOutcome: "changes_requested",
+        changesRequestedCount: 1,
+      },
+    }).where(eq(issues.id, issueId));
+    await db.insert(issueExecutionDecisions).values({
+      id: escalationDecisionId,
+      companyId,
+      issueId,
+      stageId,
+      stageType: "review",
+      actorAgentId: reviewerAgentId,
+      outcome: "changes_requested",
+      body: "The data migration drops audit records.",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      requestedResolverPolicy: "human_only",
+      effectiveResolverPolicy: "human_only",
+      payload: {
+        version: 1,
+        prompt: "The review round limit was reached.",
+        rejectRequiresReason: true,
+        supersedeOnUserComment: false,
+        reviewEscalation: {
+          version: 1,
+          decisionId: escalationDecisionId,
+          stageId,
+          reviewerAgentId,
+          responsibleUserId: ownerUserId,
+        },
+      },
+    });
+
+    const resolved = await interactionsSvc.resolveReviewEscalation({
+      issue: { id: issueId, companyId },
+      interactionId,
+      outcome,
+      reason,
+      actor: { userId: ownerUserId },
+    });
+
+    expect(resolved.interaction).toMatchObject({
+      id: interactionId,
+      status: interactionStatus,
+      resolvedByUserId: ownerUserId,
+      result: outcome === "changes_requested"
+        ? { outcome: "rejected", reason }
+        : { outcome: "accepted" },
+    });
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(updatedIssue).toMatchObject({
+      status: issueStatus,
+      assigneeAgentId: assignee === "executor" ? executorAgentId : null,
+      assigneeUserId,
+      executionState: expect.objectContaining({ status: executionStatus, changesRequestedCount: 0 }),
+    });
+    const decisions = await db
+      .select()
+      .from(issueExecutionDecisions)
+      .where(eq(issueExecutionDecisions.issueId, issueId));
+    expect(decisions).toHaveLength(2);
+    expect(decisions.find((decision) => decision.id !== escalationDecisionId)).toMatchObject({
+      actorUserId: ownerUserId,
+      outcome,
+      body: outcome === "changes_requested" ? reason : "Approved through the review decision interaction.",
+    });
+  });
+
+  it("keeps a capped review interaction pending until the owner decides", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Durable capped review");
+    const created = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      resolverPolicy: "human_only",
+      payload: {
+        version: 1,
+        prompt: "The review round limit was reached.",
+        supersedeOnUserComment: false,
+        reviewEscalation: {
+          version: 1,
+          decisionId: randomUUID(),
+          stageId: randomUUID(),
+          reviewerAgentId: randomUUID(),
+          responsibleUserId: "local-board",
+        },
+      },
+    }, { userId: "local-board", allowReviewEscalationCreation: true });
+
+    const expired = await interactionsSvc.expireRequestConfirmationsSupersededByComment({ id: issueId, companyId }, {
+      id: randomUUID(),
+      createdAt: new Date(new Date(created.createdAt).getTime() + 1_000),
+      authorUserId: "local-board",
+    }, { userId: "local-board" });
+    expect(expired).toEqual([]);
+    await expect(interactionsSvc.withdrawInteraction({ id: issueId, companyId }, created.id, {}, {
+      userId: "local-board",
+    })).rejects.toThrow("must be approved or returned to the executor");
   });
 
   it("records an authorized agent as the review-confirmation resolver", async () => {

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -6,18 +6,21 @@ import { and, eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
+  agentRuntimeState,
   agentWakeupRequests,
   agents,
   approvals,
   assets,
   companies,
   companyMemberships,
+  companySkills,
   costEvents,
   createDb,
   executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
   issueAttachments,
+  issueExecutionDecisions,
   issueComments,
   issueRelations,
   issueThreadInteractions,
@@ -32,6 +35,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { buildHostServices } from "../services/plugin-host-services.js";
 import { heartbeatService } from "../services/heartbeat.js";
+import { normalizeIssueExecutionPolicy } from "../services/issue-execution-policy.js";
 import { drainHeartbeatRunsToQuiescence } from "./helpers/drain-heartbeat-runs.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -119,6 +123,8 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     await db.delete(projects);
     await db.delete(plugins);
     await db.delete(companyMemberships);
+    await db.delete(companySkills);
+    await db.delete(agentRuntimeState);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -978,6 +984,183 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     });
     return interactionId;
   }
+
+  async function seedCappedReviewEscalation() {
+    const { companyId, agentId: executorAgentId } = await seedCompanyAndAgent();
+    const reviewerAgentId = randomUUID();
+    const ownerUserId = randomUUID();
+    const issueId = randomUUID();
+    const stageId = randomUUID();
+    const decisionId = randomUUID();
+    const interactionId = randomUUID();
+    const policy = normalizeIssueExecutionPolicy({
+      maxReviewRounds: 1,
+      stages: [{ id: stageId, type: "review", participants: [{ type: "agent", agentId: reviewerAgentId }] }],
+    })!;
+    await db.insert(agents).values({
+      id: reviewerAgentId,
+      companyId,
+      name: "Reviewer",
+      role: "reviewer",
+      status: "active",
+      adapterType: "process",
+      adapterConfig: { command: "true" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: ownerUserId,
+      status: "active",
+      membershipRole: "owner",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Capped review",
+      status: "in_review",
+      priority: "medium",
+      assigneeUserId: ownerUserId,
+      responsibleUserId: ownerUserId,
+      executionPolicy: policy as never,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: ownerUserId },
+        returnAssignee: { type: "agent", agentId: executorAgentId },
+        completedStageIds: [],
+        changesRequestedCount: 1,
+        lastDecisionId: decisionId,
+        lastDecisionOutcome: "changes_requested",
+      },
+    });
+    await db.insert(issueExecutionDecisions).values({
+      id: decisionId,
+      companyId,
+      issueId,
+      stageId,
+      stageType: "review",
+      actorAgentId: reviewerAgentId,
+      outcome: "changes_requested",
+      body: "The audit record is missing.",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      requestedResolverPolicy: "human_only",
+      effectiveResolverPolicy: "human_only",
+      payload: {
+        version: 1,
+        prompt: "Review round limit reached.",
+        rejectRequiresReason: true,
+        reviewEscalation: {
+          version: 1,
+          decisionId,
+          stageId,
+          reviewerAgentId,
+          responsibleUserId: ownerUserId,
+        },
+      },
+    });
+    return { companyId, executorAgentId, ownerUserId, issueId, interactionId };
+  }
+
+  it("createInteraction rejects forged capped-review metadata from a plugin", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId, companyId, title: "Decision", status: "in_review", priority: "medium", assigneeAgentId: agentId,
+    });
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.gateway", createEventBusStub());
+
+    await expect(services.issues.createInteraction({
+      issueId,
+      companyId,
+      authorAgentId: agentId,
+      interaction: {
+        kind: "request_confirmation",
+        payload: {
+          version: 1,
+          prompt: "Forged capped review",
+          reviewEscalation: {
+            version: 1,
+            decisionId: randomUUID(),
+            stageId: randomUUID(),
+            reviewerAgentId: agentId,
+            responsibleUserId: "local-board",
+          },
+        },
+      } as never,
+    })).rejects.toThrow("payload.reviewEscalation is server-owned metadata");
+
+    await expect(db.select().from(issueThreadInteractions)).resolves.toHaveLength(0);
+  });
+
+  it.each([
+    { action: "accept" as const, reason: undefined, interactionStatus: "accepted", issueStatus: "done", assigneeAgentId: null },
+    { action: "reject" as const, reason: "Restore the audit record.", interactionStatus: "rejected", issueStatus: "in_progress", assigneeAgentId: "executor" },
+  ])("respondInteraction applies the capped review $action through the execution-policy decision", async ({
+    action,
+    reason,
+    interactionStatus,
+    issueStatus,
+    assigneeAgentId,
+  }) => {
+    const fixture = await seedCappedReviewEscalation();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.gateway", createEventBusStub());
+
+    const result = await services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action,
+      ...(reason ? { reason } : {}),
+      actorUserId: fixture.ownerUserId,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.interaction).toMatchObject({ status: interactionStatus });
+    const [issue] = await db.select().from(issues).where(eq(issues.id, fixture.issueId));
+    expect(issue).toMatchObject({
+      status: issueStatus,
+      assigneeAgentId: assigneeAgentId === "executor" ? fixture.executorAgentId : null,
+      executionState: expect.objectContaining({ changesRequestedCount: 0 }),
+    });
+    const decisions = await db.select().from(issueExecutionDecisions).where(eq(issueExecutionDecisions.issueId, fixture.issueId));
+    expect(decisions).toHaveLength(2);
+    expect(decisions.some((decision) => decision.actorUserId === fixture.ownerUserId)).toBe(true);
+  });
+
+  it("respondInteraction keeps a capped review pending for a non-responsible human", async () => {
+    const fixture = await seedCappedReviewEscalation();
+    const otherUserId = randomUUID();
+    await db.insert(companyMemberships).values({
+      companyId: fixture.companyId,
+      principalType: "user",
+      principalId: otherUserId,
+      status: "active",
+      membershipRole: "owner",
+    });
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.gateway", createEventBusStub());
+
+    await expect(services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: otherUserId,
+    })).rejects.toThrow("Only the responsible user can resolve this review escalation");
+
+    const [interaction] = await db.select().from(issueThreadInteractions).where(eq(issueThreadInteractions.id, fixture.interactionId));
+    expect(interaction?.status).toBe("pending");
+  });
 
   it("respondInteraction fails closed when actorUserId is omitted", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9420,6 +9420,7 @@ export function issueRoutes(
     const reviewVerdictRequested =
       existing.status === "in_review"
       && (updateFields.status === "done" || updateFields.status === "cancelled");
+    const executionPolicyMutationRequested = req.body.executionPolicy !== undefined;
     const reviewPolicySensitiveMutationRequested =
       req.body.reviewPolicy !== undefined
       || updateFields.status === "done"
@@ -9660,25 +9661,31 @@ export function issueRoutes(
       req.body.executionPolicy !== undefined && monitorChanged,
     );
 
-    const transition = applyIssueExecutionPolicyTransition({
-      issue: existing,
-      policy: nextExecutionPolicy,
-      previousPolicy: previousExecutionPolicy,
-      requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
-      requestedAssigneePatch: {
-        assigneeAgentId: normalizedAssigneeAgentId,
-        assigneeUserId:
-          req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
-      },
-      actor: {
-        agentId: actor.agentId ?? null,
-        userId: actor.actorType === "user" ? actor.actorId : null,
-      },
-      allowBoardOverride: req.actor.type === "board",
-      commentBody,
-      reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
-      monitorExplicitlyUpdated: req.body.executionPolicy !== undefined && monitorChanged,
-    });
+    const deriveExecutionPolicyTransition = (issue: typeof existing) => {
+      const issuePreviousExecutionPolicy = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
+      const issueMonitorChanged = monitorPoliciesEqual(issuePreviousExecutionPolicy, nextExecutionPolicy) === false;
+      return applyIssueExecutionPolicyTransition({
+        issue,
+        policy: nextExecutionPolicy,
+        previousPolicy: issuePreviousExecutionPolicy,
+        requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
+        requestedAssigneePatch: {
+          assigneeAgentId: normalizedAssigneeAgentId,
+          assigneeUserId:
+            req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
+        },
+        actor: {
+          agentId: actor.agentId ?? null,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        },
+        allowBoardOverride: req.actor.type === "board",
+        commentBody,
+        reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
+        monitorExplicitlyUpdated: executionPolicyMutationRequested && issueMonitorChanged,
+      });
+    };
+    const transition = deriveExecutionPolicyTransition(existing);
+    const transitionBeforeDecisionId = JSON.stringify(transition);
     const decisionId = transition.decision ? randomUUID() : null;
     if (decisionId) {
       const nextExecutionState = transition.patch.executionState;
@@ -9955,7 +9962,8 @@ export function issueRoutes(
       Boolean(decision)
       || shouldRelayStop
       || persistReviewActivityTransactionally
-      || reviewPolicySensitiveMutationRequested;
+      || reviewPolicySensitiveMutationRequested
+      || executionPolicyMutationRequested;
     try {
       if (shouldUseTransactionalIssueUpdate) {
         issue = await db.transaction(async (tx) => {
@@ -9963,6 +9971,45 @@ export function issueRoutes(
             reviewPolicySensitiveMutationRequested
             && !(await assertLockedReviewPolicyAllowsMutation(tx))
           ) return null;
+          if (executionPolicyMutationRequested || transition.reviewEscalation) {
+            const lockedExisting = await svc.getByIdForUpdate(id, tx);
+            if (!lockedExisting) return null;
+
+            if (executionPolicyMutationRequested) {
+              const lockedPreviousExecutionPolicy = normalizeIssueExecutionPolicy(lockedExisting.executionPolicy ?? null);
+              if (JSON.stringify(lockedPreviousExecutionPolicy) !== JSON.stringify(previousExecutionPolicy)) {
+                throw conflict("The execution policy changed before this update could be recorded. Retry the update.");
+              }
+              const interactionSvc = issueThreadInteractionService(tx as unknown as Db);
+              if (await interactionSvc.hasPendingReviewEscalationForIssue(lockedExisting)) {
+                throw conflict("Resolve the capped review decision before changing the execution policy.");
+              }
+              const lockedTransition = deriveExecutionPolicyTransition(lockedExisting);
+              if (JSON.stringify(lockedTransition) !== transitionBeforeDecisionId) {
+                throw conflict("The active review stage changed before this update could be recorded. Retry the update.");
+              }
+            }
+
+            if (transition.reviewEscalation) {
+              const expectedState = parseIssueExecutionState(existing.executionState);
+              const lockedState = parseIssueExecutionState(lockedExisting.executionState);
+              const lockedPolicy = normalizeIssueExecutionPolicy(lockedExisting.executionPolicy ?? null);
+              if (
+                !decisionId
+                || !expectedState
+                || !lockedState
+                || lockedExisting.status !== existing.status
+                || lockedExisting.assigneeAgentId !== existing.assigneeAgentId
+                || lockedExisting.assigneeUserId !== existing.assigneeUserId
+                || JSON.stringify(lockedPolicy) !== JSON.stringify(previousExecutionPolicy)
+                || lockedState.currentStageId !== expectedState.currentStageId
+                || JSON.stringify(lockedState.currentParticipant) !== JSON.stringify(expectedState.currentParticipant)
+                || lockedState.lastDecisionId !== expectedState.lastDecisionId
+              ) {
+                throw conflict("The active review stage changed before this decision could be recorded. Retry the update.");
+              }
+            }
+          }
           const updated = await updateIssue(tx);
           if (!updated) return null;
 
@@ -9979,6 +10026,39 @@ export function issueRoutes(
               body: decision.body,
               createdByRunId: actor.runId ?? null,
             });
+          }
+
+          if (transition.reviewEscalation && decisionId) {
+            await issueThreadInteractionService(tx as unknown as Db).create(updated, {
+              kind: "request_confirmation",
+              idempotencyKey: `execution-review-escalation:${decisionId}`,
+              sourceRunId: actor.runId ?? null,
+              title: "Review decision required",
+              summary: "The review round limit was reached.",
+              continuationPolicy: "wake_assignee",
+              resolverPolicy: "human_only",
+              payload: {
+                version: 1,
+                prompt: "The review round limit was reached. Approve the reviewed work or return it to the executor.",
+                acceptLabel: "Approve reviewed work",
+                rejectRequiresReason: true,
+                allowDeclineReason: true,
+                declineReasonPlaceholder: "Describe the correction the executor must make.",
+                supersedeOnUserComment: false,
+                detailsMarkdown: [
+                  "**Review reason:**",
+                  "",
+                  transition.reviewEscalation.reason,
+                ].join("\n"),
+                reviewEscalation: {
+                  version: 1,
+                  decisionId,
+                  stageId: transition.reviewEscalation.stageId,
+                  reviewerAgentId: transition.reviewEscalation.reviewerAgentId,
+                  responsibleUserId: transition.reviewEscalation.responsibleUserId,
+                },
+              },
+            }, { allowReviewEscalationCreation: true });
           }
 
           if (shouldRelayStop) {
@@ -11243,6 +11323,9 @@ export function issueRoutes(
     if (req.body.kind === "request_confirmation" && req.body.payload?.secretProposal !== undefined) {
       throw unprocessable("payload.secretProposal is server-owned metadata and cannot be supplied when creating an interaction");
     }
+    if (req.body.kind === "request_confirmation" && req.body.payload?.reviewEscalation !== undefined) {
+      throw unprocessable("payload.reviewEscalation is server-owned metadata and cannot be supplied when creating an interaction");
+    }
 
     // Plan-document confirmation targets are validated authoritatively inside
     // issueThreadInteractionService.create, which re-reads the plan document's
@@ -11357,6 +11440,51 @@ export function issueRoutes(
       if (!suggestedTaskEffectsAuthorized) return;
 
       const actor = getActorInfo(req);
+      if (current.kind === "request_confirmation" && current.payload.reviewEscalation) {
+        const resolved = await interactionSvc.resolveReviewEscalation({
+          issue: { id: issue.id, companyId: issue.companyId },
+          interactionId,
+          outcome: "approved",
+          actor: {
+            agentId: actor.agentId,
+            runId: actor.runId,
+            userId: actor.actorType === "user" ? actor.actorId : null,
+            resolverPolicyRestriction: resolutionAuthorization.resolverPolicyRestriction,
+          },
+        });
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          action: "issue.thread_interaction_accepted",
+          entityType: "issue",
+          entityId: issue.id,
+          details: {
+            interactionId: resolved.interaction.id,
+            interactionKind: resolved.interaction.kind,
+            interactionStatus: resolved.interaction.status,
+            resolutionActorKind: actor.actorType,
+            requestedResolverPolicy: resolved.interaction.requestedResolverPolicy,
+            effectiveResolverPolicy: resolved.interaction.effectiveResolverPolicy,
+            resolverPolicyProvenance: resolved.interaction.resolverPolicyProvenance,
+            effectiveResolverPolicySource: resolved.interaction.effectiveResolverPolicySource,
+            resolverAuthorizationReason: resolutionAuthorization.decision.reason,
+          },
+        });
+        await queueResolvedInteractionContinuationWakeup({
+          db,
+          heartbeat,
+          issue: { ...resolved.issue, companyId: issue.companyId },
+          interaction: resolved.interaction,
+          actor,
+          source: "issue.interaction.accept",
+        });
+        res.json(resolved.interaction);
+        return;
+      }
       const { interaction, createdIssues, continuationIssue } = await interactionSvc.acceptInteraction(issue, interactionId, req.body, {
         agentId: actor.agentId,
         runId: actor.runId,
@@ -11593,9 +11721,56 @@ export function issueRoutes(
         interactionId,
       );
       if (!authorizedResolution) return;
-      const { interactionSvc, resolutionAuthorization } = authorizedResolution;
+      const { interactionSvc, current, resolutionAuthorization } = authorizedResolution;
 
       const actor = getActorInfo(req);
+      if (current.kind === "request_confirmation" && current.payload.reviewEscalation) {
+        const resolved = await interactionSvc.resolveReviewEscalation({
+          issue: { id: issue.id, companyId: issue.companyId },
+          interactionId,
+          outcome: "changes_requested",
+          reason: req.body.reason,
+          actor: {
+            agentId: actor.agentId,
+            runId: actor.runId,
+            userId: actor.actorType === "user" ? actor.actorId : null,
+            resolverPolicyRestriction: resolutionAuthorization.resolverPolicyRestriction,
+          },
+        });
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          action: "issue.thread_interaction_rejected",
+          entityType: "issue",
+          entityId: issue.id,
+          details: {
+            interactionId: resolved.interaction.id,
+            interactionKind: resolved.interaction.kind,
+            interactionStatus: resolved.interaction.status,
+            resolutionActorKind: actor.actorType,
+            requestedResolverPolicy: resolved.interaction.requestedResolverPolicy,
+            effectiveResolverPolicy: resolved.interaction.effectiveResolverPolicy,
+            resolverPolicyProvenance: resolved.interaction.resolverPolicyProvenance,
+            effectiveResolverPolicySource: resolved.interaction.effectiveResolverPolicySource,
+            resolverAuthorizationReason: resolutionAuthorization.decision.reason,
+            rejectionReason: req.body.reason,
+          },
+        });
+        await queueResolvedInteractionContinuationWakeup({
+          db,
+          heartbeat,
+          issue: { ...resolved.issue, companyId: issue.companyId },
+          interaction: resolved.interaction,
+          actor,
+          source: "issue.interaction.reject",
+        });
+        res.json(resolved.interaction);
+        return;
+      }
       const interaction = await interactionSvc.rejectInteraction(issue, interactionId, req.body, {
         agentId: actor.agentId,
         runId: actor.runId,

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -58,6 +58,12 @@ type TransitionInput = {
 type TransitionResult = {
   patch: Record<string, unknown>;
   decision?: Pick<IssueExecutionDecision, "stageId" | "stageType" | "outcome" | "body">;
+  reviewEscalation?: {
+    stageId: string;
+    reviewerAgentId: string;
+    responsibleUserId: string;
+    reason: string;
+  };
   workflowControlledAssignment?: boolean;
 };
 
@@ -886,6 +892,14 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
             return {
               patch,
               decision,
+              reviewEscalation: actor?.agentId
+                ? {
+                    stageId: activeStage.id,
+                    reviewerAgentId: actor.agentId,
+                    responsibleUserId: escalationUserId,
+                    reason: decision.body,
+                  }
+                : undefined,
               workflowControlledAssignment: true,
             };
           }

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { and, asc, desc, eq, inArray, isNotNull, isNull, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
@@ -9,6 +10,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueExecutionDecisions,
   issueQuestionResponseDeliveries,
   issueThreadInteractions,
   issues,
@@ -65,13 +67,18 @@ import {
 import { z } from "zod";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
-import { logActivity } from "./activity-log.js";
+import { logActivity, publishActivity, type ActivityPublication } from "./activity-log.js";
 import { evaluateAgentInvokabilityFromDb } from "./agent-invokability.js";
 import {
   assertIssueReviewVerdictActorAllowed,
   isIssueReviewVerdictInteraction,
 } from "./issue-review-policy.js";
 import { issueService, runWorkspaceIsFinalized } from "./issues.js";
+import {
+  applyIssueExecutionPolicyTransition,
+  normalizeIssueExecutionPolicy,
+  parseIssueExecutionState,
+} from "./issue-execution-policy.js";
 import { questionResponseDeliveryValues } from "./question-response-delivery.js";
 import {
   assertIssueThreadInteractionResolverAudience,
@@ -100,6 +107,7 @@ type InteractionActor = {
     | IssueThreadInteractionResolverRestriction
     | null;
   suggestedTaskEffectsAuthorized?: boolean;
+  allowReviewEscalationCreation?: boolean;
   resolutionDetails?: Record<string, unknown>;
 };
 
@@ -403,6 +411,20 @@ function isTargetBoundInteractionKind(kind: string): kind is TargetBoundInteract
 
 function isUserCommentSupersedableKind(kind: string): kind is UserCommentSupersedableKind {
   return (USER_COMMENT_SUPERSEDABLE_INTERACTION_KINDS as readonly string[]).includes(kind);
+}
+
+function hasReviewEscalationPayload(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const reviewEscalation = (payload as Record<string, unknown>).reviewEscalation;
+  return Boolean(
+    reviewEscalation
+    && typeof reviewEscalation === "object"
+    && !Array.isArray(reviewEscalation),
+  );
+}
+
+function isReviewEscalationInteraction(row: Pick<IssueThreadInteractionRow, "kind" | "payload">) {
+  return row.kind === "request_confirmation" && hasReviewEscalationPayload(row.payload);
 }
 
 function isIssueThreadInteractionIdempotencyConflict(error: unknown): boolean {
@@ -1501,6 +1523,19 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     return hydrateInteraction(current);
   }
 
+  async function hasPendingReviewEscalationForIssue(issue: { id: string; companyId: string }) {
+    const rows = await db
+      .select({ payload: issueThreadInteractions.payload })
+      .from(issueThreadInteractions)
+      .where(and(
+        eq(issueThreadInteractions.companyId, issue.companyId),
+        eq(issueThreadInteractions.issueId, issue.id),
+        eq(issueThreadInteractions.kind, "request_confirmation"),
+        eq(issueThreadInteractions.status, "pending"),
+      ));
+    return rows.some((row) => hasReviewEscalationPayload(row.payload));
+  }
+
   async function assertIssueWorkspaceFinalizedForAccept(args: {
     db: Pick<Db, "select">;
     issue: { id: string; companyId: string };
@@ -1849,8 +1884,178 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     return rejected;
   }
 
+  async function resolveReviewEscalation(args: {
+    issue: { id: string; companyId: string };
+    interactionId: string;
+    outcome: "approved" | "changes_requested";
+    reason?: string | null;
+    actor: InteractionActor;
+  }): Promise<{
+    interaction: RequestConfirmationInteraction;
+    issue: IssueWakeTarget;
+  }> {
+    if (!args.actor.userId) {
+      throw forbidden("Only the responsible user can resolve a review escalation");
+    }
+    const requestedStatus = args.outcome === "approved" ? "done" : "in_progress";
+    const commentBody = args.outcome === "approved"
+      ? "Approved through the review decision interaction."
+      : args.reason?.trim() ?? "";
+    if (!commentBody) {
+      throw unprocessable("Returning work to the executor requires a comment");
+    }
+
+    const publications: ActivityPublication[] = [];
+    const resolved = await db.transaction(async (tx) => {
+      const lockedIssue = await tx
+        .select()
+        .from(issues)
+        .where(and(eq(issues.id, args.issue.id), eq(issues.companyId, args.issue.companyId)))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (!lockedIssue) throw notFound("Issue not found");
+
+      const lockedInteraction = await tx
+        .select()
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, args.interactionId))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (
+        !lockedInteraction
+        || lockedInteraction.companyId !== args.issue.companyId
+        || lockedInteraction.issueId !== args.issue.id
+      ) {
+        throw notFound("Interaction not found");
+      }
+      if (lockedInteraction.status !== "pending") {
+        throw issueThreadInteractionResolutionError(
+          409,
+          "interaction_already_resolved",
+          "Interaction has already been resolved",
+        );
+      }
+      await assertRequestConfirmationResolutionAllowedUnderLock(
+        tx as unknown as Db,
+        lockedIssue,
+        lockedInteraction,
+        args.actor,
+      );
+
+      const interaction = hydrateInteraction(lockedInteraction);
+      if (interaction.kind !== "request_confirmation" || !interaction.payload.reviewEscalation) {
+        throw unprocessable("Interaction is not a capped review decision");
+      }
+      const escalation = interaction.payload.reviewEscalation;
+      if (escalation.responsibleUserId !== args.actor.userId) {
+        throw forbidden("Only the responsible user can resolve this review escalation");
+      }
+
+      const policy = normalizeIssueExecutionPolicy(lockedIssue.executionPolicy ?? null);
+      const executionState = parseIssueExecutionState(lockedIssue.executionState);
+      if (
+        !policy
+        || !executionState
+        || lockedIssue.status !== "in_review"
+        || executionState.status !== "pending"
+        || executionState.currentStageId !== escalation.stageId
+        || executionState.lastDecisionId !== escalation.decisionId
+        || executionState.currentParticipant?.type !== "user"
+        || executionState.currentParticipant.userId !== args.actor.userId
+      ) {
+        throw conflict("This review escalation is no longer active");
+      }
+
+      const transition = applyIssueExecutionPolicyTransition({
+        issue: lockedIssue,
+        policy,
+        previousPolicy: policy,
+        requestedStatus,
+        requestedAssigneePatch: {},
+        actor: { userId: args.actor.userId },
+        commentBody,
+      });
+      if (!transition.decision || transition.decision.stageId !== escalation.stageId) {
+        throw conflict("This review escalation can no longer advance the active stage");
+      }
+      const nextExecutionState = transition.patch.executionState;
+      if (!nextExecutionState || typeof nextExecutionState !== "object") {
+        throw new Error("Review escalation decision patch is missing executionState");
+      }
+
+      const now = new Date();
+      const resolutionDecisionId = randomUUID();
+      const [updatedInteraction] = await tx
+        .update(issueThreadInteractions)
+        .set({
+          status: args.outcome === "approved" ? "accepted" : "rejected",
+          result: {
+            version: 1,
+            outcome: args.outcome === "approved" ? "accepted" : "rejected",
+            ...(args.outcome === "changes_requested" ? { reason: commentBody } : {}),
+          },
+          resolvedByAgentId: null,
+          resolvedByRunId: null,
+          resolvedByUserId: args.actor.userId,
+          resolvedAt: now,
+          updatedAt: now,
+        })
+        .where(and(
+          eq(issueThreadInteractions.id, lockedInteraction.id),
+          eq(issueThreadInteractions.status, "pending"),
+        ))
+        .returning();
+      if (!updatedInteraction) {
+        throw issueThreadInteractionResolutionError(
+          409,
+          "interaction_already_resolved",
+          "Interaction has already been resolved",
+        );
+      }
+
+      const updatePatch: Record<string, unknown> = {
+        ...transition.patch,
+        status: transition.patch.status ?? requestedStatus,
+        executionState: {
+          ...nextExecutionState,
+          lastDecisionId: resolutionDecisionId,
+        },
+        actorAgentId: null,
+        actorUserId: args.actor.userId,
+      };
+      const updatedIssue = await issueService(db).update(args.issue.id, updatePatch, tx, publications);
+      if (!updatedIssue) throw notFound("Issue not found");
+      await tx.insert(issueExecutionDecisions).values({
+        id: resolutionDecisionId,
+        companyId: updatedIssue.companyId,
+        issueId: updatedIssue.id,
+        stageId: transition.decision.stageId,
+        stageType: transition.decision.stageType,
+        actorAgentId: null,
+        actorUserId: args.actor.userId,
+        outcome: transition.decision.outcome,
+        body: transition.decision.body,
+        createdByRunId: null,
+      });
+      return {
+        interaction: hydrateInteraction(updatedInteraction) as RequestConfirmationInteraction,
+        issue: {
+          id: updatedIssue.id,
+          assigneeAgentId: updatedIssue.assigneeAgentId ?? null,
+          assigneeUserId: updatedIssue.assigneeUserId ?? null,
+          status: updatedIssue.status,
+        },
+      };
+    });
+    for (const publication of publications) publishActivity(publication);
+    await emitInteractionResolvedTelemetry(db, resolved.interaction);
+    return resolved;
+  }
+
   return {
     getForIssue,
+    hasPendingReviewEscalationForIssue,
+    resolveReviewEscalation,
     sweepMergedPullRequestConfirmations: async () => {
       const rows = await db
         .select({
@@ -2204,7 +2409,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         replacementInteractionId: string;
       }> = [];
       for (const row of rows) {
-        if (!row.createdByAgentId) continue;
+        if (!row.createdByAgentId || isReviewEscalationInteraction(row)) continue;
         const groupKey = `${row.companyId}:${row.issueId}:${row.kind}:${row.createdByAgentId}`;
         const newest = newestByGroup.get(groupKey);
         if (!newest) {
@@ -2263,6 +2468,13 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       actor: InteractionActor,
     ) => {
       const data = normalizeCreateInteractionInput(createIssueThreadInteractionSchema.parse(input));
+      if (
+        data.kind === "request_confirmation"
+        && data.payload.reviewEscalation !== undefined
+        && actor.allowReviewEscalationCreation !== true
+      ) {
+        throw unprocessable("payload.reviewEscalation is server-owned metadata and cannot be supplied when creating an interaction");
+      }
       const usedDeprecatedResolverPolicyAlias =
         data.resolverPolicy === "board_or_agents" || data.resolverPolicy === "board_only";
       const governance = await db
@@ -2421,10 +2633,13 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
           // result shape. Scoped strictly to the same agent + issue + kind, so
           // other agents' or other kinds' pending cards are untouched.
           const canSupersedeSiblingCards =
-            (data.kind === "request_confirmation"
-              && data.payload.toolAction === undefined
-              && data.payload.secretProposal === undefined)
-            || data.kind === "ask_user_questions";
+            !hasReviewEscalationPayload(data.payload)
+            && (
+              (data.kind === "request_confirmation"
+                && data.payload.toolAction === undefined
+                && data.payload.secretProposal === undefined)
+              || data.kind === "ask_user_questions"
+            );
           if (!actor.agentId || !canSupersedeSiblingCards) {
             return { row, supersededRows: [] };
           }
@@ -2433,6 +2648,23 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
           const supersededResult = data.kind === "ask_user_questions"
             ? buildSupersededByNewerInteractionResult(row.id)
             : buildSupersededByNewerRequestResult(row.id);
+          const siblingRows = await tx
+            .select()
+            .from(issueThreadInteractions)
+            .where(and(
+              eq(issueThreadInteractions.companyId, issue.companyId),
+              eq(issueThreadInteractions.issueId, issue.id),
+              eq(issueThreadInteractions.kind, data.kind),
+              eq(issueThreadInteractions.createdByAgentId, actor.agentId),
+              eq(issueThreadInteractions.status, "pending"),
+              ne(issueThreadInteractions.id, row.id),
+            ));
+          const supersededIds = siblingRows
+            .filter((sibling) => !isReviewEscalationInteraction(sibling))
+            .map((sibling) => sibling.id);
+          if (supersededIds.length === 0) {
+            return { row, supersededRows: [] };
+          }
           const supersededRows = await tx
             .update(issueThreadInteractions)
             .set({
@@ -2444,12 +2676,8 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
               updatedAt: now,
             })
             .where(and(
-              eq(issueThreadInteractions.companyId, issue.companyId),
-              eq(issueThreadInteractions.issueId, issue.id),
-              eq(issueThreadInteractions.kind, data.kind),
-              eq(issueThreadInteractions.createdByAgentId, actor.agentId),
+              inArray(issueThreadInteractions.id, supersededIds),
               eq(issueThreadInteractions.status, "pending"),
-              ne(issueThreadInteractions.id, row.id),
             ))
             .returning();
           for (const supersededRow of supersededRows) {
@@ -3246,6 +3474,10 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         throw interactionNotFoundError();
       }
       if (current.status !== "pending") throw interactionTerminalError(current);
+      const interaction = hydrateInteraction(current);
+      if (interaction.kind === "request_confirmation" && interaction.payload.reviewEscalation) {
+        throw conflict("A capped review decision must be approved or returned to the executor");
+      }
 
       const reason = data.reason?.trim() || null;
       const now = new Date();

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2523,7 +2523,21 @@ export function buildHostServices(
           assigneeAgentId: issue.assigneeAgentId,
           status: issue.status,
         };
-        if (params.action === "accept") {
+        if (current.kind === "request_confirmation" && current.payload.reviewEscalation) {
+          const result = await interactions.resolveReviewEscalation({
+            issue: { id: issue.id, companyId },
+            interactionId: params.interactionId,
+            outcome: params.action === "accept" ? "approved" : "changes_requested",
+            reason: params.reason ?? undefined,
+            actor,
+          });
+          resolved = result.interaction as typeof current;
+          continuationTarget = {
+            id: result.issue.id,
+            assigneeAgentId: result.issue.assigneeAgentId,
+            status: result.issue.status,
+          };
+        } else if (params.action === "accept") {
           const result = await interactions.acceptInteraction(
             {
               id: issue.id,

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -655,6 +655,35 @@ describe("IssueThreadInteractionCard", () => {
     expect(host.textContent).not.toContain("Request changes");
   });
 
+  it("labels capped-review decisions as approve or return-to-executor actions", () => {
+    const host = renderCard({
+      interaction: {
+        ...pendingRequestConfirmationInteraction,
+        payload: {
+          ...pendingRequestConfirmationInteraction.payload,
+          prompt: "The review round limit was reached.",
+          acceptLabel: "Approve reviewed work",
+          rejectRequiresReason: true,
+          detailsMarkdown: "**Review reason:**\n\nPreserve audit records.",
+          reviewEscalation: {
+            version: 1,
+            decisionId: "11111111-1111-4111-8111-111111111111",
+            stageId: "22222222-2222-4222-8222-222222222222",
+            reviewerAgentId: "33333333-3333-4333-8333-333333333333",
+            responsibleUserId: "local-board",
+          },
+        },
+      },
+      onAcceptInteraction: vi.fn(async () => undefined),
+      onRejectInteraction: vi.fn(async () => undefined),
+    });
+
+    const labels = Array.from(host.querySelectorAll("button")).map((button) => button.textContent?.trim());
+    expect(labels).toContain("Approve reviewed work");
+    expect(labels).toContain("Return to executor…");
+    expect(host.textContent).toContain("Preserve audit records.");
+  });
+
   it("does not expose continuation wake policy labels in the card header", () => {
     const host = renderCard({
       interaction: {

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -2514,6 +2514,7 @@ function RequestConfirmationCard({
   // Screenshots ride along in the revise note as markdown image refs so the
   // board can attach images when sending a plan back — no schema change needed.
   const allowScreenshots = isPlan && Boolean(onUploadImage);
+  const isReviewEscalation = interaction.payload.reviewEscalation !== undefined;
   const rejectRequiresReason = interaction.payload.rejectRequiresReason === true;
   const allowRevise = interaction.payload.allowDeclineReason !== false;
   const reasonPlaceholder =
@@ -2606,6 +2607,7 @@ function RequestConfirmationCard({
         <ConfirmationActionRow
           resetKey={`${interaction.id}:${interaction.status}`}
           approveLabel={interaction.payload.acceptLabel ?? CONFIRMATION_APPROVE_LABEL}
+          reviseLabel={isReviewEscalation ? "Return to executor…" : undefined}
           rejectLabel={CONFIRMATION_REJECT_LABEL}
           approveVariant={isPlan ? "cta" : "default"}
           primaryActionOnRight={primaryActionOnRight}


### PR DESCRIPTION
## Thinking Path

> - Paperclip lets agents complete work through execution-policy stages.
> - Review policies bound agent-to-agent change-request loops with `maxReviewRounds`.
> - At the cap, the existing transition correctly assigns the pending review to the responsible human.
> - Before this change, that assignment had no durable, actionable owner interaction.
> - A generic confirmation answer would not safely represent a real review decision by itself.
> - This change persists one server-owned interaction with the triggering decision, then resolves it through the existing execution-policy transition.
> - The result is a visible, bounded human decision point: no automatic approval, rejection, or correction restart.

## Linked Issues or Issue Description

Fixes: #12325

Refs: #11904, #11917, #11925

Those recovery PRs are related but do not add an owner interaction for a `maxReviewRounds` escalation.

## What Changed

- Emit review-escalation metadata only when an agent's changes-requested decision reaches a stage's review-round cap.
- In the issue update transaction, create exactly one server-owned, human-only `request_confirmation` interaction, keyed by the triggering execution decision.
- Preserve the reviewer identity and exact changes-requested reason in the owner card. The UI presents `Approve` and reason-required `Request changes` actions.
- Route browser and plugin interaction responses through the real review-decision transition, so each owner choice updates execution state, writes the corresponding decision, and resets review rounds as normal human review does.
- Reject untrusted creation of the server-owned escalation marker. Keep a pending capped-review card durable across comments, newer ordinary confirmations, and the startup supersession sweep.
- Lock and re-check execution-policy mutations, reject policy edits while the required owner decision is pending, and avoid stale-policy lost updates.
- Add focused policy, route, interaction-service, plugin-host, and UI regression coverage. The global default review-round limit is unchanged.

## Verification

RED evidence before restoring each fix:

- The owner-interaction regression failed before the feature because the cap transition created no interaction.
- The durability regression expected `pending` but received `expired` after a newer ordinary confirmation.
- The pending-escalation policy-edit regression expected HTTP 409 but received HTTP 200.
- The concurrent transitionless policy-edit regression expected HTTP 409 but received HTTP 200.

Local checks:

- `node cli/node_modules/tsx/dist/cli.mjs scripts/ensure-workspace-package-links.ts && node_modules/.bin/vitest run server/src/__tests__/issue-execution-policy.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts server/src/__tests__/issue-thread-interactions-service.test.ts server/src/__tests__/issue-thread-interaction-routes.test.ts server/src/__tests__/plugin-orchestration-apis.test.ts server/src/__tests__/issue-activity-events-routes.test.ts ui/src/components/IssueThreadInteractionCard.test.tsx` — 7 files, 328 tests passed.
- `node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit` — passed.
- `node_modules/.bin/tsc -p ui/tsconfig.json --noEmit` — passed.
- `node_modules/.bin/tsc -p server/tsconfig.json --noEmit` is currently blocked by pre-existing upstream code outside this PR: `server/src/services/plugin-worker-manager.ts:1667` rejects `LoginCommandKey` value `"grok"` as `PluginLoginCommandKey`. This PR does not modify that file.
- `git diff --check upstream/master...HEAD` — passed.
- No root lint or formatter script/config is present; whitespace was checked with `git diff --check`.

## Risks

Low and contained to capped agent-review escalation. There is no migration and no global-default policy change. A cap never takes an automatic review decision or resumes work: the responsible human must choose an action on the active card. Resolution validates and locks the interaction, issue, policy stage, triggering decision, and responsible user before applying the normal review transition. Policy edits are intentionally rejected until that required decision is made.

The local server-only TypeScript command is presently limited by the unrelated upstream Grok login type mismatch recorded above; upstream CI is the authoritative remaining verification after this update.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex `gpt-5.6-terra`. I used tool-assisted source inspection, code editing, regression testing, type checks, Git operations, and independent code review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass, except for the documented unrelated upstream server type error
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes; no user-facing documentation is needed for this focused fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
