### PR TITLE
fix(auth): honor explicit task assignment denial

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -584,6 +584,17 @@ target issue must be visible to the agent and the responsible user represented
 by the run must also be authorized. In V1, issue visibility defaults to the
 whole company, so these writes are company-wide by default.
 
+Task assignment has one additional agent-level gate. For non-CEO agents, an explicit
+`permissions.canAssignTasks=false` is a hard deny for `tasks:assign` and takes
+precedence over active company membership, the simple-mode default, and stale
+or explicit `tasks:assign` grants. Membership continues to authorize receiving
+and executing assigned work. `permissions.canAssignTasks=true` preserves
+assignment authority subject to company boundaries, target policy, trust, and
+responsible-user checks. Agents whose legacy records omit the field retain the
+existing simple-mode compatibility behavior until their permissions are
+explicitly reconciled. The CEO role retains its existing assignment authority
+as the company control-plane fallback.
+
 The shared rule does not widen low-trust, `skill_test`, or `task_bridge` key
 scopes. It also does not replace run-lifecycle controls: checkout ownership,
 active-run conflicts, status-transition validation, interaction ownership,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -67,7 +67,7 @@ export interface AgentInstructionsBundle {
 
 export interface AgentAccessState {
   canAssignTasks: boolean;
-  taskAssignSource: "simple_default" | "explicit_grant" | "agent_creator" | "ceo_role" | "none";
+  taskAssignSource: "simple_default" | "explicit_permission" | "explicit_grant" | "explicit_deny" | "agent_creator" | "ceo_role" | "none";
   membership: CompanyMembership | null;
   grants: PrincipalPermissionGrant[];
 }

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -14,6 +14,7 @@ import { objectWithoutDefaults } from "./partial.js";
 export const agentPermissionsSchema = z.object({
   canCreateAgents: z.boolean().optional().default(false),
   canCreateSkills: z.boolean().optional().default(true),
+  canAssignTasks: z.boolean().optional().default(true),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),
 }).catchall(z.unknown());

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -941,6 +941,55 @@ describe.sequential("agent permission routes", () => {
     );
   }, 15_000);
 
+  it("preserves membership without granting tasks:assign when a hire explicitly disables it", async () => {
+    mockAgentService.create.mockResolvedValue({
+      ...baseAgent,
+      permissions: { canCreateAgents: false, canAssignTasks: false },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Receiver",
+        role: "pm",
+        adapterType: "process",
+        adapterConfig: {},
+        permissions: { canAssignTasks: false },
+      }));
+
+    expect(res.status).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({
+        permissions: expect.objectContaining({ canAssignTasks: false }),
+      }),
+      expect.any(Object),
+    );
+    expect(mockAccessService.ensureMembership).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "member",
+      "active",
+    );
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "tasks:assign",
+      false,
+      "board-user",
+    );
+  }, 15_000);
+
   it("rejects unsupported query parameters on the agent list route", async () => {
     const app = await createApp({
       type: "board",
@@ -1632,8 +1681,12 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.access.taskAssignSource).toBe("explicit_grant");
   }, 15_000);
 
-  it("reports simple-mode task assignment as enabled for active company agent members", async () => {
+  it("reports explicit task assignment denial for active company agent members", async () => {
     mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      permissions: { canCreateAgents: false, canAssignTasks: false },
+    });
 
     const app = await createApp({
       type: "board",
@@ -1646,14 +1699,14 @@ describe.sequential("agent permission routes", () => {
     const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
 
     expect(res.status).toBe(200);
-    expect(res.body.access.canAssignTasks).toBe(true);
-    expect(res.body.access.taskAssignSource).toBe("simple_default");
+    expect(res.body.access.canAssignTasks).toBe(false);
+    expect(res.body.access.taskAssignSource).toBe("explicit_deny");
   }, 15_000);
 
-  it("keeps task assignment enabled when agent creation privilege is enabled", async () => {
+  it("keeps explicit task assignment denial separate from agent creation privilege", async () => {
     mockAgentService.updatePermissions.mockResolvedValue({
       ...baseAgent,
-      permissions: { canCreateAgents: true },
+      permissions: { canCreateAgents: true, canAssignTasks: false },
     });
 
     const app = await createApp({
@@ -1674,11 +1727,11 @@ describe.sequential("agent permission routes", () => {
       "agent",
       agentId,
       "tasks:assign",
-      true,
+      false,
       "board-user",
     );
-    expect(res.body.access.canAssignTasks).toBe(true);
-    expect(res.body.access.taskAssignSource).toBe("agent_creator");
+    expect(res.body.access.canAssignTasks).toBe(false);
+    expect(res.body.access.taskAssignSource).toBe("explicit_deny");
   });
 
   it("preserves disabled skill creation when unrelated permission updates omit that field", async () => {

--- a/server/src/__tests__/agent-permissions-service.test.ts
+++ b/server/src/__tests__/agent-permissions-service.test.ts
@@ -34,6 +34,12 @@ describe("agent permissions service", () => {
     expect(normalizeAgentPermissions({ canCreateSkills: true }, "engineer").canCreateSkills).toBe(true);
   });
 
+  it("defaults legacy task assignment permission on and preserves explicit false", () => {
+    expect(normalizeAgentPermissions({}, "engineer").canAssignTasks).toBe(true);
+    expect(normalizeAgentPermissions({ canAssignTasks: false }, "pm").canAssignTasks).toBe(false);
+    expect(agentPermissionsSchema.parse({ canCreateAgents: false }).canAssignTasks).toBe(true);
+  });
+
   it("validates skill creation permission with a default-on value", () => {
     expect(agentPermissionsSchema.parse({ canCreateAgents: false }).canCreateSkills).toBe(true);
     expect(agentPermissionsSchema.parse({ canCreateAgents: false, canCreateSkills: false }).canCreateSkills).toBe(false);

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1295,6 +1295,49 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("denies task assignment when an active common agent explicitly disables it despite a stale grant", async () => {
+    const company = await createCompany(db, "ExplicitAgentAssignmentDeny");
+    const actorAgent = await createAgent(db, company.id, {
+      role: "pm",
+      permissions: { canAssignTasks: false },
+    });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    await grantAgentPermission(db, company.id, actorAgent.id, "tasks:assign");
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: targetAgent.id },
+      scope: { assigneeAgentId: targetAgent.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_agent_permission",
+    });
+  });
+
+  it("keeps an authorized CTO task assignment grant effective", async () => {
+    const company = await createCompany(db, "ExplicitCtoAssignmentAllow");
+    const actorAgent = await createAgent(db, company.id, {
+      role: "cto",
+      permissions: { canAssignTasks: true },
+    });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    await grantAgentPermission(db, company.id, actorAgent.id, "tasks:assign");
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: targetAgent.id },
+      scope: { assigneeAgentId: targetAgent.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+    });
+  });
+
   it("allows null-mapped visibility actions for active same-company board members", async () => {
     const company = await createCompany(db, "BoardVisibility");
     const userId = `user-${randomUUID()}`;
@@ -2206,6 +2249,43 @@ describeEmbeddedPostgres("authorization service", () => {
     })).resolves.toMatchObject({
       allowed: false,
       reason: "deny_scope",
+    });
+  });
+
+  it("denies task bridge assignment when the actor explicitly disables task assignment", async () => {
+    const company = await createCompany(db, "TaskBridgeExplicitDeny");
+    const bridgeAgent = await createAgent(db, company.id, {
+      permissions: { canAssignTasks: false },
+    });
+    const targetAgent = await createAgent(db, company.id);
+    const project = await createProject(db, company.id, "BridgeExplicitDeny");
+    const parentIssue = await createIssue(db, company.id, { projectId: project.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: bridgeAgent.id,
+        companyId: company.id,
+        source: "agent_jwt",
+        keyId: randomUUID(),
+        keyScope: {
+          kind: "task_bridge",
+          parentIssueId: parentIssue.id,
+          allowedAssigneeAgentIds: [targetAgent.id],
+        },
+      },
+      action: "tasks:assign",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        parentIssueId: parentIssue.id,
+        assigneeAgentId: targetAgent.id,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_agent_permission",
     });
   });
 

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -1891,6 +1891,111 @@ describe("company portability", () => {
     );
   });
 
+  it("does not widen a scoped assignment grant during a replace import", async () => {
+    const portability = companyPortabilityService({} as any);
+    agentSvc.list.mockResolvedValue([{
+      id: "agent-1",
+      name: "ClaudeCoder",
+      status: "idle",
+      role: "engineer",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+      permissions: {},
+      metadata: null,
+    }]);
+    const updatedAgent = async (id: string, patch: Record<string, unknown>) => ({
+      id,
+      name: "ClaudeCoder",
+      status: "idle",
+      ...patch,
+    });
+    agentSvc.update
+      .mockImplementationOnce(updatedAgent)
+      .mockImplementationOnce(updatedAgent);
+
+    await portability.importBundle({
+      source: {
+        type: "inline",
+        files: {
+          "COMPANY.md": [
+            "---",
+            "name: Import",
+            "includes:",
+            "  - agents/claudecoder/AGENTS.md",
+            "---",
+            "",
+          ].join("\n"),
+          "agents/claudecoder/AGENTS.md": [
+            "---",
+            "name: ClaudeCoder",
+            "slug: claudecoder",
+            "kind: agent",
+            "---",
+            "",
+            "# ClaudeCoder",
+            "",
+          ].join("\n"),
+          ".paperclip.yaml": [
+            "schema: paperclip/v1",
+            "agents:",
+            "  claudecoder:",
+            "    adapter:",
+            "      type: process",
+            "      config: {}",
+            "    permissions:",
+            "      canAssignTasks: true",
+            "    permissionGrants:",
+            "      - permissionKey: tasks:assign_scope",
+            "        scope:",
+            "          projectIds:",
+            "            - project-1",
+            "",
+          ].join("\n"),
+        },
+      },
+      include: {
+        company: false,
+        agents: true,
+        projects: false,
+        issues: false,
+      },
+      target: {
+        mode: "existing_company",
+        companyId: "company-1",
+      },
+      collisionStrategy: "replace",
+    }, "user-1");
+
+    expect(accessSvc.setPrincipalPermission).toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-1",
+      "tasks:assign",
+      false,
+      "user-1",
+    );
+    expect(accessSvc.setPrincipalPermission).not.toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-1",
+      "tasks:assign",
+      true,
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(accessSvc.setPrincipalPermission).toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-1",
+      "tasks:assign_scope",
+      true,
+      "user-1",
+      { projectIds: ["project-1"] },
+    );
+  });
+
   it("removes import secrets created before a later import failure", async () => {
     const portability = companyPortabilityService({} as any);
     agentSvc.list.mockResolvedValue([]);

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -1828,7 +1828,10 @@ describe("company portability", () => {
             "    adapter:",
             "      type: process",
             "      config: {}",
+            "    permissions:",
+            "      canAssignTasks: false",
             "    permissionGrants:",
+            "      - permissionKey: tasks:assign",
             "      - permissionKey: agents:suggest-changes",
             "      - permissionKey: skills:create",
             "        scope:",
@@ -1851,6 +1854,23 @@ describe("company portability", () => {
       collisionStrategy: "rename",
     }, "user-1");
 
+    expect(accessSvc.setPrincipalPermission).toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-imported",
+      "tasks:assign",
+      false,
+      "user-1",
+    );
+    expect(accessSvc.setPrincipalPermission).not.toHaveBeenCalledWith(
+      "company-1",
+      "agent",
+      "agent-imported",
+      "tasks:assign",
+      true,
+      expect.anything(),
+      expect.anything(),
+    );
     expect(accessSvc.setPrincipalPermission).toHaveBeenCalledWith(
       "company-1",
       "agent",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -84,6 +84,7 @@ import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { skillVersionSelectionMap } from "../services/runtime-skill-selections.js";
 import { secretService } from "../services/secrets.js";
 import { authorizationDeniedDetails } from "../services/authorization.js";
+import { agentExplicitlyDeniesTaskAssignment } from "../services/agent-permissions.js";
 import {
   detectAdapterModel,
   findActiveServerAdapter,
@@ -1035,6 +1036,9 @@ export function agentRoutes(
       ? await access.listPrincipalGrants(agent.companyId, "agent", agent.id)
       : [];
     const hasExplicitTaskAssignGrant = grants.some((grant) => grant.permissionKey === "tasks:assign");
+    const explicitCanAssignTasks = typeof agent.permissions?.canAssignTasks === "boolean"
+      ? agent.permissions.canAssignTasks
+      : null;
 
     if (agent.role === "ceo") {
       return {
@@ -1045,10 +1049,10 @@ export function agentRoutes(
       };
     }
 
-    if (canCreateAgents(agent)) {
+    if (agentExplicitlyDeniesTaskAssignment(agent)) {
       return {
-        canAssignTasks: true,
-        taskAssignSource: "agent_creator" as const,
+        canAssignTasks: false,
+        taskAssignSource: "explicit_deny" as const,
         membership,
         grants,
       };
@@ -1058,6 +1062,24 @@ export function agentRoutes(
       return {
         canAssignTasks: true,
         taskAssignSource: "explicit_grant" as const,
+        membership,
+        grants,
+      };
+    }
+
+    if (explicitCanAssignTasks === true) {
+      return {
+        canAssignTasks: true,
+        taskAssignSource: "explicit_permission" as const,
+        membership,
+        grants,
+      };
+    }
+
+    if (canCreateAgents(agent)) {
+      return {
+        canAssignTasks: true,
+        taskAssignSource: "agent_creator" as const,
         membership,
         grants,
       };
@@ -1160,17 +1182,16 @@ export function agentRoutes(
   }
 
   async function applyDefaultAgentTaskAssignGrant(
-    companyId: string,
-    agentId: string,
+    agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
     grantedByUserId: string | null,
   ) {
-    await access.ensureMembership(companyId, "agent", agentId, "member", "active");
+    await access.ensureMembership(agent.companyId, "agent", agent.id, "member", "active");
     await access.setPrincipalPermission(
-      companyId,
+      agent.companyId,
       "agent",
-      agentId,
+      agent.id,
       "tasks:assign",
-      true,
+      !agentExplicitlyDeniesTaskAssignment(agent),
       grantedByUserId,
     );
   }
@@ -3517,8 +3538,7 @@ export function agentRoutes(
     }
 
     await applyDefaultAgentTaskAssignGrant(
-      companyId,
-      agent.id,
+      agent,
       actor.actorType === "user" ? actor.actorId : null,
     );
 
@@ -3663,8 +3683,7 @@ export function agentRoutes(
     }
 
     await applyDefaultAgentTaskAssignGrant(
-      companyId,
-      agent.id,
+      agent,
       req.actor.type === "board" ? (req.actor.userId ?? null) : null,
     );
     await builtInAgentService(db).ensureCompanyDefaultAgentGrants(companyId);
@@ -3710,8 +3729,7 @@ export function agentRoutes(
       return;
     }
 
-    const effectiveCanAssignTasks =
-      agent.role === "ceo" || Boolean(agent.permissions?.canCreateAgents) || req.body.canAssignTasks;
+    const effectiveCanAssignTasks = !agentExplicitlyDeniesTaskAssignment(agent);
     await access.ensureMembership(agent.companyId, "agent", agent.id, "member", "active");
     await access.setPrincipalPermission(
       agent.companyId,

--- a/server/src/services/agent-permissions.ts
+++ b/server/src/services/agent-permissions.ts
@@ -1,12 +1,24 @@
 export type NormalizedAgentPermissions = Record<string, unknown> & {
   canCreateAgents: boolean;
   canCreateSkills: boolean;
+  canAssignTasks: boolean;
 };
+
+type AgentTaskAssignmentSubject = {
+  role: string;
+  permissions: Record<string, unknown> | null | undefined;
+};
+
+export function agentExplicitlyDeniesTaskAssignment(agent: AgentTaskAssignmentSubject): boolean {
+  return agent.role.trim().toLowerCase() !== "ceo"
+    && agent.permissions?.canAssignTasks === false;
+}
 
 export function defaultPermissionsForRole(role: string): NormalizedAgentPermissions {
   return {
     canCreateAgents: role.trim().toLowerCase() === "ceo",
     canCreateSkills: true,
+    canAssignTasks: true,
   };
 }
 
@@ -31,5 +43,9 @@ export function normalizeAgentPermissions(
       typeof record.canCreateSkills === "boolean"
         ? record.canCreateSkills
         : defaults.canCreateSkills,
+    canAssignTasks:
+      typeof record.canAssignTasks === "boolean"
+        ? record.canAssignTasks
+        : defaults.canAssignTasks,
   };
 }

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -28,6 +28,7 @@ import {
   type TrustPresetResolution,
 } from "./trust-preset-resolver.js";
 import { logger } from "../middleware/logger.js";
+import { agentExplicitlyDeniesTaskAssignment } from "./agent-permissions.js";
 
 export type AuthorizationActor =
   {
@@ -119,6 +120,7 @@ export type AuthorizationDecision = {
     | "inbox_agent_not_allowed"
     | "deny_unauthenticated"
     | "deny_company_boundary"
+    | "deny_agent_permission"
     | "deny_missing_membership"
     | "deny_missing_grant"
     | "deny_missing_consent"
@@ -1836,6 +1838,14 @@ export function authorizationService(db: Db) {
         action: input.action,
         reason: "deny_company_boundary",
         explanation: "Actor agent was not found in the target company.",
+      });
+    }
+
+    if (input.action === "tasks:assign" && agentExplicitlyDeniesTaskAssignment(actorAgent)) {
+      return deny({
+        action: input.action,
+        reason: "deny_agent_permission",
+        explanation: "Task assignment is disabled by the agent's explicit canAssignTasks permission.",
       });
     }
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3537,20 +3537,34 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     permissionGrants: PortableAgentPermissionGrant[],
     grantedByUserId: string | null,
     taskAssignmentEnabled: boolean,
+    grantTaskAssignmentByDefault: boolean,
   ) {
+    const hasUnscopedTaskAssignmentGrant = permissionGrants.some(
+      (grant) => grant.permissionKey === "tasks:assign",
+    );
+    const hasScopedTaskAssignmentGrant = permissionGrants.some(
+      (grant) => grant.permissionKey === "tasks:assign_scope",
+    );
+    const grantUnscopedTaskAssignment = taskAssignmentEnabled && (
+      hasUnscopedTaskAssignmentGrant
+      || (grantTaskAssignmentByDefault && !hasScopedTaskAssignmentGrant)
+    );
     await access.ensureMembership(companyId, "agent", agentId, "member", "active");
     await access.setPrincipalPermission(
       companyId,
       "agent",
       agentId,
       "tasks:assign",
-      taskAssignmentEnabled,
+      grantUnscopedTaskAssignment,
       grantedByUserId,
     );
     for (const grant of permissionGrants) {
+      if (grant.permissionKey === "tasks:assign") {
+        continue;
+      }
       if (
         !taskAssignmentEnabled
-        && (grant.permissionKey === "tasks:assign" || grant.permissionKey === "tasks:assign_scope")
+        && grant.permissionKey === "tasks:assign_scope"
       ) {
         continue;
       }
@@ -5644,6 +5658,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
               manifestAgent.permissionGrants ?? [],
               actorUserId ?? null,
               !agentExplicitlyDeniesTaskAssignment(manifestAgent),
+              false,
             );
             agentStatusById.set(updated.id, updated.status ?? agentStatusById.get(updated.id) ?? null);
             await secrets.syncEnvBindingsForTarget?.(
@@ -5683,6 +5698,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             manifestAgent.permissionGrants ?? [],
             actorUserId ?? null,
             !agentExplicitlyDeniesTaskAssignment(manifestAgent),
+            true,
           );
           agentStatusById.set(created.id, created.status ?? (pauseAutomations ? "paused" : "idle"));
           await secrets.syncEnvBindingsForTarget?.(

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -76,6 +76,7 @@ import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
 import { accessService } from "./access.js";
 import { agentService } from "./agents.js";
+import { agentExplicitlyDeniesTaskAssignment } from "./agent-permissions.js";
 import { agentInstructionsService } from "./agent-instructions.js";
 import { assetService } from "./assets.js";
 import { generateReadme } from "./company-export-readme.js";
@@ -3535,10 +3536,24 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     agentId: string,
     permissionGrants: PortableAgentPermissionGrant[],
     grantedByUserId: string | null,
+    taskAssignmentEnabled: boolean,
   ) {
-    if (permissionGrants.length === 0) return;
     await access.ensureMembership(companyId, "agent", agentId, "member", "active");
+    await access.setPrincipalPermission(
+      companyId,
+      "agent",
+      agentId,
+      "tasks:assign",
+      taskAssignmentEnabled,
+      grantedByUserId,
+    );
     for (const grant of permissionGrants) {
+      if (
+        !taskAssignmentEnabled
+        && (grant.permissionKey === "tasks:assign" || grant.permissionKey === "tasks:assign_scope")
+      ) {
+        continue;
+      }
       await access.setPrincipalPermission(
         companyId,
         "agent",
@@ -5628,6 +5643,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
               updated.id,
               manifestAgent.permissionGrants ?? [],
               actorUserId ?? null,
+              !agentExplicitlyDeniesTaskAssignment(manifestAgent),
             );
             agentStatusById.set(updated.id, updated.status ?? agentStatusById.get(updated.id) ?? null);
             await secrets.syncEnvBindingsForTarget?.(
@@ -5652,15 +5668,6 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             ...automationPausePatch,
             status: pauseAutomations ? "paused" : "idle",
           });
-          await access.ensureMembership(targetCompany.id, "agent", created.id, "member", "active");
-          await access.setPrincipalPermission(
-            targetCompany.id,
-            "agent",
-            created.id,
-            "tasks:assign",
-            true,
-            actorUserId ?? null,
-          );
           try {
             const materialized = await instructions.materializeManagedBundle(created, bundleFiles, {
               clearLegacyPromptTemplate: true,
@@ -5675,6 +5682,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             created.id,
             manifestAgent.permissionGrants ?? [],
             actorUserId ?? null,
+            !agentExplicitlyDeniesTaskAssignment(manifestAgent),
           );
           agentStatusById.set(created.id, created.status ?? (pauseAutomations ? "paused" : "idle"));
           await secrets.syncEnvBindingsForTarget?.(

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2159,7 +2159,7 @@ function ConfigurationTab({
   const canCreateSkills = agent.permissions?.canCreateSkills !== false;
   const canAssignTasks = Boolean(agent.access?.canAssignTasks);
   const taskAssignSource = agent.access?.taskAssignSource ?? "none";
-  const taskAssignLocked = agent.role === "ceo" || canCreateAgents;
+  const taskAssignLocked = agent.role === "ceo";
   const taskAssignHint =
     taskAssignSource === "ceo_role"
       ? "Enabled automatically for CEO agents."
@@ -2167,9 +2167,13 @@ function ConfigurationTab({
         ? "Enabled automatically while this agent can create new agents."
         : taskAssignSource === "explicit_grant"
           ? "Enabled via explicit organization permission grant."
-          : taskAssignSource === "simple_default"
-            ? "Enabled by simple organization-wide task assignment defaults."
-            : "Disabled unless explicitly granted.";
+          : taskAssignSource === "explicit_permission"
+            ? "Enabled by this agent's explicit task assignment permission."
+            : taskAssignSource === "explicit_deny"
+              ? "Disabled by this agent's explicit task assignment permission."
+              : taskAssignSource === "simple_default"
+                ? "Enabled by simple organization-wide task assignment defaults."
+                : "Disabled unless explicitly granted.";
 
   return (
     <div className="space-y-6">
@@ -2224,7 +2228,7 @@ function ConfigurationTab({
             <div className="space-y-1">
               <div>Can create new agents</div>
               <p className="text-xs text-muted-foreground">
-                Lets this agent create or hire agents. This also grants task assignment authority.
+                Lets this agent create or hire agents. Task assignment authority is configured separately.
               </p>
             </div>
             <ToggleSwitch
@@ -2233,7 +2237,7 @@ function ConfigurationTab({
                 updatePermissions.mutate({
                   canCreateAgents: !canCreateAgents,
                   canCreateSkills,
-                  canAssignTasks: !canCreateAgents ? true : canAssignTasks,
+                  canAssignTasks,
                 })
               }
               disabled={updatePermissions.isPending}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI agents for work
> - Paperclip uses agent permissions, company membership, and grants to control task assignment
> - An active membership currently enables task assignment through the simple default path
> - This path ignores an explicit `canAssignTasks: false` value for a non-CEO agent
> - This pull request makes the explicit denial take precedence across access, authorization, hire, update, and import paths
> - The benefit is that agents can receive work without gaining authority to delegate work

## Linked Issues or Issue Description

Refs #375

Refs #1426

**What happened?**

An active non-CEO agent with `permissions.canAssignTasks: false` could still receive `access.canAssignTasks: true`. The access state used `simple_default`. The authorization service also allowed task assignment through membership or a stale grant.

**Expected behavior**

An explicit `canAssignTasks: false` value must deny task assignment for a non-CEO agent. Active membership must still allow the agent to receive and execute work. An authorized agent with `canAssignTasks: true` must keep valid task assignment grants.

**Steps to reproduce**

1. Create a non-CEO agent with active company membership.
2. Set `permissions.canAssignTasks` to `false`.
3. Remove any `tasks:assign` grant, or leave a stale grant in place.
4. Read the agent access state or request a task assignment decision.
5. Observe that the current code allows assignment through `simple_default` or the stale grant.

**Paperclip version or commit**

The defect reproduces from commit `67f9867bc65002e9c4b8cc68ad57a491231e86df`. This branch is based on `3d9be6f7fe0a1ab435a89b0c99b3654e272bc49c`.

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Not adapter-specific. This is a core authorization bug.

**Database mode**

The focused authorization tests use embedded PostgreSQL. The production correction does not require a data migration.

## What Changed

- Make `canAssignTasks: false` a hard denial for non-CEO agents before membership defaults, task bridges, and grants.
- Add `explicit_deny` to the access-state source contract.
- Keep company membership active when task assignment is disabled.
- Remove or avoid broad `tasks:assign` grants during hire and permission updates when the explicit permission is false.
- Ignore incompatible task assignment grants during company import.
- Keep authorized CTO and CEO task assignment behavior.
- Separate task assignment authority from agent creation authority in the UI.
- Update the implementation specification and focused regression tests.

## Verification

- Ran eight focused regressions across authorization, agent routes, agent permissions, and company portability. All eight passed.
- Ran `pnpm --filter @paperclipai/shared typecheck`. It passed.
- Ran `pnpm --filter @paperclipai/server typecheck`. It passed.
- Ran `pnpm --filter @paperclipai/ui typecheck`. It passed.
- Ran `git diff --check`. It passed.
- Confirmed that the rebased patch has the same stable patch ID as the reviewed candidate.

## Risks

- This change removes legacy delegation from a non-CEO agent only when the stored permission is explicitly false.
- Legacy agents with no stored value keep the normalized compatibility default.
- CEO compatibility remains in place.
- The import path now rejects grants that conflict with an explicit denial.
- No schema or data migration is required.
- Rollback is a full revert of this commit.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The exact serving snapshot, context-window size, and internal reasoning trace are not exposed. Tool use and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
