### PR TITLE
fix(ui): add Approve/Request changes UI for pending review stages

### DIFF
--- a/ui/src/components/IssueExecutionStageApprovalBanner.test.tsx
+++ b/ui/src/components/IssueExecutionStageApprovalBanner.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Issue, IssueExecutionState } from "@paperclipai/shared";
+import { issuesApi } from "../api/issues";
+import { ToastProvider } from "../context/ToastContext";
+import { ToastViewport } from "./ToastViewport";
+import {
+  IssueExecutionStageApprovalBanner,
+  isExecutionStagePendingForUser,
+} from "./IssueExecutionStageApprovalBanner";
+
+vi.mock("../api/issues", () => ({
+  issuesApi: {
+    update: vi.fn(() => Promise.resolve({})),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function act<T>(cb: () => T): T {
+  let result: T | undefined;
+  flushSync(() => {
+    result = cb();
+  });
+  return result as T;
+}
+
+function createIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    companyId: "company-1",
+    projectId: null,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    title: "Reviewed issue",
+    description: null,
+    status: "in_review",
+    priority: "medium",
+    reviewPolicy: null,
+    assigneeAgentId: null,
+    assigneeUserId: "user-1",
+    responsibleUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: "user-1",
+    issueNumber: 1,
+    identifier: "PAP-1",
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    labels: [],
+    labelIds: [],
+    blockedBy: [],
+    blocks: [],
+    createdAt: new Date("2026-04-06T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-06T12:05:00.000Z"),
+    ...overrides,
+    workMode: overrides.workMode ?? "standard",
+  } as Issue;
+}
+
+function pendingReviewState(overrides: Partial<IssueExecutionState> = {}): IssueExecutionState {
+  return {
+    status: "pending",
+    currentStageId: "stage-1",
+    currentStageIndex: 0,
+    currentStageType: "review",
+    currentParticipant: { type: "user", agentId: null, userId: "user-1" },
+    returnAssignee: { type: "agent", agentId: "agent-1", userId: null },
+    reviewRequest: null,
+    completedStageIds: [],
+    lastDecisionId: null,
+    lastDecisionOutcome: null,
+    ...overrides,
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+  vi.clearAllMocks();
+});
+
+function render(issue: Issue, currentUserId: string | null) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  act(() =>
+    root?.render(
+      <ToastProvider>
+        <QueryClientProvider client={client}>
+          <IssueExecutionStageApprovalBanner issue={issue} currentUserId={currentUserId} />
+          <ToastViewport />
+        </QueryClientProvider>
+      </ToastProvider>,
+    ),
+  );
+  return container;
+}
+
+function setTextareaValue(element: HTMLTextAreaElement | null, value: string) {
+  if (!element) throw new Error("Expected a textarea to exist");
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+  act(() => {
+    setter?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function clickButton(testId: string) {
+  const button = container?.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+describe("isExecutionStagePendingForUser", () => {
+  it("is false with no execution state", () => {
+    expect(isExecutionStagePendingForUser({ id: "i1", executionState: null }, "user-1")).toBe(false);
+  });
+
+  it("is false when the stage is not pending (e.g. changes_requested)", () => {
+    const state = pendingReviewState({ status: "changes_requested" });
+    expect(isExecutionStagePendingForUser({ id: "i1", executionState: state }, "user-1")).toBe(false);
+  });
+
+  it("is false when the current participant is an agent, not a user", () => {
+    const state = pendingReviewState({ currentParticipant: { type: "agent", agentId: "agent-1", userId: null } });
+    expect(isExecutionStagePendingForUser({ id: "i1", executionState: state }, "user-1")).toBe(false);
+  });
+
+  it("is false when the current participant is a different user", () => {
+    const state = pendingReviewState({ currentParticipant: { type: "user", agentId: null, userId: "user-2" } });
+    expect(isExecutionStagePendingForUser({ id: "i1", executionState: state }, "user-1")).toBe(false);
+  });
+
+  it("is true when the pending stage's user participant matches", () => {
+    const state = pendingReviewState();
+    expect(isExecutionStagePendingForUser({ id: "i1", executionState: state }, "user-1")).toBe(true);
+  });
+});
+
+describe("IssueExecutionStageApprovalBanner", () => {
+  it("renders nothing when no stage is pending on the signed-in user", () => {
+    const issue = createIssue({ executionState: null });
+    const node = render(issue, "user-1");
+    expect(node.querySelector('[data-testid="issue-execution-stage-approval-banner"]')).toBeNull();
+  });
+
+  it("renders nothing when the pending stage belongs to a different user", () => {
+    const issue = createIssue({
+      executionState: pendingReviewState({ currentParticipant: { type: "user", agentId: null, userId: "user-2" } }),
+    });
+    const node = render(issue, "user-1");
+    expect(node.querySelector('[data-testid="issue-execution-stage-approval-banner"]')).toBeNull();
+  });
+
+  it("disables Approve and Request changes until a comment is entered, matching the backend's comment requirement", () => {
+    const issue = createIssue({ executionState: pendingReviewState() });
+    const node = render(issue, "user-1");
+    expect(node.querySelector('[data-testid="issue-execution-stage-approval-banner"]')).not.toBeNull();
+
+    const approve = node.querySelector<HTMLButtonElement>('[data-testid="issue-execution-stage-approve"]');
+    const requestChanges = node.querySelector<HTMLButtonElement>(
+      '[data-testid="issue-execution-stage-request-changes"]',
+    );
+    expect(approve?.disabled).toBe(true);
+    expect(requestChanges?.disabled).toBe(true);
+  });
+
+  it("approves with a comment via PATCH { status: 'done', comment }", async () => {
+    const issue = createIssue({ executionState: pendingReviewState() });
+    const node = render(issue, "user-1");
+
+    setTextareaValue(
+      node.querySelector<HTMLTextAreaElement>('[data-testid="issue-execution-stage-approval-comment"]'),
+      "Looks good.",
+    );
+    clickButton("issue-execution-stage-approve");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(issuesApi.update).toHaveBeenCalledWith("issue-1", { status: "done", comment: "Looks good." });
+  });
+
+  it("requests changes with a comment via PATCH { status: 'in_progress', comment }", async () => {
+    const issue = createIssue({ executionState: pendingReviewState() });
+    const node = render(issue, "user-1");
+
+    setTextareaValue(
+      node.querySelector<HTMLTextAreaElement>('[data-testid="issue-execution-stage-approval-comment"]'),
+      "Please fix the typo.",
+    );
+    clickButton("issue-execution-stage-request-changes");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(issuesApi.update).toHaveBeenCalledWith("issue-1", {
+      status: "in_progress",
+      comment: "Please fix the typo.",
+    });
+  });
+});

--- a/ui/src/components/IssueExecutionStageApprovalBanner.tsx
+++ b/ui/src/components/IssueExecutionStageApprovalBanner.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2, Loader2, RotateCcw } from "lucide-react";
+import type { Issue } from "@paperclipai/shared";
+
+import { issuesApi } from "../api/issues";
+import { useToastActions } from "../context/ToastContext";
+import { queryKeys } from "../lib/queryKeys";
+import { InlineBanner } from "./InlineBanner";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+
+type ExecutionStageStatusIssue = Pick<Issue, "id" | "executionState">;
+
+/**
+ * True when `issue`'s pending execution-policy review/approval stage is
+ * waiting on `userId` specifically. `applyIssueExecutionPolicyTransition`
+ * (server/src/services/issue-execution-policy.ts) only accepts a decision
+ * from this exact principal — everyone else's status PATCH falls through
+ * untouched, so the UI must gate on the same match (MYLA-785).
+ */
+export function isExecutionStagePendingForUser(
+  issue: ExecutionStageStatusIssue | null | undefined,
+  userId: string | null | undefined,
+): boolean {
+  const state = issue?.executionState;
+  if (!state || state.status !== "pending" || !userId) return false;
+  const participant = state.currentParticipant;
+  return participant?.type === "user" && participant.userId === userId;
+}
+
+export interface IssueExecutionStageApprovalBannerProps {
+  issue: Issue;
+  currentUserId: string | null;
+}
+
+/**
+ * Approving or requesting changes on a pending review/approval stage requires
+ * a comment in the same PATCH (the backend 422s otherwise). Before this
+ * banner, the only status control was the bare status-badge dropdown, which
+ * sends no comment — the reviewer had no first-class way to act (MYLA-785).
+ */
+export function IssueExecutionStageApprovalBanner({
+  issue,
+  currentUserId,
+}: IssueExecutionStageApprovalBannerProps) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToastActions();
+  const [comment, setComment] = useState("");
+
+  const decide = useMutation({
+    mutationFn: (status: "done" | "in_progress") =>
+      issuesApi.update(issue.id, { status, comment: comment.trim() }),
+    onSuccess: (_result, status) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issue.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.activity(issue.id) });
+      setComment("");
+      pushToast({
+        title: status === "done" ? "Approved — issue marked done." : "Changes requested.",
+        tone: "success",
+      });
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Could not record the review decision",
+        body: error instanceof Error ? error.message : "Please try again.",
+        tone: "error",
+      });
+    },
+  });
+
+  if (!isExecutionStagePendingForUser(issue, currentUserId)) return null;
+
+  const pending = decide.isPending;
+  const commentEmpty = comment.trim().length === 0;
+  const stageLabel = issue.executionState?.currentStageType === "approval" ? "approval" : "review";
+
+  return (
+    <div data-testid="issue-execution-stage-approval-banner">
+      <InlineBanner tone="warning" title={`Your ${stageLabel} is requested`} className="my-3">
+        <div className="mt-2 flex flex-col gap-2">
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            placeholder="Add a comment — required to approve or request changes…"
+            className="min-h-16 bg-background text-sm"
+            disabled={pending}
+            data-testid="issue-execution-stage-approval-comment"
+          />
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={pending || commentEmpty}
+              title={commentEmpty ? "Add a comment to request changes" : undefined}
+              onClick={() => decide.mutate("in_progress")}
+              data-testid="issue-execution-stage-request-changes"
+            >
+              {pending && decide.variables === "in_progress" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              ) : (
+                <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+              )}
+              Request changes
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={pending || commentEmpty}
+              title={commentEmpty ? "Add a comment to approve" : undefined}
+              onClick={() => decide.mutate("done")}
+              data-testid="issue-execution-stage-approve"
+            >
+              {pending && decide.variables === "done" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              ) : (
+                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+              )}
+              Approve
+            </Button>
+          </div>
+        </div>
+      </InlineBanner>
+    </div>
+  );
+}

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -19,6 +19,13 @@ interface StatusIconProps {
   showLabel?: boolean;
   /** Glyph size (PAP-243a). Default `md` (16px); lists/detail/mentions use `lg` (20px). */
   size?: StatusGlyphSize;
+  /**
+   * When set, every entry other than the current status is disabled in the
+   * picker and shows this string as its tooltip. Used while a pending
+   * execution-policy stage requires the comment-bearing Approve/Request
+   * changes flow instead of this picker's bare `{ status }` PATCH (MYLA-785).
+   */
+  changeLockedReason?: string;
 }
 
 function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | undefined) {
@@ -75,7 +82,15 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
  * glyph — the blocked shape recoloured blue — while the full blocked reason
  * still rides on the accessible label.
  */
-export function StatusIcon({ status, blockerAttention, onChange, className, showLabel, size = "md" }: StatusIconProps) {
+export function StatusIcon({
+  status,
+  blockerAttention,
+  onChange,
+  className,
+  showLabel,
+  size = "md",
+  changeLockedReason,
+}: StatusIconProps) {
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
   const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status);
@@ -125,21 +140,30 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent className="w-40 p-1" align="start">
-        {allStatuses.map((s) => (
-          <Button
-            key={s}
-            variant="ghost"
-            size="sm"
-            className={cn("w-full justify-start gap-2 text-xs", s === status && "bg-accent")}
-            onClick={() => {
-              onChange(s);
-              setOpen(false);
-            }}
-          >
-            <StatusIcon status={s} size="lg" />
-            {statusLabel(s)}
-          </Button>
-        ))}
+        {allStatuses.map((s) => {
+          const locked = Boolean(changeLockedReason) && s !== status;
+          return (
+            <Button
+              key={s}
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "w-full justify-start gap-2 text-xs",
+                s === status && "bg-accent",
+                locked && "opacity-50",
+              )}
+              disabled={locked}
+              title={locked ? changeLockedReason : undefined}
+              onClick={() => {
+                onChange(s);
+                setOpen(false);
+              }}
+            >
+              <StatusIcon status={s} size="lg" />
+              {statusLabel(s)}
+            </Button>
+          );
+        })}
       </PopoverContent>
     </Popover>
   );

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -129,6 +129,10 @@ import {
   IssueMonitorComposerStrip,
   hasVisibleMonitorSurface,
 } from "../components/IssueMonitorBanner";
+import {
+  IssueExecutionStageApprovalBanner,
+  isExecutionStagePendingForUser,
+} from "../components/IssueExecutionStageApprovalBanner";
 import { IssueScheduledRetryCard } from "../components/IssueScheduledRetryCard";
 import { IssueProperties, type IssuePropertiesDocumentDeepLink } from "../components/IssueProperties";
 import { PauseAffectsSummaryView } from "../components/interrupt-handoff/InterruptHandoffViews";
@@ -4546,6 +4550,11 @@ export function IssueDetail() {
             size="lg"
             blockerAttention={issue.blockerAttention}
             onChange={(status) => updateIssue.mutate({ status })}
+            changeLockedReason={
+              isExecutionStagePendingForUser(issue, currentUserId)
+                ? "This stage needs a comment — use Approve or Request changes below."
+                : undefined
+            }
           />
           {/* PAP-411: priority UI hidden behind SHOW_TASK_PRIORITY_UI. */}
           {SHOW_TASK_PRIORITY_UI && (
@@ -4891,6 +4900,8 @@ export function IssueDetail() {
           onCheckNow={() => checkIssueMonitorNow.mutate()}
           checkingNow={checkIssueMonitorNow.isPending}
         />
+
+        <IssueExecutionStageApprovalBanner issue={issue} currentUserId={currentUserId} />
 
         {taskChatShellEnabled ? null : (
           <InlineEditor


### PR DESCRIPTION
## Root cause

Any issue with an `executionPolicy` review/approval stage (`approvalsNeeded: 1`, a board user as participant) could not be marked `done` by a human through the UI:

1. **Backend requires a comment on the same PATCH.** `server/src/services/issue-execution-policy.ts` (`applyIssueExecutionStageTransition`): when the actor matches `executionState.currentParticipant` and `requestedStatus === "done"` (or any other non-`in_review` status), it throws `422` unless `commentBody` is non-empty in the same request.
2. **The only UI control sends no comment.** `ui/src/pages/IssueDetail.tsx`'s status-badge dropdown does `onChange={(status) => updateIssue.mutate({ status })}` — a bare `{ "status": "done" }` PATCH. There was no dedicated Approve control for execution-policy review stages anywhere in `IssueDetail.tsx`.

Net effect: every review-gated issue was stuck for a human reviewer — clicking the status badge and choosing Done always 422s with a generic "Task update failed" toast.

## Fix

- Add `IssueExecutionStageApprovalBanner` (`ui/src/components/IssueExecutionStageApprovalBanner.tsx`), rendered in `IssueDetail.tsx` between the title and description (alongside the existing `IssueMonitorBanner`). It shows only when `issue.executionState.status === "pending"` and `currentParticipant` is the signed-in user, and offers:
  - **Approve** → `PATCH { status: "done", comment }`
  - **Request changes** → `PATCH { status: "in_progress", comment }`
  Both require a non-empty comment, matching `applyIssueExecutionStageTransition`'s contract exactly.
- Export a pure `isExecutionStagePendingForUser(issue, userId)` helper from that file so the gating logic has one definition.
- Add a `changeLockedReason` prop to `StatusIcon` (`ui/src/components/StatusIcon.tsx`): when set, every status entry other than the current one is disabled in the picker with the reason as its tooltip. `IssueDetail.tsx` passes this while a stage is pending on the signed-in user, so the plain status dropdown no longer silently offers a Done option that 422s — it points the reviewer at the new banner instead.

## Testing

- `pnpm --filter @paperclipai/ui typecheck` — passes.
- `npx vitest run src/components/StatusIcon.test.tsx src/pages/IssueDetail.test.tsx src/components/IssueExecutionStageApprovalBanner.test.tsx` (from `ui/`) — 76 tests pass, including a new test file covering the gating helper and both Approve/Request changes flows (comment-required, correct PATCH payloads, hidden when not applicable).

## Acceptance criteria

- [x] A board user who is `executionState.currentParticipant` on a pending review/approval stage can mark the issue done (or request changes) from the UI without a 422 and without needing to know the hidden comment-protocol.
- [x] The generic status-badge Done option no longer silently 422s for these issues.

Fixes MYLA-785.