### PR TITLE
feat(runner): sequence ACPX sidecar input

### DIFF
--- a/packages/paperclip-runner/src/cli/acpx-sidecar-input.test.ts
+++ b/packages/paperclip-runner/src/cli/acpx-sidecar-input.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acpxBootstrapBlockedError,
+  enqueueAcpxSidecarInput,
+  recordAcpxBootstrapFailure,
+} from "./acpx-sidecar-input.js";
+
+describe("ACPX sidecar input sequencing", () => {
+  it("drains initialize, session.open, and suspend in input order", async () => {
+    const events: string[] = [];
+    let pending = Promise.resolve();
+    for (const command of ["initialize", "session.open", "session.suspend"]) {
+      pending = enqueueAcpxSidecarInput(
+        pending,
+        async () => {
+          events.push(command);
+        },
+        () => events.push(`${command}:error`),
+      );
+    }
+    const shutdown = pending.then(() => events.push("shutdown"));
+
+    await shutdown;
+    expect(events).toEqual([
+      "initialize",
+      "session.open",
+      "session.suspend",
+      "shutdown",
+    ]);
+  });
+
+  it("keeps the queue live after operation and diagnostic failures", async () => {
+    const events: string[] = [];
+    const failed = enqueueAcpxSidecarInput(
+      Promise.resolve(),
+      async () => {
+        events.push("failed");
+        throw new Error("bad frame");
+      },
+      async () => {
+        events.push("diagnostic");
+        await Promise.resolve();
+        throw new Error("diagnostic transport failed");
+      },
+    );
+    const recovered = enqueueAcpxSidecarInput(
+      failed,
+      async () => {
+        events.push("recovered");
+      },
+      () => events.push("unexpected"),
+    );
+
+    await recovered;
+    expect(events).toEqual(["failed", "diagnostic", "recovered"]);
+  });
+
+  it("does not let an unbounded diagnostic block later input or shutdown", async () => {
+    const events: string[] = [];
+    const neverSettles = new Promise<void>(() => undefined);
+    const failed = enqueueAcpxSidecarInput(
+      Promise.resolve(),
+      async () => {
+        events.push("failed");
+        throw new Error("bad frame");
+      },
+      () => {
+        events.push("diagnostic");
+        return neverSettles;
+      },
+    );
+    const recovered = enqueueAcpxSidecarInput(
+      failed,
+      async () => {
+        events.push("recovered");
+      },
+      () => events.push("unexpected"),
+    );
+
+    await expect(
+      Promise.race([
+        recovered.then(() => "drained"),
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve("blocked"), 50);
+        }),
+      ]),
+    ).resolves.toBe("drained");
+    expect(events).toEqual(["failed", "diagnostic", "recovered"]);
+  });
+
+  it("preserves the first bootstrap failure and blocks dependent commands", () => {
+    const rootCause = new Error("agent initialize exited");
+    const failure = recordAcpxBootstrapFailure(null, "session.open", rootCause);
+
+    expect(failure).toBe(rootCause);
+    expect(acpxBootstrapBlockedError(failure, "session.suspend")?.message).toBe(
+      "ACPX provider bootstrap failed before session.suspend: agent initialize exited",
+    );
+    expect(
+      recordAcpxBootstrapFailure(
+        failure,
+        "session.suspend",
+        new Error("secondary"),
+      ),
+    ).toBe(rootCause);
+  });
+
+  it("does not make an ordinary command failure a sticky bootstrap error", () => {
+    expect(
+      recordAcpxBootstrapFailure(null, "turn.start", new Error("turn failed")),
+    ).toBeNull();
+    expect(acpxBootstrapBlockedError(null, "turn.start")).toBeNull();
+  });
+});

--- a/packages/paperclip-runner/src/cli/acpx-sidecar-input.ts
+++ b/packages/paperclip-runner/src/cli/acpx-sidecar-input.ts
@@ -1,0 +1,30 @@
+import { enqueueSerialInput } from "./serial-input-queue.js";
+
+const ACPX_BOOTSTRAP_COMMANDS = new Set(["initialize", "session.open"]);
+
+export function enqueueAcpxSidecarInput(
+  pending: Promise<void>,
+  operation: () => Promise<void>,
+  onError: (error: unknown) => void | Promise<void>,
+): Promise<void> {
+  return enqueueSerialInput(pending, operation, onError);
+}
+
+export function recordAcpxBootstrapFailure(
+  current: Error | null,
+  command: string,
+  error: Error,
+): Error | null {
+  return current ?? (ACPX_BOOTSTRAP_COMMANDS.has(command) ? error : null);
+}
+
+export function acpxBootstrapBlockedError(
+  failure: Error | null,
+  command: string,
+): Error | null {
+  return failure
+    ? new Error(
+        `ACPX provider bootstrap failed before ${command}: ${failure.message}`,
+      )
+    : null;
+}

--- a/packages/paperclip-runner/src/cli/serial-input-queue.ts
+++ b/packages/paperclip-runner/src/cli/serial-input-queue.ts
@@ -1,0 +1,21 @@
+/**
+ * Append one asynchronous input operation to a queue that always remains
+ * usable after an operation or diagnostic callback fails.
+ */
+export function enqueueSerialInput(
+  pending: Promise<void>,
+  operation: () => Promise<void>,
+  onError: (error: unknown) => void | Promise<void>,
+): Promise<void> {
+  const reportError = (error: unknown): void => {
+    try {
+      // Diagnostics are best-effort side effects, not input-queue work. Start
+      // them in order, but never give an uncooperative callback authority to
+      // block later frames or the shutdown drain.
+      void Promise.resolve(onError(error)).catch(() => undefined);
+    } catch {
+      // Diagnostics must not poison the queue or skip later input frames.
+    }
+  };
+  return pending.catch(reportError).then(operation).catch(reportError);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - An ACPX sidecar will read asynchronous commands from one ordered input stream.
> - Concurrent command handling could reorder bootstrap, turn, suspend, and shutdown operations.
> - A failed diagnostic callback could also poison the input promise and skip later frames.
> - This pull request adds a small serial queue and records the first provider-bootstrap failure.
> - The benefit is deterministic input ordering and a stable fail-closed bootstrap state before the sidecar exists.

## Linked Issues or Issue Description

**Agent or provider**

The internal ACPX sidecar for qualified ACP-compatible providers.

**Why this adapter is useful**

The sidecar must process input frames in order. It must drain accepted input before shutdown, continue after an ordinary command error, and reject dependent commands after initialization or session bootstrap fails.

**How the agent is invoked**

A later pull request will connect this helper to a private sidecar process. This pull request adds no executable, dependency, adapter registration, or process launch.

**Additional context**

This pull request is stacked on #12388. The helper remains package-local and does not affect direct adapters.

## What Changed

- Add a serial asynchronous input queue that remains usable after operation and diagnostic failures.
- Add ACPX-specific input sequencing around the shared queue.
- Preserve the first `initialize` or `session.open` failure as the bootstrap cause.
- Produce a deterministic blocked-command error after bootstrap fails.
- Test ordering, EOF-style draining, error isolation, sticky bootstrap failure, and non-sticky turn failure.

## Verification

- Runner TypeScript typecheck — passed.
- Runner TypeScript tests — passed, including 4 new sequencing tests.
- `pnpm -r typecheck` — passed for all applicable workspaces.
- `pnpm build` — passed, including runner binary, server, UI, and workspace packages.
- Prettier and `git diff --check` — passed.
- The diff contains 3 files and does not change `pnpm-lock.yaml`, a workflow, a dependency, a public export, server selection, or UI behavior.

## Risks

The main risk is allowing one failed input operation to reorder or suppress later input. Each operation runs only after the previous promise settles. Both operation and diagnostic failures are contained. Bootstrap failure is recorded separately so an ordinary turn failure does not disable the sidecar session.

## Model Used

OpenAI Codex with GPT-5 and repository tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing public item or described the issue in this PR
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal task identifier
- [x] I have run the affected tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have documented the compatibility and failure boundary
- [ ] All applicable GitHub Actions are green
- [ ] Greptile is 5/5 with every actionable comment resolved
- [x] I will address all review findings before requesting merge
