### PR TITLE
fix(issues): preserve blocked and review dispositions

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -88,6 +88,8 @@ Execution work is paused because the next move belongs to a reviewer or approver
 
 An external review service can also be a valid review path when the issue keeps an agent assignee and has an active one-shot monitor that will wake that assignee to check the service later.
 
+The current typed reviewer or approver may record an exact comment disposition. `APPROVE` atomically persists the comment, execution decision, and approved status transition. `HOLD` persists the comment and leaves the current review stage pending without creating a generic assignee wake. The tokens have disposition meaning only for the current participant; comments from other actors remain ordinary commentary.
+
 ### `done`
 
 The work is complete and terminal.
@@ -182,6 +184,8 @@ Use it for:
 - automatic wakeups when all blockers resolve
 
 Blocked issues should stay idle while blockers remain unresolved. Paperclip should not create a queued heartbeat run for that issue until the final blocker is done and the `issue_blockers_resolved` wake can start real work.
+
+A plain comment does not resume a `blocked` issue, even when it comes from a human or includes the legacy `reopen` flag. The caller must send the structured `resume: true` intent, and the normal blocker and subtree-hold gates must still pass. A queued wake that observes a later `blocked` state without that structured intent is stale: it is cancelled before execution, and checkout cannot restore the old status or assignee.
 
 `cancelled` is terminal for the blocker issue itself, but it does not satisfy the dependency. A cancelled blocker edge remains unresolved until the edge is removed or replaced, and Paperclip must surface blocker attention on the dependent regardless of whether that dependent is currently displayed as `blocked`, `todo`, `backlog`, or another non-terminal agent-owned status.
 

--- a/server/src/__tests__/heartbeat-auto-checkout.test.ts
+++ b/server/src/__tests__/heartbeat-auto-checkout.test.ts
@@ -35,4 +35,27 @@ describe("shouldAutoCheckoutIssueForWake", () => {
       agentId: reviewerAgentId,
     })).toBe(false);
   });
+
+  it("does not implicitly auto-checkout a blocked issue", () => {
+    expect(shouldAutoCheckoutIssueForWake({
+      contextSnapshot: { wakeReason: "issue_blockers_resolved" },
+      issueStatus: "blocked",
+      issueAssigneeAgentId: "agent-1",
+      isDependencyReady: true,
+      agentId: "agent-1",
+    })).toBe(false);
+  });
+
+  it("allows a blocked issue to auto-checkout only with explicit structured resume intent", () => {
+    expect(shouldAutoCheckoutIssueForWake({
+      contextSnapshot: {
+        wakeReason: "issue_status_changed",
+        resumeIntent: true,
+      },
+      issueStatus: "blocked",
+      issueAssigneeAgentId: "agent-1",
+      isDependencyReady: true,
+      agentId: "agent-1",
+    })).toBe(true);
+  });
 });

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1120,6 +1120,128 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("preserves a board-blocked status and replacement assignee when an older queued run starts", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ agentName: "OriginalCoder" });
+    const replacementAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: replacementAgentId,
+      companyId,
+      name: "ReplacementCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board-blocked reassignment",
+      status: "in_progress",
+      priority: "critical",
+      assigneeAgentId: agentId,
+    });
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_assigned",
+    });
+
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: replacementAgentId })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, issue] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run).toMatchObject({ status: "cancelled", errorCode: "issue_assignee_changed" });
+    expect(issue).toEqual({ status: "blocked", assigneeAgentId: replacementAgentId });
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("cancels an older queued run after the board blocks its issue without explicit resume intent", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board-blocked queued work",
+      status: "in_progress",
+      priority: "critical",
+      assigneeAgentId: agentId,
+    });
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_assigned",
+    });
+
+    await db
+      .update(issues)
+      .set({ status: "blocked" })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup, issue] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run).toMatchObject({ status: "cancelled", errorCode: "issue_blocked_status" });
+    expect(wakeup?.status).toBe("skipped");
+    expect(wakeup?.error).toContain("explicit structured resume");
+    expect(issue).toEqual({ status: "blocked", assigneeAgentId: agentId });
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued runs when the issue reaches a terminal status before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -220,6 +220,38 @@ async function normalizePolicy(input: {
   return normalizeIssueExecutionPolicy(input);
 }
 
+async function makePendingAgentReviewIssue(
+  reviewerAgentId = "33333333-3333-4333-8333-333333333333",
+) {
+  const policy = await normalizePolicy({
+    stages: [
+      {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        type: "review",
+        participants: [{ type: "agent", agentId: reviewerAgentId }],
+      },
+    ],
+  });
+  if (!policy) throw new Error("Expected normalized review policy");
+  return {
+    ...makeIssue("todo"),
+    status: "in_review" as const,
+    assigneeAgentId: reviewerAgentId,
+    executionPolicy: policy,
+    executionState: {
+      status: "pending",
+      currentStageId: policy.stages[0]!.id,
+      currentStageIndex: 0,
+      currentStageType: "review",
+      currentParticipant: { type: "agent", agentId: reviewerAgentId },
+      returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+    },
+  };
+}
+
 function makeIssue(status: "backlog" | "todo" | "done" | "blocked" | "cancelled" | "in_progress" | "in_review") {
   return {
     id: "11111111-1111-4111-8111-111111111111",
@@ -874,40 +906,80 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("moves assigned blocked issues back to todo via POST comments", async () => {
+  it("keeps assigned blocked issues inert on plain POST comments", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
-    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
-      ...makeIssue("blocked"),
-      ...patch,
-    }));
 
     const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "please continue" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          reopenedFrom: "blocked",
-          mutation: "comment",
-        }),
-        contextSnapshot: expect.objectContaining({
-          issueId: "11111111-1111-4111-8111-111111111111",
-          wakeCommentId: "comment-1",
-          wakeReason: "issue_reopened_via_comment",
-          reopenedFrom: "blocked",
-        }),
-      }),
-    ));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
+
+  it.each(["post", "patch"] as const)(
+    "keeps blocked issues inert when %s comments only set reopen=true",
+    async (method) => {
+      const issue = makeIssue("blocked");
+      mockIssueService.getById.mockResolvedValue(issue);
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+        makeIssueUpdateReceipt(issue, patch));
+
+      const agent = request(await installActor(createApp()));
+      const res = method === "post"
+        ? await agent
+            .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+            .send({ body: "please continue", reopen: true })
+        : await agent
+            .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+            .send({ comment: "please continue", reopen: true });
+
+      expect(res.status).toBe(method === "post" ? 201 : 200);
+      expect(mockIssueService.update).not.toHaveBeenCalledWith(
+        issue.id,
+        expect.objectContaining({ status: "todo" }),
+      );
+      if (method === "patch") {
+        expect(res.body).toMatchObject({ status: "blocked", assigneeAgentId: issue.assigneeAgentId });
+      }
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["post", "patch"] as const)(
+    "reopens blocked issues only when %s comments set resume=true",
+    async (method) => {
+      const issue = makeIssue("blocked");
+      mockIssueService.getById.mockResolvedValue(issue);
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+        makeIssueUpdateReceipt(issue, patch));
+
+      const agent = request(await installActor(createApp()));
+      const res = method === "post"
+        ? await agent
+            .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+            .send({ body: "please continue", resume: true })
+        : await agent
+            .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+            .send({ comment: "please continue", resume: true });
+
+      expect(res.status).toBe(method === "post" ? 201 : 200);
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issue.id,
+        expect.objectContaining({ status: "todo" }),
+      );
+      await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        issue.assigneeAgentId,
+        expect.objectContaining({
+          reason: "issue_reopened_via_comment",
+          payload: expect.objectContaining({ reopenedFrom: "blocked", resumeIntent: true }),
+        }),
+      ));
+    },
+  );
 
   it("moves in-progress issues with a scheduled retry back to todo via POST human comments", async () => {
     const issue = {
@@ -1292,7 +1364,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
-  it("does not move dependency-blocked issues to todo via POST comments", async () => {
+  it("does not wake assignees for plain POST comments on dependency-blocked issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -1309,21 +1381,8 @@ describe.sequential("issue comment reopen routes", () => {
 
     expect(res.status).toBe(201);
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_commented",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          mutation: "comment",
-        }),
-        contextSnapshot: expect.objectContaining({
-          issueId: "11111111-1111-4111-8111-111111111111",
-          wakeCommentId: "comment-1",
-          wakeReason: "issue_commented",
-        }),
-      }),
-    ));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen a blocked issue via PATCH when the same request wires blockers", async () => {
@@ -1356,7 +1415,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(patch.blockedByIssueIds).toEqual(["33333333-3333-4333-8333-333333333333"]);
   });
 
-  it("still implicitly reopens a blocked issue via PATCH when the same request clears blockers", async () => {
+  it("does not implicitly reopen a blocked issue via PATCH when the same request clears blockers", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.getDependencyReadiness.mockResolvedValue({
@@ -1379,7 +1438,9 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalled();
     const patch = mockIssueService.update.mock.calls[0][1] as Record<string, unknown>;
-    expect(patch.status).toBe("todo");
+    expect(patch.status).toBeUndefined();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen closed issues via POST comments when no agent is assigned", async () => {
@@ -1506,7 +1567,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("moves assigned blocked issues back to todo via the PATCH comment path", async () => {
+  it("keeps assigned blocked issues inert on plain PATCH comments", async () => {
     const issue = makeIssue("blocked");
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
@@ -1520,22 +1581,16 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          reopenedFrom: "blocked",
-          mutation: "comment",
-        }),
-      }),
-    ));
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("moves in-progress issues with a scheduled retry back to todo via the PATCH comment path", async () => {
@@ -1661,7 +1716,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
-  it("does not move dependency-blocked issues to todo via the PATCH comment path", async () => {
+  it("does not wake assignees for plain PATCH comments on dependency-blocked issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -1692,16 +1747,8 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_commented",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          mutation: "comment",
-        }),
-      }),
-    ));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("wakes the assignee when an assigned blocked issue moves back to todo", async () => {
@@ -2462,6 +2509,167 @@ describe.sequential("issue comment reopen routes", () => {
       }),
     );
   });
+
+  it.each(["post", "patch"] as const)(
+    "atomically completes an active review from an exact APPROVE %s comment",
+    async (method) => {
+      const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+      const issue = await makePendingAgentReviewIssue(reviewerAgentId);
+      mockIssueService.getById.mockResolvedValue(issue);
+      mockIssueService.addComment.mockResolvedValue({
+        id: "comment-review-approve-token",
+        issueId: issue.id,
+        companyId: issue.companyId,
+        body: "APPROVE",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorAgentId: reviewerAgentId,
+        authorUserId: null,
+      });
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+        ...issue,
+        ...patch,
+        executionState: patch.executionState,
+        status: "done",
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      }));
+
+      const agent = request(await installActor(createApp(), agentActor(reviewerAgentId)));
+      const res = method === "post"
+        ? await agent
+            .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+            .send({ body: "APPROVE" })
+        : await agent
+            .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+            .send({ comment: "APPROVE" });
+
+      expect(res.status).toBe(method === "post" ? 201 : 200);
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issue.id,
+        expect.objectContaining({
+          status: "done",
+          actorAgentId: reviewerAgentId,
+          executionState: expect.objectContaining({
+            status: "completed",
+            lastDecisionId: expect.any(String),
+            lastDecisionOutcome: "approved",
+          }),
+        }),
+        mockTx,
+      );
+      expect(mockTxInsertValues).toHaveBeenCalledWith(expect.objectContaining({
+        issueId: issue.id,
+        outcome: "approved",
+        body: "APPROVE",
+      }));
+    },
+  );
+
+  it.each(["post", "patch"] as const)(
+    "persists an exact HOLD %s comment without advancing or waking the active review",
+    async (method) => {
+      const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+      const issue = await makePendingAgentReviewIssue(reviewerAgentId);
+      mockIssueService.getById.mockResolvedValue(issue);
+      mockIssueService.addComment.mockResolvedValue({
+        id: "comment-review-hold-token",
+        issueId: issue.id,
+        companyId: issue.companyId,
+        body: "HOLD",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorAgentId: reviewerAgentId,
+        authorUserId: null,
+      });
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+        makeIssueUpdateReceipt(issue, patch));
+
+      const agent = request(await installActor(createApp(), agentActor(reviewerAgentId)));
+      const res = method === "post"
+        ? await agent
+            .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+            .send({ body: "HOLD" })
+        : await agent
+            .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+            .send({ comment: "HOLD" });
+
+      expect(res.status).toBe(method === "post" ? 201 : 200);
+      expect(mockIssueService.addComment).toHaveBeenCalled();
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(mockTxInsertValues).not.toHaveBeenCalled();
+      expect(mockIssueService.update).not.toHaveBeenCalledWith(
+        issue.id,
+        expect.objectContaining({ status: "done" }),
+        expect.anything(),
+      );
+      if (method === "post") {
+        expect(mockIssueService.update).not.toHaveBeenCalled();
+      } else {
+        expect(res.body).toMatchObject({
+          status: "in_review",
+          assigneeAgentId: reviewerAgentId,
+          executionState: expect.objectContaining({
+            status: "pending",
+            currentParticipant: { type: "agent", agentId: reviewerAgentId },
+          }),
+        });
+      }
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["post", "APPROVE"],
+    ["post", "HOLD"],
+    ["patch", "APPROVE"],
+    ["patch", "HOLD"],
+  ] as const)(
+    "treats a non-participant exact %s %s comment as ordinary commentary",
+    async (method, body) => {
+      const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+      const nonParticipantAgentId = "44444444-4444-4444-8444-444444444444";
+      const issue = await makePendingAgentReviewIssue(reviewerAgentId);
+      mockIssueService.getById.mockResolvedValue(issue);
+      mockIssueService.addComment.mockResolvedValue({
+        id: "comment-review-non-participant-token",
+        issueId: issue.id,
+        companyId: issue.companyId,
+        body,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorAgentId: nonParticipantAgentId,
+        authorUserId: null,
+      });
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) =>
+        makeIssueUpdateReceipt(issue, patch));
+
+      const agent = request(await installActor(createApp(), agentActor(nonParticipantAgentId)));
+      const res = method === "post"
+        ? await agent
+            .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+            .send({ body })
+        : await agent
+            .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+            .send({ comment: body });
+
+      expect(res.status).toBe(method === "post" ? 201 : 200);
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(mockTxInsertValues).not.toHaveBeenCalled();
+      expect(mockIssueService.update).not.toHaveBeenCalledWith(
+        issue.id,
+        expect.objectContaining({ status: "done" }),
+        expect.anything(),
+      );
+      if (method === "post") expect(mockIssueService.update).not.toHaveBeenCalled();
+      await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        reviewerAgentId,
+        expect.objectContaining({ reason: "issue_commented" }),
+      ));
+    },
+  );
 
   it("auto-approves a reviewer comment with the APPROVED review marker", async () => {
     const reviewerAgentId = "33333333-3333-4333-8333-333333333333";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1684,23 +1684,31 @@ function actorMatchesExecutionParticipant(
 const APPROVAL_NEGATION_REGEX =
   /\b(?:NOT|REJECT(?:ED|ING|S)?|DENY|DENIED|DENYING|BLOCK(?:ED|ING|S)?|CHANGES?\s+REQUESTED)\b/i;
 
-function isApprovalReviewComment(body: string) {
+type ReviewCommentDisposition = "approve" | "hold";
+
+function parseReviewCommentDisposition(body: string): ReviewCommentDisposition | null {
   const normalized = body.replace(/\r\n?/g, "\n");
+  const exactDisposition = normalized.trim();
+  if (/^APPROVE$/i.test(exactDisposition)) return "approve";
+  if (/^HOLD$/i.test(exactDisposition)) return "hold";
   const headingMatch = normalized.match(/(?:^|\n)##\s*Review:\s*([^\n]*)/i);
   if (headingMatch) {
     const headingText = headingMatch[1];
     if (/\bAPPROVED\b/i.test(headingText) && !APPROVAL_NEGATION_REGEX.test(headingText)) {
-      return true;
+      return "approve";
     }
   }
   // Require the `kind: review` and `decision: approved` lines to appear on truly consecutive
   // lines (no blank-line separation) so prose like "the previous sprint decision: approved"
   // can't combine with an unrelated `kind: review` line elsewhere in the body to trigger
   // auto-approval. Use `[ \t]*` between the lines so `\s*` does not silently swallow a newline.
-  return (
+  if (
     /^[ \t]*kind[ \t]*:[ \t]*review[ \t]*\n[ \t]*decision[ \t]*:[ \t]*approved[ \t]*$/im.test(normalized)
     || /^[ \t]*decision[ \t]*:[ \t]*approved[ \t]*\n[ \t]*kind[ \t]*:[ \t]*review[ \t]*$/im.test(normalized)
-  );
+  ) {
+    return "approve";
+  }
+  return null;
 }
 
 function buildExecutionStageWakeContext(input: {
@@ -1878,10 +1886,12 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   ) {
     return false;
   }
-  // Only human comments should implicitly reopen finished work.
+  // Only human comments should implicitly reopen finished work. Blocked work
+  // requires the structured `resume: true` signal so an ordinary discussion
+  // comment cannot clear a durable blocked disposition.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (!isClosedIssueStatus(input.issueStatus)) return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -9414,6 +9424,18 @@ export function issueRoutes(
       onBehalfOfUserId: _requestedOnBehalfOfUserId,
       ...updateFields
     } = req.body;
+    const existingExecutionState = parseIssueExecutionState(existing.executionState);
+    const reviewCommentDisposition =
+      commentBody &&
+      updateFields.status === undefined &&
+      existing.status === "in_review" &&
+      existingExecutionState?.status === "pending" &&
+      actorMatchesExecutionParticipant(actor, existingExecutionState.currentParticipant ?? null)
+        ? parseReviewCommentDisposition(commentBody)
+        : null;
+    if (reviewCommentDisposition === "approve") {
+      updateFields.status = "done";
+    }
     const reviewPolicyChangeRequested =
       req.body.reviewPolicy !== undefined
       && req.body.reviewPolicy !== existing.reviewPolicy;
@@ -9464,7 +9486,8 @@ export function issueRoutes(
     await assertIssueEnvironmentSelection(existing.companyId, updateFields.executionWorkspaceSettings?.environmentId);
     const requestedAssigneeAgentId =
       normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId;
-    const explicitMoveToTodoRequested = reopenRequested || resumeRequested === true;
+    const explicitMoveToTodoRequested =
+      resumeRequested === true || (!isBlocked && reopenRequested === true);
     const recoveryRelevantSourceMutationRequested =
       req.body.status !== undefined ||
       normalizedAssigneeAgentId !== undefined ||
@@ -10679,7 +10702,15 @@ export function issueRoutes(
         // Re-derive closed-ness from the post-update issue so a status change
         // like in_progress -> done with a closure comment does not enqueue a
         // stale issue_commented wake for an already-completed issue.
-        const skipAssigneeCommentWake = selfComment || isClosedIssueStatus(issue.status);
+        const inertBlockedComment =
+          existing.status === "blocked" &&
+          resumeRequested !== true &&
+          issue.status === "blocked";
+        const skipAssigneeCommentWake =
+          selfComment ||
+          isClosedIssueStatus(issue.status) ||
+          inertBlockedComment ||
+          reviewCommentDisposition === "hold";
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
@@ -12194,7 +12225,8 @@ export function issueRoutes(
     if (effectiveResumeRequested !== true && effectiveReopenRequested === true && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     }
-    const explicitMoveToTodoRequested = effectiveReopenRequested || effectiveResumeRequested === true;
+    const explicitMoveToTodoRequested =
+      effectiveResumeRequested === true || (!isBlocked && effectiveReopenRequested === true);
     const scheduledRetryForHumanComment =
       shouldHumanCommentResumeInProgressScheduledRetry({
         hasComment: true,
@@ -12373,11 +12405,14 @@ export function issueRoutes(
 
     const currentExecutionState = parseIssueExecutionState(currentIssue.executionState);
     const currentExecutionPolicy = normalizeIssueExecutionPolicy(currentIssue.executionPolicy ?? null);
-    const shouldAutoApproveReviewComment =
+    const reviewCommentDisposition =
       currentIssue.status === "in_review" &&
       currentExecutionState?.status === "pending" &&
-      actorMatchesExecutionParticipant(actor, currentExecutionState.currentParticipant ?? null) &&
-      isApprovalReviewComment(req.body.body);
+      actorMatchesExecutionParticipant(actor, currentExecutionState.currentParticipant ?? null)
+        ? parseReviewCommentDisposition(req.body.body)
+        : null;
+    const shouldAutoApproveReviewComment =
+      reviewCommentDisposition === "approve";
 
     // Persist the comment and the auto-approval state transition atomically when both apply.
     // Without a single transaction, a 422 (or any error) thrown by the status update after the
@@ -12691,7 +12726,12 @@ export function issueRoutes(
       // Re-derive closed-ness from the post-mutation issue so the auto-approval
       // transition (in_review -> done) suppresses a stale `issue_commented` wake
       // to the returnAssignee for an already-completed issue.
-      const skipWake = selfComment || isClosedIssueStatus(wakeIssueSnapshot.status);
+      const inertBlockedComment = isBlocked && effectiveResumeRequested !== true;
+      const skipWake =
+        selfComment ||
+        isClosedIssueStatus(wakeIssueSnapshot.status) ||
+        inertBlockedComment ||
+        reviewCommentDisposition === "hold";
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           addWakeup(assigneeId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5368,10 +5368,11 @@ export function shouldAutoCheckoutIssueForWake(input: {
   if (executionState?.status === "pending") return false;
 
   const issueStatus = readNonEmptyString(input.issueStatus);
+  const hasExplicitResumeIntent = input.contextSnapshot?.resumeIntent === true;
   if (
     issueStatus !== "todo" &&
     issueStatus !== "backlog" &&
-    issueStatus !== "blocked" &&
+    !(issueStatus === "blocked" && hasExplicitResumeIntent) &&
     issueStatus !== "in_progress"
   ) {
     return false;
@@ -12868,6 +12869,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         errorCode:
           | "issue_not_found"
           | "issue_assignee_changed"
+          | "issue_blocked_status"
           | "issue_terminal_status"
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
@@ -12904,7 +12906,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const wakeCommentId = deriveCommentId(context, null);
     const isInteractionWake = allowsIssueInteractionWake(context);
-    const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
+    const hasExplicitResumeIntent = context.resumeIntent === true;
+    const resumeIntent = hasExplicitResumeIntent || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
     const interactionResolvedAt = readNonEmptyString(context.interactionResolvedAt);
@@ -13013,6 +13016,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           issueId,
           expectedExecutionRunId: run.id,
           currentExecutionRunId: issue.executionRunId,
+        },
+      };
+    }
+
+    if (issue.status === "blocked" && !hasExplicitResumeIntent) {
+      return {
+        stale: true,
+        errorCode: "issue_blocked_status",
+        reason:
+          "Cancelled because the issue was blocked before the queued run could start; an explicit structured resume is required",
+        details: {
+          issueId,
+          currentStatus: issue.status,
+          requiredResumeIntent: true,
         },
       };
     }
@@ -14196,7 +14213,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       })
     ) {
       try {
-        await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
+        const expectedStatuses = context.resumeIntent === true
+          ? ["todo", "backlog", "blocked"]
+          : ["todo", "backlog"];
+        await issuesSvc.checkout(issueId, agent.id, expectedStatuses, run.id);
         context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = true;
       } catch (error) {
         if (!isCheckoutConflictError(error)) throw error;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue comments and heartbeat checkout control task execution state.
> - A plain comment on a blocked issue could reopen work without an explicit resume request.
> - A queued heartbeat could also restore a blocked issue or its old assignee.
> - Review participants need a durable way to approve work or hold it for changes.
> - This pull request makes those transitions explicit and keeps stale execution inert.
> - The benefit is safer review and recovery behavior with a small server-only change.

## Linked Issues or Issue Description

**What happened?**

Plain comments could reopen blocked issues. A stale queued heartbeat could check out a blocked issue and restore its earlier assignment. Review comments did not provide a complete durable `APPROVE` or `HOLD` disposition contract.

**Expected behavior**

A blocked issue must stay blocked unless a caller sends a structured `resume: true` request. A stale heartbeat must not change the blocked status or assignee. The current review participant must be able to use an exact `APPROVE` or `HOLD` comment as a durable disposition.

**Steps to reproduce**

1. Block an assigned issue and change its assignee.
2. Add a plain comment or let an older queued heartbeat start.
3. Observe that the old control path can reopen or check out the issue.
4. Put an issue in review and post `HOLD` as the current participant.
5. Observe that the old path does not preserve a typed review disposition.

**Paperclip version or commit**

`master` at `4436cf00a2e2b665a4d0e93684c6a72dff085b44`.

**Deployment mode**

Local development mode with server route and heartbeat service tests.

## What Changed

- Treat exact `APPROVE` and `HOLD` comments from the current review participant as review dispositions.
- Require structured `resume: true` intent before a blocked comment path can resume work.
- Cancel stale queued heartbeats for blocked issues unless the run carries explicit resume intent.
- Add route, service, and integration tests for status and assignee preservation.
- Document the review and blocked-resume execution contract.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/heartbeat-auto-checkout.test.ts server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts server/src/__tests__/heartbeat-dependency-scheduling.test.ts` passes 144 tests.
- `pnpm -r typecheck` passes.
- `pnpm build` passes.
- `pnpm test:run` was stopped after it reported unrelated workspace-runtime, plugin fixture, listener, and project-skill failures under Node 22.22.3. This repository requires Node 24.11.0 or later. The focused changed suites pass on the same checkout.

## Risks

- The disposition parser is intentionally narrow. Only the current review participant can trigger the exact single-token actions.
- Existing blocked-comment callers must send `resume: true` when they intend to continue execution.
- A blocked queued run now ends with `issue_blocked_status` instead of checking out the issue.
- There is no database migration and no client contract change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5.6 Sol at high reasoning effort assisted with this change. It used repository tools, code execution, and isolated implementation agents from the same model family. The runtime did not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
