### PR TITLE
ci: activate trusted stacked PR routing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,6 @@ name: PR
 
 on:
   pull_request:
-    branches:
-      - master
 
 permissions:
   actions: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@c119c4bee6ebb9c81791d7a6994f1be06d7cc22b
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@d6b33d6c16ae23f38e81c25dff5e60d0a1c51f73


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Pull request checks protect the application and its contributors.
> - The trusted CI workflow sends approved contributors to isolated AWS runners.
> - Pull request #12455 added safe support for non-master base branches.
> - The active caller still filters for master and uses the previous immutable workflow SHA.
> - This pull request removes the base-branch trigger filter and pins the caller to the authorized stack-aware SHA.
> - The benefit is that trusted stacked pull requests can use the AWS fleet automatically.

## Linked Issues or Issue Description

Refs #12455

**What existing behavior does this improve?**

The active pull request caller only triggers for master and selects the master-only trusted workflow version.

**Subsystem affected**

GitHub Actions pull request routing.

**Current behavior**

Trusted stacked pull requests either do not trigger the default caller or use a branch-local older caller. Their heavy jobs remain in the GitHub-hosted queue.

**Proposed behavior**

The caller triggers for every pull request base branch. It uses the authorized stack-aware workflow at full SHA d6b33d6c16ae23f38e81c25dff5e60d0a1c51f73.

**Reason and benefit**

The change sends heavy jobs from approved stacked pull requests to the 100-runner AWS Fleet. Unlisted contributors still receive the normal GitHub-hosted checks.

**Breaking changes**

Trusted pull requests with non-master base branches now use AWS. Untrusted pull requests continue to use GitHub-hosted runners.

**Additional context**

The runner group currently authorizes both the old and new immutable workflow SHAs. The old SHA stays authorized until outstanding runs finish.

## What Changed

- Remove the caller base-branch filter so stacked pull requests trigger CI.
- Pin the thin caller to the authorized stack-aware reusable workflow SHA.

## Verification

- Ran actionlint on both pull request workflow files.
- Ran the external routing test suite against the new reusable workflow and thin caller.
- Verified that the runner group authorizes both immutable SHAs and only the Paperclip repository.

## Risks

A bad pin can stop pull request CI. The target SHA is on master, contains the reviewed reusable workflow, and is already authorized beside the prior SHA. This gives the rotation a rollback path. Every untrusted run still uses a GitHub-hosted gate and route.

> For core feature work, check ROADMAP.md first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See CONTRIBUTING.md.

## Model Used

OpenAI Codex on GPT-5. The exact deployment ID and context-window size are not exposed. The model used reasoning, tool use, GitHub API access, and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked an existing public item and described the issue in-PR
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge