### PR TITLE
ci: activate stacked merge validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@d6b33d6c16ae23f38e81c25dff5e60d0a1c51f73
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@7b199fcafa2f8b79fd25e83cb1524825ea8f9f3e


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Pull request checks protect the application and its contributors.
> - The trusted CI gate must validate both direct and stacked GitHub merge shapes.
> - Pull request #12457 added that validation at an immutable master SHA.
> - The active caller still pins the prior workflow version.
> - This pull request pins the caller to the newly authorized SHA.
> - The benefit is safe automatic AWS routing for trusted stacked pull requests.

## Linked Issues or Issue Description

Refs #12457

**What existing behavior does this improve?**

The active caller uses a gate that fails closed on GitHub synthetic stacked merge parents.

**Subsystem affected**

GitHub Actions pull request routing.

**Current behavior**

Trusted stacked pull requests run on GitHub-hosted runners after the merge-parent check rejects the synthetic base merge.

**Proposed behavior**

The caller uses the authorized workflow SHA 7b199fcafa2f8b79fd25e83cb1524825ea8f9f3e.

**Reason and benefit**

The change lets approved stack jobs use the 100-runner AWS Fleet while all numeric identity and live-state checks remain active.

**Breaking changes**

None for untrusted contributors. Their jobs continue on GitHub-hosted runners.

**Additional context**

The runner group authorizes both this SHA and the previous SHA during rotation.

## What Changed

- Pin the thin caller to the authorized stacked-merge validator SHA.

## Verification

- Ran actionlint on both pull request workflows.
- Ran the external routing suite against the trusted workflow and caller.
- Verified that the runner group authorizes both immutable workflow versions.

## Risks

A bad pin can stop CI. The target is on master, the previous SHA stays authorized, and the caller change is a one-line reversible pin update.

> For core feature work, check ROADMAP.md first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See CONTRIBUTING.md.

## Model Used

OpenAI Codex on GPT-5. The exact deployment ID and context-window size are not exposed. The model used reasoning, tool use, GitHub API access, and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked an existing public item and described the issue in-PR
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge