### PR TITLE
fix(acpx): tag mid-stream transport stalls as transient_upstream so bounded retry arms

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -27,6 +27,7 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async (importActual) => {
 });
 import {
   buildAcpxRunSummary,
+  classifyAcpxTurnFailureErrorFamily,
   createAcpxEngineExecutor,
   findAncestorBin,
   geminiVersionSupportsNativeAcpFlag,
@@ -6171,6 +6172,73 @@ describe("ACPX engine sandbox bridge run-disposition seam (fail-closed)", () => 
     expect(fake.readDisposition().failed).toBe(false);
   });
 
+  it("tags a mid-stream transport-stall terminal with errorFamily transient_upstream", async () => {
+    const sandbox = await setupRemoteSandbox();
+    const fake = createFakeBridgeHandle();
+    // The turn ends with a failed terminal whose error is the observed
+    // transport stall — the class the bounded transient-retry ladder exists for.
+    const runtime = {
+      ensureSession: async () => ({
+        backendSessionId: "backend-session",
+        agentSessionId: "agent-session",
+        runtimeSessionName: "runtime-session",
+      }),
+      startTurn: () => ({
+        events: (async function* () {
+          yield { type: "done", stopReason: "end_turn" };
+        })(),
+        result: Promise.resolve({
+          status: "failed" as const,
+          error: { message: "Response stalled mid-stream", retryable: true },
+        }),
+        cancel: async () => {},
+      }),
+      setConfigOption: async () => {},
+      close: async () => {},
+    };
+
+    const result = await runRemote(fake.handle, runtime, sandbox);
+
+    expect(result.errorCode).toBe("acpx_turn_failed");
+    // The engine emits the family both at the top level (which the server
+    // merges into resultJson) and inside resultJson, so the heartbeat
+    // classifier reads it and arms the bounded retry ladder.
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.resultJson?.errorFamily).toBe("transient_upstream");
+  });
+
+  it("leaves a capacity/session-cap terminal unclassified so it keeps its own quota path", async () => {
+    const sandbox = await setupRemoteSandbox();
+    const fake = createFakeBridgeHandle();
+    // A hard session cap shares the acpx_turn_failed code but must NOT become
+    // transient_upstream — it belongs on the provider_quota wait path (#10344).
+    const runtime = {
+      ensureSession: async () => ({
+        backendSessionId: "backend-session",
+        agentSessionId: "agent-session",
+        runtimeSessionName: "runtime-session",
+      }),
+      startTurn: () => ({
+        events: (async function* () {
+          yield { type: "done", stopReason: "end_turn" };
+        })(),
+        result: Promise.resolve({
+          status: "failed" as const,
+          error: { message: "You've hit your session limit · resets 11pm" },
+        }),
+        cancel: async () => {},
+      }),
+      setConfigOption: async () => {},
+      close: async () => {},
+    };
+
+    const result = await runRemote(fake.handle, runtime, sandbox);
+
+    expect(result.errorCode).toBe("acpx_turn_failed");
+    expect(result.errorFamily ?? null).toBeNull();
+    expect(result.resultJson?.errorFamily ?? null).toBeNull();
+  });
+
   it("releases the runtime locally and places no remote close call once the duplex channel is lost", async () => {
     const sandbox = await setupRemoteSandbox();
     const fake = createFakeBridgeHandle();
@@ -6812,5 +6880,62 @@ describe("ACPX startup handshake guard and late-completion fence", () => {
       process.off("unhandledRejection", onUnhandledRejection);
       vi.useRealTimers();
     }
+  });
+});
+
+describe("classifyAcpxTurnFailureErrorFamily", () => {
+  it("tags the observed mid-stream transport stall as transient_upstream", () => {
+    expect(
+      classifyAcpxTurnFailureErrorFamily({ message: "Response stalled mid-stream" }),
+    ).toBe("transient_upstream");
+  });
+
+  it("tags idle-timeout / connection-reset transport stalls as transient_upstream", () => {
+    for (const message of [
+      "Stream idle timeout - partial response received",
+      "The response stream stalled before completion",
+      "connection reset by peer",
+      "socket hang up",
+      "HTTP/2 bridge session stalled: no PING ack within the stall bound.",
+    ]) {
+      expect(classifyAcpxTurnFailureErrorFamily({ message })).toBe("transient_upstream");
+    }
+  });
+
+  it("also matches a transport-stall signal carried on the runtime error code, not the message", () => {
+    expect(
+      classifyAcpxTurnFailureErrorFamily({
+        message: "turn failed",
+        detailCode: "TRANSPORT_STALL",
+      }),
+    ).toBe("transient_upstream");
+  });
+
+  it("does NOT tag a capacity / session-cap failure — it stays on its own (provider_quota) path", () => {
+    for (const message of [
+      "You've hit your session limit · resets 11pm",
+      "You've hit your usage limit for this model.",
+      "The model is at capacity for this model",
+      "weekly limit reached",
+    ]) {
+      expect(classifyAcpxTurnFailureErrorFamily({ message })).toBeNull();
+    }
+  });
+
+  it("keeps the capacity guard winning even when a cap message also mentions a stall word", () => {
+    // The two subclasses must never be lumped: a cap message is vetoed first,
+    // regardless of any stall-ish wording it happens to carry.
+    expect(
+      classifyAcpxTurnFailureErrorFamily({
+        message: "You've hit your session limit; the stream stalled. resets 11pm",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unrelated failure and for an empty error", () => {
+    expect(
+      classifyAcpxTurnFailureErrorFamily({ message: "tool call raised a TypeError" }),
+    ).toBeNull();
+    expect(classifyAcpxTurnFailureErrorFamily({ message: "" })).toBeNull();
   });
 });

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -85,6 +85,7 @@ import {
   type AcpRuntimeStatus,
   type AcpRuntimeTurn,
   type AcpRuntimeTurnResult,
+  type AcpRuntimeTurnResultError,
   type AcpRuntimeUsageBreakdown,
   type AcpRuntimeUsageCost,
 } from "acpx/runtime";
@@ -2832,6 +2833,58 @@ function resultErrorMessage(result: AcpRuntimeTurnResult): string | null {
   return result.error.message;
 }
 
+// A capacity / session-cap / usage-limit failure — e.g. "You've hit your
+// session limit · resets 11pm". This is a DIFFERENT subclass of the shared
+// `acpx_turn_failed` code: it must NOT be retried on a short backoff (the wall
+// clears on the provider's own schedule), and instead belongs on the
+// `provider_quota` wait path (#10344). It is matched FIRST and vetoes the
+// transient classification unconditionally, so the two subclasses are never
+// lumped together. The "resets" alternative is deliberately anchored to a clock
+// time so it cannot swallow a "connection reset" transport stall below.
+const ACPX_CAPACITY_CAP_RE =
+  /(?:hit your (?:session|usage|weekly|daily|monthly|plan|account)\b|(?:session|usage|weekly|daily|monthly|plan|account|message|token|credit)\s+limit\b|usage limit|\bquota\b|at capacity|capacity limit|out of (?:credits?|usage)|resets?\s+(?:at\s+)?(?:\d|midnight|noon|tomorrow|today))/i;
+
+// The mid-stream transport-stall subclass of a failed ACPX turn: a transport
+// interruption that ended the turn with no terminal answer — the observed
+// "Response stalled mid-stream", an idle / PING-ack stall, or a connection
+// reset. This class is frequent, cheap to detect, and very likely to succeed on
+// a later attempt, which is exactly what the server's bounded transient-retry
+// ladder exists for.
+const ACPX_TRANSPORT_STALL_RE =
+  /(?:response[\s_-]?stalled|stalled[\s_-]?mid[\s_-]?stream|mid[\s_-]?stream[\s_-]?stall|(?:stream|response|turn)[\s_-]?stalled|stream[\s_-]?(?:stall|idle)|idle[\s_-]?timeout|no ping ack|stalled ping|transport[\s_-]?(?:stall|lost|closed|reset)|connection[\s_-]?reset|econnreset|socket hang ?up|premature[\s_-]?(?:close|end)|unexpected end of (?:stream|json|data|input)|stream[\s_-]?(?:closed|ended)[\s_-]?(?:unexpectedly|prematurely)|\bgoaway\b)/i;
+
+/**
+ * Classify a failed ACPX turn's error into an `AdapterExecutionErrorFamily`
+ * that the server's heartbeat bounded-retry ladder understands.
+ *
+ * The ACPX engine reports both a mid-stream transport stall and a hard
+ * provider capacity cap as `errorCode: "acpx_turn_failed"`, but the two want
+ * OPPOSITE retry semantics. This is the only layer that can still tell them
+ * apart (the runtime error's `message` / `code` / `detailCode` are in scope
+ * here but flattened by the time the server sees the run), so the split has to
+ * happen here — NOT by widening the server-side `errorCode` allow-list, which
+ * would make the capacity-cap class retry-storm (#10344).
+ *
+ * Returns `"transient_upstream"` ONLY for the transport-stall subclass; the
+ * capacity/quota subclass returns `null` (its family stays unset, so its
+ * behaviour is byte-for-byte identical and it keeps flowing to its own path).
+ */
+export function classifyAcpxTurnFailureErrorFamily(
+  error: Pick<AcpRuntimeTurnResultError, "message" | "code" | "detailCode">,
+): "transient_upstream" | null {
+  const haystack = [error.message, error.code, error.detailCode]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join(" ")
+    .toLowerCase();
+  if (!haystack) return null;
+  // Capacity/session cap / usage limit: never transient — checked first so it
+  // can never be relabelled, even if the message also carried a stall-ish word.
+  if (ACPX_CAPACITY_CAP_RE.test(haystack)) return null;
+  // Positive mid-stream transport-stall signature.
+  if (ACPX_TRANSPORT_STALL_RE.test(haystack)) return "transient_upstream";
+  return null;
+}
+
 function usageBreakdownsEqual(
   left: AcpRuntimeUsageBreakdown,
   right: AcpRuntimeUsageBreakdown,
@@ -4484,6 +4537,15 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         // path keeps it set, so the run root span closes with error status. A
         // completed terminal with a lost duplex channel keeps the flag set.
         runFailed = turnSucceeded ? false : true;
+        // A failed turn splits into two subclasses that share the
+        // `acpx_turn_failed` code but want opposite retry semantics. Tag the
+        // mid-stream transport-stall subclass with `transient_upstream` so the
+        // server's heartbeat bounded-retry ladder arms for it; the
+        // capacity/quota subclass stays unclassified and keeps its own path.
+        const turnFailureErrorFamily =
+          terminal.status === "failed"
+            ? classifyAcpxTurnFailureErrorFamily(terminal.error)
+            : null;
         capturedResult = {
           exitCode: turnSucceeded ? 0 : 1,
           signal: timedOut ? "SIGTERM" : null,
@@ -4496,6 +4558,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
               : channelLost
                 ? DUPLEX_CHANNEL_LOST_ERROR_CODE
                 : null,
+          ...(turnFailureErrorFamily ? { errorFamily: turnFailureErrorFamily } : {}),
           sessionId: sessionHandle.backendSessionId ?? sessionHandle.runtimeSessionName,
           sessionParams: buildSessionParams({ prepared, handle: sessionHandle }),
           sessionDisplayId: sessionHandle.agentSessionId ?? sessionHandle.backendSessionId ?? sessionHandle.runtimeSessionName,
@@ -4512,6 +4575,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             requestedModel: prepared.requestedModel || null,
             requestedThinkingEffort: prepared.requestedThinkingEffort || null,
             fastMode: prepared.fastMode,
+            ...(turnFailureErrorFamily ? { errorFamily: turnFailureErrorFamily } : {}),
             ...(turnUsage.usageDetail ? { usage: turnUsage.usageDetail } : {}),
             ...(turnUsage.cumulativeCostUsd != null
               ? { cumulativeCostUsd: turnUsage.cumulativeCostUsd }


### PR DESCRIPTION
## Thinking Path

> The ACPX engine reports a mid-stream transport stall and a hard provider capacity cap under one code, `acpx_turn_failed`, but they want opposite retry semantics. Because the engine never persists `errorFamily`, the heartbeat bounded-retry ladder never arms for transport stalls (issue #11257). This classifies the two at the adapter, tagging stalls `transient_upstream` while leaving the capacity-cap subclass on its `provider_quota` path.

## Linked Issues or Issue Description

Fixes #11257. Searched the open PR list — no existing PR adds ACPX transport-stall errorFamily classification.

## What Changed

- **`classifyAcpxTurnFailureErrorFamily(error)`** (new, pure): capacity/session-cap guard runs FIRST and vetoes (returns `null` → stays on quota path, #10344); only then is the transport-stall signature tested → `"transient_upstream"`. Never lumps the two subclasses.
- **Terminal-result path**: sets the family on a `failed` turn (top-level `errorFamily` and `resultJson.errorFamily`). No server change, no `errorCode` allow-list widening — `readHeartbeatRunErrorFamily` already arms the 2m/10m/30m/2h ladder off `transient_upstream`.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts` — 162 passed (154 + 8 new): stall variants → transient_upstream; cap messages and a cap+stall message → null; two integration runs through the real `execute()` harness. `adapter-utils` typecheck — 0 errors.

## Risks

- Text-based classification: an unmatched reword is a safe false-negative (preserves today's no-retry). Only the terminal-result path (all 32 observed stalls) is classified; a stall surfacing as a thrown error is a follow-up.

## Model Used

- Claude Opus 4.8 (Anthropic), via Claude Code with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s
