### PR TITLE
feat(adapters): add aider_local adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY packages/paperclip-runner/package.json packages/paperclip-runner/
 COPY packages/skills-catalog/package.json packages/skills-catalog/
 COPY packages/tailscale-https-broker/package.json packages/tailscale-https-broker/
 COPY packages/teams-catalog/package.json packages/teams-catalog/
+COPY packages/adapters/aider-local/package.json packages/adapters/aider-local/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
+    "@paperclipai/adapter-aider-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -1,4 +1,5 @@
 import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
+import { printAiderStreamEvent } from "@paperclipai/adapter-aider-local/cli";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
@@ -13,6 +14,11 @@ import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
+
+const aiderLocalCLIAdapter: CLIAdapterModule = {
+  type: "aider_local",
+  formatStdoutEvent: printAiderStreamEvent,
+};
 
 const claudeLocalCLIAdapter: CLIAdapterModule = {
   type: "claude_local",
@@ -76,6 +82,7 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
 
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
+    aiderLocalCLIAdapter,
     claudeLocalCLIAdapter,
     codexLocalCLIAdapter,
     openCodeLocalCLIAdapter,

--- a/packages/adapters/aider-local/package.json
+++ b/packages/adapters/aider-local/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@paperclipai/adapter-aider-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/aider-local"
+  },
+  "type": "module",
+  "paperclip": {
+    "adapterUiParser": "1.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts",
+    "./ui-parser": "./dist/ui/parse-stdout.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      },
+      "./ui-parser": {
+        "types": "./dist/ui/parse-stdout.d.ts",
+        "import": "./dist/ui/parse-stdout.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2"
+  },
+  "engines": {
+    "node": ">=24.11.0"
+  }
+}

--- a/packages/adapters/aider-local/src/cli/format-event.ts
+++ b/packages/adapters/aider-local/src/cli/format-event.ts
@@ -1,0 +1,32 @@
+import pc from "picocolors";
+
+const ESC = String.fromCharCode(27);
+const ANSI_RE = new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, "g");
+
+export function printAiderStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.replace(ANSI_RE, "").trimEnd();
+  const trimmed = line.trim();
+  if (!trimmed) return;
+
+  if (/^Tokens:|^Cost:/i.test(trimmed)) {
+    console.log(pc.blue(trimmed));
+    return;
+  }
+
+  if (/^Applied edit to /i.test(trimmed) || /^Commit [0-9a-f]{7,40}/i.test(trimmed)) {
+    console.log(pc.cyan(trimmed));
+    return;
+  }
+
+  if (/^(?:Aider v|Main model:|Weak model:|Editor model:|Git repo:|Repo-map:|Added |Scanning repo|Use \/help)/i.test(trimmed)) {
+    console.log(pc.gray(trimmed));
+    return;
+  }
+
+  if (/^Warning:|^Error:|litellm\.[A-Za-z]*(?:Error|Exception)/.test(trimmed)) {
+    console.log(pc.red(trimmed));
+    return;
+  }
+
+  console.log(pc.green(line));
+}

--- a/packages/adapters/aider-local/src/cli/index.ts
+++ b/packages/adapters/aider-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAiderStreamEvent } from "./format-event.js";

--- a/packages/adapters/aider-local/src/index.ts
+++ b/packages/adapters/aider-local/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  ADAPTER_TYPE as type,
+  ADAPTER_LABEL as label,
+  DEFAULT_AIDER_LOCAL_MODEL,
+  DEFAULT_AIDER_CHAT_HISTORY_FILE,
+  models,
+} from "./shared/constants.js";
+export { agentConfigurationDoc } from "./shared/agent-configuration-doc.js";
+
+// The external plugin loader imports the package root and calls
+// createServerAdapter(). Built-in registration imports ./server directly, so
+// both install paths resolve the same module.
+export { createServerAdapter } from "./server/index.js";

--- a/packages/adapters/aider-local/src/server/execute.test.ts
+++ b/packages/adapters/aider-local/src/server/execute.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+const ensureRuntimeInstalledMock = vi.hoisted(() => vi.fn(async () => {}));
+const ensureCommandMock = vi.hoisted(() => vi.fn(async () => {}));
+const prepareRuntimeMock = vi.hoisted(() => vi.fn(async () => ({
+  workspaceRemoteDir: null,
+  restoreWorkspace: async () => {},
+})));
+const resolveCommandForLogsMock = vi.hoisted(() => vi.fn(async () => "aider"));
+const runProcessMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/adapter-utils/execution-target", () => ({
+  adapterExecutionTargetIsRemote: () => false,
+  adapterExecutionTargetRemoteCwd: (_target: unknown, cwd: string) => cwd,
+  overrideAdapterExecutionTargetRemoteCwd: (target: unknown, _cwd: string) => target,
+  adapterExecutionTargetSessionIdentity: () => ({ kind: "local" }),
+  adapterExecutionTargetSessionMatches: () => true,
+  describeAdapterExecutionTarget: () => "local",
+  ensureAdapterExecutionTargetCommandResolvable: ensureCommandMock,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled: ensureRuntimeInstalledMock,
+  prepareAdapterExecutionTargetRuntime: prepareRuntimeMock,
+  readAdapterExecutionTarget: ({ executionTarget }: { executionTarget?: unknown }) => executionTarget ?? { kind: "local" },
+  resolveAdapterExecutionTargetCommandForLogs: resolveCommandForLogsMock,
+  resolveAdapterExecutionTargetTimeoutSec: (_target: unknown, timeoutSec: number) => timeoutSec,
+  runAdapterExecutionTargetProcess: runProcessMock,
+}));
+
+import { execute } from "./execute.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-aider-local-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function makeCtx(overrides: {
+  runId?: string;
+  config: Record<string, unknown>;
+  runtime?: AdapterExecutionContext["runtime"];
+}): AdapterExecutionContext {
+  return {
+    runId: overrides.runId ?? "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Aider Agent",
+      adapterType: "aider_local",
+      adapterConfig: {},
+    },
+    runtime: overrides.runtime ?? {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: overrides.config,
+    context: {},
+    authToken: "run-token",
+    onLog: async () => {},
+  };
+}
+
+function okRun(stdout: string) {
+  return async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout,
+    stderr: "",
+  });
+}
+
+describe("aider_local execute", () => {
+  beforeEach(() => {
+    ensureRuntimeInstalledMock.mockClear();
+    ensureCommandMock.mockClear();
+    prepareRuntimeMock.mockClear();
+    resolveCommandForLogsMock.mockClear();
+    runProcessMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  });
+
+  it("runs one-shot with unattended defaults and passes the prompt last", async () => {
+    const root = await makeTempRoot();
+    let seenArgs: string[] = [];
+    runProcessMock.mockImplementation(async (_runId, _target, _command, args) => {
+      seenArgs = args;
+      return { exitCode: 0, signal: null, timedOut: false, stdout: "done\n", stderr: "" };
+    });
+
+    const result = await execute(makeCtx({ config: { cwd: root } }));
+
+    expect(seenArgs).toEqual(
+      expect.arrayContaining(["--no-check-update", "--no-pretty", "--no-auto-commits", "--yes-always"]),
+    );
+    // The default model is a sentinel meaning "use Aider's own config".
+    expect(seenArgs).not.toContain("--model");
+    expect(seenArgs).not.toContain("--restore-chat-history");
+    expect(seenArgs[seenArgs.length - 2]).toBe("--message");
+    expect(seenArgs[seenArgs.length - 1]).toEqual(expect.any(String));
+
+    const historyIndex = seenArgs.indexOf("--chat-history-file");
+    expect(historyIndex).toBeGreaterThan(-1);
+    expect(seenArgs[historyIndex + 1]).toBe(path.join(root, ".aider.chat.history.md"));
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      errorMessage: null,
+      provider: "aider",
+      model: null,
+      billingType: "api",
+      usageBasis: "per_run",
+      sessionParams: { chatHistoryFile: path.join(root, ".aider.chat.history.md"), cwd: root },
+    });
+  });
+
+  it("attaches instructions and desired skills as read-only context files", async () => {
+    const root = await makeTempRoot();
+    const instructionsPath = path.join(root, "managed", "AGENTS.md");
+    const skillSource = path.join(root, "runtime-skills", "paperclip");
+    await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
+    await fs.writeFile(instructionsPath, "You are an Aider agent.\n", "utf8");
+    await fs.mkdir(skillSource, { recursive: true });
+    await fs.writeFile(path.join(skillSource, "SKILL.md"), "---\nname: paperclip\n---\n", "utf8");
+
+    let seenArgs: string[] = [];
+    runProcessMock.mockImplementation(async (_runId, _target, _command, args) => {
+      seenArgs = args;
+      return { exitCode: 0, signal: null, timedOut: false, stdout: "done\n", stderr: "" };
+    });
+
+    await execute(makeCtx({
+      config: {
+        cwd: root,
+        instructionsFilePath: instructionsPath,
+        paperclipRuntimeSkills: [{
+          key: "paperclip",
+          runtimeName: "paperclip",
+          source: skillSource,
+          required: false,
+        }],
+        paperclipSkillSync: { desiredSkills: ["paperclip"] },
+      },
+    }));
+
+    const readValues = seenArgs.reduce<string[]>((acc, value, index) => {
+      if (value === "--read" && seenArgs[index + 1]) acc.push(seenArgs[index + 1]!);
+      return acc;
+    }, []);
+    expect(readValues).toContain(instructionsPath);
+    expect(readValues).toContain(path.join(skillSource, "SKILL.md"));
+
+    // Nothing is copied into the workspace — Aider reads the sources in place.
+    await expect(fs.access(path.join(root, "AGENTS.md"))).rejects.toThrow();
+  });
+
+  it("restores the chat history only when the saved transcript still exists in the same cwd", async () => {
+    const root = await makeTempRoot();
+    const historyPath = path.join(root, ".aider.chat.history.md");
+    runProcessMock.mockImplementation(okRun("done\n"));
+
+    const runtime = {
+      sessionId: null,
+      sessionParams: { chatHistoryFile: historyPath, cwd: root },
+      sessionDisplayId: historyPath,
+      taskKey: null,
+    } as AdapterExecutionContext["runtime"];
+
+    await execute(makeCtx({ runId: "run-missing-history", config: { cwd: root }, runtime }));
+    expect(runProcessMock.mock.calls[0]?.[3]).not.toContain("--restore-chat-history");
+
+    await fs.writeFile(historyPath, "# aider chat started\n", "utf8");
+    await execute(makeCtx({ runId: "run-existing-history", config: { cwd: root }, runtime }));
+    expect(runProcessMock.mock.calls[1]?.[3]).toContain("--restore-chat-history");
+  });
+
+  it("maps the tokens/cost footer onto usage and flags a quota failure", async () => {
+    const root = await makeTempRoot();
+    runProcessMock.mockImplementation(okRun(
+      [
+        "Applied edit to src/app.ts",
+        "Tokens: 2.4k sent, 261 received. Cost: $0.0132 message, $0.0410 session.",
+      ].join("\n"),
+    ));
+
+    const result = await execute(makeCtx({ config: { cwd: root, model: "sonnet" } }));
+
+    expect(result).toMatchObject({
+      usage: { inputTokens: 2400, outputTokens: 261 },
+      usageBasis: "per_run",
+      model: "sonnet",
+      costUsd: 0.0132,
+    });
+    expect(result.resultJson).toMatchObject({
+      editedFiles: ["src/app.ts"],
+      sessionCostUsd: 0.041,
+      resumedChatHistory: false,
+    });
+
+    runProcessMock.mockImplementation(async () => ({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "litellm.RateLimitError: 429 rate limit exceeded",
+    }));
+
+    const failed = await execute(makeCtx({ runId: "run-quota", config: { cwd: root } }));
+    expect(failed.errorFamily).toBe("provider_quota");
+    expect(failed.errorMessage).toContain("RateLimitError");
+  });
+});

--- a/packages/adapters/aider-local/src/server/execute.test.ts
+++ b/packages/adapters/aider-local/src/server/execute.test.ts
@@ -6,15 +6,16 @@ import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 
 const ensureRuntimeInstalledMock = vi.hoisted(() => vi.fn(async () => {}));
 const ensureCommandMock = vi.hoisted(() => vi.fn(async () => {}));
-const prepareRuntimeMock = vi.hoisted(() => vi.fn(async () => ({
-  workspaceRemoteDir: null,
+const prepareRuntimeMock = vi.hoisted(() => vi.fn(async (_input: unknown) => ({
+  workspaceRemoteDir: null as string | null,
+  assetDirs: {} as Record<string, string>,
   restoreWorkspace: async () => {},
 })));
 const resolveCommandForLogsMock = vi.hoisted(() => vi.fn(async () => "aider"));
 const runProcessMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@paperclipai/adapter-utils/execution-target", () => ({
-  adapterExecutionTargetIsRemote: () => false,
+  adapterExecutionTargetIsRemote: (target: unknown) => (target as { kind?: string } | null)?.kind === "remote",
   adapterExecutionTargetRemoteCwd: (_target: unknown, cwd: string) => cwd,
   overrideAdapterExecutionTargetRemoteCwd: (target: unknown, _cwd: string) => target,
   adapterExecutionTargetSessionIdentity: () => ({ kind: "local" }),
@@ -27,6 +28,11 @@ vi.mock("@paperclipai/adapter-utils/execution-target", () => ({
   resolveAdapterExecutionTargetCommandForLogs: resolveCommandForLogsMock,
   resolveAdapterExecutionTargetTimeoutSec: (_target: unknown, timeoutSec: number) => timeoutSec,
   runAdapterExecutionTargetProcess: runProcessMock,
+  runtimeAssetDir: (
+    prepared: { assetDirs?: Record<string, string> },
+    key: string,
+    fallbackRemoteCwd: string,
+  ) => prepared.assetDirs?.[key] ?? `${fallbackRemoteCwd}/.paperclip-runtime/${key}`,
 }));
 
 import { execute } from "./execute.js";
@@ -43,9 +49,11 @@ function makeCtx(overrides: {
   runId?: string;
   config: Record<string, unknown>;
   runtime?: AdapterExecutionContext["runtime"];
+  executionTarget?: AdapterExecutionContext["executionTarget"];
 }): AdapterExecutionContext {
   return {
     runId: overrides.runId ?? "run-1",
+    executionTarget: overrides.executionTarget,
     agent: {
       id: "agent-1",
       companyId: "company-1",
@@ -181,6 +189,90 @@ describe("aider_local execute", () => {
     await fs.writeFile(historyPath, "# aider chat started\n", "utf8");
     await execute(makeCtx({ runId: "run-existing-history", config: { cwd: root }, runtime }));
     expect(runProcessMock.mock.calls[1]?.[3]).toContain("--restore-chat-history");
+  });
+
+  it("does not restore a transcript different from the persisted session's file", async () => {
+    const root = await makeTempRoot();
+    const savedHistoryPath = path.join(root, "previous-history.md");
+    const configuredHistoryPath = path.join(root, ".aider.chat.history.md");
+    await fs.writeFile(savedHistoryPath, "# aider chat started\n", "utf8");
+    await fs.writeFile(configuredHistoryPath, "# aider chat started\n", "utf8");
+    runProcessMock.mockImplementation(okRun("done\n"));
+
+    const runtime = {
+      sessionId: null,
+      sessionParams: { chatHistoryFile: savedHistoryPath, cwd: root },
+      sessionDisplayId: savedHistoryPath,
+      taskKey: null,
+    } as AdapterExecutionContext["runtime"];
+
+    await execute(makeCtx({ config: { cwd: root }, runtime }));
+    expect(runProcessMock.mock.calls[0]?.[3]).not.toContain("--restore-chat-history");
+  });
+
+  it("stages instructions and skills as runtime assets for remote targets", async () => {
+    const root = await makeTempRoot();
+    const instructionsPath = path.join(root, "managed", "AGENTS.md");
+    const skillSource = path.join(root, "runtime-skills", "paperclip");
+    await fs.mkdir(path.dirname(instructionsPath), { recursive: true });
+    await fs.writeFile(instructionsPath, "You are an Aider agent.\n", "utf8");
+    await fs.mkdir(skillSource, { recursive: true });
+    await fs.writeFile(path.join(skillSource, "SKILL.md"), "---\nname: paperclip\n---\n", "utf8");
+
+    let seenAssets: Array<{ key: string; localDir: string }> = [];
+    let stagedInstructionsContent = "";
+    prepareRuntimeMock.mockImplementationOnce(async (input) => {
+      seenAssets = (input as { assets?: Array<{ key: string; localDir: string }> }).assets ?? [];
+      const instructionsAsset = seenAssets.find((asset) => asset.key === "instructions");
+      if (instructionsAsset) {
+        stagedInstructionsContent = await fs.readFile(
+          path.join(instructionsAsset.localDir, "AGENTS.md"),
+          "utf8",
+        );
+      }
+      return {
+        workspaceRemoteDir: "/remote/ws",
+        assetDirs: { "skill-0": "/remote/runtime/skill-0", instructions: "/remote/runtime/instructions" },
+        restoreWorkspace: async () => {},
+      };
+    });
+    let seenArgs: string[] = [];
+    runProcessMock.mockImplementation(async (_runId, _target, _command, args) => {
+      seenArgs = args;
+      return { exitCode: 0, signal: null, timedOut: false, stdout: "done\n", stderr: "" };
+    });
+
+    await execute(makeCtx({
+      executionTarget: { kind: "remote" } as AdapterExecutionContext["executionTarget"],
+      config: {
+        cwd: root,
+        instructionsFilePath: instructionsPath,
+        paperclipRuntimeSkills: [{
+          key: "paperclip",
+          runtimeName: "paperclip",
+          source: skillSource,
+          required: false,
+        }],
+        paperclipSkillSync: { desiredSkills: ["paperclip"] },
+      },
+    }));
+
+    expect(seenAssets.map((asset) => asset.key)).toEqual(["skill-0", "instructions"]);
+    expect(seenAssets[0]?.localDir).toBe(skillSource);
+    // Instructions stage from a scratch copy, never the operator's directory.
+    expect(seenAssets[1]?.localDir).not.toBe(path.dirname(instructionsPath));
+    expect(stagedInstructionsContent).toBe("You are an Aider agent.\n");
+    // The staging copy is removed once the run finishes.
+    await expect(fs.access(seenAssets[1]!.localDir)).rejects.toThrow();
+
+    const readValues = seenArgs.reduce<string[]>((acc, value, index) => {
+      if (value === "--read" && seenArgs[index + 1]) acc.push(seenArgs[index + 1]!);
+      return acc;
+    }, []);
+    expect(readValues).toEqual([
+      "/remote/runtime/instructions/AGENTS.md",
+      "/remote/runtime/skill-0/SKILL.md",
+    ]);
   });
 
   it("maps the tokens/cost footer onto usage and flags a quota failure", async () => {

--- a/packages/adapters/aider-local/src/server/execute.ts
+++ b/packages/adapters/aider-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -16,6 +17,7 @@ import {
   resolveAdapterExecutionTargetCommandForLogs,
   resolveAdapterExecutionTargetTimeoutSec,
   runAdapterExecutionTargetProcess,
+  runtimeAssetDir,
 } from "@paperclipai/adapter-utils/execution-target";
 import {
   asBoolean,
@@ -152,6 +154,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   let restoreRemoteWorkspace: (() => Promise<void>) | null = null;
+  let instructionsStagingDir: string | null = null;
 
   try {
     const envConfig = parseObject(config.env);
@@ -210,17 +213,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onLog,
     });
 
+    // Local runs read instructions and skills in place. A remote target only
+    // receives the synced workspace, so those host-local files ride along as
+    // managed runtime assets and the --read args switch to the staged paths.
+    let effectiveInstructionsReadPath = instructionsFilePath;
+    let effectiveSkillReadPaths = skillReadPaths;
     if (executionTargetIsRemote) {
       await onLog(
         "stdout",
         `[paperclip] Syncing Aider workspace to ${describeAdapterExecutionTarget(executionTarget)}.\n`,
       );
+      const readAssets = skillReadPaths.map((skillPath, index) => ({
+        key: `skill-${index}`,
+        localDir: path.dirname(skillPath),
+      }));
+      if (instructionsFilePath) {
+        instructionsStagingDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-aider-read-"));
+        await fs.copyFile(
+          instructionsFilePath,
+          path.join(instructionsStagingDir, path.basename(instructionsFilePath)),
+        );
+        readAssets.push({ key: "instructions", localDir: instructionsStagingDir });
+      }
       const preparedExecutionTargetRuntime = await prepareAdapterExecutionTargetRuntime({
         runId,
         target: executionTarget,
         adapterKey: "aider",
         workspaceLocalDir: cwd,
         timeoutSec,
+        assets: readAssets,
         installCommand: ctx.runtimeCommandSpec?.installCommand ?? null,
         detectCommand: ctx.runtimeCommandSpec?.detectCommand ?? command,
         onProgress: (line) => onLog("stdout", line),
@@ -229,6 +250,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       restoreRemoteWorkspace = () =>
         preparedExecutionTargetRuntime.restoreWorkspace((line) => onLog("stdout", line));
       effectiveExecutionCwd = preparedExecutionTargetRuntime.workspaceRemoteDir ?? effectiveExecutionCwd;
+      effectiveSkillReadPaths = skillReadPaths.map((skillPath, index) =>
+        path.posix.join(
+          runtimeAssetDir(preparedExecutionTargetRuntime, `skill-${index}`, effectiveExecutionCwd),
+          path.basename(skillPath),
+        ),
+      );
+      if (instructionsFilePath) {
+        effectiveInstructionsReadPath = path.posix.join(
+          runtimeAssetDir(preparedExecutionTargetRuntime, "instructions", effectiveExecutionCwd),
+          path.basename(instructionsFilePath),
+        );
+      }
       refreshPaperclipWorkspaceEnvForExecution({
         env,
         envConfig,
@@ -277,9 +310,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
     const cwdMatches =
       runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd);
+    // The transcript inside the workspace rides the workspace sync, so remote
+    // existence mirrors the last run; only local runs can cheaply stat it.
     const historyOnDisk = executionTargetIsRemote ? true : await pathExists(chatHistoryPath);
+    const historyMatches =
+      savedHistoryFile.length > 0 && path.resolve(savedHistoryFile) === path.resolve(chatHistoryPath);
     const canResumeSession =
-      savedHistoryFile.length > 0 &&
+      historyMatches &&
       cwdMatches &&
       historyOnDisk &&
       adapterExecutionTargetSessionMatches(runtimeRemoteExecution, runtimeExecutionTarget);
@@ -287,7 +324,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (savedHistoryFile.length > 0 && !canResumeSession) {
       await onLog(
         "stdout",
-        `[paperclip] Aider chat history "${savedHistoryFile}" is not resumable in "${effectiveExecutionCwd}". Starting a fresh chat.\n`,
+        `[paperclip] Aider chat history "${savedHistoryFile}" is not resumable at "${chatHistoryPath}". Starting a fresh chat.\n`,
       );
     }
 
@@ -328,7 +365,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       if (alwaysApprove) notes.push("Added --yes-always for unattended execution.");
       if (!autoCommits) notes.push("Added --no-auto-commits so Paperclip's workspace sync owns commits.");
       if (canResumeSession) notes.push(`Resuming chat history from ${chatHistoryPath}.`);
-      if (instructionsFilePath) notes.push(`Attached instructions via --read ${instructionsFilePath}.`);
+      if (effectiveInstructionsReadPath) notes.push(`Attached instructions via --read ${effectiveInstructionsReadPath}.`);
       if (skillReadPaths.length > 0) {
         notes.push(`Attached ${skillReadPaths.length} Paperclip skill file(s) via --read.`);
       }
@@ -345,8 +382,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       list.push("--chat-history-file", chatHistoryPath);
       if (canResumeSession) list.push("--restore-chat-history");
       if (mapTokens > 0) list.push("--map-tokens", String(mapTokens));
-      if (instructionsFilePath) list.push("--read", instructionsFilePath);
-      for (const skillPath of skillReadPaths) list.push("--read", skillPath);
+      if (effectiveInstructionsReadPath) list.push("--read", effectiveInstructionsReadPath);
+      for (const skillPath of effectiveSkillReadPaths) list.push("--read", skillPath);
       for (const file of editFiles) list.push("--file", file);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
@@ -442,5 +479,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   } finally {
     await restoreRemoteWorkspace?.();
+    if (instructionsStagingDir) {
+      await fs.rm(instructionsStagingDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 }

--- a/packages/adapters/aider-local/src/server/execute.ts
+++ b/packages/adapters/aider-local/src/server/execute.ts
@@ -1,0 +1,446 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  adapterExecutionTargetIsRemote,
+  adapterExecutionTargetRemoteCwd,
+  adapterExecutionTargetSessionIdentity,
+  adapterExecutionTargetSessionMatches,
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  overrideAdapterExecutionTargetRemoteCwd,
+  prepareAdapterExecutionTargetRuntime,
+  readAdapterExecutionTarget,
+  resolveAdapterExecutionTargetCommandForLogs,
+  resolveAdapterExecutionTargetTimeoutSec,
+  runAdapterExecutionTargetProcess,
+} from "@paperclipai/adapter-utils/execution-target";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  buildInvocationEnvForLogs,
+  buildPaperclipEnv,
+  ensureAbsoluteDirectory,
+  ensurePathInEnv,
+  joinPromptSections,
+  parseObject,
+  readPaperclipIssueWorkModeFromContext,
+  readPaperclipRuntimeSkillEntries,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  isPaperclipRecoveryWakePayload,
+  resolveLegacyPaperclipDesiredSkillNames,
+  stringifyPaperclipWakePayload,
+  refreshPaperclipWorkspaceEnvForExecution,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  ADAPTER_TYPE,
+  DEFAULT_AIDER_CHAT_HISTORY_FILE,
+  DEFAULT_AIDER_LOCAL_MODEL,
+} from "../shared/constants.js";
+import { firstNonEmptyLine, isAiderQuotaError, parseAiderOutput } from "./parse.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+  const raw = env[key];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+    "",
+    "",
+  ].join("\n");
+}
+
+function renderApiAccessNote(env: Record<string, string>): string {
+  if (!hasNonEmptyEnvValue(env, "PAPERCLIP_API_URL") || !hasNonEmptyEnvValue(env, "PAPERCLIP_API_KEY")) return "";
+  return [
+    "Paperclip API access note:",
+    "Use shell commands with curl to make Paperclip API requests when needed.",
+    "Include X-Paperclip-Run-Id on mutating requests.",
+    "",
+    "",
+  ].join("\n");
+}
+
+async function pathExists(candidate: string): Promise<boolean> {
+  return fs.access(candidate).then(() => true).catch(() => false);
+}
+
+/**
+ * Aider has no skills mechanism. The closest native surface is `--read`, which
+ * loads a file as read-only context, so each desired skill contributes its
+ * SKILL.md when one exists. Nothing is written into the workspace.
+ */
+async function resolveSkillReadPaths(input: {
+  skillEntries: Array<{ key: string; runtimeName: string; source: string }>;
+  desiredSkillNames: string[];
+  skipExistenceCheck: boolean;
+}): Promise<string[]> {
+  const desired = new Set(input.desiredSkillNames);
+  const paths: string[] = [];
+  for (const entry of input.skillEntries) {
+    if (!desired.has(entry.key)) continue;
+    const candidate = path.join(entry.source, "SKILL.md");
+    if (input.skipExistenceCheck || (await pathExists(candidate))) {
+      paths.push(candidate);
+    }
+  }
+  return paths;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const executionTarget = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+  const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
+
+  const promptTemplate = asString(config.promptTemplate, DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE);
+  const command = asString(config.command, "aider");
+  const model = asString(config.model, DEFAULT_AIDER_LOCAL_MODEL).trim();
+  const alwaysApprove = asBoolean(config.alwaysApprove, true);
+  // Paperclip's workspace sync is the persistence boundary between runs, so the
+  // default leaves committing to the operator instead of letting Aider commit
+  // every turn on its own.
+  const autoCommits = asBoolean(config.autoCommits, false);
+  const stream = asBoolean(config.stream, true);
+  const pretty = asBoolean(config.pretty, false);
+  const mapTokens = asNumber(config.mapTokens, 0);
+  const editFiles = asStringArray(config.files);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+        (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null,
+      )
+    : [];
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const skillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkillNames = resolveLegacyPaperclipDesiredSkillNames(config, skillEntries);
+  const skillReadPaths = await resolveSkillReadPaths({
+    skillEntries,
+    desiredSkillNames,
+    skipExistenceCheck: executionTargetIsRemote,
+  });
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  let restoreRemoteWorkspace: (() => Promise<void>) | null = null;
+
+  try {
+    const envConfig = parseObject(config.env);
+    const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+    env.PAPERCLIP_RUN_ID = runId;
+    const wakeTaskId = asString(context.taskId, "").trim() || asString(context.issueId, "").trim() || null;
+    const wakeReason = asString(context.wakeReason, "").trim() || null;
+    const wakeCommentId =
+      asString(context.wakeCommentId, "").trim() || asString(context.commentId, "").trim() || null;
+    const approvalId = asString(context.approvalId, "").trim() || null;
+    const approvalStatus = asString(context.approvalStatus, "").trim() || null;
+    const linkedIssueIds = Array.isArray(context.issueIds)
+      ? context.issueIds.filter((value: unknown): value is string => typeof value === "string" && value.trim().length > 0)
+      : [];
+    const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+    const issueWorkMode = readPaperclipIssueWorkModeFromContext(context);
+    if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+    if (issueWorkMode) env.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
+    if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+    if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+    if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+    if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+    if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+    if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+    refreshPaperclipWorkspaceEnvForExecution({
+      env,
+      envConfig,
+      workspaceCwd: effectiveWorkspaceCwd,
+      workspaceSource,
+      workspaceId,
+      workspaceRepoUrl,
+      workspaceRepoRef,
+      workspaceHints,
+      agentHome,
+      executionTargetIsRemote,
+      executionCwd: effectiveExecutionCwd,
+    });
+    if (authToken) {
+      env.PAPERCLIP_API_KEY = authToken;
+    }
+
+    const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
+      executionTarget,
+      asNumber(config.timeoutSec, 0),
+    );
+    const graceSec = asNumber(config.graceSec, 20);
+    await ensureAdapterExecutionTargetRuntimeCommandInstalled({
+      runId,
+      target: executionTarget,
+      installCommand: ctx.runtimeCommandSpec?.installCommand,
+      detectCommand: ctx.runtimeCommandSpec?.detectCommand,
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onLog,
+    });
+
+    if (executionTargetIsRemote) {
+      await onLog(
+        "stdout",
+        `[paperclip] Syncing Aider workspace to ${describeAdapterExecutionTarget(executionTarget)}.\n`,
+      );
+      const preparedExecutionTargetRuntime = await prepareAdapterExecutionTargetRuntime({
+        runId,
+        target: executionTarget,
+        adapterKey: "aider",
+        workspaceLocalDir: cwd,
+        timeoutSec,
+        installCommand: ctx.runtimeCommandSpec?.installCommand ?? null,
+        detectCommand: ctx.runtimeCommandSpec?.detectCommand ?? command,
+        onProgress: (line) => onLog("stdout", line),
+        onRuntimeProgress: ctx.onRuntimeProgress,
+      });
+      restoreRemoteWorkspace = () =>
+        preparedExecutionTargetRuntime.restoreWorkspace((line) => onLog("stdout", line));
+      effectiveExecutionCwd = preparedExecutionTargetRuntime.workspaceRemoteDir ?? effectiveExecutionCwd;
+      refreshPaperclipWorkspaceEnvForExecution({
+        env,
+        envConfig,
+        workspaceCwd: effectiveWorkspaceCwd,
+        workspaceSource,
+        workspaceId,
+        workspaceRepoUrl,
+        workspaceRepoRef,
+        workspaceHints,
+        agentHome,
+        executionTargetIsRemote,
+        executionCwd: effectiveExecutionCwd,
+      });
+    }
+
+    const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
+    const effectiveEnv = Object.fromEntries(
+      Object.entries({ ...process.env, ...env }).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    );
+    const runtimeEnv = ensurePathInEnv(effectiveEnv);
+    await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv, {
+      installCommand: ctx.runtimeCommandSpec?.installCommand ?? null,
+      timeoutSec,
+    });
+    const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+    const loggedEnv = buildInvocationEnvForLogs(env, {
+      runtimeEnv,
+      includeRuntimeKeys: ["HOME"],
+      resolvedCommand,
+    });
+
+    // Aider keys continuity off a chat transcript file in the run cwd rather
+    // than a server-side session id, so the "session" is that file plus the cwd
+    // it belongs to.
+    const configuredHistoryFile = asString(config.chatHistoryFile, DEFAULT_AIDER_CHAT_HISTORY_FILE).trim()
+      || DEFAULT_AIDER_CHAT_HISTORY_FILE;
+    const chatHistoryPath = path.isAbsolute(configuredHistoryFile)
+      ? configuredHistoryFile
+      : path.join(effectiveExecutionCwd, configuredHistoryFile);
+
+    const runtimeSessionParams = parseObject(runtime.sessionParams);
+    const savedHistoryFile = asString(runtimeSessionParams.chatHistoryFile, "");
+    const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+    const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
+    const cwdMatches =
+      runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd);
+    const historyOnDisk = executionTargetIsRemote ? true : await pathExists(chatHistoryPath);
+    const canResumeSession =
+      savedHistoryFile.length > 0 &&
+      cwdMatches &&
+      historyOnDisk &&
+      adapterExecutionTargetSessionMatches(runtimeRemoteExecution, runtimeExecutionTarget);
+
+    if (savedHistoryFile.length > 0 && !canResumeSession) {
+      await onLog(
+        "stdout",
+        `[paperclip] Aider chat history "${savedHistoryFile}" is not resumable in "${effectiveExecutionCwd}". Starting a fresh chat.\n`,
+      );
+    }
+
+    const templateData = {
+      agentId: agent.id,
+      companyId: agent.companyId,
+      runId,
+      company: { id: agent.companyId },
+      agent,
+      run: { id: runId, source: "on_demand" },
+      context,
+    };
+    const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: canResumeSession });
+    const shouldUseResumeDeltaPrompt = canResumeSession && wakePrompt.length > 0;
+    const renderedPrompt = shouldUseResumeDeltaPrompt || isPaperclipRecoveryWakePayload(context.paperclipWake)
+      ? ""
+      : renderTemplate(promptTemplate, templateData);
+    const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+    const paperclipEnvNote = renderPaperclipEnvNote(env);
+    const apiAccessNote = renderApiAccessNote(env);
+    const prompt = joinPromptSections([
+      wakePrompt,
+      sessionHandoffNote,
+      paperclipEnvNote,
+      apiAccessNote,
+      renderedPrompt,
+    ]);
+    const promptMetrics = {
+      promptChars: prompt.length,
+      wakePromptChars: wakePrompt.length,
+      sessionHandoffChars: sessionHandoffNote.length,
+      runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
+      heartbeatPromptChars: renderedPrompt.length,
+    };
+
+    const commandNotes = (() => {
+      const notes: string[] = ["Prompt is passed to Aider via --message in one-shot mode."];
+      if (alwaysApprove) notes.push("Added --yes-always for unattended execution.");
+      if (!autoCommits) notes.push("Added --no-auto-commits so Paperclip's workspace sync owns commits.");
+      if (canResumeSession) notes.push(`Resuming chat history from ${chatHistoryPath}.`);
+      if (instructionsFilePath) notes.push(`Attached instructions via --read ${instructionsFilePath}.`);
+      if (skillReadPaths.length > 0) {
+        notes.push(`Attached ${skillReadPaths.length} Paperclip skill file(s) via --read.`);
+      }
+      return notes;
+    })();
+
+    const args = (() => {
+      const list = ["--no-check-update"];
+      if (!pretty) list.push("--no-pretty");
+      if (!stream) list.push("--no-stream");
+      if (!autoCommits) list.push("--no-auto-commits");
+      if (alwaysApprove) list.push("--yes-always");
+      if (model && model !== DEFAULT_AIDER_LOCAL_MODEL) list.push("--model", model);
+      list.push("--chat-history-file", chatHistoryPath);
+      if (canResumeSession) list.push("--restore-chat-history");
+      if (mapTokens > 0) list.push("--map-tokens", String(mapTokens));
+      if (instructionsFilePath) list.push("--read", instructionsFilePath);
+      for (const skillPath of skillReadPaths) list.push("--read", skillPath);
+      for (const file of editFiles) list.push("--file", file);
+      const extraArgs = (() => {
+        const fromExtraArgs = asStringArray(config.extraArgs);
+        if (fromExtraArgs.length > 0) return fromExtraArgs;
+        return asStringArray(config.args);
+      })();
+      if (extraArgs.length > 0) list.push(...extraArgs);
+      list.push("--message", prompt);
+      return list;
+    })();
+
+    if (onMeta) {
+      await onMeta({
+        adapterType: ADAPTER_TYPE,
+        command: resolvedCommand,
+        cwd: effectiveExecutionCwd,
+        commandNotes,
+        commandArgs: args.map((value, index) => (
+          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
+        )),
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onRuntimeProgress: ctx.onRuntimeProgress,
+      onLog,
+    });
+
+    if (proc.timedOut) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+      };
+    }
+
+    const parsed = parseAiderOutput(proc.stdout, proc.stderr);
+    const failed = (proc.exitCode ?? 0) !== 0;
+    const errorMessage = failed
+      ? parsed.errorMessage || firstNonEmptyLine(proc.stderr) || `Aider exited with code ${proc.exitCode ?? -1}`
+      : null;
+    const quotaExhausted = failed && isAiderQuotaError(proc.stdout, proc.stderr);
+
+    const sessionParams: Record<string, unknown> = {
+      chatHistoryFile: chatHistoryPath,
+      cwd: effectiveExecutionCwd,
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+      ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+      ...(executionTargetIsRemote
+        ? { remoteExecution: adapterExecutionTargetSessionIdentity(runtimeExecutionTarget) }
+        : {}),
+    };
+
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: false,
+      errorMessage,
+      ...(quotaExhausted ? { errorFamily: "provider_quota" as const } : {}),
+      usage: {
+        inputTokens: parsed.inputTokens,
+        outputTokens: parsed.outputTokens,
+      },
+      // Aider's footer reports the tokens for this `--message` turn only; the
+      // dollar figure it labels "session" is the running total and is reported
+      // separately in resultJson rather than as this run's cost.
+      usageBasis: "per_run",
+      sessionParams,
+      sessionDisplayId: chatHistoryPath,
+      provider: "aider",
+      model: model === DEFAULT_AIDER_LOCAL_MODEL ? null : model,
+      billingType: "api",
+      costUsd: parsed.messageCostUsd,
+      resultJson: {
+        editedFiles: parsed.editedFiles,
+        commits: parsed.commits,
+        sessionCostUsd: parsed.sessionCostUsd,
+        resumedChatHistory: canResumeSession,
+        ...(failed ? { stderr: proc.stderr } : {}),
+      },
+      summary: parsed.summary,
+    };
+  } finally {
+    await restoreRemoteWorkspace?.();
+  }
+}

--- a/packages/adapters/aider-local/src/server/index.ts
+++ b/packages/adapters/aider-local/src/server/index.ts
@@ -1,0 +1,145 @@
+import type {
+  AdapterConfigSchema,
+  AdapterRuntimeCommandSpec,
+  AdapterSessionCodec,
+  ServerAdapterModule,
+} from "@paperclipai/adapter-utils";
+import {
+  ADAPTER_TYPE,
+  DEFAULT_AIDER_CHAT_HISTORY_FILE,
+  DEFAULT_AIDER_LOCAL_MODEL,
+  models,
+} from "../shared/constants.js";
+import { agentConfigurationDoc } from "../shared/agent-configuration-doc.js";
+import { execute } from "./execute.js";
+import { listAiderSkills, syncAiderSkills } from "./skills.js";
+import { testEnvironment } from "./test.js";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readSession(record: Record<string, unknown>): Record<string, unknown> | null {
+  const chatHistoryFile =
+    readNonEmptyString(record.chatHistoryFile) ?? readNonEmptyString(record.chat_history_file);
+  if (!chatHistoryFile) return null;
+  const cwd = readNonEmptyString(record.cwd) ?? readNonEmptyString(record.workdir);
+  const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+  const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+  const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+  const remoteExecution =
+    typeof record.remoteExecution === "object" && record.remoteExecution !== null
+      ? (record.remoteExecution as Record<string, unknown>)
+      : null;
+  return {
+    chatHistoryFile,
+    ...(cwd ? { cwd } : {}),
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(repoUrl ? { repoUrl } : {}),
+    ...(repoRef ? { repoRef } : {}),
+    ...(remoteExecution ? { remoteExecution } : {}),
+  };
+}
+
+/**
+ * Aider has no server-side session id — continuity is the chat transcript file
+ * plus the cwd it was written in, so that pair is what persists.
+ */
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    return readSession(raw as Record<string, unknown>);
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readSession(params);
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.chatHistoryFile) ?? readNonEmptyString(params.chat_history_file);
+  },
+};
+
+export function getConfigSchema(): AdapterConfigSchema {
+  return {
+    fields: [
+      {
+        key: "model",
+        label: "Model",
+        type: "text",
+        default: DEFAULT_AIDER_LOCAL_MODEL,
+        hint: "Aider model alias (sonnet, gpt-5) or a full litellm model id. Leave as aider-default to use Aider's own configuration.",
+      },
+      {
+        key: "chatHistoryFile",
+        label: "Chat history file",
+        type: "text",
+        default: DEFAULT_AIDER_CHAT_HISTORY_FILE,
+        hint: "Transcript Aider restores on the next heartbeat. Relative paths resolve inside the run working directory.",
+      },
+      {
+        key: "autoCommits",
+        label: "Let Aider commit",
+        type: "toggle",
+        default: false,
+        hint: "Off passes --no-auto-commits so Paperclip's workspace sync decides what gets committed.",
+      },
+      {
+        key: "alwaysApprove",
+        label: "Unattended approvals",
+        type: "toggle",
+        default: true,
+        hint: "Passes --yes-always. Turn off for Aider builds that still spell the flag --yes, and add it to extra args.",
+      },
+      {
+        key: "stream",
+        label: "Stream model output",
+        type: "toggle",
+        default: true,
+        hint: "Off passes --no-stream, which prints the reply only once the turn completes.",
+      },
+      {
+        key: "mapTokens",
+        label: "Repo map tokens",
+        type: "number",
+        hint: "Optional --map-tokens budget for Aider's repository map.",
+      },
+    ],
+  };
+}
+
+export function getRuntimeCommandSpec(config: Record<string, unknown>): AdapterRuntimeCommandSpec {
+  const configured = typeof config.command === "string" ? config.command.trim() : "";
+  const command = configured.length > 0 ? configured : "aider";
+  return {
+    command,
+    detectCommand: command,
+    // Aider installs through pip/uv, not npm, and the install path varies per
+    // host, so remote provisioning stays an operator decision.
+    installCommand: null,
+  };
+}
+
+export function createServerAdapter(): ServerAdapterModule {
+  return {
+    type: ADAPTER_TYPE,
+    execute,
+    testEnvironment,
+    listSkills: listAiderSkills,
+    syncSkills: syncAiderSkills,
+    sessionCodec,
+    models,
+    supportsLocalAgentJwt: true,
+    supportsInstructionsBundle: true,
+    instructionsPathKey: "instructionsFilePath",
+    requiresMaterializedRuntimeSkills: true,
+    getRuntimeCommandSpec,
+    agentConfigurationDoc,
+    getConfigSchema,
+  };
+}
+
+export { execute } from "./execute.js";
+export { listAiderSkills, syncAiderSkills } from "./skills.js";
+export { testEnvironment, parseAiderVersion } from "./test.js";
+export { parseAiderOutput, isAiderQuotaError, stripAnsi } from "./parse.js";

--- a/packages/adapters/aider-local/src/server/parse.test.ts
+++ b/packages/adapters/aider-local/src/server/parse.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { isAiderQuotaError, parseAiderOutput, parseTokenCount, stripAnsi } from "./parse.js";
+
+const ESC = String.fromCharCode(27);
+
+describe("parseTokenCount", () => {
+  it("expands k/M suffixes and plain counts", () => {
+    expect(parseTokenCount("3.4k")).toBe(3400);
+    expect(parseTokenCount("1.2M")).toBe(1_200_000);
+    expect(parseTokenCount("156")).toBe(156);
+    expect(parseTokenCount("12,500")).toBe(12500);
+    expect(parseTokenCount("not-a-number")).toBe(0);
+  });
+});
+
+describe("stripAnsi", () => {
+  it("removes color escapes without touching bracketed text", () => {
+    expect(stripAnsi(`${ESC}[32mdone${ESC}[0m`)).toBe("done");
+    expect(stripAnsi("[paperclip] kept")).toBe("[paperclip] kept");
+  });
+});
+
+describe("parseAiderOutput", () => {
+  it("reads the tokens and cost footer and keeps only the reply in the summary", () => {
+    const stdout = [
+      "Aider v0.86.1",
+      "Main model: claude-sonnet-4-5 with diff edit format",
+      "Git repo: .git with 128 files",
+      "Added src/app.ts to the chat.",
+      "I updated the retry helper to back off exponentially.",
+      "",
+      "Applied edit to src/app.ts",
+      "Commit 9f2c1ab feat: exponential backoff",
+      "Tokens: 3.4k sent, 156 received. Cost: $0.0123 message, $0.0456 session.",
+    ].join("\n");
+
+    const parsed = parseAiderOutput(stdout);
+
+    expect(parsed.inputTokens).toBe(3400);
+    expect(parsed.outputTokens).toBe(156);
+    expect(parsed.messageCostUsd).toBeCloseTo(0.0123);
+    expect(parsed.sessionCostUsd).toBeCloseTo(0.0456);
+    expect(parsed.editedFiles).toEqual(["src/app.ts"]);
+    expect(parsed.commits).toEqual(["9f2c1ab feat: exponential backoff"]);
+    expect(parsed.summary).toBe("I updated the retry helper to back off exponentially.");
+    expect(parsed.errorMessage).toBeNull();
+  });
+
+  it("splits tokens and cost reported on separate lines", () => {
+    const parsed = parseAiderOutput(
+      ["Tokens: 812 sent, 44 received.", "Cost: $0.0009 message, $0.0009 session."].join("\n"),
+    );
+    expect(parsed.inputTokens).toBe(812);
+    expect(parsed.outputTokens).toBe(44);
+    expect(parsed.messageCostUsd).toBeCloseTo(0.0009);
+  });
+
+  it("surfaces a provider error from stderr", () => {
+    const parsed = parseAiderOutput(
+      "",
+      "litellm.AuthenticationError: AnthropicException - invalid x-api-key",
+    );
+    expect(parsed.errorMessage).toContain("litellm.AuthenticationError");
+  });
+
+  it("returns empty usage when Aider prints no footer", () => {
+    const parsed = parseAiderOutput("No changes needed.\n");
+    expect(parsed.inputTokens).toBe(0);
+    expect(parsed.outputTokens).toBe(0);
+    expect(parsed.messageCostUsd).toBeNull();
+    expect(parsed.summary).toBe("No changes needed.");
+  });
+});
+
+describe("isAiderQuotaError", () => {
+  it("detects rate limit and quota exhaustion", () => {
+    expect(isAiderQuotaError("", "litellm.RateLimitError: 429 Too Many Requests")).toBe(true);
+    expect(isAiderQuotaError("You exceeded your current quota", "")).toBe(true);
+    expect(isAiderQuotaError("Applied edit to src/app.ts", "")).toBe(false);
+  });
+});

--- a/packages/adapters/aider-local/src/server/parse.ts
+++ b/packages/adapters/aider-local/src/server/parse.ts
@@ -1,0 +1,165 @@
+// Aider writes a human transcript to stdout, not structured events. Everything
+// below is best-effort scraping of that transcript: treat adapter output as
+// untrusted and never let a missing marker fail the run.
+
+import { stripAnsi } from "../ui/parse-stdout.js";
+
+export { stripAnsi };
+
+export interface ParsedAiderOutput {
+  summary: string;
+  errorMessage: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  messageCostUsd: number | null;
+  sessionCostUsd: number | null;
+  editedFiles: string[];
+  commits: string[];
+}
+
+const TOKENS_RE = /Tokens:\s*([\d.,]+\s*[kKmM]?)\s*sent,\s*([\d.,]+\s*[kKmM]?)\s*received/;
+const COST_RE = /Cost:\s*\$([\d.]+)\s*message,\s*\$([\d.]+)\s*session/;
+const APPLIED_EDIT_RE = /^Applied edit to\s+(.+?)\s*$/;
+const COMMIT_RE = /^Commit\s+([0-9a-f]{7,40})\s+(.*)$/i;
+
+/**
+ * Status/banner lines Aider prints around the model's own reply. They stay in
+ * the raw transcript but are excluded from `summary`, which feeds the run
+ * digest.
+ */
+const NOISE_PREFIXES = [
+  "aider v",
+  "added ",
+  "applied edit to ",
+  "cost:",
+  "creating empty file",
+  "editor model:",
+  "git repo:",
+  "main model:",
+  "model:",
+  "models:",
+  "no files matched",
+  "repo-map:",
+  "scanning repo",
+  "tokens:",
+  "use /help",
+  "weak model:",
+];
+
+const ERROR_PATTERNS: RegExp[] = [
+  /^Traceback \(most recent call last\)/,
+  /litellm\.[A-Za-z]*(?:Error|Exception)/,
+  /\b(?:Authentication|Permission|BadRequest|NotFound|APIConnection)Error\b/,
+  /^(?:Error|Fatal error|Usage error):\s*\S/i,
+  /\bno such option\b/i,
+  /\bunrecognized arguments\b/i,
+  /\bcommand not found\b/i,
+];
+
+const QUOTA_PATTERNS: RegExp[] = [
+  /\brate.?limit/i,
+  /\bquota\b/i,
+  /\binsufficient_quota\b/i,
+  /\b429\b/,
+  /RateLimitError/,
+];
+
+export function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+/** "3.4k" -> 3400, "1.2M" -> 1200000, "156" -> 156. */
+export function parseTokenCount(raw: string): number {
+  const cleaned = raw.replace(/[,\s]/g, "");
+  const match = /^([\d.]+)([kKmM]?)$/.exec(cleaned);
+  if (!match?.[1]) return 0;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return 0;
+  const unit = match[2]?.toLowerCase() ?? "";
+  const multiplier = unit === "k" ? 1_000 : unit === "m" ? 1_000_000 : 1;
+  return Math.round(value * multiplier);
+}
+
+function isNoiseLine(line: string): boolean {
+  const lower = line.toLowerCase();
+  if (NOISE_PREFIXES.some((prefix) => lower.startsWith(prefix))) return true;
+  if (/^[-=_]{3,}$/.test(line)) return true;
+  if (COMMIT_RE.test(line)) return true;
+  return false;
+}
+
+export function parseAiderOutput(stdout: string, stderr = ""): ParsedAiderOutput {
+  const clean = stripAnsi(stdout);
+  const lines = clean.split(/\r?\n/);
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let messageCostUsd: number | null = null;
+  let sessionCostUsd: number | null = null;
+  const editedFiles: string[] = [];
+  const commits: string[] = [];
+  const summaryParts: string[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const trimmed = line.trim();
+
+    const tokensMatch = TOKENS_RE.exec(trimmed);
+    if (tokensMatch?.[1] && tokensMatch[2]) {
+      inputTokens = parseTokenCount(tokensMatch[1]);
+      outputTokens = parseTokenCount(tokensMatch[2]);
+    }
+
+    const costMatch = COST_RE.exec(trimmed);
+    if (costMatch?.[1] && costMatch[2]) {
+      const message = Number.parseFloat(costMatch[1]);
+      const session = Number.parseFloat(costMatch[2]);
+      if (Number.isFinite(message)) messageCostUsd = message;
+      if (Number.isFinite(session)) sessionCostUsd = session;
+    }
+
+    const editMatch = APPLIED_EDIT_RE.exec(trimmed);
+    if (editMatch?.[1]) editedFiles.push(editMatch[1]);
+
+    const commitMatch = COMMIT_RE.exec(trimmed);
+    if (commitMatch?.[1]) {
+      commits.push(`${commitMatch[1]} ${commitMatch[2] ?? ""}`.trim());
+    }
+
+    if (!isNoiseLine(trimmed)) summaryParts.push(line);
+  }
+
+  const haystack = `${clean}\n${stripAnsi(stderr)}`;
+
+  return {
+    summary: summaryParts.join("\n").replace(/\n{3,}/g, "\n\n").trim(),
+    errorMessage: findErrorMessage(haystack),
+    inputTokens,
+    outputTokens,
+    messageCostUsd,
+    sessionCostUsd,
+    editedFiles: Array.from(new Set(editedFiles)),
+    commits,
+  };
+}
+
+function findErrorMessage(haystack: string): string | null {
+  for (const line of haystack.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (ERROR_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+      return trimmed.length > 400 ? `${trimmed.slice(0, 397)}...` : trimmed;
+    }
+  }
+  return null;
+}
+
+export function isAiderQuotaError(stdout: string, stderr: string): boolean {
+  const haystack = `${stripAnsi(stdout)}\n${stripAnsi(stderr)}`;
+  return QUOTA_PATTERNS.some((pattern) => pattern.test(haystack));
+}

--- a/packages/adapters/aider-local/src/server/skills.ts
+++ b/packages/adapters/aider-local/src/server/skills.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AdapterSkillContext,
+  AdapterSkillSnapshot,
+} from "@paperclipai/adapter-utils";
+import {
+  buildRuntimeMountedSkillSnapshot,
+  readPaperclipRuntimeSkillEntries,
+  resolveLegacyPaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function buildAiderSkillSnapshot(
+  config: Record<string, unknown>,
+): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkills = resolveLegacyPaperclipDesiredSkillNames(config, availableEntries);
+  return buildRuntimeMountedSkillSnapshot({
+    adapterType: "aider_local",
+    availableEntries,
+    desiredSkills,
+    configuredDetail: "Will be attached as a read-only `--read` context file on the next run.",
+  });
+}
+
+export async function listAiderSkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return buildAiderSkillSnapshot(ctx.config);
+}
+
+export async function syncAiderSkills(
+  ctx: AdapterSkillContext,
+  _desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  return buildAiderSkillSnapshot(ctx.config);
+}

--- a/packages/adapters/aider-local/src/server/test.ts
+++ b/packages/adapters/aider-local/src/server/test.ts
@@ -1,0 +1,194 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  ensurePathInEnv,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetDirectory,
+  resolveAdapterExecutionTargetCwd,
+  runAdapterExecutionTargetProcess,
+} from "@paperclipai/adapter-utils/execution-target";
+import { ADAPTER_TYPE } from "../shared/constants.js";
+import { firstNonEmptyLine, stripAnsi } from "./parse.js";
+
+/**
+ * Any one of these is enough for Aider to reach a provider. Aider can also read
+ * credentials from ~/.aider.conf.yml or a .env file, so a miss is a warning
+ * rather than an error.
+ */
+const CREDENTIAL_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "AZURE_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GEMINI_API_KEY",
+  "GROQ_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "XAI_API_KEY",
+];
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 3)}...` : clean;
+}
+
+export function parseAiderVersion(stdout: string): string | null {
+  const match = /aider\s+v?(\d+\.\d+(?:\.\d+)?)/i.exec(stripAnsi(stdout));
+  return match?.[1] ?? null;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "aider");
+  const target = ctx.executionTarget ?? null;
+  const targetIsRemote = target?.kind === "remote";
+  const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
+  const targetLabel = targetIsRemote
+    ? ctx.environmentName ?? describeAdapterExecutionTarget(target)
+    : null;
+  const runId = `aider-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  if (targetLabel) {
+    checks.push({
+      code: "aider_environment_target",
+      level: "info",
+      message: `Probing inside environment: ${targetLabel}`,
+    });
+  }
+
+  try {
+    await ensureAdapterExecutionTargetDirectory(runId, target, cwd, {
+      cwd,
+      env: {},
+      createIfMissing: true,
+    });
+    checks.push({
+      code: "aider_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "aider_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const env = Object.fromEntries(
+    Object.entries(parseObject(config.env)).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+
+  try {
+    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    checks.push({
+      code: "aider_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "aider_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+      hint: "Install Aider on the target host (for example `python -m pip install aider-install && aider-install`).",
+    });
+  }
+
+  const canRunProbe = checks.every(
+    (check) => check.code !== "aider_cwd_invalid" && check.code !== "aider_command_unresolvable",
+  );
+
+  if (canRunProbe) {
+    // `--version` is the only safe probe: a real prompt would spend tokens and
+    // could edit files in the workspace.
+    const versionProbe = await runAdapterExecutionTargetProcess(
+      runId,
+      target,
+      command,
+      ["--version"],
+      {
+        cwd,
+        env,
+        timeoutSec: Math.max(1, asNumber(config.versionProbeTimeoutSec, 45)),
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+
+    if (versionProbe.timedOut) {
+      checks.push({
+        code: "aider_version_probe_timed_out",
+        level: "warn",
+        message: "`aider --version` timed out.",
+        hint: "Retry the probe. If this persists, run `aider --version` manually from the target environment.",
+      });
+    } else if ((versionProbe.exitCode ?? 1) !== 0) {
+      checks.push({
+        code: "aider_version_probe_failed",
+        level: "error",
+        message: "`aider --version` failed.",
+        detail: summarizeProbeDetail(versionProbe.stdout, versionProbe.stderr),
+      });
+    } else {
+      const version = parseAiderVersion(versionProbe.stdout);
+      checks.push({
+        code: "aider_version_probe_passed",
+        level: "info",
+        message: version ? `Aider ${version} is installed.` : "`aider --version` completed.",
+      });
+    }
+  }
+
+  const credentialKey = CREDENTIAL_ENV_KEYS.find((key) => {
+    const value = runtimeEnv[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+  checks.push(
+    credentialKey
+      ? {
+          code: "aider_credentials_present",
+          level: "info",
+          message: `Model credentials found in ${credentialKey}.`,
+        }
+      : {
+          code: "aider_credentials_missing",
+          level: "warn",
+          message: "No provider API key found in the adapter environment.",
+          detail: `Checked: ${CREDENTIAL_ENV_KEYS.join(", ")}`,
+          hint: "Set a provider key in the adapter env, or rely on Aider's own ~/.aider.conf.yml on the target host.",
+        },
+  );
+
+  return {
+    adapterType: ADAPTER_TYPE,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/aider-local/src/shared/agent-configuration-doc.ts
+++ b/packages/adapters/aider-local/src/shared/agent-configuration-doc.ts
@@ -1,0 +1,42 @@
+export const agentConfigurationDoc = `# aider_local agent configuration
+
+Adapter: aider_local
+
+Use when:
+- You want Paperclip to drive the Aider CLI locally on the host machine
+- You want an edit-focused coding agent that applies diffs directly in the execution workspace
+- You want chat continuity across heartbeats via Aider's chat history file
+
+Don't use when:
+- You need a webhook-style external invocation (use http or openclaw_gateway)
+- You only need a one-shot script without an AI coding agent loop (use process)
+- Aider is not installed, or no model credentials are configured on the machine that runs Paperclip
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file, passed to Aider as a read-only context file via \`--read\`
+- promptTemplate (string, optional): run prompt template
+- model (string, optional): Aider model alias or full litellm model id. Defaults to aider-default, which lets Aider pick from its own config/env
+- command (string, optional): defaults to "aider"
+- files (string[], optional): repo-relative or absolute files added to the edit set via \`--file\`
+- mapTokens (number, optional): repo-map budget passed via \`--map-tokens\`
+- autoCommits (boolean, optional): defaults to false, which passes \`--no-auto-commits\` so Paperclip's workspace sync decides what gets committed
+- alwaysApprove (boolean, optional): defaults to true, which passes \`--yes-always\` for unattended runs
+- stream (boolean, optional): defaults to true. Set false to pass \`--no-stream\`
+- pretty (boolean, optional): defaults to false, which passes \`--no-pretty\` so the transcript parses cleanly
+- chatHistoryFile (string, optional): chat transcript path used for resume. Defaults to \`.aider.chat.history.md\` in the run cwd
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables (for example OPENAI_API_KEY or ANTHROPIC_API_KEY)
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Runs use \`aider --message <prompt>\` in one-shot mode; Aider exits when the turn finishes.
+- Sessions resume with \`--restore-chat-history\` when the saved chat history file still matches the current cwd.
+- Aider has no skills concept. Desired Paperclip skills are attached as read-only context files (\`--read <skill>/SKILL.md\`) rather than copied into the workspace.
+- Usage and cost come from Aider's \`Tokens:\` / \`Cost:\` footer, so they are absent when Aider does not print it.
+- Older Aider builds spell the unattended flag \`--yes\`. Set alwaysApprove=false and add \`--yes\` to extraArgs on those versions.
+- The environment test runs \`aider --version\` only. It never issues a model call, because a probe turn would spend tokens and could edit files.
+`;

--- a/packages/adapters/aider-local/src/shared/constants.ts
+++ b/packages/adapters/aider-local/src/shared/constants.ts
@@ -1,0 +1,23 @@
+// Browser-safe constants. The UI bundle imports this module, so it must never
+// pull in node builtins or server code (the package root re-exports
+// createServerAdapter for the external plugin loader and is server-only).
+
+export const ADAPTER_TYPE = "aider_local";
+export const ADAPTER_LABEL = "Aider";
+
+/**
+ * Sentinel meaning "let Aider pick the model from its own config/env".
+ * execute.ts only passes `--model` when the configured value differs from it.
+ */
+export const DEFAULT_AIDER_LOCAL_MODEL = "aider-default";
+
+/** Aider's own default chat transcript file, written into the run cwd. */
+export const DEFAULT_AIDER_CHAT_HISTORY_FILE = ".aider.chat.history.md";
+
+export const models = [
+  { id: DEFAULT_AIDER_LOCAL_MODEL, label: "Aider default (from aider config)" },
+  { id: "sonnet", label: "sonnet" },
+  { id: "opus", label: "opus" },
+  { id: "gpt-5", label: "gpt-5" },
+  { id: "gemini", label: "gemini" },
+];

--- a/packages/adapters/aider-local/src/ui/build-config.ts
+++ b/packages/adapters/aider-local/src/ui/build-config.ts
@@ -1,0 +1,24 @@
+import { buildAdapterEnvConfig, type CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_AIDER_LOCAL_MODEL } from "../shared/constants.js";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function buildAiderLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  ac.model = v.model || DEFAULT_AIDER_LOCAL_MODEL;
+  ac.timeoutSec = 0;
+  ac.graceSec = 20;
+  const env = buildAdapterEnvConfig(v.envBindings, v.envVars);
+  if (Object.keys(env).length > 0) ac.env = env;
+
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/aider-local/src/ui/index.ts
+++ b/packages/adapters/aider-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseAiderStdoutLine } from "./parse-stdout.js";
+export { buildAiderLocalConfig } from "./build-config.js";

--- a/packages/adapters/aider-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/aider-local/src/ui/parse-stdout.ts
@@ -1,0 +1,41 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+// Browser-safe: this module is also published as the ./ui-parser bundle that
+// the board loads for external installs, so it must not import node APIs.
+
+const ESC = String.fromCharCode(27);
+const ANSI_RE = new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, "g");
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+const SYSTEM_LINE_RE =
+  /^(?:Aider v|Main model:|Weak model:|Editor model:|Model:|Models:|Git repo:|Repo-map:|Added |Applied edit to |Commit [0-9a-f]{7,40}|Tokens:|Cost:|Scanning repo|Use \/help)/i;
+
+const ERROR_LINE_RE =
+  /(?:^Traceback \(most recent call last\)|litellm\.[A-Za-z]*(?:Error|Exception)|\b(?:Authentication|RateLimit|BadRequest)Error\b|^Error:|^Warning:)/;
+
+export function parseStdoutLine(rawLine: string, ts: string): TranscriptEntry[] {
+  const line = stripAnsi(rawLine);
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  if (ERROR_LINE_RE.test(trimmed)) {
+    return [{ kind: "stderr", ts, text: line }];
+  }
+
+  if (SYSTEM_LINE_RE.test(trimmed)) {
+    return [{ kind: "system", ts, text: trimmed }];
+  }
+
+  if (trimmed.startsWith("[paperclip]")) {
+    return [{ kind: "system", ts, text: trimmed }];
+  }
+
+  // Everything else is Aider relaying the model, streamed line by line.
+  return [{ kind: "assistant", ts, text: line, delta: true }];
+}
+
+// Named alias matching the other adapter packages' UI exports.
+export const parseAiderStdoutLine = parseStdoutLine;

--- a/packages/adapters/aider-local/tsconfig.json
+++ b/packages/adapters/aider-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/aider-local/vitest.config.ts
+++ b/packages/adapters/aider-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -7,7 +7,7 @@
   {
     "dir": "packages/adapters/aider-local",
     "name": "@paperclipai/adapter-aider-local",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/adapters/claude-local",

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -7,7 +7,7 @@
   {
     "dir": "packages/adapters/aider-local",
     "name": "@paperclipai/adapter-aider-local",
-    "publishFromCi": true
+    "publishFromCi": false
   },
   {
     "dir": "packages/adapters/claude-local",

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -5,6 +5,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/aider-local",
+    "name": "@paperclipai/adapter-aider-local",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/adapters/claude-local",
     "name": "@paperclipai/adapter-claude-local",
     "publishFromCi": true

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -14,6 +14,8 @@ const generalServerShardDurations = loadShardDurations(
 const serializedShardDurations = loadShardDurations(
   path.join(scriptsDir, "serialized-shard-durations.json"),
 );
+const binDir = path.join(repoRoot, "node_modules", ".bin");
+const vitestEntry = path.join(repoRoot, "node_modules", "vitest", "vitest.mjs");
 const serverRoot = path.join(repoRoot, "server");
 const serverSrcDir = path.join(repoRoot, "server", "src");
 const serverTestsDir = path.join(repoRoot, "server", "src", "__tests__");
@@ -284,11 +286,21 @@ function runVitest(args, label) {
   };
   mkdirSync(env.PAPERCLIP_HOME, { recursive: true });
   mkdirSync(env.TMPDIR, { recursive: true });
-  const result = spawnSync("pnpm", ["exec", "vitest", "run", ...sourceOnlyVitestArgs, ...args], {
-    cwd: repoRoot,
-    env,
-    stdio: "inherit",
-  });
+  // `pnpm exec` puts node_modules/.bin on PATH; keep that for tests that shell out to workspace
+  // binaries. Windows env keys are case-insensitive, so reuse whichever casing is already there.
+  const pathKey = Object.keys(env).find((key) => key.toUpperCase() === "PATH") ?? "PATH";
+  // Run Vitest's entry directly instead of `pnpm exec vitest`: on Windows pnpm is a .cmd shim
+  // Node will not spawn without a shell, and cmd.exe's 8191-char limit cannot hold the
+  // serialized-suite exclude list.
+  const result = spawnSync(
+    process.execPath,
+    [vitestEntry, "run", ...sourceOnlyVitestArgs, ...args],
+    {
+      cwd: repoRoot,
+      env: { ...env, [pathKey]: `${binDir}${path.delimiter}${env[pathKey] ?? ""}` },
+      stdio: "inherit",
+    },
+  );
   if (result.error) {
     console.error(`[test:run] Failed to start Vitest: ${result.error.message}`);
     process.exit(1);

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -24,6 +24,7 @@ const nonServerProjects = [
   "@paperclipai/skills-catalog",
   "@paperclipai/db",
   "@paperclipai/adapter-utils",
+  "@paperclipai/adapter-aider-local",
   "@paperclipai/adapter-claude-local",
   "@paperclipai/adapter-codex-local",
   "@paperclipai/adapter-openclaw-gateway",

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1115.0",
     "@opentelemetry/api": "^1.9.0",
+    "@paperclipai/adapter-aider-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -3,6 +3,7 @@
  */
 export const BUILTIN_ADAPTER_TYPES = new Set([
   "acpx_local",
+  "aider_local",
   "claude_local",
   "codex_local",
   "paperclip_runner",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -138,6 +138,7 @@ import {
   agentConfigurationDoc as piAgentConfigurationDoc,
   modelProfiles as piModelProfiles,
 } from "@paperclipai/adapter-pi-local";
+import { createServerAdapter as createAiderLocalServerAdapter } from "@paperclipai/adapter-aider-local/server";
 import { BUILTIN_ADAPTER_TYPES } from "./builtin-adapter-types.js";
 import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
@@ -494,6 +495,10 @@ const kimiLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: kimiAgentConfigurationDoc,
 };
 
+// The Aider package builds its own ServerAdapterModule so the built-in and the
+// external (plugin store) install paths resolve the exact same module.
+const aiderLocalAdapter: ServerAdapterModule = createAiderLocalServerAdapter();
+
 const hermesGatewayAdapter = createHermesGatewayServerAdapter();
 
 const hermesLocalAdapter = createHermesLocalServerAdapter();
@@ -562,6 +567,7 @@ const pausedOverrides = new Set<string>();
 function registerBuiltInAdapters() {
   for (const adapter of [
     acpxLocalAdapter,
+    aiderLocalAdapter,
     claudeLocalAdapter,
     codexLocalAdapter,
     paperclipRunnerAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@lexical/link": "0.48.0",
     "@mdxeditor/editor": "^4.2.1",
+    "@paperclipai/adapter-aider-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -15,6 +15,7 @@ import {
   Sparkles,
   Terminal,
   Cpu,
+  Wrench,
 } from "lucide-react";
 import { OpenCodeLogoIcon } from "@/components/OpenCodeLogoIcon";
 
@@ -67,6 +68,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     comingSoon: true,
     disabledLabel: "Use Claude Code or Codex with the ACP engine",
     hideFromVisualSelection: true,
+  },
+  aider_local: {
+    label: "Aider",
+    description: "Aider CLI harness",
+    icon: Wrench,
   },
   claude_local: {
     label: "Claude Code",

--- a/ui/src/adapters/aider-local/config-fields.tsx
+++ b/ui/src/adapters/aider-local/config-fields.tsx
@@ -1,0 +1,51 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  Field,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Aider loads it as a read-only context file via --read.";
+
+export function AiderLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  if (hideInstructionsFile) return null;
+  return (
+    <>
+      <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/aider-local/index.ts
+++ b/ui/src/adapters/aider-local/index.ts
@@ -1,0 +1,14 @@
+import type { UIAdapterModule } from "../types";
+import {
+  parseAiderStdoutLine,
+  buildAiderLocalConfig,
+} from "@paperclipai/adapter-aider-local/ui";
+import { AiderLocalConfigFields } from "./config-fields";
+
+export const aiderLocalUIAdapter: UIAdapterModule = {
+  type: "aider_local",
+  label: "Aider",
+  parseStdoutLine: parseAiderStdoutLine,
+  ConfigFields: AiderLocalConfigFields,
+  buildAdapterConfig: buildAiderLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -1,4 +1,5 @@
 import type { UIAdapterModule } from "./types";
+import { aiderLocalUIAdapter } from "./aider-local";
 import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { paperclipRunnerUIAdapter } from "./paperclip-runner";
@@ -54,6 +55,7 @@ setDynamicParserResultNotifier(notifyAdapterChange);
 
 function registerBuiltInUIAdapters() {
   for (const adapter of [
+    aiderLocalUIAdapter,
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     paperclipRunnerUIAdapter,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/skills-catalog",
       "packages/db",
       "packages/adapter-utils",
+      "packages/adapters/aider-local",
       "packages/adapters/claude-local",
       "packages/adapters/codex-local",
       "packages/adapters/cursor-cloud",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Adapters connect Paperclip to agent runtimes, one package per runtime under `packages/adapters/*`
> - Aider is a widely used open source terminal coding agent, and Paperclip has no adapter for it
> - Operators who use Aider cannot drive it from Paperclip boards or track its usage and cost
> - This pull request adds an `aider_local` adapter that runs the Aider CLI in one-shot mode with chat-history resume
> - It registers the adapter across server, UI, and CLI, and ships tests and configuration docs
> - The benefit is that Aider becomes a first-class, budget-tracked runtime in Paperclip

## Linked Issues or Issue Description

No public issue exists for this request. Description follows the adapter request template:

**Agent or provider**

Aider (aider.chat), the open source terminal pair-programming agent. It runs locally as the `aider` CLI and reaches model providers through litellm.

**Why this adapter is useful**

Aider applies diffs directly in the working tree and is popular for edit-focused work. A built-in adapter lets Paperclip wake Aider on heartbeats, attach instructions and skills, resume conversations, and record usage and cost per run.

**How the agent is invoked**

One-shot runs: `aider --message <prompt> --no-check-update --no-pretty --no-auto-commits --yes-always`. Continuity uses `--chat-history-file` plus `--restore-chat-history` when the saved transcript still matches the run cwd. Skills and instructions attach as read-only context via `--read`.

**Additional context**

A search of the PR list for "aider" returns only this PR. Aider has no server-side session id and no skills mechanism, so the adapter keys continuity off the transcript file and attaches skills as `--read` context files.

## What Changed

- Add `packages/adapters/aider-local`: execution (one-shot `--message` runs, execution-target support, chat-history resume), environment test (`aider --version` probe), transcript parsing (usage, cost, edited files, commits, errors, quota detection), skills via `--read`, UI stdout parser and config builder, CLI stream formatter, config schema and agent-configuration doc.
- Register `aider_local` in the server, UI, and CLI adapter registries, the display registry, the builtin adapter types, the root `vitest.config.ts` projects, the stable test lanes (`nonServerProjects`), and the Dockerfile deps stage.
- Fix Windows spawning in `scripts/run-vitest-stable.mjs`: run Vitest's entry directly because Node does not spawn the pnpm `.cmd` shim without a shell, and cmd.exe's 8191-char limit cannot hold the serialized-suite exclude list.
- Apply a simplification pass (`/ponytail-review`): single `firstNonEmptyLine` and `stripAnsi` definitions, `asString` for wake-context fields, `parseObject` for env normalization, `COMMIT_RE` reuse, and a stateless stdout parser without a factory wrapper. The `./ui-parser` bundle keeps the generic `parseStdoutLine` contract export.

## Verification

- `pnpm exec vitest run packages/adapters/aider-local` — 11/11 pass (execute, parse)
- `pnpm exec vitest run ui/src/adapters` — 35/35 pass (transcript, registry, metadata)
- `pnpm --filter @paperclipai/adapter-aider-local typecheck` and `pnpm --filter ./ui typecheck` — clean
- `node scripts/check-docker-deps-stage.mjs` — PASS
- Manual: create an `aider_local` agent, run a heartbeat, and confirm usage and cost populate from Aider's `Tokens:` / `Cost:` footer

## Risks

- The adapter is additive. No existing adapter code paths change.
- The `run-vitest-stable.mjs` spawn change affects all test lanes. It is validated locally on Windows and by this PR's CI.
- Remote execution delivery of `--read` context files is less exercised than local runs. Greptile flagged this and the resume path identity check; both are open review items on this PR.
- `pnpm-lock.yaml` is not committed, per repo policy. CI validates resolution because manifests changed.

## Model Used

- Anthropic Claude — Claude Fable 5 (model ID `claude-fable-5`), the first Claude 5 family model, via Claude Code (agentic tool use: file edit, search, shell, subagents; extended thinking enabled). Review pass ran through the ponytail plugin's `/ponytail-review` skill on the same model.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
