### PR TITLE
fix(ci): emit one runner route

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -49,9 +49,9 @@ jobs:
 
           github_runner='ubuntu-latest'
           aws_runner='runs-on/fleet=paperclip-public-pr-x64/env=public-ci'
-          echo "runner=$github_runner" >> "$GITHUB_OUTPUT"
 
           fail_closed() {
+            echo "runner=$github_runner" >> "$GITHUB_OUTPUT"
             echo "::notice title=AWS CI routing::Using GitHub-hosted runner: $1"
             exit 0
           }


### PR DESCRIPTION
## Summary

- emit exactly one `runner` job output from the trusted gate
- write `ubuntu-latest` only inside fail-closed paths
- write the Fleet label only after every identity, PR-state, merge-equivalence, and rerun-actor check passes

## Canary finding

The live gate reached the trusted success notice, but GitHub retained the first of two duplicate `runner=` outputs, so policy still requested `ubuntu-latest`. No EC2 instance launched. Routing was disabled immediately.

## Validation

- `actionlint .github/workflows/pr-trusted.yml .github/workflows/pr.yml`
- `node --test ./scripts/__tests__/e2e-shard.test.mjs`
- internal routing harness passes and now requires exactly one runner output in all cases
- AWS routing remains disabled during rotation