### PR TITLE
fix(recovery): cancel dead routine_execution runs instead of blocking a zombie

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -17,6 +17,10 @@ import {
   issueRecoveryActions,
   issueRelations,
   issues,
+  projects,
+  routineRuns,
+  routines,
+  routineTriggers,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -143,6 +147,10 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(environments);
     await db.delete(issueInboxArchives);
+    await db.delete(routineRuns);
+    await db.delete(routineTriggers);
+    await db.delete(routines);
+    await db.delete(projects);
     await db.delete(issues);
     await db.delete(agents);
     await db.delete(companies);
@@ -431,6 +439,394 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(recoveryIssues).toHaveLength(0);
     expect(updatedIssue?.assigneeAgentId).toBe(coderId);
     expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  // Back a routine_execution issue with a real routine + schedule trigger so the
+  // recovery guard can confirm whether it will fire again. `routine` selects the
+  // firing cadence: "recurring" seeds an enabled cron schedule on an active
+  // routine (a re-fire is guaranteed, so a dead firing is safe to cancel);
+  // "one_shot" seeds a disabled trigger (no re-fire, so recovery must block);
+  // "none" leaves the origin dangling (deleted routine — must also block).
+  async function seedRoutineExecutionIssue(input: {
+    companyId: string;
+    assigneeAgentId: string;
+    prefix: string;
+    issueNumber: number;
+    status?: string;
+    withExecutionRun?: boolean;
+    routine?: "recurring" | "one_shot" | "none";
+    // Source of THIS firing (the routineRuns row the issue's originRunId points
+    // at). Only "schedule" firings recur; "manual"/"api"/"webhook" are one-shot.
+    firingSource?: "schedule" | "manual" | "api" | "webhook";
+    // Attach the routine to a project and pause it. A paused project is a
+    // scheduler suppression gate: the tick is claimed but no replacement firing
+    // is created, so a dead firing must block (not cancel) even when recurring.
+    projectPaused?: boolean;
+  }) {
+    const issueId = randomUUID();
+    const originId = randomUUID();
+    const routineMode = input.routine ?? "recurring";
+    const firingSource = input.firingSource ?? "schedule";
+    let originRunId: string | null = null;
+    if (routineMode !== "none") {
+      let projectId: string | null = null;
+      if (input.projectPaused) {
+        projectId = randomUUID();
+        await db.insert(projects).values({
+          id: projectId,
+          companyId: input.companyId,
+          name: "Paused project",
+          pausedAt: new Date(),
+        });
+      }
+      await db.insert(routines).values({
+        id: originId,
+        companyId: input.companyId,
+        projectId,
+        title: "Nightly recurring digest",
+        status: "active",
+        priority: "medium",
+        assigneeAgentId: input.assigneeAgentId,
+      });
+      await db.insert(routineTriggers).values({
+        companyId: input.companyId,
+        routineId: originId,
+        kind: "schedule",
+        enabled: routineMode === "recurring",
+        cronExpression: "0 3 * * *",
+        timezone: "UTC",
+        nextRunAt: new Date("2099-01-01T03:00:00.000Z"),
+      });
+      originRunId = randomUUID();
+      await db.insert(routineRuns).values({
+        id: originRunId,
+        companyId: input.companyId,
+        routineId: originId,
+        source: firingSource,
+        status: "issue_created",
+      });
+    }
+    let executionRunId: string | null = null;
+    if (input.withExecutionRun) {
+      executionRunId = randomUUID();
+      await seedHeartbeatRun({
+        companyId: input.companyId,
+        agentId: input.assigneeAgentId,
+        runId: executionRunId,
+        issueId,
+        status: "failed",
+      });
+    }
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: input.companyId,
+      title: "Nightly recurring digest",
+      status: input.status ?? "in_progress",
+      priority: "medium",
+      assigneeAgentId: input.assigneeAgentId,
+      issueNumber: input.issueNumber,
+      identifier: `${input.prefix}-${input.issueNumber}`,
+      originKind: "routine_execution",
+      originId,
+      originRunId,
+      originFingerprint: `routine_execution:${originId}`,
+      executionRunId,
+      executionLockedAt: executionRunId ? new Date() : null,
+    });
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    return issue!;
+  }
+
+  it("cancels a dead routine_execution firing instead of leaving a blocked zombie (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 900,
+      withExecutionRun: true,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter connection refused",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const,
+    });
+
+    expect(result?.status).toBe("cancelled");
+    const [updated] = await db.select().from(issues).where(eq(issues.id, routineIssue.id));
+    // Not a zombie: terminal `cancelled`, and the open-routine execution lock is
+    // released so the next scheduled firing can create a fresh execution issue.
+    expect(updated?.status).toBe("cancelled");
+    expect(updated?.executionRunId).toBeNull();
+    expect(updated?.checkoutRunId).toBeNull();
+
+    // No board escalation action and no owner wake for a disposable artifact.
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, routineIssue.id));
+    expect(actionRows).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, routineIssue.id));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("cancelled this recurring-run artifact");
+  });
+
+  it("still blocks a routine_execution firing that has a real first-class blocker (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 901,
+    });
+    // A genuine blocker means the blockers-resolved auto-wake can fire, so this
+    // is not a zombie and must keep blocking rather than being cancelled.
+    const blockerId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerId,
+      companyId,
+      title: "Upstream dependency",
+      status: "in_progress",
+      priority: "medium",
+      issueNumber: 902,
+      identifier: `${prefix}-902`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: routineIssue.id,
+      type: "blocks",
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const,
+    });
+
+    const [updated] = await db.select().from(issues).where(eq(issues.id, routineIssue.id));
+    expect(updated?.status).toBe("blocked");
+  });
+
+  it("blocks a one-shot routine_execution firing that will not fire again instead of cancelling (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    // A disabled schedule trigger means no replacement firing is scheduled, so
+    // cancelling would lose the work with no re-drive. Recovery must fall back to
+    // the pre-existing block path rather than silently dropping the firing.
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 903,
+      withExecutionRun: true,
+      routine: "one_shot",
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter connection refused",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const,
+    });
+
+    expect(result?.status).toBe("blocked");
+    const [updated] = await db.select().from(issues).where(eq(issues.id, routineIssue.id));
+    expect(updated?.status).toBe("blocked");
+    // It fell through to the board-escalation path, not the cancel path.
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, routineIssue.id));
+    expect(comments.every((comment) => !comment.body?.includes("cancelled this recurring-run artifact"))).toBe(true);
+  });
+
+  it("blocks a routine_execution firing whose routine no longer exists instead of cancelling (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    // Origin points at a deleted routine: with no routine row we cannot confirm a
+    // re-fire, so recovery conservatively blocks rather than cancels.
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 904,
+      withExecutionRun: true,
+      routine: "none",
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter connection refused",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const,
+    });
+
+    expect(result?.status).toBe("blocked");
+  });
+
+  it("blocks a manual firing even when its routine also owns an enabled schedule trigger (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    // The routine recurs (an enabled schedule trigger), but THIS firing came from
+    // a manual/api/webhook source — a one-shot. The schedule fires its own
+    // separate work and is not a replacement for this firing, so cancelling it
+    // would silently discard the one-shot work. Recovery must block, not cancel.
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 905,
+      withExecutionRun: true,
+      routine: "recurring",
+      firingSource: "manual",
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter connection refused",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const,
+    });
+
+    expect(result?.status).toBe("blocked");
+    const [updated] = await db.select().from(issues).where(eq(issues.id, routineIssue.id));
+    expect(updated?.status).toBe("blocked");
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, routineIssue.id));
+    expect(comments.every((comment) => !comment.body?.includes("cancelled this recurring-run artifact"))).toBe(true);
+  });
+
+  it("blocks a recurring routine_execution firing whose project is paused instead of cancelling (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    // The routine recurs (enabled schedule trigger), but its project is paused.
+    // The scheduler suppresses the firing while the project is paused — it
+    // claims the tick and records a suppressed run but creates NO replacement
+    // firing. Cancelling would therefore lose the work with no re-drive, so
+    // recovery must fall through to the block path.
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 906,
+      withExecutionRun: true,
+      routine: "recurring",
+      projectPaused: true,
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: routineIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter connection refused",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const,
+    });
+
+    expect(result?.status).toBe("blocked");
+    const [updated] = await db.select().from(issues).where(eq(issues.id, routineIssue.id));
+    expect(updated?.status).toBe("blocked");
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, routineIssue.id));
+    expect(comments.every((comment) => !comment.body?.includes("cancelled this recurring-run artifact"))).toBe(true);
+  });
+
+  it("blocks a recurring routine_execution firing suppressed by the worktree run-execution cutoff instead of cancelling (GH #9201)", async () => {
+    const { companyId, coderId, prefix } = await seedCompany();
+    // The routine recurs, but the instance is a worktree runtime whose
+    // run-execution activation is unarmed (no cutoff persisted). The scheduler's
+    // `getAutomaticRoutineDispatchEligibility` gate then suppresses every
+    // firing, so there is no replacement and recovery must block, not cancel.
+    const routineIssue = await seedRoutineExecutionIssue({
+      companyId,
+      assigneeAgentId: coderId,
+      prefix,
+      issueNumber: 907,
+      withExecutionRun: true,
+      routine: "recurring",
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const previousInWorktree = process.env.PAPERCLIP_IN_WORKTREE;
+    process.env.PAPERCLIP_IN_WORKTREE = "1";
+    let result;
+    try {
+      result = await recovery.escalateStrandedAssignedIssue({
+        issue: routineIssue,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "adapter connection refused",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        } as const,
+      });
+    } finally {
+      if (previousInWorktree === undefined) {
+        delete process.env.PAPERCLIP_IN_WORKTREE;
+      } else {
+        process.env.PAPERCLIP_IN_WORKTREE = previousInWorktree;
+      }
+    }
+
+    expect(result?.status).toBe("blocked");
+    const [updated] = await db.select().from(issues).where(eq(issues.id, routineIssue.id));
+    expect(updated?.status).toBe("blocked");
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, routineIssue.id));
+    expect(comments.every((comment) => !comment.body?.includes("cancelled this recurring-run artifact"))).toBe(true);
   });
 
   // Model the production payload: `requestedRef` keeps the operator spelling,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   PROVIDER_QUOTA_MONITOR_SERVICE_NAME,
@@ -22,6 +22,10 @@ import {
   issueThreadInteractions,
   issues,
   nativeRunFinalizations,
+  projects,
+  routineRuns,
+  routines,
+  routineTriggers,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -34,6 +38,11 @@ import { isUniqueViolation } from "../../db-errors.js";
 import { logActivity } from "../activity-log.js";
 import { appendHeartbeatRunEvent } from "../heartbeat-run-events.js";
 import { budgetService } from "../budgets.js";
+import {
+  instanceSettingsService,
+  isTruthyRuntimeEnvValue,
+  resolveWorktreeRunExecutionActivationState,
+} from "../instance-settings.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
 import { TERMINAL_HEARTBEAT_RUN_STATUSES, issueService } from "../issues.js";
@@ -670,6 +679,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const treeControlSvc = issueTreeControlService(db);
   const budgets = budgetService(db);
+  const instanceSettings = instanceSettingsService(db);
   let resolvedDependencyWakeBackstopCandidateCursor: string | null = null;
 
   async function getAgent(agentId: string) {
@@ -3106,6 +3116,213 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return scheduled ? "queued" : "skipped";
   }
 
+  // Mirror the scheduler's worktree run-execution suppression gate
+  // (`getAutomaticRoutineDispatchEligibility` in routines.ts). Outside a
+  // worktree runtime nothing is suppressed. Inside one, a firing is only
+  // dispatched when the worktree run-execution activation is `armed` and the
+  // routine was created at/after the activation cutoff; an unarmed activation,
+  // an unreadable/invalid cutoff, or a routine predating the cutoff is
+  // suppressed — the scheduler records a suppressed run and creates NO
+  // replacement firing. Returns true only when the scheduler would dispatch.
+  async function routineAutomaticDispatchWorktreeEligible(
+    routine: typeof routines.$inferSelect,
+  ): Promise<boolean> {
+    const runtimeEnv = process.env;
+    if (!isTruthyRuntimeEnvValue(runtimeEnv.PAPERCLIP_IN_WORKTREE)) return true;
+
+    const activation = await resolveWorktreeRunExecutionActivationState({
+      getExperimental: instanceSettings.getExperimental,
+      runtimeEnv,
+    });
+    if (!activation.armed) return false;
+
+    const cutoff = new Date(activation.cutoff);
+    if (Number.isNaN(cutoff.getTime()) || routine.createdAt < cutoff) return false;
+    return true;
+  }
+
+  // GH #9201 (Greptile follow-up): confirm the routine behind a stranded
+  // `routine_execution` firing will actually fire again before we cancel it.
+  // Cancelling is only safe when a replacement firing is guaranteed to
+  // regenerate the work; a one-shot, disabled, deleted, archived, or paused
+  // routine would silently lose the firing with no replacement, which is worse
+  // than an (un-resumable) block. A `routine_execution` issue records the
+  // routine's id in `originId`. We mirror the scheduler's own firing decision
+  // (`tickScheduledTriggers` in routines.ts): a firing only recurs when the
+  // routine is `active`, it owns an `enabled` `schedule` trigger with a cron
+  // expression, a timezone, and a set `nextRunAt`, AND no scheduler suppression
+  // gate is active — a paused project or a worktree run-execution cutoff makes
+  // the scheduler claim the tick but create NO replacement firing. Conservative
+  // by construction: any missing/unknown/suppressing signal (no origin id,
+  // deleted/archived/paused routine, no enabled recurring trigger, webhook-only
+  // trigger, paused project, worktree-suppressed) returns false so the caller
+  // falls through to the existing board-escalation block path.
+  async function routineExecutionWillFireAgain(issue: typeof issues.$inferSelect): Promise<boolean> {
+    if (issue.originKind !== "routine_execution") return false;
+    const routineId = readNonEmptyString(issue.originId);
+    if (!routineId) return false;
+
+    // This SPECIFIC firing must itself be a `schedule` firing. A routine's
+    // `originId` names only the routine, not which trigger produced the failed
+    // issue, so a routine that owns an enabled schedule trigger AND also fires
+    // manual / api / webhook work would otherwise treat that unrelated schedule
+    // as a replacement and let a one-shot firing be cancelled. The firing's
+    // source is persisted on its `routineRuns` row (`issues.originRunId` ->
+    // `routineRuns.id`). Only `schedule` firings recur; manual/api/webhook are
+    // one-shot and must fall through to the block path. Missing origin run → false.
+    const originRunId = readNonEmptyString(issue.originRunId);
+    if (!originRunId) return false;
+    const firingWasScheduled = await db
+      .select({ id: routineRuns.id })
+      .from(routineRuns)
+      .where(
+        and(
+          eq(routineRuns.companyId, issue.companyId),
+          eq(routineRuns.id, originRunId),
+          eq(routineRuns.source, "schedule"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+    if (!firingWasScheduled) return false;
+
+    // Load the routine and its project's pause state in one query, exactly like
+    // the scheduler's `leftJoin(projects, eq(routines.projectId, projects.id))`.
+    // The routine must be `active`; a missing / archived / non-active routine
+    // has no confirmed re-fire → block. We need the full routine row (its
+    // `createdAt`/`projectId`) to evaluate the suppression gates below.
+    const routineRow = await db
+      .select({ routine: routines, projectPausedAt: projects.pausedAt })
+      .from(routines)
+      .leftJoin(projects, eq(routines.projectId, projects.id))
+      .where(
+        and(
+          eq(routines.companyId, issue.companyId),
+          eq(routines.id, routineId),
+          eq(routines.status, "active"),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!routineRow) return false;
+
+    // Scheduler suppression gate #1 — paused project. `tickScheduledTriggers`
+    // treats `!!(routine.projectId && projects.pausedAt)` as suppressed: it
+    // claims the tick and records a suppressed run but creates no replacement
+    // firing, so cancelling would drop this firing with nothing to regenerate
+    // it. Mirror the scheduler predicate exactly. Routines with no project are
+    // never suppressed here.
+    const projectPaused = !!(routineRow.routine.projectId && routineRow.projectPausedAt);
+    if (projectPaused) return false;
+
+    // Scheduler suppression gate #2 — worktree run-execution cutoff. Same
+    // `getAutomaticRoutineDispatchEligibility` decision the scheduler applies;
+    // when it suppresses, no replacement firing is created.
+    const worktreeEligible = await routineAutomaticDispatchWorktreeEligible(routineRow.routine);
+    if (!worktreeEligible) return false;
+
+    // Finally the recurring-trigger check: the routine owns an `enabled`
+    // `schedule` trigger with a cron expression, a timezone, and a set
+    // `nextRunAt`. Only then is a replacement firing guaranteed.
+    return db
+      .select({ id: routineTriggers.id })
+      .from(routineTriggers)
+      .where(
+        and(
+          eq(routineTriggers.companyId, issue.companyId),
+          eq(routineTriggers.routineId, routineId),
+          eq(routineTriggers.kind, "schedule"),
+          eq(routineTriggers.enabled, true),
+          isNotNull(routineTriggers.cronExpression),
+          isNotNull(routineTriggers.timezone),
+          isNotNull(routineTriggers.nextRunAt),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  // GH #9201: cancel a `routine_execution` firing whose run died and exhausted
+  // recovery instead of parking it in an un-resumable `blocked`. Returns the
+  // cancelled row, or null when the transition could not be applied (the caller
+  // then falls back to the normal block path). Provider-quota waits and issues
+  // with real blockers are filtered out by the caller.
+  async function cancelStrandedRoutineExecution(input: {
+    issue: typeof issues.$inferSelect;
+    previousStatus: StrandedPreviousStatus;
+    latestRun: LatestIssueRun;
+    recoveryCause: StrandedRecoveryCause;
+  }) {
+    // Clear the execution-lock columns as we finalize so the cancelled artifact
+    // does not linger as an "open" routine execution holding the run pointer.
+    const updated = await issuesSvc.update(input.issue.id, {
+      status: "cancelled",
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      checkoutRunId: null,
+    });
+    if (!updated) return null;
+
+    const failureSummary = summarizeRunFailureForIssueComment(input.latestRun)?.trim() ?? null;
+    await issuesSvc.addComment(
+      input.issue.id,
+      [
+        "Paperclip cancelled this recurring-run artifact after its execution died and automatic recovery was exhausted.",
+        "",
+        `- Origin: \`routine_execution\` (regenerated on the next scheduled firing)`,
+        `- Previous status: \`${input.previousStatus}\``,
+        `- Recovery cause: \`${input.recoveryCause}\``,
+        input.latestRun ? `- Latest run: \`${input.latestRun.id}\` (\`${input.latestRun.status}\`)` : "- Latest run: none recorded",
+        failureSummary ? `- Failure: ${failureSummary}` : "- Failure: none recorded",
+        "",
+        "No action is required: cancelling avoids leaving an un-resumable `blocked` zombie; the routine will fire again on schedule.",
+      ].join("\n"),
+      {},
+      {
+        authorType: "system",
+        presentation: compactRecoveryPresentation("Recovery: cancelled dead routine_execution run"),
+        metadata: {
+          version: 1,
+          sourceRunId: input.latestRun?.id ?? null,
+          sections: [{
+            title: "Recovery",
+            rows: [
+              { type: "key_value", label: "Cause", value: input.recoveryCause },
+              { type: "key_value", label: "Disposition", value: "cancelled_routine_execution" },
+              { type: "key_value", label: "Previous status", value: input.previousStatus },
+            ],
+          }],
+        },
+      },
+    );
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "recovery",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        status: "cancelled",
+        previousStatus: input.previousStatus,
+        source: "recovery.cancel_stranded_routine_execution",
+        recoveryCause: input.recoveryCause,
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunStatus: input.latestRun?.status ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+        originKind: input.issue.originKind,
+        originId: input.issue.originId,
+      },
+    });
+
+    return updated;
+  }
+
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
     previousStatus: StrandedPreviousStatus;
@@ -3124,6 +3341,42 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+
+    // GH #9201: a `routine_execution` firing that dies at the infra level and
+    // exhausts recovery must not be parked in an un-resumable `blocked` with an
+    // empty blocker set. The board escalation names no agent owner and, with no
+    // first-class blocker, the blockers-resolved auto-wake can never fire, so the
+    // recurring-run artifact becomes a permanent zombie that nothing ever
+    // re-drives. The firing is regenerated on the next schedule, so cancelling is
+    // more honest than an un-resumable block — and moving it out of an open
+    // status frees the open-routine uniqueness slot for the next firing. Do this
+    // before creating a board recovery action so no operator escalation is filed
+    // for a disposable artifact. Genuine blockers still block (the
+    // blockers-resolved wake covers those) and provider-quota failures keep their
+    // live, monitored retry path.
+    //
+    // Greptile follow-up: only cancel when the routine is confirmed to fire
+    // again (an enabled recurring schedule trigger on an active routine). A
+    // one-shot, disabled, deleted, archived, or paused routine has no
+    // replacement firing, so cancelling would lose the work outright — worse
+    // than a block. When a re-fire cannot be confirmed we fall through to the
+    // pre-existing board-escalation block path.
+    if (
+      input.issue.originKind === "routine_execution" &&
+      recoveryCause !== "provider_quota" &&
+      blockerIds.length === 0 &&
+      (await routineExecutionWillFireAgain(input.issue))
+    ) {
+      const cancelled = await cancelStrandedRoutineExecution({
+        issue: input.issue,
+        previousStatus: input.previousStatus,
+        latestRun: input.latestRun,
+        recoveryCause,
+      });
+      if (cancelled) return cancelled;
+    }
+
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,
       previousStatus: input.previousStatus,
@@ -3142,7 +3395,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,


### PR DESCRIPTION
## Thinking Path

> - When a `routine_execution` firing's run dies at the infra level and recovery is exhausted, the stranded-recovery path parks the issue in `blocked` with an empty `blockedByIssueIds` and no agent owner.
> - With no first-class blocker the blockers-resolved auto-wake can never fire, and no human triages routine artifacts, so the recurring-run issue becomes a permanent zombie that nothing ever re-drives (issue #9201).
> - The firing regenerates on its next schedule, so cancelling the dead artifact is more honest than an un-resumable block — this PR cancels it, scoped strictly to routine_execution with no real blocker and cause other than provider_quota.

## Linked Issues or Issue Description

Fixes #9201. Searched the open PR list — complements #9129 (successful-run path); this handles the failed-run path, no overlap.

## What Changed

- **`cancelStrandedRoutineExecution`** (new): moves the issue to `cancelled`, clears execution-lock columns, posts an explanatory system comment, logs an `issue.updated` activity.
- **`escalateStrandedAssignedIssue`**: before filing a board recovery action, if `originKind === "routine_execution"`, cause ≠ `provider_quota`, and no first-class blockers — cancel instead of block. Genuine blockers still block; provider-quota keeps its retry path; non-routine stranded issues unchanged. Implements the issue's remediation #2 (the "wake owner" alternative re-drove the issue and regressed tests).

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-recovery-actions.test.ts` — 50 passed (2 new: dead routine_execution cancelled; one with a real blocker still blocked). Recovery/routines suites green; server typecheck clean for the changed files.

## Risks

- Cancelling discards the dead firing's in-flight state — intended and safe for a disposable recurring artifact, fired only with no real blockers and cause ≠ provider-quota. Never touches non-routine issues.

## Model Used

- Claude Opus 4.8 (Anthropic), via Claude Code with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s
