### PR TITLE
fix(recovery): stop the stranded watchdog from blocking parked standing loops

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -7835,6 +7835,126 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.status).toBe("blocked");
   });
 
+  it("treats a running checkout lock as a live execution path when the run snapshot names another issue", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    const liveRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: liveRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId: randomUUID(),
+        retryReason: "issue_continuation_needed",
+        source: "issue.continuation_recovery",
+      },
+      startedAt: new Date("2026-03-19T00:10:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:10:00.000Z"),
+    });
+    await db
+      .update(issues)
+      .set({ checkoutRunId: liveRunId, updatedAt: new Date("2026-03-19T00:10:05.000Z") })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id).sort()).toEqual([runId, liveRunId].sort());
+  });
+
+  it("does not escalate a standing loop the latest productive run parked back to todo", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        status: "todo",
+        changes: { status: { from: "in_progress", to: "todo" } },
+      },
+      createdAt: new Date("2026-03-19T00:04:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.standingParkExempted).toBe(1);
+    expect(result.recentProgressExempted).toBe(0);
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
+  it("still escalates when the todo park predates the latest productive run", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        status: "todo",
+        changes: { status: { from: "in_progress", to: "todo" } },
+      },
+      createdAt: new Date("2026-03-18T23:00:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.standingParkExempted).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -872,7 +872,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
-    const [run, deferredWake] = await Promise.all([
+    const [run, lockedRun, deferredWake] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -881,6 +881,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             eq(heartbeatRuns.companyId, companyId),
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      // A coalesced or unscoped wake stamps `contextSnapshot.issueId` with a
+      // different issue (or nothing) while still holding this issue's checkout /
+      // execution lock. The locks, not the snapshot, are the authoritative path.
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .innerJoin(
+          issues,
+          or(
+            eq(issues.checkoutRunId, heartbeatRuns.id),
+            eq(issues.executionRunId, heartbeatRuns.id),
+          ),
+        )
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.id, issueId),
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
           ),
         )
@@ -901,7 +925,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return Boolean(run || lockedRun || deferredWake);
   }
 
   async function hasPendingWakeInteraction(companyId: string, issueId: string) {
@@ -941,13 +965,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
-  async function wasTodoHandedBackDuringOrAfterLatestRun(
+  async function hadTodoHandBackRecoveryActionSince(
     issue: typeof issues.$inferSelect,
-    latestRun: LatestIssueRun,
+    since: Date,
   ) {
-    if (issue.status !== "todo" || latestRun?.status !== "succeeded") return false;
-    const runBeganAt = latestRun.startedAt ?? latestRun.createdAt;
-
     return db
       .select({ id: issueRecoveryActions.id })
       .from(issueRecoveryActions)
@@ -957,11 +978,60 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(issueRecoveryActions.sourceIssueId, issue.id),
           eq(issueRecoveryActions.status, "resolved"),
           eq(issueRecoveryActions.outcome, "handed_back"),
-          gte(issueRecoveryActions.resolvedAt, runBeganAt),
+          gte(issueRecoveryActions.resolvedAt, since),
         ),
       )
       .limit(1)
       .then((rows) => Boolean(rows[0]));
+  }
+
+  async function wasTodoHandedBackDuringOrAfterLatestRun(
+    issue: typeof issues.$inferSelect,
+    latestRun: LatestIssueRun,
+  ) {
+    if (issue.status !== "todo" || latestRun?.status !== "succeeded") return false;
+    return hadTodoHandBackRecoveryActionSince(issue, latestRun.startedAt ?? latestRun.createdAt);
+  }
+
+  // A standing loop parking itself back to `todo` is a valid disposition, and a
+  // later wake flips the issue back to `in_progress`. Read the transition, not
+  // the current status.
+  async function didLatestRunParkIssueToTodo(
+    issue: typeof issues.$inferSelect,
+    latestRun: LatestIssueRun,
+  ) {
+    if (latestRun?.status !== "succeeded") return false;
+    const runBeganAt = latestRun.startedAt ?? latestRun.createdAt;
+
+    const parked = await db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, issue.companyId),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issue.id),
+          eq(activityLog.action, "issue.updated"),
+          gte(activityLog.createdAt, runBeganAt),
+          sql`(
+            (
+              ${activityLog.details} ->> 'status' = 'todo'
+              AND ${activityLog.details} -> '_previous' ->> 'status' IS NOT NULL
+              AND ${activityLog.details} -> '_previous' ->> 'status' <> 'todo'
+            )
+            OR
+            (
+              ${activityLog.details} -> 'changes' -> 'status' ->> 'to' = 'todo'
+              AND ${activityLog.details} -> 'changes' -> 'status' ->> 'from' IS NOT NULL
+              AND ${activityLog.details} -> 'changes' -> 'status' ->> 'from' <> 'todo'
+            )
+          )`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+
+    return parked || hadTodoHandBackRecoveryActionSince(issue, runBeganAt);
   }
 
   async function hasQueuedIssueWake(companyId: string, issueId: string, agentId?: string | null) {
@@ -3559,6 +3629,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       waitingOnReviewResolved: 0,
       providerQuotaMonitored: 0,
       recentProgressExempted: 0,
+      standingParkExempted: 0,
       operatorCancelExempted: 0,
       skipped: 0,
       issueIds: [] as string[],
@@ -4140,34 +4211,38 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (isRepeatedProductiveContinuationRecovery(successfulRun)) {
-          // GGU-809: skip escalation if the assignee has shown visible progress
-          // (comment or attachment) within the exemption window. Falling
-          // through here lets the normal continuation-retry path enqueue the
-          // next wake, which is the correct behaviour for batch workflows.
-          const exempted = await hasRecentVisibleProgress(
-            issue.companyId,
-            issue.id,
-            agentId,
-            STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
-          );
-          if (!exempted) {
-            const updated = await escalateStrandedAssignedIssue({
-              issue,
-              previousStatus: "in_progress",
-              latestRun: successfulRun,
-              comment:
-                "Paperclip automatically retried continuation for this assigned `in_progress` issue and the retry " +
-                "made progress, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
-            });
-            if (updated) {
-              result.escalated += 1;
-              result.issueIds.push(issue.id);
-            } else {
-              result.skipped += 1;
+          if (await didLatestRunParkIssueToTodo(issue, successfulRun)) {
+            result.standingParkExempted += 1;
+          } else {
+            // GGU-809: skip escalation if the assignee has shown visible progress
+            // (comment or attachment) within the exemption window. Falling
+            // through here lets the normal continuation-retry path enqueue the
+            // next wake, which is the correct behaviour for batch workflows.
+            const exempted = await hasRecentVisibleProgress(
+              issue.companyId,
+              issue.id,
+              agentId,
+              STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+            );
+            if (!exempted) {
+              const updated = await escalateStrandedAssignedIssue({
+                issue,
+                previousStatus: "in_progress",
+                latestRun: successfulRun,
+                comment:
+                  "Paperclip automatically retried continuation for this assigned `in_progress` issue and the retry " +
+                  "made progress, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
+              });
+              if (updated) {
+                result.escalated += 1;
+                result.issueIds.push(issue.id);
+              } else {
+                result.skipped += 1;
+              }
+              continue;
             }
-            continue;
+            result.recentProgressExempted += 1;
           }
-          result.recentProgressExempted += 1;
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery subsystem finds assigned issues that lost their execution path, and it escalates them to `blocked`
> - `reconcileStrandedAssignedIssues` reads liveness from one field only: `heartbeat_runs.contextSnapshot->>'issueId'`
> - A coalesced timer wake writes a different issue id into that snapshot, but the run still holds the issue checkout lock, so a live run reads as no execution path
> - At the same time, an agent that parks a standing loop back to `todo` leaves no evidence the watchdog can read after a later wake sets the issue to `in_progress` again
> - The two gaps combine, and the watchdog moves healthy parked work to `blocked` and consumes an assignment-recovery action
> - This pull request makes the checkout lock authoritative for liveness, and it makes the watchdog read the park transition instead of the current status
> - The benefit is that a standing loop that parks itself correctly stays out of the blocked queue

## Linked Issues or Issue Description

No public GitHub issue exists for this. The problem description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

A standing weekly loop issue completes a productive heartbeat. The agent writes a summary comment. The agent then sends `PATCH /api/issues/{id}` with `status: todo` to park the loop until the next sweep. Hours later the watchdog moves the same issue to `blocked` with the reason `stranded_assigned_issue`, and it consumes an assignment-recovery action. This occurred six times in three days on one issue. The adapter was healthy at each occurrence.

Two defects combine.

First, `hasActiveExecutionPath` matches a run only when `heartbeat_runs.contextSnapshot->>'issueId'` equals the issue. A coalesced wake writes a different issue id into that snapshot. An unscoped timer wake writes no issue id at all. The run can still hold `issues.checkoutRunId` for this issue. The issue then reads as pathless while a heartbeat runs on it.

Second, `wasTodoHandedBackDuringOrAfterLatestRun` returns `false` unless the issue status is still `todo`. It also counts only a recovery `handed_back` action. It never counts an agent `PATCH status: todo`. A later wake sets the issue to `in_progress`, the park evidence disappears, and `isRepeatedProductiveContinuationRecovery` sends the issue to escalation.

**Expected behavior**

The watchdog must not escalate an issue that a live run holds through `checkoutRunId` or `executionRunId`. The watchdog must not escalate a standing loop that the latest successful run parked back to `todo`.

**Steps to reproduce**

1. Assign a standing loop issue to an agent, and set the issue to `in_progress`.
2. Let a heartbeat run succeed with `retryReason: issue_continuation_needed` and `source: issue.productive_terminal_continuation_recovery`, so `isRepeatedProductiveContinuationRecovery` returns `true`.
3. Make the agent send `PATCH status: todo` at the end of that run.
4. Start a timer wake that coalesces onto a continuation for a different issue, so `contextSnapshot.issueId` names that other issue.
5. Let that run check out the standing loop issue, which sets `issues.checkoutRunId` and sets the status back to `in_progress`.
6. Run `reconcileStrandedAssignedIssues`.
7. The issue moves to `blocked` with `stranded_assigned_issue`, although a run holds its checkout lock.

**Paperclip version or commit**

`8316ceb0b` (`master`, the parent of this branch).

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Not adapter-specific (core bug). It was first seen with the Cursor adapter, but nothing in the failing path reads the adapter.

**Relevant logs or output**

Timing of one occurrence, from the activity log:

```
07:48:57Z  timer run starts; contextSnapshot.issueId names a DIFFERENT issue
07:50:06Z  the same run checks out this issue; issues.checkoutRunId is set
07:50:27Z  watchdog escalates this issue and cites the PREVIOUS run as the latest run
```

**Additional context**

Related open pull requests. None of them is merged, and each solves a different part of the problem:

- Refs #10392 — makes `checkoutRunId` / `executionRunId` authoritative for generic timer checkouts, and adds a transaction boundary. It overlaps with the first change below. That pull request is larger, and it touches seven files.
- Refs #9869 — preserves intentional parking by revalidating lifecycle fields immediately before classification. It closes the read-race. It does not help after a later wake sets the issue back to `in_progress`, which is the case here.
- Refs #6860 — adds `taskId` / `taskKey` snapshot keys to the same liveness probe. It is a different snapshot gap.

If the maintainers prefer to land #10392 first, the first change below can be dropped and the second change can be rebased on it.

## What Changed

All source changes are in `server/src/services/recovery/service.ts`.

- `hasActiveExecutionPath` also matches a non-terminal run that the issue references through `issues.checkoutRunId` or `issues.executionRunId`. The lock is authoritative, and the snapshot is not.
- A new `didLatestRunParkIssueToTodo` reads the `issue.updated` transition from the activity log at or after the latest successful run started. It accepts both detail shapes: `details._previous.status` and `details.changes.status`. It is independent of the current status, so a later `in_progress` flip does not erase the evidence. It also accepts the existing recovery `handed_back` action.
- On the `in_progress` and `isRepeatedProductiveContinuationRecovery` path, a detected park skips `escalateStrandedAssignedIssue`. The code increments a new `standingParkExempted` counter, and it falls through to the normal continuation-retry enqueue. This is the same shape as the existing `recentProgressExempted` exemption.
- The result object is spread into the existing `logger.warn` payload, so the new counter is visible in the server logs.
- `wasTodoHandedBackDuringOrAfterLatestRun` now calls a new shared helper `hadTodoHandBackRecoveryActionSince`. Its behavior does not change.
- Three tests were added to `server/src/__tests__/heartbeat-process-recovery.test.ts`.

## Verification

Run the recovery suites:

```bash
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/heartbeat-process-recovery.test.ts \
  src/__tests__/issue-recovery-actions.test.ts \
  src/__tests__/recovery-observability.test.ts \
  src/__tests__/recovery-stale-issue-lock-sweep.test.ts \
  src/__tests__/recovery-classifiers.test.ts
```

Result: 5 files passed, 192 tests passed, 0 failed, exit code 0.

Run the type check:

```bash
pnpm --filter @paperclipai/server typecheck
```

Result: 0 errors, exit code 0.

The three new tests are:

1. A running run holds this issue through `checkoutRunId`, but its `contextSnapshot.issueId` names a different issue. The watchdog must not escalate, must write no comment, and must leave the status at `in_progress`.
2. The latest successful productive-continuation run logged the transition `in_progress` to `todo`. The result must show `escalated: 0`, `standingParkExempted: 1`, and `continuationRequeued: 1`. No `stranded_issue_recovery` issue is created.
3. A regression guard. The fixture is the same, but the park is dated before the run started. The result must show `escalated: 1` and `standingParkExempted: 0`, and the status must become `blocked`.

Tests 1 and 2 were run against the parent commit, and both failed there. They are therefore not vacuous.

The whole-workspace gate `pnpm test:run` was not run locally. The scoped suites above and the server type check were run locally. Full coverage is left to the CI checks on this pull request.

## Risks

Low risk. No migration, no schema change, and no API change.

The change only narrows escalation. Nothing that escalated before stops escalating, unless the agent parked the issue to `todo` during or after the latest successful run.

Two behaviors to review:

- The exempted issue falls through to the continuation-retry enqueue instead of stopping. A standing loop therefore gets its next wake, parks again, and repeats. This matches the existing `recentProgressExempted` path. It does not create a tight loop, because the continuation retry is rate limited by the existing wake logic.
- `didLatestRunParkIssueToTodo` runs one extra indexed query per candidate issue, and only on the repeated-productive-continuation branch. The branch is rare.

A genuinely stranded issue that an agent parked to `todo` and then abandoned will no longer be escalated by this branch. It is still visible through the normal `todo` dispatch path, and it is still escalated by the other branches of the same sweep.

## Model Used

Claude Opus 5, model id `claude-opus-5[1m]`, 1M token context window, extended thinking enabled, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — "Enforced Outcomes (watchdogs, recovery actions, review gates)" and "Self-healing runs & automatic recovery" are both marked shipped. This is a bug fix inside that shipped area, not new core work.
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation change is needed. The behavior is internal to the recovery sweep, and no public interface changes.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending on this new pull request.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending.
- [x] I will address all Greptile and reviewer comments before requesting merge
