### PR TITLE
feat(adapter-claude): add Claude Opus 4.5 to the static model fallback

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -14,6 +14,7 @@ export const models = [
   { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
   { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
 ];

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -66,6 +66,7 @@ describe("adapter model listing", () => {
     // Newer flagship models are offered, but Opus 4.8 stays the default (first) option.
     expect(models[0]?.id).toBe("claude-opus-4-8");
     expect(models.some((model) => model.id === "claude-sonnet-5")).toBe(true);
+    expect(models.some((model) => model.id === "claude-opus-4-5")).toBe(true);
     expect(models.some((model) => model.id === "claude-fable-5")).toBe(true);
     expect(models.some((model) => model.id === "claude-mythos-5")).toBe(true);
     // Opus 5 is a current GA flagship and must be offered even when live discovery is unavailable.


### PR DESCRIPTION
## Thinking Path

> - Agents pick their model in agent configuration from a per-adapter dropdown populated by `listAdapterModels()` — the live provider catalog merged over a static fallback list.
> - For `claude_local`, the static fallback in `packages/adapters/claude-local/src/index.ts` only listed Opus 4.6 and newer, so Claude Opus 4.5 (`claude-opus-4-5`) could not be selected unless live `/v1/models` discovery happened to succeed.
> - This PR adds `claude-opus-4-5` to the static list so it is selectable regardless of the live-discovery path (same shape as #10280 / #10327).

## Linked Issues or Issue Description

No public GitHub issue.

**What happened**
The `claude_local` agent configuration model dropdown (`/:company/agents/:agent/configuration`) did not offer Claude Opus 4.5 — the static fallback list started at Opus 4.6.

**Expected behavior**
Claude Opus 4.5 is still an active Anthropic model and should be selectable per agent.

**Steps to reproduce**
1. Run the server without a working live Anthropic `/v1/models` path (no `ANTHROPIC_API_KEY`, Bedrock mode, or a discovery miss).
2. Open a `claude_local` agent's configuration and inspect the model dropdown.
3. Observe that `claude-opus-4-5` is absent.

## What Changed

- Added `{ id: "claude-opus-4-5", label: "Claude Opus 4.5" }` to the `claude_local` static `models` fallback, after Sonnet 4.6 and before Sonnet 4.5 (Opus 4.8 stays the first/default option).
- Added a regression assertion in `server/src/__tests__/adapter-models.test.ts` that `claude-opus-4-5` is present in the fallback when live discovery is unavailable.

## Verification

- `pnpm -C server exec vitest run src/__tests__/adapter-models.test.ts` — 17/17 pass.

## Risks

- Low. Pure additive change to a static list; no control-flow change.

## Model Used

Claude Fable 5 (`claude-fable-5`) via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have described the issue in-PR following the bug template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)