### PR TITLE
feat(docker): ship rtk in the harness tool layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,20 +102,37 @@ RUN echo "cli-tools-epoch: ${CLI_TOOLS_CACHE_EPOCH}" \
 
 # rtk (github.com/rtk-ai/rtk): token-compressing CLI proxy for the harness
 # CLIs above. Version-pinned in its own layer so it never rides the weekly
-# epoch bust; the installer verifies the release checksum. `init` seeds
-# /paperclip with the Claude Code Bash auto-rewrite hook and the Codex
-# AGENTS.md instructions. The seed reaches a deployment only when /paperclip
-# starts as a fresh named volume (Docker copies image content into new
-# volumes); an existing volume — or a settings.json bind mount over it —
-# keeps its own files, so those deployments wire the hook themselves and get
-# just the binary from this layer.
+# epoch bust. The release tarball is verified against the per-arch SHA-256
+# pinned below (no remote installer script runs; bump the hashes together
+# with RTK_VERSION). `init --hook-only` seeds the Claude Code Bash
+# auto-rewrite hook and `init --codex` the Codex AGENTS.md instructions into
+# /paperclip. The seed reaches a deployment only when /paperclip starts as a
+# fresh named volume (Docker copies image content into new volumes); an
+# existing volume — or a settings.json bind mount over it — keeps its own
+# files, so those deployments wire the hook themselves and get just the
+# binary from this layer. Scope: the hook rewrites commands only where this
+# image's binary exists — managed remote/sandbox Claude settings strip hooks
+# (claude-config.ts) and the codex sandbox sync allowlist excludes the rtk
+# files (codex-home.ts), so sandbox runs are untouched — and rtk defers to
+# Claude Code deny rules before rewriting, so permission gates keep matching
+# the original command.
+ARG TARGETARCH
 ARG RTK_VERSION=v0.46.0
-RUN curl -fsSL "https://raw.githubusercontent.com/rtk-ai/rtk/${RTK_VERSION}/install.sh" \
-    | RTK_VERSION="${RTK_VERSION}" RTK_INSTALL_DIR=/usr/local/bin sh \
-  && mkdir -p /paperclip/.claude \
-  && HOME=/paperclip rtk init -g --auto-patch \
-  && HOME=/paperclip rtk init -g --codex \
-  && chown -R node:node /paperclip
+RUN set -eu; \
+  case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+    amd64) rtk_target=x86_64-unknown-linux-musl; rtk_sha256=79aa5b89c69566bbfeceb66c8a27cfbe52237fc7ee3e683115f43745a3262d21 ;; \
+    arm64) rtk_target=aarch64-unknown-linux-gnu; rtk_sha256=e8c2e1787f46017ea7c5a711b2bc6a7f7cf61c7ad69385b4c1e4daff1135dcd1 ;; \
+    *) echo "unsupported TARGETARCH for rtk: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL -o /tmp/rtk.tar.gz "https://github.com/rtk-ai/rtk/releases/download/${RTK_VERSION}/rtk-${rtk_target}.tar.gz"; \
+  echo "${rtk_sha256}  /tmp/rtk.tar.gz" | sha256sum -c -; \
+  tar -xzf /tmp/rtk.tar.gz -C /usr/local/bin rtk; \
+  rm /tmp/rtk.tar.gz; \
+  chmod 0755 /usr/local/bin/rtk; \
+  mkdir -p /paperclip/.claude; \
+  HOME=/paperclip rtk init -g --hook-only --auto-patch; \
+  HOME=/paperclip rtk init -g --codex; \
+  chown -R node:node /paperclip
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,23 @@ RUN echo "cli-tools-epoch: ${CLI_TOOLS_CACHE_EPOCH}" \
   && mkdir -p /paperclip \
   && chown node:node /paperclip
 
+# rtk (github.com/rtk-ai/rtk): token-compressing CLI proxy for the harness
+# CLIs above. Version-pinned in its own layer so it never rides the weekly
+# epoch bust; the installer verifies the release checksum. `init` seeds
+# /paperclip with the Claude Code Bash auto-rewrite hook and the Codex
+# AGENTS.md instructions. The seed reaches a deployment only when /paperclip
+# starts as a fresh named volume (Docker copies image content into new
+# volumes); an existing volume — or a settings.json bind mount over it —
+# keeps its own files, so those deployments wire the hook themselves and get
+# just the binary from this layer.
+ARG RTK_VERSION=v0.46.0
+RUN curl -fsSL "https://raw.githubusercontent.com/rtk-ai/rtk/${RTK_VERSION}/install.sh" \
+    | RTK_VERSION="${RTK_VERSION}" RTK_INSTALL_DIR=/usr/local/bin sh \
+  && mkdir -p /paperclip/.claude \
+  && HOME=/paperclip rtk init -g --auto-patch \
+  && HOME=/paperclip rtk init -g --codex \
+  && chown -R node:node /paperclip
+
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
@@ -120,7 +137,8 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private \
   OPENCODE_ALLOW_ALL_MODELS=true \
-  GEMINI_SANDBOX=false
+  GEMINI_SANDBOX=false \
+  RTK_TELEMETRY_DISABLED=1
 
 EXPOSE 3100
 

--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -384,6 +384,24 @@ describe("seedManagedCodexHome", () => {
     }
   });
 
+  it("copies AGENTS.md and RTK.md from the shared source into the managed home", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-rtk-"));
+    try {
+      const sharedCodexHome = path.join(root, "shared-codex-home");
+      const agentHome = path.join(root, "agent-home");
+      await fs.mkdir(sharedCodexHome, { recursive: true });
+      await fs.writeFile(path.join(sharedCodexHome, "AGENTS.md"), "@/paperclip/.codex/RTK.md\n", "utf8");
+      await fs.writeFile(path.join(sharedCodexHome, "RTK.md"), "# RTK\n", "utf8");
+
+      await seedManagedCodexHome(agentHome, { CODEX_HOME: sharedCodexHome }, async () => {});
+
+      expect(await fs.readFile(path.join(agentHome, "AGENTS.md"), "utf8")).toBe("@/paperclip/.codex/RTK.md\n");
+      expect(await fs.readFile(path.join(agentHome, "RTK.md"), "utf8")).toBe("# RTK\n");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("writes an API-key auth.json into the home when an apiKey is supplied", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-apikey-"));
     try {
@@ -935,6 +953,12 @@ describe("stageCodexHomeForSync", () => {
     await fs.mkdir(path.join(home, "skills"), { recursive: true });
     await fs.symlink(skillSource, path.join(home, "skills", "demo.md"));
 
+    // Local-only copies: seeded into the managed home but excluded from the
+    // sandbox sync (the rtk binary they reference does not exist in sandbox
+    // runtime images).
+    await fs.writeFile(path.join(home, "AGENTS.md"), "@/paperclip/.codex/RTK.md\n", "utf8");
+    await fs.writeFile(path.join(home, "RTK.md"), "# RTK\n", "utf8");
+
     // Decoys: large runtime state the 4-name denylist missed.
     await fs.writeFile(path.join(home, "logs_2.sqlite"), "x", "utf8");
     await fs.writeFile(path.join(home, "state_5.sqlite"), "x", "utf8");
@@ -959,7 +983,7 @@ describe("stageCodexHomeForSync", () => {
       expect(entries).toEqual([...CODEX_SYNC_ALLOWLIST].sort());
 
       // Decoys must be absent.
-      for (const decoy of ["logs_2.sqlite", "state_5.sqlite", "plugins", "sessions", "tmp"]) {
+      for (const decoy of ["logs_2.sqlite", "state_5.sqlite", "plugins", "sessions", "tmp", "AGENTS.md", "RTK.md"]) {
         expect(entries).not.toContain(decoy);
       }
 

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -7,6 +7,13 @@ import { readSubscriptionAccountId } from "./codex-auth-cache.js";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
+// Copied into managed homes like COPIED_SHARED_FILES, but excluded from the
+// sandbox sync allowlist below. AGENTS.md and RTK.md carry the rtk usage
+// instructions (see the rtk layer in the root Dockerfile); the rtk binary
+// ships in this image but not in the agent-runtime sandbox images, so staging
+// these files into a sandbox would instruct Codex to call a binary that does
+// not exist there.
+const LOCAL_ONLY_COPIED_SHARED_FILES = ["AGENTS.md", "RTK.md"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const MANAGED_MCP_BLOCK_START = "# BEGIN PAPERCLIP MANAGED MCP";
 const MANAGED_MCP_BLOCK_END = "# END PAPERCLIP MANAGED MCP";
@@ -20,6 +27,8 @@ const MANAGED_MCP_BLOCK_END = "# END PAPERCLIP MANAGED MCP";
  * stock upstream `codex` binary writes at runtime (`*.sqlite`, `*-wal`,
  * `plugins/`, `cache/`, `sessions/`, `shell_snapshots/`, …) is intentionally
  * excluded — it is large host-local runtime state the sandbox run never needs.
+ * `LOCAL_ONLY_COPIED_SHARED_FILES` is also excluded on purpose: those files
+ * reference the container-local rtk binary, which sandbox images do not ship.
  */
 export const CODEX_SYNC_ALLOWLIST = [
   ...COPIED_SHARED_FILES,
@@ -672,7 +681,7 @@ export async function seedManagedCodexHome(
       await ensureSymlink(path.join(targetHome, name), source);
     }
 
-    for (const name of COPIED_SHARED_FILES) {
+    for (const name of [...COPIED_SHARED_FILES, ...LOCAL_ONLY_COPIED_SHARED_FILES]) {
       const source = path.join(sourceHome, name);
       if (!(await pathExists(source))) continue;
       await ensureCopiedFile(path.join(targetHome, name), source);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs shell out through harness CLIs (Claude Code, Codex) inside the production image
> - Common read commands (`git status`, `git diff`, `git log`, `ls`, `grep`) return verbose output that the model pays for on every run
> - [rtk](https://github.com/rtk-ai/rtk) is a CLI proxy that compresses this output by 60–90% and integrates through a Claude Code hook and Codex instructions
> - This pull request ships the pinned, checksum-verified rtk binary in the production image, seeds its Claude and Codex configuration, and makes the seed reach locally-managed codex homes
> - The benefit is a lower token cost for every agent run in this image, with no behavior change for sandbox runs or permission gates

## Linked Issues or Issue Description

No existing issue. Inline description per the enhancement template:

**What existing behavior does this improve?**

Agent runs in the production image spend tokens on uncompressed CLI output. Every `git status` or `grep` result travels to the model in full.

**Subsystem affected**

Production Dockerfile (harness tool layer) and the codex-local adapter's managed-home seeding.

**Current behavior**

The image ships no output-compression tooling. Codex managed homes (`companies/<companyId>/codex-home`) copy only `config.json`, `config.toml`, and `instructions.md` from the shared home.

**Proposed behavior**

The image ships rtk (pinned, checksum-verified). Build time seeds the Claude Code auto-rewrite hook (hook-only) and the Codex `AGENTS.md`/`RTK.md` instructions into `/paperclip`. The codex-local adapter copies `AGENTS.md` and `RTK.md` into locally-managed homes, and keeps them out of the sandbox sync allowlist.

**Reason and benefit**

60–90% output compression on common dev commands lowers the token cost of every local agent run.

**Breaking changes**

None. Sandbox runs are untouched. Deny rules keep matching original commands.

## What Changed

- `Dockerfile`: install rtk in its own version-pinned layer. Download the release tarball directly and verify it against per-arch SHA-256 pins embedded in the Dockerfile. No remote installer script runs.
- `Dockerfile`: seed `/paperclip` with `rtk init -g --hook-only --auto-patch` (Claude Code `PreToolUse` hook only, no `@RTK.md` reference in `CLAUDE.md`) and `rtk init -g --codex` (Codex `AGENTS.md` + `RTK.md`). Set `RTK_TELEMETRY_DISABLED=1`.
- `codex-home.ts`: add `LOCAL_ONLY_COPIED_SHARED_FILES` (`AGENTS.md`, `RTK.md`). `seedManagedCodexHome` copies them into managed homes. `CODEX_SYNC_ALLOWLIST` excludes them on purpose: sandbox runtime images do not ship the rtk binary.
- `codex-home.test.ts`: new test that the seed copies both files; the staging test now proves the sandbox sync excludes them.

## Verification

- `npx vitest run packages/adapters/codex-local/src/server/codex-home.test.ts` — 50 tests pass, including the new seed-copy test and the extended sync-exclusion assertions.
- `pnpm --filter @paperclipai/adapter-codex-local typecheck` — clean.
- Ran the exact Dockerfile layer commands in a `node:24-trixie-slim` container on both arm64 (natively) and amd64 (binary + checksum verified for both arches): checksum check passes, `rtk 0.46.0` runs, `/paperclip/.claude/settings.json` contains only the hook entry, `/paperclip/.codex/` contains `AGENTS.md` + `RTK.md`, all files owned by `node`.
- Fed `PreToolUse` JSON to `rtk hook claude` against a settings file with deny rules: `git status` rewrites to `rtk git status`; `git push --force`, `gh pr merge`, and deny-listed commands return empty output, which defers to the native deny. Permission gates keep matching the original command because every `PreToolUse` hook receives the original tool input.

## Risks

- Supply chain: the binary is pinned by version and by SHA-256 in the Dockerfile. A compromised upstream release cannot change the bytes this build accepts.
- Command interception: the hook rewrites only commands rtk can compress, checks Claude Code permission rules first, and defers to native deny on a match. Managed remote and sandbox Claude runs strip hooks (`sanitizeRemoteClaudeSettings`), so the hook is active only where this image's binary exists.
- Volume seeding: `/paperclip` content reaches a deployment only when the volume starts fresh. Existing volumes keep their own files and gain only the binary. This is documented in the Dockerfile comment.
- Image size: one static binary (~10 MB) plus three small text files.

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic, Claude Code CLI, extended thinking, tool use). All changes reviewed and verified by a human before push.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (searched "rtk", "token compression", "install.sh checksum" — no related PRs found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
