### PR TITLE
Stop the stranded watchdog from blocking parked standing loops

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -7835,6 +7835,126 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.status).toBe("blocked");
   });
 
+  it("treats a running checkout lock as a live execution path when the run snapshot names another issue", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    const liveRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: liveRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId: randomUUID(),
+        retryReason: "issue_continuation_needed",
+        source: "issue.continuation_recovery",
+      },
+      startedAt: new Date("2026-03-19T00:10:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:10:00.000Z"),
+    });
+    await db
+      .update(issues)
+      .set({ checkoutRunId: liveRunId, updatedAt: new Date("2026-03-19T00:10:05.000Z") })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id).sort()).toEqual([runId, liveRunId].sort());
+  });
+
+  it("does not escalate a standing loop the latest productive run parked back to todo", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        status: "todo",
+        changes: { status: { from: "in_progress", to: "todo" } },
+      },
+      createdAt: new Date("2026-03-19T00:04:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.standingParkExempted).toBe(1);
+    expect(result.recentProgressExempted).toBe(0);
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
+  it("still escalates when the todo park predates the latest productive run", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        status: "todo",
+        changes: { status: { from: "in_progress", to: "todo" } },
+      },
+      createdAt: new Date("2026-03-18T23:00:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.standingParkExempted).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -872,7 +872,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
-    const [run, deferredWake] = await Promise.all([
+    const [run, lockedRun, deferredWake] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -881,6 +881,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             eq(heartbeatRuns.companyId, companyId),
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      // A coalesced or unscoped wake stamps `contextSnapshot.issueId` with a
+      // different issue (or nothing) while still holding this issue's checkout /
+      // execution lock. The locks, not the snapshot, are the authoritative path.
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .innerJoin(
+          issues,
+          or(
+            eq(issues.checkoutRunId, heartbeatRuns.id),
+            eq(issues.executionRunId, heartbeatRuns.id),
+          ),
+        )
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.id, issueId),
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
           ),
         )
@@ -901,7 +925,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return Boolean(run || lockedRun || deferredWake);
   }
 
   async function hasPendingWakeInteraction(companyId: string, issueId: string) {
@@ -941,13 +965,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
-  async function wasTodoHandedBackDuringOrAfterLatestRun(
+  async function hadTodoHandBackRecoveryActionSince(
     issue: typeof issues.$inferSelect,
-    latestRun: LatestIssueRun,
+    since: Date,
   ) {
-    if (issue.status !== "todo" || latestRun?.status !== "succeeded") return false;
-    const runBeganAt = latestRun.startedAt ?? latestRun.createdAt;
-
     return db
       .select({ id: issueRecoveryActions.id })
       .from(issueRecoveryActions)
@@ -957,11 +978,60 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(issueRecoveryActions.sourceIssueId, issue.id),
           eq(issueRecoveryActions.status, "resolved"),
           eq(issueRecoveryActions.outcome, "handed_back"),
-          gte(issueRecoveryActions.resolvedAt, runBeganAt),
+          gte(issueRecoveryActions.resolvedAt, since),
         ),
       )
       .limit(1)
       .then((rows) => Boolean(rows[0]));
+  }
+
+  async function wasTodoHandedBackDuringOrAfterLatestRun(
+    issue: typeof issues.$inferSelect,
+    latestRun: LatestIssueRun,
+  ) {
+    if (issue.status !== "todo" || latestRun?.status !== "succeeded") return false;
+    return hadTodoHandBackRecoveryActionSince(issue, latestRun.startedAt ?? latestRun.createdAt);
+  }
+
+  // A standing loop parking itself back to `todo` is a valid disposition, and a
+  // later wake flips the issue back to `in_progress`. Read the transition, not
+  // the current status.
+  async function didLatestRunParkIssueToTodo(
+    issue: typeof issues.$inferSelect,
+    latestRun: LatestIssueRun,
+  ) {
+    if (latestRun?.status !== "succeeded") return false;
+    const runBeganAt = latestRun.startedAt ?? latestRun.createdAt;
+
+    const parked = await db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, issue.companyId),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issue.id),
+          eq(activityLog.action, "issue.updated"),
+          gte(activityLog.createdAt, runBeganAt),
+          sql`(
+            (
+              ${activityLog.details} ->> 'status' = 'todo'
+              AND ${activityLog.details} -> '_previous' ->> 'status' IS NOT NULL
+              AND ${activityLog.details} -> '_previous' ->> 'status' <> 'todo'
+            )
+            OR
+            (
+              ${activityLog.details} -> 'changes' -> 'status' ->> 'to' = 'todo'
+              AND ${activityLog.details} -> 'changes' -> 'status' ->> 'from' IS NOT NULL
+              AND ${activityLog.details} -> 'changes' -> 'status' ->> 'from' <> 'todo'
+            )
+          )`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+
+    return parked || hadTodoHandBackRecoveryActionSince(issue, runBeganAt);
   }
 
   async function hasQueuedIssueWake(companyId: string, issueId: string, agentId?: string | null) {
@@ -3559,6 +3629,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       waitingOnReviewResolved: 0,
       providerQuotaMonitored: 0,
       recentProgressExempted: 0,
+      standingParkExempted: 0,
       operatorCancelExempted: 0,
       skipped: 0,
       issueIds: [] as string[],
@@ -4140,34 +4211,38 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (isRepeatedProductiveContinuationRecovery(successfulRun)) {
-          // GGU-809: skip escalation if the assignee has shown visible progress
-          // (comment or attachment) within the exemption window. Falling
-          // through here lets the normal continuation-retry path enqueue the
-          // next wake, which is the correct behaviour for batch workflows.
-          const exempted = await hasRecentVisibleProgress(
-            issue.companyId,
-            issue.id,
-            agentId,
-            STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
-          );
-          if (!exempted) {
-            const updated = await escalateStrandedAssignedIssue({
-              issue,
-              previousStatus: "in_progress",
-              latestRun: successfulRun,
-              comment:
-                "Paperclip automatically retried continuation for this assigned `in_progress` issue and the retry " +
-                "made progress, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
-            });
-            if (updated) {
-              result.escalated += 1;
-              result.issueIds.push(issue.id);
-            } else {
-              result.skipped += 1;
+          if (await didLatestRunParkIssueToTodo(issue, successfulRun)) {
+            result.standingParkExempted += 1;
+          } else {
+            // GGU-809: skip escalation if the assignee has shown visible progress
+            // (comment or attachment) within the exemption window. Falling
+            // through here lets the normal continuation-retry path enqueue the
+            // next wake, which is the correct behaviour for batch workflows.
+            const exempted = await hasRecentVisibleProgress(
+              issue.companyId,
+              issue.id,
+              agentId,
+              STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+            );
+            if (!exempted) {
+              const updated = await escalateStrandedAssignedIssue({
+                issue,
+                previousStatus: "in_progress",
+                latestRun: successfulRun,
+                comment:
+                  "Paperclip automatically retried continuation for this assigned `in_progress` issue and the retry " +
+                  "made progress, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
+              });
+              if (updated) {
+                result.escalated += 1;
+                result.issueIds.push(issue.id);
+              } else {
+                result.skipped += 1;
+              }
+              continue;
             }
-            continue;
+            result.recentProgressExempted += 1;
           }
-          result.recentProgressExempted += 1;
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {


### PR DESCRIPTION
## Problem

A standing weekly loop that parks itself back to `todo` after a productive sweep gets escalated to
`blocked` by `reconcileStrandedAssignedIssues` with `stranded_assigned_issue`, burning an
assignment-recovery action. Observed on the same issue six times in three days.

Two independent defects combine:

**1. `hasActiveExecutionPath` cannot see checkout/execution locks.**
It matched only `heartbeat_runs.contextSnapshot->>'issueId' = <issue>`. A coalesced wake stamps the
snapshot with a *different* issue (or an unscoped timer stamps nothing) while the run still holds
this issue's `checkoutRunId`. The issue then looks pathless while a heartbeat is actively running on
it. Real sequence: a timer run coalesced onto a continuation for issue B, checked out issue A 69s
later, and the watchdog escalated A 21s after that.

**2. The park itself is invisible.**
`wasTodoHandedBackDuringOrAfterLatestRun` only fires when the issue's *current* status is still
`todo`, and only counts recovery `handed_back` actions — never an agent's own `PATCH status: todo`.
Once a later wake flips the issue back to `in_progress`, the evidence of a valid disposition is gone
and `isRepeatedProductiveContinuationRecovery` sends it straight to escalation.

## Change

`server/src/services/recovery/service.ts`

- `hasActiveExecutionPath` additionally matches non-terminal runs referenced by
  `issues.checkoutRunId` / `issues.executionRunId`. The locks, not the snapshot, are authoritative.
- New `didLatestRunParkIssueToTodo` reads the `issue.updated` **transition** from the activity log
  (both `details._previous.status` and `details.changes.status` shapes) since the latest successful
  run began, plus the existing recovery `handed_back` signal. Status-independent, so a later
  `in_progress` flip no longer erases the evidence.
- On the `in_progress` + repeated-productive-continuation path, a detected park skips escalation and
  increments a new `standingParkExempted` counter, falling through to the normal continuation-retry
  enqueue (same shape as the existing `recentProgressExempted` exemption). The counter is spread into
  the existing `logger.warn` payload, so exemptions are observable.
- `wasTodoHandedBackDuringOrAfterLatestRun` is refactored onto a shared
  `hadTodoHandBackRecoveryActionSince` helper; its behaviour is unchanged.

Escalation is *narrowed*, never widened: nothing that escalated before stops escalating unless the
agent demonstrably parked the issue during or after the latest successful run.

## Tests

`server/src/__tests__/heartbeat-process-recovery.test.ts`, three cases:

1. **Live checkout lock, foreign snapshot** — running run whose `contextSnapshot.issueId` is another
   issue but which holds this issue's `checkoutRunId`. Expects no escalation, no comment, status
   stays `in_progress`.
2. **Standing-loop park** — latest succeeded productive-continuation run logged
   `in_progress -> todo`. Expects `escalated: 0`, `standingParkExempted: 1`,
   `continuationRequeued: 1`, and no `stranded_issue_recovery` issue created.
3. **Regression guard** — identical fixture with the park timestamped *before* the run started.
   Expects `escalated: 1`, `standingParkExempted: 0`, status `blocked`.

Cases 1 and 2 were confirmed to fail on the parent commit before the fix.

## Note, not fixed here

`classifyIssueGraphLiveness`'s `activeRuns` input joins `issues.executionRunId` only, so the same
checkout-lock blind spot exists in the issue-graph liveness watchdog. Left alone deliberately —
different watchdog, no observed misfire, and narrowing that one belongs in its own change.

## How to test

```
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/heartbeat-process-recovery.test.ts \
  src/__tests__/issue-recovery-actions.test.ts
```

```test-evidence:
sha: 1c8bb9b704d080af9088375a1a1e86120a4ef170
command: pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/issue-recovery-actions.test.ts src/__tests__/recovery-observability.test.ts src/__tests__/recovery-stale-issue-lock-sweep.test.ts src/__tests__/recovery-classifiers.test.ts
exit: 0
totals: 5 test files passed, 192 tests passed, 0 failed (64.08s)
command: pnpm --filter @paperclipai/server typecheck
exit: 0
totals: tsc clean, 0 errors
worktree: clean before and after; local == fork remote == PR head (1c8bb9b704d080af9088375a1a1e86120a4ef170)
scope: this repo has no bin/ci; the full gate is `pnpm test:run` (whole-workspace). The scoped
  recovery suites above plus the server typecheck were run locally; full-suite coverage is left to
  the PR's GitHub checks.
finished_at: 2026-08-28T08:30:21Z
```
