### PR TITLE
fix(ci): validate the workflow merge ref

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -42,7 +42,7 @@ jobs:
           EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          EVENT_MERGE_SHA: ${{ github.sha }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -u


### PR DESCRIPTION
## Summary

- use `${{ github.sha }}` as the event merge commit validated by the trusted gate
- retain exact base/head parent and identical-tree comparison against the current live merge ref

## Canary finding

GitHub leaves `pull_request.merge_commit_sha` empty on some `opened` payloads even though the workflow runs against a valid merge ref. The gate safely fell back to GitHub-hosted and no EC2 instance launched.

## Validation

- `actionlint .github/workflows/pr-trusted.yml .github/workflows/pr.yml`
- `node --test ./scripts/__tests__/e2e-shard.test.mjs`
- internal routing harness passes and asserts `EVENT_MERGE_SHA` is sourced from `${{ github.sha }}`
- AWS routing remains disabled during rotation