### PR TITLE
feat(runner): bind ACPX event scope

### DIFF
--- a/packages/paperclip-runner/README.md
+++ b/packages/paperclip-runner/README.md
@@ -60,6 +60,11 @@ request identity, event order, frame and queue limits, timeouts, redacted
 diagnostics, and process-group cleanup. This transport remains package-local.
 It does not change runnerd provider selection in this slice.
 
+Before a later provider adapter consumes a valid sidecar event, the Rust core
+also requires its optional or mandatory run and turn scope to match the active
+execution. Process and diagnostic events can remain global. All operational,
+tool, input, permission, and terminal events require the exact active binding.
+
 Run the complete contract gate with:
 
 ```sh

--- a/packages/paperclip-runner/runner/crates/runner-core/src/acpx_event_scope.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/acpx_event_scope.rs
@@ -1,0 +1,124 @@
+use crate::acpx_sidecar_transport::AcpxSidecarEvent;
+use crate::generated_acpx_sidecar_contract::GeneratedAcpxSidecarEventType;
+use crate::local_runner::LocalRunnerError;
+
+const MAX_SCOPE_ID_CHARS: usize = 160;
+
+/// Holds the run and turn authority used to admit ACPX sidecar events.
+///
+/// The sidecar transport validates framing and sequence identity. This scope
+/// validates that a well-formed event still belongs to the run and turn that
+/// runnerd is currently executing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcpxEventScope {
+    run_id: String,
+    active_turn_id: Option<String>,
+}
+
+impl AcpxEventScope {
+    pub fn new(run_id: impl Into<String>) -> Result<Self, LocalRunnerError> {
+        let run_id = run_id.into();
+        validate_scope_id(&run_id, "run")?;
+        Ok(Self {
+            run_id,
+            active_turn_id: None,
+        })
+    }
+
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    pub fn active_turn_id(&self) -> Option<&str> {
+        self.active_turn_id.as_deref()
+    }
+
+    pub fn bind_turn(&mut self, turn_id: impl Into<String>) -> Result<(), LocalRunnerError> {
+        let turn_id = turn_id.into();
+        validate_scope_id(&turn_id, "turn")?;
+        match self.active_turn_id.as_deref() {
+            Some(active_turn_id) if active_turn_id == turn_id.as_str() => Ok(()),
+            Some(_) => Err(LocalRunnerError::invalid(
+                "ACPX event scope already has a different active turn",
+            )),
+            None => {
+                self.active_turn_id = Some(turn_id);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn clear_turn(&mut self, turn_id: &str) -> Result<(), LocalRunnerError> {
+        validate_scope_id(turn_id, "turn")?;
+        if self.active_turn_id.as_deref() != Some(turn_id) {
+            return Err(LocalRunnerError::invalid(
+                "ACPX event scope cannot clear a stale turn",
+            ));
+        }
+        self.active_turn_id = None;
+        Ok(())
+    }
+
+    pub fn validate_event(&self, event: &AcpxSidecarEvent) -> Result<(), LocalRunnerError> {
+        if let Some(run_id) = event.run_id.as_deref() {
+            validate_scope_id(run_id, "event run")?;
+        }
+        if let Some(turn_id) = event.turn_id.as_deref() {
+            validate_scope_id(turn_id, "event turn")?;
+        }
+        let global_event = matches!(
+            event.event_type,
+            GeneratedAcpxSidecarEventType::RuntimeProcess
+                | GeneratedAcpxSidecarEventType::RuntimeDiagnostic
+        );
+
+        match event.run_id.as_deref() {
+            Some(run_id) if run_id != self.run_id => {
+                return Err(LocalRunnerError::invalid(
+                    "ACPX sidecar event named a stale run",
+                ));
+            }
+            Some(_) => {}
+            None if !global_event => {
+                return Err(LocalRunnerError::invalid(
+                    "ACPX sidecar event omitted its run binding",
+                ));
+            }
+            None => {}
+        }
+
+        if global_event && event.turn_id.is_none() {
+            return Ok(());
+        }
+        if global_event && event.run_id.is_none() {
+            return Err(LocalRunnerError::invalid(
+                "ACPX sidecar event named a turn without a run binding",
+            ));
+        }
+
+        let turn_id = event.turn_id.as_deref().ok_or_else(|| {
+            LocalRunnerError::invalid("ACPX sidecar event omitted its turn binding")
+        })?;
+        match self.active_turn_id.as_deref() {
+            Some(active_turn_id) if active_turn_id == turn_id => Ok(()),
+            Some(_) => Err(LocalRunnerError::invalid(
+                "ACPX sidecar event named a stale turn",
+            )),
+            None => Err(LocalRunnerError::invalid(
+                "ACPX sidecar event requires an active turn",
+            )),
+        }
+    }
+}
+
+fn validate_scope_id(value: &str, label: &str) -> Result<(), LocalRunnerError> {
+    if value.is_empty()
+        || value.chars().count() > MAX_SCOPE_ID_CHARS
+        || value.chars().any(char::is_control)
+    {
+        return Err(LocalRunnerError::invalid(format!(
+            "ACPX event scope {label} id is invalid"
+        )));
+    }
+    Ok(())
+}

--- a/packages/paperclip-runner/runner/crates/runner-core/src/lib.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+pub mod acpx_event_scope;
 pub mod acpx_sidecar_transport;
 pub mod codex_provider;
 pub mod durable;

--- a/packages/paperclip-runner/runner/crates/runner-core/tests/acpx_event_scope.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/tests/acpx_event_scope.rs
@@ -1,0 +1,150 @@
+use paperclip_runner_core::acpx_event_scope::AcpxEventScope;
+use paperclip_runner_core::acpx_sidecar_transport::AcpxSidecarEvent;
+use paperclip_runner_core::generated_acpx_sidecar_contract::GeneratedAcpxSidecarEventType;
+use serde_json::json;
+
+fn event(
+    event_type: GeneratedAcpxSidecarEventType,
+    run_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> AcpxSidecarEvent {
+    AcpxSidecarEvent {
+        sequence: 1,
+        event_type,
+        run_id: run_id.map(str::to_owned),
+        turn_id: turn_id.map(str::to_owned),
+        payload: json!({}),
+    }
+}
+
+#[test]
+fn admits_every_turn_scoped_event_only_for_the_active_run_and_turn() {
+    let mut scope = AcpxEventScope::new("run-1").unwrap();
+    scope.bind_turn("turn-1").unwrap();
+    for event_type in [
+        GeneratedAcpxSidecarEventType::RuntimeEvent,
+        GeneratedAcpxSidecarEventType::RuntimePermissionRequested,
+        GeneratedAcpxSidecarEventType::RuntimeInputRequested,
+        GeneratedAcpxSidecarEventType::RuntimeToolCalled,
+        GeneratedAcpxSidecarEventType::RuntimeTurnTerminal,
+    ] {
+        scope
+            .validate_event(&event(event_type, Some("run-1"), Some("turn-1")))
+            .unwrap();
+    }
+}
+
+#[test]
+fn rejects_missing_and_cross_run_turn_bindings() {
+    let mut scope = AcpxEventScope::new("run-1").unwrap();
+    scope.bind_turn("turn-1").unwrap();
+    for (run_id, turn_id, message) in [
+        (None, Some("turn-1"), "omitted its run binding"),
+        (Some("run-2"), Some("turn-1"), "stale run"),
+        (Some("run-1"), None, "omitted its turn binding"),
+        (Some("run-1"), Some("turn-2"), "stale turn"),
+    ] {
+        let error = scope
+            .validate_event(&event(
+                GeneratedAcpxSidecarEventType::RuntimeToolCalled,
+                run_id,
+                turn_id,
+            ))
+            .unwrap_err();
+        assert!(error.to_string().contains(message), "{error}");
+    }
+
+    scope.clear_turn("turn-1").unwrap();
+    let error = scope
+        .validate_event(&event(
+            GeneratedAcpxSidecarEventType::RuntimeToolCalled,
+            Some("run-1"),
+            Some("turn-1"),
+        ))
+        .unwrap_err();
+    assert!(error.to_string().contains("requires an active turn"));
+}
+
+#[test]
+fn admits_unbound_process_and_diagnostic_events() {
+    let scope = AcpxEventScope::new("run-1").unwrap();
+    for event_type in [
+        GeneratedAcpxSidecarEventType::RuntimeProcess,
+        GeneratedAcpxSidecarEventType::RuntimeDiagnostic,
+    ] {
+        scope
+            .validate_event(&event(event_type, None, None))
+            .unwrap();
+        scope
+            .validate_event(&event(event_type, Some("run-1"), None))
+            .unwrap();
+    }
+}
+
+#[test]
+fn validates_optional_scope_on_process_and_diagnostic_events() {
+    let mut scope = AcpxEventScope::new("run-1").unwrap();
+    scope.bind_turn("turn-1").unwrap();
+    let wrong_run = scope
+        .validate_event(&event(
+            GeneratedAcpxSidecarEventType::RuntimeProcess,
+            Some("run-2"),
+            None,
+        ))
+        .unwrap_err();
+    assert!(wrong_run.to_string().contains("stale run"));
+
+    let missing_run = scope
+        .validate_event(&event(
+            GeneratedAcpxSidecarEventType::RuntimeDiagnostic,
+            None,
+            Some("turn-1"),
+        ))
+        .unwrap_err();
+    assert!(missing_run.to_string().contains("without a run binding"));
+
+    let wrong_turn = scope
+        .validate_event(&event(
+            GeneratedAcpxSidecarEventType::RuntimeDiagnostic,
+            Some("run-1"),
+            Some("turn-2"),
+        ))
+        .unwrap_err();
+    assert!(wrong_turn.to_string().contains("stale turn"));
+
+    scope
+        .validate_event(&event(
+            GeneratedAcpxSidecarEventType::RuntimeProcess,
+            Some("run-1"),
+            Some("turn-1"),
+        ))
+        .unwrap();
+}
+
+#[test]
+fn binds_and_clears_one_turn_idempotently() {
+    let mut scope = AcpxEventScope::new("run-1").unwrap();
+    scope.bind_turn("turn-1").unwrap();
+    scope.bind_turn("turn-1").unwrap();
+    assert_eq!(scope.active_turn_id(), Some("turn-1"));
+    assert!(scope.bind_turn("turn-2").is_err());
+    scope.clear_turn("turn-1").unwrap();
+    assert_eq!(scope.active_turn_id(), None);
+    assert!(scope.clear_turn("turn-1").is_err());
+}
+
+#[test]
+fn rejects_invalid_scope_identifiers() {
+    assert!(AcpxEventScope::new("").is_err());
+    assert!(AcpxEventScope::new("run\n1").is_err());
+    let mut scope = AcpxEventScope::new("run-1").unwrap();
+    assert!(scope.bind_turn("t".repeat(161)).is_err());
+    let oversized_run_id = "r".repeat(161);
+    assert!(scope
+        .validate_event(&event(
+            GeneratedAcpxSidecarEventType::RuntimeDiagnostic,
+            Some(&oversized_run_id),
+            None,
+        ))
+        .is_err());
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The runner needs a bounded process boundary for each qualified provider runtime
> - The package now has a fail-closed transport for the Codex ACPX sidecar
> - A valid sidecar frame can still name the wrong run or turn
> - A later provider adapter must reject those events before it maps or persists them
> - This pull request adds package-local run and turn scope validation and keeps it unselected
> - The benefit is an explicit authorization boundary without a production behavior change

## Linked Issues or Issue Description

Refs #12412

Refs #12410

## What Changed

- Add an `AcpxEventScope` for one run and at most one active turn.
- Validate run and turn identifiers before they enter scope state.
- Make repeated binding of the same turn safe.
- Reject a second active turn and a stale turn clear.
- Require exact run and active turn bindings for operational, tool, input, permission, and terminal events.
- Permit process and diagnostic events without a scope because they can describe the sidecar process itself.
- Validate every optional run or turn binding on process and diagnostic events.
- Add an integration-test file for all seven event families, missing scope, cross-run scope, cross-turn scope, inactive turns, turn lifecycle, and invalid identifiers.
- Document the event authorization boundary.
- Do not change dependencies, lockfiles, workflows, runnerd selection, server behavior, UI, or migrations.

## Verification

- Replay base: `75708fec6d421a247ba2fc832997de24ed10a085` (`master` after #12412 merged).
- Exact replay head: `88bb248442b8f628c20e977d2c2dbc21d85fb6dd`.
- Stable patch ID: `0b6443b1bc32ed244f650936026367dd84bcfd65`, identical to the reviewed `c5654218..972a3b38` delta.
- The exact delta is 4 files and 280 additions, all in `packages/paperclip-runner`; it contains no lockfile, workflow, server, UI, or migration change.
- Focused Rust scope, package, repository, security, and Greptile checks: **PASSED** on the replayed exact head. Full CI run `33360199404` completed successfully, Greptile is exact-head 5/5, all security checks pass, and no review threads remain unresolved.
- No local test result is claimed. GitHub Actions is the authoritative verification environment for this replayed revision.

## Risks

- Event scope is a security boundary because it rejects data from another run or turn.
- The validator fails closed on missing, malformed, stale, or cross-scope identifiers.
- Process and diagnostic events can remain global, but any scope they provide must be valid.
- The package exports a new Rust module, but no production path constructs it in this pull request.
- A later provider adapter must bind and clear the exact turn around each sidecar turn.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5.6, agentic reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
