### PR TITLE
ci: synchronize trusted PR policy

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -167,6 +167,12 @@ jobs:
         with:
           node-version: 24
 
+      - name: Validate migration ordering against target branch
+        run: >-
+          node .github/scripts/check-pr-migration-order.mjs
+          "${{ github.event.pull_request.base.sha }}"
+          "${{ github.event.pull_request.head.sha }}"
+
       - name: Validate Dockerfile deps stage
         run: node ./scripts/check-docker-deps-stage.mjs
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -489,6 +489,8 @@ jobs:
           specs="$(node ./scripts/e2e-shard.mjs \
             --shard-index ${{ matrix.shard_index }} --shard-count ${{ matrix.shard_count }})"
           echo "shard ${{ matrix.shard_label }} specs: $specs"
+          # specs is an intentional argument list.
+          # shellcheck disable=SC2086
           pnpm run test:e2e $specs
 
       - name: Upload Playwright report


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses pull request CI to protect changes before merge
> - The trusted reusable workflow will select isolated AWS capacity
> - The active workflow changed while the reusable workflow waited for merge
> - The reusable policy must contain every current CI policy step before activation
> - This pull request synchronizes the migration-order check and shell validation
> - The benefit is one reviewed workflow version with verified job parity

## Linked Issues or Issue Description

Refs #12436

**What existing behavior does this improve?**

This improves the pull request CI workflow synchronization before AWS runner activation.

**Subsystem affected**

Cross-cutting CI automation.

**Current behavior**

The active workflow validates migration order. The new reusable workflow does not yet contain that check.

**Proposed behavior**

Both workflow definitions contain the same heavy jobs and policy steps before the active workflow becomes a thin caller.

**Reason and benefit**

The synchronization prevents policy drift during the two-step secure rollout.

**Breaking changes**

None. AWS routing remains disabled.

## What Changed

- Added the current migration-order validation to the trusted workflow.
- Added the existing shellcheck intent annotation to the active workflow.
- Verified normalized heavy-job parity between both definitions.

## Verification

- actionlint on both workflow files
- Local trusted-routing and normalized workflow-parity tests
- git diff --check

## Risks

Low risk. The migration check already runs in active CI. This change copies it into the inactive trusted definition. AWS routing stays disabled.

## Model Used

OpenAI Codex with GPT-5, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked a related public PR or described the issue with the matching template fields
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
