### PR TITLE
fix(release): normalize discovered package dirs to forward slashes

### DIFF
--- a/scripts/release-package-map.mjs
+++ b/scripts/release-package-map.mjs
@@ -26,7 +26,10 @@ function discoverPublicPackages() {
       const pkg = readJson(pkgPath);
       if (!pkg.private) {
         packages.push({
-          dir: relDir,
+          // The manifest and downstream consumers (check-release-package-bootstrap
+          // compares against git-reported changed paths) use forward slashes, so
+          // the discovered dir must not carry win32 separators.
+          dir: relDir.replaceAll("\\", "/"),
           pkgPath,
           name: pkg.name,
           version: pkg.version,

--- a/scripts/release-package-map.test.mjs
+++ b/scripts/release-package-map.test.mjs
@@ -18,6 +18,13 @@ test("release package manifest covers all public packages with explicit CI enrol
   assert.ok(packages.every((pkg) => typeof pkg.publishFromCi === "boolean"));
 });
 
+test("discovered package dirs use forward slashes on every platform", () => {
+  // On win32 the walk joins with backslashes; a dir that keeps them never
+  // matches the forward-slash manifest, so every entry reports as missing.
+  const packages = buildReleasePackagePlan();
+  assert.ok(packages.every((pkg) => !pkg.dir.includes("\\")));
+});
+
 test("release package list only contains CI-enrolled packages", () => {
   const enabledPackages = getReleasePackages();
   assert.ok(enabledPackages.length > 0);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The release subsystem plans npm publishes from `scripts/release-package-map.mjs`, which discovers workspace packages and validates them against `scripts/release-package-manifest.json`
> - On Windows, discovery builds each package dir with `path.join`, so the plan carries `packages\adapter-utils` while the manifest uses `packages/adapter-utils`
> - No dir ever matches, so every manifest entry reports "not a public package in this repo" and the check fails before it validates anything
> - The same plan feeds `check-release-package-bootstrap.mjs` and the release-registry tests, so those fail on Windows too
> - A Windows contributor cannot reproduce the `ci / policy` release checks locally, and iterates blind against CI
> - This pull request normalizes the separator at the one point the dir enters the plan
> - The benefit is that the release checks and their tests run correctly from a Windows checkout

## Linked Issues or Issue Description

No open issue covers this. The problem is described below.

**What happened?**

On a Windows clone, `node scripts/release-package-map.mjs check` throws "release package manifest validation failed" and lists every manifest entry as "listed in scripts/release-package-manifest.json but is not a public package in this repo". `node --test scripts/release-package-map.test.mjs` fails the same way through `buildReleasePackagePlan()`. Nothing in the repository is misconfigured. The discovered dirs carry backslashes and never match the forward-slash manifest.

**Expected behavior**

The check validates the same way on every platform. A correct manifest passes; a real inconsistency fails with its specific message.

**Steps to reproduce**

1. Clone the repository on Windows.
2. Run `node scripts/release-package-map.mjs check`.
3. The script throws and lists every manifest entry as not a public package.

**Operating system**

Windows 11 Pro (26220). Not reproducible on Linux or macOS, where `path.join` already produces forward slashes.

**Paperclip version or commit**

`ad474abec` (master).

This surfaced while debugging the `ci / policy` failure on #12472; the fix was verified against that branch's manifest states. Refs #12472.

## What Changed

- `scripts/release-package-map.mjs`: `discoverPublicPackages()` normalizes the discovered dir with `relDir.replaceAll("\\", "/")` before it enters the plan. `pkgPath` stays a native path because it is only used for local file IO.
- `scripts/release-package-map.test.mjs`: adds a regression test asserting no discovered dir contains a backslash. It is trivially green on POSIX and pins the win32 behavior.

## Verification

On Windows, before the fix both commands fail as described above. After the fix:

```
node scripts/release-package-map.mjs check
node --test scripts/release-package-map.test.mjs
node --test scripts/check-release-package-bootstrap.test.mjs
```

The check prints `Release package manifest OK: 30 enabled for CI publish, 3 disabled pending bootstrap.` The test files pass 13 and 6 tests. On Linux the change is inert: `replaceAll("\\", "/")` finds nothing to replace in POSIX paths, and backslashes are not legal in the repo's directory names.

## Risks

Low risk. One line of behavior change, exercised on every platform by the existing test suite plus the new regression test. The only observable difference is on win32, where the plan's `dir` values become correct.

## Model Used

Claude Fable 5 (`claude-fable-5`), through Claude Code, with extended thinking and tool use. The model found the bug while verifying a release-manifest change locally on Windows, wrote the fix and the regression test, and verified both.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
