### PR TITLE
fix(issues): honor stored unblockDescriptor when re-entering blocked

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1804,6 +1804,8 @@ export {
   issueBlockedInboxReasonSchema,
   issueBlockedInboxSeveritySchema,
   issueBlockedInboxStateSchema,
+  issueUnblockDescriptorSchema,
+  isValidIssueUnblockDescriptor,
   updateIssueSchema,
   stalledReviewDecisionSchema,
   issueExecutionPolicySchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -418,6 +418,8 @@ export {
   issueBlockedInboxReasonSchema,
   issueBlockedInboxSeveritySchema,
   issueBlockedInboxStateSchema,
+  issueUnblockDescriptorSchema,
+  isValidIssueUnblockDescriptor,
   updateIssueSchema,
   stalledReviewDecisionSchema,
   issueExecutionPolicySchema,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -39,6 +39,7 @@ import {
 import { multilineTextSchema } from "./text.js";
 import { lowTrustReviewPresetPolicySchema, trustAuthorizationPolicySchema } from "./trust-policy.js";
 import { objectWithoutDefaults } from "./partial.js";
+import type { IssueUnblockDescriptor } from "../types/issue.js";
 
 export const issueBlockedInboxStateSchema = z.enum([
   "needs_attention",
@@ -472,20 +473,26 @@ function withCreateIssueStatusDefault<T extends z.ZodRawShape>(schema: z.ZodObje
   }, schema);
 }
 
+export const issueUnblockDescriptorSchema = z.object({
+  owner: z.union([
+    z.object({ agentId: z.string().guid() }).strict(),
+    z.object({ userId: z.string().trim().min(1) }).strict(),
+    z.literal("board"),
+  ]),
+  action: multilineTextSchema.pipe(z.string().trim().min(1).max(2_000)),
+}).strict();
+
+export function isValidIssueUnblockDescriptor(value: unknown): value is IssueUnblockDescriptor {
+  return issueUnblockDescriptorSchema.safeParse(value).success;
+}
+
 const createIssueBaseSchema = z.object({
   projectId: z.string().guid().optional().nullable(),
   projectWorkspaceId: z.string().guid().optional().nullable(),
   goalId: z.string().guid().optional().nullable(),
   parentId: z.string().guid().optional().nullable(),
   blockedByIssueIds: z.array(z.string().guid()).optional(),
-  unblockDescriptor: z.object({
-    owner: z.union([
-      z.object({ agentId: z.string().guid() }).strict(),
-      z.object({ userId: z.string().trim().min(1) }).strict(),
-      z.literal("board"),
-    ]),
-    action: multilineTextSchema.pipe(z.string().trim().min(1).max(2_000)),
-  }).strict().optional().nullable(),
+  unblockDescriptor: issueUnblockDescriptorSchema.optional().nullable(),
   inheritExecutionWorkspaceFromIssueId: z.string().guid().optional().nullable(),
   title: z.string().min(1),
   description: multilineTextSchema.optional().nullable(),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -22,6 +22,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getByIdForUpdate: vi.fn(),
   getComment: vi.fn(),
+  getCurrentScheduledRetry: vi.fn(),
   getDependencyReadiness: vi.fn(),
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
@@ -363,6 +364,55 @@ async function createApp(actor: Record<string, unknown>, db?: unknown) {
   return app;
 }
 
+// Variant of createRunContextDb whose row resolution does not fabricate a
+// phantom row for arbitrary keyed selects (e.g. `{ id: ... }`), so guard
+// queries for pending interactions/approvals genuinely resolve to empty.
+function createGuardStrictDb() {
+  const runRows = [{
+    id: ownerRunId,
+    companyId,
+    agentId: ownerAgentId,
+    agentCompanyId: companyId,
+    contextSnapshot: {},
+  }];
+  const rowsForSelection = async (selection: Record<string, unknown>) => {
+    const keys = Object.keys(selection);
+    if (keys.includes("entityId")) return [];
+    if (keys.includes("contextSnapshot")) return runRows;
+    if (keys.includes("agentCompanyId")) return runRows;
+    if (keys.length === 0) {
+      const issue = await mockIssueService.getById(issueId);
+      return issue ? [issue] : [];
+    }
+    return [];
+  };
+  const buildQuery = (selection: Record<string, unknown>) => {
+    const whereResult = {
+      orderBy: vi.fn(async () => []),
+      limit: vi.fn(() => ({
+        then: async (resolve: (limitedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection)),
+      })),
+      for: vi.fn(() => ({
+        then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection)),
+      })),
+      then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(await rowsForSelection(selection)),
+    };
+    const query = {
+      innerJoin: vi.fn(() => query),
+      where: vi.fn(() => whereResult),
+    };
+    return query;
+  };
+  const dbStub = {
+    transaction: async (callback: (tx: typeof dbStub) => Promise<unknown>) => callback(dbStub),
+    select: vi.fn((selection: Record<string, unknown> = {}) => ({
+      from: vi.fn(() => buildQuery(selection)),
+    })),
+    insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+  };
+  return dbStub;
+}
+
 function peerActor(overrides: Record<string, unknown> = {}) {
   return {
     type: "agent",
@@ -459,6 +509,8 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.getById.mockReset();
     mockIssueService.getByIdForUpdate.mockReset();
     mockIssueService.getComment.mockReset();
+    mockIssueService.getCurrentScheduledRetry.mockReset();
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
     mockIssueService.getDependencyReadiness.mockReset();
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       blockerIssueIds: [],
@@ -1688,6 +1740,63 @@ describe("agent issue mutation checkout ownership", () => {
         unblockDescriptor: { owner: "board", action: "Review the blocker" },
       }),
     );
+  });
+
+  it("applies a board blocked transition that carries a comment alongside the unblockDescriptor", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "in_progress" }),
+      ...patch,
+    }));
+
+    const res = await request(await createApp(boardActor(), createGuardStrictDb())).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      comment: "Deferring remaining scope to the rebaseline window.",
+      unblockDescriptor: { owner: "board", action: "Rebaseline date arrives" },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+        unblockDescriptor: { owner: "board", action: "Rebaseline date arrives" },
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+  });
+
+  it("honors a stored unblockDescriptor when re-entering blocked without a payload descriptor", async () => {
+    const storedDescriptor = { owner: "board", action: "Rebaseline date arrives" };
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", unblockDescriptor: storedDescriptor }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "in_progress", unblockDescriptor: storedDescriptor }),
+      ...patch,
+    }));
+
+    const res = await request(await createApp(boardActor(), createGuardStrictDb()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "blocked" }),
+    );
+  });
+
+  it("still rejects entering blocked with no blockers, pending review path, or stored owner", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+
+    const res = await request(await createApp(boardActor(), createGuardStrictDb()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toBe("Entering blocked requires unresolved blockers, a pending interaction/approval, or unblockDescriptor");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("rejects peer-agent status updates that would clear a recovery action they do not own", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1787,6 +1787,21 @@ describe("agent issue mutation checkout ownership", () => {
     );
   });
 
+  it("rejects entering blocked with an explicit null unblockDescriptor even when one is stored", async () => {
+    const storedDescriptor = { owner: "board", action: "Rebaseline date arrives" };
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", unblockDescriptor: storedDescriptor }),
+    );
+
+    const res = await request(await createApp(boardActor(), createGuardStrictDb()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked", unblockDescriptor: null });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toBe("Entering blocked requires unresolved blockers, a pending interaction/approval, or unblockDescriptor");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("still rejects entering blocked with no blockers, pending review path, or stored owner", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -66,6 +66,7 @@ import {
   updateDocumentAnnotationThreadSchema,
   upsertIssueDocumentSchema,
   updateIssueSchema,
+  isValidIssueUnblockDescriptor,
   isClosedIsolatedExecutionWorkspace,
   isMarkdownArtifactWorkProduct,
   isMarkdownAttachmentContent,
@@ -9697,6 +9698,11 @@ export function issueRoutes(
       throw unprocessable("unblockDescriptor requires blocked status");
     }
     const descriptor = updateFields.unblockDescriptor ?? null;
+    // A descriptor persisted by an earlier blocked transition still names the
+    // unblock owner, so re-entering blocked (e.g. repairing an issue whose
+    // status enum drifted from its stored descriptor) must not be rejected
+    // just because this request omits the descriptor payload.
+    const storedDescriptorNamesOwner = isValidIssueUnblockDescriptor(existing.unblockDescriptor);
     if (descriptor && typeof descriptor === "object") {
       const owner = descriptor.owner;
       if (req.actor.type === "agent" && (owner === "board" || "userId" in owner)) {
@@ -9745,7 +9751,7 @@ export function issueRoutes(
           eq(approvals.status, "pending"),
         )).limit(1).then((rows) => rows[0] ?? null),
       ]);
-      if (!hasUnresolvedBlocker && !pendingInteraction && !pendingApproval && !descriptor) {
+      if (!hasUnresolvedBlocker && !pendingInteraction && !pendingApproval && !descriptor && !storedDescriptorNamesOwner) {
         res.status(422).json({ error: "Entering blocked requires unresolved blockers, a pending interaction/approval, or unblockDescriptor" });
         return;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9701,8 +9701,12 @@ export function issueRoutes(
     // A descriptor persisted by an earlier blocked transition still names the
     // unblock owner, so re-entering blocked (e.g. repairing an issue whose
     // status enum drifted from its stored descriptor) must not be rejected
-    // just because this request omits the descriptor payload.
-    const storedDescriptorNamesOwner = isValidIssueUnblockDescriptor(existing.unblockDescriptor);
+    // just because this request omits the descriptor payload. An explicit
+    // null payload clears the descriptor, so it must NOT borrow the stored
+    // one here or the update would persist blocked with no unblock path.
+    const storedDescriptorNamesOwner =
+      updateFields.unblockDescriptor === undefined &&
+      isValidIssueUnblockDescriptor(existing.unblockDescriptor);
     if (descriptor && typeof descriptor === "object") {
       const owner = descriptor.owner;
       if (req.actor.type === "agent" && (owner === "board" || "userId" in owner)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - An issue may enter `blocked` status without issue blockers. In that case the request must name an unblock owner with `unblockDescriptor`.
> - The route guard for entering `blocked` only looked at the descriptor inside the request payload.
> - An issue can already store a valid descriptor, and a later status-only PATCH to `blocked` was still rejected with 422.
> - This can strand an issue that stores a descriptor while its status enum shows something else, because the repair call is the one the guard refuses.
> - This pull request lets the guard accept a valid stored descriptor as proof that an unblock owner exists.
> - The benefit is that re-entering `blocked` works when an owner is already recorded, and repair of drifted issues is no longer blocked.

## Linked Issues or Issue Description

**What happened?**

An operator moved an issue to `blocked` with an `unblockDescriptor`. The descriptor was stored on the issue. A later PATCH with only `{ "status": "blocked" }` returned `422` with `Entering blocked requires unresolved blockers, a pending interaction/approval, or unblockDescriptor`. A GET before the call showed the stored descriptor. The guard read only the request payload, so the stored descriptor was ignored.

**Expected behavior**

A stored, valid `unblockDescriptor` names the unblock owner. A PATCH that sets `status: "blocked"` must succeed when the issue already stores such a descriptor, with or without a descriptor in the payload. This matches the rule the error message states.

**Steps to reproduce**

1. Create an issue in a non-blocked status.
2. Store a descriptor on the issue (an earlier blocked transition, or a direct update that persists `unblockDescriptor`).
3. Send `PATCH /api/issues/:id` with body `{ "status": "blocked" }` and no `unblockDescriptor` field.
4. Observe the 422 even though the issue stores a descriptor.

**Paperclip version or commit**

Observed on a self-hosted instance near `master` at the time of PR #11952. The guard code is unchanged on current `master` (`server/src/routes/issues.ts`, the `enteringBlocked` block).

**Deployment mode**

Self-hosted local instance.

Related work: #11952 fixes the sibling case where a review stage rewrites the requested status and the payload descriptor then fails validation. That PR keeps the caller request for the payload check. This PR covers the stored-descriptor side. Refs #11952. Refs #10395.

## What Changed

- Extracted the inline descriptor object schema in `packages/shared/src/validators/issue.ts` into an exported `issueUnblockDescriptorSchema`.
- Added `isValidIssueUnblockDescriptor` type guard in shared, and re-exported both from the shared package root.
- The entering-blocked guard in `server/src/routes/issues.ts` now accepts a valid stored `unblockDescriptor` when the payload has no descriptor.
- Added route tests: a stored descriptor satisfies the guard; a comment plus payload descriptor applies the transition; the guard still rejects entry to `blocked` when no blocker, review path, or stored owner exists.
- Added a strict db stub for tests so pending-interaction and pending-approval queries resolve to empty rows instead of phantom rows.

## Verification

- `cd server && ./node_modules/.bin/vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 90 passed.
- `cd packages/shared && ../../node_modules/.bin/vitest run src/validators/issue.test.ts` — 32 passed.
- `cd server && ./node_modules/.bin/tsc --noEmit` — clean.
- The new stored-descriptor test fails with 422 when the one-line guard change is reverted, and passes with it.

## Risks

Low risk. The change only widens the guard for requests that carry no descriptor. Payload descriptors keep full owner validation. Stored descriptors are only shape-checked, because they were validated when they were written. An issue with a corrupt stored descriptor keeps the old 422 behavior.

## Model Used

GLM by Z.ai — model id `zai-coding-plan/glm-5.2`, long-context coding model with tool use, run inside a Paperclip opencode adapter session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
