### PR TITLE
fix(recovery): bound notice metadata link text

### DIFF
--- a/server/src/services/recovery/notice-format.ts
+++ b/server/src/services/recovery/notice-format.ts
@@ -1,10 +1,19 @@
-import type { IssueCommentMetadata, IssueCommentPresentation } from "@paperclipai/shared";
+import type {
+  IssueCommentMetadata,
+  IssueCommentPresentation,
+} from "@paperclipai/shared";
 
-export type NoticeMetadataRow = IssueCommentMetadata["sections"][number]["rows"][number];
+export type NoticeMetadataRow =
+  IssueCommentMetadata["sections"][number]["rows"][number];
 export type NoticeMetadataSection = IssueCommentMetadata["sections"][number];
 
 export function metadataText(value: unknown, fallback = "unknown") {
-  const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
+  const text =
+    typeof value === "string"
+      ? value.trim()
+      : value == null
+        ? ""
+        : String(value).trim();
   const resolved = text.length > 0 ? text : fallback;
   return resolved.length > 2000 ? `${resolved.slice(0, 1997)}...` : resolved;
 }
@@ -13,23 +22,38 @@ export function keyValueRow(label: string, value: unknown): NoticeMetadataRow {
   return { type: "key_value", label, value: metadataText(value) };
 }
 
+function boundedMetadataText(value: unknown, maxLength: number) {
+  const text = metadataText(value);
+  if (text.length <= maxLength) return text;
+
+  const limit = maxLength - 3;
+  let truncated = "";
+  for (const { segment } of new Intl.Segmenter().segment(text)) {
+    if (truncated.length + segment.length > limit) break;
+    truncated += segment;
+  }
+  return `${truncated}...`;
+}
+
 export function issueLinkRow(
   label: string,
-  issue: { id: string; identifier: string | null; title: string } | null | undefined,
+  issue:
+    { id: string; identifier: string | null; title: string } | null | undefined,
 ): NoticeMetadataRow {
   if (!issue) return keyValueRow(label, "unknown");
   return {
     type: "issue_link",
     label,
     issueId: issue.id,
-    identifier: issue.identifier,
-    title: issue.title,
+    identifier: issue.identifier == null ? null : boundedMetadataText(issue.identifier, 80),
+    title: boundedMetadataText(issue.title, 240),
   };
 }
 
 export function runLinkRow(
   label: string,
-  run: { id: string; status: string; agentId?: string | null } | null | undefined,
+  run:
+    { id: string; status: string; agentId?: string | null } | null | undefined,
 ): NoticeMetadataRow {
   if (!run) return keyValueRow(label, "unknown");
   return {
@@ -37,7 +61,7 @@ export function runLinkRow(
     label,
     runId: run.id,
     ...(run.agentId ? { agentId: run.agentId } : {}),
-    title: run.status,
+    title: boundedMetadataText(run.status, 160),
   };
 }
 
@@ -51,7 +75,7 @@ export function agentLinkRow(
     label,
     agentId: agent.id,
     // Issue-comment metadata constrains link names to 160 characters.
-    name: agent.name?.slice(0, 160) ?? null,
+    name: agent.name == null ? null : boundedMetadataText(agent.name, 160),
   };
 }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -64,6 +64,10 @@ import {
   type SuccessfulRunHandoffNotice,
 } from "./successful-run-handoff.js";
 import {
+  agentLinkRow,
+  runLinkRow,
+} from "./notice-format.js";
+import {
   buildExecutionReviewParticipantRecoveryNoticeSeed,
   buildExecutionReviewParticipantUnavailableNoticeSeed,
   buildStrandedRecoveryEscalationNotice,
@@ -236,20 +240,10 @@ function recoveryNoticeMetadata(input: {
     { type: "key_value", label: "Cause", value: input.cause },
     { type: "key_value", label: "Previous status", value: input.previousStatus },
     ...(input.recoveryOwner
-      ? [{
-          type: "agent_link" as const,
-          label: "Recovery owner",
-          agentId: input.recoveryOwner.id,
-          name: input.recoveryOwner.name.slice(0, 160),
-        }]
+      ? [agentLinkRow("Recovery owner", input.recoveryOwner)]
       : [{ type: "key_value" as const, label: "Recovery owner", value: "board" }]),
     ...(input.latestRun
-      ? [{
-          type: "run_link" as const,
-          label: "Latest run",
-          runId: input.latestRun.id,
-          title: input.latestRun.status,
-        }]
+      ? [runLinkRow("Latest run", input.latestRun)]
       : []),
   ];
 
@@ -2354,12 +2348,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               { type: "key_value", label: "Cause", value: "recovery_issue_failed" },
               { type: "key_value", label: "Previous status", value: input.previousStatus },
               ...(input.latestRun
-                ? [{
-                    type: "run_link" as const,
-                    label: "Latest run",
-                    runId: input.latestRun.id,
-                    title: input.latestRun.status,
-                  }]
+                ? [runLinkRow("Latest run", input.latestRun)]
                 : []),
             ],
           }],

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { issueCommentMetadataSchema } from "@paperclipai/shared";
 import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
@@ -436,6 +437,48 @@ describe("successful run handoff decision", () => {
     expect(isIdempotentFinishSuccessfulRunHandoffWakeStatus("completed")).toBe(true);
     expect(isIdempotentFinishSuccessfulRunHandoffWakeStatus("failed")).toBe(false);
     expect(isIdempotentFinishSuccessfulRunHandoffWakeStatus("cancelled")).toBe(false);
+  });
+
+  it("keeps long recovery link metadata within the validation bounds", () => {
+    const notice = buildSuccessfulRunHandoffRequiredNotice({
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        identifier: "n".repeat(81),
+        title: "😀".repeat(120) + "x",
+        status: "in_progress",
+      } as any,
+      run: {
+        id: "22222222-2222-4222-8222-222222222222",
+        status: "r".repeat(161),
+        agentId: "33333333-3333-4333-8333-333333333333",
+      } as any,
+      agent: {
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "a".repeat(161),
+      } as any,
+      detectedProgressSummary: "progress recorded",
+    });
+
+    issueCommentMetadataSchema.parse(notice.metadata);
+
+    const rows = notice.metadata.sections.flatMap((section) => section.rows);
+    const issueRow = rows.find((row) => row.type === "issue_link");
+    const runRow = rows.find((row) => row.type === "run_link");
+    const agentRow = rows.find((row) => row.type === "agent_link");
+
+    expect(issueRow).toMatchObject({ type: "issue_link", title: expect.any(String) });
+    expect(runRow).toMatchObject({ type: "run_link", title: expect.any(String) });
+    expect(agentRow).toMatchObject({ type: "agent_link", name: expect.any(String) });
+    if (issueRow?.type !== "issue_link" || runRow?.type !== "run_link" || agentRow?.type !== "agent_link") return;
+    expect(issueRow.identifier).toHaveLength(80);
+    expect(issueRow.identifier).toMatch(/\.\.\.$/);
+    expect(issueRow.title).toHaveLength(239);
+    expect(issueRow.title).toMatch(/\.\.\.$/);
+    expect(issueRow.title).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    expect(runRow.title).toHaveLength(160);
+    expect(runRow.title).toMatch(/\.\.\.$/);
+    expect(agentRow.name).toHaveLength(160);
+    expect(agentRow.name).toMatch(/\.\.\.$/);
   });
 
   it("builds the required system notice with hidden structured metadata", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip helps people manage AI agents and their work.
> - Recovery notices tell users when a run needs a handoff or a recovery action.
> - These notices include hidden metadata that links to an issue, a run, and an agent.
> - Metadata has field length and non-empty text limits.
> - Long or blank link text can fail metadata validation after a run has completed.
> - This pull request uses one bounded formatter for all affected recovery link rows.
> - The result is valid recovery metadata for normal and unusually long link text.

## Linked Issues or Issue Description

Fixes #7594

Related: #5369. This older pull request combined this repair with unrelated changes and no longer merges cleanly with the current base.

## What Changed

- Bound issue identifiers to 80 characters and issue titles to 240 characters.
- Bound run titles and agent link names to 160 characters.
- Use the shared formatter in direct recovery-service notice paths.
- Preserve a visible truncation marker when text is shortened.
- Add a schema-parse regression test for long issue, run, and agent link text.

## Verification

- Added the regression test first. It failed against current `master` because a 241-character issue title and an 81-character issue identifier remained unbounded.
- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/successful-run-handoff.test.ts --pool=forks --maxWorkers=1` passes: 32 tests.
- `git diff --check` passes.
- A public-diff scan found no credentials, private paths, private hosts, or internal issue references.
- The full local server suite could not complete in this fresh worktree because unrelated test packages lack installed dependencies. CI is required before merge.

## Risks

Low risk. The change only normalises link metadata that exceeds existing validation limits or is blank. It does not change the handoff decision, authorisation, persistence schema, or the full instruction text.

## Model Used

OpenAI Codex, `gpt-5.6-terra`. Tool-assisted code generation, test execution, static review, and Git operations. Context window: platform-managed and not exposed to the contributor.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked the existing issue with `Fixes: #7594`
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run the focused regression test locally and it passes
- [x] I have added a regression test
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
