### PR TITLE
Fix blocker ID projections

### DIFF
--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -243,6 +243,9 @@ describe("issue activity event routes", () => {
       .send({ blockedByIssueIds: ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"] });
 
     expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual([
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ]);
     await vi.waitFor(() => {
       expect(mockLogActivity).toHaveBeenCalledWith(
         expect.anything(),

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -264,6 +264,30 @@ describe.sequential("issue goal context routes", () => {
     expect(mockGoalService.getDefaultCompanyGoal).not.toHaveBeenCalled();
   });
 
+  it("projects blockedByIssueIds from persisted relations on GET /issues/:id", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [
+        {
+          id: "55555555-5555-4555-8555-555555555555",
+          identifier: "PAP-580",
+          title: "Finish wakeup plumbing",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: null,
+          assigneeUserId: null,
+        },
+      ],
+      blocks: [],
+    });
+
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual([
+      "55555555-5555-4555-8555-555555555555",
+    ]);
+  });
+
   it("surfaces the project goal from GET /issues/:id/heartbeat-context", async () => {
     const res = await request(createApp()).get(
       "/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context",
@@ -328,6 +352,9 @@ describe.sequential("issue goal context routes", () => {
     );
 
     expect(res.status).toBe(200);
+    expect(res.body.issue.blockedByIssueIds).toEqual([
+      "55555555-5555-4555-8555-555555555555",
+    ]);
     expect(res.body.issue.blockedBy).toEqual([
       expect.objectContaining({
         id: "55555555-5555-4555-8555-555555555555",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1636,6 +1636,7 @@ export function issueRoutes(
         projectId: issue.projectId,
         goalId: goal?.id ?? issue.goalId,
         parentId: issue.parentId,
+        blockedByIssueIds: relationsWithRecoveryActions.blockedBy.map((relation) => relation.id),
         blockedBy: relationsWithRecoveryActions.blockedBy,
         blocks: relationsWithRecoveryActions.blocks,
         assigneeAgentId: issue.assigneeAgentId,
@@ -1753,6 +1754,7 @@ export function issueRoutes(
       successfulRunHandoff: successfulRunHandoffStates.get(issue.id) ?? null,
       scheduledRetry,
       activeRecoveryAction,
+      blockedByIssueIds: relationsWithRecoveryActions.blockedBy.map((relation) => relation.id),
       blockedBy: relationsWithRecoveryActions.blockedBy,
       blocks: relationsWithRecoveryActions.blocks,
       relatedWork: referenceSummary,
@@ -3062,6 +3064,7 @@ export function issueRoutes(
       ? issueReferencesSvc.diffIssueReferenceSummary(updateReferenceSummaryBefore, updateReferenceSummaryAfter)
       : null;
     let issueResponse: typeof issue & {
+      blockedByIssueIds?: string[];
       blockedBy?: unknown;
       blocks?: unknown;
       relatedWork?: Awaited<ReturnType<typeof issueReferencesSvc.listIssueReferenceSummary>>;
@@ -3072,6 +3075,7 @@ export function issueRoutes(
       updatedRelations = await svc.getRelationSummaries(issue.id);
       issueResponse = {
         ...issue,
+        blockedByIssueIds: updatedRelations.blockedBy.map((relation) => relation.id),
         blockedBy: updatedRelations.blockedBy,
         blocks: updatedRelations.blocks,
       };


### PR DESCRIPTION
## Summary
- project persisted blocker relation IDs into PATCH responses
- include blocker IDs in direct issue GET responses
- include blocker IDs in heartbeat context payloads
- add route-level regression coverage for write/read projections

## Verification
- 
 RUN  v3.2.4 /private/var/folders/p7/9lz5xg8n281gfb5th7587td80000gp/T/paperclip-run-cyr-2498-0ec0cf1d-f54-NqlOfu/cyr-2498-paperclip

 ✓ |@paperclipai/server| src/__tests__/issues-goal-context-routes.test.ts (6 tests) 32ms
 ✓ |@paperclipai/server| src/__tests__/issue-activity-events-routes.test.ts (5 tests) 757ms
   ✓ issue activity event routes > logs blocker activity with added and removed issue summaries  524ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  22:15:04
   Duration  1.30s (transform 604ms, setup 69ms, collect 1.16s, tests 789ms, environment 0ms, prepare 92ms)
- 2 test files passed, 11 tests passed
- 

Paperclip issue: CYR-2498