### PR TITLE
fix(ci): validate the PR base snapshot

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -120,17 +120,6 @@ jobs:
           live_merge_sha="$(jq -r '.merge_commit_sha // empty' <<< "$pr_json")"
           is_commit_sha "$live_merge_sha" || fail_closed 'current pull request has no valid merge SHA'
 
-          base_ref_json="$(gh api \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "/repos/paperclipai/paperclip/git/ref/heads/$EVENT_BASE_REF" 2>/dev/null)" \
-            || fail_closed 'could not refresh the base branch ref'
-
-          jq -e --arg base_sha "$EVENT_BASE_SHA" '
-            .object.type == "commit" and .object.sha == $base_sha
-          ' <<< "$base_ref_json" >/dev/null 2>&1 \
-            || fail_closed 'base branch moved after the triggering event'
-
           event_merge_json="$(gh api \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \


### PR DESCRIPTION
## Summary

- validate the event base ref/SHA against the live PR state instead of requiring the moving `master` branch tip to remain unchanged while a hosted gate queues
- retain exact event/live merge parent and tree validation, plus author/sender/rerun checks

## Canary finding

A seven-minute hosted-gate queue allowed `master` to advance. Requiring the live branch tip to equal the event base snapshot would route otherwise valid trusted runs back to GitHub-hosted indefinitely on a busy repository.

## Validation

- actionlint and workflow-contract tests pass
- internal routing harness passes
- replaced PR base snapshot, stale head, changed merge parent/tree, and untrusted actors all remain fail-closed
- AWS routing remains disabled during rotation