### PR TITLE
ci: activate live stacked base validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@7b199fcafa2f8b79fd25e83cb1524825ea8f9f3e
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@f929355fb9f4781ca46e542397fcaf2a110e6ca9


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses pull request checks to protect changes.
> - The trusted CI workflow selects GitHub or AWS runners.
> - Pull request #12459 fixed validation when a stacked base advances.
> - The public caller must use an immutable trusted workflow SHA.
> - This pull request changes only that SHA.
> - The benefit is automatic AWS routing for the affected trusted stack runs.

## Linked Issues or Issue Description

Refs #12339
Refs #12459

## What Changed

- Pin the thin pull request caller to f929355fb9f4781ca46e542397fcaf2a110e6ca9.

## Verification

- actionlint .github/workflows/pr-trusted.yml .github/workflows/pr.yml
- github-runners/tests/test-workflow.sh .github/workflows/pr-trusted.yml .github/workflows/pr.yml
- The runner group already authorizes the old and new exact workflow SHAs.

## Risks

- Low risk. This changes one immutable workflow reference.
- The old workflow SHA remains authorized while current runs finish.

## Model Used

- OpenAI Codex, GPT-5.6, with reasoning and terminal tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked existing public pull requests
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open findings
- [x] I will address all Greptile and reviewer comments before requesting merge