### PR TITLE
ci: activate PR fail-safe after parent squash merge

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,7 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@39b8ee2960541d14b380f95365deecba6723d9bd
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@e2e5002b96a363b3cf6f86d787590b101a20250c
+    with:
+      heavy_runner_mode: github
+      trusted_workflow_sha: e2e5002b96a363b3cf6f86d787590b101a20250c


### PR DESCRIPTION
> [!WARNING]
> **Do not merge this pull request yet.** Pull request #12512 can only squash-merge. Its current head will not become an ancestor of `master`. After #12512 merges, this pull request must pin both `uses` and `trusted_workflow_sha` to the actual squash commit on `master`. The current pin is a template only.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The pull request workflow protects changes to the control plane.
> - Pull request #12512 adds a safe runner contract to the trusted reusable workflow.
> - The caller must pin that workflow by its exact commit before it can use the new contract.
> - The caller must also pass the same commit as the trusted workflow identity.
> - This pull request adds that immutable pin and selects GitHub-hosted heavy jobs.
> - It does not authorize Fleet routing.
> - The benefit is that the fail-safe becomes active after the stack merges in order.

## Linked Issues or Issue Description

Refs #12512

Refs #12507

Refs #12509

**What happened?**

The trusted pull request workflow can add a safe runner contract, but the current caller cannot use that contract until it pins the implementation commit.

**Expected behavior**

The caller must pin the exact trusted workflow commit. It must pass the same commit as `trusted_workflow_sha`. It must select GitHub-hosted heavy jobs until a separate change safely authorizes Fleet.

**Steps to reproduce**

1. Open `.github/workflows/pr.yml` before this change.
2. Observe that it pins the previous reusable workflow commit.
3. Observe that it does not pass the new runner mode or workflow identity inputs.

**Paperclip version or commit**

`e2e5002b96a363b3cf6f86d787590b101a20250c`

**Deployment mode**

GitHub Actions for the public repository.

## What Changed

- Pin the trusted pull request workflow to `e2e5002b96a363b3cf6f86d787590b101a20250c`.
- Pass the identical commit as `trusted_workflow_sha`.
- Set `heavy_runner_mode` to `github`.
- Change only `.github/workflows/pr.yml`.

## Verification

- `node --test scripts/__tests__/e2e-shard.test.mjs` passed with 14 tests.
- `actionlint .github/workflows/pr.yml .github/workflows/pr-trusted.yml` passed.
- `git diff --check` passed.
- The workflow reference and `trusted_workflow_sha` use the same 40-character commit.
- I did not run Playwright or another browser test locally. This change does not modify a browser path.

## Risks

- Pull request #12512 must merge before this pull request.
- A mismatched or mutable workflow identity makes the reusable workflow fail closed to GitHub-hosted runners.
- This change keeps all heavy jobs on GitHub-hosted runners. A separate reviewed change is required before Fleet can run heavy jobs.
- No documentation change is required because this pull request only activates the tested internal CI contract.

> I checked [`ROADMAP.md`](ROADMAP.md). This internal CI activation does not duplicate planned core product work.

## Model Used

OpenAI Codex, `gpt-5.6-sol`, high reasoning mode, with tool use and code execution. Context window: platform-managed (exact size not exposed).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


