### PR TITLE
ci: allow validated stacked base advances

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -105,17 +105,18 @@ jobs:
             --argjson repository_id 1170821064 \
             --argjson author_id "$EVENT_PR_AUTHOR_ID" \
             --arg base_ref "$EVENT_BASE_REF" \
-            --arg base_sha "$EVENT_BASE_SHA" \
             --arg head_sha "$EVENT_HEAD_SHA" \
             '
               .state == "open" and
               .user.id == $author_id and
               .base.repo.id == $repository_id and
               .base.ref == $base_ref and
-              .base.sha == $base_sha and
               .head.sha == $head_sha
             ' <<< "$pr_json" >/dev/null 2>&1 \
             || fail_closed 'current pull request state does not match the triggering event'
+
+          live_pr_base_sha="$(jq -r '.base.sha // empty' <<< "$pr_json")"
+          is_commit_sha "$live_pr_base_sha" || fail_closed 'current pull request has no valid base SHA'
 
           live_merge_sha="$(jq -r '.merge_commit_sha // empty' <<< "$pr_json")"
           is_commit_sha "$live_merge_sha" || fail_closed 'current pull request has no valid merge SHA'
@@ -127,6 +128,8 @@ jobs:
             || fail_closed 'could not inspect the current base branch'
           live_base_ref_sha="$(jq -r '.object.sha // empty' <<< "$base_ref_json")"
           is_commit_sha "$live_base_ref_sha" || fail_closed 'current base branch has no valid commit SHA'
+          [[ "$live_pr_base_sha" == "$live_base_ref_sha" ]] \
+            || fail_closed 'current pull request base changed during validation'
 
           base_comparison="$(gh api \
             -H 'Accept: application/vnd.github+json' \


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses pull request checks to protect changes.
> - The trusted CI workflow selects GitHub or AWS runners.
> - Stacked pull requests can advance their base branch while a gate waits.
> - The gate already proves that the live base descends from the event base.
> - An earlier exact base check rejects that safe state before the ancestry check runs.
> - This pull request removes the conflicting check and verifies live API consistency.
> - The benefit is automatic AWS routing for trusted stacked pull requests without weaker identity checks.

## Linked Issues or Issue Description

Refs #12339
Refs #12457

## What Changed

- Allow the live pull request base SHA to advance from the signed event base snapshot.
- Require the pull request API base SHA to match the live Git ref during validation.
- Keep the numeric author, sender, and triggering actor checks.
- Keep descendant ancestry and synthetic merge validation.

## Verification

- actionlint .github/workflows/pr-trusted.yml .github/workflows/pr.yml
- github-runners/tests/test-workflow.sh .github/workflows/pr-trusted.yml .github/workflows/pr.yml
- The routing suite covers a live stacked base advance and a base change during validation.

## Risks

- A trusted stacked run can use a newer descendant base than its signed event snapshot.
- Replaced ancestry still fails closed.
- A live base change during gate validation still fails closed.

## Model Used

- OpenAI Codex, GPT-5.6, with reasoning and terminal tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked existing issues or described the issue in this pull request
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation in the operations repository
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open findings
- [x] I will address all Greptile and reviewer comments before requesting merge