### PR TITLE
ci: exercise secure AWS runner canary

### DIFF
--- a/.github/aws-ci-canary.md
+++ b/.github/aws-ci-canary.md
@@ -1,0 +1,4 @@
+# Secure AWS CI canary
+
+This temporary pull-request-only marker exercises the allowlisted RunsOn Fleet
+routing path. It is not intended to merge into `master`.

--- a/.github/workflows/aws-ci-negative-boundary.yml
+++ b/.github/workflows/aws-ci-negative-boundary.yml
@@ -1,0 +1,17 @@
+name: AWS CI negative boundary
+
+on:
+  pull_request:
+    types: [reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  direct-fleet-request:
+    name: Direct Fleet request must be denied
+    runs-on: runs-on/fleet=paperclip-public-pr-x64/env=public-ci
+    timeout-minutes: 3
+    steps:
+      - name: Fail if an untrusted workflow reaches AWS
+        run: exit 1

--- a/.github/workflows/storybook-visual.yml
+++ b/.github/workflows/storybook-visual.yml
@@ -27,10 +27,8 @@ permissions:
 jobs:
   visual:
     name: Storybook visual regression
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'storybook-visual'))
-    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: runs-on/fleet=paperclip-public-pr-x64/env=public-ci
     timeout-minutes: 35
 
     steps:


### PR DESCRIPTION
## Temporary live canary

This PR exists only to exercise the allowlisted AWS runner route from a fresh branch based on current `master`.

Expected behavior:

- the identity gate runs on GitHub-hosted
- policy and all heavy jobs request `runs-on/fleet=paperclip-public-pr-x64/env=public-ci`
- RunsOn launches ephemeral EC2 instances, capped at 20
- instances terminate after jobs complete or the run is cancelled

This PR will be closed without merging after validation.