### PR TITLE
test(adapter-utils): wait for the handshake guard timers before advancing the fake clock

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -217,17 +217,47 @@ async function runExecutor(
   return { logs, meta, events, runtimeOptions, configOptions, sessionInputs, result };
 }
 
+// The ceiling on microtask turns spent waiting for the startup path to arm the
+// handshake guard. It exists only so a regression that stops the guard being
+// armed fails as an assertion instead of spinning; it is not a tuning knob, and
+// the wait below almost always ends after a few dozen turns.
+const MAX_SETUP_FLUSH_TURNS = 10_000;
+
 // Under `vi.useFakeTimers()`, the setup work before a run reaches its
 // `ensureSession` call (staging, warm-handle lookups, real `fs` calls) still
-// runs through ordinary promise chains, not timers. `advanceTimersByTimeAsync`
-// only drains microtasks in the windows between the timer ticks it processes;
-// with no timer due yet, a single call can return before that setup chain
-// finishes unwinding. Flushing a few zero-length advances first lets it fully
-// unwind before the real, deadline-length advance below.
+// runs through ordinary promise chains, not timers, and its completion is
+// driven by libuv rather than by the fake clock. `advanceTimersByTimeAsync`
+// only drains microtasks in the windows between the timer ticks it processes,
+// so with no timer due yet a single call can return before that setup chain has
+// finished unwinding.
+//
+// So the clock must not be advanced until the run has actually armed the
+// handshake guard's timers (its deadline `setTimeout` and its transport-loss
+// poll `setInterval`, both armed together). A fixed number of flush turns only
+// guesses at that: the turn count the startup path needs varies with how
+// quickly the real filesystem work completes, so under load the guess elapses
+// first, the clock jumps past a deadline that does not exist yet, and the timer
+// is then armed against a clock that never moves again. The awaited result
+// promise never settles and the test dies at the vitest timeout instead.
+//
+// Wait on the observable condition — a pending fake timer — and then advance.
 async function flushSetupThenAdvanceTimersByTimeAsync(ms: number): Promise<void> {
-  for (let i = 0; i < 50; i++) {
+  let turns = 0;
+  while (vi.getTimerCount() === 0 && turns < MAX_SETUP_FLUSH_TURNS) {
     await vi.advanceTimersByTimeAsync(0);
+    turns++;
   }
+
+  // Every caller drives a run that is expected to trip the handshake guard, so
+  // a run that armed no timer can never reach its deadline no matter how far
+  // the clock advances. Fail here, on the real cause, rather than leaving the
+  // caller to await a promise that will not settle.
+  expect(
+    vi.getTimerCount(),
+    `the run armed no timer within ${MAX_SETUP_FLUSH_TURNS} microtask turns, so advancing ` +
+      `the clock by ${ms}ms cannot trip the handshake guard`,
+  ).toBeGreaterThan(0);
+
   await vi.advanceTimersByTimeAsync(ms);
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The ACPX engine starts an agent runtime and must complete a startup handshake before it runs a turn
> - A guard puts a deadline on that handshake, and a fence stops a late handshake result from reaching a run that already ended
> - The tests for that guard and that fence use fake timers, and they share one helper that advances the fake clock to the deadline
> - The helper flushed a fixed number of microtask turns first, which is a guess at when the run arms its timers, so the tests fail intermittently under load
> - This pull request makes the helper wait for the run to actually arm a timer before it advances the clock
> - The benefit is that the startup handshake tests stop failing intermittently, so CI stops blocking unrelated pull requests

## Linked Issues or Issue Description

No public issue exists for this flaky test. The description follows the bug report template.

**What happened?**

Seven tests in the `ACPX startup handshake guard and late-completion fence` block of `packages/adapter-utils/src/acpx-engine/execute.test.ts` fail intermittently. Each failure stops at exactly the vitest default timeout of 5000ms. The failures move between tests from run to run, which makes them look unrelated to each other.

These tests share the helper `flushSetupThenAdvanceTimersByTimeAsync`. The helper flushed a fixed 50 microtask turns and then advanced the fake clock past the handshake deadline. The fixed count is a guess at "the startup path has finished". The startup path does real filesystem work. Libuv drives the completion of that work, not the fake clock, so the number of turns the path needs changes with machine load.

When 50 turns are not enough, the helper advances the clock past a deadline that does not exist yet. The run arms its guard timers after that, against a clock that never moves again. The timer never fires. The awaited result promise never settles, and vitest kills the test at 5000ms. This is why the failure duration is always about 5000ms and never relates to the 60s handshake budget.

**Expected behavior**

The block passes on every run, on an idle machine and under load.

**Steps to reproduce**

Run the block in isolation, several times, on a loaded machine:

```
pnpm vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts \
  -t "ACPX startup handshake guard and late-completion fence"
```

On an 8-core machine, run eight of these at the same time. Before this change, 22 of 24 such runs fail.

**Paperclip version or commit**

Reproduced on `master` at 35fca95. The block was added in e127faa14.

**Relevant logs or output**

```
FAIL src/acpx-engine/execute.test.ts > ACPX startup handshake guard and
  late-completion fence > never promotes a late ensureSession resolution
  into the live handle after a guard rejection
Error: Test timed out in 5000ms.
```

## What Changed

- `flushSetupThenAdvanceTimersByTimeAsync` now waits until the run has a pending fake timer, and then advances the clock. It no longer flushes a fixed 50 turns.
- The wait has an upper bound, `MAX_SETUP_FLUSH_TURNS`. The bound exists only to stop a spin. It is not a tuning knob.
- The helper now asserts that a timer is pending before it advances the clock. If a change ever stops the run arming its guard, the test fails with a message that names the cause. It no longer hangs to the vitest timeout.
- The comment above the helper explains why a fixed turn count cannot work here.

This is a test-only change. `execute.ts`, the handshake constants, and the guard itself are untouched.

## Verification

All measurements were taken on an idle 8-core machine, on the branch commit.

Reproduction of the defect, before the change:

- The block, run 10 times in isolation: 3 runs failed. Every failure stopped at 5000ms.
- The block, 24 runs at 8-way concurrency: 22 runs failed. The failures covered 7 of the 9 tests in the block.

Proof of the mechanism. The turn budget was temporarily made a variable, and the number of turns the startup path really needs was measured:

- The startup path needs 6 to 28 turns on an idle machine. The old fixed budget of 50 therefore had under 2x margin over the idle maximum.
- The pending timer count is 0 or 2 at every helper call, and never 1. The run arms its deadline `setTimeout` and its transport poll `setInterval` together, so a pending timer is an exact signal that the guard is armed.
- With the budget starved below what the path needs, and no condition wait, 6 tests fail at 5000ms and the timer count is 0 at every call. With the same starved budget and the condition wait added, all 9 tests pass. This isolates the condition wait as the single cause.

Results after the change:

- The block, 20 consecutive runs in isolation: 20 passed, 0 failed.
- The block, 24 runs at 8-way concurrency: 24 passed, 0 failed.
- The full file: 154 of 154 passed.
- Runtime of the full file: 37.67s with the change, against a 37.79s baseline on the same machine. There is no increase.
- `tsc --noEmit` for `packages/adapter-utils`: clean.

The assertion path was checked directly. The bound was temporarily set to 0 to force the failure. The test then failed in 49ms with `AssertionError: the run armed no timer within 0 microtask turns, so advancing the clock by 60050ms cannot trip the handshake guard`, instead of hanging for 5000ms.

## Risks

Low risk. The change touches one test helper and no product code.

The helper asserts that a pending timer exists. Every one of its 8 call sites drives a run that is expected to trip the handshake guard, and each asserts the `acpx_handshake_timeout` error code. The helper has no other callers. So the assertion cannot fire for a caller that legitimately expects no timer, and the wait cannot spin.

The assertion uses "at least one pending timer" rather than an exact count of two. This keeps the helper from breaking if the guard's internal timer count ever changes.

The helper now stops flushing as soon as a timer is armed, so it usually runs fewer turns than the old fixed 50. The advance that follows still drains microtasks between timer ticks, so later work still unwinds. The full file passing 154 of 154 supports this.

Depends-on: none — this change is self-contained and touches one test file only

## Model Used

Claude Opus 5 (`claude-opus-5`), with extended thinking and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
