### PR TITLE
ci: ignore stale PR API base snapshots

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -115,9 +115,6 @@ jobs:
             ' <<< "$pr_json" >/dev/null 2>&1 \
             || fail_closed 'current pull request state does not match the triggering event'
 
-          live_pr_base_sha="$(jq -r '.base.sha // empty' <<< "$pr_json")"
-          is_commit_sha "$live_pr_base_sha" || fail_closed 'current pull request has no valid base SHA'
-
           live_merge_sha="$(jq -r '.merge_commit_sha // empty' <<< "$pr_json")"
           is_commit_sha "$live_merge_sha" || fail_closed 'current pull request has no valid merge SHA'
 
@@ -128,8 +125,6 @@ jobs:
             || fail_closed 'could not inspect the current base branch'
           live_base_ref_sha="$(jq -r '.object.sha // empty' <<< "$base_ref_json")"
           is_commit_sha "$live_base_ref_sha" || fail_closed 'current base branch has no valid commit SHA'
-          [[ "$live_pr_base_sha" == "$live_base_ref_sha" ]] \
-            || fail_closed 'current pull request base changed during validation'
 
           base_comparison="$(gh api \
             -H 'Accept: application/vnd.github+json' \


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses pull request checks to protect changes.
> - The trusted CI gate selects GitHub or AWS runners.
> - GitHub can return an old pull request base SHA after the live base advances.
> - The signed event, live Git ref, ancestry, and merge parents provide the required proof.
> - The stale API field rejects a safe run even when those proofs pass.
> - This pull request removes that unreliable equality.
> - The benefit is correct AWS routing for trusted stacked pull requests.

## Linked Issues or Issue Description

Refs #12339
Refs #12459

## What Changed

- Stop treating pull request base.sha as a current-state signal.
- Keep the signed event base SHA and live ref descendant check.
- Keep the live base or synthetic base merge-parent proof.
- Keep all numeric identity, repository, head SHA, and triggering actor checks.

## Verification

- actionlint .github/workflows/pr-trusted.yml .github/workflows/pr.yml
- github-runners/tests/test-workflow.sh .github/workflows/pr-trusted.yml .github/workflows/pr.yml
- The corrected gate selected the Fleet label with the exact live event data from PR #12339 run 33201610330.

## Risks

- The pull request API base SHA can be stale and is no longer compared.
- Replaced ancestry, a changed head, a changed merge parent, and a changed merge tree still fail closed.

## Model Used

- OpenAI Codex, GPT-5.6, with reasoning and terminal tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked existing public pull requests
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation in the operations repository
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open findings
- [x] I will address all Greptile and reviewer comments before requesting merge