### PR TITLE
Fix blocker ID projections

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -185,6 +185,11 @@ Blocked issues should stay idle while blockers remain unresolved. Paperclip shou
 
 `cancelled` is terminal for the blocker issue itself, but it does not satisfy the dependency. A cancelled blocker edge remains unresolved until the edge is removed or replaced, and Paperclip must surface blocker attention on the dependent regardless of whether that dependent is currently displayed as `blocked`, `todo`, `backlog`, or another non-terminal agent-owned status.
 
+Readback contract:
+
+- issue read routes return `blockedByIssueIds` as the stored blocker id set
+- issue read routes also return `blockedBy` and `blocks` relation summaries so callers can render the dependency graph without extra joins
+
 If a parent is truly waiting on a child, model that with blockers. Do not rely on the parent/child relationship alone.
 
 ### Child→Parent Reporting

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -791,6 +791,7 @@ export interface Issue {
   projectWorkspaceId: string | null;
   goalId: string | null;
   parentId: string | null;
+  blockedByIssueIds?: string[];
   ancestors?: IssueAncestor[];
   title: string;
   description: string | null;

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -432,6 +432,9 @@ describe("issue activity event routes", () => {
       .send({ blockedByIssueIds: ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"] });
 
     expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual([
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ]);
     await vi.waitFor(() => {
       expect(mockLogActivity).toHaveBeenCalledWith(
         expect.anything(),

--- a/server/src/__tests__/issue-blocker-readback-routes.test.ts
+++ b/server/src/__tests__/issue-blocker-readback-routes.test.ts
@@ -1,0 +1,219 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  createDb,
+  heartbeatRuns,
+  instanceSettings,
+  issueComments,
+  issueInboxArchives,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue blocker route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue blocker readback routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-blockers-routes-");
+    db = createDb(tempDb.connectionString);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: [],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompanyAndBlockers() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerA = randomUUID();
+    const blockerB = randomUUID();
+    const blockerC = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerA, companyId, title: "Blocker A", status: "todo", priority: "high" },
+      { id: blockerB, companyId, title: "Blocker B", status: "todo", priority: "high" },
+      { id: blockerC, companyId, title: "Blocker C", status: "todo", priority: "high" },
+    ]);
+
+    return { companyId, blockerA, blockerB, blockerC };
+  }
+
+  it("returns blockedByIssueIds, blockedBy, and blocks across create and patch readback", async () => {
+    const app = createApp();
+    const { companyId, blockerA, blockerB, blockerC } = await seedCompanyAndBlockers();
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Dependent issue",
+        status: "blocked",
+        priority: "medium",
+        blockedByIssueIds: [blockerA],
+      });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.blockedByIssueIds).toEqual([blockerA]);
+    expect(createRes.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerA, title: "Blocker A" }),
+    ]);
+    expect(createRes.body.blocks).toEqual([]);
+
+    const dependentId = createRes.body.id as string;
+
+    const createReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(createReadback.status).toBe(200);
+    expect(createReadback.body.blockedByIssueIds).toEqual([blockerA]);
+    expect(createReadback.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerA, title: "Blocker A" }),
+    ]);
+
+    const blockerAReadback = await request(app).get(`/api/issues/${blockerA}`);
+    expect(blockerAReadback.status).toBe(200);
+    expect(blockerAReadback.body.blocks).toEqual([
+      expect.objectContaining({ id: dependentId, title: "Dependent issue" }),
+    ]);
+
+    const addRes = await request(app)
+      .patch(`/api/issues/${dependentId}`)
+      .send({ blockedByIssueIds: [blockerA, blockerB] });
+
+    expect(addRes.status).toBe(200);
+    expect(addRes.body.blockedByIssueIds).toEqual([blockerA, blockerB]);
+    expect(addRes.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerA, title: "Blocker A" }),
+      expect.objectContaining({ id: blockerB, title: "Blocker B" }),
+    ]);
+
+    const addReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(addReadback.status).toBe(200);
+    expect(addReadback.body.blockedByIssueIds).toEqual([blockerA, blockerB]);
+
+    const replaceRes = await request(app)
+      .patch(`/api/issues/${dependentId}`)
+      .send({ blockedByIssueIds: [blockerB, blockerC] });
+
+    expect(replaceRes.status).toBe(200);
+    expect(replaceRes.body.blockedByIssueIds).toEqual([blockerB, blockerC]);
+    expect(replaceRes.body.blockedBy).toEqual([
+      expect.objectContaining({ id: blockerB, title: "Blocker B" }),
+      expect.objectContaining({ id: blockerC, title: "Blocker C" }),
+    ]);
+
+    const replaceReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(replaceReadback.status).toBe(200);
+    expect(replaceReadback.body.blockedByIssueIds).toEqual([blockerB, blockerC]);
+
+    const blockerCReadback = await request(app).get(`/api/issues/${blockerC}`);
+    expect(blockerCReadback.status).toBe(200);
+    expect(blockerCReadback.body.blocks).toEqual([
+      expect.objectContaining({ id: dependentId, title: "Dependent issue" }),
+    ]);
+
+    const clearRes = await request(app)
+      .patch(`/api/issues/${dependentId}`)
+      .send({ blockedByIssueIds: [] });
+
+    expect(clearRes.status).toBe(200);
+    expect(clearRes.body.blockedByIssueIds).toEqual([]);
+    expect(clearRes.body.blockedBy).toEqual([]);
+
+    const clearReadback = await request(app).get(`/api/issues/${dependentId}`);
+    expect(clearReadback.status).toBe(200);
+    expect(clearReadback.body.blockedByIssueIds).toEqual([]);
+    expect(clearReadback.body.blockedBy).toEqual([]);
+
+    const blockerBReadback = await request(app).get(`/api/issues/${blockerB}`);
+    expect(blockerBReadback.status).toBe(200);
+    expect(blockerBReadback.body.blocks).toEqual([]);
+  });
+
+  it("returns empty blocker fields on create when blockedByIssueIds is omitted", async () => {
+    const app = createApp();
+    const { companyId } = await seedCompanyAndBlockers();
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Standalone issue",
+        status: "todo",
+        priority: "medium",
+      });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.blockedByIssueIds).toEqual([]);
+    expect(createRes.body.blockedBy).toEqual([]);
+    expect(createRes.body.blocks).toEqual([]);
+  });
+});

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -287,6 +287,30 @@ describe.sequential("issue goal context routes", () => {
     expect(mockGoalService.getDefaultCompanyGoal).not.toHaveBeenCalled();
   });
 
+  it("projects blockedByIssueIds from persisted relations on GET /issues/:id", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [
+        {
+          id: "55555555-5555-4555-8555-555555555555",
+          identifier: "PAP-580",
+          title: "Finish wakeup plumbing",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: null,
+          assigneeUserId: null,
+        },
+      ],
+      blocks: [],
+    });
+
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual([
+      "55555555-5555-4555-8555-555555555555",
+    ]);
+  });
+
   it("keeps GET /issues/:id project and workspace embeds compact for fast detail loads", async () => {
     const workspaceId = "55555555-5555-4555-8555-555555555555";
     const runtimeServiceBase = {
@@ -493,6 +517,9 @@ describe.sequential("issue goal context routes", () => {
     );
 
     expect(res.status).toBe(200);
+    expect(res.body.issue.blockedByIssueIds).toEqual([
+      "55555555-5555-4555-8555-555555555555",
+    ]);
     expect(res.body.issue.blockedBy).toEqual([
       expect.objectContaining({
         id: "55555555-5555-4555-8555-555555555555",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6463,6 +6463,7 @@ export function issueRoutes(
         projectId: issue.projectId,
         goalId: goal?.id ?? issue.goalId,
         parentId: issue.parentId,
+        blockedByIssueIds: relationsWithRecoveryActions.blockedBy.map((relation) => relation.id),
         blockedBy: relationsWithRecoveryActions.blockedBy,
         blocks: relationsWithRecoveryActions.blocks,
         assigneeAgentId: issue.assigneeAgentId,
@@ -6723,6 +6724,7 @@ export function issueRoutes(
       successfulRunHandoff: successfulRunHandoffStates.get(issue.id) ?? null,
       scheduledRetry,
       activeRecoveryAction: revalidatedActiveRecoveryAction,
+      blockedByIssueIds: relationsWithRecoveryActions.blockedBy.map((relation) => relation.id),
       blockedBy: relationsWithRecoveryActions.blockedBy,
       blocks: relationsWithRecoveryActions.blocks,
       relatedWork: referenceSummary,
@@ -8804,8 +8806,13 @@ export function issueRoutes(
     });
     await queueTaskWatchdogEvaluation(issue, actor.runId);
 
+    const relations = await svc.getRelationSummaries(issue.id);
+
     res.status(201).json({
       ...issue,
+      blockedByIssueIds: relations.blockedBy.map((relation) => relation.id),
+      blockedBy: relations.blockedBy,
+      blocks: relations.blocks,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
     });
@@ -10089,6 +10096,7 @@ export function issueRoutes(
       ? issueReferencesSvc.diffIssueReferenceSummary(updateReferenceSummaryBefore, updateReferenceSummaryAfter)
       : null;
     let issueResponse: typeof issue & {
+      blockedByIssueIds?: string[];
       blockedBy?: unknown;
       blocks?: unknown;
       activeRecoveryAction?: unknown;
@@ -10100,8 +10108,7 @@ export function issueRoutes(
       updatedRelations = await svc.getRelationSummaries(issue.id);
       issueResponse = {
         ...issue,
-        blockedByIssueIds:
-          issue.blockedByIssueIds ?? [...new Set(req.body.blockedByIssueIds as string[])].sort(),
+        blockedByIssueIds: updatedRelations.blockedBy.map((relation) => relation.id),
         blockedBy: updatedRelations.blockedBy,
         blocks: updatedRelations.blocks,
       };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous companies.
> - Issue blockers are persisted as issue relations and must remain inspectable through the issue API.
> - PATCH already persists those relations, but response paths omitted or echoed the legacy `blockedByIssueIds` projection instead of deriving it from stored relations.
> - Clients therefore mistook successful writes for non-persisting writes during direct GET verification.
> - This pull request reconciles the minimal current-master fix with #4099 and derives the ID projection from persisted relation summaries across create, PATCH, direct GET, and heartbeat context.

## Linked Issues or Issue Description

- Refs #4099 (reconciled broader prior implementation; tracked internally as CYR-2498)

## What Changed

- Return `blockedByIssueIds` from persisted relation summaries on create, direct issue GET, and heartbeat context.
- Return the persisted relation projection after blocker-changing PATCH requests instead of echoing request data.
- Add embedded-Postgres regression coverage for create, add, replace, clear, and direct GET readback.
- Document the blocker readback contract and keep the shared `Issue` type aligned.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-blocker-readback-routes.test.ts src/__tests__/issues-goal-context-routes.test.ts src/__tests__/issue-activity-events-routes.test.ts`
  - 3 files passed, 19 tests passed.
- `TMPDIR=/private/tmp pnpm -r typecheck`
  - Passed.
- `TMPDIR=/private/tmp pnpm build`
  - Passed.
- `TMPDIR=/private/tmp pnpm test:run`
  - The full suite reached 9 failures in the unrelated `workspace-runtime.test.ts` suite; the run was stopped after the gate was already red. The blocker-focused suites above pass.

## Risks

- Low mutation risk: blocker relations continue to use the existing service write path.
- Response shape is additive/consistent: IDs are derived from persisted relation summaries already loaded for each response.
- The dedicated integration test exercises the persistence/readback mismatch against embedded PostgreSQL.

> Checked ROADMAP.md; this is a bug fix and does not duplicate planned feature work.

## Model Used

- OpenAI Codex, GPT-5 family agentic coding model, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes:/Closes:/Refs: OR (b) described the issue in-PR following the relevant issue template
- [x] I have run targeted tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

