### PR TITLE
fix(server): preserve manual review workflow guards

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -556,8 +556,8 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("shared default-open");
   });
 
-  it("allows standard-trust agents to comment on and update visible peer-owned issues", async () => {
-    const company = await createCompany(db, "DefaultOpenPeerWrites");
+  it("denies standard-trust agents from commenting on or mutating peer-owned issues without an explicit collaboration path", async () => {
+    const company = await createCompany(db, "PeerOwnedIssueWritesDenied");
     const actorAgent = await createAgent(db, company.id);
     const ownerAgent = await createAgent(db, company.id);
     const issue = await createIssue(db, company.id, { assigneeAgentId: ownerAgent.id });
@@ -578,18 +578,24 @@ describeEmbeddedPostgres("authorization service", () => {
 
     for (const action of ["issue:comment", "issue:mutate"] as const) {
       await expect(authorization.decide({ actor, action, resource })).resolves.toMatchObject({
-        allowed: true,
-        reason: "allow_visible_issue_write",
+        allowed: false,
+        reason: "deny_missing_grant",
       });
     }
   });
 
-  it("keeps the responsible-user ceiling on every default-open peer write", async () => {
-    const company = await createCompany(db, "DefaultOpenPeerWriteCeiling");
+  it("keeps the responsible-user ceiling on mention-granted peer comments", async () => {
+    const company = await createCompany(db, "MentionGrantedPeerWriteCeiling");
     const actorAgent = await createAgent(db, company.id);
     const ownerAgent = await createAgent(db, company.id);
     const issue = await createIssue(db, company.id, { assigneeAgentId: ownerAgent.id });
     const unavailableUserId = await createUser(db);
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      authorAgentId: ownerAgent.id,
+      body: `[@Mentioned](agent://${actorAgent.id}) please respond here`,
+    });
     const actor = {
       type: "agent" as const,
       agentId: actorAgent.id,
@@ -606,13 +612,11 @@ describeEmbeddedPostgres("authorization service", () => {
     };
     const authorization = authorizationService(db);
 
-    for (const action of ["issue:comment", "issue:mutate"] as const) {
-      await expect(authorization.decide({ actor, action, resource })).resolves.toMatchObject({
-        allowed: false,
-        code: "RESPONSIBLE_USER_UNAVAILABLE",
-        reason: "deny_missing_membership",
-      });
-    }
+    await expect(authorization.decide({ actor, action: "issue:comment", resource })).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
+      reason: "deny_missing_membership",
+    });
   });
 
   it("structurally keeps default-open comments inside issue visibility", async () => {
@@ -666,8 +670,8 @@ describeEmbeddedPostgres("authorization service", () => {
     }
   });
 
-  it("does not let default-open non-assignee comments mint mention grants", async () => {
-    const company = await createCompany(db, "DefaultOpenMentionNonTransitive");
+  it("does not let unauthorized non-assignee comments mint mention grants", async () => {
+    const company = await createCompany(db, "MentionNonTransitive");
     const ownerAgent = await createAgent(db, company.id);
     const commentingAgent = await createAgent(db, company.id);
     const mentionedAgent = await createAgent(db, company.id);
@@ -695,8 +699,8 @@ describeEmbeddedPostgres("authorization service", () => {
         status: issue.status,
       },
     })).resolves.toMatchObject({
-      allowed: true,
-      reason: "allow_visible_issue_write",
+      allowed: false,
+      reason: "deny_missing_grant",
     });
   });
 

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -1902,6 +1902,111 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     });
   });
 
+  it("does not promote a provider-quota retry after the issue is parked in manual review", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const sourceRunId = randomUUID();
+    const now = new Date("2026-04-20T14:45:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "QuotaLimitedCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "You've hit your usage limit for GPT-5. Try again at 4:00 PM (UTC).",
+      errorCode: "provider_quota",
+      resultJson: {
+        errorFamily: "provider_quota",
+        providerQuotaRetryNotBefore: "2026-04-20T16:00:00.000Z",
+      },
+      finishedAt: now,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Manual review handoff",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      executionRunId: sourceRunId,
+      executionAgentNameKey: "quotalimitedcoder",
+      executionLockedAt: now,
+      issueNumber: 31,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-31`,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    await db.update(issues).set({
+      status: "in_review",
+      updatedAt: now,
+    }).where(eq(issues.id, issueId));
+
+    const promotion = await heartbeat.promoteDueScheduledRetries(scheduled.dueAt);
+    expect(promotion).toEqual({ promoted: 0, runIds: [] });
+
+    const retryRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, scheduled.run.id))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun).toEqual({
+      status: "cancelled",
+      errorCode: "issue_waiting_on_review",
+    });
+
+    const issue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+  });
+
   it("does not promote a scheduled retry after the issue is cancelled", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1586,6 +1586,61 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels a queued assignee wake once the issue is parked in review without an active agent participant", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Manual review handoff",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_assigned",
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          resultJson: heartbeatRuns.resultJson,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_waiting_on_review");
+    expect(run?.resultJson).toMatchObject({ stopReason: "issue_waiting_on_review" });
+    expect(wakeup?.status).toBe("skipped");
+    expect(wakeup?.error).toContain("parked in review");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("runs accepted-interaction continuation recovery despite a pre-acceptance review park", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -849,50 +849,40 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it("keeps visible peer comments agent-class even when authorType tries to smuggle user wake privilege", async () => {
+  it("rejects unmentioned peer comments on another agent-owned issue even when authorType tries to smuggle user wake privilege", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
-      allowed: input.action === "issue:read" || input.action === "issue:comment",
+      allowed: input.action === "issue:read",
       action: input.action,
-      reason: input.action === "issue:comment" ? "allow_visible_issue_write" : "allow_explicit_grant",
-      explanation: "Allowed by the shared visible-issue write rule.",
+      reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "issue:read" ? "Allowed by test boundary default." : "Missing permission.",
     }));
 
     const res = await request(await createApp(peerActor()))
       .post(`/api/issues/${issueId}/comments`)
       .send({ body: "I was not mentioned.", authorType: "user" });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(201);
-    expect(mockIssueService.addComment).toHaveBeenCalledWith(
-      issueId,
-      "I was not mentioned.",
-      expect.any(Object),
-      expect.any(Object),
-    );
-    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      ownerAgentId,
-      expect.objectContaining({
-        reason: "issue_commented",
-        requestedByActorType: "agent",
-        requestedByActorId: peerAgentId,
-      }),
-    ));
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("issue_write_not_visible");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
-  it("keeps default-open peer comments on closed issues inert", async () => {
+  it("rejects default-open peer comments on closed agent-owned issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "done", assigneeAgentId: ownerAgentId }));
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
-      allowed: input.action === "issue:comment" || input.action === "issue:read",
+      allowed: input.action === "issue:read",
       action: input.action,
-      reason: input.action === "issue:comment" ? "allow_visible_issue_write" : "allow_company_agent",
-      explanation: "Allowed by the shared visible-issue write rule.",
+      reason: input.action === "issue:read" ? "allow_company_agent" : "deny_missing_grant",
+      explanation: input.action === "issue:read" ? "Allowed by standard visibility." : "Missing permission.",
     }));
 
     const res = await request(await createApp(peerActor()))
       .post(`/api/issues/${issueId}/comments`)
       .send({ body: "Closed issue context only." });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(201);
-    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("issue_write_not_visible");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2168,7 +2168,14 @@ export function authorizationService(db: Db) {
       ) {
         return allowIssueMentionGrant(input.action);
       }
-      if (visibleIssueWriteDecision) return visibleIssueWriteDecision;
+      return deny({
+        action: input.action,
+        reason: "deny_missing_grant",
+        explanation:
+          input.action === "issue:comment"
+            ? "Agent cannot comment on another agent-owned issue without being the assignee, an explicitly mentioned addressee, or another route-specific collaboration grant."
+            : "Agent cannot mutate another agent-owned issue without owning the issue or reaching it through a route-specific governed handoff.",
+      });
     }
     if (
       input.action === "agent_config:update" &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10918,6 +10918,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     executionState: unknown;
     runAgentId: string;
     mode: "queued_run" | "scheduled_retry";
+    allowResolvedInteractionContinuation?: boolean;
   }): {
     errorCode: "issue_review_participant_changed" | "issue_waiting_on_review";
     reason: string;
@@ -10928,6 +10929,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const executionState = parseIssueExecutionState(input.executionState);
     const currentParticipant = executionState?.currentParticipant ?? null;
     if (currentParticipant?.type === "agent" && currentParticipant.agentId === input.runAgentId) {
+      return null;
+    }
+    if (!currentParticipant && input.allowResolvedInteractionContinuation) {
       return null;
     }
 
@@ -11126,6 +11130,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
+    const allowResolvedInteractionContinuation = isResolvedInteractionContinuationWakeContext({
+      ...contextSnapshot,
+      ...(retryReason && readNonEmptyString(contextSnapshot.retryReason) !== retryReason
+        ? { retryReason }
+        : {}),
+    });
     const reviewWaitGate = describeReviewWaitGate({
       issueId,
       issueStatus: issue.status,
@@ -11133,6 +11143,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       executionState: issue.executionState,
       runAgentId: run.agentId,
       mode: "scheduled_retry",
+      allowResolvedInteractionContinuation,
     });
     if (reviewWaitGate) {
       return {
@@ -13055,6 +13066,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "in_review" && !wakeCommentId) {
+      const allowResolvedInteractionContinuation = isResolvedInteractionContinuationWakeContext({
+        ...context,
+        ...(retryReason && readNonEmptyString(context.retryReason) !== retryReason
+          ? { retryReason }
+          : {}),
+      });
       const reviewWaitGate = describeReviewWaitGate({
         issueId,
         issueStatus: issue.status,
@@ -13062,6 +13079,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         executionState: issue.executionState,
         runAgentId: run.agentId,
         mode: "queued_run",
+        allowResolvedInteractionContinuation,
       });
       if (reviewWaitGate) {
         return {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10902,6 +10902,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
+          | "issue_waiting_on_review"
           | "issue_paused"
           | "issue_dependencies_blocked"
           | "issue_disposition_repair_superseded";
@@ -10909,6 +10910,56 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         details: Record<string, unknown>;
       };
   type BlockedScheduledRetryGate = Extract<ScheduledRetryGate, { allowed: false }>;
+
+  function describeReviewWaitGate(input: {
+    issueId: string;
+    issueStatus: string | null;
+    assigneeUserId: string | null;
+    executionState: unknown;
+    runAgentId: string;
+    mode: "queued_run" | "scheduled_retry";
+  }): {
+    errorCode: "issue_review_participant_changed" | "issue_waiting_on_review";
+    reason: string;
+    details: Record<string, unknown>;
+  } | null {
+    if (input.issueStatus !== "in_review") return null;
+
+    const executionState = parseIssueExecutionState(input.executionState);
+    const currentParticipant = executionState?.currentParticipant ?? null;
+    if (currentParticipant?.type === "agent" && currentParticipant.agentId === input.runAgentId) {
+      return null;
+    }
+
+    if (currentParticipant) {
+      return {
+        errorCode: "issue_review_participant_changed",
+        reason:
+          input.mode === "scheduled_retry"
+            ? "Scheduled retry suppressed because the issue is waiting on another review participant"
+            : "Cancelled because the in-review participant changed before the queued run could start; the current participant will be woken instead",
+        details: {
+          issueId: input.issueId,
+          currentStageType: executionState?.currentStageType ?? null,
+          currentParticipant,
+        },
+      };
+    }
+
+    return {
+      errorCode: "issue_waiting_on_review",
+      reason:
+        input.mode === "scheduled_retry"
+          ? "Scheduled retry suppressed because the issue is parked in review without an active agent participant"
+          : "Cancelled because the issue is parked in review without an active agent participant",
+      details: {
+        issueId: input.issueId,
+        currentStageType: executionState?.currentStageType ?? null,
+        currentParticipant: null,
+        assigneeUserId: input.assigneeUserId,
+      },
+    };
+  }
 
   async function evaluateScheduledRetryGate(input: {
     run: typeof heartbeatRuns.$inferSelect;
@@ -11075,26 +11126,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (issue.status === "in_review") {
-      const executionState = parseIssueExecutionState(issue.executionState);
-      const currentParticipant = executionState?.currentParticipant ?? null;
-      if (currentParticipant) {
-        const participantMatches =
-          currentParticipant.type === "agent" && currentParticipant.agentId === run.agentId;
-        if (!participantMatches) {
-          return {
-            allowed: false,
-            reason: "Scheduled retry suppressed because the issue is waiting on another review participant",
-            errorCode: "issue_review_participant_changed",
-            issueId,
-            details: {
-              issueId,
-              currentStageType: executionState?.currentStageType ?? null,
-              currentParticipant,
-            },
-          };
-        }
-      }
+    const reviewWaitGate = describeReviewWaitGate({
+      issueId,
+      issueStatus: issue.status,
+      assigneeUserId: issue.assigneeUserId,
+      executionState: issue.executionState,
+      runAgentId: run.agentId,
+      mode: "scheduled_retry",
+    });
+    if (reviewWaitGate) {
+      return {
+        allowed: false,
+        issueId,
+        ...reviewWaitGate,
+      };
     }
 
     const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
@@ -12862,6 +12907,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
+          | "issue_waiting_on_review"
           | "issue_continuation_waiting_on_review";
         details: Record<string, unknown>;
       };
@@ -12876,6 +12922,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         id: issues.id,
         status: issues.status,
         assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
       })
@@ -13007,24 +13054,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (issue.status === "in_review") {
-      const currentParticipant = reviewExecutionState?.currentParticipant ?? null;
-      if (currentParticipant) {
-        const participantMatches =
-          currentParticipant.type === "agent" && currentParticipant.agentId === run.agentId;
-        if (!participantMatches && !wakeCommentId) {
-          return {
-            stale: true,
-            errorCode: "issue_review_participant_changed",
-            reason:
-              "Cancelled because the in-review participant changed before the queued run could start; the current participant will be woken instead",
-            details: {
-              issueId,
-              currentStageType: reviewExecutionState?.currentStageType ?? null,
-              currentParticipant,
-            },
-          };
-        }
+    if (issue.status === "in_review" && !wakeCommentId) {
+      const reviewWaitGate = describeReviewWaitGate({
+        issueId,
+        issueStatus: issue.status,
+        assigneeUserId: issue.assigneeUserId,
+        executionState: issue.executionState,
+        runAgentId: run.agentId,
+        mode: "queued_run",
+      });
+      if (reviewWaitGate) {
+        return {
+          stale: true,
+          ...reviewWaitGate,
+        };
       }
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip has review and recovery paths for issue execution
> - Queued runs and scheduled retries must stop when an issue is parked for manual review
> - Accepted interaction continuations must still resume when that review handoff is the expected next step
> - Peer-owned issue writes also need a clear collaboration grant instead of a broad visible-issue write path
> - This pull request restores those workflow guards after the recovery branch was left unpublished
> - The benefit is that review handoffs stay safe, and valid accepted continuations still move forward

## Linked Issues or Issue Description

**What happened?**
When an issue moved into review without an active agent participant, queued assignee wakes and provider-quota retries could stay eligible. A peer agent could also reach another agent-owned issue through the shared visible-issue write path instead of an explicit collaboration grant.

**Expected behavior**
Queued runs and scheduled retries should stop when the issue is waiting on manual review. Accepted interaction continuations should still resume when the review handoff is the expected path. Peer-owned issue comments and mutations should require an explicit collaboration route.

**Steps to reproduce**
1. Create an agent-owned issue and enqueue a wake or provider-quota retry for its assignee.
2. Move the issue to `in_review` without an active agent review participant.
3. Observe that the queued run or retry can still promote, or that a peer agent can comment on the issue without a mention or other grant.

**Paperclip version or commit**
Reproduced from `master` before this fix. Fixed on top of `35fca9562`.

**Deployment mode**
Local dev (`pnpm dev`)

**Installation method**
Built from source (`pnpm dev` / `pnpm build`)

**Agent adapter(s) involved**
Not adapter-specific (core bug)

**Database mode**
Embedded PGlite (default — `DATABASE_URL` unset)

**Access context**
Agent (bearer API key via `agent_api_keys`)

## What Changed

- Deny peer-agent comments and mutations on another agent-owned issue unless the actor is the assignee, is explicitly mentioned, or reaches a route-specific collaboration path.
- Cancel queued assignee wakes and suppress scheduled retries when an issue is parked in review without an active agent participant.
- Allow resolved interaction continuations to pass the new review wait gate so accepted review cards can still resume execution.
- Add regression coverage for authorization, stale queued-run invalidation, and bounded retry scheduling.

## Verification

- `../node_modules/.bin/vitest run --config vitest.config.ts src/__tests__/authorization-service.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/heartbeat-stale-queue-invalidation.test.ts src/__tests__/heartbeat-retry-scheduling.test.ts`

## Risks

- Low to medium. The authorization change narrows peer-agent write access, so any missed legitimate collaboration path would surface as a 403 and need a follow-up route-specific grant.
- The review-wait gate now blocks more queued and retry paths, so the main regression risk is over-blocking a continuation that should still resume. The added continuation regression test covers that case.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex GPT-5, local coding-agent runtime, large-context tool-using mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
