### PR TITLE
fix(ui): align sidebar section labels with nav item text column

### DIFF
--- a/ui/src/components/SidebarSection.test.tsx
+++ b/ui/src/components/SidebarSection.test.tsx
@@ -105,6 +105,15 @@ describe("SidebarSection", () => {
     expect(projectsLabel?.parentElement?.textContent).toBe("Projects");
     expect(projectsLabel?.parentElement?.querySelector("svg")).toBeNull();
     expect(container.querySelector('button[aria-label="Collapse Projects"] svg')).toBeTruthy();
+
+    // Leading icon slot (caret or spacer) sits before the label so section
+    // text shares SidebarNavItem's label column — not the icon column.
+    const workRow = workLabel?.closest(".group\\/sidebar-section")?.firstElementChild;
+    const projectsRow = projectsLabel?.closest(".group\\/sidebar-section")?.firstElementChild;
+    expect(workRow?.children[0]?.getAttribute("aria-hidden")).toBe("true");
+    expect(projectsRow?.children[0]?.getAttribute("aria-label")).toBe("Collapse Projects");
+    expect(workRow?.className).toContain("gap-2.5");
+    expect(projectsRow?.className).toContain("gap-2.5");
   });
 
   it("keeps collapse on the caret and opens the menu from the heading", async () => {

--- a/ui/src/components/SidebarSection.tsx
+++ b/ui/src/components/SidebarSection.tsx
@@ -98,7 +98,9 @@ function SidebarSectionHeader({
           type="button"
           data-slot="icon-button"
           className={cn(
-            "inline-flex min-w-0 max-w-full items-center rounded-md px-1 py-0.5 text-left outline-none transition-colors",
+            // No horizontal padding — the row's icon slot + gap-2.5 already
+            // match SidebarNavItem's label column (EMO-7609).
+            "inline-flex min-w-0 max-w-full items-center rounded-md py-0.5 text-left outline-none transition-colors",
             "hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
             menuOpen && "bg-accent/50",
           )}
@@ -148,24 +150,32 @@ function SidebarSectionHeader({
       </DropdownMenuContent>
     </DropdownMenu>
   ) : (
-    <div className="inline-flex min-w-0 max-w-full items-center px-1 py-0.5">{headerContent}</div>
+    <div className="inline-flex min-w-0 max-w-full items-center py-0.5">{headerContent}</div>
+  );
+
+  // Leading slot mirrors SidebarNavItem's h-4 w-4 icon column + gap-2.5 so
+  // section labels (Work / Agents / Company) share the same text column as
+  // Dashboard / Inbox / Tasks. Absolute gutter carets previously left the
+  // label on the icon column and read as a misaligned "Work" row (EMO-7609).
+  const leadingSlot = collapsible ? (
+    <CollapsibleTrigger asChild>
+      <button
+        type="button"
+        data-slot="icon-button"
+        className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+        aria-label={collapsible.open ? `Collapse ${label}` : `Expand ${label}`}
+      >
+        <ChevronRight className={caretClassName} aria-hidden="true" />
+      </button>
+    </CollapsibleTrigger>
+  ) : (
+    <span className="h-4 w-4 shrink-0" aria-hidden="true" />
   );
 
   return (
-    <div className="group/sidebar-section px-3 py-1.5 pointer-coarse:py-1">
-      <div className="relative flex min-h-6 min-w-0 items-center gap-1">
-        {collapsible ? (
-          <CollapsibleTrigger asChild>
-            <button
-              type="button"
-              data-slot="icon-button"
-              className="absolute -left-4 flex h-5 w-5 items-center justify-center rounded-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-              aria-label={collapsible.open ? `Collapse ${label}` : `Expand ${label}`}
-            >
-              <ChevronRight className={caretClassName} aria-hidden="true" />
-            </button>
-          </CollapsibleTrigger>
-        ) : null}
+    <div className="group/sidebar-section mx-2 px-2 py-1.5 pointer-coarse:py-1">
+      <div className="flex min-h-6 min-w-0 items-center gap-2.5">
+        {leadingSlot}
         {headingControl}
         {headerAction && HeaderActionIcon ? (
           <Button
@@ -201,13 +211,14 @@ export function SidebarSection({
   // rail), and the items always render so their icons stay reachable.
   //
   // The header wrapper mirrors the expanded header's vertical footprint exactly
-  // (outer `px-3 py-1.5 pointer-coarse:py-1` + inner `min-h-6`) so item icons land
-  // at the identical y-position in both states — no movement on collapse/expand
-  // (PAP-10676). The divider is vertically centered within that same row.
+  // (outer `mx-2 px-2 py-1.5 pointer-coarse:py-1` + inner `min-h-6`) so item
+  // icons land at the identical y-position in both states — no movement on
+  // collapse/expand (PAP-10676). The divider is vertically centered within that
+  // same row.
   if (rail) {
     return (
       <div>
-        <div className="px-3 py-1.5 pointer-coarse:py-1">
+        <div className="mx-2 px-2 py-1.5 pointer-coarse:py-1">
           <div className="flex min-h-6 items-center">
             <span className="sr-only">{label}</span>
             <div className="h-px w-full bg-border/60" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Sidebar section headers (`Work` / `Agents` / `Company`) used an absolute gutter caret and different horizontal padding than `SidebarNavItem`, so the **WORK** label sat on the icon column and read as a misaligned menu row.
- Reserve a `h-4 w-4` leading slot (caret or spacer) with the same `mx-2 px-2` + `gap-2.5` rhythm as nav items so section labels share the **label** column with Dashboard / Inbox / Tasks.
- Static and collapsible sections stay on the same text column via the spacer slot.

Source ticket: EMO-7609 (local board).

## Verification

- Local viewport render at 1440×900: measured label `left` for Work / Agents / Company / Inbox / Dashboard / Tasks — all **54px** after the fix (Work was **28px** before).
- Hot-patched the running local `ui-dist` with the same change to confirm the visual delta on the live board.
- Unit test updated for the leading-slot structure. Full `SidebarSection` suite couldn't run in this environment (host Node 20 vs package engine Node ≥24 / jsdom undici), so relying on CI for the suite.

## Design lenses

- **Gestalt Similarity / Common Region** — section headers and nav items share one text column.
- **Jakob's Law** — tree carets occupy the icon slot rather than shifting the label.