### PR TITLE
ci: pin equivalent merge validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@d9fc93d8383ece6fba721881a7aba638867f4996
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@3b295b05dc8c8dd82c12e4a9c6f721446c5cb2e8


### PR DESCRIPTION
## Summary

- rotate the thin PR caller from `d9fc93d8383ece6fba721881a7aba638867f4996` to `3b295b05dc8c8dd82c12e4a9c6f721446c5cb2e8`
- keep both exact workflow SHAs authorized in the runner group during the rotation
- keep `AWS_CI_ENABLED=false` until this caller is merged and verified

## Validation

- `actionlint .github/workflows/pr.yml .github/workflows/pr-trusted.yml`
- `node --test ./scripts/__tests__/e2e-shard.test.mjs`
- full AWS/GitHub boundary verification passes with zero active runners