### PR TITLE
feat(runner): stage managed Codex credentials

### DIFF
--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -1,0 +1,1109 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+  type FileHandle,
+} from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { stageManagedCodexCredential } from "./codex-credentials.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.doUnmock("node:fs/promises");
+  vi.resetModules();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("managed Codex credentials", () => {
+  it("stages inline JSON privately and removes it idempotently", async () => {
+    const fixture = await credentialFixture();
+    const lease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: JSON.stringify({
+          tokens: { access_token: "inline-canary" },
+        }),
+      },
+    });
+
+    expect(lease.mode).toBe("inline_json");
+    const cleanupIntent = join(
+      fixture.home,
+      ".paperclip-auth-cleanup-required",
+    );
+    await expect(readFile(lease.path, "utf8")).resolves.toContain(
+      "inline-canary",
+    );
+    await expect(readFile(cleanupIntent, "utf8")).resolves.toBe(
+      "paperclip-managed-codex-cleanup-v1\n",
+    );
+    if (process.platform !== "win32") {
+      expect((await stat(lease.path)).mode & 0o777).toBe(0o600);
+    }
+    await lease.close();
+    await lease.close();
+    await expect(readFile(lease.path)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(cleanupIntent)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("fences overlapping leases for the same isolated home", async () => {
+    const fixture = await credentialFixture();
+    const firstLease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"first"}',
+      },
+    });
+
+    await expect(
+      stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+        },
+      }),
+    ).rejects.toThrow("already has an active lease");
+    await expect(readFile(firstLease.path, "utf8")).resolves.toBe(
+      '{"owner":"first"}',
+    );
+
+    await firstLease.close();
+    const secondLease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+      },
+    });
+    await expect(readFile(secondLease.path, "utf8")).resolves.toBe(
+      '{"owner":"second"}',
+    );
+    await secondLease.close();
+  });
+
+  it("falls through when an unrelated listener occupies the primary lease port", async () => {
+    const fixture = await credentialFixture();
+    const canonicalHome = await realpath(fixture.home);
+    const primaryPort = credentialLeasePrimaryPort(canonicalHome);
+    const unrelated = createServer((socket) => {
+      socket.end("unrelated-loopback-service\n");
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      unrelated.once("error", rejectListen);
+      unrelated.listen(primaryPort, "127.0.0.1", resolveListen);
+    });
+
+    try {
+      const lease = await stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"paperclip"}',
+        },
+      });
+      await expect(readFile(lease.path, "utf8")).resolves.toBe(
+        '{"owner":"paperclip"}',
+      );
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
+          },
+        }),
+      ).rejects.toThrow("already has an active lease");
+      await lease.close();
+
+      const successor = await freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"successor"}',
+        },
+      });
+      await expect(readFile(successor.path, "utf8")).resolves.toBe(
+        '{"owner":"successor"}',
+      );
+      await successor.close();
+    } finally {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        unrelated.close((error) => {
+          if (error) rejectClose(error);
+          else resolveClose();
+        });
+      });
+    }
+  });
+
+  it("fails closed while the primary lease owner is not yet responsive", async () => {
+    const fixture = await credentialFixture();
+    const canonicalHome = await realpath(fixture.home);
+    const primaryPort = credentialLeasePrimaryPort(canonicalHome);
+    const acceptedSockets = new Set<import("node:net").Socket>();
+    const publishingOwner = createServer((socket) => {
+      acceptedSockets.add(socket);
+      socket.once("close", () => acceptedSockets.delete(socket));
+      socket.pause();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      publishingOwner.once("error", rejectListen);
+      publishingOwner.listen(primaryPort, "127.0.0.1", resolveListen);
+    });
+
+    try {
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
+          },
+        }),
+      ).rejects.toThrow(
+        "could not safely bypass an unresponsive lease endpoint",
+      );
+      await expect(
+        readFile(join(fixture.home, "auth.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      for (const socket of acceptedSockets) socket.destroy();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        publishingOwner.close((error) => {
+          if (error) rejectClose(error);
+          else resolveClose();
+        });
+      });
+    }
+  });
+
+  it("fails closed when a competing candidate is unresponsive after bind", async () => {
+    const fixture = await credentialFixture();
+    const canonicalHome = await realpath(fixture.home);
+    const competingPort = credentialLeasePort(canonicalHome, 1);
+    const acceptedSockets = new Set<import("node:net").Socket>();
+    const publishingOwner = createServer((socket) => {
+      acceptedSockets.add(socket);
+      socket.once("close", () => acceptedSockets.delete(socket));
+      socket.pause();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      publishingOwner.once("error", rejectListen);
+      publishingOwner.listen(competingPort, "127.0.0.1", resolveListen);
+    });
+
+    try {
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
+          },
+        }),
+      ).rejects.toThrow("already has an active lease");
+      await expect(
+        readFile(join(fixture.home, "auth.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      for (const socket of acceptedSockets) socket.destroy();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        publishingOwner.close((error) => {
+          if (error) rejectClose(error);
+          else resolveClose();
+        });
+      });
+    }
+  });
+
+  it(
+    "fences another process and recovers only after its kernel lease dies",
+    async () => {
+      const fixture = await credentialFixture();
+      const destination = join(fixture.home, "auth.json");
+      const childScript = join(fixture.root, "credential-owner.mjs");
+      const credentialModule = new URL(
+        "./codex-credentials.ts",
+        import.meta.url,
+      ).href;
+      await writeFile(
+        childScript,
+        [
+          `const { stageManagedCodexCredential } = await import(${JSON.stringify(credentialModule)});`,
+          "const lease = await stageManagedCodexCredential({",
+          "  agentHomeDirectory: process.argv[2],",
+          '  environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: \'{"owner":"first"}\' },',
+          "});",
+          'process.send?.({ type: "ready", path: lease.path });',
+          "process.on('message', async (message) => {",
+          "  if (message?.type !== 'close') return;",
+          "  await lease.close();",
+          "  process.exit(0);",
+          "});",
+        ].join("\n"),
+      );
+      const owner = fork(childScript, [fixture.home], {
+        execArgv: ["--import", "tsx"],
+        stdio: ["ignore", "pipe", "pipe", "ipc"],
+      });
+      try {
+        await waitForChildMessage(owner, "ready");
+        await expect(readFile(destination, "utf8")).resolves.toBe(
+          '{"owner":"first"}',
+        );
+
+        if (process.platform !== "win32") {
+          owner.kill("SIGSTOP");
+          await new Promise<void>((resolveSignal) =>
+            setTimeout(resolveSignal, 50),
+          );
+        }
+        await expect(
+          stageManagedCodexCredential({
+            agentHomeDirectory: fixture.home,
+            environment: {
+              PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+            },
+          }),
+        ).rejects.toThrow("already has an active lease");
+        await expect(readFile(destination, "utf8")).resolves.toBe(
+          '{"owner":"first"}',
+        );
+
+        if (process.platform !== "win32") owner.kill("SIGCONT");
+        owner.kill(process.platform === "win32" ? undefined : "SIGKILL");
+        await waitForChildExit(owner);
+
+        const successor = await stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+          },
+        });
+        await expect(readFile(destination, "utf8")).resolves.toBe(
+          '{"owner":"second"}',
+        );
+        await successor.close();
+      } finally {
+        if (owner.exitCode === null && owner.signalCode === null) {
+          if (process.platform !== "win32") owner.kill("SIGCONT");
+          owner.kill(process.platform === "win32" ? undefined : "SIGKILL");
+          await waitForChildExit(owner).catch(() => undefined);
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "holds kernel ownership until credential cleanup is durable",
+    async () => {
+      const fixture = await credentialFixture();
+      const lease = await stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+      });
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      let releaseCleanup!: () => void;
+      const cleanupGate = new Promise<void>((resolveCleanup) => {
+        releaseCleanup = resolveCleanup;
+      });
+      let signalCleanupStarted!: () => void;
+      const cleanupStarted = new Promise<void>((resolveStarted) => {
+        signalCleanupStarted = resolveStarted;
+      });
+      let heldCleanup = false;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if (!heldCleanup && (await this.stat()).isDirectory()) {
+            heldCleanup = true;
+            signalCleanupStarted();
+            await cleanupGate;
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        const closing = lease.close();
+        await cleanupStarted;
+        vi.resetModules();
+        const freshCredentials = await import("./codex-credentials.js");
+        await expect(
+          freshCredentials.stageManagedCodexCredential({
+            agentHomeDirectory: fixture.home,
+            environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+          }),
+        ).rejects.toThrow("already has an active lease");
+
+        releaseCleanup();
+        await expect(closing).resolves.toBeUndefined();
+        const successor = await freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+        });
+        await successor.close();
+      } finally {
+        releaseCleanup();
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it("does not let an older failed close remove a successor credential", async () => {
+    const fixture = await credentialFixture();
+    const firstLease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"first"}',
+      },
+    });
+    await rm(firstLease.path, { force: true });
+    await mkdir(firstLease.path);
+
+    await expect(firstLease.close()).rejects.toThrow(
+      "credential destination is a directory",
+    );
+    await rm(firstLease.path, { force: true, recursive: true });
+
+    const secondLease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+      },
+    });
+    await expect(firstLease.close()).resolves.toBeUndefined();
+    await expect(readFile(secondLease.path, "utf8")).resolves.toBe(
+      '{"owner":"second"}',
+    );
+    await secondLease.close();
+  });
+
+  it("keeps ownership live while retrying lease-marker removal", async () => {
+    const fixture = await credentialFixture();
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises",
+    );
+    let markerUnlinkAttempts = 0;
+    vi.doMock("node:fs/promises", () => ({
+      ...actualFs,
+      unlink: async (path: Parameters<typeof actualFs.unlink>[0]) => {
+        if (String(path).includes(".paperclip-auth-lease-v1-")) {
+          markerUnlinkAttempts += 1;
+          if (markerUnlinkAttempts === 1) {
+            throw Object.assign(new Error("injected marker unlink failure"), {
+              code: "EACCES",
+            });
+          }
+        }
+        await actualFs.unlink(path);
+      },
+    }));
+    vi.resetModules();
+    const freshCredentials = await import("./codex-credentials.js");
+    const lease = await freshCredentials.stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+    });
+
+    await expect(lease.close()).rejects.toThrow(
+      "injected marker unlink failure",
+    );
+    const successor = await freshCredentials.stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+    });
+    await successor.close();
+    expect(markerUnlinkAttempts).toBeGreaterThanOrEqual(3);
+  });
+
+  it("recovers a persisted cleanup intent before admitting another provider", async () => {
+    const fixture = await credentialFixture();
+    const destination = join(fixture.home, "auth.json");
+    const cleanupIntent = join(
+      fixture.home,
+      ".paperclip-auth-cleanup-required",
+    );
+    await writeFile(destination, '{"crash_stale":true}', { mode: 0o600 });
+    await writeFile(
+      cleanupIntent,
+      "paperclip-managed-codex-cleanup-v1\n",
+      { mode: 0o600 },
+    );
+
+    const lease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: { OPENAI_API_KEY: "launch-only-key" },
+    });
+    await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(cleanupIntent, "utf8")).resolves.toBe(
+      "paperclip-managed-codex-cleanup-v1\n",
+    );
+    await lease.close();
+    await expect(readFile(cleanupIntent)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "retries the directory sync after unlink already succeeded",
+    async () => {
+      const fixture = await credentialFixture();
+      const lease = await stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+      });
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      let syncAttempts = 0;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if ((await this.stat()).isDirectory()) {
+            syncAttempts += 1;
+            if (syncAttempts === 1) {
+              throw new Error("injected directory sync failure");
+            }
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        await expect(lease.close()).resolves.toBeUndefined();
+        await expect(readFile(lease.path)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(syncAttempts).toBe(3);
+      } finally {
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "retries preflight, installation, and removal until each is durable",
+    async () => {
+      const fixture = await credentialFixture();
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      let directorySyncAttempts = 0;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if ((await this.stat()).isDirectory()) {
+            directorySyncAttempts += 1;
+          }
+          // The first attempt at each namespace boundary fails; the durable
+          // helper must retry before staging or cleanup reports success.
+          if ([1, 3, 5].includes(directorySyncAttempts)) {
+            throw new Error("injected directory sync failure");
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        const lease = await stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+        });
+        await expect(readFile(lease.path, "utf8")).resolves.toBe("{}");
+        await expect(lease.close()).resolves.toBeUndefined();
+        await expect(readFile(lease.path)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(directorySyncAttempts).toBe(8);
+      } finally {
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it("copies an explicit private source without changing the source", async () => {
+    const fixture = await credentialFixture();
+    const source = join(fixture.root, "managed-auth.json");
+    await writeFile(
+      source,
+      JSON.stringify({ tokens: { access_token: "managed-canary" } }),
+      { mode: 0o600 },
+    );
+    await chmod(source, 0o600);
+
+    const lease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      sourcePath: source,
+    });
+    expect(lease.mode).toBe("managed_file");
+    await expect(readFile(lease.path, "utf8")).resolves.toContain(
+      "managed-canary",
+    );
+    await lease.close();
+    await expect(readFile(source, "utf8")).resolves.toContain("managed-canary");
+  });
+
+  it("replaces a stale regular auth destination in JSON modes", async () => {
+    const fixture = await credentialFixture();
+    const destination = join(fixture.home, "auth.json");
+    await writeFile(destination, '{"stale":true}', { mode: 0o600 });
+
+    const lease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"fresh":true}',
+      },
+    });
+    await expect(readFile(destination, "utf8")).resolves.toBe(
+      '{"fresh":true}',
+    );
+    await lease.close();
+  });
+
+  it("cleans stale and provider-generated auth in API-key mode", async () => {
+    const fixture = await credentialFixture();
+    const destination = join(fixture.home, "auth.json");
+    await writeFile(destination, '{"stale":true}');
+
+    const lease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: { OPENAI_API_KEY: "launch-only-key" },
+    });
+    expect(lease.mode).toBe("api_key");
+    await expect(readFile(destination)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await writeFile(destination, '{"provider_generated":true}');
+    await lease.close();
+    await expect(readFile(destination)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps API-key staging pending until stale removal is durable",
+    async () => {
+      const fixture = await credentialFixture();
+      const destination = join(fixture.home, "auth.json");
+      await writeFile(destination, '{"stale":true}', { mode: 0o600 });
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      let syncAttempts = 0;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if ((await this.stat()).isDirectory()) {
+            syncAttempts += 1;
+            if (syncAttempts === 1) {
+              throw new Error("injected directory sync failure");
+            }
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        const lease = await stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        });
+        await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(lease.close()).resolves.toBeUndefined();
+        expect(syncAttempts).toBe(5);
+      } finally {
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "fails a non-durable admission within a bound and scrubs again on retry",
+    async () => {
+      const fixture = await credentialFixture();
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if ((await this.stat()).isDirectory()) {
+            throw new Error("persistent directory sync failure");
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        const staging = stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        });
+        await expect(staging).rejects.toThrow(
+          "remained non-durable after 8 attempts",
+        );
+        expect(syncSpy.mock.calls.length).toBeGreaterThanOrEqual(8);
+        syncSpy.mockRestore();
+        const lease = await stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        });
+        await expect(lease.close()).resolves.toBeUndefined();
+      } finally {
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "bounds a directory open that never settles",
+    async () => {
+      const fixture = await credentialFixture();
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
+        "node:fs/promises",
+      );
+      let directoryOpenAttempts = 0;
+      let observeFirstOpen!: () => void;
+      const firstOpen = new Promise<void>((resolveOpen) => {
+        observeFirstOpen = resolveOpen;
+      });
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) {
+            directoryOpenAttempts += 1;
+            observeFirstOpen();
+            return await new Promise<FileHandle>(() => undefined);
+          }
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const staging = freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      const rejection = expect(staging).rejects.toThrow(
+        "remained non-durable after 1 attempt",
+      );
+      await firstOpen;
+      await vi.advanceTimersByTimeAsync(20_000);
+      await rejection;
+      expect(directoryOpenAttempts).toBe(8);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "bounds a directory fsync without accumulating pending handles",
+    async () => {
+      const fixture = await credentialFixture();
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
+        "node:fs/promises",
+      );
+      let directorySyncAttempts = 0;
+      let observeFirstSync!: () => void;
+      const firstSync = new Promise<void>((resolveSync) => {
+        observeFirstSync = resolveSync;
+      });
+      const stalledDirectoryHandle = {
+        close: async (): Promise<void> => undefined,
+        sync: async (): Promise<void> => {
+          directorySyncAttempts += 1;
+          observeFirstSync();
+          return await new Promise<void>(() => undefined);
+        },
+      } as FileHandle;
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) return stalledDirectoryHandle;
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const staging = freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      const rejection = expect(staging).rejects.toThrow(
+        "remained non-durable after 8 attempts",
+      );
+      await firstSync;
+      await vi.advanceTimersByTimeAsync(20_000);
+      await rejection;
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow("remained non-durable after 1 attempt");
+      expect(directorySyncAttempts).toBe(1);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "bounds a directory close that never settles after a durable fsync",
+    async () => {
+      const fixture = await credentialFixture();
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
+        "node:fs/promises",
+      );
+      let directoryCloseAttempts = 0;
+      let observeFirstClose!: () => void;
+      let observeLeaseClose!: () => void;
+      const firstClose = new Promise<void>((resolveClose) => {
+        observeFirstClose = resolveClose;
+      });
+      const leaseClose = new Promise<void>((resolveClose) => {
+        observeLeaseClose = resolveClose;
+      });
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) {
+            return {
+              close: async (): Promise<void> => {
+                directoryCloseAttempts += 1;
+                if (directoryCloseAttempts === 1) observeFirstClose();
+                if (directoryCloseAttempts === 3) observeLeaseClose();
+                return await new Promise<void>(() => undefined);
+              },
+              sync: async (): Promise<void> => undefined,
+            } as FileHandle;
+          }
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const staging = freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      await firstClose;
+      await vi.advanceTimersByTimeAsync(20_000);
+      const lease = await staging;
+
+      const closing = lease.close();
+      await leaseClose;
+      await vi.advanceTimersByTimeAsync(20_000);
+      await closing;
+      expect(directoryCloseAttempts).toBe(4);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps intent-publication failure before credential mutation and scrubs without process memory",
+    async () => {
+      const fixture = await credentialFixture();
+      const destination = join(fixture.home, "auth.json");
+      const cleanupIntent = join(
+        fixture.home,
+        ".paperclip-auth-cleanup-required",
+      );
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      let directorySyncAttempts = 0;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if ((await this.stat()).isDirectory()) {
+            directorySyncAttempts += 1;
+            if (directorySyncAttempts > 1) {
+              throw new Error("persistent intent sync failure");
+            }
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        await expect(stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+        })).rejects.toThrow("remained non-durable after 8 attempts");
+        await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+
+        // Model a crash losing the unsynced intent directory entry and the
+        // next process finding an unexpected auth file. A fresh module has no
+        // quarantine map from the failed process, so admission must rely on
+        // the isolated-home scrub rather than process memory.
+        syncSpy.mockRestore();
+        await rm(cleanupIntent, { force: true });
+        await writeFile(destination, '{"orphaned":true}', { mode: 0o600 });
+        vi.resetModules();
+        const freshCredentials = await import("./codex-credentials.js");
+        const persistentSyncFailure = vi.spyOn(prototype, "sync").mockImplementation(
+          async function (this: FileHandle): Promise<void> {
+            if ((await this.stat()).isDirectory()) {
+              throw new Error("persistent recovery sync failure");
+            }
+            await originalSync.call(this);
+          },
+        );
+        try {
+          await expect(freshCredentials.stageManagedCodexCredential({
+            agentHomeDirectory: fixture.home,
+            environment: { OPENAI_API_KEY: "launch-only-key" },
+          })).rejects.toThrow("remained non-durable after 8 attempts");
+          await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+        } finally {
+          persistentSyncFailure.mockRestore();
+        }
+      } finally {
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "owns cleanup when post-rename directory durability fails",
+    async () => {
+      const fixture = await credentialFixture();
+      const destination = join(fixture.home, "auth.json");
+      const probe = await open(fixture.home, "r");
+      const prototype = Object.getPrototypeOf(probe) as {
+        sync(this: FileHandle): Promise<void>;
+      };
+      await probe.close();
+      const originalSync = prototype.sync;
+      let directorySyncAttempts = 0;
+      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
+        async function (this: FileHandle): Promise<void> {
+          if ((await this.stat()).isDirectory()) {
+            directorySyncAttempts += 1;
+            if (directorySyncAttempts > 2) {
+              throw new Error("persistent post-rename sync failure");
+            }
+          }
+          await originalSync.call(this);
+        },
+      );
+      try {
+        await expect(stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+        })).rejects.toThrow("remained non-durable after 8 attempts");
+        await expect(readFile(destination, "utf8")).resolves.toBe("{}");
+
+        syncSpy.mockRestore();
+        const lease = await stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+        });
+        await expect(readFile(destination, "utf8")).resolves.toBe("{}");
+        await lease.close();
+      } finally {
+        syncSpy.mockRestore();
+      }
+    },
+  );
+
+  it("rejects missing, ambiguous, malformed, and unsafe sources", async () => {
+    const fixture = await credentialFixture();
+    await expect(
+      stageManagedCodexCredential({ agentHomeDirectory: fixture.home }),
+    ).rejects.toThrow(/credential missing/);
+    await expect(
+      stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          OPENAI_API_KEY: "key",
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}",
+        },
+      }),
+    ).rejects.toThrow(/ambiguous/);
+    await expect(
+      stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "[]" },
+      }),
+    ).rejects.toThrow(/malformed/);
+
+    const source = join(fixture.root, "unsafe-auth.json");
+    await writeFile(source, "{}", { mode: 0o644 });
+    await chmod(source, 0o644);
+    if (process.platform !== "win32") {
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          sourcePath: source,
+        }),
+      ).rejects.toThrow(/permissions are unsafe/);
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a credential home that is not private",
+    async () => {
+      const fixture = await credentialFixture();
+      await chmod(fixture.home, 0o755);
+
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow(/home permissions are unsafe/);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symbolic-link source",
+    async () => {
+      const fixture = await credentialFixture();
+      const target = join(fixture.root, "auth-target.json");
+      const source = join(fixture.root, "auth-link.json");
+      await writeFile(target, "{}", { mode: 0o600 });
+      await symlink(target, source);
+
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          sourcePath: source,
+        }),
+      ).rejects.toThrow(/credential missing/);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "replaces a stale destination link without touching its target",
+    async () => {
+      const fixture = await credentialFixture();
+      const target = join(fixture.root, "outside.json");
+      const destination = join(fixture.home, "auth.json");
+      await writeFile(target, '{"outside":true}', { mode: 0o600 });
+      await symlink(target, destination);
+
+      const lease = await stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+      });
+      await expect(readFile(target, "utf8")).resolves.toBe('{"outside":true}');
+      expect((await stat(lease.path)).isFile()).toBe(true);
+      await lease.close();
+    },
+  );
+});
+
+async function credentialFixture(): Promise<{ root: string; home: string }> {
+  const root = await mkdtemp(join(tmpdir(), "paperclip-acpx-credential-"));
+  temporaryDirectories.push(root);
+  const home = join(root, "codex-home");
+  await mkdir(home, { mode: 0o700 });
+  await chmod(home, 0o700);
+  return { root, home };
+}
+
+function credentialLeasePrimaryPort(home: string): number {
+  return credentialLeasePort(home, 0);
+}
+
+function credentialLeasePort(home: string, index: number): number {
+  const scope = `${
+    typeof process.getuid === "function" ? process.getuid() : "win32"
+  }\0${home}`;
+  const digest = createHash("sha256").update(scope).digest();
+  const start = digest.readUInt16BE(0) % 16_384;
+  const stride = digest.readUInt16BE(2) | 1;
+  return 49_152 + ((start + index * stride) % 16_384);
+}
+
+async function waitForChildMessage(
+  child: ChildProcess,
+  type: string,
+): Promise<void> {
+  let diagnostic = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    diagnostic = `${diagnostic}${chunk.toString("utf8")}`.slice(-4_096);
+  });
+  await new Promise<void>((resolveMessage, rejectMessage) => {
+    const timeout = setTimeout(() => {
+      rejectMessage(new Error(`child message timed out: ${diagnostic}`));
+    }, 10_000);
+    const finish = (error?: Error): void => {
+      clearTimeout(timeout);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+      if (error) rejectMessage(error);
+      else resolveMessage();
+    };
+    const onMessage = (message: unknown): void => {
+      if (
+        typeof message === "object" &&
+        message !== null &&
+        "type" in message &&
+        (message as { type?: unknown }).type === type
+      ) {
+        finish();
+      }
+    };
+    const onExit = (code: number | null): void => {
+      finish(
+        new Error(
+          `credential owner exited before ${type} (code ${String(code)}): ${diagnostic}`,
+        ),
+      );
+    };
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+  });
+}
+
+async function waitForChildExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolveExit, rejectExit) => {
+    const timeout = setTimeout(
+      () => rejectExit(new Error("credential owner exit timed out")),
+      10_000,
+    );
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolveExit();
+    });
+  });
+}

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -718,7 +718,7 @@ describe("managed Codex credentials", () => {
       await firstOpen;
       await vi.advanceTimersByTimeAsync(20_000);
       await rejection;
-      expect(directoryOpenAttempts).toBe(8);
+      expect(directoryOpenAttempts).toBe(1);
     },
   );
 
@@ -762,7 +762,7 @@ describe("managed Codex credentials", () => {
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
       const rejection = expect(staging).rejects.toThrow(
-        "remained non-durable after 8 attempts",
+        "remained non-durable after 1 attempt",
       );
       await firstSync;
       await vi.advanceTimersByTimeAsync(20_000);
@@ -823,17 +823,20 @@ describe("managed Codex credentials", () => {
         agentHomeDirectory: fixture.home,
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
-      await firstClose;
-      await vi.advanceTimersByTimeAsync(20_000);
-      const lease = await staging;
-
-      await expect(lease.close()).rejects.toThrow(
+      const rejection = expect(staging).rejects.toThrow(
         "remained non-durable after 1 attempt",
       );
+      await firstClose;
+      await vi.advanceTimersByTimeAsync(20_000);
+      await rejection;
       expect(directoryCloseAttempts).toBe(1);
 
       settleFirstClose();
       await vi.advanceTimersByTimeAsync(20_000);
+      const lease = await freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
       await expect(lease.close()).resolves.toBeUndefined();
       expect(directoryCloseAttempts).toBeGreaterThan(1);
     },

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -786,12 +786,12 @@ describe("managed Codex credentials", () => {
       );
       let directoryCloseAttempts = 0;
       let observeFirstClose!: () => void;
-      let observeLeaseClose!: () => void;
+      let settleFirstClose!: () => void;
       const firstClose = new Promise<void>((resolveClose) => {
         observeFirstClose = resolveClose;
       });
-      const leaseClose = new Promise<void>((resolveClose) => {
-        observeLeaseClose = resolveClose;
+      const retainedClose = new Promise<void>((resolveClose) => {
+        settleFirstClose = resolveClose;
       });
       vi.doMock("node:fs/promises", () => ({
         ...actualFs,
@@ -804,9 +804,10 @@ describe("managed Codex credentials", () => {
             return {
               close: async (): Promise<void> => {
                 directoryCloseAttempts += 1;
-                if (directoryCloseAttempts === 1) observeFirstClose();
-                if (directoryCloseAttempts === 3) observeLeaseClose();
-                return await new Promise<void>(() => undefined);
+                if (directoryCloseAttempts === 1) {
+                  observeFirstClose();
+                  return await retainedClose;
+                }
               },
               sync: async (): Promise<void> => undefined,
             } as FileHandle;
@@ -826,11 +827,15 @@ describe("managed Codex credentials", () => {
       await vi.advanceTimersByTimeAsync(20_000);
       const lease = await staging;
 
-      const closing = lease.close();
-      await leaseClose;
+      await expect(lease.close()).rejects.toThrow(
+        "remained non-durable after 1 attempt",
+      );
+      expect(directoryCloseAttempts).toBe(1);
+
+      settleFirstClose();
       await vi.advanceTimersByTimeAsync(20_000);
-      await closing;
-      expect(directoryCloseAttempts).toBe(4);
+      await expect(lease.close()).resolves.toBeUndefined();
+      expect(directoryCloseAttempts).toBeGreaterThan(1);
     },
   );
 

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -1,10 +1,12 @@
 import { fork, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
 import {
   chmod,
   mkdir,
   mkdtemp,
   open,
+  readdir,
   readFile,
   realpath,
   rm,
@@ -13,7 +15,8 @@ import {
   writeFile,
   type FileHandle,
 } from "node:fs/promises";
-import { createServer } from "node:net";
+import { createRequire } from "node:module";
+import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -25,8 +28,16 @@ const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
   vi.useRealTimers();
+  vi.doUnmock("node:child_process");
   vi.doUnmock("node:fs/promises");
   vi.resetModules();
+  (
+    globalThis as typeof globalThis & {
+      __paperclipDirectorySyncHelperRegistryV1?: {
+        activeParentOperations: Set<symbol>;
+      };
+    }
+  ).__paperclipDirectorySyncHelperRegistryV1?.activeParentOperations.clear();
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -35,6 +46,18 @@ afterEach(async () => {
 });
 
 describe("managed Codex credentials", () => {
+  it("derives deterministic quorum candidates from distinct user scopes", () => {
+    expect(credentialLeasePortsForScope("1000", "/canonical/home")).toEqual(
+      credentialLeasePortsForScope("1000", "/canonical/home"),
+    );
+    expect(credentialLeasePortsForScope("1000", "/canonical/home")).not.toEqual(
+      credentialLeasePortsForScope("1001", "/canonical/home"),
+    );
+    expect(credentialLeasePortsForScope("1000", "/canonical/home")).not.toEqual(
+      credentialLeasePortsForScope("1000", "/canonical/other-home"),
+    );
+  });
+
   it("stages inline JSON privately and removes it idempotently", async () => {
     const fixture = await credentialFixture();
     const lease = await stageManagedCodexCredential({
@@ -104,216 +127,199 @@ describe("managed Codex credentials", () => {
     await secondLease.close();
   });
 
-  it("falls through when an unrelated listener occupies the primary lease port", async () => {
+  it("fences a contender loaded through a fresh module instance", async () => {
     const fixture = await credentialFixture();
-    const canonicalHome = await realpath(fixture.home);
-    const primaryPort = credentialLeasePrimaryPort(canonicalHome);
-    const unrelated = createServer((socket) => {
-      socket.end("unrelated-loopback-service\n");
-    });
-    await new Promise<void>((resolveListen, rejectListen) => {
-      unrelated.once("error", rejectListen);
-      unrelated.listen(primaryPort, "127.0.0.1", resolveListen);
+    const firstLease = await stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"first"}',
+      },
     });
 
-    try {
-      const lease = await stageManagedCodexCredential({
+    vi.resetModules();
+    const freshCredentials = await import("./codex-credentials.js");
+    await expect(
+      freshCredentials.stageManagedCodexCredential({
         agentHomeDirectory: fixture.home,
         environment: {
-          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"paperclip"}',
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
         },
-      });
-      await expect(readFile(lease.path, "utf8")).resolves.toBe(
-        '{"owner":"paperclip"}',
-      );
-      vi.resetModules();
-      const freshCredentials = await import("./codex-credentials.js");
-      await expect(
-        freshCredentials.stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: {
-            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
-          },
-        }),
-      ).rejects.toThrow("already has an active lease");
-      await lease.close();
+      }),
+    ).rejects.toThrow("already has an active lease");
 
-      const successor = await freshCredentials.stageManagedCodexCredential({
-        agentHomeDirectory: fixture.home,
-        environment: {
-          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"successor"}',
-        },
-      });
-      await expect(readFile(successor.path, "utf8")).resolves.toBe(
-        '{"owner":"successor"}',
-      );
-      await successor.close();
-    } finally {
-      await new Promise<void>((resolveClose, rejectClose) => {
-        unrelated.close((error) => {
-          if (error) rejectClose(error);
-          else resolveClose();
-        });
-      });
-    }
+    await firstLease.close();
   });
 
-  it("fails closed while the primary lease owner is not yet responsive", async () => {
-    const fixture = await credentialFixture();
-    const canonicalHome = await realpath(fixture.home);
-    const primaryPort = credentialLeasePrimaryPort(canonicalHome);
-    const acceptedSockets = new Set<import("node:net").Socket>();
-    const publishingOwner = createServer((socket) => {
-      acceptedSockets.add(socket);
-      socket.once("close", () => acceptedSockets.delete(socket));
-      socket.pause();
-    });
-    await new Promise<void>((resolveListen, rejectListen) => {
-      publishingOwner.once("error", rejectListen);
-      publishingOwner.listen(primaryPort, "127.0.0.1", resolveListen);
-    });
-
-    try {
-      await expect(
-        stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: {
-            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
-          },
-        }),
-      ).rejects.toThrow(
-        "could not safely bypass an unresponsive lease endpoint",
-      );
-      await expect(
-        readFile(join(fixture.home, "auth.json")),
-      ).rejects.toMatchObject({ code: "ENOENT" });
-    } finally {
-      for (const socket of acceptedSockets) socket.destroy();
-      await new Promise<void>((resolveClose, rejectClose) => {
-        publishingOwner.close((error) => {
-          if (error) rejectClose(error);
-          else resolveClose();
-        });
-      });
-    }
-  });
-
-  it("fails closed when a competing candidate is unresponsive after bind", async () => {
-    const fixture = await credentialFixture();
-    const canonicalHome = await realpath(fixture.home);
-    const competingPort = credentialLeasePort(canonicalHome, 1);
-    const acceptedSockets = new Set<import("node:net").Socket>();
-    const publishingOwner = createServer((socket) => {
-      acceptedSockets.add(socket);
-      socket.once("close", () => acceptedSockets.delete(socket));
-      socket.pause();
-    });
-    await new Promise<void>((resolveListen, rejectListen) => {
-      publishingOwner.once("error", rejectListen);
-      publishingOwner.listen(competingPort, "127.0.0.1", resolveListen);
-    });
-
-    try {
-      await expect(
-        stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: {
-            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
-          },
-        }),
-      ).rejects.toThrow("already has an active lease");
-      await expect(
-        readFile(join(fixture.home, "auth.json")),
-      ).rejects.toMatchObject({ code: "ENOENT" });
-    } finally {
-      for (const socket of acceptedSockets) socket.destroy();
-      await new Promise<void>((resolveClose, rejectClose) => {
-        publishingOwner.close((error) => {
-          if (error) rejectClose(error);
-          else resolveClose();
-        });
-      });
-    }
-  });
-
-  it(
-    "fences another process and recovers only after its kernel lease dies",
-    async () => {
+  it.each([
+    ["primary", 0],
+    ["non-primary", 1],
+  ] as const)(
+    "tolerates one unrelated silent %s quorum listener",
+    async (_label, occupiedIndex) => {
       const fixture = await credentialFixture();
-      const destination = join(fixture.home, "auth.json");
-      const childScript = join(fixture.root, "credential-owner.mjs");
-      const credentialModule = new URL(
-        "./codex-credentials.ts",
-        import.meta.url,
-      ).href;
-      await writeFile(
-        childScript,
-        [
-          `const { stageManagedCodexCredential } = await import(${JSON.stringify(credentialModule)});`,
-          "const lease = await stageManagedCodexCredential({",
-          "  agentHomeDirectory: process.argv[2],",
-          '  environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: \'{"owner":"first"}\' },',
-          "});",
-          'process.send?.({ type: "ready", path: lease.path });',
-          "process.on('message', async (message) => {",
-          "  if (message?.type !== 'close') return;",
-          "  await lease.close();",
-          "  process.exit(0);",
-          "});",
-        ].join("\n"),
-      );
-      const owner = fork(childScript, [fixture.home], {
-        execArgv: ["--import", "tsx"],
-        stdio: ["ignore", "pipe", "pipe", "ipc"],
-      });
+      const ports = credentialLeasePorts(await realpath(fixture.home));
+      const occupied = await listenSilently(ports[occupiedIndex]);
       try {
-        await waitForChildMessage(owner, "ready");
-        await expect(readFile(destination, "utf8")).resolves.toBe(
-          '{"owner":"first"}',
-        );
-
-        if (process.platform !== "win32") {
-          owner.kill("SIGSTOP");
-          await new Promise<void>((resolveSignal) =>
-            setTimeout(resolveSignal, 50),
-          );
-        }
-        await expect(
-          stageManagedCodexCredential({
-            agentHomeDirectory: fixture.home,
-            environment: {
-              PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
-            },
-          }),
-        ).rejects.toThrow("already has an active lease");
-        await expect(readFile(destination, "utf8")).resolves.toBe(
-          '{"owner":"first"}',
-        );
-
-        if (process.platform !== "win32") owner.kill("SIGCONT");
-        owner.kill(process.platform === "win32" ? undefined : "SIGKILL");
-        await waitForChildExit(owner);
-
-        const successor = await stageManagedCodexCredential({
+        const lease = await stageManagedCodexCredential({
           agentHomeDirectory: fixture.home,
           environment: {
-            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"paperclip"}',
           },
         });
-        await expect(readFile(destination, "utf8")).resolves.toBe(
-          '{"owner":"second"}',
+        await expect(readFile(lease.path, "utf8")).resolves.toBe(
+          '{"owner":"paperclip"}',
         );
-        await successor.close();
+        await lease.close();
       } finally {
-        if (owner.exitCode === null && owner.signalCode === null) {
-          if (process.platform !== "win32") owner.kill("SIGCONT");
-          owner.kill(process.platform === "win32" ? undefined : "SIGKILL");
-          await waitForChildExit(owner).catch(() => undefined);
-        }
+        await occupied.close();
       }
     },
   );
 
+  it("fails before auth mutation when two quorum candidates are occupied", async () => {
+    const fixture = await credentialFixture();
+    const destination = join(fixture.home, "auth.json");
+    await writeFile(destination, '{"sentinel":true}', { mode: 0o600 });
+    const ports = credentialLeasePorts(await realpath(fixture.home));
+    const first = await listenSilently(ports[0]);
+    const second = await listenSilently(ports[1]);
+    try {
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"contender"}',
+          },
+        }),
+      ).rejects.toThrow("already has an active lease");
+      await expect(readFile(destination, "utf8")).resolves.toBe(
+        '{"sentinel":true}',
+      );
+    } finally {
+      await Promise.all([first.close(), second.close()]);
+    }
+  });
+
+  it("admits only one of two concurrent fresh-module contenders", async () => {
+    const fixture = await credentialFixture();
+    vi.resetModules();
+    const firstCredentials = await import("./codex-credentials.js");
+    vi.resetModules();
+    const secondCredentials = await import("./codex-credentials.js");
+
+    const results = await Promise.allSettled([
+      firstCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"first"}',
+        },
+      }),
+      secondCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+        },
+      }),
+    ]);
+    const winners = results.filter(
+      (
+        result,
+      ): result is PromiseFulfilledResult<
+        Awaited<ReturnType<typeof stageManagedCodexCredential>>
+      > => result.status === "fulfilled",
+    );
+    expect(winners).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+    await winners[0].value.close();
+  });
+
+  it("fences another process and recovers only after its kernel lease dies", async () => {
+    const fixture = await credentialFixture();
+    const destination = join(fixture.home, "auth.json");
+    const childScript = join(fixture.root, "credential-owner.mjs");
+    const credentialModule = new URL("./codex-credentials.ts", import.meta.url)
+      .href;
+    // paperclip-runner intentionally does not ship a TS runtime dependency.
+    // Resolve the existing monorepo dev loader from a workspace that declares
+    // it, instead of asking the child to resolve an undeclared bare package.
+    const tsxLoader = createRequire(
+      new URL("../../../../../server/package.json", import.meta.url),
+    ).resolve("tsx");
+    await writeFile(
+      childScript,
+      [
+        `const { stageManagedCodexCredential } = await import(${JSON.stringify(credentialModule)});`,
+        "const lease = await stageManagedCodexCredential({",
+        "  agentHomeDirectory: process.argv[2],",
+        '  environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: \'{"owner":"first"}\' },',
+        "});",
+        'process.send?.({ type: "ready", path: lease.path });',
+        "process.on('message', async (message) => {",
+        "  if (message?.type !== 'close') return;",
+        "  await lease.close();",
+        "  process.exit(0);",
+        "});",
+      ].join("\n"),
+    );
+    const owner = fork(childScript, [fixture.home], {
+      execArgv: ["--import", tsxLoader],
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+    });
+    try {
+      await waitForChildMessage(owner, "ready");
+      await expect(readFile(destination, "utf8")).resolves.toBe(
+        '{"owner":"first"}',
+      );
+
+      if (process.platform !== "win32") {
+        owner.kill("SIGSTOP");
+        await new Promise<void>((resolveSignal) =>
+          setTimeout(resolveSignal, 50),
+        );
+      }
+      await expect(
+        stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+          },
+        }),
+      ).rejects.toThrow("already has an active lease");
+      await expect(readFile(destination, "utf8")).resolves.toBe(
+        '{"owner":"first"}',
+      );
+
+      if (process.platform !== "win32") owner.kill("SIGCONT");
+      owner.kill(process.platform === "win32" ? undefined : "SIGKILL");
+      await waitForChildExit(owner);
+
+      const successor = await stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"second"}',
+        },
+      });
+      await expect(readFile(destination, "utf8")).resolves.toBe(
+        '{"owner":"second"}',
+      );
+      await successor.close();
+      expect(
+        (await readdir(fixture.home)).filter(
+          (name) =>
+            name.includes("paperclip-auth-lease") ||
+            name.includes("paperclip-auth-home-claim"),
+        ),
+      ).toEqual([]);
+    } finally {
+      if (owner.exitCode === null && owner.signalCode === null) {
+        if (process.platform !== "win32") owner.kill("SIGCONT");
+        owner.kill(process.platform === "win32" ? undefined : "SIGKILL");
+        await waitForChildExit(owner).catch(() => undefined);
+      }
+    }
+  });
   it.runIf(process.platform !== "win32")(
     "holds kernel ownership until credential cleanup is durable",
     async () => {
@@ -337,16 +343,16 @@ describe("managed Codex credentials", () => {
         signalCleanupStarted = resolveStarted;
       });
       let heldCleanup = false;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if (!heldCleanup && (await this.stat()).isDirectory()) {
             heldCleanup = true;
             signalCleanupStarted();
             await cleanupGate;
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
         const closing = lease.close();
         await cleanupStarted;
@@ -402,117 +408,23 @@ describe("managed Codex credentials", () => {
     await secondLease.close();
   });
 
-  it("fences successor admission while an older lock release fails", async () => {
+  it("leaves no ownership artifacts in the credential home", async () => {
     const fixture = await credentialFixture();
-    const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
-      "node:fs/promises",
-    );
-    let markerUnlinkAttempts = 0;
-    let signalMarkerReleaseStarted!: () => void;
-    const markerReleaseStarted = new Promise<void>((resolveStarted) => {
-      signalMarkerReleaseStarted = resolveStarted;
-    });
-    let failMarkerRelease!: () => void;
-    const markerReleaseFailureGate = new Promise<void>((resolveFailure) => {
-      failMarkerRelease = resolveFailure;
-    });
-    vi.doMock("node:fs/promises", () => ({
-      ...actualFs,
-      unlink: async (path: Parameters<typeof actualFs.unlink>[0]) => {
-        if (String(path).includes(".paperclip-auth-lease-v1-")) {
-          markerUnlinkAttempts += 1;
-          if (markerUnlinkAttempts === 1) {
-            signalMarkerReleaseStarted();
-            await markerReleaseFailureGate;
-            throw Object.assign(new Error("injected marker unlink failure"), {
-              code: "EACCES",
-            });
-          }
-        }
-        await actualFs.unlink(path);
-      },
-    }));
-    vi.resetModules();
-    const freshCredentials = await import("./codex-credentials.js");
-    const firstLease = await freshCredentials.stageManagedCodexCredential({
+    const lease = await stageManagedCodexCredential({
       agentHomeDirectory: fixture.home,
-      environment: {
-        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"first"}',
-      },
+      environment: { OPENAI_API_KEY: "launch-only-key" },
     });
+    await lease.close();
 
-    const firstClose = firstLease.close();
-    try {
-      await markerReleaseStarted;
-      await expect(
-        freshCredentials.stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: {
-            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"overlap"}',
-          },
-        }),
-      ).rejects.toThrow("already has an active lease");
-
-      failMarkerRelease();
-      await expect(firstClose).rejects.toThrow(
-        "injected marker unlink failure",
-      );
-      const successor = await freshCredentials.stageManagedCodexCredential({
-        agentHomeDirectory: fixture.home,
-        environment: {
-          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"successor"}',
-        },
-      });
-      await expect(firstLease.close()).resolves.toBeUndefined();
-      await expect(readFile(successor.path, "utf8")).resolves.toBe(
-        '{"owner":"successor"}',
-      );
-      await successor.close();
-      expect(markerUnlinkAttempts).toBeGreaterThanOrEqual(2);
-    } finally {
-      failMarkerRelease();
-      await firstClose.catch(() => undefined);
-    }
+    expect(
+      (await readdir(fixture.home)).filter(
+        (name) =>
+          name.includes("paperclip-auth-lease") ||
+          name.includes("paperclip-auth-home-claim") ||
+          name.includes("paperclip-auth-lock"),
+      ),
+    ).toEqual([]);
   });
-
-  it("keeps ownership live while retrying lease-marker removal", async () => {
-    const fixture = await credentialFixture();
-    const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
-      "node:fs/promises",
-    );
-    let markerUnlinkAttempts = 0;
-    vi.doMock("node:fs/promises", () => ({
-      ...actualFs,
-      unlink: async (path: Parameters<typeof actualFs.unlink>[0]) => {
-        if (String(path).includes(".paperclip-auth-lease-v1-")) {
-          markerUnlinkAttempts += 1;
-          if (markerUnlinkAttempts === 1) {
-            throw Object.assign(new Error("injected marker unlink failure"), {
-              code: "EACCES",
-            });
-          }
-        }
-        await actualFs.unlink(path);
-      },
-    }));
-    vi.resetModules();
-    const freshCredentials = await import("./codex-credentials.js");
-    const lease = await freshCredentials.stageManagedCodexCredential({
-      agentHomeDirectory: fixture.home,
-      environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
-    });
-
-    await expect(lease.close()).rejects.toThrow(
-      "injected marker unlink failure",
-    );
-    const successor = await freshCredentials.stageManagedCodexCredential({
-      agentHomeDirectory: fixture.home,
-      environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
-    });
-    await successor.close();
-    expect(markerUnlinkAttempts).toBeGreaterThanOrEqual(3);
-  });
-
   it("recovers a persisted cleanup intent before admitting another provider", async () => {
     const fixture = await credentialFixture();
     const destination = join(fixture.home, "auth.json");
@@ -521,22 +433,97 @@ describe("managed Codex credentials", () => {
       ".paperclip-auth-cleanup-required",
     );
     await writeFile(destination, '{"crash_stale":true}', { mode: 0o600 });
-    await writeFile(
-      cleanupIntent,
-      "paperclip-managed-codex-cleanup-v1\n",
-      { mode: 0o600 },
-    );
+    await writeFile(cleanupIntent, "paperclip-managed-codex-cleanup-v1\n", {
+      mode: 0o600,
+    });
 
     const lease = await stageManagedCodexCredential({
       agentHomeDirectory: fixture.home,
       environment: { OPENAI_API_KEY: "launch-only-key" },
     });
-    await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(destination)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     await expect(readFile(cleanupIntent, "utf8")).resolves.toBe(
       "paperclip-managed-codex-cleanup-v1\n",
     );
     await lease.close();
-    await expect(readFile(cleanupIntent)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(cleanupIntent)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("scrubs a crash-left credential staging file before admission", async () => {
+    const fixture = await credentialFixture();
+    const stagingPath = join(fixture.home, ".paperclip-auth-staging-v1");
+    const cleanupIntent = join(
+      fixture.home,
+      ".paperclip-auth-cleanup-required",
+    );
+    await writeFile(stagingPath, '{"crash_secret":"must-not-survive"}', {
+      mode: 0o600,
+    });
+    await writeFile(cleanupIntent, "paperclip-managed-codex-cleanup-v1\n", {
+      mode: 0o600,
+    });
+
+    vi.resetModules();
+    const freshCredentials = await import("./codex-credentials.js");
+    const lease = await freshCredentials.stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"successor"}',
+      },
+    });
+    await expect(readFile(stagingPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(lease.path, "utf8")).resolves.toBe(
+      '{"owner":"successor"}',
+    );
+    await lease.close();
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "unlinks a crash-left staging symlink without touching its target",
+    async () => {
+      const fixture = await credentialFixture();
+      const target = join(fixture.root, "external-secret.json");
+      const stagingPath = join(fixture.home, ".paperclip-auth-staging-v1");
+      await writeFile(target, '{"external":"unchanged"}', { mode: 0o600 });
+      await symlink(target, stagingPath);
+
+      const lease = await stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      await expect(readFile(stagingPath)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(readFile(target, "utf8")).resolves.toBe(
+        '{"external":"unchanged"}',
+      );
+      await lease.close();
+    },
+  );
+
+  it("fails closed instead of recursively removing a staging directory", async () => {
+    const fixture = await credentialFixture();
+    const stagingPath = join(fixture.home, ".paperclip-auth-staging-v1");
+    await mkdir(stagingPath, { mode: 0o700 });
+
+    await expect(
+      stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      }),
+    ).rejects.toThrow("credential destination is a directory");
+    expect((await stat(stagingPath)).isDirectory()).toBe(true);
+    await expect(
+      readFile(join(fixture.home, "auth.json")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it.runIf(process.platform !== "win32")(
@@ -554,8 +541,9 @@ describe("managed Codex credentials", () => {
       await probe.close();
       const originalSync = prototype.sync;
       let syncAttempts = 0;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if ((await this.stat()).isDirectory()) {
             syncAttempts += 1;
             if (syncAttempts === 1) {
@@ -563,11 +551,12 @@ describe("managed Codex credentials", () => {
             }
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
         await expect(lease.close()).resolves.toBeUndefined();
-        await expect(readFile(lease.path)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(readFile(lease.path)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
         expect(syncAttempts).toBe(3);
       } finally {
         syncSpy.mockRestore();
@@ -586,8 +575,9 @@ describe("managed Codex credentials", () => {
       await probe.close();
       const originalSync = prototype.sync;
       let directorySyncAttempts = 0;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if ((await this.stat()).isDirectory()) {
             directorySyncAttempts += 1;
           }
@@ -597,8 +587,7 @@ describe("managed Codex credentials", () => {
             throw new Error("injected directory sync failure");
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
         const lease = await stageManagedCodexCredential({
           agentHomeDirectory: fixture.home,
@@ -606,7 +595,9 @@ describe("managed Codex credentials", () => {
         });
         await expect(readFile(lease.path, "utf8")).resolves.toBe("{}");
         await expect(lease.close()).resolves.toBeUndefined();
-        await expect(readFile(lease.path)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(readFile(lease.path)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
         expect(directorySyncAttempts).toBe(8);
       } finally {
         syncSpy.mockRestore();
@@ -647,9 +638,7 @@ describe("managed Codex credentials", () => {
         PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"fresh":true}',
       },
     });
-    await expect(readFile(destination, "utf8")).resolves.toBe(
-      '{"fresh":true}',
-    );
+    await expect(readFile(destination, "utf8")).resolves.toBe('{"fresh":true}');
     await lease.close();
   });
 
@@ -686,8 +675,9 @@ describe("managed Codex credentials", () => {
       await probe.close();
       const originalSync = prototype.sync;
       let syncAttempts = 0;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if ((await this.stat()).isDirectory()) {
             syncAttempts += 1;
             if (syncAttempts === 1) {
@@ -695,14 +685,15 @@ describe("managed Codex credentials", () => {
             }
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
         const lease = await stageManagedCodexCredential({
           agentHomeDirectory: fixture.home,
           environment: { OPENAI_API_KEY: "launch-only-key" },
         });
-        await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(readFile(destination)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
         await expect(lease.close()).resolves.toBeUndefined();
         expect(syncAttempts).toBe(5);
       } finally {
@@ -721,14 +712,14 @@ describe("managed Codex credentials", () => {
       };
       await probe.close();
       const originalSync = prototype.sync;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if ((await this.stat()).isDirectory()) {
             throw new Error("persistent directory sync failure");
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
         const staging = stageManagedCodexCredential({
           agentHomeDirectory: fixture.home,
@@ -751,36 +742,108 @@ describe("managed Codex credentials", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "blocks retries until a timed-out directory open and its late close settle",
+    "shares the four-slot parent filesystem budget across fresh modules",
+    async () => {
+      const fixtures = await Promise.all(
+        Array.from({ length: 5 }, () => credentialFixture()),
+      );
+      const retainedHomes = new Set(
+        fixtures.slice(0, 4).map((fixture) => fixture.home),
+      );
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
+      let directoryOpenAttempts = 0;
+      let fifthHomeOpenAttempts = 0;
+      let observeFourOpens!: () => void;
+      const fourOpens = new Promise<void>((resolveOpens) => {
+        observeFourOpens = resolveOpens;
+      });
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          const pathname = String(path);
+          if (retainedHomes.has(pathname)) {
+            directoryOpenAttempts += 1;
+            if (directoryOpenAttempts === 4) observeFourOpens();
+            return await new Promise<FileHandle>(() => undefined);
+          }
+          if (pathname === fixtures[4].home) fifthHomeOpenAttempts += 1;
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      const spawnMock = vi.fn(() => {
+        const child = Object.assign(new EventEmitter(), {
+          kill: vi.fn(() => true),
+          pid: 12345,
+          unref: vi.fn(),
+        }) as unknown as ChildProcess;
+        queueMicrotask(() => child.emit("exit", 0, null));
+        return child;
+      });
+      vi.doMock("node:child_process", () => ({ spawn: spawnMock }));
+      vi.resetModules();
+      const firstCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const firstStaging = Promise.all(
+        fixtures.slice(0, 4).map((fixture) =>
+          firstCredentials.stageManagedCodexCredential({
+            agentHomeDirectory: fixture.home,
+            environment: { OPENAI_API_KEY: "launch-only-key" },
+          }),
+        ),
+      );
+      let leases: Awaited<ReturnType<typeof stageManagedCodexCredential>>[] =
+        [];
+      try {
+        await fourOpens;
+        await vi.advanceTimersByTimeAsync(1_001);
+        leases = await firstStaging;
+        const registry = (
+          globalThis as typeof globalThis & {
+            __paperclipDirectorySyncHelperRegistryV1?: {
+              activeParentOperations: Set<symbol>;
+            };
+          }
+        ).__paperclipDirectorySyncHelperRegistryV1;
+        expect(registry?.activeParentOperations.size).toBe(4);
+
+        vi.resetModules();
+        const freshCredentials = await import("./codex-credentials.js");
+        const fifthLease = await freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixtures[4].home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        });
+        leases.push(fifthLease);
+        expect(directoryOpenAttempts).toBe(4);
+        expect(fifthHomeOpenAttempts).toBe(0);
+        expect(spawnMock).toHaveBeenCalled();
+      } finally {
+        await Promise.allSettled(leases.map((lease) => lease.close()));
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "isolates retries after a directory open never settles",
     async () => {
       const fixture = await credentialFixture();
-      const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
-        "node:fs/promises",
-      );
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
       let directoryOpenAttempts = 0;
       let observeFirstOpen!: () => void;
-      let settleFirstOpen!: (handle: FileHandle) => void;
-      let observeFirstClose!: () => void;
-      let settleFirstClose!: () => void;
       const firstOpen = new Promise<void>((resolveOpen) => {
         observeFirstOpen = resolveOpen;
       });
-      const retainedOpen = new Promise<FileHandle>((resolveOpen) => {
-        settleFirstOpen = resolveOpen;
-      });
-      const firstClose = new Promise<void>((resolveClose) => {
-        observeFirstClose = resolveClose;
-      });
-      const retainedClose = new Promise<void>((resolveClose) => {
-        settleFirstClose = resolveClose;
-      });
-      const lateHandle = {
-        close: async (): Promise<void> => {
-          observeFirstClose();
-          await retainedClose;
-        },
-        sync: async (): Promise<void> => undefined,
-      } as FileHandle;
+      const retainedOpen = new Promise<FileHandle>(() => undefined);
       vi.doMock("node:fs/promises", () => ({
         ...actualFs,
         open: async (
@@ -806,50 +869,28 @@ describe("managed Codex credentials", () => {
         agentHomeDirectory: fixture.home,
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
-      const rejection = expect(staging).rejects.toThrow(
-        "remained non-durable after 1 attempt",
-      );
       await firstOpen;
-      await vi.advanceTimersByTimeAsync(20_000);
-      await rejection;
+      await vi.advanceTimersByTimeAsync(1_001);
+      const lease = await staging;
       expect(directoryOpenAttempts).toBe(1);
-
-      await expect(
-        freshCredentials.stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: { OPENAI_API_KEY: "launch-only-key" },
-        }),
-      ).rejects.toThrow("remained non-durable after 1 attempt");
-      expect(directoryOpenAttempts).toBe(1);
-
-      settleFirstOpen(lateHandle);
-      await firstClose;
-      await expect(
-        freshCredentials.stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: { OPENAI_API_KEY: "launch-only-key" },
-        }),
-      ).rejects.toThrow("remained non-durable after 1 attempt");
-      expect(directoryOpenAttempts).toBe(1);
-
-      settleFirstClose();
-      await vi.advanceTimersByTimeAsync(20_000);
-      const lease = await freshCredentials.stageManagedCodexCredential({
+      await lease.close();
+      const successor = await freshCredentials.stageManagedCodexCredential({
         agentHomeDirectory: fixture.home,
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
-      await expect(lease.close()).resolves.toBeUndefined();
-      expect(directoryOpenAttempts).toBeGreaterThan(1);
+      await successor.close();
+      expect(directoryOpenAttempts).toBe(1);
     },
   );
 
   it.runIf(process.platform !== "win32")(
-    "bounds a directory fsync without accumulating pending handles",
+    "isolates retries after a directory fsync never settles",
     async () => {
       const fixture = await credentialFixture();
-      const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
-        "node:fs/promises",
-      );
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
       let directorySyncAttempts = 0;
       let observeFirstSync!: () => void;
       const firstSync = new Promise<void>((resolveSync) => {
@@ -882,38 +923,33 @@ describe("managed Codex credentials", () => {
         agentHomeDirectory: fixture.home,
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
-      const rejection = expect(staging).rejects.toThrow(
-        "remained non-durable after 1 attempt",
-      );
       await firstSync;
-      await vi.advanceTimersByTimeAsync(20_000);
-      await rejection;
-      await expect(
-        freshCredentials.stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: { OPENAI_API_KEY: "launch-only-key" },
-        }),
-      ).rejects.toThrow("remained non-durable after 1 attempt");
+      await vi.advanceTimersByTimeAsync(1_001);
+      const lease = await staging;
+      await lease.close();
+      const successor = await freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      await successor.close();
       expect(directorySyncAttempts).toBe(1);
     },
   );
 
   it.runIf(process.platform !== "win32")(
-    "bounds a directory close that never settles after a durable fsync",
+    "isolates later syncs after a directory close never settles",
     async () => {
       const fixture = await credentialFixture();
-      const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
-        "node:fs/promises",
-      );
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
       let directoryCloseAttempts = 0;
       let observeFirstClose!: () => void;
-      let settleFirstClose!: () => void;
       const firstClose = new Promise<void>((resolveClose) => {
         observeFirstClose = resolveClose;
       });
-      const retainedClose = new Promise<void>((resolveClose) => {
-        settleFirstClose = resolveClose;
-      });
+      const retainedClose = new Promise<void>(() => undefined);
       vi.doMock("node:fs/promises", () => ({
         ...actualFs,
         open: async (
@@ -944,22 +980,286 @@ describe("managed Codex credentials", () => {
         agentHomeDirectory: fixture.home,
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
-      const rejection = expect(staging).rejects.toThrow(
-        "remained non-durable after 1 attempt",
-      );
       await firstClose;
-      await vi.advanceTimersByTimeAsync(20_000);
-      await rejection;
+      await vi.advanceTimersByTimeAsync(1_001);
+      const lease = await staging;
       expect(directoryCloseAttempts).toBe(1);
-
-      settleFirstClose();
-      await vi.advanceTimersByTimeAsync(20_000);
-      const lease = await freshCredentials.stageManagedCodexCredential({
+      await lease.close();
+      const successor = await freshCredentials.stageManagedCodexCredential({
         agentHomeDirectory: fixture.home,
         environment: { OPENAI_API_KEY: "launch-only-key" },
       });
-      await expect(lease.close()).resolves.toBeUndefined();
-      expect(directoryCloseAttempts).toBeGreaterThan(1);
+      await successor.close();
+      expect(directoryCloseAttempts).toBe(1);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "permanently fails closed when a killed sync helper never exits",
+    async () => {
+      const fixture = await credentialFixture();
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
+      let observeDirectoryOpen!: () => void;
+      const directoryOpen = new Promise<void>((resolveOpen) => {
+        observeDirectoryOpen = resolveOpen;
+      });
+      let directoryOpenAttempts = 0;
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) {
+            directoryOpenAttempts += 1;
+            observeDirectoryOpen();
+            return await new Promise<FileHandle>(() => undefined);
+          }
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      let spawnAttempts = 0;
+      const stuckChild = Object.assign(new EventEmitter(), {
+        kill: vi.fn(() => true),
+        pid: 12345,
+        unref: vi.fn(),
+      }) as unknown as ChildProcess;
+      vi.doMock("node:child_process", () => ({
+        spawn: vi.fn(() => {
+          spawnAttempts += 1;
+          return stuckChild;
+        }),
+      }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const staging = freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      const rejection = expect(staging).rejects.toThrow(
+        /remained non-durable after 1 attempt/,
+      );
+      await directoryOpen;
+      await vi.advanceTimersByTimeAsync(1_001);
+      await vi.advanceTimersByTimeAsync(1_001);
+      await vi.advanceTimersByTimeAsync(1_001);
+      await rejection;
+      expect(spawnAttempts).toBe(1);
+      expect(directoryOpenAttempts).toBe(1);
+      expect(stuckChild.unref).toHaveBeenCalledOnce();
+
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow(/remained non-durable after 1 attempt/);
+      expect(spawnAttempts).toBe(1);
+      expect(directoryOpenAttempts).toBe(1);
+      stuckChild.emit("exit", null, "SIGKILL");
+    },
+  );
+
+  it.runIf(process.platform !== "win32").each([
+    ["returns false", (): boolean => false],
+    [
+      "throws",
+      (): boolean => {
+        throw new Error("injected kill failure");
+      },
+    ],
+  ])(
+    "permanently fences a home when helper kill %s",
+    async (_label, killImplementation) => {
+      const fixture = await credentialFixture();
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
+      let observeDirectoryOpen!: () => void;
+      const directoryOpen = new Promise<void>((resolveOpen) => {
+        observeDirectoryOpen = resolveOpen;
+      });
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) {
+            observeDirectoryOpen();
+            return await new Promise<FileHandle>(() => undefined);
+          }
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      const child = Object.assign(new EventEmitter(), {
+        kill: vi.fn(killImplementation),
+        pid: 12345,
+        unref: vi.fn(),
+      }) as unknown as ChildProcess;
+      const spawnMock = vi.fn(() => child);
+      vi.doMock("node:child_process", () => ({ spawn: spawnMock }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const staging = freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      const rejection = expect(staging).rejects.toThrow(
+        /remained non-durable after 1 attempt/,
+      );
+      await directoryOpen;
+      await vi.advanceTimersByTimeAsync(1_001);
+      await vi.advanceTimersByTimeAsync(1_001);
+      await rejection;
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow(/remained non-durable after 1 attempt/);
+      expect(spawnMock).toHaveBeenCalledOnce();
+      expect(child.unref).toHaveBeenCalledOnce();
+      child.emit("exit", null, "SIGKILL");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "permanently fences a home after an asynchronous helper error",
+    async () => {
+      const fixture = await credentialFixture();
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
+      let observeDirectoryOpen!: () => void;
+      const directoryOpen = new Promise<void>((resolveOpen) => {
+        observeDirectoryOpen = resolveOpen;
+      });
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) {
+            observeDirectoryOpen();
+            return await new Promise<FileHandle>(() => undefined);
+          }
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      const child = Object.assign(new EventEmitter(), {
+        kill: vi.fn(() => true),
+        pid: 12345,
+        unref: vi.fn(),
+      }) as unknown as ChildProcess;
+      const spawnMock = vi.fn(() => {
+        queueMicrotask(() => child.emit("error", new Error("spawn failed")));
+        return child;
+      });
+      vi.doMock("node:child_process", () => ({ spawn: spawnMock }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+
+      const staging = freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      const rejection = expect(staging).rejects.toThrow(
+        /remained non-durable after 1 attempt/,
+      );
+      await directoryOpen;
+      await vi.advanceTimersByTimeAsync(1_001);
+      await rejection;
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow(/remained non-durable after 1 attempt/);
+      expect(spawnMock).toHaveBeenCalledOnce();
+      child.emit("exit", null, null);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "shares the helper process cap across fresh module instances",
+    async () => {
+      const fixture = await credentialFixture();
+      const registry = (
+        globalThis as typeof globalThis & {
+          __paperclipDirectorySyncHelperRegistryV1?: {
+            activeChildren: Set<ChildProcess>;
+          };
+        }
+      ).__paperclipDirectorySyncHelperRegistryV1;
+      expect(registry).toBeDefined();
+      const reservations = Array.from(
+        { length: 4 },
+        () => new EventEmitter() as unknown as ChildProcess,
+      );
+      for (const reservation of reservations) {
+        registry!.activeChildren.add(reservation);
+      }
+      const actualFs =
+        await vi.importActual<typeof import("node:fs/promises")>(
+          "node:fs/promises",
+        );
+      let observeDirectoryOpen!: () => void;
+      const directoryOpen = new Promise<void>((resolveOpen) => {
+        observeDirectoryOpen = resolveOpen;
+      });
+      vi.doMock("node:fs/promises", () => ({
+        ...actualFs,
+        open: async (
+          path: Parameters<typeof open>[0],
+          flags: Parameters<typeof open>[1],
+          mode?: Parameters<typeof open>[2],
+        ): Promise<FileHandle> => {
+          if (String(path) === fixture.home) {
+            observeDirectoryOpen();
+            return await new Promise<FileHandle>(() => undefined);
+          }
+          return await actualFs.open(path, flags, mode);
+        },
+      }));
+      const spawnMock = vi.fn(() => {
+        throw new Error("helper cap was bypassed");
+      });
+      vi.doMock("node:child_process", () => ({ spawn: spawnMock }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+      vi.useFakeTimers();
+      try {
+        const staging = freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        });
+        const rejection = expect(staging).rejects.toThrow(
+          /remained non-durable after 8 attempts/,
+        );
+        await directoryOpen;
+        await vi.advanceTimersByTimeAsync(3_000);
+        await rejection;
+        expect(spawnMock).not.toHaveBeenCalled();
+      } finally {
+        for (const reservation of reservations) {
+          registry!.activeChildren.delete(reservation);
+        }
+      }
     },
   );
 
@@ -979,8 +1279,9 @@ describe("managed Codex credentials", () => {
       await probe.close();
       const originalSync = prototype.sync;
       let directorySyncAttempts = 0;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if ((await this.stat()).isDirectory()) {
             directorySyncAttempts += 1;
             if (directorySyncAttempts > 1) {
@@ -988,14 +1289,17 @@ describe("managed Codex credentials", () => {
             }
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
-        await expect(stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
-        })).rejects.toThrow("remained non-durable after 8 attempts");
-        await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(
+          stageManagedCodexCredential({
+            agentHomeDirectory: fixture.home,
+            environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+          }),
+        ).rejects.toThrow("remained non-durable after 8 attempts");
+        await expect(readFile(destination)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
 
         // Model a crash losing the unsynced intent directory entry and the
         // next process finding an unexpected auth file. A fresh module has no
@@ -1006,20 +1310,24 @@ describe("managed Codex credentials", () => {
         await writeFile(destination, '{"orphaned":true}', { mode: 0o600 });
         vi.resetModules();
         const freshCredentials = await import("./codex-credentials.js");
-        const persistentSyncFailure = vi.spyOn(prototype, "sync").mockImplementation(
-          async function (this: FileHandle): Promise<void> {
+        const persistentSyncFailure = vi
+          .spyOn(prototype, "sync")
+          .mockImplementation(async function (this: FileHandle): Promise<void> {
             if ((await this.stat()).isDirectory()) {
               throw new Error("persistent recovery sync failure");
             }
             await originalSync.call(this);
-          },
-        );
+          });
         try {
-          await expect(freshCredentials.stageManagedCodexCredential({
-            agentHomeDirectory: fixture.home,
-            environment: { OPENAI_API_KEY: "launch-only-key" },
-          })).rejects.toThrow("remained non-durable after 8 attempts");
-          await expect(readFile(destination)).rejects.toMatchObject({ code: "ENOENT" });
+          await expect(
+            freshCredentials.stageManagedCodexCredential({
+              agentHomeDirectory: fixture.home,
+              environment: { OPENAI_API_KEY: "launch-only-key" },
+            }),
+          ).rejects.toThrow("remained non-durable after 8 attempts");
+          await expect(readFile(destination)).rejects.toMatchObject({
+            code: "ENOENT",
+          });
         } finally {
           persistentSyncFailure.mockRestore();
         }
@@ -1041,8 +1349,9 @@ describe("managed Codex credentials", () => {
       await probe.close();
       const originalSync = prototype.sync;
       let directorySyncAttempts = 0;
-      const syncSpy = vi.spyOn(prototype, "sync").mockImplementation(
-        async function (this: FileHandle): Promise<void> {
+      const syncSpy = vi
+        .spyOn(prototype, "sync")
+        .mockImplementation(async function (this: FileHandle): Promise<void> {
           if ((await this.stat()).isDirectory()) {
             directorySyncAttempts += 1;
             if (directorySyncAttempts > 2) {
@@ -1050,13 +1359,14 @@ describe("managed Codex credentials", () => {
             }
           }
           await originalSync.call(this);
-        },
-      );
+        });
       try {
-        await expect(stageManagedCodexCredential({
-          agentHomeDirectory: fixture.home,
-          environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
-        })).rejects.toThrow("remained non-durable after 8 attempts");
+        await expect(
+          stageManagedCodexCredential({
+            agentHomeDirectory: fixture.home,
+            environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+          }),
+        ).rejects.toThrow("remained non-durable after 8 attempts");
         await expect(readFile(destination, "utf8")).resolves.toBe("{}");
 
         syncSpy.mockRestore();
@@ -1168,18 +1478,61 @@ async function credentialFixture(): Promise<{ root: string; home: string }> {
   return { root, home };
 }
 
-function credentialLeasePrimaryPort(home: string): number {
-  return credentialLeasePort(home, 0);
+function credentialLeasePorts(home: string): readonly number[] {
+  const userScope =
+    typeof process.getuid === "function" ? String(process.getuid()) : "win32";
+  return credentialLeasePortsForScope(userScope, home);
 }
 
-function credentialLeasePort(home: string, index: number): number {
-  const scope = `${
-    typeof process.getuid === "function" ? process.getuid() : "win32"
-  }\0${home}`;
-  const digest = createHash("sha256").update(scope).digest();
+function credentialLeasePortsForScope(
+  userScope: string,
+  home: string,
+): readonly number[] {
+  const digest = createHash("sha256")
+    .update("paperclip-managed-codex-lease-v2:")
+    .update(userScope)
+    .update("\0")
+    .update(home)
+    .digest();
   const start = digest.readUInt16BE(0) % 16_384;
-  const stride = digest.readUInt16BE(2) | 1;
-  return 49_152 + ((start + index * stride) % 16_384);
+  const step = (digest.readUInt16BE(2) | 1) % 16_384;
+  return Array.from(
+    { length: 3 },
+    (_, index) => 49_152 + ((start + index * step) % 16_384),
+  );
+}
+
+async function listenSilently(
+  port: number,
+): Promise<{ close(): Promise<void> }> {
+  const sockets = new Set<Socket>();
+  const server: Server = createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+    socket.pause();
+  });
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(
+      {
+        exclusive: true,
+        host: "127.0.0.1",
+        port,
+      },
+      resolveListen,
+    );
+  });
+  return {
+    async close(): Promise<void> {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => {
+          if (error) rejectClose(error);
+          else resolveClose();
+        });
+      });
+    },
+  };
 }
 
 async function waitForChildMessage(

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -1264,6 +1264,102 @@ describe("managed Codex credentials", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "reclaims kernel-confirmed helper exits when child events are lost",
+    async () => {
+      const fixture = await credentialFixture();
+      const registry = (
+        globalThis as typeof globalThis & {
+          __paperclipDirectorySyncHelperRegistryV1?: {
+            activeChildren: Set<ChildProcess>;
+            activeParentOperations: Set<symbol>;
+            failedHomes: Set<string>;
+            stuckChildren: Map<string, ChildProcess>;
+          };
+        }
+      ).__paperclipDirectorySyncHelperRegistryV1;
+      expect(registry).toBeDefined();
+
+      const parentReservations = Array.from({ length: 4 }, () => Symbol());
+      for (const reservation of parentReservations) {
+        registry!.activeParentOperations.add(reservation);
+      }
+      const departedPids = new Set<number>();
+      const departedHelpers = Array.from({ length: 4 }, (_, index) => {
+        const pid = 41_000 + index;
+        departedPids.add(pid);
+        const child = Object.assign(new EventEmitter(), {
+          exitCode: null,
+          kill: vi.fn(() => true),
+          pid,
+          signalCode: null,
+          unref: vi.fn(),
+        }) as unknown as ChildProcess;
+        const directory = `/departed-credential-helper-${String(index)}`;
+        registry!.activeChildren.add(child);
+        registry!.failedHomes.add(directory);
+        registry!.stuckChildren.set(directory, child);
+        return { child, directory };
+      });
+      const killSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation((pid, signal) => {
+          if (signal === 0 && departedPids.has(Number(pid))) {
+            throw Object.assign(new Error("process no longer exists"), {
+              code: "ESRCH",
+            });
+          }
+          return true;
+        });
+      const observedActiveChildren: number[] = [];
+      let nextPid = 42_000;
+      const spawnMock = vi.fn(() => {
+        observedActiveChildren.push(registry!.activeChildren.size);
+        const child = Object.assign(new EventEmitter(), {
+          exitCode: null,
+          kill: vi.fn(() => true),
+          pid: nextPid++,
+          signalCode: null,
+          unref: vi.fn(),
+        }) as unknown as ChildProcess;
+        queueMicrotask(() => {
+          child.emit("exit", 0, null);
+          child.emit("close", 0, null);
+        });
+        return child;
+      });
+      vi.doMock("node:child_process", () => ({ spawn: spawnMock }));
+      vi.resetModules();
+      const freshCredentials = await import("./codex-credentials.js");
+
+      try {
+        const lease = await freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        });
+        await lease.close();
+
+        expect(spawnMock).toHaveBeenCalled();
+        expect(observedActiveChildren.every((count) => count < 4)).toBe(true);
+        for (const { child, directory } of departedHelpers) {
+          expect(registry!.activeChildren).not.toContain(child);
+          expect(registry!.failedHomes).not.toContain(directory);
+          expect(registry!.stuckChildren.has(directory)).toBe(false);
+        }
+      } finally {
+        killSpy.mockRestore();
+        for (const reservation of parentReservations) {
+          registry!.activeParentOperations.delete(reservation);
+        }
+        for (const { child, directory } of departedHelpers) {
+          registry!.activeChildren.delete(child);
+          registry!.failedHomes.delete(directory);
+          registry!.stuckChildren.delete(directory);
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "keeps intent-publication failure before credential mutation and scrubs without process memory",
     async () => {
       const fixture = await credentialFixture();

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -1271,6 +1271,7 @@ describe("managed Codex credentials", () => {
         globalThis as typeof globalThis & {
           __paperclipDirectorySyncHelperRegistryV1?: {
             activeChildren: Set<ChildProcess>;
+            childDirectories: Map<ChildProcess, string>;
             activeParentOperations: Set<symbol>;
             failedHomes: Set<string>;
             stuckChildren: Map<string, ChildProcess>;
@@ -1296,8 +1297,11 @@ describe("managed Codex credentials", () => {
         }) as unknown as ChildProcess;
         const directory = `/departed-credential-helper-${String(index)}`;
         registry!.activeChildren.add(child);
-        registry!.failedHomes.add(directory);
-        registry!.stuckChildren.set(directory, child);
+        registry!.childDirectories.set(child, directory);
+        if (index < 2) {
+          registry!.failedHomes.add(directory);
+          registry!.stuckChildren.set(directory, child);
+        }
         return { child, directory };
       });
       const killSpy = vi
@@ -1342,6 +1346,7 @@ describe("managed Codex credentials", () => {
         expect(observedActiveChildren.every((count) => count < 4)).toBe(true);
         for (const { child, directory } of departedHelpers) {
           expect(registry!.activeChildren).not.toContain(child);
+          expect(registry!.childDirectories.has(child)).toBe(false);
           expect(registry!.failedHomes).not.toContain(directory);
           expect(registry!.stuckChildren.has(directory)).toBe(false);
         }
@@ -1352,6 +1357,7 @@ describe("managed Codex credentials", () => {
         }
         for (const { child, directory } of departedHelpers) {
           registry!.activeChildren.delete(child);
+          registry!.childDirectories.delete(child);
           registry!.failedHomes.delete(directory);
           registry!.stuckChildren.delete(directory);
         }

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -402,6 +402,79 @@ describe("managed Codex credentials", () => {
     await secondLease.close();
   });
 
+  it("fences successor admission while an older lock release fails", async () => {
+    const fixture = await credentialFixture();
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises",
+    );
+    let markerUnlinkAttempts = 0;
+    let signalMarkerReleaseStarted!: () => void;
+    const markerReleaseStarted = new Promise<void>((resolveStarted) => {
+      signalMarkerReleaseStarted = resolveStarted;
+    });
+    let failMarkerRelease!: () => void;
+    const markerReleaseFailureGate = new Promise<void>((resolveFailure) => {
+      failMarkerRelease = resolveFailure;
+    });
+    vi.doMock("node:fs/promises", () => ({
+      ...actualFs,
+      unlink: async (path: Parameters<typeof actualFs.unlink>[0]) => {
+        if (String(path).includes(".paperclip-auth-lease-v1-")) {
+          markerUnlinkAttempts += 1;
+          if (markerUnlinkAttempts === 1) {
+            signalMarkerReleaseStarted();
+            await markerReleaseFailureGate;
+            throw Object.assign(new Error("injected marker unlink failure"), {
+              code: "EACCES",
+            });
+          }
+        }
+        await actualFs.unlink(path);
+      },
+    }));
+    vi.resetModules();
+    const freshCredentials = await import("./codex-credentials.js");
+    const firstLease = await freshCredentials.stageManagedCodexCredential({
+      agentHomeDirectory: fixture.home,
+      environment: {
+        PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"first"}',
+      },
+    });
+
+    const firstClose = firstLease.close();
+    try {
+      await markerReleaseStarted;
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: {
+            PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"overlap"}',
+          },
+        }),
+      ).rejects.toThrow("already has an active lease");
+
+      failMarkerRelease();
+      await expect(firstClose).rejects.toThrow(
+        "injected marker unlink failure",
+      );
+      const successor = await freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: {
+          PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: '{"owner":"successor"}',
+        },
+      });
+      await expect(firstLease.close()).resolves.toBeUndefined();
+      await expect(readFile(successor.path, "utf8")).resolves.toBe(
+        '{"owner":"successor"}',
+      );
+      await successor.close();
+      expect(markerUnlinkAttempts).toBeGreaterThanOrEqual(2);
+    } finally {
+      failMarkerRelease();
+      await firstClose.catch(() => undefined);
+    }
+  });
+
   it("keeps ownership live while retrying lease-marker removal", async () => {
     const fixture = await credentialFixture();
     const actualFs = await vi.importActual<typeof import("node:fs/promises")>(

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -751,7 +751,7 @@ describe("managed Codex credentials", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "bounds a directory open that never settles",
+    "blocks retries until a timed-out directory open and its late close settle",
     async () => {
       const fixture = await credentialFixture();
       const actualFs = await vi.importActual<typeof import("node:fs/promises")>(
@@ -759,9 +759,28 @@ describe("managed Codex credentials", () => {
       );
       let directoryOpenAttempts = 0;
       let observeFirstOpen!: () => void;
+      let settleFirstOpen!: (handle: FileHandle) => void;
+      let observeFirstClose!: () => void;
+      let settleFirstClose!: () => void;
       const firstOpen = new Promise<void>((resolveOpen) => {
         observeFirstOpen = resolveOpen;
       });
+      const retainedOpen = new Promise<FileHandle>((resolveOpen) => {
+        settleFirstOpen = resolveOpen;
+      });
+      const firstClose = new Promise<void>((resolveClose) => {
+        observeFirstClose = resolveClose;
+      });
+      const retainedClose = new Promise<void>((resolveClose) => {
+        settleFirstClose = resolveClose;
+      });
+      const lateHandle = {
+        close: async (): Promise<void> => {
+          observeFirstClose();
+          await retainedClose;
+        },
+        sync: async (): Promise<void> => undefined,
+      } as FileHandle;
       vi.doMock("node:fs/promises", () => ({
         ...actualFs,
         open: async (
@@ -771,8 +790,10 @@ describe("managed Codex credentials", () => {
         ): Promise<FileHandle> => {
           if (String(path) === fixture.home) {
             directoryOpenAttempts += 1;
-            observeFirstOpen();
-            return await new Promise<FileHandle>(() => undefined);
+            if (directoryOpenAttempts === 1) {
+              observeFirstOpen();
+              return await retainedOpen;
+            }
           }
           return await actualFs.open(path, flags, mode);
         },
@@ -792,6 +813,33 @@ describe("managed Codex credentials", () => {
       await vi.advanceTimersByTimeAsync(20_000);
       await rejection;
       expect(directoryOpenAttempts).toBe(1);
+
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow("remained non-durable after 1 attempt");
+      expect(directoryOpenAttempts).toBe(1);
+
+      settleFirstOpen(lateHandle);
+      await firstClose;
+      await expect(
+        freshCredentials.stageManagedCodexCredential({
+          agentHomeDirectory: fixture.home,
+          environment: { OPENAI_API_KEY: "launch-only-key" },
+        }),
+      ).rejects.toThrow("remained non-durable after 1 attempt");
+      expect(directoryOpenAttempts).toBe(1);
+
+      settleFirstClose();
+      await vi.advanceTimersByTimeAsync(20_000);
+      const lease = await freshCredentials.stageManagedCodexCredential({
+        agentHomeDirectory: fixture.home,
+        environment: { OPENAI_API_KEY: "launch-only-key" },
+      });
+      await expect(lease.close()).resolves.toBeUndefined();
+      expect(directoryOpenAttempts).toBeGreaterThan(1);
     },
   );
 

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.test.ts
@@ -1025,7 +1025,8 @@ describe("managed Codex credentials", () => {
       let spawnAttempts = 0;
       const stuckChild = Object.assign(new EventEmitter(), {
         kill: vi.fn(() => true),
-        pid: 12345,
+        // Signal-0 must observe a live process for this retained-helper fixture.
+        pid: process.pid,
         unref: vi.fn(),
       }) as unknown as ChildProcess;
       vi.doMock("node:child_process", () => ({
@@ -1102,7 +1103,8 @@ describe("managed Codex credentials", () => {
       }));
       const child = Object.assign(new EventEmitter(), {
         kill: vi.fn(killImplementation),
-        pid: 12345,
+        // Signal-0 must observe a live process for this retained-helper fixture.
+        pid: process.pid,
         unref: vi.fn(),
       }) as unknown as ChildProcess;
       const spawnMock = vi.fn(() => child);
@@ -1162,7 +1164,8 @@ describe("managed Codex credentials", () => {
       }));
       const child = Object.assign(new EventEmitter(), {
         kill: vi.fn(() => true),
-        pid: 12345,
+        // Signal-0 must observe a live process for this retained-helper fixture.
+        pid: process.pid,
         unref: vi.fn(),
       }) as unknown as ChildProcess;
       const spawnMock = vi.fn(() => {

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -1,0 +1,1205 @@
+import { createHash, randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  lstat,
+  open,
+  readdir,
+  realpath,
+  rename,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import {
+  createConnection,
+  createServer,
+  type Server,
+  type Socket,
+} from "node:net";
+import { isAbsolute, join, resolve } from "node:path";
+
+const MAX_CODEX_CREDENTIAL_BYTES = 256 * 1024;
+const PRIVATE_FILE_MODE = 0o600;
+const MAX_DIRECTORY_SYNC_ATTEMPTS = 8;
+const DIRECTORY_SYNC_OPERATION_TIMEOUT_MS = 1_000;
+const MAX_AUTONOMOUS_CREDENTIAL_CLEANUP_ATTEMPTS = 8;
+const CREDENTIAL_CLEANUP_INTENT = ".paperclip-auth-cleanup-required";
+const CREDENTIAL_LEASE_HOST = "127.0.0.1";
+const CREDENTIAL_LEASE_PORT_MIN = 49_152;
+const CREDENTIAL_LEASE_PORT_COUNT = 16_384;
+const MAX_CREDENTIAL_LEASE_PORT_CANDIDATES = 32;
+const CREDENTIAL_LEASE_PROBE_TIMEOUT_MS = 1_000;
+const CREDENTIAL_LEASE_PROTOCOL = "paperclip-managed-codex-lease-v1";
+const CREDENTIAL_LEASE_FOREIGN_PROBE =
+  "GET /__paperclip_credential_lease_probe__ HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n";
+const CREDENTIAL_LEASE_MARKER_PREFIX = ".paperclip-auth-lease-v1-";
+const MAX_CREDENTIAL_LEASE_MARKERS = 1_024;
+
+interface CredentialHomeLock {
+  assertHeld(): void;
+  release(): Promise<void>;
+}
+
+interface CredentialLeaseMarker {
+  version: 1;
+  identity: string;
+  pid: number;
+  port: number;
+  token: string;
+}
+
+interface QuarantinedCredentialCleanup {
+  path: string;
+  home: string;
+  intentPath: string;
+  lock: CredentialHomeLock;
+  recovery: Promise<void> | null;
+}
+
+type CredentialLeaseGeneration = number;
+type CredentialLeaseProbe =
+  | "matching_owner"
+  | "different_owner"
+  | "unresponsive"
+  | "unoccupied";
+
+const quarantinedCredentialCleanups = new Map<
+  string,
+  QuarantinedCredentialCleanup
+>();
+const pendingDirectorySyncCleanups = new Map<string, Promise<void>>();
+const activeCredentialLeaseGenerations = new Map<
+  string,
+  CredentialLeaseGeneration
+>();
+const processCredentialLeaseState = globalThis as typeof globalThis & {
+  __paperclipCredentialLeaseIdentitiesV1?: Map<number, string>;
+};
+const processCredentialLeaseIdentities =
+  processCredentialLeaseState.__paperclipCredentialLeaseIdentitiesV1 ??
+  new Map<number, string>();
+processCredentialLeaseState.__paperclipCredentialLeaseIdentitiesV1 =
+  processCredentialLeaseIdentities;
+let nextCredentialLeaseGeneration = 0;
+
+export type ManagedCodexCredentialMode =
+  "api_key" | "inline_json" | "managed_file";
+
+export interface ManagedCodexCredentialLease {
+  readonly path: string;
+  readonly mode: ManagedCodexCredentialMode;
+  close(): Promise<void>;
+}
+
+/** Stage one explicit Codex authentication source in its isolated runtime home. */
+export async function stageManagedCodexCredential(input: {
+  agentHomeDirectory: string;
+  environment?: NodeJS.ProcessEnv;
+  sourcePath?: string;
+}): Promise<ManagedCodexCredentialLease> {
+  const home = await realpath(input.agentHomeDirectory);
+  const homeMetadata = await lstat(home);
+  if (!homeMetadata.isDirectory() || homeMetadata.isSymbolicLink()) {
+    throw new Error("Managed Codex credential home must be a real directory");
+  }
+  if (
+    process.platform !== "win32" &&
+    ((homeMetadata.mode & 0o077) !== 0 ||
+      (typeof process.getuid === "function" &&
+        homeMetadata.uid !== process.getuid()))
+  ) {
+    throw new Error("Managed Codex credential home permissions are unsafe");
+  }
+  const ownerGeneration = claimCredentialLeaseGeneration(home);
+  let lock: CredentialHomeLock | null = null;
+  try {
+    await recoverQuarantinedCredentialCleanup(join(home, "auth.json"), home);
+    lock = await acquireCredentialHomeLock(home);
+    return await stageClaimedManagedCodexCredential(
+      input,
+      home,
+      ownerGeneration,
+      lock,
+    );
+  } catch (error) {
+    if (lock !== null && quarantinedCredentialCleanups.get(home)?.lock !== lock) {
+      await lock.release().catch(() => undefined);
+    }
+    releaseCredentialLeaseGeneration(home, ownerGeneration);
+    throw error;
+  }
+}
+
+async function stageClaimedManagedCodexCredential(
+  input: {
+    environment?: NodeJS.ProcessEnv;
+    sourcePath?: string;
+  },
+  home: string,
+  ownerGeneration: CredentialLeaseGeneration,
+  lock: CredentialHomeLock,
+): Promise<ManagedCodexCredentialLease> {
+  const destination = join(home, "auth.json");
+  const intentPath = join(home, CREDENTIAL_CLEANUP_INTENT);
+  lock.assertHeld();
+  await recoverPersistedCredentialCleanup(destination, home, intentPath);
+  // The isolated home is itself the durable recovery anchor. Scrub auth.json
+  // before every admission, even when a prior cleanup-intent entry was lost
+  // with a runner crash. Only after this absence is durable may a new intent
+  // be created and a credential installed.
+  await removeCredential(destination, home);
+  const environment = input.environment ?? {};
+  const hasApiKey = Boolean(
+    environment.CODEX_API_KEY || environment.OPENAI_API_KEY,
+  );
+  const inlineJson = environment.PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET;
+  const hasInlineJson = typeof inlineJson === "string" && inlineJson.length > 0;
+  const hasManagedFile =
+    typeof input.sourcePath === "string" && input.sourcePath.length > 0;
+  const sourceCount = [hasApiKey, hasInlineJson, hasManagedFile].filter(
+    Boolean,
+  ).length;
+  if (sourceCount === 0) {
+    throw new Error(
+      "provider_initialize_protocol_error: provider=acpx stage=credential.stage managed Codex credential missing",
+    );
+  }
+  if (sourceCount !== 1) {
+    throw new Error("Managed Codex credential source is ambiguous");
+  }
+
+  if (
+    hasManagedFile &&
+    (!isAbsolute(input.sourcePath!) ||
+      resolve(input.sourcePath!) === destination)
+  ) {
+    throw new Error(
+      "Managed Codex credential source must be an external absolute path",
+    );
+  }
+
+  if (hasApiKey) {
+    // Codex will read the API key from the launch environment. Persist cleanup
+    // intent before admitting the provider and retain it for the lease
+    // lifetime, so a replacement runner removes provider-generated auth after
+    // a crash before it admits another provider.
+    // Failure while publishing the intent cannot strand a staged credential:
+    // the unconditional admission scrub above is already durable and this
+    // mode has not allowed the provider to create auth.json yet.
+    await createCredentialCleanupIntent(intentPath, home);
+    return credentialLease(
+      destination,
+      home,
+      intentPath,
+      "api_key",
+      ownerGeneration,
+      lock,
+    );
+  }
+
+  const credential = hasInlineJson
+    ? boundedInlineCredential(inlineJson!)
+    : await readManagedCredential(input.sourcePath!);
+  try {
+    validateCredentialDocument(credential);
+    // As with API-key mode, an intent-publication failure occurs before any
+    // credential mutation and therefore needs no process-only quarantine.
+    await createCredentialCleanupIntent(intentPath, home);
+    try {
+      await writeCredential(destination, home, credential);
+    } catch (error) {
+      // Rename may already have installed the credential before directory
+      // durability failed. Retain a bounded process owner and the persisted
+      // intent so later staging must recover both before admission.
+      quarantineCredentialCleanup(destination, home, intentPath, lock);
+      throw error;
+    }
+  } finally {
+    credential.fill(0);
+  }
+  return credentialLease(
+    destination,
+    home,
+    intentPath,
+    hasInlineJson ? "inline_json" : "managed_file",
+    ownerGeneration,
+    lock,
+  );
+}
+
+function claimCredentialLeaseGeneration(
+  home: string,
+): CredentialLeaseGeneration {
+  if (activeCredentialLeaseGenerations.has(home)) {
+    throw new Error(
+      "Managed Codex credential home already has an active lease",
+    );
+  }
+  if (nextCredentialLeaseGeneration >= Number.MAX_SAFE_INTEGER) {
+    throw new Error("Managed Codex credential lease generation exhausted");
+  }
+  nextCredentialLeaseGeneration += 1;
+  activeCredentialLeaseGenerations.set(home, nextCredentialLeaseGeneration);
+  return nextCredentialLeaseGeneration;
+}
+
+function releaseCredentialLeaseGeneration(
+  home: string,
+  ownerGeneration: CredentialLeaseGeneration,
+): void {
+  if (activeCredentialLeaseGenerations.get(home) === ownerGeneration) {
+    activeCredentialLeaseGenerations.delete(home);
+  }
+}
+
+async function acquireCredentialHomeLock(
+  home: string,
+): Promise<CredentialHomeLock> {
+  // ACPX credential homes are local-runtime resources: every contender for a
+  // canonical home runs on the same host and network namespace. A bounded set
+  // of deterministic loopback endpoints therefore provides a kernel-owned,
+  // process-lifetime lease without making one hash collision authoritative.
+  // The local runner also supervises its provider lifetime; a provider cannot
+  // remain an authorized writer after this owning process dies. Every
+  // Paperclip listener identifies its canonical home, so confirmed unrelated
+  // collisions fall through to another candidate while a matching live owner
+  // still fences the home. An occupied endpoint that does not answer within
+  // the bounded probe is authoritative: it may be a concurrent owner between
+  // bind and marker publication, so admission fails closed instead of letting
+  // two contenders select different ports. After binding, probing every other
+  // candidate closes the race where an earlier unrelated listener disappears
+  // while an owner uses a later one.
+  const identity = credentialLeaseIdentity(home);
+  const ports = credentialLeasePorts(home);
+  if (await hasActiveCredentialLeaseMarker(home, identity, ports)) {
+    throw new Error(
+      "Managed Codex credential home already has an active lease",
+    );
+  }
+  let server: Server | null = null;
+  let port: number | null = null;
+  let acceptedSockets = new Set<Socket>();
+  for (const candidatePort of ports) {
+    const candidateSockets = new Set<Socket>();
+    const candidate = createCredentialLeaseServer(identity, candidateSockets);
+    try {
+      await listenForCredentialLease(candidate, candidatePort);
+      processCredentialLeaseIdentities.set(candidatePort, identity);
+      server = candidate;
+      port = candidatePort;
+      acceptedSockets = candidateSockets;
+      break;
+    } catch (error) {
+      for (const socket of candidateSockets) socket.destroy();
+      if (errorCode(error) !== "EADDRINUSE") {
+        throw new Error(
+          "Managed Codex credential ownership could not be established",
+          { cause: error },
+        );
+      }
+      const probe = await probeCredentialLease(candidatePort, identity);
+      if (probe === "matching_owner") {
+        throw new Error(
+          "Managed Codex credential home already has an active lease",
+        );
+      }
+      if (probe === "unresponsive") {
+        throw new Error(
+          "Managed Codex credential ownership could not safely bypass an unresponsive lease endpoint",
+        );
+      }
+    }
+  }
+  if (server === null || port === null) {
+    throw new Error(
+      "Managed Codex credential ownership could not find a free loopback lease endpoint",
+    );
+  }
+
+  let invalid: Error | null = null;
+  let expectedClose = false;
+  server.on("error", (error) => {
+    invalid ??= error;
+  });
+  server.on("close", () => {
+    if (processCredentialLeaseIdentities.get(port) === identity) {
+      processCredentialLeaseIdentities.delete(port);
+    }
+    if (!expectedClose) {
+      invalid ??= new Error(
+        "Managed Codex credential ownership listener closed unexpectedly",
+      );
+    }
+  });
+  try {
+    const address = server.address();
+    if (
+      address === null ||
+      typeof address === "string" ||
+      address.address !== CREDENTIAL_LEASE_HOST ||
+      address.family !== "IPv4" ||
+      address.port !== port
+    ) {
+      throw new Error(
+        "Managed Codex credential ownership listener bound unexpectedly",
+      );
+    }
+    const competingEndpoints = await Promise.all(
+      ports
+        .filter((candidatePort) => candidatePort !== port)
+        .map((candidatePort) => probeCredentialLease(candidatePort, identity)),
+    );
+    if (
+      competingEndpoints.some(
+        (probe) =>
+          probe === "matching_owner" || probe === "unresponsive",
+      )
+    ) {
+      throw new Error(
+        "Managed Codex credential home already has an active lease",
+      );
+    }
+    if (await hasActiveCredentialLeaseMarker(home, identity, ports)) {
+      throw new Error(
+        "Managed Codex credential home already has an active lease",
+      );
+    }
+    if (invalid !== null || !server.listening) {
+      throw new Error("Managed Codex credential ownership was lost", {
+        cause: invalid,
+      });
+    }
+  } catch (error) {
+    expectedClose = true;
+    for (const socket of acceptedSockets) socket.destroy();
+    if (server.listening) await closeCredentialLeaseServer(server);
+    throw error;
+  }
+
+  const markerPath = await publishCredentialLeaseMarker(home, {
+    version: 1,
+    identity,
+    pid: process.pid,
+    port,
+    token: randomBytes(16).toString("hex"),
+  }).catch(async (error: unknown) => {
+    expectedClose = true;
+    for (const socket of acceptedSockets) socket.destroy();
+    if (server.listening) await closeCredentialLeaseServer(server);
+    throw new Error(
+      "Managed Codex credential ownership marker could not be established",
+      { cause: error },
+    );
+  });
+
+  let released = false;
+  let releaseAttempt: Promise<void> | null = null;
+  return Object.freeze({
+    assertHeld(): void {
+      if (released || invalid !== null || !server.listening) {
+        throw new Error("Managed Codex credential ownership was lost", {
+          cause: invalid,
+        });
+      }
+    },
+    async release(): Promise<void> {
+      if (released) return;
+      if (releaseAttempt !== null) return await releaseAttempt;
+      const attempt = (async () => {
+        const ownershipError = invalid;
+        // Keep the kernel fence live until its marker is gone. If unlinking
+        // the marker fails, quarantine recovery can still assert ownership
+        // and retry instead of inheriting a closed, permanently unusable
+        // lock.
+        await unlink(markerPath).catch((error: unknown) => {
+          if (errorCode(error) !== "ENOENT") throw error;
+        });
+        expectedClose = true;
+        for (const socket of acceptedSockets) socket.destroy();
+        if (server.listening) await closeCredentialLeaseServer(server);
+        released = true;
+        if (ownershipError !== null) throw ownershipError;
+      })();
+      releaseAttempt = attempt;
+      try {
+        await attempt;
+      } finally {
+        if (releaseAttempt === attempt) releaseAttempt = null;
+      }
+    },
+  });
+}
+
+function credentialLeaseIdentity(home: string): string {
+  const scope = `${
+    typeof process.getuid === "function" ? process.getuid() : "win32"
+  }\0${home}`;
+  return createHash("sha256").update(scope).digest("hex");
+}
+
+function credentialLeasePorts(home: string): number[] {
+  const digest = Buffer.from(credentialLeaseIdentity(home), "hex");
+  const start = digest.readUInt16BE(0) % CREDENTIAL_LEASE_PORT_COUNT;
+  const stride = digest.readUInt16BE(2) | 1;
+  return Array.from(
+    { length: MAX_CREDENTIAL_LEASE_PORT_CANDIDATES },
+    (_, index) =>
+      CREDENTIAL_LEASE_PORT_MIN +
+      ((start + index * stride) % CREDENTIAL_LEASE_PORT_COUNT),
+  );
+}
+
+function createCredentialLeaseServer(
+  identity: string,
+  acceptedSockets: Set<Socket>,
+): Server {
+  const response = `${CREDENTIAL_LEASE_PROTOCOL} ${identity}\n`;
+  return createServer((socket) => {
+    acceptedSockets.add(socket);
+    socket.once("close", () => acceptedSockets.delete(socket));
+    socket.end(response);
+  });
+}
+
+async function probeCredentialLease(
+  port: number,
+  expectedIdentity: string,
+): Promise<CredentialLeaseProbe> {
+  const processIdentity = processCredentialLeaseIdentities.get(port);
+  if (processIdentity !== undefined) {
+    return processIdentity === expectedIdentity
+      ? "matching_owner"
+      : "different_owner";
+  }
+  const expected = `${CREDENTIAL_LEASE_PROTOCOL} ${expectedIdentity}\n`;
+  return await new Promise<CredentialLeaseProbe>((resolveProbe) => {
+    const socket = createConnection({ host: CREDENTIAL_LEASE_HOST, port });
+    let settled = false;
+    let response = "";
+    let foreignProbe: NodeJS.Timeout | null = null;
+    const finish = (result: CredentialLeaseProbe): void => {
+      if (settled) return;
+      settled = true;
+      if (foreignProbe !== null) clearTimeout(foreignProbe);
+      socket.destroy();
+      resolveProbe(result);
+    };
+    socket.setEncoding("utf8");
+    socket.setTimeout(CREDENTIAL_LEASE_PROBE_TIMEOUT_MS, () =>
+      finish("unresponsive"),
+    );
+    socket.once("connect", () => {
+      foreignProbe = setTimeout(() => {
+        if (!settled) socket.write(CREDENTIAL_LEASE_FOREIGN_PROBE);
+      }, 10);
+      foreignProbe.unref();
+    });
+    socket.on("data", (chunk: string) => {
+      response += chunk;
+      if (response === expected) finish("matching_owner");
+      else if (
+        response.length >= expected.length ||
+        !expected.startsWith(response)
+      ) {
+        finish("different_owner");
+      }
+    });
+    socket.once("error", (error) =>
+      finish(
+        errorCode(error) === "ECONNREFUSED"
+          ? "unoccupied"
+          : "unresponsive",
+      ),
+    );
+    socket.once("end", () =>
+      finish(response === expected ? "matching_owner" : "different_owner"),
+    );
+    socket.once("close", () =>
+      finish(response === expected ? "matching_owner" : "different_owner"),
+    );
+  });
+}
+
+async function hasActiveCredentialLeaseMarker(
+  home: string,
+  expectedIdentity: string,
+  candidatePorts: readonly number[],
+): Promise<boolean> {
+  const entries = (await readdir(home, { withFileTypes: true })).filter(
+    (entry) =>
+      entry.isFile() &&
+      entry.name.startsWith(CREDENTIAL_LEASE_MARKER_PREFIX) &&
+      entry.name.endsWith(".json"),
+  );
+  if (entries.length > MAX_CREDENTIAL_LEASE_MARKERS) {
+    throw new Error("Managed Codex credential lease marker limit exceeded");
+  }
+  for (const entry of entries) {
+    const markerPath = join(home, entry.name);
+    const marker = await readCredentialLeaseMarker(markerPath);
+    if (
+      marker === null ||
+      marker.identity !== expectedIdentity ||
+      !candidatePorts.includes(marker.port)
+    ) {
+      continue;
+    }
+    if (
+      (await probeCredentialLease(marker.port, expectedIdentity)) ===
+      "matching_owner"
+    ) {
+      return true;
+    }
+    if (
+      credentialLeaseProcessIsAlive(marker.pid) &&
+      (await credentialLeasePortIsOccupied(marker.port))
+    ) {
+      return true;
+    }
+    await unlink(markerPath).catch((error: unknown) => {
+      if (errorCode(error) !== "ENOENT") throw error;
+    });
+  }
+  return false;
+}
+
+async function readCredentialLeaseMarker(
+  markerPath: string,
+): Promise<CredentialLeaseMarker | null> {
+  let handle: FileHandle;
+  try {
+    handle = await open(
+      markerPath,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
+  } catch (error) {
+    if (errorCode(error) === "ENOENT" || errorCode(error) === "ELOOP") {
+      return null;
+    }
+    throw error;
+  }
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size < 1 || metadata.size > 4_096) {
+      return null;
+    }
+    const bytes = await readHandle(handle, metadata.size);
+    const value = JSON.parse(bytes.toString("utf8")) as Partial<CredentialLeaseMarker>;
+    if (
+      value.version !== 1 ||
+      typeof value.identity !== "string" ||
+      !/^[0-9a-f]{64}$/.test(value.identity) ||
+      !Number.isInteger(value.pid) ||
+      (value.pid ?? 0) < 1 ||
+      !Number.isInteger(value.port) ||
+      (value.port ?? 0) < 1 ||
+      (value.port ?? 0) > 65_535 ||
+      typeof value.token !== "string" ||
+      !/^[0-9a-f]{32}$/.test(value.token)
+    ) {
+      return null;
+    }
+    return value as CredentialLeaseMarker;
+  } catch {
+    return null;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function publishCredentialLeaseMarker(
+  home: string,
+  marker: CredentialLeaseMarker,
+): Promise<string> {
+  const markerPath = join(
+    home,
+    `${CREDENTIAL_LEASE_MARKER_PREFIX}${marker.token}.json`,
+  );
+  const handle = await open(
+    markerPath,
+    constants.O_WRONLY |
+      constants.O_CREAT |
+      constants.O_EXCL |
+      (constants.O_NOFOLLOW ?? 0),
+    PRIVATE_FILE_MODE,
+  );
+  try {
+    await handle.writeFile(`${JSON.stringify(marker)}\n`, "utf8");
+    await handle.sync();
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    await unlink(markerPath).catch(() => undefined);
+    throw error;
+  }
+  await handle.close();
+  return markerPath;
+}
+
+function credentialLeaseProcessIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
+}
+
+async function credentialLeasePortIsOccupied(port: number): Promise<boolean> {
+  const probe = createServer();
+  try {
+    await listenForCredentialLease(probe, port);
+    await closeCredentialLeaseServer(probe);
+    return false;
+  } catch (error) {
+    if (errorCode(error) === "EADDRINUSE") return true;
+    throw error;
+  }
+}
+
+async function listenForCredentialLease(
+  server: Server,
+  port: number,
+): Promise<void> {
+  await new Promise<void>((resolveListen, rejectListen) => {
+    const onError = (error: Error): void => rejectListen(error);
+    server.once("error", onError);
+    server.listen(
+      {
+        host: CREDENTIAL_LEASE_HOST,
+        port,
+        exclusive: true,
+        reusePort: false,
+      },
+      () => {
+        server.off("error", onError);
+        resolveListen();
+      },
+    );
+  });
+}
+
+async function closeCredentialLeaseServer(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+  });
+}
+
+function quarantineCredentialCleanup(
+  path: string,
+  home: string,
+  intentPath: string,
+  lock: CredentialHomeLock,
+): void {
+  const existing = quarantinedCredentialCleanups.get(home);
+  if (existing !== undefined) return;
+  const cleanup: QuarantinedCredentialCleanup = {
+    path,
+    home,
+    intentPath,
+    lock,
+    recovery: null,
+  };
+  quarantinedCredentialCleanups.set(home, cleanup);
+  startCredentialCleanupRecovery(
+    cleanup,
+    MAX_AUTONOMOUS_CREDENTIAL_CLEANUP_ATTEMPTS,
+  );
+}
+
+function startCredentialCleanupRecovery(
+  cleanup: QuarantinedCredentialCleanup,
+  maxAttempts: number,
+): Promise<void> {
+  if (cleanup.recovery) return cleanup.recovery;
+  const recovery = (async () => {
+    let retryDelayMs = 10;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        // Never let a stale cleanup callback mutate a successor's credential
+        // after kernel ownership has been lost.
+        cleanup.lock.assertHeld();
+        await removeReplaceableCredential(cleanup.path);
+        await syncDirectory(cleanup.home);
+        await removeCredentialCleanupIntent(
+          cleanup.intentPath,
+          cleanup.home,
+        );
+        await cleanup.lock.release();
+        quarantinedCredentialCleanups.delete(cleanup.home);
+        return;
+      } catch {
+        if (attempt === maxAttempts) return;
+        await new Promise<void>((resolveRetry) => {
+          const timer = setTimeout(resolveRetry, retryDelayMs);
+          timer.unref?.();
+        });
+        retryDelayMs = Math.min(retryDelayMs * 2, 1_000);
+      }
+    }
+  })();
+  cleanup.recovery = recovery;
+  void recovery.finally(() => {
+    if (cleanup.recovery === recovery) cleanup.recovery = null;
+  }).catch(() => undefined);
+  return recovery;
+}
+
+async function recoverQuarantinedCredentialCleanup(
+  path: string,
+  home: string,
+): Promise<void> {
+  const cleanup = quarantinedCredentialCleanups.get(home);
+  if (cleanup === undefined) return;
+  await (cleanup.recovery ?? startCredentialCleanupRecovery(cleanup, 1));
+  if (!quarantinedCredentialCleanups.has(home)) return;
+  const admissionRecovery = startCredentialCleanupRecovery(cleanup, 1);
+  await admissionRecovery;
+  if (quarantinedCredentialCleanups.has(home)) {
+    throw new Error(
+      `Managed Codex credential cleanup remains non-durable for ${path}`,
+    );
+  }
+}
+
+async function recoverPersistedCredentialCleanup(
+  path: string,
+  home: string,
+  intentPath: string,
+): Promise<void> {
+  if (!(await pathExists(intentPath))) return;
+  await removeCredential(path, home);
+  await removeCredentialCleanupIntent(intentPath, home);
+}
+
+function credentialLease(
+  path: string,
+  home: string,
+  intentPath: string,
+  mode: ManagedCodexCredentialMode,
+  ownerGeneration: CredentialLeaseGeneration,
+  lock: CredentialHomeLock,
+): ManagedCodexCredentialLease {
+  // Do not admit a provider if kernel ownership was lost while its credential
+  // was being staged.
+  lock.assertHeld();
+  let closed = false;
+  let closeAttempt: Promise<void> | null = null;
+  return Object.freeze({
+    path,
+    mode,
+    async close(): Promise<void> {
+      if (closed) return;
+      if (closeAttempt !== null) return await closeAttempt;
+      const attempt = (async () => {
+        const activeGeneration = activeCredentialLeaseGenerations.get(home);
+        if (activeGeneration !== ownerGeneration) {
+          // A failed close releases its generation only after publishing a
+          // quarantine owner. If no successor exists, synchronously join that
+          // cleanup before acknowledging the retry. If a successor does
+          // exist, this stale lease has no authority over its credential.
+          if (activeGeneration === undefined) {
+            await recoverQuarantinedCredentialCleanup(path, home);
+            await lock.release();
+          }
+          closed = true;
+          return;
+        }
+        try {
+          lock.assertHeld();
+          await removeCredential(path, home);
+          await removeCredentialCleanupIntent(intentPath, home);
+          await lock.release();
+          closed = true;
+        } catch (error) {
+          quarantineCredentialCleanup(path, home, intentPath, lock);
+          throw error;
+        } finally {
+          releaseCredentialLeaseGeneration(home, ownerGeneration);
+        }
+      })();
+      closeAttempt = attempt;
+      try {
+        await attempt;
+      } finally {
+        if (closeAttempt === attempt) closeAttempt = null;
+      }
+    },
+  });
+}
+
+async function createCredentialCleanupIntent(
+  intentPath: string,
+  home: string,
+): Promise<void> {
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(
+      intentPath,
+      constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        (constants.O_NOFOLLOW ?? 0),
+      PRIVATE_FILE_MODE,
+    );
+    await handle.chmod(PRIVATE_FILE_MODE);
+    await handle.writeFile("paperclip-managed-codex-cleanup-v1\n", "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await syncDirectoryDurably(home);
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function removeCredentialCleanupIntent(
+  intentPath: string,
+  home: string,
+): Promise<void> {
+  await removeReplaceableCredential(intentPath);
+  await syncDirectoryDurably(home);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function boundedInlineCredential(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length < 1 || bytes.length > MAX_CODEX_CREDENTIAL_BYTES) {
+    bytes.fill(0);
+    throw new Error(
+      "Managed Codex credential document exceeds its bounded size",
+    );
+  }
+  return bytes;
+}
+
+async function readManagedCredential(sourcePath: string): Promise<Buffer> {
+  let handle: FileHandle;
+  try {
+    handle = await open(
+      sourcePath,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
+  } catch {
+    throw new Error(
+      "provider_initialize_protocol_error: provider=acpx stage=credential.stage managed Codex credential missing",
+    );
+  }
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (
+      !before.isFile() ||
+      before.size < 1n ||
+      before.size > BigInt(MAX_CODEX_CREDENTIAL_BYTES)
+    ) {
+      throw new Error(
+        "Managed Codex credential source is not a bounded regular file",
+      );
+    }
+    if (process.platform !== "win32" && (before.mode & 0o077n) !== 0n) {
+      throw new Error("Managed Codex credential source permissions are unsafe");
+    }
+    if (
+      process.platform !== "win32" &&
+      typeof process.getuid === "function" &&
+      before.uid !== BigInt(process.getuid())
+    ) {
+      throw new Error("Managed Codex credential source ownership is unsafe");
+    }
+    const bytes = await readHandle(handle, Number(before.size));
+    const after = await handle.stat({ bigint: true });
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeNs !== after.mtimeNs ||
+      before.ctimeNs !== after.ctimeNs ||
+      after.size !== BigInt(bytes.length)
+    ) {
+      bytes.fill(0);
+      throw new Error("Managed Codex credential source changed while read");
+    }
+    return bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readHandle(handle: FileHandle, size: number): Promise<Buffer> {
+  const bytes = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const result = await handle.read(bytes, offset, size - offset, offset);
+    if (result.bytesRead === 0) break;
+    offset += result.bytesRead;
+  }
+  if (offset !== size) {
+    bytes.fill(0);
+    throw new Error("Managed Codex credential source ended while read");
+  }
+  return bytes;
+}
+
+function validateCredentialDocument(bytes: Buffer): void {
+  let value: unknown;
+  try {
+    value = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("Managed Codex credential source is malformed");
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Managed Codex credential source is malformed");
+  }
+}
+
+async function writeCredential(
+  destination: string,
+  home: string,
+  bytes: Buffer,
+): Promise<void> {
+  const temporaryPath = join(
+    home,
+    `.auth.json.tmp-${randomBytes(12).toString("hex")}`,
+  );
+  let handle: FileHandle;
+  try {
+    handle = await open(
+      temporaryPath,
+      constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        (constants.O_NOFOLLOW ?? 0),
+      PRIVATE_FILE_MODE,
+    );
+  } catch {
+    throw new Error("Managed Codex credential destination could not be opened");
+  }
+  try {
+    await handle.chmod(PRIVATE_FILE_MODE);
+    await handle.writeFile(bytes);
+    await handle.sync();
+    await handle.close();
+    try {
+      await rename(temporaryPath, destination);
+    } catch (error) {
+      if (
+        process.platform !== "win32" ||
+        !["EACCES", "EEXIST", "ENOTEMPTY", "EPERM"].includes(
+          errorCode(error) ?? "",
+        )
+      ) {
+        throw error;
+      }
+      // Win32 rename does not replace an existing destination. Remove only
+      // the already-conflicting pathname (never a real directory), then move
+      // the fully synced private temporary file into place.
+      await removeReplaceableCredential(destination);
+      await rename(temporaryPath, destination);
+    }
+  } finally {
+    await handle.close().catch(() => undefined);
+    await unlink(temporaryPath).catch(() => undefined);
+  }
+  // Do not acknowledge the lease until the namespace update is durable. A
+  // directory-sync failure is a fail-closed admission condition: retry here so
+  // neither a returned lease nor a thrown pre-lease error can lose ownership
+  // of auth.json across a crash.
+  await syncDirectoryDurably(home);
+}
+
+async function removeReplaceableCredential(path: string): Promise<void> {
+  try {
+    const metadata = await lstat(path);
+    if (metadata.isDirectory() && !metadata.isSymbolicLink()) {
+      throw new Error("Managed Codex credential destination is a directory");
+    }
+    await unlink(path);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+  }
+}
+
+async function removeCredential(path: string, home: string): Promise<void> {
+  try {
+    const metadata = await lstat(path);
+    if (metadata.isDirectory() && !metadata.isSymbolicLink()) {
+      throw new Error("Managed Codex credential destination is a directory");
+    }
+    await unlink(path);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+  }
+  // Sync even after ENOENT: a previous unlink may have succeeded before its
+  // directory sync failed. Never report cleanup or finish preflight while the
+  // removal can still be rolled back by a crash.
+  await syncDirectoryDurably(home);
+}
+
+async function syncDirectoryDurably(directory: string): Promise<void> {
+  let retryDelayMs = 10;
+  let lastError: unknown;
+  let attempts = 0;
+  for (let attempt = 1; attempt <= MAX_DIRECTORY_SYNC_ATTEMPTS; attempt += 1) {
+    attempts = attempt;
+    try {
+      await syncDirectory(directory);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (
+        attempt === MAX_DIRECTORY_SYNC_ATTEMPTS ||
+        error instanceof DirectorySyncOperationTimeoutError
+      ) {
+        break;
+      }
+      // Keep admission closed during transient failures, while bounding total
+      // startup/shutdown latency for a persistently unhealthy filesystem.
+      await new Promise<void>((resolveRetry) => {
+        setTimeout(resolveRetry, retryDelayMs);
+      });
+      retryDelayMs = Math.min(retryDelayMs * 2, 1_000);
+    }
+  }
+  const attemptNoun = attempts === 1 ? "attempt" : "attempts";
+  throw new Error(
+    `Managed Codex credential directory remained non-durable after ${attempts} ${attemptNoun}`,
+    { cause: lastError },
+  );
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  if (process.platform === "win32") return;
+  // A timed-out fsync cannot be cancelled, and FileHandle.close() cannot
+  // finish ahead of it. Do not open another handle for this directory until
+  // the one outstanding operation and its close have settled.
+  if (pendingDirectorySyncCleanups.has(directory)) {
+    throw new DirectorySyncOperationTimeoutError("fsync", directory);
+  }
+  const openAttempt = open(
+    directory,
+    constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
+  );
+  let handle: FileHandle;
+  try {
+    handle = await waitForDirectorySyncOperation(
+      openAttempt,
+      "open",
+      directory,
+    );
+  } catch (error) {
+    if (error instanceof DirectorySyncOperationTimeoutError) {
+      // open(2) cannot be cancelled. If the kernel eventually returns a
+      // handle after our retry budget has advanced, close it without keeping
+      // credential admission or cleanup pending.
+      void openAttempt
+        .then((lateHandle) => closeDirectoryHandle(lateHandle, directory))
+        .catch(() => undefined);
+    }
+    throw error;
+  }
+
+  let syncAttempt: Promise<void>;
+  try {
+    syncAttempt = handle.sync();
+  } catch (error) {
+    await closeDirectoryHandle(handle, directory);
+    throw error;
+  }
+  let syncTimedOut = false;
+  try {
+    await waitForDirectorySyncOperation(syncAttempt, "fsync", directory);
+  } catch (error) {
+    syncTimedOut = error instanceof DirectorySyncOperationTimeoutError;
+    if (syncTimedOut) {
+      // FileHandle.close() waits for outstanding operations. Retain one
+      // process-wide cleanup barrier for this directory so retries fail
+      // closed without accumulating handles or filesystem requests. Use the
+      // actual close promise here: the barrier must remain until the resource
+      // is really released, not merely until the bounded close observer gives
+      // up waiting.
+      const cleanupAttempt = syncAttempt.then(
+        () => handle.close().catch(() => undefined),
+        () => handle.close().catch(() => undefined),
+      );
+      pendingDirectorySyncCleanups.set(directory, cleanupAttempt);
+      void cleanupAttempt
+        .finally(() => {
+          if (pendingDirectorySyncCleanups.get(directory) === cleanupAttempt) {
+            pendingDirectorySyncCleanups.delete(directory);
+          }
+        })
+        .catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    // A completed fsync is the durability boundary. Close is resource cleanup:
+    // bound and detach it rather than turning durable state into a failure or
+    // masking the original fsync error.
+    if (!syncTimedOut) await closeDirectoryHandle(handle, directory);
+  }
+}
+
+async function closeDirectoryHandle(
+  handle: FileHandle,
+  directory: string,
+): Promise<void> {
+  try {
+    const closeAttempt = handle.close();
+    try {
+      await waitForDirectorySyncOperation(closeAttempt, "close", directory);
+    } catch {
+      // close(2) cannot be cancelled. Keep observing a late rejection without
+      // holding credential admission, cleanup, or the process open.
+      void closeAttempt.catch(() => undefined);
+    }
+  } catch {
+    // Closing cannot invalidate an fsync that already completed, and callers
+    // with a failed fsync must retain that original durability error.
+  }
+}
+
+class DirectorySyncOperationTimeoutError extends Error {
+  constructor(operation: "open" | "fsync" | "close", directory: string) {
+    super(
+      `Managed Codex credential directory ${operation} timed out after ${DIRECTORY_SYNC_OPERATION_TIMEOUT_MS}ms for ${directory}`,
+    );
+    this.name = "DirectorySyncOperationTimeoutError";
+  }
+}
+
+async function waitForDirectorySyncOperation<T>(
+  operationAttempt: Promise<T>,
+  operation: "open" | "fsync" | "close",
+  directory: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operationAttempt,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new DirectorySyncOperationTimeoutError(operation, directory));
+        }, DIRECTORY_SYNC_OPERATION_TIMEOUT_MS);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function errorCode(error: unknown): string | null {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : null;
+}

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -1131,14 +1131,7 @@ async function syncDirectory(directory: string): Promise<void> {
         () => handle.close().catch(() => undefined),
         () => handle.close().catch(() => undefined),
       );
-      pendingDirectorySyncCleanups.set(directory, cleanupAttempt);
-      void cleanupAttempt
-        .finally(() => {
-          if (pendingDirectorySyncCleanups.get(directory) === cleanupAttempt) {
-            pendingDirectorySyncCleanups.delete(directory);
-          }
-        })
-        .catch(() => undefined);
+      retainDirectorySyncCleanup(directory, cleanupAttempt);
     }
     throw error;
   } finally {
@@ -1157,15 +1150,43 @@ async function closeDirectoryHandle(
     const closeAttempt = handle.close();
     try {
       await waitForDirectorySyncOperation(closeAttempt, "close", directory);
-    } catch {
+    } catch (error) {
       // close(2) cannot be cancelled. Keep observing a late rejection without
-      // holding credential admission, cleanup, or the process open.
-      void closeAttempt.catch(() => undefined);
+      // leaking additional directory handles. Admission remains closed until
+      // the real close settles, while a completed fsync stays successful.
+      if (error instanceof DirectorySyncOperationTimeoutError) {
+        retainDirectorySyncCleanup(directory, closeAttempt);
+      } else {
+        void closeAttempt.catch(() => undefined);
+      }
     }
   } catch {
     // Closing cannot invalidate an fsync that already completed, and callers
     // with a failed fsync must retain that original durability error.
   }
+}
+
+function retainDirectorySyncCleanup(
+  directory: string,
+  attempt: Promise<unknown>,
+): void {
+  const observed = attempt.then(
+    () => undefined,
+    () => undefined,
+  );
+  const prior = pendingDirectorySyncCleanups.get(directory);
+  const barrier =
+    prior === undefined
+      ? observed
+      : Promise.allSettled([prior, observed]).then(() => undefined);
+  pendingDirectorySyncCleanups.set(directory, barrier);
+  void barrier
+    .finally(() => {
+      if (pendingDirectorySyncCleanups.get(directory) === barrier) {
+        pendingDirectorySyncCleanups.delete(directory);
+      }
+    })
+    .catch(() => undefined);
 }
 
 class DirectorySyncOperationTimeoutError extends Error {

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -51,6 +51,7 @@ interface QuarantinedCredentialCleanup {
   path: string;
   home: string;
   intentPath: string;
+  ownerGeneration: CredentialLeaseGeneration;
   lock: CredentialHomeLock;
   recovery: Promise<void> | null;
 }
@@ -109,10 +110,13 @@ export async function stageManagedCodexCredential(input: {
   ) {
     throw new Error("Managed Codex credential home permissions are unsafe");
   }
+  // Join an older failed close before claiming the next generation. This
+  // keeps quarantine recovery authoritative over the shared paths without
+  // mistaking a waiting admission for an already-active successor.
+  await recoverQuarantinedCredentialCleanup(join(home, "auth.json"), home);
   const ownerGeneration = claimCredentialLeaseGeneration(home);
   let lock: CredentialHomeLock | null = null;
   try {
-    await recoverQuarantinedCredentialCleanup(join(home, "auth.json"), home);
     lock = await acquireCredentialHomeLock(home);
     return await stageClaimedManagedCodexCredential(
       input,
@@ -210,7 +214,13 @@ async function stageClaimedManagedCodexCredential(
       // Rename may already have installed the credential before directory
       // durability failed. Retain a bounded process owner and the persisted
       // intent so later staging must recover both before admission.
-      quarantineCredentialCleanup(destination, home, intentPath, lock);
+      quarantineCredentialCleanup(
+        destination,
+        home,
+        intentPath,
+        ownerGeneration,
+        lock,
+      );
       throw error;
     }
   } finally {
@@ -690,6 +700,7 @@ function quarantineCredentialCleanup(
   path: string,
   home: string,
   intentPath: string,
+  ownerGeneration: CredentialLeaseGeneration,
   lock: CredentialHomeLock,
 ): void {
   const existing = quarantinedCredentialCleanups.get(home);
@@ -698,6 +709,7 @@ function quarantineCredentialCleanup(
     path,
     home,
     intentPath,
+    ownerGeneration,
     lock,
     recovery: null,
   };
@@ -719,13 +731,16 @@ function startCredentialCleanupRecovery(
       try {
         // Never let a stale cleanup callback mutate a successor's credential
         // after kernel ownership has been lost.
-        cleanup.lock.assertHeld();
+        assertCredentialCleanupAuthority(cleanup);
         await removeReplaceableCredential(cleanup.path);
+        assertCredentialCleanupAuthority(cleanup);
         await syncDirectory(cleanup.home);
+        assertCredentialCleanupAuthority(cleanup);
         await removeCredentialCleanupIntent(
           cleanup.intentPath,
           cleanup.home,
         );
+        assertCredentialCleanupAuthority(cleanup);
         await cleanup.lock.release();
         quarantinedCredentialCleanups.delete(cleanup.home);
         return;
@@ -744,6 +759,21 @@ function startCredentialCleanupRecovery(
     if (cleanup.recovery === recovery) cleanup.recovery = null;
   }).catch(() => undefined);
   return recovery;
+}
+
+function assertCredentialCleanupAuthority(
+  cleanup: QuarantinedCredentialCleanup,
+): void {
+  const activeGeneration = activeCredentialLeaseGenerations.get(cleanup.home);
+  if (
+    activeGeneration !== undefined &&
+    activeGeneration !== cleanup.ownerGeneration
+  ) {
+    throw new Error(
+      "Managed Codex credential cleanup was superseded by an active lease",
+    );
+  }
+  cleanup.lock.assertHeld();
 }
 
 async function recoverQuarantinedCredentialCleanup(
@@ -813,7 +843,13 @@ function credentialLease(
           await lock.release();
           closed = true;
         } catch (error) {
-          quarantineCredentialCleanup(path, home, intentPath, lock);
+          quarantineCredentialCleanup(
+            path,
+            home,
+            intentPath,
+            ownerGeneration,
+            lock,
+          );
           throw error;
         } finally {
           releaseCredentialLeaseGeneration(home, ownerGeneration);

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -1,20 +1,15 @@
-import { createHash, randomBytes } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import {
   lstat,
   open,
-  readdir,
   realpath,
   rename,
   unlink,
   type FileHandle,
 } from "node:fs/promises";
-import {
-  createConnection,
-  createServer,
-  type Server,
-  type Socket,
-} from "node:net";
+import { createServer, type Server } from "node:net";
 import { isAbsolute, join, resolve } from "node:path";
 
 const MAX_CODEX_CREDENTIAL_BYTES = 256 * 1024;
@@ -23,28 +18,35 @@ const MAX_DIRECTORY_SYNC_ATTEMPTS = 8;
 const DIRECTORY_SYNC_OPERATION_TIMEOUT_MS = 1_000;
 const MAX_AUTONOMOUS_CREDENTIAL_CLEANUP_ATTEMPTS = 8;
 const CREDENTIAL_CLEANUP_INTENT = ".paperclip-auth-cleanup-required";
+const CREDENTIAL_STAGING_FILE = ".paperclip-auth-staging-v1";
 const CREDENTIAL_LEASE_HOST = "127.0.0.1";
 const CREDENTIAL_LEASE_PORT_MIN = 49_152;
 const CREDENTIAL_LEASE_PORT_COUNT = 16_384;
-const MAX_CREDENTIAL_LEASE_PORT_CANDIDATES = 32;
-const CREDENTIAL_LEASE_PROBE_TIMEOUT_MS = 1_000;
-const CREDENTIAL_LEASE_PROTOCOL = "paperclip-managed-codex-lease-v1";
-const CREDENTIAL_LEASE_FOREIGN_PROBE =
-  "GET /__paperclip_credential_lease_probe__ HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n";
-const CREDENTIAL_LEASE_MARKER_PREFIX = ".paperclip-auth-lease-v1-";
-const MAX_CREDENTIAL_LEASE_MARKERS = 1_024;
+const CREDENTIAL_LEASE_CANDIDATES = 3;
+const CREDENTIAL_LEASE_QUORUM = 2;
+const DIRECTORY_SYNC_HELPER_KILL_ACK_TIMEOUT_MS = 1_000;
+const MAX_DIRECTORY_SYNC_HELPERS = 4;
+const MAX_PARENT_DIRECTORY_SYNC_OPERATIONS = 4;
+const DIRECTORY_SYNC_HELPER_SOURCE = String.raw`
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+
+const directory = process.argv[1];
+if (typeof directory !== "string") throw new Error("directory is required");
+const handle = await open(
+  directory,
+  constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
+);
+try {
+  await handle.sync();
+} finally {
+  await handle.close();
+}
+`;
 
 interface CredentialHomeLock {
   assertHeld(): void;
   release(): Promise<void>;
-}
-
-interface CredentialLeaseMarker {
-  version: 1;
-  identity: string;
-  pid: number;
-  port: number;
-  token: string;
 }
 
 interface QuarantinedCredentialCleanup {
@@ -57,29 +59,47 @@ interface QuarantinedCredentialCleanup {
 }
 
 type CredentialLeaseGeneration = number;
-type CredentialLeaseProbe =
-  | "matching_owner"
-  | "different_owner"
-  | "unresponsive"
-  | "unoccupied";
+
+interface DirectorySyncHelperRegistry {
+  activeChildren: Set<ChildProcess>;
+  activeParentOperations: Set<symbol>;
+  attempts: Map<string, Promise<void>>;
+  failedHomes: Set<string>;
+  isolatedHomes: Set<string>;
+  pendingCleanups: Map<string, Promise<void>>;
+  stuckChildren: Map<string, ChildProcess>;
+}
 
 const quarantinedCredentialCleanups = new Map<
   string,
   QuarantinedCredentialCleanup
 >();
-const pendingDirectorySyncCleanups = new Map<string, Promise<void>>();
+const processDirectorySyncHelperState = globalThis as typeof globalThis & {
+  __paperclipDirectorySyncHelperRegistryV1?: DirectorySyncHelperRegistry;
+};
+const directorySyncHelperRegistry =
+  processDirectorySyncHelperState.__paperclipDirectorySyncHelperRegistryV1 ?? {
+    activeChildren: new Set<ChildProcess>(),
+    activeParentOperations: new Set<symbol>(),
+    attempts: new Map<string, Promise<void>>(),
+    failedHomes: new Set<string>(),
+    isolatedHomes: new Set<string>(),
+    pendingCleanups: new Map<string, Promise<void>>(),
+    stuckChildren: new Map<string, ChildProcess>(),
+  };
+processDirectorySyncHelperState.__paperclipDirectorySyncHelperRegistryV1 =
+  directorySyncHelperRegistry;
+const pendingDirectorySyncCleanups =
+  directorySyncHelperRegistry.pendingCleanups;
+const isolatedDirectorySyncHomes = directorySyncHelperRegistry.isolatedHomes;
+const isolatedDirectorySyncAttempts = directorySyncHelperRegistry.attempts;
+const failedIsolatedDirectorySyncHomes =
+  directorySyncHelperRegistry.failedHomes;
+const stuckDirectorySyncHelpers = directorySyncHelperRegistry.stuckChildren;
 const activeCredentialLeaseGenerations = new Map<
   string,
   CredentialLeaseGeneration
 >();
-const processCredentialLeaseState = globalThis as typeof globalThis & {
-  __paperclipCredentialLeaseIdentitiesV1?: Map<number, string>;
-};
-const processCredentialLeaseIdentities =
-  processCredentialLeaseState.__paperclipCredentialLeaseIdentitiesV1 ??
-  new Map<number, string>();
-processCredentialLeaseState.__paperclipCredentialLeaseIdentitiesV1 =
-  processCredentialLeaseIdentities;
 let nextCredentialLeaseGeneration = 0;
 
 export type ManagedCodexCredentialMode =
@@ -125,7 +145,10 @@ export async function stageManagedCodexCredential(input: {
       lock,
     );
   } catch (error) {
-    if (lock !== null && quarantinedCredentialCleanups.get(home)?.lock !== lock) {
+    if (
+      lock !== null &&
+      quarantinedCredentialCleanups.get(home)?.lock !== lock
+    ) {
       await lock.release().catch(() => undefined);
     }
     releaseCredentialLeaseGeneration(home, ownerGeneration);
@@ -143,14 +166,20 @@ async function stageClaimedManagedCodexCredential(
   lock: CredentialHomeLock,
 ): Promise<ManagedCodexCredentialLease> {
   const destination = join(home, "auth.json");
+  const stagingPath = join(home, CREDENTIAL_STAGING_FILE);
   const intentPath = join(home, CREDENTIAL_CLEANUP_INTENT);
   lock.assertHeld();
-  await recoverPersistedCredentialCleanup(destination, home, intentPath);
-  // The isolated home is itself the durable recovery anchor. Scrub auth.json
-  // before every admission, even when a prior cleanup-intent entry was lost
-  // with a runner crash. Only after this absence is durable may a new intent
-  // be created and a credential installed.
-  await removeCredential(destination, home);
+  await recoverPersistedCredentialCleanup(
+    destination,
+    stagingPath,
+    home,
+    intentPath,
+  );
+  // The isolated home is itself the durable recovery anchor. Scrub both the
+  // installed credential and the deterministic staging pathname before every
+  // admission, even when a prior cleanup-intent entry was lost with a runner
+  // crash. Only after their absence is durable may a new intent be created.
+  await removeCredentialArtifacts([destination, stagingPath], home);
   const environment = input.environment ?? {};
   const hasApiKey = Boolean(
     environment.CODEX_API_KEY || environment.OPENAI_API_KEY,
@@ -209,7 +238,7 @@ async function stageClaimedManagedCodexCredential(
     // credential mutation and therefore needs no process-only quarantine.
     await createCredentialCleanupIntent(intentPath, home);
     try {
-      await writeCredential(destination, home, credential);
+      await writeCredential(destination, stagingPath, home, credential);
     } catch (error) {
       // Rename may already have installed the credential before directory
       // durability failed. Retain a bounded process owner and the persisted
@@ -264,405 +293,103 @@ function releaseCredentialLeaseGeneration(
 async function acquireCredentialHomeLock(
   home: string,
 ): Promise<CredentialHomeLock> {
-  // ACPX credential homes are local-runtime resources: every contender for a
-  // canonical home runs on the same host and network namespace. A bounded set
-  // of deterministic loopback endpoints therefore provides a kernel-owned,
-  // process-lifetime lease without making one hash collision authoritative.
-  // The local runner also supervises its provider lifetime; a provider cannot
-  // remain an authorized writer after this owning process dies. Every
-  // Paperclip listener identifies its canonical home, so confirmed unrelated
-  // collisions fall through to another candidate while a matching live owner
-  // still fences the home. An occupied endpoint that does not answer within
-  // the bounded probe is authoritative: it may be a concurrent owner between
-  // bind and marker publication, so admission fails closed instead of letting
-  // two contenders select different ports. After binding, probing every other
-  // candidate closes the race where an earlier unrelated listener disappears
-  // while an owner uses a later one.
-  const identity = credentialLeaseIdentity(home);
-  const ports = credentialLeasePorts(home);
-  if (await hasActiveCredentialLeaseMarker(home, identity, ports)) {
-    throw new Error(
-      "Managed Codex credential home already has an active lease",
-    );
-  }
-  let server: Server | null = null;
-  let port: number | null = null;
-  let acceptedSockets = new Set<Socket>();
-  for (const candidatePort of ports) {
-    const candidateSockets = new Set<Socket>();
-    const candidate = createCredentialLeaseServer(identity, candidateSockets);
-    try {
-      await listenForCredentialLease(candidate, candidatePort);
-      processCredentialLeaseIdentities.set(candidatePort, identity);
-      server = candidate;
-      port = candidatePort;
-      acceptedSockets = candidateSockets;
-      break;
-    } catch (error) {
-      for (const socket of candidateSockets) socket.destroy();
-      if (errorCode(error) !== "EADDRINUSE") {
+  // This is deliberately markerless: authority is the live kernel ownership
+  // of any two candidates. Any two subsets of a three-port set intersect, so
+  // contenders cannot both reach quorum; one unrelated occupied listener is
+  // tolerated without probing or trusting the process behind it.
+  const servers: Server[] = [];
+  let invalid: Error | null = null;
+  let released = false;
+  try {
+    for (const port of credentialLeasePorts(home)) {
+      const server = createServer((socket) => socket.destroy());
+      try {
+        await listenForCredentialLease(server, port);
+      } catch (error) {
+        await closeCredentialLeaseServer(server);
+        if (errorCode(error) === "EADDRINUSE") continue;
         throw new Error(
           "Managed Codex credential ownership could not be established",
           { cause: error },
         );
       }
-      const probe = await probeCredentialLease(candidatePort, identity);
-      if (probe === "matching_owner") {
-        throw new Error(
-          "Managed Codex credential home already has an active lease",
-        );
-      }
-      if (probe === "unresponsive") {
-        throw new Error(
-          "Managed Codex credential ownership could not safely bypass an unresponsive lease endpoint",
-        );
-      }
-    }
-  }
-  if (server === null || port === null) {
-    throw new Error(
-      "Managed Codex credential ownership could not find a free loopback lease endpoint",
-    );
-  }
-
-  let invalid: Error | null = null;
-  let expectedClose = false;
-  server.on("error", (error) => {
-    invalid ??= error;
-  });
-  server.on("close", () => {
-    if (processCredentialLeaseIdentities.get(port) === identity) {
-      processCredentialLeaseIdentities.delete(port);
-    }
-    if (!expectedClose) {
-      invalid ??= new Error(
-        "Managed Codex credential ownership listener closed unexpectedly",
-      );
-    }
-  });
-  try {
-    const address = server.address();
-    if (
-      address === null ||
-      typeof address === "string" ||
-      address.address !== CREDENTIAL_LEASE_HOST ||
-      address.family !== "IPv4" ||
-      address.port !== port
-    ) {
-      throw new Error(
-        "Managed Codex credential ownership listener bound unexpectedly",
-      );
-    }
-    const competingEndpoints = await Promise.all(
-      ports
-        .filter((candidatePort) => candidatePort !== port)
-        .map((candidatePort) => probeCredentialLease(candidatePort, identity)),
-    );
-    if (
-      competingEndpoints.some(
-        (probe) =>
-          probe === "matching_owner" || probe === "unresponsive",
-      )
-    ) {
-      throw new Error(
-        "Managed Codex credential home already has an active lease",
-      );
-    }
-    if (await hasActiveCredentialLeaseMarker(home, identity, ports)) {
-      throw new Error(
-        "Managed Codex credential home already has an active lease",
-      );
-    }
-    if (invalid !== null || !server.listening) {
-      throw new Error("Managed Codex credential ownership was lost", {
-        cause: invalid,
+      server.on("error", (error) => {
+        invalid ??= error;
       });
+      server.on("close", () => {
+        if (!released) {
+          invalid ??= new Error(
+            "Managed Codex credential ownership listener closed unexpectedly",
+          );
+        }
+      });
+      servers.push(server);
+      if (servers.length === CREDENTIAL_LEASE_QUORUM) break;
+    }
+    if (servers.length !== CREDENTIAL_LEASE_QUORUM) {
+      throw new Error(
+        "Managed Codex credential home already has an active lease",
+      );
     }
   } catch (error) {
-    expectedClose = true;
-    for (const socket of acceptedSockets) socket.destroy();
-    if (server.listening) await closeCredentialLeaseServer(server);
+    released = true;
+    await Promise.allSettled(servers.map(closeCredentialLeaseServer));
     throw error;
   }
 
-  const markerPath = await publishCredentialLeaseMarker(home, {
-    version: 1,
-    identity,
-    pid: process.pid,
-    port,
-    token: randomBytes(16).toString("hex"),
-  }).catch(async (error: unknown) => {
-    expectedClose = true;
-    for (const socket of acceptedSockets) socket.destroy();
-    if (server.listening) await closeCredentialLeaseServer(server);
-    throw new Error(
-      "Managed Codex credential ownership marker could not be established",
-      { cause: error },
-    );
-  });
-
-  let released = false;
-  let releaseAttempt: Promise<void> | null = null;
   return Object.freeze({
     assertHeld(): void {
-      if (released || invalid !== null || !server.listening) {
-        throw new Error("Managed Codex credential ownership was lost", {
-          cause: invalid,
-        });
+      if (
+        released ||
+        invalid !== null ||
+        servers.filter((server) => server.listening).length <
+          CREDENTIAL_LEASE_QUORUM
+      ) {
+        throw new Error("Managed Codex credential ownership was lost");
       }
     },
     async release(): Promise<void> {
       if (released) return;
-      if (releaseAttempt !== null) return await releaseAttempt;
-      const attempt = (async () => {
-        const ownershipError = invalid;
-        // Keep the kernel fence live until its marker is gone. If unlinking
-        // the marker fails, quarantine recovery can still assert ownership
-        // and retry instead of inheriting a closed, permanently unusable
-        // lock.
-        await unlink(markerPath).catch((error: unknown) => {
-          if (errorCode(error) !== "ENOENT") throw error;
-        });
-        expectedClose = true;
-        for (const socket of acceptedSockets) socket.destroy();
-        if (server.listening) await closeCredentialLeaseServer(server);
-        released = true;
-        if (ownershipError !== null) throw ownershipError;
-      })();
-      releaseAttempt = attempt;
-      try {
-        await attempt;
-      } finally {
-        if (releaseAttempt === attempt) releaseAttempt = null;
+      const outcomes = await Promise.allSettled(
+        servers.map(closeCredentialLeaseServer),
+      );
+      const listenersStillHeld = servers.filter(
+        (server) => server.listening,
+      ).length;
+      if (listenersStillHeld >= CREDENTIAL_LEASE_QUORUM) {
+        const failure = outcomes.find(
+          (outcome): outcome is PromiseRejectedResult =>
+            outcome.status === "rejected",
+        );
+        throw new Error(
+          "Managed Codex credential ownership could not be released",
+          { cause: failure?.reason },
+        );
       }
+      // Once fewer than two listeners remain, quorum authority is gone. Never
+      // throw after that point: a stale quarantine must not touch a successor.
+      released = true;
     },
   });
 }
 
-function credentialLeaseIdentity(home: string): string {
-  const scope = `${
-    typeof process.getuid === "function" ? process.getuid() : "win32"
-  }\0${home}`;
-  return createHash("sha256").update(scope).digest("hex");
-}
-
-function credentialLeasePorts(home: string): number[] {
-  const digest = Buffer.from(credentialLeaseIdentity(home), "hex");
+function credentialLeasePorts(home: string): readonly number[] {
+  const userScope =
+    typeof process.getuid === "function" ? String(process.getuid()) : "win32";
+  const digest = createHash("sha256")
+    .update("paperclip-managed-codex-lease-v2:")
+    .update(userScope)
+    .update("\0")
+    .update(home)
+    .digest();
   const start = digest.readUInt16BE(0) % CREDENTIAL_LEASE_PORT_COUNT;
-  const stride = digest.readUInt16BE(2) | 1;
+  const step = (digest.readUInt16BE(2) | 1) % CREDENTIAL_LEASE_PORT_COUNT;
   return Array.from(
-    { length: MAX_CREDENTIAL_LEASE_PORT_CANDIDATES },
+    { length: CREDENTIAL_LEASE_CANDIDATES },
     (_, index) =>
       CREDENTIAL_LEASE_PORT_MIN +
-      ((start + index * stride) % CREDENTIAL_LEASE_PORT_COUNT),
+      ((start + index * step) % CREDENTIAL_LEASE_PORT_COUNT),
   );
-}
-
-function createCredentialLeaseServer(
-  identity: string,
-  acceptedSockets: Set<Socket>,
-): Server {
-  const response = `${CREDENTIAL_LEASE_PROTOCOL} ${identity}\n`;
-  return createServer((socket) => {
-    acceptedSockets.add(socket);
-    socket.once("close", () => acceptedSockets.delete(socket));
-    socket.end(response);
-  });
-}
-
-async function probeCredentialLease(
-  port: number,
-  expectedIdentity: string,
-): Promise<CredentialLeaseProbe> {
-  const processIdentity = processCredentialLeaseIdentities.get(port);
-  if (processIdentity !== undefined) {
-    return processIdentity === expectedIdentity
-      ? "matching_owner"
-      : "different_owner";
-  }
-  const expected = `${CREDENTIAL_LEASE_PROTOCOL} ${expectedIdentity}\n`;
-  return await new Promise<CredentialLeaseProbe>((resolveProbe) => {
-    const socket = createConnection({ host: CREDENTIAL_LEASE_HOST, port });
-    let settled = false;
-    let response = "";
-    let foreignProbe: NodeJS.Timeout | null = null;
-    const finish = (result: CredentialLeaseProbe): void => {
-      if (settled) return;
-      settled = true;
-      if (foreignProbe !== null) clearTimeout(foreignProbe);
-      socket.destroy();
-      resolveProbe(result);
-    };
-    socket.setEncoding("utf8");
-    socket.setTimeout(CREDENTIAL_LEASE_PROBE_TIMEOUT_MS, () =>
-      finish("unresponsive"),
-    );
-    socket.once("connect", () => {
-      foreignProbe = setTimeout(() => {
-        if (!settled) socket.write(CREDENTIAL_LEASE_FOREIGN_PROBE);
-      }, 10);
-      foreignProbe.unref();
-    });
-    socket.on("data", (chunk: string) => {
-      response += chunk;
-      if (response === expected) finish("matching_owner");
-      else if (
-        response.length >= expected.length ||
-        !expected.startsWith(response)
-      ) {
-        finish("different_owner");
-      }
-    });
-    socket.once("error", (error) =>
-      finish(
-        errorCode(error) === "ECONNREFUSED"
-          ? "unoccupied"
-          : "unresponsive",
-      ),
-    );
-    socket.once("end", () =>
-      finish(response === expected ? "matching_owner" : "different_owner"),
-    );
-    socket.once("close", () =>
-      finish(response === expected ? "matching_owner" : "different_owner"),
-    );
-  });
-}
-
-async function hasActiveCredentialLeaseMarker(
-  home: string,
-  expectedIdentity: string,
-  candidatePorts: readonly number[],
-): Promise<boolean> {
-  const entries = (await readdir(home, { withFileTypes: true })).filter(
-    (entry) =>
-      entry.isFile() &&
-      entry.name.startsWith(CREDENTIAL_LEASE_MARKER_PREFIX) &&
-      entry.name.endsWith(".json"),
-  );
-  if (entries.length > MAX_CREDENTIAL_LEASE_MARKERS) {
-    throw new Error("Managed Codex credential lease marker limit exceeded");
-  }
-  for (const entry of entries) {
-    const markerPath = join(home, entry.name);
-    const marker = await readCredentialLeaseMarker(markerPath);
-    if (
-      marker === null ||
-      marker.identity !== expectedIdentity ||
-      !candidatePorts.includes(marker.port)
-    ) {
-      continue;
-    }
-    if (
-      (await probeCredentialLease(marker.port, expectedIdentity)) ===
-      "matching_owner"
-    ) {
-      return true;
-    }
-    if (
-      credentialLeaseProcessIsAlive(marker.pid) &&
-      (await credentialLeasePortIsOccupied(marker.port))
-    ) {
-      return true;
-    }
-    await unlink(markerPath).catch((error: unknown) => {
-      if (errorCode(error) !== "ENOENT") throw error;
-    });
-  }
-  return false;
-}
-
-async function readCredentialLeaseMarker(
-  markerPath: string,
-): Promise<CredentialLeaseMarker | null> {
-  let handle: FileHandle;
-  try {
-    handle = await open(
-      markerPath,
-      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
-    );
-  } catch (error) {
-    if (errorCode(error) === "ENOENT" || errorCode(error) === "ELOOP") {
-      return null;
-    }
-    throw error;
-  }
-  try {
-    const metadata = await handle.stat();
-    if (!metadata.isFile() || metadata.size < 1 || metadata.size > 4_096) {
-      return null;
-    }
-    const bytes = await readHandle(handle, metadata.size);
-    const value = JSON.parse(bytes.toString("utf8")) as Partial<CredentialLeaseMarker>;
-    if (
-      value.version !== 1 ||
-      typeof value.identity !== "string" ||
-      !/^[0-9a-f]{64}$/.test(value.identity) ||
-      !Number.isInteger(value.pid) ||
-      (value.pid ?? 0) < 1 ||
-      !Number.isInteger(value.port) ||
-      (value.port ?? 0) < 1 ||
-      (value.port ?? 0) > 65_535 ||
-      typeof value.token !== "string" ||
-      !/^[0-9a-f]{32}$/.test(value.token)
-    ) {
-      return null;
-    }
-    return value as CredentialLeaseMarker;
-  } catch {
-    return null;
-  } finally {
-    await handle.close();
-  }
-}
-
-async function publishCredentialLeaseMarker(
-  home: string,
-  marker: CredentialLeaseMarker,
-): Promise<string> {
-  const markerPath = join(
-    home,
-    `${CREDENTIAL_LEASE_MARKER_PREFIX}${marker.token}.json`,
-  );
-  const handle = await open(
-    markerPath,
-    constants.O_WRONLY |
-      constants.O_CREAT |
-      constants.O_EXCL |
-      (constants.O_NOFOLLOW ?? 0),
-    PRIVATE_FILE_MODE,
-  );
-  try {
-    await handle.writeFile(`${JSON.stringify(marker)}\n`, "utf8");
-    await handle.sync();
-  } catch (error) {
-    await handle.close().catch(() => undefined);
-    await unlink(markerPath).catch(() => undefined);
-    throw error;
-  }
-  await handle.close();
-  return markerPath;
-}
-
-function credentialLeaseProcessIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return errorCode(error) !== "ESRCH";
-  }
-}
-
-async function credentialLeasePortIsOccupied(port: number): Promise<boolean> {
-  const probe = createServer();
-  try {
-    await listenForCredentialLease(probe, port);
-    await closeCredentialLeaseServer(probe);
-    return false;
-  } catch (error) {
-    if (errorCode(error) === "EADDRINUSE") return true;
-    throw error;
-  }
 }
 
 async function listenForCredentialLease(
@@ -670,32 +397,34 @@ async function listenForCredentialLease(
   port: number,
 ): Promise<void> {
   await new Promise<void>((resolveListen, rejectListen) => {
-    const onError = (error: Error): void => rejectListen(error);
+    const onError = (error: Error): void => {
+      server.off("listening", onListening);
+      rejectListen(error);
+    };
+    const onListening = (): void => {
+      server.off("error", onError);
+      resolveListen();
+    };
     server.once("error", onError);
-    server.listen(
-      {
-        host: CREDENTIAL_LEASE_HOST,
-        port,
-        exclusive: true,
-        reusePort: false,
-      },
-      () => {
-        server.off("error", onError);
-        resolveListen();
-      },
-    );
+    server.once("listening", onListening);
+    server.listen({
+      exclusive: true,
+      host: CREDENTIAL_LEASE_HOST,
+      port,
+    });
   });
 }
 
 async function closeCredentialLeaseServer(server: Server): Promise<void> {
+  if (!server.listening) return;
   await new Promise<void>((resolveClose, rejectClose) => {
     server.close((error) => {
       if (error) rejectClose(error);
       else resolveClose();
     });
+    server.closeAllConnections();
   });
 }
-
 function quarantineCredentialCleanup(
   path: string,
   home: string,
@@ -733,13 +462,13 @@ function startCredentialCleanupRecovery(
         // after kernel ownership has been lost.
         assertCredentialCleanupAuthority(cleanup);
         await removeReplaceableCredential(cleanup.path);
+        await removeReplaceableCredential(
+          join(cleanup.home, CREDENTIAL_STAGING_FILE),
+        );
         assertCredentialCleanupAuthority(cleanup);
         await syncDirectory(cleanup.home);
         assertCredentialCleanupAuthority(cleanup);
-        await removeCredentialCleanupIntent(
-          cleanup.intentPath,
-          cleanup.home,
-        );
+        await removeCredentialCleanupIntent(cleanup.intentPath, cleanup.home);
         assertCredentialCleanupAuthority(cleanup);
         await cleanup.lock.release();
         quarantinedCredentialCleanups.delete(cleanup.home);
@@ -755,9 +484,11 @@ function startCredentialCleanupRecovery(
     }
   })();
   cleanup.recovery = recovery;
-  void recovery.finally(() => {
-    if (cleanup.recovery === recovery) cleanup.recovery = null;
-  }).catch(() => undefined);
+  void recovery
+    .finally(() => {
+      if (cleanup.recovery === recovery) cleanup.recovery = null;
+    })
+    .catch(() => undefined);
   return recovery;
 }
 
@@ -795,11 +526,12 @@ async function recoverQuarantinedCredentialCleanup(
 
 async function recoverPersistedCredentialCleanup(
   path: string,
+  stagingPath: string,
   home: string,
   intentPath: string,
 ): Promise<void> {
   if (!(await pathExists(intentPath))) return;
-  await removeCredential(path, home);
+  await removeCredentialArtifacts([path, stagingPath], home);
   await removeCredentialCleanupIntent(intentPath, home);
 }
 
@@ -1000,13 +732,10 @@ function validateCredentialDocument(bytes: Buffer): void {
 
 async function writeCredential(
   destination: string,
+  temporaryPath: string,
   home: string,
   bytes: Buffer,
 ): Promise<void> {
-  const temporaryPath = join(
-    home,
-    `.auth.json.tmp-${randomBytes(12).toString("hex")}`,
-  );
   let handle: FileHandle;
   try {
     handle = await open(
@@ -1066,14 +795,15 @@ async function removeReplaceableCredential(path: string): Promise<void> {
 }
 
 async function removeCredential(path: string, home: string): Promise<void> {
-  try {
-    const metadata = await lstat(path);
-    if (metadata.isDirectory() && !metadata.isSymbolicLink()) {
-      throw new Error("Managed Codex credential destination is a directory");
-    }
-    await unlink(path);
-  } catch (error) {
-    if (errorCode(error) !== "ENOENT") throw error;
+  await removeCredentialArtifacts([path], home);
+}
+
+async function removeCredentialArtifacts(
+  paths: readonly string[],
+  home: string,
+): Promise<void> {
+  for (const path of paths) {
+    await removeReplaceableCredential(path);
   }
   // Sync even after ENOENT: a previous unlink may have succeeded before its
   // directory sync failed. Never report cleanup or finish preflight while the
@@ -1094,7 +824,8 @@ async function syncDirectoryDurably(directory: string): Promise<void> {
       lastError = error;
       if (
         attempt === MAX_DIRECTORY_SYNC_ATTEMPTS ||
-        error instanceof DirectorySyncOperationTimeoutError
+        error instanceof DirectorySyncOperationTimeoutError ||
+        error instanceof PermanentDirectorySyncHelperError
       ) {
         break;
       }
@@ -1115,75 +846,104 @@ async function syncDirectoryDurably(directory: string): Promise<void> {
 
 async function syncDirectory(directory: string): Promise<void> {
   if (process.platform === "win32") return;
-  // A timed-out fsync cannot be cancelled, and FileHandle.close() cannot
-  // finish ahead of it. Do not open another handle for this directory until
-  // the one outstanding operation and its close have settled.
-  if (pendingDirectorySyncCleanups.has(directory)) {
-    throw new DirectorySyncOperationTimeoutError("fsync", directory);
+  // Once an in-process filesystem request times out it cannot be cancelled.
+  // Keep that single request observed, and permanently use killable helper
+  // processes for this home so recovery remains available without accumulating
+  // additional parent-process handles or requests.
+  if (isolatedDirectorySyncHomes.has(directory)) {
+    if (failedIsolatedDirectorySyncHomes.has(directory)) {
+      throw new PermanentDirectorySyncHelperError(directory);
+    }
+    await syncDirectoryInIsolatedProcess(directory);
+    return;
   }
-  const openAttempt = open(
-    directory,
-    constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
-  );
-  let handle: FileHandle;
+  const parentOperation = reserveParentDirectorySyncOperation();
+  if (parentOperation === null) {
+    // Never start a fifth uncancellable parent filesystem request. The helper
+    // pool has its own global bound and can be killed independently.
+    isolatedDirectorySyncHomes.add(directory);
+    await syncDirectoryInIsolatedProcess(directory);
+    return;
+  }
+  let retainParentOperation = false;
   try {
-    handle = await waitForDirectorySyncOperation(
-      openAttempt,
-      "open",
+    const openAttempt = open(
       directory,
+      constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
     );
-  } catch (error) {
-    if (error instanceof DirectorySyncOperationTimeoutError) {
-      // open(2) cannot be cancelled. If the kernel eventually returns a
-      // handle after our retry budget has advanced, close it without keeping
-      // another open from racing the unresolved request or its late close.
-      const cleanupAttempt = openAttempt.then(
-        (lateHandle) => closeDirectoryHandle(lateHandle, directory),
-        () => undefined,
+    let handle: FileHandle;
+    try {
+      handle = await waitForDirectorySyncOperation(
+        openAttempt,
+        "open",
+        directory,
       );
-      retainDirectorySyncCleanup(directory, cleanupAttempt);
+    } catch (error) {
+      if (error instanceof DirectorySyncOperationTimeoutError) {
+        // open(2) cannot be cancelled. Retain this process-global reservation
+        // for the process lifetime and observe/close a late handle without
+        // ever starting another parent request for this home.
+        retainParentOperation = true;
+        const cleanupAttempt = openAttempt.then(
+          (lateHandle) => closeDirectoryHandle(lateHandle, directory),
+          () => undefined,
+        );
+        retainDirectorySyncCleanup(directory, cleanupAttempt);
+        isolatedDirectorySyncHomes.add(directory);
+        await syncDirectoryInIsolatedProcess(directory);
+        return;
+      }
+      throw error;
     }
-    throw error;
-  }
 
-  let syncAttempt: Promise<void>;
-  try {
-    syncAttempt = handle.sync();
-  } catch (error) {
-    await closeDirectoryHandle(handle, directory);
-    throw error;
-  }
-  let syncTimedOut = false;
-  try {
-    await waitForDirectorySyncOperation(syncAttempt, "fsync", directory);
-  } catch (error) {
-    syncTimedOut = error instanceof DirectorySyncOperationTimeoutError;
-    if (syncTimedOut) {
-      // FileHandle.close() waits for outstanding operations. Retain one
-      // process-wide cleanup barrier for this directory so retries fail
-      // closed without accumulating handles or filesystem requests. Use the
-      // actual close promise here: the barrier must remain until the resource
-      // is really released, not merely until the bounded close observer gives
-      // up waiting.
-      const cleanupAttempt = syncAttempt.then(
-        () => handle.close().catch(() => undefined),
-        () => handle.close().catch(() => undefined),
-      );
-      retainDirectorySyncCleanup(directory, cleanupAttempt);
+    let syncAttempt: Promise<void>;
+    try {
+      syncAttempt = handle.sync();
+    } catch (error) {
+      retainParentOperation = await closeDirectoryHandle(handle, directory);
+      throw error;
     }
-    throw error;
+    let syncTimedOut = false;
+    try {
+      await waitForDirectorySyncOperation(syncAttempt, "fsync", directory);
+    } catch (error) {
+      syncTimedOut = error instanceof DirectorySyncOperationTimeoutError;
+      if (syncTimedOut) {
+        // FileHandle.close() waits for outstanding operations. Retain both the
+        // cleanup observer and the parent-operation slot for process lifetime.
+        retainParentOperation = true;
+        const cleanupAttempt = syncAttempt.then(
+          () => handle.close().catch(() => undefined),
+          () => handle.close().catch(() => undefined),
+        );
+        retainDirectorySyncCleanup(directory, cleanupAttempt);
+        isolatedDirectorySyncHomes.add(directory);
+        await syncDirectoryInIsolatedProcess(directory);
+        return;
+      }
+      throw error;
+    } finally {
+      // A completed fsync is the durability boundary. Close is resource
+      // cleanup; a timed-out close retains the global parent-operation slot.
+      if (!syncTimedOut) {
+        retainParentOperation =
+          (await closeDirectoryHandle(handle, directory)) ||
+          retainParentOperation;
+      }
+    }
   } finally {
-    // A completed fsync is the durability boundary. Close is resource cleanup:
-    // bound and detach it rather than turning durable state into a failure or
-    // masking the original fsync error.
-    if (!syncTimedOut) await closeDirectoryHandle(handle, directory);
+    if (!retainParentOperation) {
+      directorySyncHelperRegistry.activeParentOperations.delete(
+        parentOperation,
+      );
+    }
   }
 }
 
 async function closeDirectoryHandle(
   handle: FileHandle,
   directory: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const closeAttempt = handle.close();
     try {
@@ -1194,6 +954,8 @@ async function closeDirectoryHandle(
       // the real close settles, while a completed fsync stays successful.
       if (error instanceof DirectorySyncOperationTimeoutError) {
         retainDirectorySyncCleanup(directory, closeAttempt);
+        isolatedDirectorySyncHomes.add(directory);
+        return true;
       } else {
         void closeAttempt.catch(() => undefined);
       }
@@ -1202,6 +964,156 @@ async function closeDirectoryHandle(
     // Closing cannot invalidate an fsync that already completed, and callers
     // with a failed fsync must retain that original durability error.
   }
+  return false;
+}
+
+function reserveParentDirectorySyncOperation(): symbol | null {
+  if (
+    directorySyncHelperRegistry.activeParentOperations.size >=
+    MAX_PARENT_DIRECTORY_SYNC_OPERATIONS
+  ) {
+    return null;
+  }
+  const reservation = Symbol("parent-directory-sync");
+  directorySyncHelperRegistry.activeParentOperations.add(reservation);
+  return reservation;
+}
+
+async function syncDirectoryInIsolatedProcess(
+  directory: string,
+): Promise<void> {
+  if (failedIsolatedDirectorySyncHomes.has(directory)) {
+    throw new PermanentDirectorySyncHelperError(directory);
+  }
+  const activeAttempt = isolatedDirectorySyncAttempts.get(directory);
+  if (activeAttempt !== undefined) return await activeAttempt;
+  const attempt = runDirectorySyncHelper(directory);
+  isolatedDirectorySyncAttempts.set(directory, attempt);
+  try {
+    await attempt;
+  } finally {
+    if (isolatedDirectorySyncAttempts.get(directory) === attempt) {
+      isolatedDirectorySyncAttempts.delete(directory);
+    }
+  }
+}
+
+async function runDirectorySyncHelper(directory: string): Promise<void> {
+  if (
+    directorySyncHelperRegistry.activeChildren.size >=
+    MAX_DIRECTORY_SYNC_HELPERS
+  ) {
+    throw new Error(
+      `Managed Codex credential directory helper process limit of ${MAX_DIRECTORY_SYNC_HELPERS} was reached`,
+    );
+  }
+  let child: ChildProcess;
+  try {
+    child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        DIRECTORY_SYNC_HELPER_SOURCE,
+        directory,
+      ],
+      {
+        // The helper imports only Node built-ins. Do not inherit loader hooks or
+        // any credential-bearing process environment into the durability worker.
+        env: {},
+        stdio: "ignore",
+        windowsHide: true,
+      },
+    );
+    directorySyncHelperRegistry.activeChildren.add(child);
+    child.unref();
+  } catch {
+    failedIsolatedDirectorySyncHomes.add(directory);
+    throw new PermanentDirectorySyncHelperError(directory);
+  }
+  await new Promise<void>((resolveHelper, rejectHelper) => {
+    let timeout: NodeJS.Timeout | undefined;
+    let killAcknowledgementTimeout: NodeJS.Timeout | undefined;
+    let timedOut = false;
+    let settled = false;
+    let reaped = false;
+    const settle = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout !== undefined) clearTimeout(timeout);
+      if (killAcknowledgementTimeout !== undefined) {
+        clearTimeout(killAcknowledgementTimeout);
+      }
+      if (error === undefined) resolveHelper();
+      else rejectHelper(error);
+    };
+    const reap = (): void => {
+      if (reaped) return;
+      reaped = true;
+      directorySyncHelperRegistry.activeChildren.delete(child);
+      if (stuckDirectorySyncHelpers.get(directory) === child) {
+        stuckDirectorySyncHelpers.delete(directory);
+      }
+      child.off("error", onError);
+      child.off("exit", onExit);
+      child.off("close", onClose);
+    };
+    const fencePermanently = (): void => {
+      failedIsolatedDirectorySyncHomes.add(directory);
+      stuckDirectorySyncHelpers.set(directory, child);
+      settle(new PermanentDirectorySyncHelperError(directory));
+    };
+    const onError = (): void => {
+      fencePermanently();
+      // A missing pid proves spawn never created a process, so no retained
+      // reaper or global capacity slot is necessary.
+      if (child.pid === undefined) reap();
+    };
+    const onExit = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ): void => {
+      reap();
+      if (timedOut) {
+        settle(new DirectorySyncOperationTimeoutError("helper", directory));
+      } else if (code === 0) {
+        settle();
+      } else {
+        settle(
+          new Error(
+            `Managed Codex credential directory helper failed with ${
+              signal === null ? `code ${String(code)}` : `signal ${signal}`
+            }`,
+          ),
+        );
+      }
+    };
+    const onClose = (): void => reap();
+    child.on("error", onError);
+    child.once("exit", onExit);
+    child.once("close", onClose);
+    timeout = setTimeout(() => {
+      timedOut = true;
+      // Wait for the exit event after SIGKILL before permitting another helper;
+      // this is the resource-release acknowledgement the in-process API lacks.
+      try {
+        if (!child.kill("SIGKILL")) {
+          fencePermanently();
+          return;
+        }
+        killAcknowledgementTimeout = setTimeout(() => {
+          // A child that does not acknowledge SIGKILL is retained as the sole
+          // reaper for this home. Permanently fail closed so no later attempt
+          // can accumulate another possibly stuck process.
+          fencePermanently();
+        }, DIRECTORY_SYNC_HELPER_KILL_ACK_TIMEOUT_MS);
+        killAcknowledgementTimeout.unref?.();
+      } catch {
+        fencePermanently();
+      }
+    }, DIRECTORY_SYNC_OPERATION_TIMEOUT_MS);
+    timeout.unref?.();
+  });
 }
 
 function retainDirectorySyncCleanup(
@@ -1228,11 +1140,23 @@ function retainDirectorySyncCleanup(
 }
 
 class DirectorySyncOperationTimeoutError extends Error {
-  constructor(operation: "open" | "fsync" | "close", directory: string) {
+  constructor(
+    operation: "open" | "fsync" | "close" | "helper",
+    directory: string,
+  ) {
     super(
       `Managed Codex credential directory ${operation} timed out after ${DIRECTORY_SYNC_OPERATION_TIMEOUT_MS}ms for ${directory}`,
     );
     this.name = "DirectorySyncOperationTimeoutError";
+  }
+}
+
+class PermanentDirectorySyncHelperError extends Error {
+  constructor(directory: string) {
+    super(
+      `Managed Codex credential directory helper termination was not acknowledged and is permanently unavailable for ${directory}`,
+    );
+    this.name = "PermanentDirectorySyncHelperError";
   }
 }
 

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -62,6 +62,7 @@ type CredentialLeaseGeneration = number;
 
 interface DirectorySyncHelperRegistry {
   activeChildren: Set<ChildProcess>;
+  childDirectories: Map<ChildProcess, string>;
   activeParentOperations: Set<symbol>;
   attempts: Map<string, Promise<void>>;
   failedHomes: Set<string>;
@@ -80,6 +81,7 @@ const processDirectorySyncHelperState = globalThis as typeof globalThis & {
 const directorySyncHelperRegistry =
   processDirectorySyncHelperState.__paperclipDirectorySyncHelperRegistryV1 ?? {
     activeChildren: new Set<ChildProcess>(),
+    childDirectories: new Map<ChildProcess, string>(),
     activeParentOperations: new Set<symbol>(),
     attempts: new Map<string, Promise<void>>(),
     failedHomes: new Set<string>(),
@@ -96,6 +98,8 @@ const isolatedDirectorySyncAttempts = directorySyncHelperRegistry.attempts;
 const failedIsolatedDirectorySyncHomes =
   directorySyncHelperRegistry.failedHomes;
 const stuckDirectorySyncHelpers = directorySyncHelperRegistry.stuckChildren;
+const directorySyncHelperDirectories =
+  directorySyncHelperRegistry.childDirectories;
 const activeCredentialLeaseGenerations = new Map<
   string,
   CredentialLeaseGeneration
@@ -1028,6 +1032,7 @@ async function runDirectorySyncHelper(directory: string): Promise<void> {
       },
     );
     directorySyncHelperRegistry.activeChildren.add(child);
+    directorySyncHelperDirectories.set(child, directory);
     child.unref();
   } catch (error) {
     throw new Error(
@@ -1055,6 +1060,7 @@ async function runDirectorySyncHelper(directory: string): Promise<void> {
       if (reaped) return;
       reaped = true;
       directorySyncHelperRegistry.activeChildren.delete(child);
+      directorySyncHelperDirectories.delete(child);
       if (stuckDirectorySyncHelpers.get(directory) === child) {
         stuckDirectorySyncHelpers.delete(directory);
         failedIsolatedDirectorySyncHomes.delete(directory);
@@ -1125,7 +1131,7 @@ async function runDirectorySyncHelper(directory: string): Promise<void> {
 }
 
 function reclaimConfirmedExitedDirectorySyncHelpers(): void {
-  for (const [directory, child] of stuckDirectorySyncHelpers) {
+  for (const child of directorySyncHelperRegistry.activeChildren) {
     let exited =
       (child.exitCode !== null && child.exitCode !== undefined) ||
       (child.signalCode !== null && child.signalCode !== undefined);
@@ -1142,7 +1148,11 @@ function reclaimConfirmedExitedDirectorySyncHelpers(): void {
     }
     if (!exited) continue;
     directorySyncHelperRegistry.activeChildren.delete(child);
-    if (stuckDirectorySyncHelpers.get(directory) === child) {
+    const directory =
+      directorySyncHelperDirectories.get(child) ??
+      [...stuckDirectorySyncHelpers].find(([, owner]) => owner === child)?.[0];
+    directorySyncHelperDirectories.delete(child);
+    if (directory && stuckDirectorySyncHelpers.get(directory) === child) {
       stuckDirectorySyncHelpers.delete(directory);
       failedIsolatedDirectorySyncHomes.delete(directory);
     }

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -1136,10 +1136,12 @@ async function syncDirectory(directory: string): Promise<void> {
     if (error instanceof DirectorySyncOperationTimeoutError) {
       // open(2) cannot be cancelled. If the kernel eventually returns a
       // handle after our retry budget has advanced, close it without keeping
-      // credential admission or cleanup pending.
-      void openAttempt
-        .then((lateHandle) => closeDirectoryHandle(lateHandle, directory))
-        .catch(() => undefined);
+      // another open from racing the unresolved request or its late close.
+      const cleanupAttempt = openAttempt.then(
+        (lateHandle) => closeDirectoryHandle(lateHandle, directory),
+        () => undefined,
+      );
+      retainDirectorySyncCleanup(directory, cleanupAttempt);
     }
     throw error;
   }

--- a/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-credentials.ts
@@ -422,7 +422,6 @@ async function closeCredentialLeaseServer(server: Server): Promise<void> {
       if (error) rejectClose(error);
       else resolveClose();
     });
-    server.closeAllConnections();
   });
 }
 function quarantineCredentialCleanup(
@@ -825,7 +824,7 @@ async function syncDirectoryDurably(directory: string): Promise<void> {
       if (
         attempt === MAX_DIRECTORY_SYNC_ATTEMPTS ||
         error instanceof DirectorySyncOperationTimeoutError ||
-        error instanceof PermanentDirectorySyncHelperError
+        error instanceof UnconfirmedDirectorySyncHelperTerminationError
       ) {
         break;
       }
@@ -846,13 +845,14 @@ async function syncDirectoryDurably(directory: string): Promise<void> {
 
 async function syncDirectory(directory: string): Promise<void> {
   if (process.platform === "win32") return;
+  reclaimConfirmedExitedDirectorySyncHelpers();
   // Once an in-process filesystem request times out it cannot be cancelled.
   // Keep that single request observed, and permanently use killable helper
   // processes for this home so recovery remains available without accumulating
   // additional parent-process handles or requests.
   if (isolatedDirectorySyncHomes.has(directory)) {
     if (failedIsolatedDirectorySyncHomes.has(directory)) {
-      throw new PermanentDirectorySyncHelperError(directory);
+      throw new UnconfirmedDirectorySyncHelperTerminationError(directory);
     }
     await syncDirectoryInIsolatedProcess(directory);
     return;
@@ -982,8 +982,9 @@ function reserveParentDirectorySyncOperation(): symbol | null {
 async function syncDirectoryInIsolatedProcess(
   directory: string,
 ): Promise<void> {
+  reclaimConfirmedExitedDirectorySyncHelpers();
   if (failedIsolatedDirectorySyncHomes.has(directory)) {
-    throw new PermanentDirectorySyncHelperError(directory);
+    throw new UnconfirmedDirectorySyncHelperTerminationError(directory);
   }
   const activeAttempt = isolatedDirectorySyncAttempts.get(directory);
   if (activeAttempt !== undefined) return await activeAttempt;
@@ -999,6 +1000,7 @@ async function syncDirectoryInIsolatedProcess(
 }
 
 async function runDirectorySyncHelper(directory: string): Promise<void> {
+  reclaimConfirmedExitedDirectorySyncHelpers();
   if (
     directorySyncHelperRegistry.activeChildren.size >=
     MAX_DIRECTORY_SYNC_HELPERS
@@ -1027,9 +1029,11 @@ async function runDirectorySyncHelper(directory: string): Promise<void> {
     );
     directorySyncHelperRegistry.activeChildren.add(child);
     child.unref();
-  } catch {
-    failedIsolatedDirectorySyncHomes.add(directory);
-    throw new PermanentDirectorySyncHelperError(directory);
+  } catch (error) {
+    throw new Error(
+      `Managed Codex credential directory helper could not start for ${directory}`,
+      { cause: error },
+    );
   }
   await new Promise<void>((resolveHelper, rejectHelper) => {
     let timeout: NodeJS.Timeout | undefined;
@@ -1053,18 +1057,19 @@ async function runDirectorySyncHelper(directory: string): Promise<void> {
       directorySyncHelperRegistry.activeChildren.delete(child);
       if (stuckDirectorySyncHelpers.get(directory) === child) {
         stuckDirectorySyncHelpers.delete(directory);
+        failedIsolatedDirectorySyncHomes.delete(directory);
       }
       child.off("error", onError);
       child.off("exit", onExit);
       child.off("close", onClose);
     };
-    const fencePermanently = (): void => {
+    const fenceUntilExitConfirmed = (): void => {
       failedIsolatedDirectorySyncHomes.add(directory);
       stuckDirectorySyncHelpers.set(directory, child);
-      settle(new PermanentDirectorySyncHelperError(directory));
+      settle(new UnconfirmedDirectorySyncHelperTerminationError(directory));
     };
     const onError = (): void => {
-      fencePermanently();
+      fenceUntilExitConfirmed();
       // A missing pid proves spawn never created a process, so no retained
       // reaper or global capacity slot is necessary.
       if (child.pid === undefined) reap();
@@ -1098,22 +1103,50 @@ async function runDirectorySyncHelper(directory: string): Promise<void> {
       // this is the resource-release acknowledgement the in-process API lacks.
       try {
         if (!child.kill("SIGKILL")) {
-          fencePermanently();
+          fenceUntilExitConfirmed();
+          reclaimConfirmedExitedDirectorySyncHelpers();
           return;
         }
         killAcknowledgementTimeout = setTimeout(() => {
           // A child that does not acknowledge SIGKILL is retained as the sole
-          // reaper for this home. Permanently fail closed so no later attempt
-          // can accumulate another possibly stuck process.
-          fencePermanently();
+          // reaper for this home. Fail closed until an event or a kernel probe
+          // confirms exit, so no later attempt can accumulate another process.
+          fenceUntilExitConfirmed();
+          reclaimConfirmedExitedDirectorySyncHelpers();
         }, DIRECTORY_SYNC_HELPER_KILL_ACK_TIMEOUT_MS);
         killAcknowledgementTimeout.unref?.();
       } catch {
-        fencePermanently();
+        fenceUntilExitConfirmed();
+        reclaimConfirmedExitedDirectorySyncHelpers();
       }
     }, DIRECTORY_SYNC_OPERATION_TIMEOUT_MS);
     timeout.unref?.();
   });
+}
+
+function reclaimConfirmedExitedDirectorySyncHelpers(): void {
+  for (const [directory, child] of stuckDirectorySyncHelpers) {
+    let exited =
+      (child.exitCode !== null && child.exitCode !== undefined) ||
+      (child.signalCode !== null && child.signalCode !== undefined);
+    if (!exited && child.pid !== undefined) {
+      try {
+        // ChildProcess events are advisory for capacity accounting: an exited
+        // helper can fail to deliver `exit`/`close` while its owner is under
+        // pressure. A signal-0 ESRCH result is the kernel confirmation that
+        // reclaiming this global slot cannot permit another live helper.
+        process.kill(child.pid, 0);
+      } catch (error) {
+        exited = errorCode(error) === "ESRCH";
+      }
+    }
+    if (!exited) continue;
+    directorySyncHelperRegistry.activeChildren.delete(child);
+    if (stuckDirectorySyncHelpers.get(directory) === child) {
+      stuckDirectorySyncHelpers.delete(directory);
+      failedIsolatedDirectorySyncHomes.delete(directory);
+    }
+  }
 }
 
 function retainDirectorySyncCleanup(
@@ -1151,12 +1184,12 @@ class DirectorySyncOperationTimeoutError extends Error {
   }
 }
 
-class PermanentDirectorySyncHelperError extends Error {
+class UnconfirmedDirectorySyncHelperTerminationError extends Error {
   constructor(directory: string) {
     super(
-      `Managed Codex credential directory helper termination was not acknowledged and is permanently unavailable for ${directory}`,
+      `Managed Codex credential directory helper termination was not acknowledged for ${directory}`,
     );
-    this.name = "PermanentDirectorySyncHelperError";
+    this.name = "UnconfirmedDirectorySyncHelperTerminationError";
   }
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Codex can authenticate through an API key or an `auth.json` document.
> - Forwarding managed credentials in process arguments, durable session options, or general environment state would leak them across the runner boundary.
> - The ACPX sandbox therefore needs a private Codex home, bounded staging, crash-safe cleanup intent, and cross-process ownership that fails closed without relying on writable marker files.
> - This pull request establishes that credential boundary before later PRs connect the Codex ACP process.

## Linked Issues or Issue Description

**Agent or provider**

The qualified Codex ACPX profile.

**Why this adapter is useful**

Managed installations may already have a Codex login document, while service deployments may provide an API key or inline JSON. The runner needs all three modes without copying ambient home state, accepting ambiguous sources, persisting secret values in ordinary runner state, following links, or allowing concurrent processes to mutate the same credential home.

**How the agent is invoked**

A later runtime-host pull request acquires this credential lease before opening Codex and closes it during shutdown and failed-start paths. API keys remain launch-only environment values. JSON credentials are atomically staged as `auth.json` inside the isolated Codex home. This pull request does not spawn Codex, add a dependency, register an adapter, or change execution selection.

**Additional context**

This is the lowest unmerged PR in the runner series and targets `master` directly. It deliberately requires one explicit credential source and never reads the Paperclip server user's ambient home by default.

## What Changed

- Add one-use managed Codex credential leases for API-key, inline-JSON, and explicit managed-file modes.
- Reject missing and ambiguous source combinations.
- Require absolute external managed-file paths, private ownership and permissions on POSIX, bounded documents, no-follow opens, and stable file identity during reads.
- Stage JSON through a deterministic private no-follow staging path, scrub stale staging state on admission, sync the file, rename atomically, and sync the parent directory.
- Persist a bounded cleanup intent and remove staged or provider-generated authentication files without following links.
- Fence each canonical credential home with a markerless 2-of-3 exclusive loopback quorum derived from the current UID and canonical home. One unrelated occupied candidate is tolerated; two occupied candidates fail closed before credential mutation.
- Bound stuck parent filesystem operations and cleanup helpers process-wide so an unresponsive filesystem cannot create unbounded work.
- Zero temporary credential buffers and make cleanup retryable without allowing a stale cleanup generation to affect a successor.
- Add focused tests for credential modes, permissions, malformed and ambiguous sources, symlink rejection, deterministic staging, quorum contention and crash release, stuck-operation bounds, and idempotent cleanup.

## Verification

- Prettier and `git diff --check` passed for the exact pushed head.
- Greptile reviewed the exact head at 5/5 with no blocking finding; independent static audits found no remaining correctness, security, test-contract, or resource-bound blocker.
- GitHub Actions passed on the exact head `29e75afb7b8529b9d070070e0c1462e795d115bb`, including Build, Typecheck, the complete test matrix, e2e, verify, and security checks. One unrelated hosted-runner `npm ENOENT` shard passed on its GitHub rerun.
- The diff contains 2 files and does not change `pnpm-lock.yaml`, workflows, dependencies, public package exports, server selection, or UI behavior.

## Risks

The primary risks are credential disclosure, concurrent ownership, and cleanup that outlives its authority. Secret values never enter returned identity or durable runner data. Source and destination operations are bounded, no-follow, privately permissioned, and crash-durable. The markerless kernel quorum prevents concurrent home mutation without trusting a replaceable marker, while process-global operation/helper caps prevent unresponsive filesystem work from growing without bound. Cleanup is generation-scoped so a stale retry cannot remove a successor's credential.

## Model Used

OpenAI Codex with GPT-5 and repository tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing public item or described the issue in this PR
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal task identifier
- [ ] I have run the affected tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have documented the credential and cleanup boundary
- [x] All applicable GitHub Actions are green
- [x] Greptile is 5/5 with every actionable comment resolved
- [x] I will address all review findings before requesting merge
