### PR TITLE
Reject unknown issue fields and preserve parent blocker gates

### DIFF
--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -4,7 +4,7 @@ import {
   askUserQuestionsPayloadSchema,
   checkoutIssueSchema,
   createApprovalSchema,
-  createIssueInputSchema,
+  createIssueInputObjectSchema,
   issueThreadInteractionContinuationPolicySchema,
   requestCheckboxConfirmationPayloadSchema,
   requestConfirmationPayloadSchema,
@@ -97,7 +97,7 @@ const upsertDocumentToolSchema = z.object({
 
 const createIssueToolSchema = z.object({
   companyId: companyIdOptional,
-}).merge(createIssueInputSchema);
+}).merge(createIssueInputObjectSchema);
 
 const updateIssueToolSchema = z.object({
   issueId: issueIdSchema,

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -462,7 +462,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipCreateIssue",
-      "Create a new issue",
+      "Create a new issue. With parentId, optional blockParentUntilDone adds a parent blocker edge; acceptanceCriteria append to the description.",
       createIssueToolSchema,
       async ({ companyId, ...body }) =>
         client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, { body }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -5,6 +5,7 @@ import {
   checkoutIssueSchema,
   createApprovalSchema,
   createIssueInputObjectSchema,
+  createIssueInputSchema,
   issueThreadInteractionContinuationPolicySchema,
   requestCheckboxConfirmationPayloadSchema,
   requestConfirmationPayloadSchema,
@@ -464,8 +465,10 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       "paperclipCreateIssue",
       "Create a new issue. With parentId, optional blockParentUntilDone adds a parent blocker edge; acceptanceCriteria append to the description.",
       createIssueToolSchema,
-      async ({ companyId, ...body }) =>
-        client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, { body }),
+      async ({ companyId, ...body }) => {
+        const validatedBody = createIssueInputSchema.parse(body);
+        return client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, { body: validatedBody });
+      },
     ),
     makeTool(
       "paperclipUpdateIssue",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1795,6 +1795,7 @@ export {
   type CompanySearchExtractQuery,
   type CompanySearchQuery,
   createIssueSchema,
+  createIssueInputObjectSchema,
   createIssueInputSchema,
   createChildIssueSchema,
   createAcceptedPlanDecompositionSchema,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -411,6 +411,7 @@ export interface IssueBlockerAttention {
   state: IssueBlockerAttentionState;
   reason: IssueBlockerAttentionReason;
   unresolvedBlockerCount: number;
+  unresolvedBlockerIssueIds: string[];
   coveredBlockerCount: number;
   stalledBlockerCount: number;
   attentionBlockerCount: number;

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -411,7 +411,8 @@ export interface IssueBlockerAttention {
   state: IssueBlockerAttentionState;
   reason: IssueBlockerAttentionReason;
   unresolvedBlockerCount: number;
-  unresolvedBlockerIssueIds: string[];
+  /** Present on API responses; optional for compatibility with older UI fixtures and callers. */
+  unresolvedBlockerIssueIds?: string[];
   coveredBlockerCount: number;
   stalledBlockerCount: number;
   attentionBlockerCount: number;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -408,6 +408,7 @@ export {
 
 export {
   createIssueSchema,
+  createIssueInputObjectSchema,
   createIssueInputSchema,
   createChildIssueSchema,
   createAcceptedPlanDecompositionSchema,

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
 import {
   addIssueCommentSchema,
+  createChildIssueSchema,
   createIssueSchema,
   issueBlockedInboxAttentionSchema,
   resolveIssueRecoveryActionSchema,
@@ -46,6 +47,39 @@ describe("issue validators", () => {
       .toBeUndefined();
     expect(updateIssueSchema.parse({ comment: undefined }).comment)
       .toBeUndefined();
+  });
+
+  it("rejects unknown fields on issue create and update", () => {
+    const create = createIssueSchema.safeParse({
+      title: "Reject unsupported create field",
+      totallyMadeUpField: 123,
+    });
+    const update = updateIssueSchema.safeParse({
+      totallyMadeUpField: 123,
+    });
+    const child = createChildIssueSchema.safeParse({
+      title: "Reject unsupported child field",
+      totallyMadeUpField: 123,
+    });
+
+    expect(create.success).toBe(false);
+    expect(update.success).toBe(false);
+    expect(child.success).toBe(false);
+    if (!create.success) {
+      expect(create.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "unrecognized_keys", keys: ["totallyMadeUpField"] }),
+      ]));
+    }
+    if (!update.success) {
+      expect(update.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "unrecognized_keys", keys: ["totallyMadeUpField"] }),
+      ]));
+    }
+    if (!child.success) {
+      expect(child.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "unrecognized_keys", keys: ["totallyMadeUpField"] }),
+      ]));
+    }
   });
 
   it("accepts review policies on create and update while rejecting unknown values", () => {
@@ -155,7 +189,7 @@ describe("issue validators", () => {
       createdByUserId: "spoofed-creator",
       responsibleUserId: "spoofed-responsible",
     });
-    const updated = updateIssueSchema.parse({
+    const updated = updateIssueSchema.safeParse({
       title: "Do not update attribution",
       createdByUserId: "spoofed-creator",
       responsibleUserId: "spoofed-responsible",
@@ -163,8 +197,15 @@ describe("issue validators", () => {
 
     expect(created.createdByUserId).toBe("spoofed-creator");
     expect(created.responsibleUserId).toBe("spoofed-responsible");
-    expect(updated).not.toHaveProperty("createdByUserId");
-    expect(updated).not.toHaveProperty("responsibleUserId");
+    expect(updated.success).toBe(false);
+    if (!updated.success) {
+      expect(updated.error.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          code: "unrecognized_keys",
+          keys: ["createdByUserId", "responsibleUserId"],
+        }),
+      ]));
+    }
   });
 
   it("allows false-positive recovery resolutions to atomically restore the source issue status", () => {

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -361,6 +361,16 @@ describe("issue validators", () => {
       assigneeAgentId: "22222222-2222-4222-8222-222222222222",
     }).status).toBe("todo");
     expect(createIssueSchema.parse({ title: "Unassigned work" }).status).toBe("backlog");
+
+    expect(createIssueSchema.parse({
+      title: "Child with parent blocker",
+      parentId: "11111111-1111-4111-8111-111111111111",
+      blockParentUntilDone: true,
+    }).blockParentUntilDone).toBe(true);
+    expect(createIssueSchema.safeParse({
+      title: "Flag without parent",
+      blockParentUntilDone: true,
+    }).success).toBe(false);
     expect(createIssueSchema.parse({
       title: "Deliberately parked",
       assigneeAgentId: "22222222-2222-4222-8222-222222222222",

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -514,7 +514,7 @@ const createIssueBaseSchema = z.object({
     agentId: z.string().guid(),
     instructions: multilineTextSchema.optional().nullable(),
   }).strict().optional().nullable(),
-});
+}).strict();
 
 function requireBlockedStatusForUnblockDescriptor(
   value: { status?: string; unblockDescriptor?: unknown },

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -626,7 +626,7 @@ export const updateIssueSchema = objectWithoutDefaults(
     responsibleUserId: true,
     watchdog: true,
   }),
-).partial().extend({
+).strict().partial().extend({
   requestDepth: issueRequestDepthInputSchema.optional(),
   assigneeAgentId: z.string().trim().min(1).optional().nullable(),
   comment: multilineTextSchema.pipe(z.string().min(1)).optional(),

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -564,12 +564,14 @@ function requireParentIdForBlockParentUntilDone(
   }
 }
 
-export const createIssueInputSchema = createIssueBaseSchema.extend({
+export const createIssueInputObjectSchema = createIssueBaseSchema.extend({
   status: createIssueBaseSchema.shape.status.optional(),
   ...createIssueDuplicateGuardSchema,
   ...onboardingFirstTaskMarkerSchema,
   ...createIssueParentBlockerFields,
-}).superRefine((value, ctx) => {
+});
+
+export const createIssueInputSchema = createIssueInputObjectSchema.superRefine((value, ctx) => {
   requireBlockedStatusForUnblockDescriptor(value, ctx);
   requireParentIdForBlockParentUntilDone(value, ctx);
 });

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -544,18 +544,46 @@ const onboardingFirstTaskMarkerSchema = {
   onboardingFirstTask: z.boolean().optional(),
 };
 
+const createIssueParentBlockerFields = {
+  acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional()
+    .describe("Appended to the issue description as Acceptance Criteria; create-only"),
+  blockParentUntilDone: z.boolean().optional().default(false)
+    .describe("When true with parentId, adds this issue as a blocks-edge on the parent (same as POST /issues/:id/children)"),
+};
+
+function requireParentIdForBlockParentUntilDone(
+  value: { parentId?: string | null; blockParentUntilDone?: boolean },
+  ctx: z.RefinementCtx,
+) {
+  if (value.blockParentUntilDone && !value.parentId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "blockParentUntilDone requires parentId",
+      path: ["blockParentUntilDone"],
+    });
+  }
+}
+
 export const createIssueInputSchema = createIssueBaseSchema.extend({
   status: createIssueBaseSchema.shape.status.optional(),
   ...createIssueDuplicateGuardSchema,
   ...onboardingFirstTaskMarkerSchema,
+  ...createIssueParentBlockerFields,
+}).superRefine((value, ctx) => {
+  requireBlockedStatusForUnblockDescriptor(value, ctx);
+  requireParentIdForBlockParentUntilDone(value, ctx);
 });
 
 export const createIssueSchema = withCreateIssueStatusDefault(
   createIssueBaseSchema.extend({
     ...createIssueDuplicateGuardSchema,
     ...onboardingFirstTaskMarkerSchema,
+    ...createIssueParentBlockerFields,
   }),
-).superRefine(requireBlockedStatusForUnblockDescriptor);
+).superRefine((value, ctx) => {
+  requireBlockedStatusForUnblockDescriptor(value, ctx);
+  requireParentIdForBlockParentUntilDone(value, ctx);
+});
 
 export type CreateIssue = z.infer<typeof createIssueSchema>;
 
@@ -572,10 +600,7 @@ export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBa
     inheritExecutionWorkspaceFromIssueId: true,
     watchdogDiscovery: true,
   })
-  .extend({
-    acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
-    blockParentUntilDone: z.boolean().optional().default(false),
-  })).superRefine(requireBlockedStatusForUnblockDescriptor);
+  .extend(createIssueParentBlockerFields)).superRefine(requireBlockedStatusForUnblockDescriptor);
 
 export type CreateChildIssue = z.infer<typeof createChildIssueSchema>;
 

--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -190,6 +190,7 @@ describe("assigned backlog creation contract", () => {
         id: String(data.id),
         title: String(data.title),
         status: String(data.status),
+        parentId: data.parentId as string | null | undefined,
         assigneeAgentId: data.assigneeAgentId as string | null | undefined,
       }));
     mockIssueService.createChild.mockImplementation(async (_parentId: string, data: Record<string, unknown>) => ({
@@ -252,6 +253,54 @@ describe("assigned backlog creation contract", () => {
           statusDefaultReason: "assigned_omitted_status",
           assignmentWakeSkipped: false,
         }),
+      }),
+    );
+  });
+
+  it("rejects unknown fields on issue create and update", async () => {
+    const create = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({ title: "Unsupported create field", totallyMadeUpField: 123 });
+    const update = await request(await createApp())
+      .patch("/api/issues/parent-1")
+      .send({ totallyMadeUpField: 123 });
+
+    expect(create.status).toBe(400);
+    expect(update.status).toBe(400);
+    expect(create.body.details).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "unrecognized_keys", keys: ["totallyMadeUpField"] }),
+    ]));
+    expect(update.body.details).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "unrecognized_keys", keys: ["totallyMadeUpField"] }),
+    ]));
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("passes the parent blocker flag through plain issue create", async () => {
+    const parentId = "11111111-1111-4111-8111-111111111111";
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Plain-create child blocker",
+        parentId,
+        blockParentUntilDone: true,
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        title: "Plain-create child blocker",
+        parentId,
+        blockParentUntilDone: true,
+      }),
+    );
+    expect(res.body).toEqual(expect.objectContaining({ parentId }));
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.created",
+        details: expect.objectContaining({ parentBlockerAdded: true }),
       }),
     );
   });

--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -295,7 +295,7 @@ describe("assigned backlog creation contract", () => {
         blockParentUntilDone: true,
       }),
     );
-    expect(res.body).toEqual(expect.objectContaining({ parentId }));
+    expect(res.body).toEqual(expect.objectContaining({ parentId, parentBlockerAdded: true }));
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -190,9 +190,18 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       status: "todo",
       parentId,
     });
+    const ordinaryChildId = await insertIssue({
+      companyId,
+      identifier: "PBN-3",
+      title: "Open child without blocker relation",
+      status: "todo",
+      parentId,
+    });
     await block({ companyId, blockerIssueId: childId, blockedIssueId: parentId });
 
-    const parent = (await svc.list(companyId, { status: "in_progress" })).find((issue) => issue.id === parentId);
+    const result = await svc.list(companyId);
+    const parent = result.find((issue) => issue.id === parentId);
+    const ordinaryChild = result.find((issue) => issue.id === ordinaryChildId);
 
     expect(parent?.blockerAttention).toMatchObject({
       state: "none",
@@ -203,6 +212,12 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       stalledBlockerCount: 0,
       attentionBlockerCount: 0,
       blockingTreeLive: false,
+    });
+    expect(ordinaryChild?.blockerAttention).toMatchObject({
+      state: "none",
+      reason: null,
+      unresolvedBlockerCount: 0,
+      unresolvedBlockerIssueIds: [],
     });
   });
 

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -180,6 +180,32 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("reports unresolved blockers for a non-blocked parent without changing attention state semantics", async () => {
+    const { companyId } = await createCompany("PBN");
+    const parentId = await insertIssue({ companyId, identifier: "PBN-1", title: "Open parent", status: "in_progress" });
+    const childId = await insertIssue({
+      companyId,
+      identifier: "PBN-2",
+      title: "Open child blocker",
+      status: "todo",
+      parentId,
+    });
+    await block({ companyId, blockerIssueId: childId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "in_progress" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "none",
+      reason: null,
+      unresolvedBlockerCount: 1,
+      unresolvedBlockerIssueIds: [childId],
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      blockingTreeLive: false,
+    });
+  });
+
   it("classifies an assigned backlog blocker leaf without a waiting path as attention-needed", async () => {
     const { companyId, agentId } = await createCompany("PBB");
     const parentId = await insertIssue({ companyId, identifier: "PBB-1", title: "Parent", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -187,7 +187,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       companyId,
       identifier: "PBN-2",
       title: "Open child blocker",
-      status: "todo",
+      status: "in_progress",
       parentId,
     });
     const ordinaryChildId = await insertIssue({
@@ -211,7 +211,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       coveredBlockerCount: 0,
       stalledBlockerCount: 0,
       attentionBlockerCount: 0,
-      blockingTreeLive: false,
+      blockingTreeLive: true,
     });
     expect(ordinaryChild?.blockerAttention).toMatchObject({
       state: "none",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4311,6 +4311,44 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ].sort());
   });
 
+  it("preserves parent blockers across concurrent child creates", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Concurrent child parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const [first, second] = await Promise.all([
+      svc.createChild(parentId, {
+        title: "Concurrent helper child one",
+        status: "todo",
+        priority: "medium",
+        blockParentUntilDone: true,
+      }),
+      svc.createChild(parentId, {
+        title: "Concurrent helper child two",
+        status: "todo",
+        priority: "medium",
+        blockParentUntilDone: true,
+      }),
+    ]);
+
+    expect((await svc.getRelationSummaries(parentId)).blockedBy.map((issue) => issue.id).sort()).toEqual([
+      first.issue.id,
+      second.issue.id,
+    ].sort());
+  });
+
   it("rejects blockParentUntilDone on create without parentId", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4368,6 +4368,46 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 
+  it("rejects a parent from another company before creating a parent blocker relation", async () => {
+    const childCompanyId = randomUUID();
+    const parentCompanyId = randomUUID();
+    const foreignParentId = randomUUID();
+    await db.insert(companies).values([
+      {
+        id: childCompanyId,
+        name: "Child company",
+        issuePrefix: `T${childCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: parentCompanyId,
+        name: "Parent company",
+        issuePrefix: `T${parentCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await db.insert(issues).values({
+      id: foreignParentId,
+      companyId: parentCompanyId,
+      title: "Foreign parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(svc.create(childCompanyId, {
+      title: "Cross-company child",
+      status: "todo",
+      priority: "medium",
+      parentId: foreignParentId,
+      blockParentUntilDone: true,
+    })).rejects.toMatchObject({
+      status: 404,
+      message: "Parent issue not found",
+    });
+    expect(await svc.getById(foreignParentId)).toMatchObject({ id: foreignParentId });
+    expect((await db.select().from(issues).where(eq(issues.companyId, childCompanyId)))).toEqual([]);
+  });
+
   it("adds terminal blockers to immediate blocked-by summaries", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4115,6 +4115,45 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ]);
   });
 
+  it("adds the parent blocker relation when a recent-title dedup receives the flag", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Dedup parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const first = await svc.create(companyId, {
+      title: "Deduplicated child",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      allowDuplicate: false,
+    });
+    const second = await svc.create(companyId, {
+      title: "  deduplicated   child ",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      allowDuplicate: false,
+      blockParentUntilDone: true,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect((await svc.getRelationSummaries(parentId)).blockedBy).toEqual([
+      expect.objectContaining({ id: first.id, title: "Deduplicated child" }),
+    ]);
+  });
+
   it("rejects blockParentUntilDone on create without parentId", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4193,6 +4193,124 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ]);
   });
 
+  it("rejects an idempotency replay that adds a parent blocker to a root issue", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Replay parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const first = await svc.create(companyId, {
+      title: "Root idempotent issue",
+      status: "todo",
+      priority: "medium",
+      idempotencyKey: "root-idempotent-replay",
+    });
+
+    await expect(svc.create(companyId, {
+      title: "Different replay payload",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      idempotencyKey: "root-idempotent-replay",
+      blockParentUntilDone: true,
+    })).rejects.toMatchObject({
+      status: 409,
+      message: expect.stringContaining("cannot change parentId"),
+    });
+    expect((await svc.getRelationSummaries(parentId)).blockedBy).toEqual([]);
+    expect((await svc.getById(first.id))?.parentId).toBeNull();
+  });
+
+  it("rejects an idempotency replay that changes the parent blocker target", async () => {
+    const companyId = randomUUID();
+    const originalParentId = randomUUID();
+    const requestedParentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values([
+      { id: originalParentId, companyId, title: "Original parent", status: "todo", priority: "medium" },
+      { id: requestedParentId, companyId, title: "Requested parent", status: "todo", priority: "medium" },
+    ]);
+
+    const first = await svc.create(companyId, {
+      title: "Parent-bound idempotent issue",
+      status: "todo",
+      priority: "medium",
+      parentId: originalParentId,
+      idempotencyKey: "parent-change-replay",
+    });
+
+    await expect(svc.create(companyId, {
+      title: "Different replay payload",
+      status: "todo",
+      priority: "medium",
+      parentId: requestedParentId,
+      idempotencyKey: "parent-change-replay",
+      blockParentUntilDone: true,
+    })).rejects.toMatchObject({
+      status: 409,
+      message: expect.stringContaining("cannot change parentId"),
+    });
+    expect((await svc.getRelationSummaries(originalParentId)).blockedBy).toEqual([]);
+    expect((await svc.getRelationSummaries(requestedParentId)).blockedBy).toEqual([]);
+    expect((await svc.getById(first.id))?.parentId).toBe(originalParentId);
+  });
+
+  it("preserves parent blockers across concurrent plain creates", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Concurrent parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const [first, second] = await Promise.all([
+      svc.create(companyId, {
+        title: "Concurrent child one",
+        status: "todo",
+        priority: "medium",
+        parentId,
+        blockParentUntilDone: true,
+      }),
+      svc.create(companyId, {
+        title: "Concurrent child two",
+        status: "todo",
+        priority: "medium",
+        parentId,
+        blockParentUntilDone: true,
+      }),
+    ]);
+
+    expect((await svc.getRelationSummaries(parentId)).blockedBy.map((issue) => issue.id).sort()).toEqual([
+      first.id,
+      second.id,
+    ].sort());
+  });
+
   it("rejects blockParentUntilDone on create without parentId", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4154,6 +4154,45 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ]);
   });
 
+  it("adds the parent blocker relation when an idempotency replay receives the flag", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Idempotency parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const first = await svc.create(companyId, {
+      title: "Idempotent child",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      idempotencyKey: "idempotent-child-replay",
+    });
+    const second = await svc.create(companyId, {
+      title: "Different replay payload",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      idempotencyKey: "idempotent-child-replay",
+      blockParentUntilDone: true,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect((await svc.getRelationSummaries(parentId)).blockedBy).toEqual([
+      expect.objectContaining({ id: first.id, title: "Idempotent child" }),
+    ]);
+  });
+
   it("rejects blockParentUntilDone on create without parentId", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4073,6 +4073,67 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     expect(child.blockedBy).toEqual([]);
   });
 
+  it("honours blockParentUntilDone on company create with parentId", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const parentId = randomUUID();
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Delegation parent",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const child = await svc.create(companyId, {
+      title: "Company-create child blocker",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      description: "Implement the workstream.",
+      acceptanceCriteria: ["Parent blockedBy includes this child"],
+      blockParentUntilDone: true,
+    });
+
+    expect(child.parentId).toBe(parentId);
+    expect(child.description).toContain("## Acceptance Criteria");
+    expect(child.description).toContain("- Parent blockedBy includes this child");
+    expect(child.blocks.map((relation) => relation.id)).toEqual([parentId]);
+
+    const parentRelations = await svc.getRelationSummaries(parentId);
+    expect(parentRelations.blockedBy).toEqual([
+      expect.objectContaining({
+        id: child.id,
+        title: "Company-create child blocker",
+      }),
+    ]);
+  });
+
+  it("rejects blockParentUntilDone on create without parentId", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await expect(svc.create(companyId, {
+      title: "Orphan blocker flag",
+      status: "todo",
+      priority: "medium",
+      blockParentUntilDone: true,
+    })).rejects.toMatchObject({
+      message: expect.stringContaining("blockParentUntilDone requires parentId"),
+    });
+  });
+
   it("adds terminal blockers to immediate blocked-by summaries", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -176,10 +176,18 @@ describe("openapi routes", () => {
     expect(res.body.info.title).toBe("Paperclip API");
     expect(res.body.paths["/api/openapi.json"].get.summary).toBe("Get the generated OpenAPI document");
     expect(res.body.paths["/api/companies/{companyId}/agents"].get.summary).toBe("List agents in a company");
-    expect(res.body.paths["/api/companies/{companyId}/issues"].post.requestBody.content["application/json"].schema)
-      .toMatchObject({ additionalProperties: false });
-    expect(res.body.paths["/api/issues/{id}"].patch.requestBody.content["application/json"].schema)
-      .toMatchObject({ additionalProperties: false });
+    const createIssueBodySchema = res.body.paths["/api/companies/{companyId}/issues"]
+      .post.requestBody.content["application/json"].schema;
+    expect(createIssueBodySchema).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        acceptanceCriteria: { type: "array" },
+        blockParentUntilDone: { type: "boolean" },
+      },
+    });
+    const updateIssueBodySchema = res.body.paths["/api/issues/{id}"].patch
+      .requestBody.content["application/json"].schema;
+    expect(updateIssueBodySchema).toMatchObject({ additionalProperties: false });
     expect(res.body.paths["/api/agents/{id}/keys"].post.summary).toBe("Create an agent API key");
     expect(res.body.components.securitySchemes).toMatchObject({
       BoardSessionAuth: { type: "apiKey", in: "cookie" },

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -176,6 +176,10 @@ describe("openapi routes", () => {
     expect(res.body.info.title).toBe("Paperclip API");
     expect(res.body.paths["/api/openapi.json"].get.summary).toBe("Get the generated OpenAPI document");
     expect(res.body.paths["/api/companies/{companyId}/agents"].get.summary).toBe("List agents in a company");
+    expect(res.body.paths["/api/companies/{companyId}/issues"].post.requestBody.content["application/json"].schema)
+      .toMatchObject({ additionalProperties: false });
+    expect(res.body.paths["/api/issues/{id}"].patch.requestBody.content["application/json"].schema)
+      .toMatchObject({ additionalProperties: false });
     expect(res.body.paths["/api/agents/{id}/keys"].post.summary).toBe("Create an agent API key");
     expect(res.body.components.securitySchemes).toMatchObject({
       BoardSessionAuth: { type: "apiKey", in: "cookie" },

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8644,6 +8644,8 @@ export function issueRoutes(
       actorRunId: actor.runId,
       actorResponsibleUserId: authenticatedActorResponsibleUserId(req),
       trustExplicitResponsibleUserId: actor.actorType === "user",
+      actorAgentId: actor.agentId,
+      actorUserId: actor.actorType === "user" ? actor.actorId : null,
       watchdogActorRunId: actor.runId,
       onDeduplicated: (reason: "idempotency_key" | "recent_open_title") => {
         deduplicationReason = reason;
@@ -8708,6 +8710,7 @@ export function issueRoutes(
           : {}),
         ...buildCreateIssueActivityStatusDetails(issue, res),
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
+        ...(req.body.blockParentUntilDone ? { parentBlockerAdded: true } : {}),
         ...summarizeIssueReferenceActivityDetails({
           addedReferencedIssues: referenceDiff.addedReferencedIssues.map(summarizeIssueRelationForActivity),
           removedReferencedIssues: referenceDiff.removedReferencedIssues.map(summarizeIssueRelationForActivity),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8670,6 +8670,7 @@ export function issueRoutes(
         ...issue,
         deduplicated: true,
         deduplicationReason,
+        ...(req.body.blockParentUntilDone ? { parentBlockerAdded: true } : {}),
         relatedWork: referenceSummary,
         referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
       });
@@ -8809,6 +8810,7 @@ export function issueRoutes(
 
     res.status(201).json({
       ...issue,
+      ...(req.body.blockParentUntilDone ? { parentBlockerAdded: true } : {}),
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
     });

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -273,6 +273,12 @@ function unwrapSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
   // A `.transform()` or `.pipe()` becomes a pipe. Read the input schema so the
   // published contract describes the value a client sends.
   if (def.type === "pipe") {
+    // `z.preprocess()` is represented as a pipe whose input is a transform and
+    // whose output is the object schema receiving the preprocessed value. The
+    // transform has no shape to publish; use the output contract instead.
+    if (zodTypeName(def.in as z.ZodTypeAny) === "transform") {
+      return unwrapSchema(def.out as z.ZodTypeAny);
+    }
     return unwrapSchema(def.in as z.ZodTypeAny);
   }
   return schema;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -657,6 +657,7 @@ type IssueUserContextInput = {
 };
 type ProjectGoalReader = Pick<Db, "select">;
 type DbReader = Pick<Db, "select">;
+type DbWriter = Pick<Db, "select" | "execute" | "delete" | "insert">;
 type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
@@ -2338,8 +2339,25 @@ async function listIssueBlockerAttentionMap(
   companyId: string,
   issueRows: IssueBlockerAttentionInputNode[],
 ): Promise<Map<string, IssueBlockerAttention>> {
-  const roots = issueRows.filter((row) => row.companyId === companyId);
   const attentionMap = new Map<string, IssueBlockerAttention>();
+  const roots = issueRows.filter((row) => row.companyId === companyId && row.status === "blocked");
+  const nonBlockedIssueIds = issueRows
+    .filter((row) => row.companyId === companyId && row.status !== "blocked")
+    .map((row) => row.id);
+
+  for (const row of issueRows) {
+    if (row.companyId !== companyId || row.status === "blocked") continue;
+    attentionMap.set(row.id, createIssueBlockerAttention());
+  }
+  for (const chunk of chunkList(nonBlockedIssueIds, ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
+    const readinessByIssueId = await listIssueDependencyReadinessMap(dbOrTx, companyId, chunk);
+    for (const readiness of readinessByIssueId.values()) {
+      attentionMap.set(readiness.issueId, createIssueBlockerAttention({
+        unresolvedBlockerCount: readiness.unresolvedBlockerCount,
+        unresolvedBlockerIssueIds: readiness.unresolvedBlockerIssueIds,
+      }));
+    }
+  }
   if (roots.length === 0) return attentionMap;
 
   const nodesById = new Map<string, IssueBlockerAttentionNode>();
@@ -5201,6 +5219,31 @@ export function issueService(db: Db) {
     );
   }
 
+  async function ensureParentBlockedByChild(
+    companyId: string,
+    parentId: string,
+    childId: string,
+    actor: { agentId?: string | null; userId?: string | null } = {},
+    dbOrTx: DbWriter = db,
+  ) {
+    const existingBlockers = await dbOrTx
+      .select({ blockerIssueId: issueRelations.issueId })
+      .from(issueRelations)
+      .where(and(
+        eq(issueRelations.companyId, companyId),
+        eq(issueRelations.relatedIssueId, parentId),
+        eq(issueRelations.type, "blocks"),
+      ));
+    if (existingBlockers.some((row) => row.blockerIssueId === childId)) return false;
+    await syncBlockedByIssueIds(
+      parentId,
+      companyId,
+      [...new Set([...existingBlockers.map((row) => row.blockerIssueId), childId])],
+      actor,
+      dbOrTx,
+    );
+    return true;
+  }
   async function isTerminalOrMissingHeartbeatRun(runId: string, dbOrTx: DbReader = db) {
     return heartbeatRunIsTerminalOrMissing(dbOrTx, runId);
   }
@@ -6694,6 +6737,7 @@ export function issueService(db: Db) {
       };
     },
 
+    ensureParentBlockedByChild,
     createChild: async (
       parentIssueId: string,
       data: IssueChildCreateInput,
@@ -7153,6 +7197,18 @@ export function issueService(db: Db) {
               .insert(issueCreateIdempotencyKeys)
               .values({ companyId, idempotencyKey, issueId: existingIssue.id })
               .onConflictDoNothing();
+          }
+          if (deduplicationReason === "recent_open_title" && blockParentUntilDone && existingIssue.parentId) {
+            await ensureParentBlockedByChild(
+              companyId,
+              existingIssue.parentId,
+              existingIssue.id,
+              {
+                agentId: actorAgentId ?? issueData.createdByAgentId ?? null,
+                userId: actorUserId ?? issueData.createdByUserId ?? null,
+              },
+              tx,
+            );
           }
           if (deduplicationReason) onDeduplicated?.(deduplicationReason);
           const [enriched] = await withIssueLabels(tx, [existingIssue]);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -670,13 +670,13 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   idempotencyKey?: string | null;
   allowDuplicate?: boolean;
   onDeduplicated?: (reason: "idempotency_key" | "recent_open_title") => void;
-};
-type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
   blockParentUntilDone?: boolean;
-  executionWorkspaceInheritanceMode?: "linkage" | "strategy_only";
   actorAgentId?: string | null;
   actorUserId?: string | null;
+};
+type IssueChildCreateInput = IssueCreateInput & {
+  executionWorkspaceInheritanceMode?: "linkage" | "strategy_only";
 };
 type AcceptedPlanDecompositionInput = {
   acceptedPlanRevisionId: string;
@@ -7054,8 +7054,19 @@ export function issueService(db: Db) {
         idempotencyKey: rawIdempotencyKey,
         allowDuplicate,
         onDeduplicated,
+        acceptanceCriteria,
+        blockParentUntilDone,
+        actorAgentId,
+        actorUserId,
         ...issueData
       } = data;
+      if (blockParentUntilDone && !issueData.parentId) {
+        throw unprocessable("blockParentUntilDone requires parentId");
+      }
+      issueData.description = appendAcceptanceCriteriaToDescription(
+        issueData.description,
+        acceptanceCriteria,
+      );
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -7358,6 +7369,26 @@ export function issueService(db: Db) {
             {
               agentId: issueData.createdByAgentId ?? null,
               userId: issueData.createdByUserId ?? null,
+            },
+            tx,
+          );
+        }
+        if (blockParentUntilDone && issueData.parentId) {
+          const existingBlockers = await tx
+            .select({ blockerIssueId: issueRelations.issueId })
+            .from(issueRelations)
+            .where(and(
+              eq(issueRelations.companyId, companyId),
+              eq(issueRelations.relatedIssueId, issueData.parentId),
+              eq(issueRelations.type, "blocks"),
+            ));
+          await syncBlockedByIssueIds(
+            issueData.parentId,
+            companyId,
+            [...new Set([...existingBlockers.map((row) => row.blockerIssueId), issue.id])],
+            {
+              agentId: actorAgentId ?? issueData.createdByAgentId ?? null,
+              userId: actorUserId ?? issueData.createdByUserId ?? null,
             },
             tx,
           );

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5226,6 +5226,12 @@ export function issueService(db: Db) {
     actor: { agentId?: string | null; userId?: string | null } = {},
     dbOrTx: DbWriter = db,
   ) {
+    await dbOrTx.execute(sql`
+      SELECT ${issues.id}
+      FROM ${issues}
+      WHERE ${and(eq(issues.companyId, companyId), eq(issues.id, parentId))}
+      FOR UPDATE
+    `);
     const existingBlockers = await dbOrTx
       .select({ blockerIssueId: issueRelations.issueId })
       .from(issueRelations)
@@ -7198,7 +7204,7 @@ export function issueService(db: Db) {
               .values({ companyId, idempotencyKey, issueId: existingIssue.id })
               .onConflictDoNothing();
           }
-          if (deduplicationReason === "recent_open_title" && blockParentUntilDone && existingIssue.parentId) {
+          if (blockParentUntilDone && existingIssue.parentId) {
             await ensureParentBlockedByChild(
               companyId,
               existingIssue.parentId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2089,6 +2089,7 @@ function createIssueBlockerAttention(input: Partial<IssueBlockerAttention> = {})
     state: input.state ?? "none",
     reason: input.reason ?? null,
     unresolvedBlockerCount: input.unresolvedBlockerCount ?? 0,
+    unresolvedBlockerIssueIds: input.unresolvedBlockerIssueIds ?? [],
     coveredBlockerCount: input.coveredBlockerCount ?? 0,
     stalledBlockerCount: input.stalledBlockerCount ?? 0,
     attentionBlockerCount: input.attentionBlockerCount ?? 0,
@@ -2337,13 +2338,8 @@ async function listIssueBlockerAttentionMap(
   companyId: string,
   issueRows: IssueBlockerAttentionInputNode[],
 ): Promise<Map<string, IssueBlockerAttention>> {
-  const roots = issueRows.filter((row) => row.companyId === companyId && row.status === "blocked");
+  const roots = issueRows.filter((row) => row.companyId === companyId);
   const attentionMap = new Map<string, IssueBlockerAttention>();
-  for (const row of issueRows) {
-    if (row.status !== "blocked") {
-      attentionMap.set(row.id, createIssueBlockerAttention());
-    }
-  }
   if (roots.length === 0) return attentionMap;
 
   const nodesById = new Map<string, IssueBlockerAttentionNode>();
@@ -2783,6 +2779,14 @@ async function listIssueBlockerAttentionMap(
       const blocker = nodesById.get(edge.blockerIssueId);
       return blocker?.status !== "done" || pendingFinalizeBlockerIssueIds.has(edge.blockerIssueId);
     });
+    const unresolvedBlockerIssueIds = [...new Set(topLevelEdges.map((edge) => edge.blockerIssueId))];
+    if (root.status !== "blocked") {
+      attentionMap.set(root.id, createIssueBlockerAttention({
+        unresolvedBlockerCount: unresolvedBlockerIssueIds.length,
+        unresolvedBlockerIssueIds,
+      }));
+      continue;
+    }
     if (topLevelEdges.length === 0) {
       attentionMap.set(root.id, createIssueBlockerAttention({
         state: "needs_attention",
@@ -2836,7 +2840,8 @@ async function listIssueBlockerAttentionMap(
     attentionMap.set(root.id, createIssueBlockerAttention({
       state,
       reason,
-      unresolvedBlockerCount: topLevelEdges.length,
+      unresolvedBlockerCount: unresolvedBlockerIssueIds.length,
+      unresolvedBlockerIssueIds,
       coveredBlockerCount,
       stalledBlockerCount,
       attentionBlockerCount,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -676,6 +676,9 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   actorAgentId?: string | null;
   actorUserId?: string | null;
 };
+type IssueCreateOptions = {
+  afterCreateInTransaction?: (tx: DbWriter, issue: typeof issues.$inferSelect) => Promise<void>;
+};
 type IssueChildCreateInput = IssueCreateInput & {
   executionWorkspaceInheritanceMode?: "linkage" | "strategy_only";
 };
@@ -755,6 +758,8 @@ export type IssueDependencyReadiness = {
   blockerIssueIds: string[];
   unresolvedBlockerIssueIds: string[];
   unresolvedBlockerCount: number;
+  /** True when a direct blocker is in progress or has a queued/running execution. */
+  blockingTreeLive?: boolean;
   /** Blockers whose status is `done` but whose execution workspace has not yet finalized. */
   pendingFinalizeBlockerIssueIds: string[];
   allBlockersDone: boolean;
@@ -990,6 +995,7 @@ function createIssueDependencyReadiness(issueId: string): IssueDependencyReadine
     blockerIssueIds: [],
     unresolvedBlockerIssueIds: [],
     unresolvedBlockerCount: 0,
+    blockingTreeLive: false,
     pendingFinalizeBlockerIssueIds: [],
     allBlockersDone: true,
     isDependencyReady: true,
@@ -1228,6 +1234,7 @@ async function listIssueDependencyReadinessMap(
       blockerIssueId: issueRelations.issueId,
       blockerStatus: issues.status,
       blockerExecutionWorkspaceId: issues.executionWorkspaceId,
+      blockerExecutionRunId: issues.executionRunId,
     })
     .from(issueRelations)
     .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -1256,10 +1263,27 @@ async function listIssueDependencyReadinessMap(
     companyId,
     doneBlockerWorkspacePairs,
   );
+  const activeBlockerRunIds = new Set<string>();
+  const blockerRunIds = [...new Set(blockerRows
+    .map((row) => row.blockerExecutionRunId)
+    .filter((runId): runId is string => runId !== null))];
+  if (blockerRunIds.length > 0) {
+    const activeRuns = await dbOrTx
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(
+        inArray(heartbeatRuns.id, blockerRunIds),
+        inArray(heartbeatRuns.status, BLOCKER_ATTENTION_ACTIVE_RUN_STATUSES),
+      ));
+    for (const run of activeRuns) activeBlockerRunIds.add(run.id);
+  }
 
   for (const row of blockerRows) {
     const current = readinessMap.get(row.issueId) ?? createIssueDependencyReadiness(row.issueId);
     current.blockerIssueIds.push(row.blockerIssueId);
+    if (row.blockerStatus === "in_progress" || (row.blockerExecutionRunId && activeBlockerRunIds.has(row.blockerExecutionRunId))) {
+      current.blockingTreeLive = true;
+    }
     // Only done blockers resolve dependents; cancelled blockers stay unresolved
     // until an operator removes or replaces the blocker relationship explicitly.
     if (row.blockerStatus !== "done") {
@@ -2355,6 +2379,7 @@ async function listIssueBlockerAttentionMap(
       attentionMap.set(readiness.issueId, createIssueBlockerAttention({
         unresolvedBlockerCount: readiness.unresolvedBlockerCount,
         unresolvedBlockerIssueIds: readiness.unresolvedBlockerIssueIds,
+        blockingTreeLive: readiness.blockingTreeLive,
       }));
     }
   }
@@ -5225,7 +5250,10 @@ export function issueService(db: Db) {
     childId: string,
     actor: { agentId?: string | null; userId?: string | null } = {},
     dbOrTx: DbWriter = db,
-  ) {
+  ): Promise<boolean> {
+    if (dbOrTx === db) {
+      return db.transaction((tx) => ensureParentBlockedByChild(companyId, parentId, childId, actor, tx));
+    }
     await dbOrTx.execute(sql`
       SELECT ${issues.id}
       FROM ${issues}
@@ -6780,7 +6808,7 @@ export function issueService(db: Db) {
         inheritStrategyOnly && !hasExplicitExecutionWorkspaceOverride
           ? buildPreRealizationExecutionWorkspaceSettings(parent.executionWorkspaceSettings)
           : null;
-      let child = await issueService(db).create(parent.companyId, {
+      const child = await issueService(db).create(parent.companyId, {
         ...issueData,
         parentId: parent.id,
         projectId: issueData.projectId ?? parent.projectId,
@@ -6798,21 +6826,17 @@ export function issueService(db: Db) {
         ...(inheritStrategyOnly
           ? { skipExecutionWorkspaceInheritance: true }
           : { inheritExecutionWorkspaceFromIssueId: parent.id }),
-      });
-
-      if (blockParentUntilDone) {
-        const existingBlockers = await db
-          .select({ blockerIssueId: issueRelations.issueId })
-          .from(issueRelations)
-          .where(and(eq(issueRelations.companyId, parent.companyId), eq(issueRelations.relatedIssueId, parent.id), eq(issueRelations.type, "blocks")));
-        await syncBlockedByIssueIds(
-          parent.id,
-          parent.companyId,
-          [...new Set([...existingBlockers.map((row) => row.blockerIssueId), child.id])],
-          { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
-        );
-        [child] = await withIssueRelationSummaries(parent.companyId, [child], db);
-      }
+      }, blockParentUntilDone
+        ? {
+            afterCreateInTransaction: (tx, createdChild) => ensureParentBlockedByChild(
+              parent.companyId,
+              parent.id,
+              createdChild.id,
+              { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
+              tx,
+            ).then(() => undefined),
+          }
+        : undefined);
 
       return {
         issue: child,
@@ -7095,7 +7119,7 @@ export function issueService(db: Db) {
       });
     },
 
-    create: async (companyId: string, data: IssueCreateInput) => {
+    create: async (companyId: string, data: IssueCreateInput, options: IssueCreateOptions = {}) => {
       const {
         labelIds: inputLabelIds,
         blockedByIssueIds,
@@ -7458,6 +7482,9 @@ export function issueService(db: Db) {
             },
             tx,
           );
+        }
+        if (options.afterCreateInTransaction) {
+          await options.afterCreateInTransaction(tx, issue);
         }
         const [enriched] = await withIssueLabels(tx, [issue]);
         const [withRelations] = await withIssueRelationSummaries(companyId, [enriched], tx);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7142,6 +7142,13 @@ export function issueService(db: Db) {
       if (blockParentUntilDone && !issueData.parentId) {
         throw unprocessable("blockParentUntilDone requires parentId");
       }
+      if (blockParentUntilDone && issueData.parentId) {
+        const [parent] = await db
+          .select({ id: issues.id })
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.id, issueData.parentId)));
+        if (!parent) throw notFound("Parent issue not found");
+      }
       issueData.description = appendAcceptanceCriteriaToDescription(
         issueData.description,
         acceptanceCriteria,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7204,17 +7204,24 @@ export function issueService(db: Db) {
               .values({ companyId, idempotencyKey, issueId: existingIssue.id })
               .onConflictDoNothing();
           }
-          if (blockParentUntilDone && existingIssue.parentId) {
-            await ensureParentBlockedByChild(
-              companyId,
-              existingIssue.parentId,
-              existingIssue.id,
-              {
-                agentId: actorAgentId ?? issueData.createdByAgentId ?? null,
-                userId: actorUserId ?? issueData.createdByUserId ?? null,
-              },
-              tx,
-            );
+          if (blockParentUntilDone) {
+            if (deduplicationReason === "idempotency_key" && existingIssue.parentId !== issueData.parentId) {
+              throw conflict("Idempotency replay cannot change parentId for blockParentUntilDone");
+            }
+            if (existingIssue.parentId) {
+              await ensureParentBlockedByChild(
+                companyId,
+                existingIssue.parentId,
+                existingIssue.id,
+                {
+                  agentId: actorAgentId ?? issueData.createdByAgentId ?? null,
+                  userId: actorUserId ?? issueData.createdByUserId ?? null,
+                },
+                tx,
+              );
+            } else if (deduplicationReason === "idempotency_key") {
+              throw conflict("Idempotency replay cannot add blockParentUntilDone to an issue without parentId");
+            }
           }
           if (deduplicationReason) onDeduplicated?.(deduplicationReason);
           const [enriched] = await withIssueLabels(tx, [existingIssue]);
@@ -7441,18 +7448,10 @@ export function issueService(db: Db) {
           );
         }
         if (blockParentUntilDone && issueData.parentId) {
-          const existingBlockers = await tx
-            .select({ blockerIssueId: issueRelations.issueId })
-            .from(issueRelations)
-            .where(and(
-              eq(issueRelations.companyId, companyId),
-              eq(issueRelations.relatedIssueId, issueData.parentId),
-              eq(issueRelations.type, "blocks"),
-            ));
-          await syncBlockedByIssueIds(
-            issueData.parentId,
+          await ensureParentBlockedByChild(
             companyId,
-            [...new Set([...existingBlockers.map((row) => row.blockerIssueId), issue.id])],
+            issueData.parentId,
+            issue.id,
             {
               agentId: actorAgentId ?? issueData.createdByAgentId ?? null,
               userId: actorUserId ?? issueData.createdByUserId ?? null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5254,12 +5254,12 @@ export function issueService(db: Db) {
     if (dbOrTx === db) {
       return db.transaction((tx) => ensureParentBlockedByChild(companyId, parentId, childId, actor, tx));
     }
-    await dbOrTx.execute(sql`
-      SELECT ${issues.id}
-      FROM ${issues}
-      WHERE ${and(eq(issues.companyId, companyId), eq(issues.id, parentId))}
-      FOR UPDATE
-    `);
+    const [parent] = await dbOrTx
+      .select({ id: issues.id })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.id, parentId)))
+      .for("update");
+    if (!parent) throw notFound("Parent issue not found");
     const existingBlockers = await dbOrTx
       .select({ blockerIssueId: issueRelations.issueId })
       .from(issueRelations)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue creation and update validation define the public contract for issue mutations.
> - The company issue-create route silently removed blocker fields before the service handled the request.
> - A child issue that requests a parent blocker must preserve that request and create the blocks edge.
> - Strict validation also prevents unknown fields from being silently discarded.
> - This pull request aligns validators, routes, services, and tests with that contract.
> - The benefit is predictable issue creation and safer API evolution.

## Linked Issues or Issue Description

**What happened?**

The company issue-create endpoint accepted `blockParentUntilDone` and `acceptanceCriteria` in the request type, but the route schema removed those fields before the issue service received them. Unknown create and update fields were also silently stripped instead of rejected.

**Expected behavior**

The endpoint must preserve supported blocker fields and create the parent blocks edge when `blockParentUntilDone` is true with a `parentId`. Unknown mutation fields must return a validation error.

**Steps to reproduce**

1. Send `POST /api/companies/{companyId}/issues` with `parentId` and `blockParentUntilDone: true`.
2. Inspect the service input and response for the blocker request.
3. Send an issue create or update request with an unsupported field.
4. Confirm supported fields are preserved and unsupported fields return a client error.

**Paperclip version or commit**

Master base commit `40d8cbc41a6b4ffb1405a2a489ae6e11ba1f663d`.

**Deployment mode**

Built from source with the Paperclip test suite.

GitHub search found no separate duplicate PR for this change.

## What Changed

- Preserve `acceptanceCriteria` and `blockParentUntilDone` through company issue creation.
- Validate the parent requirement for `blockParentUntilDone`.
- Add the parent blocks edge when the flag is enabled.
- Reject unknown fields in issue create and update mutations.
- Keep parent blocker repair and blocker-attention calculations consistent across related paths.
- Add focused validator, route, service, and OpenAPI coverage.

## Verification

- `pnpm exec vitest run packages/shared/src/validators/issue.test.ts`
- `pnpm exec vitest run server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- GitHub PR checks cover build, policy, security, general tests, serialized tests, and end-to-end tests.

## Risks

- This is a behavioral tightening for malformed issue mutations. Clients that relied on silent field stripping will receive validation errors.
- Parent blocker creation now rejects a true flag without a parent, which prevents an incomplete relation.
- No database migration or data backfill is required.

## Model Used

- OpenAI Codex, exact model `gpt-5.6-luna`, extended reasoning effort `xhigh`, with tool-assisted code execution and tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR following the relevant bug template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile review completed with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
