### PR TITLE
fix(server): resolve an environment provider credential with its owner

### DIFF
--- a/server/src/__tests__/agent-test-environment-routes.test.ts
+++ b/server/src/__tests__/agent-test-environment-routes.test.ts
@@ -291,9 +291,6 @@ describe("agent test-environment route", () => {
     expect(mockEnvironmentRuntime.acquireRunLease).toHaveBeenCalledWith(
       expect.objectContaining({
         applyCustomImageTemplate: true,
-        // The Test lease re-checks the company binding, so a binding change
-        // between the route guard and the lease cannot open a foreign sandbox.
-        assertCompanyBinding: true,
         environment: expect.objectContaining({
           config: expect.objectContaining({
             reuseLease: false,

--- a/server/src/__tests__/codex-login-session-runtime.test.ts
+++ b/server/src/__tests__/codex-login-session-runtime.test.ts
@@ -174,4 +174,35 @@ describe("createProductionLoginSessionRuntime lease-acquisition gate", () => {
     expect(acquireRunLease).toHaveBeenCalledTimes(1);
     expect(acquired.providerLeaseId).toBe("provider-lease-1");
   });
+
+  it("propagates a foreign-company binding rejection from the runtime acquire and tags no lease", async () => {
+    mockEnvironmentService.getById.mockResolvedValue({
+      id: "env-1",
+      driver: "sandbox",
+      config: { provider: "daytona" },
+    });
+    mockEnvironmentService.updateLeaseMetadata.mockClear();
+    const mismatchError = Object.assign(new Error("The selected environment belongs to another company."), {
+      status: 403,
+      details: { code: "environment_company_mismatch" },
+    });
+    const acquireRunLease = vi.fn().mockRejectedValue(mismatchError);
+    const assertProviderSupportsLoginPty = vi.fn(async () => {});
+    const runtime = createProductionLoginSessionRuntime({
+      db: {} as never,
+      environmentRuntime: { acquireRunLease, getDriver: vi.fn() } as never,
+      assertProviderSupportsLoginPty,
+    });
+
+    // The Codex sign-in reaches the same mandatory company-binding check the
+    // runtime's acquireRunLease now always runs, and does not swallow or
+    // retry around a rejection.
+    await expect(
+      runtime.acquireLoginLease({ ...acquireInput, sessionId: randomUUID() }),
+    ).rejects.toBe(mismatchError);
+    expect(acquireRunLease).toHaveBeenCalledTimes(1);
+    // The rejected acquire holds no lease, so the runtime tags no lease
+    // metadata with the session identifier.
+    expect(mockEnvironmentService.updateLeaseMetadata).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/environment-probe.test.ts
+++ b/server/src/__tests__/environment-probe.test.ts
@@ -263,6 +263,48 @@ describe("probeEnvironment", () => {
     }));
   });
 
+  it("fails closed and calls no provider when the lease acquire rejects a foreign-company binding", async () => {
+    const mismatchError = Object.assign(new Error("The selected environment belongs to another company."), {
+      status: 403,
+      details: { code: "environment_company_mismatch" },
+    });
+    mockRuntimeAcquireRunLease.mockRejectedValue(mismatchError);
+
+    const environment = {
+      id: "env-sandbox-foreign",
+      companyId: "company-1",
+      name: "Daytona",
+      description: null,
+      driver: "sandbox" as const,
+      status: "active" as const,
+      config: {
+        provider: "daytona",
+        image: "daytonaio/sandbox:0.8.0",
+        reuseLease: true,
+      },
+      metadata: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const result = await probeEnvironment({} as any, environment, {
+      companyId: "company-2",
+      pluginWorkerManager: {} as any,
+      acquireSandboxRuntimeLease: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      driver: "sandbox",
+      details: expect.objectContaining({
+        error: "The selected environment belongs to another company.",
+      }),
+    });
+    // The rejected acquire holds no lease, so the probe releases nothing and
+    // makes no further provider call.
+    expect(mockRuntimeReleaseRunLease).not.toHaveBeenCalled();
+  });
+
   it("routes plugin environment probes through the plugin worker host", async () => {
     mockProbePluginEnvironmentDriver.mockResolvedValue({
       ok: true,

--- a/server/src/__tests__/environment-probe.test.ts
+++ b/server/src/__tests__/environment-probe.test.ts
@@ -305,6 +305,81 @@ describe("probeEnvironment", () => {
     expect(mockRuntimeReleaseRunLease).not.toHaveBeenCalled();
   });
 
+  it("boots a runtime lease for a second company on a shared unbound environment", async () => {
+    // The probe adds no company-specific gating of its own: it forwards
+    // `companyId` straight to the runtime and trusts the runtime's own
+    // mandatory binding check. An unbound (instance-global) environment
+    // succeeds for any company, including one that does not own it.
+    mockRuntimeAcquireRunLease.mockResolvedValue({
+      environment: {},
+      leaseContext: {
+        executionWorkspaceId: null,
+        executionWorkspaceMode: null,
+      },
+      lease: {
+        id: "lease-2",
+        companyId: "company-2",
+        environmentId: "env-sandbox-shared",
+        executionWorkspaceId: null,
+        issueId: null,
+        heartbeatRunId: null,
+        status: "active",
+        leasePolicy: "ephemeral",
+        provider: "daytona",
+        providerLeaseId: "sandbox-runtime-2",
+        acquiredAt: new Date(),
+        lastUsedAt: new Date(),
+        expiresAt: null,
+        releasedAt: null,
+        failureReason: null,
+        cleanupStatus: "pending",
+        metadata: {
+          provider: "daytona",
+          sandboxName: "paperclip-probe-shared",
+          reuseLease: false,
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const environment = {
+      id: "env-sandbox-shared",
+      companyId: "company-1",
+      name: "Shared Daytona",
+      description: null,
+      driver: "sandbox" as const,
+      status: "active" as const,
+      config: {
+        provider: "daytona",
+        image: "daytonaio/sandbox:0.8.0",
+        reuseLease: true,
+      },
+      metadata: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const result = await probeEnvironment({} as any, environment, {
+      companyId: "company-2",
+      pluginWorkerManager: {} as any,
+      acquireSandboxRuntimeLease: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      driver: "sandbox",
+      summary: "Connected to daytona sandbox paperclip-probe-shared.",
+    });
+    expect(mockRuntimeAcquireRunLease).toHaveBeenCalledWith(expect.objectContaining({
+      companyId: "company-2",
+    }));
+    expect(mockRuntimeReleaseRunLease).toHaveBeenCalledWith(expect.objectContaining({
+      lease: expect.objectContaining({ id: "lease-2" }),
+      status: "released",
+    }));
+  });
+
   it("routes plugin environment probes through the plugin worker host", async () => {
     mockProbePluginEnvironmentDriver.mockResolvedValue({
       ok: true,

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -729,3 +729,45 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(mockResolveEnvironmentExecutionTarget).not.toHaveBeenCalled();
   });
 });
+
+describe("environmentRunOrchestrator — acquireLease", () => {
+  const mockDb = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates a foreign-company binding rejection as lease_acquire_failed and holds no lease", async () => {
+    const mismatchError = Object.assign(new Error("The selected environment belongs to another company."), {
+      status: 403,
+      details: { code: "environment_company_mismatch" },
+    });
+    const runtime = makeMockRuntime({
+      acquireRunLease: vi.fn().mockRejectedValue(mismatchError),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+    const environment = makeEnvironment("sandbox");
+
+    await expect(
+      orchestrator.acquireLease({
+        companyId: "company-1",
+        environment,
+        issueId: null,
+        agentId: "agent-1",
+        heartbeatRunId: "run-1",
+        persistedExecutionWorkspace: null,
+        executionWorkspaceSettings: null,
+        adapterType: null,
+      }),
+    ).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof EnvironmentRunError &&
+        err.code === "lease_acquire_failed" &&
+        err.cause === mismatchError,
+    );
+
+    // The agent run path calls straight through to the runtime's mandatory
+    // company-binding check; it never bypasses or retries around it.
+    expect(runtime.acquireRunLease).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -770,4 +770,33 @@ describe("environmentRunOrchestrator — acquireLease", () => {
     // company-binding check; it never bypasses or retries around it.
     expect(runtime.acquireRunLease).toHaveBeenCalledOnce();
   });
+
+  it("acquires a lease for a second company on a shared unbound environment", async () => {
+    // The environment carries no `built_in_managed_resources` row, so every
+    // company may lease it. The orchestrator adds no company-specific gating
+    // of its own: it forwards `companyId` straight to the runtime and trusts
+    // whatever the runtime's own mandatory binding check decides.
+    const lease = makeLease({ companyId: "company-2" });
+    const runtime = makeMockRuntime({
+      acquireRunLease: vi.fn().mockResolvedValue(lease),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+    const environment = makeEnvironment("sandbox");
+
+    const result = await orchestrator.acquireLease({
+      companyId: "company-2",
+      environment,
+      issueId: null,
+      agentId: "agent-1",
+      heartbeatRunId: "run-1",
+      persistedExecutionWorkspace: null,
+      executionWorkspaceSettings: null,
+      adapterType: null,
+    });
+
+    expect(result).toBe(lease);
+    expect(runtime.acquireRunLease).toHaveBeenCalledWith(
+      expect.objectContaining({ companyId: "company-2" }),
+    );
+  });
 });

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -23,6 +23,7 @@ import {
   heartbeatRuns,
   plugins,
   projects,
+  secretAccessEvents,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -37,6 +38,7 @@ import {
 } from "../services/environment-runtime.ts";
 import * as sandboxProviderRuntime from "../services/sandbox-provider-runtime.ts";
 import * as environmentsModule from "../services/environments.ts";
+import * as environmentConfigModule from "../services/environment-config.ts";
 import { logger } from "../middleware/logger.ts";
 import { environmentService } from "../services/environments.ts";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -189,6 +191,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     await db.delete(environments);
     await db.delete(executionWorkspaces);
     await db.delete(plugins);
+    await db.delete(secretAccessEvents);
     await db.delete(companySecretVersions);
     await db.delete(companySecrets);
     await db.delete(projects);
@@ -312,6 +315,32 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       } as const,
       runId,
     };
+  }
+
+  /**
+   * Simulate the check-to-lease race the locked insert closes: the early
+   * company-binding check reads an empty company list once, as if a managed
+   * reconciliation had not yet written the binding row when the check ran.
+   * The binding row already sits in the database by the time this runs, so
+   * the later, locked check inside `acquireLease` still finds it and
+   * rejects. Every other environment-service method keeps its real
+   * behavior. A test that installs this spy must build its runtime instance
+   * AFTER installing it, and must restore the spy when it finishes.
+   */
+  function mockEarlyBindingCheckAsUnbound() {
+    const realEnvironmentService = environmentsModule.environmentService;
+    return vi
+      .spyOn(environmentsModule, "environmentService")
+      .mockImplementation((database: Parameters<typeof realEnvironmentService>[0]) => {
+        const real = realEnvironmentService(database);
+        return {
+          ...real,
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
+        };
+      });
   }
 
   async function seedReusablePluginSandboxLease() {
@@ -639,7 +668,14 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     });
 
     const destroySpy = vi.spyOn(sandboxProviderRuntime, "destroySandboxProviderLease");
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     try {
+      const runtime = environmentRuntimeService(db);
       await expect(
         runtime.acquireRunLease({
           companyId,
@@ -675,6 +711,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       );
     } finally {
       destroySpy.mockRestore();
+      environmentServiceSpy.mockRestore();
     }
   });
 
@@ -765,43 +802,498 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         throw new Error(`Unexpected plugin method: ${method}`);
       }),
     } as unknown as PluginWorkerManager;
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
 
-    await expect(
-      runtimeWithPlugin.acquireRunLease({
+    try {
+      await expect(
+        runtimeWithPlugin.acquireRunLease({
+          companyId,
+          environment,
+          issueId: null,
+          heartbeatRunId: runId,
+          persistedExecutionWorkspace: null,
+        }),
+      ).rejects.toMatchObject({
+        status: 403,
+        details: { code: "environment_company_mismatch" },
+      });
+
+      // The acquire records the durable pending-cleanup row before the teardown,
+      // so the row lands while the database is proven reachable. The successful
+      // teardown then releases the row to the terminal `expired` state, so no
+      // active or pending_cleanup row remains for the orphan.
+      const leaseRows = await db
+        .select()
+        .from(environmentLeases)
+        .where(eq(environmentLeases.environmentId, environment.id));
+      expect(leaseRows).toHaveLength(1);
+      expect(leaseRows[0]?.status).toBe("expired");
+      expect(leaseRows[0]?.cleanupStatus).toBe("success");
+
+      // The acquire provisioned the remote plugin sandbox, so it destroys the
+      // sandbox on the rejection. Without this teardown the rejected insert leaks a
+      // live sandbox that no lease row tracks.
+      const destroyCalls = (workerManager.call as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (callArgs) => callArgs[1] === "environmentDestroyLease",
+      );
+      expect(destroyCalls).toHaveLength(1);
+      expect(destroyCalls[0]?.[2]).toMatchObject({ providerLeaseId: "plugin-lease-1" });
+    } finally {
+      environmentServiceSpy.mockRestore();
+    }
+
+    await environmentService(db).update(environment.id, { driver: "local", config: {} });
+  });
+
+  it("rejects a foreign-company bound environment before it resolves the provider config or calls the provider", async () => {
+    // Once the provider config resolves a secret-ref with its owning company,
+    // a rejection that arrives only at the lease insert would let a foreign
+    // company reach the provider call first, using the owning company's
+    // credential to create a real sandbox. The runtime must reject before it
+    // resolves the config, so neither the config resolver nor the provider
+    // mock below may ever run.
+    const pluginId = randomUUID();
+    const { companyId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const ownerSecret = await secretService(db).create(companyId, {
+      name: `early-check-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "owner-provider-key",
+    });
+    const providerConfig = {
+      provider: "early-check-plugin",
+      apiKey: ownerSecret.id,
+      reuseLease: false,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Early Check Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await secretService(db).createBinding({
+      companyId,
+      secretId: ownerSecret.id,
+      targetType: "environment",
+      targetId: environment.id,
+      configPath: "apiKey",
+    });
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.early-check-sandbox-provider",
+      packageName: "@acme/early-check-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.early-check-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Early Check Sandbox",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "early-check-plugin",
+            kind: "sandbox_provider",
+            displayName: "Early Check Sandbox",
+            configSchema: {
+              type: "object",
+              properties: {
+                apiKey: { type: "string", format: "secret-ref" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    // Bind the environment to the owning company, then lease it as a second,
+    // foreign company.
+    await db.insert(builtInManagedResources).values({
+      companyId,
+      bundleKey: "managed-environment",
+      resourceKind: "environment",
+      resourceKey: "managed-sandbox",
+      resourceId: environment.id,
+      stockVersion: "1",
+      stockHash: "hash",
+    });
+    const otherCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: otherCompanyId,
+      name: "Other Co Early Check",
+      issuePrefix: "OTE",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async () => {
+        throw new Error("The provider must never be called for a rejected foreign-company lease.");
+      }),
+      getWorker: vi.fn(() => ({ supportedMethods: [] })),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+    const configSpy = vi.spyOn(environmentConfigModule, "resolveEnvironmentDriverConfigForRuntime");
+
+    try {
+      await expect(
+        runtimeWithPlugin.acquireRunLease({
+          companyId: otherCompanyId,
+          environment,
+          issueId: null,
+          heartbeatRunId: runId,
+          persistedExecutionWorkspace: null,
+        }),
+      ).rejects.toMatchObject({
+        status: 403,
+        details: { code: "environment_company_mismatch" },
+      });
+
+      expect(configSpy).not.toHaveBeenCalled();
+      expect(workerManager.call).not.toHaveBeenCalled();
+
+      const leaseRows = await db
+        .select()
+        .from(environmentLeases)
+        .where(eq(environmentLeases.environmentId, environment.id));
+      expect(leaseRows).toHaveLength(0);
+    } finally {
+      configSpy.mockRestore();
+    }
+  });
+
+  it("returns a scrubbed 422 for an environment provider config secret-ref with no binding row, and never calls the provider", async () => {
+    const pluginId = randomUUID();
+    const { companyId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const ownerSecret = await secretService(db).create(companyId, {
+      name: `unbound-config-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "unbound-provider-key",
+    });
+    const providerConfig = {
+      provider: "unbound-config-plugin",
+      apiKey: ownerSecret.id,
+      reuseLease: false,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Missing Binding Secret Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    // No `createBinding` call: the config names a real secret, but no binding
+    // row records who owns it for this environment and config path.
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.unbound-config-sandbox-provider",
+      packageName: "@acme/unbound-config-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.unbound-config-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Unbound Config Sandbox",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "unbound-config-plugin",
+            kind: "sandbox_provider",
+            displayName: "Unbound Config Sandbox",
+            configSchema: {
+              type: "object",
+              properties: {
+                apiKey: { type: "string", format: "secret-ref" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async () => {
+        throw new Error("The provider must never be called when the credential cannot resolve.");
+      }),
+      getWorker: vi.fn(() => ({ supportedMethods: [] })),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    let caught: any;
+    try {
+      await runtimeWithPlugin.acquireRunLease({
         companyId,
         environment,
         issueId: null,
         heartbeatRunId: runId,
         persistedExecutionWorkspace: null,
-      }),
-    ).rejects.toMatchObject({
-      status: 403,
-      details: { code: "environment_company_mismatch" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught.status).toBe(422);
+    expect(caught.details).toMatchObject({ code: "environment_provider_credential_unavailable" });
+    expect(caught.message).toContain(environment.name);
+    // The message names the environment and a short reason; it never carries
+    // the secret id, the owning company id, the config path, or a stack trace.
+    const serializedDetails = JSON.stringify(caught.details ?? {});
+    expect(caught.message).not.toContain(ownerSecret.id);
+    expect(caught.message).not.toContain(companyId);
+    expect(caught.message).not.toContain("apiKey");
+    expect(serializedDetails).not.toContain(ownerSecret.id);
+    expect(serializedDetails).not.toContain(companyId);
+    expect(serializedDetails).not.toContain("apiKey");
+    expect(serializedDetails).not.toContain("stack");
+    expect(workerManager.call).not.toHaveBeenCalled();
+  });
+
+  it("resolves a shared unbound environment's provider credential with its owning company for a second company, and records the cross-company access event", async () => {
+    const pluginId = randomUUID();
+    const { companyId, environment: baseEnvironment } = await seedEnvironment();
+    const ownerSecret = await secretService(db).create(companyId, {
+      name: `shared-env-api-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "owner-provider-key-shared",
+    });
+    const providerConfig = {
+      provider: "shared-secret-plugin",
+      apiKey: ownerSecret.id,
+      reuseLease: false,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Shared Unbound Secret Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await secretService(db).createBinding({
+      companyId,
+      secretId: ownerSecret.id,
+      targetType: "environment",
+      targetId: environment.id,
+      configPath: "apiKey",
+    });
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.shared-secret-sandbox-provider",
+      packageName: "@acme/shared-secret-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.shared-secret-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Shared Secret Sandbox",
+        description: "Test schema-driven provider",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "shared-secret-plugin",
+            kind: "sandbox_provider",
+            displayName: "Shared Secret Sandbox",
+            configSchema: {
+              type: "object",
+              properties: {
+                apiKey: { type: "string", format: "secret-ref" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    // No `built_in_managed_resources` row: the environment is instance-global,
+    // and a second company (distinct from the credential owner) leases it.
+    const secondCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: secondCompanyId,
+      name: "Second Co Shared Secret",
+      issuePrefix: "SCS",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const secondAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: secondAgentId,
+      companyId: secondCompanyId,
+      name: "SecondCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const secondRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: secondRunId,
+      companyId: secondCompanyId,
+      agentId: secondAgentId,
+      invocationSource: "manual",
+      status: "running",
+      createdAt: new Date(),
+      updatedAt: new Date(),
     });
 
-    // The acquire records the durable pending-cleanup row before the teardown,
-    // so the row lands while the database is proven reachable. The successful
-    // teardown then releases the row to the terminal `expired` state, so no
-    // active or pending_cleanup row remains for the orphan.
-    const leaseRows = await db
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: any) => {
+        if (method === "environmentAcquireLease") {
+          expect(params.config.apiKey).toBe("owner-provider-key-shared");
+          return {
+            providerLeaseId: "shared-secret-lease-1",
+            metadata: {
+              provider: "shared-secret-plugin",
+              apiKey: "owner-provider-key-shared",
+              reuseLease: false,
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+      getWorker: vi.fn(() => ({ supportedMethods: [] })),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId: secondCompanyId,
+      environment,
+      issueId: null,
+      heartbeatRunId: secondRunId,
+      persistedExecutionWorkspace: null,
+    });
+
+    expect(acquired.lease.status).toBe("active");
+    expect(acquired.lease.companyId).toBe(secondCompanyId);
+    // The lease metadata carries the secret id back, not the resolved value.
+    expect(acquired.lease.metadata).toMatchObject({ apiKey: ownerSecret.id });
+
+    const accessEvents = await db
       .select()
-      .from(environmentLeases)
-      .where(eq(environmentLeases.environmentId, environment.id));
-    expect(leaseRows).toHaveLength(1);
-    expect(leaseRows[0]?.status).toBe("expired");
-    expect(leaseRows[0]?.cleanupStatus).toBe("success");
+      .from(secretAccessEvents)
+      .where(eq(secretAccessEvents.secretId, ownerSecret.id));
+    expect(accessEvents).toHaveLength(1);
+    expect(accessEvents[0]).toMatchObject({
+      companyId,
+      consumerType: "environment",
+      consumerId: environment.id,
+      configPath: "apiKey",
+      credentialSubjectType: "company",
+      credentialSubjectId: secondCompanyId,
+      outcome: "success",
+    });
+  });
 
-    // The acquire provisioned the remote plugin sandbox, so it destroys the
-    // sandbox on the rejection. Without this teardown the rejected insert leaks a
-    // live sandbox that no lease row tracks.
-    const destroyCalls = (workerManager.call as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (callArgs) => callArgs[1] === "environmentDestroyLease",
-    );
-    expect(destroyCalls).toHaveLength(1);
-    expect(destroyCalls[0]?.[2]).toMatchObject({ providerLeaseId: "plugin-lease-1" });
+  it("leases a shared unbound environment as a second company", async () => {
+    const { environment } = await seedEnvironment({
+      driver: "sandbox",
+      name: "Shared Unbound Fake Sandbox",
+      config: { provider: "fake", image: "ubuntu:24.04", reuseLease: false },
+    });
+    // The environment carries no `built_in_managed_resources` row, so it is
+    // instance-global: every company may lease it.
+    const secondCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: secondCompanyId,
+      name: "Second Co Unbound Fake",
+      issuePrefix: "SCU",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const secondAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: secondAgentId,
+      companyId: secondCompanyId,
+      name: "SecondCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const secondRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: secondRunId,
+      companyId: secondCompanyId,
+      agentId: secondAgentId,
+      invocationSource: "manual",
+      status: "running",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
 
-    await environmentService(db).update(environment.id, { driver: "local", config: {} });
+    const acquired = await runtime.acquireRunLease({
+      companyId: secondCompanyId,
+      environment,
+      issueId: null,
+      heartbeatRunId: secondRunId,
+      persistedExecutionWorkspace: null,
+    });
+
+    expect(acquired.lease.status).toBe("active");
+    expect(acquired.lease.companyId).toBe(secondCompanyId);
+
+    const released = await runtime.releaseRunLeases(secondRunId);
+    expect(released).toHaveLength(1);
+    expect(released[0]?.lease.status).toBe("released");
   });
 
   it("records a durable pending-cleanup lease when the built-in teardown fails after a foreign-company rejection", async () => {
@@ -834,7 +1326,14 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     const destroySpy = vi
       .spyOn(sandboxProviderRuntime, "destroySandboxProviderLease")
       .mockRejectedValue(new Error("teardown failed"));
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     try {
+      const runtime = environmentRuntimeService(db);
       await expect(
         runtime.acquireRunLease({
           companyId,
@@ -858,6 +1357,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       expect(rows[0]?.providerLeaseId).toMatch(new RegExp(`^sandbox://fake/${runId}/[0-9a-f-]{36}$`));
     } finally {
       destroySpy.mockRestore();
+      environmentServiceSpy.mockRestore();
     }
   });
 
@@ -901,7 +1401,14 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           .where(eq(environmentLeases.environmentId, environment.id));
         pendingCleanupRowsAtTeardown = rows.filter((row) => row.status === "pending_cleanup").length;
       });
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     try {
+      const runtime = environmentRuntimeService(db);
       await expect(
         runtime.acquireRunLease({
           companyId,
@@ -927,6 +1434,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       expect(rows[0]?.cleanupStatus).toBe("success");
     } finally {
       destroySpy.mockRestore();
+      environmentServiceSpy.mockRestore();
     }
   });
 
@@ -968,6 +1476,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           ...real,
           insertPendingCleanupLease: () =>
             Promise.reject(new Error("pending-cleanup write failed; database down")),
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     const destroySpy = vi
@@ -1095,28 +1612,38 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         throw new Error(`Unexpected plugin method: ${method}`);
       }),
     } as unknown as PluginWorkerManager;
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
 
-    await expect(
-      runtimeWithPlugin.acquireRunLease({
-        companyId,
-        environment,
-        issueId: null,
-        heartbeatRunId: runId,
-        persistedExecutionWorkspace: null,
-      }),
-    ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
+    try {
+      await expect(
+        runtimeWithPlugin.acquireRunLease({
+          companyId,
+          environment,
+          issueId: null,
+          heartbeatRunId: runId,
+          persistedExecutionWorkspace: null,
+        }),
+      ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
-    // The failed plugin teardown left a durable pending-cleanup row that carries
-    // the provider lease id for a later sweep.
-    const rows = await db
-      .select()
-      .from(environmentLeases)
-      .where(eq(environmentLeases.environmentId, environment.id));
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.status).toBe("pending_cleanup");
-    expect(rows[0]?.cleanupStatus).toBe("failed");
-    expect(rows[0]?.providerLeaseId).toBe("plugin-lease-2");
+      // The failed plugin teardown left a durable pending-cleanup row that carries
+      // the provider lease id for a later sweep.
+      const rows = await db
+        .select()
+        .from(environmentLeases)
+        .where(eq(environmentLeases.environmentId, environment.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.status).toBe("pending_cleanup");
+      expect(rows[0]?.cleanupStatus).toBe("failed");
+      expect(rows[0]?.providerLeaseId).toBe("plugin-lease-2");
+    } finally {
+      environmentServiceSpy.mockRestore();
+    }
 
     await environmentService(db).update(environment.id, { driver: "local", config: {} });
   });
@@ -1165,6 +1692,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         return {
           ...real,
           insertPendingCleanupLease: failingInsert,
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     // The durable database write fails, so the only durable handle left is the
@@ -1282,6 +1818,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
             }
             return real.insertPendingCleanupLease(input);
           },
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     try {
@@ -1379,6 +1924,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
             }
             return real.insertPendingCleanupLease(input);
           },
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     const logSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
@@ -1498,6 +2052,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
             }
             return real.insertPendingCleanupLease(input);
           },
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     const logSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
@@ -1621,6 +2184,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
             }
             return real.insertPendingCleanupLease(input);
           },
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     const logSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
@@ -1722,6 +2294,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
             }
             return real.insertPendingCleanupLease(input);
           },
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     const errorLogSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
@@ -1875,6 +2456,15 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           ...real,
           insertPendingCleanupLease: () =>
             Promise.reject(new Error("pending-cleanup write failed")),
+          // The binding row above already sits in the database before the acquire
+          // runs, so the new early company-binding check would reject before the
+          // provider call this test exercises. Simulate the real race the locked
+          // insert closes: the early check reads an empty list once, and the
+          // locked insert still finds the row and rejects.
+          listBoundCompanyIds: vi
+            .fn()
+            .mockResolvedValueOnce([])
+            .mockImplementation((environmentId: string) => real.listBoundCompanyIds(environmentId)),
         };
       });
     try {
@@ -1985,7 +2575,14 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       .spyOn(sandboxProviderRuntime, "destroySandboxProviderLease")
       .mockRejectedValueOnce(new Error("teardown failed"))
       .mockResolvedValue(undefined);
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     try {
+      const runtime = environmentRuntimeService(db);
       await expect(
         runtime.acquireRunLease({
           companyId,
@@ -2014,6 +2611,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       expect(destroySpy).toHaveBeenLastCalledWith(expect.objectContaining({ providerLeaseId }));
     } finally {
       destroySpy.mockRestore();
+      environmentServiceSpy.mockRestore();
     }
   });
 
@@ -2045,7 +2643,14 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     const destroySpy = vi
       .spyOn(sandboxProviderRuntime, "destroySandboxProviderLease")
       .mockRejectedValue(new Error("teardown failed"));
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     try {
+      const runtime = environmentRuntimeService(db);
       await expect(
         runtime.acquireRunLease({
           companyId,
@@ -2079,6 +2684,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       expect(still.cleanupStatus).toBe("failed");
     } finally {
       destroySpy.mockRestore();
+      environmentServiceSpy.mockRestore();
     }
   });
 
@@ -2117,7 +2723,14 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       .spyOn(sandboxProviderRuntime, "destroySandboxProviderLease")
       .mockRejectedValueOnce(new Error("teardown failed"))
       .mockResolvedValue(undefined);
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     try {
+      const runtime = environmentRuntimeService(db);
       await expect(
         runtime.acquireRunLease({
           companyId,
@@ -2148,6 +2761,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       expect(destroySpy).toHaveBeenLastCalledWith(expect.objectContaining({ providerLeaseId }));
     } finally {
       destroySpy.mockRestore();
+      environmentServiceSpy.mockRestore();
     }
   });
 
@@ -2837,33 +3451,43 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         throw new Error(`Unexpected plugin method: ${method}`);
       }),
     } as unknown as PluginWorkerManager;
+    // The binding row above already sits in the database before the acquire
+    // runs, so the new early company-binding check would reject before the
+    // provider call this test exercises. Simulate the real race the locked
+    // insert closes: the early check reads an empty list once, and the
+    // locked insert still finds the row and rejects.
+    const environmentServiceSpy = mockEarlyBindingCheckAsUnbound();
     const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
 
-    await expect(
-      runtimeWithPlugin.acquireRunLease({
-        companyId,
-        environment,
-        issueId: null,
-        heartbeatRunId: runId,
-        persistedExecutionWorkspace: null,
-      }),
-    ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
+    try {
+      await expect(
+        runtimeWithPlugin.acquireRunLease({
+          companyId,
+          environment,
+          issueId: null,
+          heartbeatRunId: runId,
+          persistedExecutionWorkspace: null,
+        }),
+      ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
-    const orphan = await db
-      .select()
-      .from(environmentLeases)
-      .where(eq(environmentLeases.environmentId, environment.id))
-      .then((r) => r[0]!);
-    expect(orphan.status).toBe("pending_cleanup");
-    expect(orphan.providerLeaseId).toBe("plugin-lease-3");
+      const orphan = await db
+        .select()
+        .from(environmentLeases)
+        .where(eq(environmentLeases.environmentId, environment.id))
+        .then((r) => r[0]!);
+      expect(orphan.status).toBe("pending_cleanup");
+      expect(orphan.providerLeaseId).toBe("plugin-lease-3");
 
-    const lease = await environmentService(db).getLeaseById(orphan.id);
-    await runtimeWithPlugin.retryPendingSandboxTeardown({ environment: null, lease: lease! });
-    expect(destroyAttempts).toBe(2);
-    const destroyCall = (workerManager.call as unknown as ReturnType<typeof vi.fn>).mock.calls
-      .filter((callArgs) => callArgs[1] === "environmentDestroyLease")
-      .at(-1);
-    expect(destroyCall?.[2]).toMatchObject({ providerLeaseId: "plugin-lease-3" });
+      const lease = await environmentService(db).getLeaseById(orphan.id);
+      await runtimeWithPlugin.retryPendingSandboxTeardown({ environment: null, lease: lease! });
+      expect(destroyAttempts).toBe(2);
+      const destroyCall = (workerManager.call as unknown as ReturnType<typeof vi.fn>).mock.calls
+        .filter((callArgs) => callArgs[1] === "environmentDestroyLease")
+        .at(-1);
+      expect(destroyCall?.[2]).toMatchObject({ providerLeaseId: "plugin-lease-3" });
+    } finally {
+      environmentServiceSpy.mockRestore();
+    }
 
     await environmentService(db).update(environment.id, { driver: "local", config: {} });
   });

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -647,7 +647,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         }),
       ).rejects.toMatchObject({
         status: 403,
@@ -775,7 +774,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         issueId: null,
         heartbeatRunId: runId,
         persistedExecutionWorkspace: null,
-        assertCompanyBinding: true,
       }),
     ).rejects.toMatchObject({
       status: 403,
@@ -844,7 +842,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         }),
       ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
@@ -912,7 +909,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         }),
       ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
@@ -988,7 +984,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1109,7 +1104,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         issueId: null,
         heartbeatRunId: runId,
         persistedExecutionWorkspace: null,
-        assertCompanyBinding: true,
       }),
     ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
@@ -1188,7 +1182,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1303,7 +1296,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1400,7 +1392,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1523,7 +1514,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1654,7 +1644,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1746,7 +1735,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -1901,7 +1889,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         })
         .then(
           () => {
@@ -2006,7 +1993,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         }),
       ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
@@ -2067,7 +2053,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         }),
       ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
@@ -2140,7 +2125,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           issueId: null,
           heartbeatRunId: runId,
           persistedExecutionWorkspace: null,
-          assertCompanyBinding: true,
         }),
       ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 
@@ -2862,7 +2846,6 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         issueId: null,
         heartbeatRunId: runId,
         persistedExecutionWorkspace: null,
-        assertCompanyBinding: true,
       }),
     ).rejects.toMatchObject({ status: 403, details: { code: "environment_company_mismatch" } });
 

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -1860,7 +1860,7 @@ describeEmbeddedPostgres("environmentService leases", () => {
       await bindEnvironmentToCompany(environmentId, otherCompanyId);
 
       await expect(
-        svc.acquireLease({ companyId, environmentId, assertCompanyBinding: true }),
+        svc.acquireLease({ companyId, environmentId }),
       ).rejects.toMatchObject({
         status: 403,
         details: { code: "environment_company_mismatch" },
@@ -1876,7 +1876,7 @@ describeEmbeddedPostgres("environmentService leases", () => {
     it("acquires when the environment is unbound (instance-global)", async () => {
       const { companyId, environmentId } = await seedSandboxEnvironment("Unbound Sandbox");
 
-      const lease = await svc.acquireLease({ companyId, environmentId, assertCompanyBinding: true });
+      const lease = await svc.acquireLease({ companyId, environmentId });
       expect(lease.status).toBe("active");
       expect(lease.companyId).toBe(companyId);
     });
@@ -1885,12 +1885,12 @@ describeEmbeddedPostgres("environmentService leases", () => {
       const { companyId, environmentId } = await seedSandboxEnvironment("Own Sandbox");
       await bindEnvironmentToCompany(environmentId, companyId);
 
-      const lease = await svc.acquireLease({ companyId, environmentId, assertCompanyBinding: true });
+      const lease = await svc.acquireLease({ companyId, environmentId });
       expect(lease.status).toBe("active");
     });
 
-    it("does not check the binding for callers that omit the flag", async () => {
-      const { companyId, environmentId } = await seedSandboxEnvironment("Legacy Path Sandbox");
+    it("rejects a foreign-company bind even when the caller passes no other lease options", async () => {
+      const { companyId, environmentId } = await seedSandboxEnvironment("No-Flag Sandbox");
       const otherCompanyId = randomUUID();
       await db.insert(companies).values({
         id: otherCompanyId,
@@ -1902,10 +1902,14 @@ describeEmbeddedPostgres("environmentService leases", () => {
       });
       await bindEnvironmentToCompany(environmentId, otherCompanyId);
 
-      // The heartbeat run path does not set the flag, so the binding check does
-      // not run and the lease acquires as before.
-      const lease = await svc.acquireLease({ companyId, environmentId });
-      expect(lease.status).toBe("active");
+      // Every caller now reaches the locked binding check, so no caller can
+      // opt out of it and acquire a lease in a foreign-company environment.
+      await expect(
+        svc.acquireLease({ companyId, environmentId }),
+      ).rejects.toMatchObject({
+        status: 403,
+        details: { code: "environment_company_mismatch" },
+      });
     });
   });
 });

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -334,12 +334,13 @@ describeEmbeddedPostgres("secretService", () => {
       targetType: "environment",
       targetId: environmentId,
       configPath: "apiKey",
+      secretId: rows[0]!.secretId,
     });
     expect(binding).not.toBeNull();
     expect(binding?.companyId).toBe(rows[0]?.companyId);
   });
 
-  it("getBindingForTarget fails closed when a race leaves rows from two companies for the same target and config path", async () => {
+  it("getBindingForTarget resolves a duplicate binding row by matching the exact secret id", async () => {
     const companyA = await seedCompany("A");
     const companyB = await seedCompany("B");
     const svc = secretService(db);
@@ -381,16 +382,41 @@ describeEmbeddedPostgres("secretService", () => {
       },
     ]);
 
-    const binding = await svc.getBindingForTarget({
+    // The stored config value picks which of the two leftover rows is the
+    // real owner. Filtering by that exact secret id resolves the row
+    // instead of failing closed on the duplicate.
+    const bindingA = await svc.getBindingForTarget({
       targetType: "environment",
       targetId: environmentId,
       configPath: "apiKey",
+      secretId: secretA.id,
     });
+    expect(bindingA).toEqual({ companyId: companyA, secretId: secretA.id });
 
-    expect(binding).toBeNull();
+    const bindingB = await svc.getBindingForTarget({
+      targetType: "environment",
+      targetId: environmentId,
+      configPath: "apiKey",
+      secretId: secretB.id,
+    });
+    expect(bindingB).toEqual({ companyId: companyB, secretId: secretB.id });
+
+    // A secret id that matches neither leftover row still fails closed.
+    const secretC = await svc.create(companyA, {
+      name: `race-key-c-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "c",
+    });
+    const bindingC = await svc.getBindingForTarget({
+      targetType: "environment",
+      targetId: environmentId,
+      configPath: "apiKey",
+      secretId: secretC.id,
+    });
+    expect(bindingC).toBeNull();
   });
 
-  it("getBindingForTarget returns the single row for a target and config path", async () => {
+  it("getBindingForTarget returns the single row for a target, config path, and secret id", async () => {
     const companyId = await seedCompany();
     const svc = secretService(db);
     const secret = await svc.create(companyId, {
@@ -411,6 +437,7 @@ describeEmbeddedPostgres("secretService", () => {
       targetType: "environment",
       targetId: environmentId,
       configPath: "apiKey",
+      secretId: secret.id,
     });
 
     expect(binding).toEqual({ companyId, secretId: secret.id });

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -286,6 +286,59 @@ describeEmbeddedPostgres("secretService", () => {
     expect(rows[0]?.companyId).toBe(companyA);
   });
 
+  it("replaceSecretRefsForInstanceTarget serializes two concurrent calls for the same target instead of leaving rows from both companies", async () => {
+    const companyA = await seedCompany("A");
+    const companyB = await seedCompany("B");
+    const svc = secretService(db);
+    const secretA = await svc.create(companyA, {
+      name: `concurrent-key-a-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "a",
+    });
+    const secretB = await svc.create(companyB, {
+      name: `concurrent-key-b-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "b",
+    });
+    const environmentId = randomUUID();
+
+    // Race two calls for the same target and config path, one per company.
+    // Without the transaction-scoped advisory lock, both calls' delete
+    // steps can run before either call's insert commits, so both inserts
+    // survive and leave one row per company behind.
+    await Promise.all([
+      svc.replaceSecretRefsForInstanceTarget(
+        { targetType: "environment", targetId: environmentId },
+        [{ secretId: secretA.id, configPath: "apiKey" }],
+      ),
+      svc.replaceSecretRefsForInstanceTarget(
+        { targetType: "environment", targetId: environmentId },
+        [{ secretId: secretB.id, configPath: "apiKey" }],
+      ),
+    ]);
+
+    const rows = await db
+      .select()
+      .from(companySecretBindings)
+      .where(
+        and(
+          eq(companySecretBindings.targetType, "environment"),
+          eq(companySecretBindings.targetId, environmentId),
+          eq(companySecretBindings.configPath, "apiKey"),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+    expect([companyA, companyB]).toContain(rows[0]?.companyId);
+
+    const binding = await svc.getBindingForTarget({
+      targetType: "environment",
+      targetId: environmentId,
+      configPath: "apiKey",
+    });
+    expect(binding).not.toBeNull();
+    expect(binding?.companyId).toBe(rows[0]?.companyId);
+  });
+
   it("getBindingForTarget fails closed when a race leaves rows from two companies for the same target and config path", async () => {
     const companyA = await seedCompany("A");
     const companyB = await seedCompany("B");

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -286,6 +286,83 @@ describeEmbeddedPostgres("secretService", () => {
     expect(rows[0]?.companyId).toBe(companyA);
   });
 
+  it("getBindingForTarget fails closed when a race leaves rows from two companies for the same target and config path", async () => {
+    const companyA = await seedCompany("A");
+    const companyB = await seedCompany("B");
+    const svc = secretService(db);
+    const secretA = await svc.create(companyA, {
+      name: `race-key-a-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "a",
+    });
+    const secretB = await svc.create(companyB, {
+      name: `race-key-b-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "b",
+    });
+    const environmentId = randomUUID();
+    // Two concurrent replaceSecretRefsForInstanceTarget calls can each
+    // commit an insert for the same target and config path under a
+    // different company, because the unique index is scoped per company.
+    // Seed that left-behind state directly instead of racing real calls.
+    await db.insert(companySecretBindings).values([
+      {
+        companyId: companyA,
+        secretId: secretA.id,
+        targetType: "environment",
+        targetId: environmentId,
+        configPath: "apiKey",
+        versionSelector: "latest",
+        required: true,
+        projectionClass: "unclassified",
+      },
+      {
+        companyId: companyB,
+        secretId: secretB.id,
+        targetType: "environment",
+        targetId: environmentId,
+        configPath: "apiKey",
+        versionSelector: "latest",
+        required: true,
+        projectionClass: "unclassified",
+      },
+    ]);
+
+    const binding = await svc.getBindingForTarget({
+      targetType: "environment",
+      targetId: environmentId,
+      configPath: "apiKey",
+    });
+
+    expect(binding).toBeNull();
+  });
+
+  it("getBindingForTarget returns the single row for a target and config path", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+    const secret = await svc.create(companyId, {
+      name: `single-key-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "one",
+    });
+    const environmentId = randomUUID();
+    await svc.createBinding({
+      companyId,
+      secretId: secret.id,
+      targetType: "environment",
+      targetId: environmentId,
+      configPath: "apiKey",
+    });
+
+    const binding = await svc.getBindingForTarget({
+      targetType: "environment",
+      targetId: environmentId,
+      configPath: "apiKey",
+    });
+
+    expect(binding).toEqual({ companyId, secretId: secret.id });
+  });
+
   it("describeSecretRefs names secrets across companies and omits unknown ids", async () => {
     const companyA = await seedCompany("Alpha");
     const companyB = await seedCompany("Beta");

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -809,11 +809,6 @@ export function agentRoutes(
         issueId: null,
         heartbeatRunId: null,
         persistedExecutionWorkspace: null,
-        // Re-check the company binding atomically at lease time. The route
-        // guard already rejected a foreign environment, but the binding could
-        // change between the guard check and the lease acquire. This closes
-        // that check-to-lease race so a foreign sandbox never gets a lease.
-        assertCompanyBinding: true,
         // Apply the active custom-image template so the Test boots with the
         // operator's captured sandbox customizations and prepared image state,
         // matching what real agent runs use. Without this the test would

--- a/server/src/services/adapter-login-lease.test.ts
+++ b/server/src/services/adapter-login-lease.test.ts
@@ -52,19 +52,6 @@ describe("buildLoginLeaseAcquireArgs", () => {
     expect(withoutAgent.agentId).toBeNull();
   });
 
-  it("passes the company-binding assertion through and leaves it unset by default", () => {
-    const asserted = buildLoginLeaseAcquireArgs({
-      metadata: { companyId: "co-1", environment: ENVIRONMENT },
-      assertCompanyBinding: true,
-    });
-    expect(asserted.assertCompanyBinding).toBe(true);
-
-    const unset = buildLoginLeaseAcquireArgs({
-      metadata: { companyId: "co-1", environment: ENVIRONMENT },
-    });
-    expect(unset.assertCompanyBinding).toBeUndefined();
-  });
-
   it("passes the requested expiry through and defaults to null", () => {
     const deadline = new Date("2026-01-01T00:00:00.000Z");
     const bounded = buildLoginLeaseAcquireArgs({

--- a/server/src/services/adapter-login-lease.ts
+++ b/server/src/services/adapter-login-lease.ts
@@ -32,11 +32,6 @@ export interface BuildLoginLeaseAcquireArgsOptions {
    */
   targetAgentId?: string | null;
   /**
-   * Re-check the environment company binding inside the lease insert
-   * transaction. The setup-token flow sets this to true.
-   */
-  assertCompanyBinding?: boolean;
-  /**
    * The latest time the acquired lease may stay active. The setup-token flow
    * passes the session deadline. The codex flow passes nothing.
    */
@@ -66,7 +61,6 @@ export function buildLoginLeaseAcquireArgs(
     // Apply the active custom-image template, so the sandbox binds to the
     // trusted image and runtime identity.
     applyCustomImageTemplate: true,
-    assertCompanyBinding: options.assertCompanyBinding,
     requestedExpiresAt: options.requestedExpiresAt ?? null,
   };
 }

--- a/server/src/services/environment-config.ts
+++ b/server/src/services/environment-config.ts
@@ -324,15 +324,19 @@ async function resolveConfigSecretRefsForRuntime(input: {
     // Resolve with the company that the environment's own binding row records
     // as the secret's owner, not with the requesting company, so a shared
     // environment's credential authorizes correctly for every company that
-    // leases it. A missing or mismatched binding row means the current config
-    // value carries no recorded owner, so resolution fails closed instead of
+    // leases it. The lookup is scoped to the exact secret this config path
+    // currently references, so a duplicate binding row left over from an
+    // old write race still resolves to the one owner that matches the
+    // stored value. A missing binding row means the current config value
+    // carries no recorded owner, so resolution fails closed instead of
     // falling back to the requesting company.
     const binding = await secrets.getBindingForTarget({
       targetType: "environment",
       targetId: input.context.consumerId,
       configPath: path,
+      secretId: trimmed,
     });
-    if (!binding || binding.secretId !== trimmed) {
+    if (!binding) {
       throw await environmentProviderCredentialUnavailableError({
         db: input.db,
         environmentId: input.context.consumerId,

--- a/server/src/services/environment-config.ts
+++ b/server/src/services/environment-config.ts
@@ -16,6 +16,7 @@ import type {
 import { unprocessable } from "../errors.js";
 import { parseObject } from "../adapters/utils.js";
 import { secretService } from "./secrets.js";
+import { environmentService } from "./environments.js";
 import {
   resolvePluginSandboxProviderDriverByKey,
   validatePluginEnvironmentDriverConfig,
@@ -277,6 +278,26 @@ async function persistConfigSecretRefs(input: {
   return nextConfig;
 }
 
+/**
+ * Build the named, scrubbed error for an environment provider credential that
+ * cannot resolve. The message names the environment and a short reason. It
+ * never carries the secret id, the owning company id, the config path, or a
+ * stack trace, so an onboarding user in another company never sees another
+ * tenant's identifiers.
+ */
+async function environmentProviderCredentialUnavailableError(input: {
+  db: Db;
+  environmentId: string;
+  reason: string;
+}) {
+  const environment = await environmentService(input.db).getById(input.environmentId);
+  const label = environment?.name ?? input.environmentId;
+  return unprocessable(
+    `Environment "${label}" has no working provider credential: ${input.reason}.`,
+    { code: "environment_provider_credential_unavailable" },
+  );
+}
+
 async function resolveConfigSecretRefsForRuntime(input: {
   db: Db;
   companyId: string;
@@ -298,10 +319,29 @@ async function resolveConfigSecretRefsForRuntime(input: {
     if (!input.context.consumerId) {
       throw unprocessable("Runtime secret resolution requires an environment id");
     }
-    nextConfig = writeConfigValueAtPath(
-      nextConfig,
-      path,
-      await secrets.resolveSecretValue(input.companyId, trimmed, "latest", {
+    // The execution environment catalog is instance-scoped, so this config can
+    // serve a company that does not own the referenced provider credential.
+    // Resolve with the company that the environment's own binding row records
+    // as the secret's owner, not with the requesting company, so a shared
+    // environment's credential authorizes correctly for every company that
+    // leases it. A missing or mismatched binding row means the current config
+    // value carries no recorded owner, so resolution fails closed instead of
+    // falling back to the requesting company.
+    const binding = await secrets.getBindingForTarget({
+      targetType: "environment",
+      targetId: input.context.consumerId,
+      configPath: path,
+    });
+    if (!binding || binding.secretId !== trimmed) {
+      throw await environmentProviderCredentialUnavailableError({
+        db: input.db,
+        environmentId: input.context.consumerId,
+        reason: "no owner is recorded for this provider credential",
+      });
+    }
+    let resolvedValue: string;
+    try {
+      resolvedValue = await secrets.resolveSecretValue(binding.companyId, trimmed, "latest", {
         consumerType: "environment",
         consumerId: input.context.consumerId,
         actorType: "system",
@@ -309,8 +349,16 @@ async function resolveConfigSecretRefsForRuntime(input: {
         issueId: input.context.issueId ?? null,
         heartbeatRunId: input.context.heartbeatRunId ?? null,
         configPath: path,
-      }),
-    );
+        requestingCompanyId: input.companyId,
+      });
+    } catch {
+      throw await environmentProviderCredentialUnavailableError({
+        db: input.db,
+        environmentId: input.context.consumerId,
+        reason: "the provider credential could not be resolved",
+      });
+    }
+    nextConfig = writeConfigValueAtPath(nextConfig, path, resolvedValue);
   }
   return nextConfig;
 }

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -456,17 +456,6 @@ export interface EnvironmentDriverAcquireInput {
    * behavior.
    */
   requestedExpiresAt?: Date | null;
-  /**
-   * Re-check the environment company binding inside the lease insert
-   * transaction. The login acquire paths set this so a managed reconciliation
-   * that binds the sandbox to another company between the route guard and this
-   * acquire cannot let the login run in a foreign-company sandbox. The lease
-   * insert then rejects a foreign-company environment with the 403
-   * `environment_company_mismatch` and holds no lease. An unbound
-   * (instance-global) environment stays open. Other callers keep the current
-   * behavior.
-   */
-  assertCompanyBinding?: boolean;
 }
 
 export interface EnvironmentDriverReleaseInput {
@@ -1915,7 +1904,6 @@ function createSandboxEnvironmentDriver(
             executionWorkspaceId: input.executionWorkspaceId,
             issueId: input.issueId,
             heartbeatRunId: input.heartbeatRunId,
-            assertCompanyBinding: input.assertCompanyBinding,
             leasePolicy: resolvedLeasePolicy,
             provider: parsed.config.provider,
             providerLeaseId: acquiredLease.providerLeaseId,
@@ -2121,7 +2109,6 @@ function createSandboxEnvironmentDriver(
           executionWorkspaceId: input.executionWorkspaceId,
           issueId: input.issueId,
           heartbeatRunId: input.heartbeatRunId,
-          assertCompanyBinding: input.assertCompanyBinding,
           leasePolicy: resolvedLeasePolicy,
           provider: parsed.config.provider,
           providerLeaseId: providerLease.providerLeaseId,
@@ -3345,12 +3332,6 @@ export function environmentRuntimeService(
        * provider expiry only.
        */
       requestedExpiresAt?: Date | null;
-      /**
-       * Re-check the environment company binding inside the lease insert
-       * transaction. The login acquire paths set this to reject a foreign-company
-       * environment with the 403 `environment_company_mismatch`.
-       */
-      assertCompanyBinding?: boolean;
     }): Promise<EnvironmentRuntimeLeaseRecord> {
       if (input.environment.status !== "active") {
         throw new Error(`Environment "${input.environment.name}" is not active.`);
@@ -3372,7 +3353,6 @@ export function environmentRuntimeService(
         adapterType: input.adapterType ?? null,
         applyCustomImageTemplate: input.applyCustomImageTemplate ?? false,
         requestedExpiresAt: input.requestedExpiresAt ?? null,
-        assertCompanyBinding: input.assertCompanyBinding,
       });
 
       return {

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -81,6 +81,7 @@ import {
   type SandboxOrphanCleanupSpool,
 } from "./sandbox-orphan-cleanup-spool.js";
 import { logger } from "../middleware/logger.js";
+import { forbidden } from "../errors.js";
 
 // The constant error kind for the durable orphan-cleanup-write-failed log. The
 // log never reads the caught exception, because the exception can carry a
@@ -1646,6 +1647,22 @@ function createSandboxEnvironmentDriver(
     driver: "sandbox",
 
     async acquireRunLease(input) {
+      // Reject a foreign-company bound environment before the driver resolves
+      // the provider config or calls the provider. Once the provider config
+      // resolves a secret-ref with its owning company, a late rejection would
+      // let a foreign company use the owning company's provider credential to
+      // create a real sandbox before the lease insert catches the mismatch.
+      // This early read is not itself race-free: the locked check inside
+      // `environmentsSvc.acquireLease` still runs on every call below and
+      // closes the window between this read and the lease insert. The two
+      // checks stay independent; this one narrows the credential-exposure
+      // window, the other one closes the check-to-lease race.
+      const boundCompanyIds = await environmentsSvc.listBoundCompanyIds(input.environment.id);
+      if (boundCompanyIds.length > 0 && !boundCompanyIds.includes(input.companyId)) {
+        throw forbidden("The selected environment belongs to another company.", {
+          code: "environment_company_mismatch",
+        });
+      }
       const storedParsed = parseEnvironmentDriverConfig(input.environment);
       const parsed = await resolveEnvironmentDriverConfigForRuntime(db, input.companyId, input.environment, {
         issueId: input.issueId,

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -1335,17 +1335,6 @@ export function environmentService(db: Db) {
       providerLeaseId?: string | null;
       expiresAt?: Date | null;
       metadata?: Record<string, unknown> | null;
-      /**
-       * Re-check the environment company binding inside the lease insert
-       * transaction. The login routes set this to close the check-to-lease
-       * race: managed reconciliation can bind a sandbox to another company
-       * between the route guard and this acquire. When the environment is
-       * bound to a company other than `companyId`, the insert throws the 403
-       * `environment_company_mismatch` and no lease row is created (fail
-       * closed). An unbound (instance-global) environment stays open to every
-       * member. All other callers keep the plain, non-transactional insert.
-       */
-      assertCompanyBinding?: boolean;
     }): Promise<EnvironmentLease> => {
       const now = new Date();
       const values = {
@@ -1368,47 +1357,49 @@ export function environmentService(db: Db) {
         createdAt: now,
         updatedAt: now,
       };
-      const row = input.assertCompanyBinding
-        ? await db.transaction(async (tx) => {
-            // Lock the environment row first. Managed reconciliation locks the
-            // same sandbox environment rows with `for update` before it writes a
-            // company binding, so this lock serializes the two transactions on
-            // this row and closes the time-of-check to time-of-use window.
-            await tx
-              .select({ id: environments.id })
-              .from(environments)
-              .where(eq(environments.id, input.environmentId))
-              .for("update");
-            // Re-read the company binding inside the locked transaction. A
-            // binding a reconciliation committed after the route guard now
-            // appears here. Reject a foreign-company environment before the
-            // insert, so the login holds no lease.
-            const boundRows = await tx
-              .select({ companyId: builtInManagedResources.companyId })
-              .from(builtInManagedResources)
-              .where(
-                and(
-                  eq(builtInManagedResources.resourceKind, MANAGED_ENVIRONMENT_RESOURCE_KIND),
-                  eq(builtInManagedResources.resourceId, input.environmentId),
-                ),
-              );
-            const boundCompanyIds = Array.from(new Set(boundRows.map((boundRow) => boundRow.companyId)));
-            if (boundCompanyIds.length > 0 && !boundCompanyIds.includes(input.companyId)) {
-              throw forbidden("The selected environment belongs to another company.", {
-                code: "environment_company_mismatch",
-              });
-            }
-            return tx
-              .insert(environmentLeases)
-              .values(values)
-              .returning()
-              .then((rows) => rows[0] ?? null);
-          })
-        : await db
-            .insert(environmentLeases)
-            .values(values)
-            .returning()
-            .then((rows) => rows[0] ?? null);
+      // Re-check the environment company binding inside the lease insert
+      // transaction, for every caller. Managed reconciliation can bind a
+      // sandbox to another company between an earlier route guard and this
+      // acquire, so this check closes that check-to-lease race. When the
+      // environment is bound to a company other than `companyId`, the insert
+      // throws the 403 `environment_company_mismatch` and no lease row is
+      // created (fail closed). An unbound (instance-global) environment stays
+      // open to every company.
+      const row = await db.transaction(async (tx) => {
+        // Lock the environment row first. Managed reconciliation locks the
+        // same sandbox environment rows with `for update` before it writes a
+        // company binding, so this lock serializes the two transactions on
+        // this row and closes the time-of-check to time-of-use window.
+        await tx
+          .select({ id: environments.id })
+          .from(environments)
+          .where(eq(environments.id, input.environmentId))
+          .for("update");
+        // Re-read the company binding inside the locked transaction. A
+        // binding a reconciliation committed after an earlier route guard now
+        // appears here. Reject a foreign-company environment before the
+        // insert, so the caller holds no lease.
+        const boundRows = await tx
+          .select({ companyId: builtInManagedResources.companyId })
+          .from(builtInManagedResources)
+          .where(
+            and(
+              eq(builtInManagedResources.resourceKind, MANAGED_ENVIRONMENT_RESOURCE_KIND),
+              eq(builtInManagedResources.resourceId, input.environmentId),
+            ),
+          );
+        const boundCompanyIds = Array.from(new Set(boundRows.map((boundRow) => boundRow.companyId)));
+        if (boundCompanyIds.length > 0 && !boundCompanyIds.includes(input.companyId)) {
+          throw forbidden("The selected environment belongs to another company.", {
+            code: "environment_company_mismatch",
+          });
+        }
+        return tx
+          .insert(environmentLeases)
+          .values(values)
+          .returning()
+          .then((rows) => rows[0] ?? null);
+      });
       if (!row) {
         throw new Error("Failed to acquire environment lease");
       }

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -4730,18 +4730,26 @@ export function secretService(db: Db) {
         .then((rows) => [...new Set(rows.map((row) => row.companyId))]),
 
     /**
-     * Read the binding row for one target and one config path, with no known
-     * owning company. `replaceSecretRefsForInstanceTarget` deletes every row
-     * for a target before it writes fresh rows, so at most one row exists for
-     * a given target and config path. Returns null when no row exists, so a
-     * caller can fail closed instead of guessing an owner.
+     * Read the binding row for one target and one config path. The caller
+     * does not know the owning company in advance.
+     *
+     * `replaceSecretRefsForInstanceTarget` deletes every existing row for a
+     * target before it writes fresh rows. So exactly one row should exist
+     * for a given target and config path. A race between two concurrent
+     * replace calls can still leave more than one row behind: each call's
+     * delete step only removes rows that an earlier call had already
+     * committed.
+     *
+     * This function returns null when no row exists. It also returns null
+     * when more than one row exists, so the caller fails closed instead of
+     * guessing an owner among rows left by a race.
      */
     getBindingForTarget: async (input: {
       targetType: SecretBindingTargetType;
       targetId: string;
       configPath: string;
-    }): Promise<{ companyId: string; secretId: string } | null> =>
-      db
+    }): Promise<{ companyId: string; secretId: string } | null> => {
+      const rows = await db
         .select({ companyId: companySecretBindings.companyId, secretId: companySecretBindings.secretId })
         .from(companySecretBindings)
         .where(
@@ -4750,8 +4758,22 @@ export function secretService(db: Db) {
             eq(companySecretBindings.targetId, input.targetId),
             eq(companySecretBindings.configPath, input.configPath),
           ),
-        )
-        .then((rows) => rows[0] ?? null),
+        );
+      if (rows.length === 0) return null;
+      if (rows.length > 1) {
+        logger.warn(
+          {
+            targetType: input.targetType,
+            targetId: input.targetId,
+            configPath: input.configPath,
+            rowCount: rows.length,
+          },
+          "multiple owner rows found for one environment binding target and config path; failing closed",
+        );
+        return null;
+      }
+      return rows[0];
+    },
 
     syncEnvBindingsForTarget: async (
       companyId: string,

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -4584,11 +4584,11 @@ export function secretService(db: Db) {
      * company, then the insert step writes fresh rows under each ref's
      * owning company. Two concurrent calls for the same target could
      * otherwise interleave their delete and insert steps and leave one row
-     * per company behind, an ambiguous state `getBindingForTarget` cannot
-     * resolve. A transaction-scoped Postgres advisory lock keyed on the
-     * target serializes concurrent calls for the same target, so this
-     * state cannot occur. Calls for different targets still run
-     * concurrently.
+     * per company behind. `getBindingForTarget` resolves that leftover
+     * state by matching on the exact secret id, but this lock still stops
+     * new leftover rows: it serializes concurrent calls for the same
+     * target, so the state cannot occur going forward. Calls for different
+     * targets still run concurrently.
      */
     replaceSecretRefsForInstanceTarget: async (
       target: { targetType: SecretBindingTargetType; targetId: string },
@@ -4749,24 +4749,30 @@ export function secretService(db: Db) {
         .then((rows) => [...new Set(rows.map((row) => row.companyId))]),
 
     /**
-     * Read the binding row for one target and one config path. The caller
-     * does not know the owning company in advance.
+     * Read the binding row for one target, one config path, and the secret
+     * the caller's stored config currently references. The caller does not
+     * know the owning company in advance.
      *
      * `replaceSecretRefsForInstanceTarget` deletes every existing row for a
-     * target before it writes fresh rows. So exactly one row should exist
+     * target before it writes fresh rows, so exactly one row should exist
      * for a given target and config path. A race between two concurrent
-     * replace calls can still leave more than one row behind: each call's
-     * delete step only removes rows that an earlier call had already
-     * committed.
+     * replace calls (or an old row left over from before that function's
+     * advisory lock started serializing those calls) can still leave more
+     * than one row behind. Each surviving row belongs to a different
+     * secret, because the two calls' inserts each ran with a different ref.
+     * A secret belongs to exactly one company, so filtering by the exact
+     * secret id resolves that ambiguity: at most one row can match the
+     * target, the config path, and the secret id together.
      *
-     * This function returns null when no row exists. It also returns null
-     * when more than one row exists, so the caller fails closed instead of
-     * guessing an owner among rows left by a race.
+     * This function returns null when no row matches. It also returns null,
+     * and logs a warning, in the case the schema does not allow: two rows
+     * for the same secret id under different companies.
      */
     getBindingForTarget: async (input: {
       targetType: SecretBindingTargetType;
       targetId: string;
       configPath: string;
+      secretId: string;
     }): Promise<{ companyId: string; secretId: string } | null> => {
       const rows = await db
         .select({ companyId: companySecretBindings.companyId, secretId: companySecretBindings.secretId })
@@ -4776,6 +4782,7 @@ export function secretService(db: Db) {
             eq(companySecretBindings.targetType, input.targetType),
             eq(companySecretBindings.targetId, input.targetId),
             eq(companySecretBindings.configPath, input.configPath),
+            eq(companySecretBindings.secretId, input.secretId),
           ),
         );
       if (rows.length === 0) return null;
@@ -4785,9 +4792,10 @@ export function secretService(db: Db) {
             targetType: input.targetType,
             targetId: input.targetId,
             configPath: input.configPath,
+            secretId: input.secretId,
             rowCount: rows.length,
           },
-          "multiple owner rows found for one environment binding target and config path; failing closed",
+          "multiple owner rows found for one environment binding target, config path, and secret; failing closed",
         );
         return null;
       }

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -4579,6 +4579,16 @@ export function secretService(db: Db) {
      * written, and the delete + insert run on one executor, so an invalid
      * ref (deleted or unknown secret) fails the whole call without leaving
      * the target half-bound.
+     *
+     * The delete step removes every row for the target across every
+     * company, then the insert step writes fresh rows under each ref's
+     * owning company. Two concurrent calls for the same target could
+     * otherwise interleave their delete and insert steps and leave one row
+     * per company behind, an ambiguous state `getBindingForTarget` cannot
+     * resolve. A transaction-scoped Postgres advisory lock keyed on the
+     * target serializes concurrent calls for the same target, so this
+     * state cannot occur. Calls for different targets still run
+     * concurrently.
      */
     replaceSecretRefsForInstanceTarget: async (
       target: { targetType: SecretBindingTargetType; targetId: string },
@@ -4591,7 +4601,10 @@ export function secretService(db: Db) {
         projectionClass?: SecretProjectionClass;
         projectionAllowlistKey?: string | null;
       }>,
-      options?: { db?: SecretBindingDb },
+      // The lock this function takes to serialize the delete + insert below
+      // (see the docstring) is transaction-scoped, so a caller-supplied
+      // executor must be a transaction, not a plain `Db`.
+      options?: { db?: DbTransaction },
     ) => {
       const normalizedRefs: Array<{
         companyId: string;
@@ -4633,7 +4646,13 @@ export function secretService(db: Db) {
         });
       }
 
-      const writeBindings = async (executor: SecretBindingDb) => {
+      const writeBindings = async (executor: DbTransaction) => {
+        // Hold this lock for the rest of the transaction so a concurrent
+        // call for the same target waits instead of interleaving its
+        // delete + insert with this one (see the docstring above).
+        await executor.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`secret-binding-target:${target.targetType}:${target.targetId}`}, 0))`,
+        );
         await executor
           .delete(companySecretBindings)
           .where(

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -590,6 +590,14 @@ type SecretConsumerContext = {
   heartbeatRunId?: string | null;
   pluginId?: string | null;
   allowedBindingIds?: string[] | null;
+  /**
+   * The company that made this resolution request, when it can differ from
+   * the resolution `companyId` (the secret's owner). A shared, instance-scoped
+   * environment can resolve a provider credential another company owns; the
+   * access-event record then tags the requester as the credential subject, so
+   * the row shows which company used another company's credential.
+   */
+  requestingCompanyId?: string | null;
 };
 
 type SecretBindingContext = Omit<SecretConsumerContext, "consumerType"> & {
@@ -1309,6 +1317,13 @@ export function secretService(db: Db) {
   ): Promise<RuntimeSecretResolution> {
     const bindingContext = options?.bindingContext;
     const accessContext = options?.accessContext ?? bindingContext;
+    // A requester that differs from the resolution company used another
+    // company's credential. Record that requester as the credential subject,
+    // so the access event shows the cross-company use.
+    const crossCompanyRequesterId =
+      accessContext?.requestingCompanyId && accessContext.requestingCompanyId !== companyId
+        ? accessContext.requestingCompanyId
+        : null;
     const secret = await getById(secretId);
     if (!secret) throw notFound("Secret not found");
     if (secret.companyId !== companyId) throw unprocessable("Secret must belong to same company");
@@ -1366,8 +1381,8 @@ export function secretService(db: Db) {
           provider: providerId,
           context: accessContext,
           credentialOwnerUserId: secret.ownerUserId ?? null,
-          credentialSubjectType: secret.scope === "user" ? "user" : null,
-          credentialSubjectId: secret.ownerUserId ?? null,
+          credentialSubjectType: crossCompanyRequesterId ? "company" : secret.scope === "user" ? "user" : null,
+          credentialSubjectId: crossCompanyRequesterId ?? secret.ownerUserId ?? null,
           outcome: "success",
         }).catch(() => undefined),
       ]);
@@ -1396,8 +1411,8 @@ export function secretService(db: Db) {
         provider: providerId,
         context: accessContext,
         credentialOwnerUserId: secret.ownerUserId ?? null,
-        credentialSubjectType: secret.scope === "user" ? "user" : null,
-        credentialSubjectId: secret.ownerUserId ?? null,
+        credentialSubjectType: crossCompanyRequesterId ? "company" : secret.scope === "user" ? "user" : null,
+        credentialSubjectId: crossCompanyRequesterId ?? secret.ownerUserId ?? null,
         outcome: "failure",
         errorCode,
       }).catch(() => undefined);
@@ -4713,6 +4728,30 @@ export function secretService(db: Db) {
           ),
         )
         .then((rows) => [...new Set(rows.map((row) => row.companyId))]),
+
+    /**
+     * Read the binding row for one target and one config path, with no known
+     * owning company. `replaceSecretRefsForInstanceTarget` deletes every row
+     * for a target before it writes fresh rows, so at most one row exists for
+     * a given target and config path. Returns null when no row exists, so a
+     * caller can fail closed instead of guessing an owner.
+     */
+    getBindingForTarget: async (input: {
+      targetType: SecretBindingTargetType;
+      targetId: string;
+      configPath: string;
+    }): Promise<{ companyId: string; secretId: string } | null> =>
+      db
+        .select({ companyId: companySecretBindings.companyId, secretId: companySecretBindings.secretId })
+        .from(companySecretBindings)
+        .where(
+          and(
+            eq(companySecretBindings.targetType, input.targetType),
+            eq(companySecretBindings.targetId, input.targetId),
+            eq(companySecretBindings.configPath, input.configPath),
+          ),
+        )
+        .then((rows) => rows[0] ?? null),
 
     syncEnvBindingsForTarget: async (
       companyId: string,

--- a/server/src/services/setup-token-transport-binding.test.ts
+++ b/server/src/services/setup-token-transport-binding.test.ts
@@ -409,6 +409,34 @@ describe("production sandbox provider", () => {
     });
   });
 
+  it("propagates a foreign-company binding rejection and opens no pseudo-terminal", async () => {
+    const mismatchError = Object.assign(new Error("The selected environment belongs to another company."), {
+      status: 403,
+      details: { code: "environment_company_mismatch" },
+    });
+    const acquireRunLease = vi.fn().mockRejectedValue(mismatchError);
+    const openLivePtySession = vi.fn();
+    const provider = createProductionSetupTokenSandboxProvider({
+      environments: {
+        getById: async () => ({ id: "env-1", name: "Sandbox", driver: "sandbox", status: "active" }) as never,
+        getLeaseById: async () => null,
+        releaseLease: async () => ({}) as never,
+      },
+      environmentRuntime: {
+        acquireRunLease,
+        getDriver: () => null,
+      },
+      openLivePtySession,
+    });
+
+    await expect(
+      provider.acquire({ scope: SCOPE, deadline: Date.now() + 1000 }),
+    ).rejects.toBe(mismatchError);
+    // The rejected acquire holds no lease, so the login never opens a
+    // pseudo-terminal for the foreign-company sandbox.
+    expect(openLivePtySession).not.toHaveBeenCalled();
+  });
+
   it("acquires a lease and binds the live opener when it is present", async () => {
     const openPtySession: LoginPtySessionOpener = async () => ({
       onData(): void {},

--- a/server/src/services/setup-token-transport-binding.ts
+++ b/server/src/services/setup-token-transport-binding.ts
@@ -426,13 +426,6 @@ export function createProductionSetupTokenSandboxProvider(
           // The setup-token login is company-and-environment scoped. It carries
           // no target agent, so the lease binds no agent.
           targetAgentId: null,
-          // Re-check the environment company binding inside the lease insert
-          // transaction. The route guard ran earlier, so a managed
-          // reconciliation can bind this sandbox to another company between the
-          // guard and this acquire. The lease insert then rejects a
-          // foreign-company environment with the 403
-          // `environment_company_mismatch` and holds no lease.
-          assertCompanyBinding: true,
           // Bound the lease expiry to the session deadline. The runtime records
           // the earlier of this deadline and the provider expiry on the lease
           // row.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip can lease execution environments for agent work
> - An environment can belong to one company while another company leases it
> - The lease used the requesting company to resolve the provider credential
> - That lookup failed for a shared environment and blocked agent work
> - This pull request checks the environment owner before provider access and resolves the credential with that owner
> - The benefit is safe shared-environment access with clear errors and no provider call on a foreign binding

## Linked Issues or Issue Description

**What happened**

When a second company leased a shared environment, Paperclip resolved the provider secret with the requesting company. The lookup failed with an unnamed ownership error.

**Expected behavior**

Paperclip must check the environment binding before provider access. It must resolve the provider secret with the company that owns the binding.

**Steps to reproduce**

1. Create an environment for company A.
2. Configure a provider secret for company A.
3. Lease the environment from company B.
4. Start an agent action that uses the provider.

**Paperclip version or commit**

`df4e305556157ce8d445b72f880bdf52eb61f992`

**Deployment mode**

Local dev and server test suites.

**Agent adapter(s) involved**

Not adapter-specific. The change applies to shared environment access.

**Additional context**

The repository search found no duplicate or related public pull request for this fix.

## What Changed

- Check the environment company binding before provider configuration resolution and provider calls.
- Resolve a provider `secret-ref` with the company recorded by the environment binding.
- Return a named 422 error when the provider credential cannot resolve.
- Run the locked company-binding check for every persisted lease acquisition.
- Add focused tests for shared environments, credential errors, and lease enforcement.

## Verification

- Run the focused environment runtime, probe, and run-orchestrator suites.
- Run the environment service, setup-token transport binding, and adapter login lease suites.
- Run the wider server test sweep.
- Confirm that foreign bindings return 403 before credential resolution or provider calls.

## Risks

The lease path now rejects a foreign company binding on every acquisition. This protects company boundaries but can reject callers that relied on the removed opt-out flag. The change has focused regression tests and does not change the schema.

## Model Used

OpenAI Codex, GPT-5, tool use and code execution enabled. The deployment does not expose a more specific model build identifier.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge