### PR TITLE
fix(server): normalize created_by_run_id before heartbeat_runs FK inserts

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -202,6 +202,7 @@ import {
   ISSUE_WAKE_DIAGNOSTICS_MAX_ACTIVITY_RECORDS,
   ISSUE_WAKE_DIAGNOSTICS_MAX_WAKE_REQUESTS,
   readAcceptedPlanConfirmationTarget,
+  resolveCreatedByRunId,
 } from "../services/issues.js";
 import { authorizationDeniedDetails } from "../services/authorization.js";
 import { stalledReviewDecisionService } from "../services/stalled-review-decisions.js";
@@ -6978,7 +6979,7 @@ export function issueRoutes(
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
               outcome: transition.decision.outcome,
               body: transition.decision.body,
-              createdByRunId: actor.runId ?? null,
+              createdByRunId: await resolveCreatedByRunId(tx, lockedIssue.companyId, actor.runId),
             });
           }
         }
@@ -8104,7 +8105,7 @@ export function issueRoutes(
             },
           },
           sourceTrust: promotionTrust,
-          createdByRunId: actor.runId ?? null,
+          createdByRunId: await resolveCreatedByRunId(tx, issue.companyId, actor.runId),
         })
         .returning()
         .then((rows) => rows[0] ?? null);
@@ -9977,7 +9978,7 @@ export function issueRoutes(
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
               outcome: decision.outcome,
               body: decision.body,
-              createdByRunId: actor.runId ?? null,
+              createdByRunId: await resolveCreatedByRunId(tx, updated.companyId, actor.runId),
             });
           }
 
@@ -12456,7 +12457,7 @@ export function issueRoutes(
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
               outcome: transition.decision.outcome,
               body: transition.decision.body,
-              createdByRunId: actor.runId ?? null,
+              createdByRunId: await resolveCreatedByRunId(tx, updated.companyId, actor.runId),
             });
           }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -385,9 +385,15 @@ type DerivedIssueCommentAttribution = {
 
 /**
  * Resolve a `created_by_run_id` safe for the heartbeat_runs FK; returns null for
- * missing/invalid ids so an unknown run id never 500s a comment insert.
+ * missing/invalid ids so an unknown or malformed run id never 500s an insert.
+ *
+ * Guards both failure modes of a client-supplied `X-Paperclip-Run-Id`:
+ *  - non-UUID header value -> Postgres `invalid input syntax for type uuid`
+ *  - well-formed UUID with no matching `heartbeat_runs` row -> FK violation
+ *
+ * Use at every insert that writes `created_by_run_id` from `actor.runId`.
  */
-async function resolveCommentCreatedByRunId(
+export async function resolveCreatedByRunId(
   dbOrTx: any,
   companyId: string,
   runId: string | null | undefined,
@@ -8830,7 +8836,7 @@ export function issueService(db: Db) {
       const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
       const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
       // Invalid/stale run ids must not 500 the insert — null out unknowns.
-      const createdByRunId = await resolveCommentCreatedByRunId(dbOrTx, issue.companyId, actor.runId);
+      const createdByRunId = await resolveCreatedByRunId(dbOrTx, issue.companyId, actor.runId);
       if (actor.runId && !createdByRunId) {
         logger.warn(
           { issueId, companyId: issue.companyId, runId: actor.runId },


### PR DESCRIPTION
Fixes the route-level portion of #12504.

## Problem
The client-supplied `X-Paperclip-Run-Id` header lands verbatim in `actor.runId` and is
inserted as `created_by_run_id` (uuid, FK → `heartbeat_runs`) without validation. A
non-UUID value 500s with `invalid input syntax for type uuid`; a well-formed UUID with no
matching `heartbeat_runs` row 500s on the FK constraint. The comment path was fixed via
`resolveCommentCreatedByRunId`; the other insert sites still carry the raw value.

## Change
- Rename/export the existing guard as `resolveCreatedByRunId` in `services/issues.ts`
  (behaviour unchanged: trim → `isUuidLike` → company-scoped `heartbeat_runs` existence
  check → null on any miss).
- Apply it at the four direct insert sites in `routes/issues.ts`:
  - work-product promotion (`issue_work_products`)
  - execution decision + the two stage-transition decision inserts (`issue_execution_decisions`)

Unknown or malformed run ids degrade to `null` instead of failing the request — same
contract as the comment path.

## Out of scope
Service-level sites (`documents.ts`, `pipelines.ts`, `document-annotations.ts`,
`routines.ts`, `summary-slots.ts`, `status-cards.ts`, `decision-queues.ts`) span multiple
inserts per transaction; #12504 lists them — left for a choke-point decision by the
maintainers.

## Verification
`tsc --noEmit` on `server/` reports no errors in the touched files (remaining errors are
the pre-existing unbuilt-`plugin-sdk` ones also present on `master`).
