### PR TITLE
ci: pin single runner route output

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@3b295b05dc8c8dd82c12e4a9c6f721446c5cb2e8
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@b88fadb0390d2113933d5d155f16b07cbd5dafee


### PR DESCRIPTION
## Summary

- rotate the thin PR caller from `3b295b05dc8c8dd82c12e4a9c6f721446c5cb2e8` to `b88fadb0390d2113933d5d155f16b07cbd5dafee`
- keep both exact SHAs authorized during the rotation
- keep AWS routing disabled until the caller and boundary verify

## Validation

- `actionlint .github/workflows/pr.yml .github/workflows/pr-trusted.yml`
- `node --test ./scripts/__tests__/e2e-shard.test.mjs`
- internal routing harness requires exactly one runner output per gate execution