### PR TITLE
ci: add GitHub-hosted fail-safe for trusted PR jobs

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -5,6 +5,16 @@ name: Trusted PR CI
 # drift from this file.
 on:
   workflow_call:
+    inputs:
+      heavy_runner_mode:
+        description: Route heavy CI jobs to GitHub-hosted or trusted Fleet runners.
+        required: false
+        type: string
+        default: github
+      trusted_workflow_sha:
+        description: Immutable SHA used by the trusted caller for this reusable workflow.
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -32,6 +42,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           AWS_CI_ENABLED: ${{ vars.AWS_CI_ENABLED }}
           TRUSTED_USER_IDS: ${{ vars.AWS_CI_TRUSTED_USER_IDS }}
+          HEAVY_RUNNER_MODE: ${{ inputs.heavy_runner_mode }}
+          EXPECTED_TRUSTED_WORKFLOW_SHA: ${{ inputs.trusted_workflow_sha }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REPOSITORY: ${{ github.repository }}
           EVENT_REPOSITORY_ID: ${{ github.repository_id }}
@@ -70,6 +82,15 @@ jobs:
             jq -e --argjson user_id "$user_id" 'index($user_id) != null' \
               <<< "$TRUSTED_USER_IDS" >/dev/null
           }
+
+          case "$HEAVY_RUNNER_MODE" in
+            github) fail_closed 'caller selected GitHub-hosted heavy jobs' ;;
+            fleet) ;;
+            *) fail_closed 'heavy runner mode is invalid' ;;
+          esac
+
+          is_commit_sha "$EXPECTED_TRUSTED_WORKFLOW_SHA" \
+            || fail_closed 'trusted workflow pin is not an immutable commit SHA'
 
           [[ "$AWS_CI_ENABLED" == 'true' ]] || fail_closed 'AWS_CI_ENABLED is not true'
           # Reusable workflows retain the caller's github context and event
@@ -209,11 +230,17 @@ jobs:
 
           jq -e \
             --argjson repository_id 1170821064 \
-            --arg event_name "$EVENT_NAME" '
+            --arg event_name "$EVENT_NAME" \
+            --arg expected_sha "$EXPECTED_TRUSTED_WORKFLOW_SHA" \
+            --arg expected_workflow "paperclipai/paperclip/.github/workflows/pr-trusted.yml@$EXPECTED_TRUSTED_WORKFLOW_SHA" '
               .repository.id == $repository_id and
-              .event == $event_name
+              .event == $event_name and
+              .path == ".github/workflows/pr.yml" and
+              ((.referenced_workflows // []) | length) == 1 and
+              .referenced_workflows[0].path == $expected_workflow and
+              .referenced_workflows[0].sha == $expected_sha
             ' <<< "$run_json" >/dev/null 2>&1 \
-            || fail_closed 'current workflow run does not match the expected repository event'
+            || fail_closed 'current workflow run does not match the immutable trusted caller'
 
           echo "runner=$aws_runner" >> "$GITHUB_OUTPUT"
           echo '::notice title=AWS CI routing::Using an ephemeral RunsOn Fleet runner'
@@ -255,7 +282,7 @@ jobs:
 
   policy:
     needs: [gate]
-    runs-on: ${{ needs.gate.outputs.runner }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       lockfile_regenerated: ${{ steps.regen_lockfile.outputs.regenerated }}
@@ -491,7 +518,7 @@ jobs:
     name: verify
     if: ${{ always() }}
     needs: [gate, policy, typecheck_release_registry, general_tests, build]
-    runs-on: ${{ needs.gate.outputs.runner }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -787,7 +814,7 @@ jobs:
     name: e2e
     if: ${{ always() }}
     needs: [gate, policy, e2e_shards]
-    runs-on: ${{ needs.gate.outputs.runner }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/scripts/__tests__/e2e-shard.test.mjs
+++ b/scripts/__tests__/e2e-shard.test.mjs
@@ -92,6 +92,44 @@ function runStackScope(stack, prBaseRef) {
   }
 }
 
+function runHeavyRunnerMode(mode, trustedWorkflowSha) {
+  const workflow = readFileSync(trustedPrWorkflow, "utf8");
+  const match = workflow.match(
+    /      - name: Validate PR identity and select runner[\s\S]*?        run: \|\n([\s\S]*?)\n\n      - name: Select stacked PR CI scope/,
+  );
+  assert.ok(match, "trusted workflow must define the runner route script");
+  const routeScript = match[1]
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n");
+  const identityChecks = routeScript.indexOf('[[ "$AWS_CI_ENABLED"');
+  assert.ok(identityChecks > 0, "runner mode checks must happen before identity and Fleet checks");
+  const modeScript = `${routeScript.slice(0, identityChecks)}\necho "continued=true" >> "$GITHUB_OUTPUT"\n`;
+  const scratch = mkdtempSync(path.join(tmpdir(), "paperclip-runner-mode-"));
+  const output = path.join(scratch, "github-output");
+
+  try {
+    const result = spawnSync("bash", ["-c", modeScript], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        EXPECTED_TRUSTED_WORKFLOW_SHA: trustedWorkflowSha,
+        GITHUB_OUTPUT: output,
+        HEAVY_RUNNER_MODE: mode,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return Object.fromEntries(
+      readFileSync(output, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split("=")),
+    );
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
 test("the e2e shards form a complete, non-overlapping partition", () => {
   const specs = listE2eSpecs();
   assert.ok(specs.length > 0, "expected a non-empty e2e spec set");
@@ -161,6 +199,76 @@ test("shard arguments are validated", () => {
 
 test("pr.yml calls the trusted PR workflow at an immutable SHA", () => {
   assert.ok(readPinnedTrustedPrWorkflow().length > 0);
+});
+
+test("the trusted PR workflow defaults heavy jobs to GitHub-hosted runners", () => {
+  const workflow = readFileSync(trustedPrWorkflow, "utf8");
+  const jobs = readWorkflowJobs(workflow);
+
+  assert.match(
+    workflow,
+    /heavy_runner_mode:\n {8}description:[^\n]+\n {8}required: false\n {8}type: string\n {8}default: github/,
+    "the reusable workflow must fail safe when the trusted caller omits the runner mode",
+  );
+  assert.match(
+    workflow,
+    /trusted_workflow_sha:\n {8}description:[^\n]+\n {8}required: true\n {8}type: string/,
+    "the reusable workflow must require its immutable caller pin",
+  );
+
+  const gate = jobs.get("gate");
+  assert.match(gate, /HEAVY_RUNNER_MODE: \$\{\{ inputs\.heavy_runner_mode \}\}/);
+  assert.match(gate, /EXPECTED_TRUSTED_WORKFLOW_SHA: \$\{\{ inputs\.trusted_workflow_sha \}\}/);
+  assert.match(gate, /github\) fail_closed 'caller selected GitHub-hosted heavy jobs'/);
+  assert.match(gate, /fleet\) ;;/);
+  assert.match(gate, /\*\) fail_closed 'heavy runner mode is invalid'/);
+
+  const immutableSha = "a".repeat(40);
+  assert.equal(runHeavyRunnerMode("github", immutableSha).runner, "ubuntu-latest");
+  assert.equal(runHeavyRunnerMode("invalid", immutableSha).runner, "ubuntu-latest");
+  assert.equal(runHeavyRunnerMode("fleet", "main").runner, "ubuntu-latest");
+  assert.equal(runHeavyRunnerMode("fleet", immutableSha).continued, "true");
+});
+
+test("the trusted PR workflow validates its immutable caller before Fleet routing", () => {
+  const workflow = readFileSync(trustedPrWorkflow, "utf8");
+  const gate = readWorkflowJobs(workflow).get("gate");
+
+  assert.match(
+    gate,
+    /is_commit_sha "\$EXPECTED_TRUSTED_WORKFLOW_SHA"[\s\\\n]+\|\| fail_closed 'trusted workflow pin is not an immutable commit SHA'/,
+  );
+  assert.match(gate, /\.path == "\.github\/workflows\/pr\.yml"/);
+  assert.match(gate, /\(\(\.referenced_workflows \/\/ \[\]\) \| length\) == 1/);
+  assert.match(gate, /\.referenced_workflows\[0\]\.path == \$expected_workflow/);
+  assert.match(gate, /\.referenced_workflows\[0\]\.sha == \$expected_sha/);
+
+  const validation = gate.indexOf(".referenced_workflows[0].sha == $expected_sha");
+  const fleetRoute = gate.indexOf('echo "runner=$aws_runner"');
+  assert.ok(validation >= 0 && fleetRoute > validation, "Fleet routing must follow immutable caller validation");
+});
+
+test("only heavy CI jobs use the selected runner", () => {
+  const workflow = readFileSync(trustedPrWorkflow, "utf8");
+  const jobs = readWorkflowJobs(workflow);
+  const dynamicRunner = /^ {4}runs-on: \$\{\{ needs\.gate\.outputs\.runner \}\}$/m;
+  const expectedHeavyJobs = [
+    "build",
+    "canary_dry_run",
+    "e2e_shards",
+    "general_tests",
+    "typecheck_release_registry",
+    "verify_serialized_server",
+  ];
+  const actualHeavyJobs = [...jobs]
+    .filter(([, body]) => dynamicRunner.test(body))
+    .map(([id]) => id)
+    .sort();
+
+  assert.deepEqual(actualHeavyJobs, expectedHeavyJobs);
+  for (const jobId of ["gate", "policy", "verify", "e2e"]) {
+    assert.match(jobs.get(jobId), /^ {4}runs-on: ubuntu-latest$/m, `${jobId} must stay GitHub-hosted`);
+  }
 });
 
 test("the trusted PR workflow keeps a stable aggregate check named e2e over the shard matrix", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The pull request workflow protects changes to the control plane.
> - The trusted workflow can send approved heavy jobs to a RunsOn Fleet.
> - The same route also sent policy and required aggregate jobs to that Fleet.
> - A missing or unhealthy Fleet can leave required checks queued for many hours.
> - This pull request keeps the lightweight required path on GitHub-hosted runners.
> - It also makes heavy runner selection fail safe and verifies the immutable caller pin.
> - The benefit is that required checks do not depend on Fleet capacity.

## Linked Issues or Issue Description

Refs #12507

Refs #12509

**What happened?**

Trusted pull request runs sent policy and required aggregate jobs to the RunsOn Fleet. These jobs stayed queued when the Fleet did not serve them.

**Expected behavior**

Policy and required aggregate jobs must run on GitHub-hosted runners. Heavy jobs must use Fleet only when a trusted caller requests it and the live workflow run proves the immutable workflow pin.

**Steps to reproduce**

1. Enable AWS CI routing for a trusted pull request.
2. Make the Fleet unavailable.
3. Observe that policy and required aggregate jobs remain queued on Fleet.

**Paperclip version or commit**

`6154e00f2644827981dd790494dbda130fffbbc8`

**Deployment mode**

GitHub Actions for the public repository.

## What Changed

- Keep `policy`, `verify`, and `e2e` on `ubuntu-latest`.
- Add `heavy_runner_mode` with a safe `github` default.
- Reject invalid runner modes and non-immutable trusted workflow pins.
- Check the live run path, commit, and referenced workflow before the gate selects Fleet.
- Keep only the six heavy jobs on the gate-selected runner.
- Add contract tests for the safe route and the exact heavy-job set.
- Leave the current caller unchanged. A follow-up pull request must pin this merged commit and pass the same SHA as `trusted_workflow_sha`.

## Verification

- `node --test scripts/__tests__/e2e-shard.test.mjs` passed with 14 tests.
- `node --test '.github/scripts/tests/*.test.mjs'` passed with 133 tests.
- `actionlint .github/workflows/pr-trusted.yml` passed.
- `git diff --check` passed.
- The live GitHub Actions API predicate matched a known trusted run and its current immutable pin.
- I did not run Playwright or another browser test locally. This change does not modify a browser path.

## Risks

- This pull request does not activate the new contract. The current caller must remain unchanged until this commit is available from the default branch.
- The activation pull request must use this exact merged commit for both the reusable workflow reference and `trusted_workflow_sha`.
- A missing or invalid input fails closed to GitHub-hosted runners.
- A GitHub Actions API response that does not match the expected immutable caller also fails closed to GitHub-hosted runners.
- The lightweight required jobs can use more GitHub-hosted runner time. Heavy jobs keep their separate runner route.

> I checked [`ROADMAP.md`](ROADMAP.md). This internal CI reliability change does not duplicate planned core product work.

## Model Used

OpenAI Codex, `gpt-5.6-sol`, high reasoning mode, with tool use and code execution. Context window: platform-managed (exact size not exposed).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


