### PR TITLE
feat(runner): bind semantic tools to ACPX sessions

### DIFF
--- a/packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.test.ts
@@ -325,7 +325,7 @@ describe("Codex ACPX runtime adapter", () => {
         },
         { signal: new AbortController().signal },
       ),
-    ).resolves.toEqual({ outcome: "allow_once" });
+    ).resolves.toEqual({ outcome: "reject_once" });
     await expect(
       runtimeOptions?.onPermissionRequest?.(
         {

--- a/packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.test.ts
@@ -267,7 +267,11 @@ describe("Codex ACPX runtime adapter", () => {
     const signal = new AbortController().signal;
 
     expect(
-      port.startTurn({ text: "Complete the task.", requestId: "turn-1", signal }),
+      port.startTurn({
+        text: "Complete the task.",
+        requestId: "turn-1",
+        signal,
+      }),
     ).toBe(turn);
     expect(runtime.startTurn).toHaveBeenCalledWith({
       handle: HANDLE,
@@ -276,6 +280,91 @@ describe("Codex ACPX runtime adapter", () => {
       requestId: "turn-1",
       signal,
     });
+  });
+
+  it("projects only ephemeral MCP bindings and applies fail-closed permissions", async () => {
+    const runtime = fakeRuntime();
+    let runtimeOptions: AcpRuntimeOptions | undefined;
+    const port = await openCodexAcpxRuntime(
+      {
+        ...openOptions(fakeCommand()),
+        permissionMode: "deny-all",
+        mcpServers: [
+          {
+            name: "paperclip",
+            url: "http://127.0.0.1:3210/mcp",
+            bearerToken: "bridge-secret",
+            runnerOwned: true,
+          },
+        ],
+      },
+      {
+        createRegistry: () => registry(),
+        createStore: () => store(),
+        createRuntime: (options) => {
+          runtimeOptions = options;
+          return runtime;
+        },
+      },
+    );
+
+    expect(runtimeOptions?.mcpServers).toEqual([
+      {
+        type: "http",
+        name: "paperclip",
+        url: "http://127.0.0.1:3210/mcp",
+        headers: [{ name: "Authorization", value: "Bearer bridge-secret" }],
+      },
+    ]);
+    await expect(
+      runtimeOptions?.onPermissionRequest?.(
+        {
+          sessionId: "session-1",
+          inferredKind: "execute",
+          raw: { _meta: { is_mcp_tool_approval: true } },
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).resolves.toEqual({ outcome: "allow_once" });
+    await expect(
+      runtimeOptions?.onPermissionRequest?.(
+        {
+          sessionId: "session-1",
+          inferredKind: "execute",
+          raw: {},
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).resolves.toEqual({ outcome: "reject_once" });
+    expect(
+      JSON.stringify(vi.mocked(runtime.ensureSession).mock.calls),
+    ).not.toContain("bridge-secret");
+    await port.close({ reason: "complete" });
+  });
+
+  it("delegates permissions that require an unavailable coordinator", async () => {
+    const runtime = fakeRuntime();
+    let runtimeOptions: AcpRuntimeOptions | undefined;
+    const port = await openCodexAcpxRuntime(openOptions(fakeCommand()), {
+      createRegistry: () => registry(),
+      createStore: () => store(),
+      createRuntime: (options) => {
+        runtimeOptions = options;
+        return runtime;
+      },
+    });
+
+    await expect(
+      runtimeOptions?.onPermissionRequest?.(
+        {
+          sessionId: "session-1",
+          inferredKind: "write",
+          raw: {},
+        },
+        { signal: new AbortController().signal },
+      ),
+    ).resolves.toBeUndefined();
+    await port.close({ reason: "complete" });
   });
 
   it("fails closed and closes the session when ACPX omits recovery identity", async () => {
@@ -1177,6 +1266,7 @@ function openOptions(
       OMITTED: undefined,
     },
     systemInstructions: "Use Paperclip tools.",
+    mcpServers: [],
   };
 }
 

--- a/packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.ts
@@ -18,6 +18,7 @@ import type {
   AcpxRuntimePortIdentity,
   AcpxRuntimePortOpenOptions,
 } from "./runtime-host.js";
+import { decideAcpxPermission } from "./permission-policy.js";
 
 const VERIFIED_COMMAND_SENTINEL = "paperclip-verified-acpx-command";
 const DEFAULT_RUNTIME_CLOSE_TIMEOUT_MS = 2_000;
@@ -142,6 +143,11 @@ export async function openCodexAcpxRuntime(
       await baseStore.save(record);
     },
   };
+  const runnerOwnedMcpServerNames = new Set(
+    options.mcpServers
+      .filter((server) => server.runnerOwned)
+      .map((server) => server.name),
+  );
   const runtime = createRuntime({
     cwd: options.cwd,
     sessionStore,
@@ -158,6 +164,28 @@ export async function openCodexAcpxRuntime(
       escalate: options.permissionPolicy.escalate
         ? [...options.permissionPolicy.escalate]
         : undefined,
+    },
+    mcpServers: options.mcpServers.map((server) => ({
+      type: "http" as const,
+      name: server.name,
+      url: server.url,
+      headers: [
+        { name: "Authorization", value: `Bearer ${server.bearerToken}` },
+      ],
+    })),
+    onPermissionRequest: async (request) => {
+      const disposition = decideAcpxPermission(
+        options.profile.agent,
+        options.permissionMode,
+        request,
+        {
+          runnerOwnedMcpServerNames,
+          allConfiguredMcpServersAreRunnerOwned:
+            options.mcpServers.length > 0 &&
+            options.mcpServers.every((server) => server.runnerOwned),
+        },
+      );
+      return disposition === "delegate" ? undefined : { outcome: disposition };
     },
     spawnEnvironment: () => definedEnvironment(options.launchEnvironment),
     spawnCwd: options.cwd,

--- a/packages/paperclip-runner/src/drivers/acpx/runtime-host.test.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/runtime-host.test.ts
@@ -111,6 +111,78 @@ describe("ACPX runtime host", () => {
     expect(fixture.commandClose).toHaveBeenCalledOnce();
   });
 
+  it("owns an authenticated semantic bridge without persisting its secret", async () => {
+    const fixture = await hostFixture();
+    const handler = vi.fn(async ({ tool }) => ({ tool, ok: true }));
+    let bridge:
+      | { url: string; bearerToken: string; name: string; runnerOwned: boolean }
+      | undefined;
+    const host = await AcpxRuntimeHost.open(
+      {
+        ...fixture.options,
+        agent: "codex",
+        model: "gpt-5.6-sol",
+        permissionMode: "deny-all",
+        environment: { PAPERCLIP_ACPX_CODEX_AUTH_JSON_SECRET: "{}" },
+        semanticTools: {
+          tools: [
+            {
+              name: "documents.read",
+              description: "Read one document.",
+              inputSchema: {
+                type: "object",
+                properties: { id: { type: "string" } },
+                required: ["id"],
+                additionalProperties: false,
+              },
+            },
+          ],
+          handler,
+        },
+      },
+      fixture.dependencies({
+        openRuntime: async (options) => {
+          bridge = options.mcpServers[0];
+          return runtimePort();
+        },
+      }),
+    );
+
+    expect(bridge).toMatchObject({
+      name: "paperclip",
+      runnerOwned: true,
+    });
+    expect(new URL(bridge!.url).hostname).toBe("127.0.0.1");
+    const response = await fetch(bridge!.url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${bridge!.bearerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "call-1",
+        method: "tools/call",
+        params: { name: "documents.read", arguments: { id: "doc-1" } },
+      }),
+    });
+    expect(await response.json()).toMatchObject({
+      result: { content: [{ text: '{"tool":"documents.read","ok":true}' }] },
+    });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(JSON.stringify(host.persistedEnvironment())).not.toContain(
+      bridge!.bearerToken,
+    );
+
+    await host.close({ reason: "complete" });
+    await expect(
+      fetch(bridge!.url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${bridge!.bearerToken}` },
+      }),
+    ).rejects.toThrow();
+  });
+
   it("selects and verifies Claude's qualified reported model", async () => {
     const fixture = await hostFixture();
     let selected = false;

--- a/packages/paperclip-runner/src/drivers/acpx/runtime-host.ts
+++ b/packages/paperclip-runner/src/drivers/acpx/runtime-host.ts
@@ -2,6 +2,11 @@ import type { AcpRuntimeEvent, AcpRuntimeTurnResult } from "acpx/runtime";
 
 import type { NativeAcpxPermissionMode } from "../../contracts/native-execution.js";
 import {
+  startRunnerToolBridge,
+  type RunnerToolBridge,
+  type RunnerToolBridgeOptions,
+} from "../runner-tool-bridge.js";
+import {
   stageManagedCodexCredential,
   type ManagedCodexCredentialLease,
 } from "./codex-credentials.js";
@@ -77,13 +82,23 @@ export interface AcpxRuntimePortOpenOptions {
   systemInstructions: string;
   /** Abort provider admission and clean any runtime that resolves too late. */
   signal?: AbortSignal;
+  mcpServers: readonly AcpxMcpServerBinding[];
 }
 
 export interface AcpxRetainedCleanupFailure {
-  resource: "credential" | "command" | "runtime";
+  resource: "credential" | "command" | "runtime" | "tool_bridge";
   attempt: number;
   error: unknown;
 }
+
+export interface AcpxMcpServerBinding {
+  name: string;
+  url: string;
+  bearerToken: string;
+  runnerOwned: boolean;
+}
+
+export type AcpxSemanticToolSession = Omit<RunnerToolBridgeOptions, "secret">;
 
 export interface AcpxRuntimeHostDependencies {
   verifyInstallation?: (
@@ -112,6 +127,7 @@ export interface OpenAcpxRuntimeHostOptions {
   expectedIdentity?: AcpxExpectedSessionIdentity;
   /** Abort admission without admitting resources that resolve afterward. */
   signal?: AbortSignal;
+  semanticTools?: AcpxSemanticToolSession;
 }
 
 const activeRuntimeHostCleanupOwners = new Set<Promise<unknown>>();
@@ -125,6 +141,7 @@ export class AcpxRuntimeHost {
   readonly #sandbox: AcpxRuntimeSandbox;
   readonly #credential: ManagedCodexCredentialLease | null;
   readonly #command: VerifiedAcpxCommandLease;
+  readonly #toolBridge: RunnerToolBridge | null;
   #activeTurn: AcpxRuntimeTurn | null = null;
   #closingStarted = false;
   #closePromise: Promise<void> | null = null;
@@ -137,6 +154,7 @@ export class AcpxRuntimeHost {
     sandbox: AcpxRuntimeSandbox;
     credential: ManagedCodexCredentialLease | null;
     command: VerifiedAcpxCommandLease;
+    toolBridge: RunnerToolBridge | null;
   }) {
     this.#runtime = input.runtime;
     this.#binding = input.binding;
@@ -144,6 +162,7 @@ export class AcpxRuntimeHost {
     this.#sandbox = input.sandbox;
     this.#credential = input.credential;
     this.#command = input.command;
+    this.#toolBridge = input.toolBridge;
   }
 
   static async open(
@@ -184,6 +203,7 @@ export class AcpxRuntimeHost {
     }
     let command: VerifiedAcpxCommandLease | null = null;
     let credential: ManagedCodexCredentialLease | null = null;
+    let toolBridge: RunnerToolBridge | null = null;
     let runtime: AcpxRuntimePort | null = null;
     try {
       const sandbox = await runAbortableAdmissionStage(options.signal, () =>
@@ -216,6 +236,16 @@ export class AcpxRuntimeHost {
         reportFailure: (failure) =>
           dependencies.reportRetainedCleanupFailure(failure),
       });
+      toolBridge = options.semanticTools
+        ? await acquireAbortableAdmissionResource({
+            signal: options.signal,
+            acquire: () => startRunnerToolBridge(options.semanticTools!),
+            resource: "tool_bridge",
+            releaseLate: (lateToolBridge) => lateToolBridge.close(),
+            reportFailure: (failure) =>
+              dependencies.reportRetainedCleanupFailure(failure),
+          })
+        : null;
       runtime = await acquireAbortableAdmissionResource({
         signal: options.signal,
         acquire: () =>
@@ -232,6 +262,16 @@ export class AcpxRuntimeHost {
             launchEnvironment: sandbox.launchEnvironment,
             systemInstructions: boundedInstructions(options.systemInstructions),
             ...(options.signal === undefined ? {} : { signal: options.signal }),
+            mcpServers: toolBridge
+              ? [
+                  {
+                    name: "paperclip",
+                    url: toolBridge.url,
+                    bearerToken: toolBridge.secret,
+                    runnerOwned: true,
+                  },
+                ]
+              : [],
           }),
         resource: "runtime",
         releaseLate: (lateRuntime) =>
@@ -270,10 +310,12 @@ export class AcpxRuntimeHost {
         sandbox,
         credential,
         command,
+        toolBridge,
       });
     } catch (error) {
       const cleanupError = await cleanupRuntimeResources(
         runtime,
+        toolBridge,
         credential,
         command,
         "ACPX runtime initialization failed",
@@ -361,6 +403,7 @@ export class AcpxRuntimeHost {
     }
     const cleanupError = await cleanupRuntimeResources(
       this.#runtime,
+      this.#toolBridge,
       this.#credential,
       this.#command,
       reason,
@@ -514,6 +557,7 @@ async function boundedCancellation(
 
 async function cleanupRuntimeResources(
   runtime: AcpxRuntimePort | null,
+  toolBridge: RunnerToolBridge | null,
   credential: ManagedCodexCredentialLease | null,
   command: VerifiedAcpxCommandLease | null,
   reason: string,
@@ -536,6 +580,12 @@ async function cleanupRuntimeResources(
   const runtimeOutcome = runtime
     ? settle(() => runtime.close({ reason }))
     : Promise.resolve(null);
+  const toolBridgeOutcome = (async (): Promise<unknown | null> => {
+    // Preserve the semantic-session cleanup order: the bridge is revoked once
+    // the runtime close attempt settles, even when that attempt fails.
+    await runtimeOutcome;
+    return toolBridge === null ? null : await settle(() => toolBridge.close());
+  })();
   const commandOutcome = command
     ? settle(() => command.close())
     : Promise.resolve(null);
@@ -546,6 +596,7 @@ async function cleanupRuntimeResources(
   })();
   const outcomes = await Promise.all([
     runtimeOutcome,
+    toolBridgeOutcome,
     commandOutcome,
     credentialOutcome,
   ]);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The runner package provides a provider-neutral execution boundary.
> - The admitted Codex ACPX runtime needs access to the run-scoped semantic tool catalog.
> - The tool endpoint contains an authentication secret and must stay outside durable session state.
> - ACPX permission requests must follow the same run policy as semantic tool authorization.
> - The deny-all mode must reject every request, including requests for runner-owned MCP tools.
> - This pull request composes the authenticated loopback bridge into the admitted Codex runtime.
> - The benefit is a closed tool catalog with fail-closed permissions and bounded cleanup.

## Linked Issues or Issue Description

Refs #12403

**Subsystem affected**

This change affects `packages/paperclip-runner` and its package-local Codex ACPX runtime boundary.

**Problem or motivation**

The package has an authenticated semantic MCP bridge and an admitted Codex ACPX session. The two components are not connected. A direct connection must not persist the bridge token. It must not allow unrelated MCP operations. The deny-all mode must remain closed for runner-owned MCP requests.

**Proposed solution**

The runtime host starts one loopback bridge when semantic tools are configured. It passes an ephemeral bearer binding to ACPX. The adapter projects that binding into the ACP runtime configuration. It sends each permission request through the existing ACPX permission policy. The deny-all mode rejects every request. Other requests either receive the policy result or delegate to an available coordinator.

**Alternatives considered**

Persisting MCP configuration with the ACPX session was rejected because it would retain authentication material. A global MCP endpoint was rejected because it would weaken run isolation.

**Roadmap alignment**

This is package-local hardening for the existing experimental runner work. It does not enable a new user-facing adapter.

## What Changed

- Start and own one authenticated semantic MCP bridge when a host receives semantic tool options.
- Pass one ephemeral loopback MCP binding to the Codex ACPX adapter.
- Keep the bridge token out of the persisted environment and ACPX session options.
- Map the runner-owned HTTP MCP binding into ACPX runtime configuration with a bearer header.
- Apply the existing ACPX permission policy to runtime permission requests.
- Keep the deny-all mode closed for runner-owned MCP requests.
- Delegate only the permission decisions that require a coordinator.
- Revoke the tool bridge after the runtime close attempt settles, including when runtime close fails.
- Release staged credentials only after the exact runtime close succeeds.
- Add focused host and adapter tests for bridge dispatch, secret isolation, fail-closed permissions, delegation, and cleanup.

## Verification

- Exact head: `8ec3bec234beb56dfe744099ff9a45109fc583bc`.
- Stack position: #12403 is merged. This pull request targets `master`. #12405 is stacked on this pull request.
- The exact pull request delta contains four files:
  - `packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.ts`
  - `packages/paperclip-runner/src/drivers/acpx/codex-runtime-adapter.test.ts`
  - `packages/paperclip-runner/src/drivers/acpx/runtime-host.ts`
  - `packages/paperclip-runner/src/drivers/acpx/runtime-host.test.ts`
- `git diff --check` passed for the exact four-file delta.
- This delta does not change dependencies, `pnpm-lock.yaml`, workflows, migrations, server selection, UI behavior, or production runner wiring.
- GitHub Actions: **PASS** for the exact head, including policy, build, typecheck/release, server, workspace, serialized-server, canary, and e2e lanes. An unrelated fixed-port `EADDRINUSE` failure in `loopback-listener.test.ts` passed on the targeted GitHub rerun without a patch change.
- Security checks: **PASS** for the exact head, including Superagent, Snyk, contributor trust, and Socket.
- Greptile: **5/5** for the exact head with no open P2s, recommendations, follow-ups, or review threads.
- No local test result is claimed. GitHub Actions is the authoritative verification environment for this revision.

## Risks

The main risk is secret or permission leakage at the ACP boundary. The host passes the bearer token only in ephemeral runtime configuration. It does not put the token in the persisted environment or ACPX session options. The existing permission policy controls every ACPX permission request. The deny-all mode rejects runner-owned MCP requests too. Another risk is partial cleanup. The host revokes the tool bridge after the runtime close attempt settles. It retains staged credentials if the exact runtime close fails. This pull request stays inside the runner package and does not select the experimental runner in the server.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5.6, extended reasoning, repository tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
