### PR TITLE
ci: pin workflow merge ref validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@b88fadb0390d2113933d5d155f16b07cbd5dafee
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@5ac66b3fdd5dc22c0c4e5fdb234ac063cf1d9ff8


### PR DESCRIPTION
## Summary

- rotate the thin caller from `b88fadb0390d2113933d5d155f16b07cbd5dafee` to `5ac66b3fdd5dc22c0c4e5fdb234ac063cf1d9ff8`
- keep both exact SHAs authorized during rotation
- keep AWS routing disabled until verification completes

## Validation

- actionlint passes
- e2e workflow-contract tests pass
- internal routing harness validates a single output and `${{ github.sha }}` merge-ref source