### PR TITLE
fix(ui): improve mobile inbox navigation

### DIFF
--- a/tests/e2e/mobile-header-scroll.spec.ts
+++ b/tests/e2e/mobile-header-scroll.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createCompany(page: Page): Promise<{ id: string; prefix: string }> {
+  const response = await page.request.post("/api/companies", {
+    data: { name: `Mobile header scroll ${Date.now()}` },
+  });
+  expect(response.ok(), `create company failed ${response.status()}: ${await response.text()}`).toBe(true);
+  const company = await response.json();
+  return {
+    id: company.id,
+    prefix: company.issuePrefix ?? company.prefix ?? company.urlKey ?? "E2E",
+  };
+}
+
+async function addScrollableContent(page: Page) {
+  await page.locator("#main-content").evaluate((main) => {
+    const spacer = document.createElement("div");
+    spacer.dataset.mobileHeaderScrollSpacer = "true";
+    spacer.style.height = "2400px";
+    main.append(spacer);
+  });
+}
+
+async function scrollBy(page: Page, browserName: string, deltaY: number) {
+  if (browserName === "webkit") {
+    await page.evaluate((amount) => window.scrollBy(0, amount), deltaY);
+    return;
+  }
+  await page.mouse.wheel(0, deltaY);
+}
+
+test("mobile header hides and restores deterministically under real browser scroll", async ({ page, browserName }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const company = await createCompany(page);
+  const header = page.locator("[data-mobile-header='true']");
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await page.goto(`/${company.prefix}/dashboard`);
+    await expect(header).toBeVisible();
+    await addScrollableContent(page);
+
+    await scrollBy(page, browserName, 160);
+    await expect(header).toHaveAttribute("aria-hidden", "true");
+    await expect(header).toHaveAttribute("inert", "");
+
+    await page.waitForTimeout(300);
+    await scrollBy(page, browserName, -20);
+    await expect(header).not.toHaveAttribute("aria-hidden", "true");
+    await expect(header).not.toHaveAttribute("inert", "");
+
+    await page.waitForTimeout(300);
+    await scrollBy(page, browserName, 160);
+    await expect(header).toHaveAttribute("aria-hidden", "true");
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expect(header).not.toHaveAttribute("aria-hidden", "true");
+  }
+});

--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -338,12 +338,16 @@ describe("Layout", () => {
     expect(header()?.getAttribute("aria-hidden")).toBe("true");
     expect(header()?.hasAttribute("inert")).toBe(true);
 
+    await act(async () => { header()?.dispatchEvent(new Event("transitionend", { bubbles: true })); });
+
     for (const nextTop of [35, 30]) {
       scrollTop = nextTop;
       await act(async () => { window.dispatchEvent(new Event("scroll")); });
     }
     expect(header()?.className).toContain("max-h-(--sz-240px)");
     expect(header()?.hasAttribute("inert")).toBe(false);
+
+    await act(async () => { header()?.dispatchEvent(new Event("transitionend", { bubbles: true })); });
 
     scrollTop = 0;
     await act(async () => { window.dispatchEvent(new Event("scroll")); });

--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -330,14 +330,18 @@ describe("Layout", () => {
     expect(header()?.className).toContain("max-h-(--sz-240px)");
     expect(header()?.getAttribute("aria-hidden")).toBeNull();
 
-    scrollTop = 120;
-    await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    for (const nextTop of [28, 33, 39]) {
+      scrollTop = nextTop;
+      await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    }
     expect(header()?.className).toContain("max-h-0");
     expect(header()?.getAttribute("aria-hidden")).toBe("true");
     expect(header()?.hasAttribute("inert")).toBe(true);
 
-    scrollTop = 80;
-    await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    for (const nextTop of [35, 30]) {
+      scrollTop = nextTop;
+      await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    }
     expect(header()?.className).toContain("max-h-(--sz-240px)");
     expect(header()?.hasAttribute("inert")).toBe(false);
 

--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -310,6 +310,43 @@ describe("Layout", () => {
     });
   });
 
+  it("hides the mobile header on downward scroll and restores it on upward scroll and at the top", async () => {
+    mockSidebarState.isMobile = true;
+    mockSidebarState.sidebarOpen = false;
+    let scrollTop = 0;
+    Object.defineProperty(window, "scrollY", { configurable: true, get: () => scrollTop });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Layout />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    const header = () => container.querySelector<HTMLElement>("[data-mobile-header='true']");
+    expect(header()?.className).toContain("max-h-(--sz-240px)");
+    expect(header()?.getAttribute("aria-hidden")).toBeNull();
+
+    scrollTop = 120;
+    await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    expect(header()?.className).toContain("max-h-0");
+    expect(header()?.getAttribute("aria-hidden")).toBe("true");
+    expect(header()?.hasAttribute("inert")).toBe(true);
+
+    scrollTop = 80;
+    await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    expect(header()?.className).toContain("max-h-(--sz-240px)");
+    expect(header()?.hasAttribute("inert")).toBe(false);
+
+    scrollTop = 0;
+    await act(async () => { window.dispatchEvent(new Event("scroll")); });
+    expect(header()?.getAttribute("aria-hidden")).toBeNull();
+    await act(async () => root.unmount());
+  });
+
   it("collapses atomically when the pointer is still over the sidebar (no re-peek) — PAP-10676", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -649,8 +649,14 @@ export function Layout() {
 
         <div className={cn("flex min-w-0 flex-col", isMobile ? "w-full" : "h-full flex-1")}>
           <div
+            data-mobile-header={isMobile ? "true" : undefined}
+            aria-hidden={isMobile && !mobileNavVisible ? true : undefined}
+            inert={isMobile && !mobileNavVisible ? true : undefined}
             className={cn(
-              isMobile && "sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85",
+              isMobile && "sticky top-0 z-20 overflow-hidden bg-background/95 backdrop-blur transition-[max-height,opacity,transform] duration-200 ease-out motion-reduce:transition-none supports-[backdrop-filter]:bg-background/85",
+              isMobile && (mobileNavVisible
+                ? "max-h-(--sz-240px) translate-y-0 opacity-100"
+                : "pointer-events-none max-h-0 -translate-y-full opacity-0"),
             )}
           >
             <StandaloneBrowserControls mobile={isMobile} />

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -134,6 +134,8 @@ export function Layout() {
   const isSkillsRoute = isSkillsStoreRoute(location.pathname, companyPrefix);
   const onboardingTriggered = useRef(false);
   const lastMainScrollTop = useRef(0);
+  const mobileNavScrollAnchor = useRef(0);
+  const mobileNavScrollDirection = useRef<-1 | 0 | 1>(0);
   const previousPathname = useRef<string | null>(null);
   const mainContentRef = useRef<HTMLElement | null>(null);
   const scrollMemory = useRef(new NavigationScrollMemory());
@@ -474,13 +476,21 @@ export function Layout() {
   }, [isMobile, sidebarOpen, setSidebarOpen]);
 
   const updateMobileNavVisibility = useCallback((currentTop: number) => {
-    const delta = currentTop - lastMainScrollTop.current;
+    const previousTop = lastMainScrollTop.current;
+    const direction = currentTop > previousTop ? 1 : currentTop < previousTop ? -1 : 0;
+
+    if (direction !== 0 && direction !== mobileNavScrollDirection.current) {
+      mobileNavScrollDirection.current = direction;
+      mobileNavScrollAnchor.current = previousTop;
+    }
 
     if (currentTop <= 24) {
       setMobileNavVisible(true);
-    } else if (delta > 8) {
+      mobileNavScrollAnchor.current = currentTop;
+      mobileNavScrollDirection.current = 0;
+    } else if (direction > 0 && currentTop - mobileNavScrollAnchor.current > 8) {
       setMobileNavVisible(false);
-    } else if (delta < -8) {
+    } else if (direction < 0 && mobileNavScrollAnchor.current - currentTop > 8) {
       setMobileNavVisible(true);
     }
 
@@ -491,6 +501,8 @@ export function Layout() {
     if (!isMobile) {
       setMobileNavVisible(true);
       lastMainScrollTop.current = 0;
+      mobileNavScrollAnchor.current = 0;
+      mobileNavScrollDirection.current = 0;
       return;
     }
 

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -136,6 +136,8 @@ export function Layout() {
   const lastMainScrollTop = useRef(0);
   const mobileNavScrollAnchor = useRef(0);
   const mobileNavScrollDirection = useRef<-1 | 0 | 1>(0);
+  const mobileNavVisibleRef = useRef(true);
+  const mobileNavTransitioning = useRef(false);
   const previousPathname = useRef<string | null>(null);
   const mainContentRef = useRef<HTMLElement | null>(null);
   const scrollMemory = useRef(new NavigationScrollMemory());
@@ -475,7 +477,41 @@ export function Layout() {
     };
   }, [isMobile, sidebarOpen, setSidebarOpen]);
 
+  const syncMobileNavScroll = useCallback((currentTop: number) => {
+    lastMainScrollTop.current = currentTop;
+    mobileNavScrollAnchor.current = currentTop;
+    mobileNavScrollDirection.current = 0;
+  }, []);
+
+  const finishMobileNavTransition = useCallback(() => {
+    if (!mobileNavTransitioning.current) return;
+    mobileNavTransitioning.current = false;
+    syncMobileNavScroll(window.scrollY || document.documentElement.scrollTop || 0);
+  }, [syncMobileNavScroll]);
+
+  const setMobileNavVisibility = useCallback((visible: boolean, currentTop: number) => {
+    if (mobileNavVisibleRef.current === visible) return;
+    mobileNavVisibleRef.current = visible;
+    mobileNavTransitioning.current = true;
+    syncMobileNavScroll(currentTop);
+    setMobileNavVisible(visible);
+  }, [syncMobileNavScroll]);
+
   const updateMobileNavVisibility = useCallback((currentTop: number) => {
+    // Collapsing max-height changes the document geometry and can move scrollY.
+    // Do not interpret those transition-generated events as user direction.
+    // The top boundary remains authoritative so navigation is never hidden there.
+    if (currentTop <= 24) {
+      setMobileNavVisibility(true, currentTop);
+      syncMobileNavScroll(currentTop);
+      return;
+    }
+
+    if (mobileNavTransitioning.current) {
+      syncMobileNavScroll(currentTop);
+      return;
+    }
+
     const previousTop = lastMainScrollTop.current;
     const direction = currentTop > previousTop ? 1 : currentTop < previousTop ? -1 : 0;
 
@@ -484,25 +520,21 @@ export function Layout() {
       mobileNavScrollAnchor.current = previousTop;
     }
 
-    if (currentTop <= 24) {
-      setMobileNavVisible(true);
-      mobileNavScrollAnchor.current = currentTop;
-      mobileNavScrollDirection.current = 0;
-    } else if (direction > 0 && currentTop - mobileNavScrollAnchor.current > 8) {
-      setMobileNavVisible(false);
+    if (direction > 0 && currentTop - mobileNavScrollAnchor.current > 8) {
+      setMobileNavVisibility(false, currentTop);
     } else if (direction < 0 && mobileNavScrollAnchor.current - currentTop > 8) {
-      setMobileNavVisible(true);
+      setMobileNavVisibility(true, currentTop);
     }
 
     lastMainScrollTop.current = currentTop;
-  }, []);
+  }, [setMobileNavVisibility, syncMobileNavScroll]);
 
   useEffect(() => {
     if (!isMobile) {
       setMobileNavVisible(true);
-      lastMainScrollTop.current = 0;
-      mobileNavScrollAnchor.current = 0;
-      mobileNavScrollDirection.current = 0;
+      mobileNavVisibleRef.current = true;
+      mobileNavTransitioning.current = false;
+      syncMobileNavScroll(0);
       return;
     }
 
@@ -516,7 +548,13 @@ export function Layout() {
     return () => {
       window.removeEventListener("scroll", onScroll);
     };
-  }, [isMobile, updateMobileNavVisibility]);
+  }, [isMobile, syncMobileNavScroll, updateMobileNavVisibility]);
+
+  useEffect(() => {
+    if (!isMobile || !mobileNavTransitioning.current) return;
+    const timeout = window.setTimeout(finishMobileNavTransition, 250);
+    return () => window.clearTimeout(timeout);
+  }, [finishMobileNavTransition, isMobile, mobileNavVisible]);
 
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
@@ -662,6 +700,7 @@ export function Layout() {
         <div className={cn("flex min-w-0 flex-col", isMobile ? "w-full" : "h-full flex-1")}>
           <div
             data-mobile-header={isMobile ? "true" : undefined}
+            onTransitionEnd={finishMobileNavTransition}
             aria-hidden={isMobile && !mobileNavVisible ? true : undefined}
             inert={isMobile && !mobileNavVisible ? true : undefined}
             className={cn(

--- a/ui/src/components/SwipeBetweenTabs.test.tsx
+++ b/ui/src/components/SwipeBetweenTabs.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SwipeBetweenTabs } from "./SwipeBetweenTabs";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function touch(node: Element, type: "touchstart" | "touchend", x: number, y: number) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const point = { clientX: x, clientY: y };
+  Object.defineProperty(event, "touches", { value: type === "touchend" ? [] : [point] });
+  Object.defineProperty(event, "changedTouches", { value: [point] });
+  node.dispatchEvent(event);
+}
+
+describe("SwipeBetweenTabs", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => container.remove());
+
+  const render = (value: string, onValueChange = vi.fn(), filled = false) => {
+    const root = createRoot(container);
+    flushSync(() => {
+      root.render(
+        <SwipeBetweenTabs items={["mine", "recent", "unread"]} value={value} onValueChange={onValueChange}>
+          {filled ? <div data-testid="card">Task card</div> : <div data-testid="empty">Inbox zero</div>}
+        </SwipeBetweenTabs>,
+      );
+    });
+    return { root, onValueChange };
+  };
+
+  it("changes an empty screen in both horizontal directions", () => {
+    const onValueChange = vi.fn();
+    const { root } = render("recent", onValueChange);
+    const surface = container.querySelector("[data-swipe-between-tabs]")!;
+
+    flushSync(() => {
+      touch(surface, "touchstart", 240, 100);
+      touch(surface, "touchend", 120, 104);
+    });
+    expect(onValueChange).toHaveBeenLastCalledWith("unread");
+
+    flushSync(() => {
+      touch(surface, "touchstart", 120, 100);
+      touch(surface, "touchend", 240, 104);
+    });
+    expect(onValueChange).toHaveBeenLastCalledWith("mine");
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    flushSync(() => root.unmount());
+  });
+
+  it("changes a filled screen but leaves row swipe actions in control", () => {
+    const onValueChange = vi.fn();
+    const { root } = render("recent", onValueChange, true);
+    const surface = container.querySelector("[data-swipe-between-tabs]")!;
+    const card = container.querySelector("[data-testid='card']")!;
+
+    flushSync(() => {
+      touch(card, "touchstart", 240, 100);
+      touch(card, "touchend", 120, 102);
+    });
+    expect(onValueChange).toHaveBeenCalledWith("unread");
+
+    card.setAttribute("data-row-swipe-action", "");
+    flushSync(() => {
+      touch(card, "touchstart", 240, 100);
+      touch(card, "touchend", 120, 102);
+    });
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(surface.className).toContain("touch-pan-y");
+    flushSync(() => root.unmount());
+  });
+
+  it("ignores vertical gestures, controls, and the end of the tab list", () => {
+    const onValueChange = vi.fn();
+    const root = createRoot(container);
+    flushSync(() => {
+      root.render(
+        <SwipeBetweenTabs items={["mine", "recent"]} value="recent" onValueChange={onValueChange}>
+          <button type="button">Filter</button>
+          <div data-testid="body">Body</div>
+        </SwipeBetweenTabs>,
+      );
+    });
+    const body = container.querySelector("[data-testid='body']")!;
+    const button = container.querySelector("button")!;
+
+    flushSync(() => {
+      touch(body, "touchstart", 200, 80);
+      touch(body, "touchend", 190, 180);
+      touch(button, "touchstart", 220, 80);
+      touch(button, "touchend", 100, 82);
+      touch(body, "touchstart", 220, 80);
+      touch(body, "touchend", 100, 82);
+    });
+    expect(onValueChange).not.toHaveBeenCalled();
+    flushSync(() => root.unmount());
+  });
+});

--- a/ui/src/components/SwipeBetweenTabs.tsx
+++ b/ui/src/components/SwipeBetweenTabs.tsx
@@ -1,0 +1,83 @@
+import { useRef, type ReactNode, type TouchEvent } from "react";
+import { cn } from "../lib/utils";
+
+interface SwipeBetweenTabsProps {
+  children: ReactNode;
+  items: readonly string[];
+  value: string;
+  onValueChange: (value: string) => void;
+  className?: string;
+}
+
+const MIN_DISTANCE = 56;
+const MAX_VERTICAL_DRIFT = 48;
+const HORIZONTAL_INTENT_RATIO = 1.25;
+const INTERACTIVE_SELECTOR = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "[contenteditable='true']",
+  "[data-swipe-navigation-ignore]",
+  "[data-row-swipe-action]",
+].join(",");
+
+export function SwipeBetweenTabs({
+  children,
+  items,
+  value,
+  onValueChange,
+  className,
+}: SwipeBetweenTabsProps) {
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    if (event.touches.length !== 1) {
+      startPointRef.current = null;
+      return;
+    }
+
+    const target = event.target;
+    if (target instanceof Element && target.closest(INTERACTIVE_SELECTOR)) {
+      startPointRef.current = null;
+      return;
+    }
+
+    const touch = event.touches[0];
+    startPointRef.current = { x: touch.clientX, y: touch.clientY };
+  };
+
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    const startPoint = startPointRef.current;
+    startPointRef.current = null;
+    if (!startPoint || event.changedTouches.length !== 1) return;
+
+    const touch = event.changedTouches[0];
+    const deltaX = touch.clientX - startPoint.x;
+    const deltaY = touch.clientY - startPoint.y;
+    if (
+      Math.abs(deltaX) < MIN_DISTANCE
+      || Math.abs(deltaY) > MAX_VERTICAL_DRIFT
+      || Math.abs(deltaX) < Math.abs(deltaY) * HORIZONTAL_INTENT_RATIO
+    ) return;
+
+    const currentIndex = items.indexOf(value);
+    if (currentIndex < 0) return;
+    const nextIndex = deltaX < 0 ? currentIndex + 1 : currentIndex - 1;
+    const nextValue = items[nextIndex];
+    if (nextValue) onValueChange(nextValue);
+  };
+
+  return (
+    <div
+      className={cn("touch-pan-y", className)}
+      data-swipe-between-tabs
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={() => { startPointRef.current = null; }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ui/src/components/SwipeToArchive.tsx
+++ b/ui/src/components/SwipeToArchive.tsx
@@ -173,6 +173,7 @@ export function SwipeToArchive({
   return (
     <div
       ref={containerRef}
+      data-row-swipe-action
       className={cn("relative overflow-hidden touch-pan-y", className)}
       style={{
         height: lockedHeight === null ? undefined : isCollapsing ? 0 : lockedHeight,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3,7 +3,7 @@
 
 @font-face {
   font-family: "InterVariable";
-  src: url("../fonts/InterVariable.woff2") format("woff2");
+  src: url("/fonts/InterVariable.woff2") format("woff2");
   font-display: swap;
   font-style: normal;
   font-weight: 100 900;
@@ -11,7 +11,7 @@
 
 @font-face {
   font-family: "InterVariable";
-  src: url("../fonts/InterVariable-Italic.woff2") format("woff2");
+  src: url("/fonts/InterVariable-Italic.woff2") format("woff2");
   font-display: swap;
   font-style: italic;
   font-weight: 100 900;

--- a/ui/src/lib/ui-font-assets.test.ts
+++ b/ui/src/lib/ui-font-assets.test.ts
@@ -18,7 +18,7 @@ describe("bundled UI font assets", () => {
       expect(existsSync(fontPath), `${fileName} should exist in ui/public/fonts`).toBe(true);
       expect(statSync(fontPath).isFile(), `${fileName} should be a file`).toBe(true);
       expect(readFileSync(fontPath).subarray(0, 4).toString("ascii")).toBe("wOF2");
-      expect(css).toContain(`url("../fonts/${fileName}")`);
+      expect(css).toContain(`url("/fonts/${fileName}")`);
     }
 
     expect(css).toContain('--font-sans: "InterVariable"');

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -82,6 +82,7 @@ import { IssueFiltersPopover } from "../components/IssueFiltersPopover";
 import { InboxArchiveButton, IssueRow } from "../components/IssueRow";
 import { BlockedInboxView } from "../components/BlockedInboxView";
 import { SwipeToArchive } from "../components/SwipeToArchive";
+import { SwipeBetweenTabs } from "../components/SwipeBetweenTabs";
 
 import { StatusIcon } from "../components/StatusIcon";
 import { cn } from "../lib/utils";
@@ -729,6 +730,7 @@ export function Inbox() {
       ? pathSegment
       : "mine";
   const canArchiveFromTab = isMineInboxTab(tab);
+  const inboxTabs = ["mine", "recent", "unread", "blocked", "all"] as const;
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
@@ -2261,7 +2263,12 @@ export function Inbox() {
   const activeIssueFilterCount = countActiveIssueFilters(issueFilters, true);
   const showGeneralIssueToolbarControls = tab !== "blocked";
   return (
-    <div className="space-y-6">
+    <SwipeBetweenTabs
+      className="space-y-6"
+      items={inboxTabs}
+      value={tab}
+      onValueChange={(value) => navigate(`/inbox/${value}`)}
+    >
       <div className="space-y-2">
         {/* Search — full-width row on mobile, inline on desktop */}
         <div className="relative sm:hidden">
@@ -3152,6 +3159,6 @@ export function Inbox() {
         </>
       )}
 
-    </div>
+    </SwipeBetweenTabs>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that people use to supervise AI agent work.
> - The inbox is the main place where an operator reviews that work.
> - Mobile operators move between inbox tabs with a horizontal gesture.
> - The gesture did not work when a tab had no rows.
> - The mobile header also kept too much vertical space while the operator scrolled.
> - This pull request adds one tab swipe surface and a compact mobile header state.
> - The benefit is faster mobile review with more space for task content.

## Linked Issues or Issue Description

**What happened?**

The mobile inbox could not change tabs with a horizontal swipe when the current tab was empty. The mobile header also stayed fully visible during downward scroll.

**Expected behavior**

A horizontal swipe must change between Mine, Recent, Unread, Blocked, and All on empty and filled tabs. A downward scroll must hide the mobile header. An upward scroll or a return to the top must restore it.

**Steps to reproduce**

1. Start Paperclip from commit `7b73b0825030d06823f05089cbaec49fe87fb714`.
2. Open the inbox in a mobile viewport.
3. Select an empty inbox tab and swipe left or right.
4. Open a filled inbox tab and scroll down.

**Paperclip version or commit**

`7b73b0825030d06823f05089cbaec49fe87fb714`

**Deployment mode**

Local development from source with embedded PostgreSQL.

## What Changed

- Add a shared swipe surface for inbox tab navigation.
- Keep row archive gestures and interactive controls outside tab navigation.
- Hide the mobile header on downward scroll.
- Restore the mobile header on upward scroll and at the top.
- Set `aria-hidden` and `inert` while the header is hidden.
- Use absolute public font URLs so Vite does not serve an HTML fallback for font requests.
- Add tests for empty and filled tab swipes and mobile header states.

## Verification

- `pnpm exec vitest run ui/src/components/SwipeBetweenTabs.test.tsx ui/src/components/SwipeToArchive.test.tsx ui/src/components/Layout.test.tsx ui/src/pages/Inbox.test.tsx ui/src/lib/ui-font-assets.test.ts` passed with 58 tests.
- `pnpm --filter @paperclipai/ui typecheck` passed.
- `pnpm --filter @paperclipai/ui build` passed.
- `git diff --check` passed.
- Chromium headless passed on an iPhone 390 by 844 viewport and a desktop 1440 by 900 viewport.
- The browser test covered empty and filled tabs, left and right swipes, downward scroll, upward scroll, and return to the top.
- The browser test found no console error, page error, failed request, HTTP error response, or HTML asset fallback.
- `pnpm check:token-gates` still reports nine existing color literals in `ui/src/components/onboarding/PillGuy.tsx`. This pull request does not change that file.

## Risks

- A tab swipe could conflict with a row archive swipe. The tab swipe ignores rows that own an archive gesture.
- A hidden header could remain in the accessibility tree. The hidden state sets both `aria-hidden` and `inert`.
- Absolute font URLs assume the existing public font directory. The build and browser asset checks confirm this path.

> This change does not overlap with a planned item in `ROADMAP.md`.

## Model Used

- OpenAI Codex with GPT-5. The context window size was not exposed. The run used reasoning, tool use, code execution, Vitest, TypeScript, Vite, and Playwright.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
