### PR TITLE
fix(ui): keep agent secret assignment on Secrets tab

### DIFF
--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Agent, Environment, UserSecretDefinition } from "@paperclipai/shared";
+import type { Agent, Environment } from "@paperclipai/shared";
 import { getEnvironmentCapabilities } from "@paperclipai/shared";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ToastProvider } from "../context/ToastContext";
@@ -255,6 +255,7 @@ async function renderForm(
   options: {
     showAdapterTestEnvironmentButton?: boolean;
     content?: "configuration" | "secrets";
+    hideInlineSave?: boolean;
   } = {},
 ) {
   mockEnvironmentsApi.list.mockResolvedValue(environments);
@@ -268,21 +269,43 @@ async function renderForm(
       mutations: { retry: false },
     },
   });
+  const onSave = vi.fn();
+  let saveAction: (() => void) | null = null;
+  let refreshAgent = () => {};
+
+  function FormHarness() {
+    const [agent, setAgent] = useState(() => makeAgent(agentOverrides));
+    refreshAgent = () => setAgent((current) => ({ ...current }));
+    return (
+      <>
+        {options.hideInlineSave ? (
+          <button type="button" onClick={() => saveAction?.()}>
+            Save agent
+          </button>
+        ) : null}
+        <AgentConfigForm
+          mode="edit"
+          agent={agent}
+          onSave={onSave}
+          onSaveActionChange={(next) => {
+            saveAction = next;
+          }}
+          hideInlineSave={options.hideInlineSave}
+          hidePromptTemplate
+          content={options.content}
+          showAdapterTypeField={false}
+          showAdapterTestEnvironmentButton={options.showAdapterTestEnvironmentButton ?? false}
+        />
+      </>
+    );
+  }
 
   await act(async () => {
     root.render(
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
           <TooltipProvider>
-            <AgentConfigForm
-              mode="edit"
-              agent={makeAgent(agentOverrides)}
-              onSave={vi.fn()}
-              hidePromptTemplate
-              content={options.content}
-              showAdapterTypeField={false}
-              showAdapterTestEnvironmentButton={options.showAdapterTestEnvironmentButton ?? false}
-            />
+            <FormHarness />
           </TooltipProvider>
         </ToastProvider>
       </QueryClientProvider>,
@@ -290,7 +313,7 @@ async function renderForm(
   });
 
   await flushReact();
-  return { container, root };
+  return { container, root, onSave, refreshAgent };
 }
 
 async function renderCreateForm(
@@ -737,6 +760,57 @@ describe("AgentConfigForm environment selector", () => {
     expect(result.container.textContent).not.toContain("Secret access");
   });
 
+  it("persists a new plain environment variable while preserving hidden secret assignments", async () => {
+    const result = await renderForm(
+      [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
+      {
+        adapterConfig: {
+          env: {
+            YANDEX_ID_CLIENT_ID: {
+              type: "secret_ref",
+              secretId: "company-secret",
+              version: "latest",
+            },
+          },
+        },
+      },
+      { hideInlineSave: true },
+    );
+    roots.push(result.root);
+
+    await act(() => findButton(result.container, "Add variable")!.click());
+
+    const nameInput = result.container.querySelector<HTMLInputElement>(
+      'input[aria-label="Variable name"]',
+    )!;
+    const valueInput = result.container.querySelector<HTMLInputElement>(
+      'input[aria-label="Variable value"]',
+    )!;
+    await act(() => {
+      setInputValue(nameInput, "QA_PLAIN_CHECK");
+      setInputValue(valueInput, "zol12429");
+    });
+
+    await act(() => findButton(result.container, "Save")!.click());
+    await flushReact();
+    await act(() => result.refreshAgent());
+    await flushReact();
+    await act(() => findButton(result.container, "Save agent")!.click());
+    await flushReact();
+
+    expect(result.onSave).toHaveBeenCalledTimes(1);
+    const patch = result.onSave.mock.calls[0]![0] as Record<string, unknown>;
+    const adapterConfig = patch.adapterConfig as Record<string, unknown>;
+    expect(adapterConfig.env).toEqual({
+      YANDEX_ID_CLIENT_ID: {
+        type: "secret_ref",
+        secretId: "company-secret",
+        version: "latest",
+      },
+      QA_PLAIN_CHECK: { type: "plain", value: "zol12429" },
+    });
+  });
+
   it("renders secret access as dedicated form content", async () => {
     const result = await renderForm(
       [makeEnvironment({ id: "local-1", name: "Local", driver: "local" })],
@@ -746,8 +820,9 @@ describe("AgentConfigForm environment selector", () => {
     roots.push(result.root);
 
     expect(result.container.textContent).toContain("Secret access");
-    expect(result.container.textContent).toContain("No secrets are bound to this agent yet.");
-    expect(result.container.textContent).not.toContain("Environment variables");
+    expect(result.container.textContent).toContain("Environment variables");
+    expect(result.container.textContent).toContain("No environment secrets assigned.");
+    expect(result.container.textContent).toContain("Add environment secret");
   });
 
   it("shows concise Environment copy when one runnable non-local environment exists", async () => {
@@ -1849,11 +1924,7 @@ describe("AgentConfigForm environment selector", () => {
     expect("storedSessionId" in payload).toBe(false);
   });
 
-  it("clears the false missing-definition error on the bound row after a login stores the token", async () => {
-    // Regression: the user-secret-definitions list read at page load does not
-    // yet contain the Claude token key, but it is not empty. A stale non-empty
-    // list makes the bound row show a false "no longer exists" error. The login
-    // must invalidate the list so the refetch clears the error.
+  it("keeps the login-created user-secret binding out of Configuration", async () => {
     mockAgentsApi.testEnvironment.mockResolvedValue(CLAUDE_AUTH_MISSING_RESULT);
     mockAgentsApi.getClaudeSetupTokenLoginStatus.mockResolvedValue({
       sessionId: "claude-session-1",
@@ -1862,32 +1933,6 @@ describe("AgentConfigForm environment selector", () => {
       expiresAt: null,
       failure: null,
     });
-    const makeDefinition = (key: string): UserSecretDefinition => ({
-      id: `def-${key}`,
-      companyId: "company-1",
-      key,
-      name: key.toUpperCase(),
-      description: null,
-      status: "active",
-      provider: "local_encrypted",
-      managedMode: "paperclip_managed",
-      providerConfigId: null,
-      providerMetadata: null,
-      usageGuidance: null,
-      createdByAgentId: null,
-      createdByUserId: null,
-      updatedByAgentId: null,
-      updatedByUserId: null,
-      deletedAt: null,
-      createdAt: new Date(0),
-      updatedAt: new Date(0),
-    });
-    const staleList = [makeDefinition("OTHER_SECRET")];
-    const freshList = [makeDefinition("OTHER_SECRET"), makeDefinition("CLAUDE_CODE_OAUTH_TOKEN")];
-    mockSecretsApi.listUserSecretDefinitions.mockReset();
-    mockSecretsApi.listUserSecretDefinitions
-      .mockResolvedValueOnce(staleList)
-      .mockResolvedValue(freshList);
 
     const result = await renderStatefulCreateClaudeSandbox([
       makeEnvironment({ id: "local-1", name: "Local", driver: "local" }),
@@ -1906,20 +1951,9 @@ describe("AgentConfigForm environment selector", () => {
 
     // The login bound the fixed Claude token row.
     expect("CLAUDE_CODE_OAUTH_TOKEN" in (result.valuesRef.current.envBindings ?? {})).toBe(true);
-
-    // The invalidation refetched the definitions, so the stale list no longer
-    // drives the row.
-    await flushUntil(() => mockSecretsApi.listUserSecretDefinitions.mock.calls.length >= 2);
-    await flushUntil(() => {
-      const inputs = Array.from(result.container.querySelectorAll("input"));
-      return inputs.some((input) => (input as HTMLInputElement).value === "CLAUDE_CODE_OAUTH_TOKEN");
-    });
-
-    // Vacuous-pass guard: the bound row rendered.
     const inputs = Array.from(result.container.querySelectorAll("input"));
-    expect(inputs.some((input) => (input as HTMLInputElement).value === "CLAUDE_CODE_OAUTH_TOKEN")).toBe(true);
-    // The row shows no false missing-definition error.
-    expect(result.container.textContent ?? "").not.toContain("no longer exists");
+    expect(inputs.some((input) => (input as HTMLInputElement).value === "CLAUDE_CODE_OAUTH_TOKEN")).toBe(false);
+    expect(result.container.textContent ?? "").toContain("Assign secrets on the Secrets tab");
   });
 
   it("reports the non-secret stored-session claim to the parent on success", async () => {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -59,10 +59,11 @@ import { MarkdownEditor } from "./MarkdownEditor";
 import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 import { ReportsToPicker } from "./ReportsToPicker";
+import type { EnvironmentVariablesEditorHandle } from "./environment-variables-editor";
 import {
-  EnvironmentVariablesEditor,
-  type EnvironmentVariablesEditorHandle,
-} from "./environment-variables-editor";
+  AgentEnvironmentVariablesEditor,
+  replaceAgentCompanySecretEnv,
+} from "./AgentEnvironmentVariablesEditor";
 import { buildFixedClaudeOAuthBinding, CLAUDE_OAUTH_TOKEN_ENV_KEY } from "./environment-variables-editor/model";
 import { AgentSecretAccessEditor } from "./AgentSecretAccessEditor";
 import { useProposalReview } from "../pages/secrets/proposal-review";
@@ -253,16 +254,6 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     queryFn: () => secretsApi.list(selectedCompanyId!),
     enabled: Boolean(selectedCompanyId),
   });
-  // User-secret definitions power the "User secret" env binding source. Requires
-  // secret-admin; non-admins simply get the free-text key fallback in the editor.
-  const { data: userSecretDefinitions = [] } = useQuery({
-    queryKey: selectedCompanyId
-      ? queryKeys.secrets.userDefinitions(selectedCompanyId)
-      : ["user-secret-definitions", "none"],
-    queryFn: () => secretsApi.listUserSecretDefinitions(selectedCompanyId!),
-    enabled: Boolean(selectedCompanyId),
-    retry: false,
-  });
   // Pending binding proposals targeting this agent (PAP-14731). Board-only route;
   // non-permitted viewers simply get an empty list.
   const editAgentId = !isCreate ? props.agent.id : null;
@@ -331,17 +322,6 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     () => resolveForcedKubernetesEnvironment(generalSettings?.executionMode, environments),
     [generalSettings?.executionMode, environments],
   );
-  const createSecret = useMutation({
-    mutationFn: (input: { name: string; value: string }) => {
-      if (!selectedCompanyId) throw new Error("Select an organization to create secrets");
-      return secretsApi.create(selectedCompanyId, input);
-    },
-    onSuccess: () => {
-      if (!selectedCompanyId) return;
-      queryClient.invalidateQueries({ queryKey: queryKeys.secrets.list(selectedCompanyId) });
-    },
-  });
-
   const uploadMarkdownImage = useMutation({
     mutationFn: async ({ file, namespace }: { file: File; namespace: string }) => {
       if (!selectedCompanyId) throw new Error("Select an organization to upload images");
@@ -353,10 +333,16 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const [overlay, setOverlay] = useState<AgentConfigOverlay>(emptyOverlay);
   const agentRef = useRef<Agent | null>(null);
 
-  // Clear overlay when agent data refreshes (after save)
+  // Clear the overlay only when the persisted agent version changes. Query
+  // refreshes routinely replace the object without changing updatedAt; treating
+  // those as saves discards a promoted environment-variable draft.
   useEffect(() => {
     if (!isCreate) {
-      if (agentRef.current !== null && props.agent !== agentRef.current) {
+      const previous = agentRef.current;
+      if (
+        previous !== null
+        && (previous.id !== props.agent.id || String(previous.updatedAt) !== String(props.agent.updatedAt))
+      ) {
         setOverlay({ ...emptyOverlay });
       }
       agentRef.current = props.agent;
@@ -406,6 +392,22 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
         if (!(alias in next)) nextAdapterConfig[key] = undefined;
       }
       return { ...prev, adapterConfig: nextAdapterConfig };
+    });
+  }, [isCreate, !isCreate ? props.agent : undefined]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  /** Replace env-delivered company secrets while retaining plain and user-secret bindings. */
+  const applyEnvironmentSecretBindings = useCallback((next: Record<string, EnvSecretRefBinding>) => {
+    if (isCreate) return;
+    setOverlay((prev) => {
+      const effective = { ...(props.agent.adapterConfig ?? {}), ...prev.adapterConfig } as Record<string, unknown>;
+      const currentEnv = (effective.env ?? {}) as Record<string, EnvBinding>;
+      return {
+        ...prev,
+        adapterConfig: {
+          ...prev.adapterConfig,
+          env: replaceAgentCompanySecretEnv(currentEnv, next),
+        },
+      };
     });
   }, [isCreate, !isCreate ? props.agent : undefined]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1341,8 +1343,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             <AgentSecretAccessEditor
               config={{ ...config, ...overlay.adapterConfig }}
               secrets={availableSecrets}
+              onEnvChange={applyEnvironmentSecretBindings}
               onChange={applyAccessGrants}
-              onCreateSecret={(name, value) => createSecret.mutateAsync({ name, value })}
               proposals={agentBindingProposals}
               onApproveProposal={proposalReview.requestApprove}
               onRejectProposal={proposalReview.requestReject}
@@ -1841,19 +1843,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               </Field>
 
               <Field label="Environment variables" hint={help.envVars}>
-                <EnvironmentVariablesEditor
+                <AgentEnvironmentVariablesEditor
                   ref={environmentVariablesEditorRef}
                   value={
                     isCreate
                       ? ((val!.envBindings ?? EMPTY_ENV) as Record<string, EnvBinding>)
                       : (eff("adapterConfig", "env", (config.env ?? EMPTY_ENV) as Record<string, EnvBinding>))
                   }
-                  secrets={availableSecrets}
-                  userSecretDefinitions={userSecretDefinitions}
-                  onCreateSecret={async (name, value) => {
-                    const created = await createSecret.mutateAsync({ name, value });
-                    return created;
-                  }}
                   onChange={(env) =>
                     isCreate
                       ? set!({ envBindings: env ?? {}, envVars: "" })

--- a/ui/src/components/AgentEnvironmentSecretAccessEditor.tsx
+++ b/ui/src/components/AgentEnvironmentSecretAccessEditor.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Plus, Trash2, Variable } from "lucide-react";
+import type { CompanySecret, EnvSecretRefBinding } from "@paperclipai/shared";
+import { Badge } from "@/components/ui/badge";
+import { SecretPicker } from "./environment-variables-editor/SecretPicker";
+import {
+  entriesToEnvironmentRows,
+  nextEnvironmentRowId,
+  nextAvailableEnvKey,
+  normalizeAccessMapKey,
+  rowsToEnvMap,
+  type AgentSecretRefEntry,
+  type EnvironmentSecretRow,
+} from "./agent-secret-access-model";
+
+interface AgentEnvironmentSecretAccessEditorProps {
+  bindings: readonly AgentSecretRefEntry[];
+  secrets: readonly CompanySecret[];
+  onChange: (next: Record<string, EnvSecretRefBinding>) => void;
+  disabled?: boolean;
+}
+
+export function AgentEnvironmentSecretAccessEditor({
+  bindings,
+  secrets,
+  onChange,
+  disabled,
+}: AgentEnvironmentSecretAccessEditorProps) {
+  const incomingMap = useMemo(() => rowsToEnvMap(entriesToEnvironmentRows(bindings)), [bindings]);
+  const incomingKey = useMemo(() => normalizeAccessMapKey(incomingMap), [incomingMap]);
+  const [rows, setRows] = useState<EnvironmentSecretRow[]>(() => entriesToEnvironmentRows(bindings));
+  const lastEmittedKeyRef = useRef(incomingKey);
+  const lastIncomingKeyRef = useRef(incomingKey);
+
+  useEffect(() => {
+    if (incomingKey === lastIncomingKeyRef.current) return;
+    lastIncomingKeyRef.current = incomingKey;
+    if (incomingKey === lastEmittedKeyRef.current) return;
+    setRows(entriesToEnvironmentRows(bindings));
+  }, [bindings, incomingKey]);
+
+  function emit(nextRows: EnvironmentSecretRow[]) {
+    setRows(nextRows);
+    const map = rowsToEnvMap(nextRows);
+    lastEmittedKeyRef.current = normalizeAccessMapKey(map);
+    onChange(map);
+  }
+
+  function patchRow(id: string, patch: Partial<EnvironmentSecretRow>) {
+    emit(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+  }
+
+  function addRow() {
+    setRows((current) => [
+      ...current,
+      { id: nextEnvironmentRowId(), name: "", secretId: "", version: "latest" },
+    ]);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="text-(length:--text-micro) font-medium uppercase tracking-wide text-muted-foreground">
+        Environment variables
+      </div>
+      {rows.length > 0 ? (
+        <div className="space-y-2">
+          {rows.map((row) => {
+            const selectedSecret = secrets.find((secret) => secret.id === row.secretId) ?? null;
+            return (
+              <div key={row.id} className="grid grid-cols-(--gtc-65) items-start gap-1.5">
+                <div className="min-w-0">
+                  <SecretPicker
+                    secretId={row.secretId}
+                    secrets={secrets}
+                    onSelect={(secretId) => {
+                      const secret = secrets.find((candidate) => candidate.id === secretId);
+                      patchRow(row.id, {
+                        secretId,
+                        name: secret
+                          ? nextAvailableEnvKey(
+                              secret.name,
+                              rows
+                                .filter((candidate) => candidate.id !== row.id)
+                                .map((candidate) => candidate.name),
+                            )
+                          : row.name,
+                        version: "latest",
+                      });
+                    }}
+                    disabled={disabled}
+                    triggerClassName="h-9 min-h-9"
+                  />
+                  {row.name ? (
+                    <div className="mt-1 flex items-center gap-1.5 text-(length:--text-micro) text-muted-foreground">
+                      <Badge variant="outline" className="h-5 gap-1 px-1.5 font-normal">
+                        <Variable className="size-3" /> Env var
+                      </Badge>
+                      <code>env.{row.name}</code>
+                    </div>
+                  ) : null}
+                </div>
+                <select
+                  className="h-9 shrink-0 rounded-md border border-border bg-background px-2 text-xs outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                  value={row.version === undefined ? "latest" : String(row.version)}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    patchRow(row.id, {
+                      version: raw === "latest" ? "latest" : Number.parseInt(raw, 10),
+                    });
+                  }}
+                  disabled={disabled || !selectedSecret}
+                  aria-label="Environment secret version"
+                >
+                  <option value="latest">latest</option>
+                  {selectedSecret
+                    ? Array.from({ length: Math.max(0, selectedSecret.latestVersion) }, (_, index) => {
+                        const version = selectedSecret.latestVersion - index;
+                        return version > 0 ? <option key={version} value={version}>v{version}</option> : null;
+                      })
+                    : null}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => emit(rows.filter((candidate) => candidate.id !== row.id))}
+                  disabled={disabled}
+                  aria-label="Remove environment secret"
+                  className="mt-1 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No environment secrets assigned.</p>
+      )}
+
+      <button
+        type="button"
+        onClick={addRow}
+        disabled={disabled}
+        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+      >
+        <Plus className="size-3.5" />
+        Add environment secret
+      </button>
+    </div>
+  );
+}

--- a/ui/src/components/AgentEnvironmentVariablesEditor.test.tsx
+++ b/ui/src/components/AgentEnvironmentVariablesEditor.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { createRef } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import type { EnvBinding } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentEnvironmentVariablesEditor,
+  mergeAgentConfigurationEnv,
+  replaceAgentCompanySecretEnv,
+  selectAgentConfigurationEnv,
+} from "./AgentEnvironmentVariablesEditor";
+import type { EnvironmentVariablesEditorHandle } from "./environment-variables-editor";
+
+describe("agent configuration environment model", () => {
+  const env: Record<string, EnvBinding> = {
+    PLAIN: { type: "plain", value: "visible" },
+    COMPANY_TOKEN: { type: "secret_ref", secretId: "company-secret", version: "latest" },
+    USER_TOKEN: { type: "user_secret_ref", key: "personal-token", required: true },
+  };
+
+  it("shows only non-secret variables in Configuration", () => {
+    expect(selectAgentConfigurationEnv(env)).toEqual({
+      PLAIN: { type: "plain", value: "visible" },
+    });
+  });
+
+  it("preserves hidden secret bindings when plain variables change", () => {
+    expect(
+      mergeAgentConfigurationEnv(env, {
+        PLAIN: { type: "plain", value: "changed" },
+        OTHER: { type: "plain", value: "new" },
+      }),
+    ).toEqual({
+      COMPANY_TOKEN: { type: "secret_ref", secretId: "company-secret", version: "latest" },
+      USER_TOKEN: { type: "user_secret_ref", key: "personal-token", required: true },
+      PLAIN: { type: "plain", value: "changed" },
+      OTHER: { type: "plain", value: "new" },
+    });
+  });
+
+  it("replaces company-secret assignments without touching other environment values", () => {
+    expect(
+      replaceAgentCompanySecretEnv(env, {
+        NEW_TOKEN: { type: "secret_ref", secretId: "new-company-secret", version: 3 },
+      }),
+    ).toEqual({
+      PLAIN: { type: "plain", value: "visible" },
+      USER_TOKEN: { type: "user_secret_ref", key: "personal-token", required: true },
+      NEW_TOKEN: { type: "secret_ref", secretId: "new-company-secret", version: 3 },
+    });
+  });
+});
+
+describe("AgentEnvironmentVariablesEditor", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    container.remove();
+  });
+
+  it("hides secret rows and sources while preserving them in emitted values", () => {
+    const onChange = vi.fn();
+    const ref = createRef<EnvironmentVariablesEditorHandle>();
+    const value: Record<string, EnvBinding> = {
+      PLAIN: { type: "plain", value: "visible" },
+      COMPANY_TOKEN: { type: "secret_ref", secretId: "company-secret", version: "latest" },
+      USER_TOKEN: { type: "user_secret_ref", key: "personal-token", required: true },
+    };
+
+    flushSync(() => {
+      root.render(
+        <AgentEnvironmentVariablesEditor
+          ref={ref}
+          value={value}
+          onChange={onChange}
+        />,
+      );
+    });
+
+    const names = [...container.querySelectorAll<HTMLInputElement>('input[aria-label="Variable name"]')]
+      .map((input) => input.value);
+    expect(names).toEqual(["PLAIN"]);
+    expect(container.querySelector('[aria-label="Value source"]')).toBeNull();
+    expect(container.textContent).not.toContain("Store as secret");
+
+    const valueInput = container.querySelector<HTMLInputElement>('input[aria-label="Variable value"]')!;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+    setter.call(valueInput, "changed");
+    flushSync(() => valueInput.dispatchEvent(new Event("input", { bubbles: true })));
+    const flushed = ref.current?.flushPendingDraft();
+
+    expect(flushed).toEqual({
+      COMPANY_TOKEN: { type: "secret_ref", secretId: "company-secret", version: "latest" },
+      USER_TOKEN: { type: "user_secret_ref", key: "personal-token", required: true },
+      PLAIN: { type: "plain", value: "changed" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(flushed);
+  });
+});

--- a/ui/src/components/AgentEnvironmentVariablesEditor.tsx
+++ b/ui/src/components/AgentEnvironmentVariablesEditor.tsx
@@ -1,0 +1,87 @@
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import type { EnvBinding } from "@paperclipai/shared";
+import {
+  EnvironmentVariablesEditor,
+  type EnvironmentVariablesEditorHandle,
+} from "./environment-variables-editor";
+
+function isSecretBinding(binding: EnvBinding): boolean {
+  return (
+    typeof binding === "object" &&
+    binding !== null &&
+    (binding.type === "secret_ref" || binding.type === "user_secret_ref")
+  );
+}
+
+/** Values that remain editable on the agent Configuration tab. */
+export function selectAgentConfigurationEnv(
+  value: Record<string, EnvBinding> | null | undefined,
+): Record<string, EnvBinding> {
+  return Object.fromEntries(
+    Object.entries(value ?? {}).filter(([, binding]) => !isSecretBinding(binding)),
+  );
+}
+
+/** Keep hidden secret assignments intact while Configuration edits plain values. */
+export function mergeAgentConfigurationEnv(
+  current: Record<string, EnvBinding> | null | undefined,
+  editable: Record<string, EnvBinding> | null | undefined,
+): Record<string, EnvBinding> {
+  const hiddenSecrets = Object.fromEntries(
+    Object.entries(current ?? {}).filter(([, binding]) => isSecretBinding(binding)),
+  );
+  return { ...(editable ?? {}), ...hiddenSecrets };
+}
+
+/** Replace company-secret env refs while preserving plain and user-secret bindings. */
+export function replaceAgentCompanySecretEnv(
+  current: Record<string, EnvBinding> | null | undefined,
+  secretBindings: Record<string, EnvBinding> | null | undefined,
+): Record<string, EnvBinding> {
+  const retained = Object.fromEntries(
+    Object.entries(current ?? {}).filter(([, binding]) => {
+      return !(typeof binding === "object" && binding !== null && binding.type === "secret_ref");
+    }),
+  );
+  return { ...retained, ...(secretBindings ?? {}) };
+}
+
+interface AgentEnvironmentVariablesEditorProps {
+  value: Record<string, EnvBinding>;
+  onChange: (next: Record<string, EnvBinding> | undefined) => void;
+  disabled?: boolean;
+}
+
+export const AgentEnvironmentVariablesEditor = forwardRef<
+  EnvironmentVariablesEditorHandle,
+  AgentEnvironmentVariablesEditorProps
+>(function AgentEnvironmentVariablesEditor({ value, onChange, disabled }, ref) {
+  const editorRef = useRef<EnvironmentVariablesEditorHandle | null>(null);
+  const editableValue = useMemo(() => selectAgentConfigurationEnv(value), [value]);
+
+  function emitEditable(next: Record<string, EnvBinding> | undefined) {
+    onChange(mergeAgentConfigurationEnv(value, next));
+  }
+
+  useImperativeHandle(ref, () => ({
+    flushPendingDraft() {
+      const editableDraft = editorRef.current?.flushPendingDraft() ?? null;
+      return editableDraft ? mergeAgentConfigurationEnv(value, editableDraft) : null;
+    },
+  }), [value]);
+
+  return (
+    <EnvironmentVariablesEditor
+      ref={editorRef}
+      value={editableValue}
+      onChange={emitEditable}
+      secrets={[]}
+      onCreateSecret={async () => {
+        throw new Error("Secret assignment is available on the Secrets tab");
+      }}
+      disabled={disabled}
+      plainOnly
+      footerHint="Plain environment values only. Assign secrets on the Secrets tab."
+    />
+  );
+});

--- a/ui/src/components/AgentSecretAccessEditor.test.tsx
+++ b/ui/src/components/AgentSecretAccessEditor.test.tsx
@@ -32,9 +32,11 @@ vi.mock("./environment-variables-editor/SecretPicker", () => ({
 
 import {
   AgentSecretAccessEditor,
+  nextAvailableEnvKey,
   parseAccessGrants,
   parseEnvSecretRefs,
   rowsToAccessMap,
+  rowsToEnvMap,
   summarizeAgentBindings,
 } from "./AgentSecretAccessEditor";
 
@@ -99,6 +101,25 @@ describe("AgentSecretAccessEditor model", () => {
       ]),
     ).toEqual({ OK: { type: "secret_ref", secretId: "s1", version: "latest" } });
   });
+
+  it("emits complete environment-secret rows without changing their env keys", () => {
+    expect(
+      rowsToEnvMap([
+        { id: "1", name: "GH_TOKEN", secretId: "s1", version: 2 },
+        { id: "2", name: "", secretId: "s1", version: "latest" },
+        { id: "3", name: "NO_SECRET", secretId: "", version: "latest" },
+        { id: "4", name: "1INVALID", secretId: "s2", version: "latest" },
+        { id: "5", name: "GH_TOKEN", secretId: "s2", version: "latest" },
+      ]),
+    ).toEqual({ GH_TOKEN: { type: "secret_ref", secretId: "s1", version: 2 } });
+  });
+
+  it("derives valid unique env keys for selected secrets", () => {
+    expect(nextAvailableEnvKey("123 token", [])).toBe("_123_TOKEN");
+    expect(nextAvailableEnvKey("!!!", [])).toBe("SECRET");
+    expect(nextAvailableEnvKey("github token", ["GITHUB_TOKEN", "GITHUB_TOKEN_2"]))
+      .toBe("GITHUB_TOKEN_3");
+  });
 });
 
 describe("AgentSecretAccessEditor component", () => {
@@ -124,7 +145,7 @@ describe("AgentSecretAccessEditor component", () => {
 
   const secrets = [makeSecret("s1", "STRIPE_KEY")];
 
-  it("shows the delivery-mode overview for existing bindings", () => {
+  it("renders existing environment and API bindings on the Secrets tab", () => {
     render(
       <AgentSecretAccessEditor
         config={{
@@ -135,11 +156,11 @@ describe("AgentSecretAccessEditor component", () => {
         onChange={() => {}}
       />,
     );
-    expect(container.textContent).toContain("STRIPE_KEY");
     expect(container.textContent).toContain("Env var");
     expect(container.textContent).toContain("API access");
     expect(container.textContent).toContain("env.GH_TOKEN");
-    expect(container.textContent).toContain("access.STRIPE");
+    expect(container.querySelector<HTMLInputElement>('input[aria-label="Access alias"]')?.value).toBe("STRIPE");
+    expect(container.querySelector('[aria-label="Remove environment secret"]')).toBeTruthy();
   });
 
   it("adds an API-access grant, emitting an access.<ALIAS> secret_ref", () => {
@@ -175,32 +196,46 @@ describe("AgentSecretAccessEditor component", () => {
     expect(last).toEqual({ STRIPE: { type: "secret_ref", secretId: "s1", version: "latest" } });
   });
 
-  it("keeps the create form open when focus returns to the shared picker anchor", async () => {
-    vi.useFakeTimers();
-    try {
-      render(
-        <AgentSecretAccessEditor
-          config={{ "access.STRIPE": { type: "secret_ref", secretId: "s1" } }}
-          secrets={secrets}
-          onChange={() => {}}
-          onCreateSecret={async () => secrets[0]!}
-        />,
-      );
+  it("adds and removes an environment-secret binding from the Secrets tab", () => {
+    const emitted: Array<Record<string, EnvSecretRefBinding>> = [];
+    render(
+      <AgentSecretAccessEditor
+        config={{}}
+        secrets={secrets}
+        onEnvChange={(next) => emitted.push(next)}
+        onChange={() => {}}
+      />,
+    );
 
-      const createButton = container.querySelector<HTMLButtonElement>('[data-testid="create-secret"]')!;
-      flushSync(() => createButton.click());
-      flushSync(() => vi.runAllTimers());
-      expect(document.body.textContent).toContain("Create secret");
+    const addButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Add environment secret"),
+    )!;
+    flushSync(() => addButton.click());
 
-      const pickerButton = container.querySelector<HTMLButtonElement>('[data-testid="pick-secret"]')!;
-      pickerButton.focus();
-      flushSync(() => {});
+    const pickers = container.querySelectorAll<HTMLButtonElement>('[data-testid="pick-secret"]');
+    flushSync(() => pickers[0]!.click());
+    expect(emitted.at(-1)).toEqual({
+      STRIPE_KEY: { type: "secret_ref", secretId: "s1", version: "latest" },
+    });
 
-      expect(document.body.textContent).toContain("Create secret");
-      expect(document.querySelector('input[aria-label="Secret name"]')).toBeTruthy();
-    } finally {
-      vi.useRealTimers();
-    }
+    const removeButton = container.querySelector<HTMLButtonElement>('[aria-label="Remove environment secret"]')!;
+    flushSync(() => removeButton.click());
+    expect(emitted.at(-1)).toEqual({});
+  });
+
+  it("only assigns existing secrets and never asks for a value again", () => {
+    render(
+      <AgentSecretAccessEditor
+        config={{ "access.STRIPE": { type: "secret_ref", secretId: "s1" } }}
+        secrets={secrets}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('[data-testid="create-secret"]')).toBeNull();
+    expect(mockSecretPickerRender).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ onCreateNew: expect.any(Function) }),
+    );
   });
 
   it("renders pending binding proposals as Proposed rows with approve/reject", () => {

--- a/ui/src/components/AgentSecretAccessEditor.tsx
+++ b/ui/src/components/AgentSecretAccessEditor.tsx
@@ -1,24 +1,38 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { KeyRound, Plus, ServerCog, Trash2, Variable } from "lucide-react";
+import { KeyRound, Plus, Trash2 } from "lucide-react";
 import type {
   CompanySecret,
   EnvSecretRefBinding,
   SecretProposalView,
-  SecretVersionSelector,
 } from "@paperclipai/shared";
 import { cn } from "../lib/utils";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { SecretPicker } from "./environment-variables-editor/SecretPicker";
-import { CreateSecretPopover } from "./environment-variables-editor/CreateSecretPopover";
-import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import {
   AGENT_ACCESS_CONFIG_PATH_PREFIX,
-  ENV_CONFIG_PATH_PREFIX,
   SECRET_ALIAS_RE,
   deliveryModeDescription,
 } from "../lib/secret-delivery";
-import { envKeyFromSecretName, secretNameFromKey } from "./environment-variables-editor/model";
+import { envKeyFromSecretName } from "./environment-variables-editor/model";
+import { AgentEnvironmentSecretAccessEditor } from "./AgentEnvironmentSecretAccessEditor";
+import {
+  entriesToAccessRows,
+  nextAccessRowId,
+  normalizeAccessMapKey,
+  parseAccessGrants,
+  parseEnvSecretRefs,
+  rowsToAccessMap,
+  type AccessRow,
+} from "./agent-secret-access-model";
+export {
+  nextAvailableEnvKey,
+  normalizeAccessMapKey,
+  parseAccessGrants,
+  parseEnvSecretRefs,
+  rowsToAccessMap,
+  rowsToEnvMap,
+  summarizeAgentBindings,
+} from "./agent-secret-access-model";
 import {
   DeliveryBadge as ProposalDeliveryBadge,
   ProposalActions,
@@ -26,125 +40,6 @@ import {
   bindingEnvKey,
   bindingSecretLabel,
 } from "../pages/secrets/proposal-review";
-
-/* -------------------------------------------------------------------------- */
-/* Pure model (exported for tests)                                            */
-/* -------------------------------------------------------------------------- */
-
-export interface AgentSecretRefEntry {
-  /** env KEY (env delivery) or access ALIAS (API-access delivery). */
-  name: string;
-  secretId: string;
-  version: SecretVersionSelector;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-function readSecretRef(raw: unknown): { secretId: string; version: SecretVersionSelector } | null {
-  const binding = asRecord(raw);
-  if (!binding || binding.type !== "secret_ref") return null;
-  const secretId = typeof binding.secretId === "string" ? binding.secretId : "";
-  if (!secretId) return null;
-  const version: SecretVersionSelector = typeof binding.version === "number" ? binding.version : "latest";
-  return { secretId, version };
-}
-
-/** Secret-ref bindings delivered as environment variables (`config.env.<KEY>`). */
-export function parseEnvSecretRefs(config: Record<string, unknown> | null | undefined): AgentSecretRefEntry[] {
-  const env = asRecord(config?.env);
-  if (!env) return [];
-  const entries: AgentSecretRefEntry[] = [];
-  for (const [key, raw] of Object.entries(env)) {
-    const ref = readSecretRef(raw);
-    if (ref) entries.push({ name: key, ...ref });
-  }
-  return entries;
-}
-
-/** Secret-ref bindings delivered via the agent API (top-level `access.<ALIAS>`). */
-export function parseAccessGrants(config: Record<string, unknown> | null | undefined): AgentSecretRefEntry[] {
-  if (!config) return [];
-  const entries: AgentSecretRefEntry[] = [];
-  for (const [key, raw] of Object.entries(config)) {
-    if (!key.startsWith(AGENT_ACCESS_CONFIG_PATH_PREFIX)) continue;
-    const ref = readSecretRef(raw);
-    if (ref) entries.push({ name: key.slice(AGENT_ACCESS_CONFIG_PATH_PREFIX.length), ...ref });
-  }
-  return entries;
-}
-
-export interface AgentSecretBindingSummary {
-  secretId: string;
-  envKeys: string[];
-  apiAliases: string[];
-}
-
-/** Group env + API bindings by secret so the overview can show delivery mode per secret. */
-export function summarizeAgentBindings(
-  envBindings: readonly AgentSecretRefEntry[],
-  apiBindings: readonly AgentSecretRefEntry[],
-): AgentSecretBindingSummary[] {
-  const bySecret = new Map<string, AgentSecretBindingSummary>();
-  const ensure = (secretId: string) => {
-    let summary = bySecret.get(secretId);
-    if (!summary) {
-      summary = { secretId, envKeys: [], apiAliases: [] };
-      bySecret.set(secretId, summary);
-    }
-    return summary;
-  };
-  for (const entry of envBindings) ensure(entry.secretId).envKeys.push(entry.name);
-  for (const entry of apiBindings) ensure(entry.secretId).apiAliases.push(entry.name);
-  return [...bySecret.values()];
-}
-
-let accessRowCounter = 0;
-function nextAccessRowId(): string {
-  accessRowCounter += 1;
-  return `access-row-${accessRowCounter}`;
-}
-
-interface AccessRow {
-  id: string;
-  alias: string;
-  secretId: string;
-  version: SecretVersionSelector;
-}
-
-function entriesToRows(entries: readonly AgentSecretRefEntry[]): AccessRow[] {
-  return entries.map((entry) => ({
-    id: nextAccessRowId(),
-    alias: entry.name,
-    secretId: entry.secretId,
-    version: entry.version,
-  }));
-}
-
-/** Complete, valid API-access grants keyed by alias. Incomplete/invalid/duplicate rows are dropped. */
-export function rowsToAccessMap(rows: readonly AccessRow[]): Record<string, EnvSecretRefBinding> {
-  const map: Record<string, EnvSecretRefBinding> = {};
-  for (const row of rows) {
-    const alias = row.alias.trim();
-    if (!alias || !SECRET_ALIAS_RE.test(alias) || !row.secretId) continue;
-    map[alias] = { type: "secret_ref", secretId: row.secretId, version: row.version };
-  }
-  return map;
-}
-
-/** Stable key for change-detection between the controlled value and the local draft. */
-export function normalizeAccessMapKey(map: Record<string, EnvSecretRefBinding>): string {
-  return JSON.stringify(
-    Object.keys(map)
-      .sort()
-      .map((alias) => {
-        const binding = map[alias]!;
-        return [alias, binding.secretId, binding.version ?? "latest"];
-      }),
-  );
-}
 
 /* -------------------------------------------------------------------------- */
 /* Component                                                                  */
@@ -159,8 +54,8 @@ export interface AgentSecretAccessEditorProps {
    * parent diffs this against the current `access.*` keys to add/remove them.
    */
   onChange: (next: Record<string, EnvSecretRefBinding>) => void;
-  /** Create a company secret from the shared picker's pinned create action. */
-  onCreateSecret?: (name: string, value: string) => Promise<CompanySecret>;
+  /** Replace environment-delivered company-secret bindings (`env.<KEY>`). */
+  onEnvChange?: (next: Record<string, EnvSecretRefBinding>) => void;
   disabled?: boolean;
   /** Pending binding proposals targeting this agent (PAP-14731). */
   proposals?: readonly SecretProposalView[];
@@ -170,32 +65,11 @@ export interface AgentSecretAccessEditorProps {
   onRejectProposal?: (proposal: SecretProposalView) => void;
 }
 
-function DeliveryBadge({ mode }: { mode: "env" | "api" }) {
-  if (mode === "env") {
-    return (
-      <Badge
-        variant="outline"
-        className="h-5 gap-1 px-1.5 text-(length:--text-nano) font-normal border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300"
-      >
-        <Variable className="size-3" /> Env var
-      </Badge>
-    );
-  }
-  return (
-    <Badge
-      variant="outline"
-      className="h-5 gap-1 px-1.5 text-(length:--text-nano) font-normal border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300"
-    >
-      <ServerCog className="size-3" /> API access
-    </Badge>
-  );
-}
-
 export function AgentSecretAccessEditor({
   config,
   secrets,
   onChange,
-  onCreateSecret,
+  onEnvChange,
   disabled,
   proposals,
   onApproveProposal,
@@ -207,14 +81,11 @@ export function AgentSecretAccessEditor({
   );
   const envBindings = useMemo(() => parseEnvSecretRefs(config), [config]);
   const apiBindings = useMemo(() => parseAccessGrants(config), [config]);
-  const summaries = useMemo(() => summarizeAgentBindings(envBindings, apiBindings), [envBindings, apiBindings]);
 
-  const incomingMap = useMemo(() => rowsToAccessMap(entriesToRows(apiBindings)), [apiBindings]);
+  const incomingMap = useMemo(() => rowsToAccessMap(entriesToAccessRows(apiBindings)), [apiBindings]);
   const incomingKey = useMemo(() => normalizeAccessMapKey(incomingMap), [incomingMap]);
 
-  const [rows, setRows] = useState<AccessRow[]>(() => entriesToRows(apiBindings));
-  const [createRequest, setCreateRequest] = useState<{ rowId: string; name: string } | null>(null);
-  const pickerAnchorRefs = useRef(new Map<string, HTMLDivElement>());
+  const [rows, setRows] = useState<AccessRow[]>(() => entriesToAccessRows(apiBindings));
   const lastEmittedKeyRef = useRef(incomingKey);
   const lastIncomingKeyRef = useRef(incomingKey);
 
@@ -225,7 +96,7 @@ export function AgentSecretAccessEditor({
     if (incomingKey === lastIncomingKeyRef.current) return;
     lastIncomingKeyRef.current = incomingKey;
     if (incomingKey === lastEmittedKeyRef.current) return;
-    setRows(entriesToRows(apiBindings));
+    setRows(entriesToAccessRows(apiBindings));
   }, [incomingKey, apiBindings]);
 
   const secretName = (secretId: string): string =>
@@ -259,34 +130,14 @@ export function AgentSecretAccessEditor({
     return counts;
   }, [rows]);
 
-  const hasBindings = summaries.length > 0;
-
   return (
     <div className="space-y-3">
-      {/* Overview: every secret bound to this agent + how it is delivered. */}
-      {hasBindings ? (
-        <div className="space-y-1.5">
-          {summaries.map((summary) => (
-            <div
-              key={summary.secretId}
-              className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs"
-            >
-              <KeyRound className="size-3.5 shrink-0 text-muted-foreground" />
-              <span className="font-medium">{secretName(summary.secretId)}</span>
-              {summary.envKeys.length > 0 ? <DeliveryBadge mode="env" /> : null}
-              {summary.apiAliases.length > 0 ? <DeliveryBadge mode="api" /> : null}
-              <span className="min-w-0 truncate font-mono text-(length:--text-micro) text-muted-foreground">
-                {[
-                  ...summary.envKeys.map((key) => `${ENV_CONFIG_PATH_PREFIX}${key}`),
-                  ...summary.apiAliases.map((alias) => `${AGENT_ACCESS_CONFIG_PATH_PREFIX}${alias}`),
-                ].join(" · ")}
-              </span>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">No secrets are bound to this agent yet.</p>
-      )}
+      <AgentEnvironmentSecretAccessEditor
+        bindings={envBindings}
+        secrets={secrets}
+        onChange={onEnvChange ?? (() => {})}
+        disabled={disabled || !onEnvChange}
+      />
 
       {/* Pending binding proposals targeting this agent (PAP-14731). */}
       {bindingProposals.length > 0 && onApproveProposal && onRejectProposal ? (
@@ -366,80 +217,24 @@ export function AgentSecretAccessEditor({
                       />
                     </div>
                     <div className="flex min-w-0 items-start gap-1.5">
-                      <Popover
-                        open={createRequest?.rowId === row.id}
-                        onOpenChange={(open) => {
-                          if (!open && createRequest?.rowId === row.id) setCreateRequest(null);
-                        }}
-                      >
-                        <PopoverAnchor asChild>
-                          <div
-                            ref={(node) => {
-                              if (node) pickerAnchorRefs.current.set(row.id, node);
-                              else pickerAnchorRefs.current.delete(row.id);
-                            }}
-                            className="min-w-0 flex-1"
-                          >
-                            <SecretPicker
-                              secretId={row.secretId}
-                              secrets={secrets}
-                              onSelect={(secretId) =>
-                                patchRow(row.id, {
-                                  secretId,
-                                  version: "latest",
-                                  alias:
-                                    !row.alias.trim() && secretId
-                                      ? envKeyFromSecretName(secretName(secretId))
-                                      : row.alias,
-                                })
-                              }
-                              onCreateNew={onCreateSecret
-                                ? (query) => {
-                                    window.setTimeout(() => {
-                                      setCreateRequest({
-                                        rowId: row.id,
-                                        name: secretNameFromKey(query) || query.trim(),
-                                      });
-                                    }, 0);
-                                  }
-                                : undefined}
-                              disabled={disabled}
-                              triggerClassName="h-9 min-h-9"
-                            />
-                          </div>
-                        </PopoverAnchor>
-                        <PopoverContent
-                          align="start"
-                          className="w-auto p-3"
-                          onInteractOutside={(event) => {
-                            // Closing the picker returns focus to its trigger inside
-                            // this popover's anchor. Keep that focus restoration from
-                            // dismissing the create form that just opened.
-                            const target = event.detail.originalEvent.target as Node | null;
-                            if (target && pickerAnchorRefs.current.get(row.id)?.contains(target)) {
-                              event.preventDefault();
-                            }
-                          }}
-                        >
-                          {createRequest?.rowId === row.id && onCreateSecret ? (
-                            <CreateSecretPopover
-                              initialName={createRequest.name}
-                              initialValue=""
-                              existingSecretNames={secrets.map((secret) => secret.name)}
-                              onCancel={() => setCreateRequest(null)}
-                              onSubmit={async (name, value) => {
-                                const created = await onCreateSecret(name, value);
-                                patchRow(row.id, {
-                                  secretId: created.id,
-                                  version: "latest",
-                                  alias: row.alias.trim() || envKeyFromSecretName(created.name),
-                                });
-                                setCreateRequest(null);
-                              }}
-                            />
-                          ) : null}
-                        </PopoverContent>
-                      </Popover>
+                      <div className="min-w-0 flex-1">
+                        <SecretPicker
+                          secretId={row.secretId}
+                          secrets={secrets}
+                          onSelect={(secretId) =>
+                            patchRow(row.id, {
+                              secretId,
+                              version: "latest",
+                              alias:
+                                !row.alias.trim() && secretId
+                                  ? envKeyFromSecretName(secretName(secretId))
+                                  : row.alias,
+                            })
+                          }
+                          disabled={disabled}
+                          triggerClassName="h-9 min-h-9"
+                        />
+                      </div>
                       <select
                         className="h-9 shrink-0 rounded-md border border-border bg-background px-2 text-xs outline-none disabled:cursor-not-allowed disabled:opacity-60"
                         value={row.version === undefined ? "latest" : String(row.version)}

--- a/ui/src/components/agent-secret-access-model.ts
+++ b/ui/src/components/agent-secret-access-model.ts
@@ -1,0 +1,169 @@
+import type { EnvSecretRefBinding, SecretVersionSelector } from "@paperclipai/shared";
+import { AGENT_ACCESS_CONFIG_PATH_PREFIX, SECRET_ALIAS_RE } from "../lib/secret-delivery";
+import { envKeyFromSecretName } from "./environment-variables-editor/model";
+
+export interface AgentSecretRefEntry {
+  /** env KEY (env delivery) or access ALIAS (API-access delivery). */
+  name: string;
+  secretId: string;
+  version: SecretVersionSelector;
+}
+
+export interface AgentSecretBindingSummary {
+  secretId: string;
+  envKeys: string[];
+  apiAliases: string[];
+}
+
+export interface EnvironmentSecretRow {
+  id: string;
+  name: string;
+  secretId: string;
+  version: SecretVersionSelector;
+}
+
+export interface AccessRow {
+  id: string;
+  alias: string;
+  secretId: string;
+  version: SecretVersionSelector;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readSecretRef(raw: unknown): { secretId: string; version: SecretVersionSelector } | null {
+  const binding = asRecord(raw);
+  if (!binding || binding.type !== "secret_ref") return null;
+  const secretId = typeof binding.secretId === "string" ? binding.secretId : "";
+  if (!secretId) return null;
+  const version: SecretVersionSelector = typeof binding.version === "number" ? binding.version : "latest";
+  return { secretId, version };
+}
+
+/** Secret-ref bindings delivered as environment variables (`config.env.<KEY>`). */
+export function parseEnvSecretRefs(config: Record<string, unknown> | null | undefined): AgentSecretRefEntry[] {
+  const env = asRecord(config?.env);
+  if (!env) return [];
+  const entries: AgentSecretRefEntry[] = [];
+  for (const [key, raw] of Object.entries(env)) {
+    const ref = readSecretRef(raw);
+    if (ref) entries.push({ name: key, ...ref });
+  }
+  return entries;
+}
+
+/** Secret-ref bindings delivered via the agent API (top-level `access.<ALIAS>`). */
+export function parseAccessGrants(config: Record<string, unknown> | null | undefined): AgentSecretRefEntry[] {
+  if (!config) return [];
+  const entries: AgentSecretRefEntry[] = [];
+  for (const [key, raw] of Object.entries(config)) {
+    if (!key.startsWith(AGENT_ACCESS_CONFIG_PATH_PREFIX)) continue;
+    const ref = readSecretRef(raw);
+    if (ref) entries.push({ name: key.slice(AGENT_ACCESS_CONFIG_PATH_PREFIX.length), ...ref });
+  }
+  return entries;
+}
+
+/** Group env + API bindings by secret for callers that need a combined summary. */
+export function summarizeAgentBindings(
+  envBindings: readonly AgentSecretRefEntry[],
+  apiBindings: readonly AgentSecretRefEntry[],
+): AgentSecretBindingSummary[] {
+  const bySecret = new Map<string, AgentSecretBindingSummary>();
+  const ensure = (secretId: string) => {
+    let summary = bySecret.get(secretId);
+    if (!summary) {
+      summary = { secretId, envKeys: [], apiAliases: [] };
+      bySecret.set(secretId, summary);
+    }
+    return summary;
+  };
+  for (const entry of envBindings) ensure(entry.secretId).envKeys.push(entry.name);
+  for (const entry of apiBindings) ensure(entry.secretId).apiAliases.push(entry.name);
+  return [...bySecret.values()];
+}
+
+let accessRowCounter = 0;
+let environmentRowCounter = 0;
+
+export function nextAccessRowId(): string {
+  accessRowCounter += 1;
+  return `access-row-${accessRowCounter}`;
+}
+
+export function nextEnvironmentRowId(): string {
+  environmentRowCounter += 1;
+  return `environment-secret-row-${environmentRowCounter}`;
+}
+
+export function entriesToAccessRows(entries: readonly AgentSecretRefEntry[]): AccessRow[] {
+  return entries.map((entry) => ({
+    id: nextAccessRowId(),
+    alias: entry.name,
+    secretId: entry.secretId,
+    version: entry.version,
+  }));
+}
+
+export function entriesToEnvironmentRows(entries: readonly AgentSecretRefEntry[]): EnvironmentSecretRow[] {
+  return entries.map((entry) => ({
+    id: nextEnvironmentRowId(),
+    name: entry.name,
+    secretId: entry.secretId,
+    version: entry.version,
+  }));
+}
+
+/** Derive a valid, collision-free env key for a newly selected company secret. */
+export function nextAvailableEnvKey(secretName: string, existingNames: Iterable<string>): string {
+  const used = new Set(
+    Array.from(existingNames, (name) => name.trim()).filter(Boolean),
+  );
+  const base = envKeyFromSecretName(secretName);
+  if (!used.has(base)) return base;
+
+  for (let index = 2; ; index += 1) {
+    const suffix = `_${index}`;
+    const candidate = `${base.slice(0, 64 - suffix.length)}${suffix}`;
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+/** Complete environment-secret bindings keyed by their preserved env names. */
+export function rowsToEnvMap(rows: readonly EnvironmentSecretRow[]): Record<string, EnvSecretRefBinding> {
+  const map: Record<string, EnvSecretRefBinding> = {};
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const name = row.name.trim();
+    if (!name || !SECRET_ALIAS_RE.test(name) || !row.secretId || seen.has(name)) continue;
+    seen.add(name);
+    map[name] = { type: "secret_ref", secretId: row.secretId, version: row.version };
+  }
+  return map;
+}
+
+/** Complete, valid API-access grants keyed by alias. */
+export function rowsToAccessMap(rows: readonly AccessRow[]): Record<string, EnvSecretRefBinding> {
+  const map: Record<string, EnvSecretRefBinding> = {};
+  for (const row of rows) {
+    const alias = row.alias.trim();
+    if (!alias || !SECRET_ALIAS_RE.test(alias) || !row.secretId) continue;
+    map[alias] = { type: "secret_ref", secretId: row.secretId, version: row.version };
+  }
+  return map;
+}
+
+/** Stable key for controlled secret-ref maps. */
+export function normalizeAccessMapKey(map: Record<string, EnvSecretRefBinding>): string {
+  return JSON.stringify(
+    Object.keys(map)
+      .sort()
+      .map((name) => {
+        const binding = map[name]!;
+        return [name, binding.secretId, binding.version ?? "latest"];
+      }),
+  );
+}

--- a/ui/src/components/environment-variables-editor/Row.tsx
+++ b/ui/src/components/environment-variables-editor/Row.tsx
@@ -50,6 +50,8 @@ export interface EnvironmentVariableRowProps {
   userSecretDefinitions?: readonly UserSecretDefinition[];
   recentlyUsedSecrets?: readonly CompanySecret[];
   disabled?: boolean;
+  /** Render only inline text values; secret assignment belongs to another surface. */
+  plainOnly?: boolean;
   nameIssue: NameIssue | null;
   showNameIssue: boolean;
   dirtyFields: EnvironmentVariableDirtyFields;
@@ -74,6 +76,7 @@ export function EnvironmentVariableRow({
   userSecretDefinitions,
   recentlyUsedSecrets,
   disabled,
+  plainOnly = false,
   nameIssue,
   showNameIssue,
   dirtyFields,
@@ -255,46 +258,65 @@ export function EnvironmentVariableRow({
                 disabled && "opacity-60",
               )}
             >
-              {/* Source switch (inside the field) */}
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild disabled={disabled}>
-                      <button
-                        type="button"
-                        aria-label="Value source"
-                        className="flex shrink-0 items-center gap-0.5 border-r border-border px-2 text-muted-foreground hover:bg-accent/50 disabled:pointer-events-none"
-                      >
-                        {row.source === "text" ? (
-                          <TypeIcon className="size-3.5" />
-                        ) : row.source === "secret" ? (
-                          <KeyRound className="size-3.5" />
-                        ) : (
-                          <UserRound className="size-3.5" />
-                        )}
-                        <ChevronDown className="size-3 opacity-60" />
-                      </button>
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">{sourceLabel}</TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent align="start" className="w-56">
-                  <DropdownMenuItem className="flex-col items-start gap-0.5" onSelect={() => switchSource("text")}>
-                    <span className="text-sm">Text value</span>
-                    <span className="text-(length:--text-micro) text-muted-foreground">Store the value inline as plain text.</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem className="flex-col items-start gap-0.5" onSelect={() => switchSource("secret")}>
-                    <span className="text-sm">Organization secret</span>
-                    <span className="text-(length:--text-micro) text-muted-foreground">Resolve a stored organization secret at run start.</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem className="flex-col items-start gap-0.5" onSelect={() => switchSource("user_secret")}>
-                    <span className="text-sm">User secret</span>
-                    <span className="text-(length:--text-micro) text-muted-foreground">
-                      Resolve the responsible user&apos;s own value at run start.
-                    </span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              {/* Source switch (inside the field). Agent Configuration is plain-only. */}
+              {plainOnly ? (
+                <span className="flex shrink-0 items-center border-r border-border px-2 text-muted-foreground">
+                  <TypeIcon className="size-3.5" />
+                </span>
+              ) : (
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild disabled={disabled}>
+                        <button
+                          type="button"
+                          aria-label="Value source"
+                          className="flex shrink-0 items-center gap-0.5 border-r border-border px-2 text-muted-foreground hover:bg-accent/50 disabled:pointer-events-none"
+                        >
+                          {row.source === "text" ? (
+                            <TypeIcon className="size-3.5" />
+                          ) : row.source === "secret" ? (
+                            <KeyRound className="size-3.5" />
+                          ) : (
+                            <UserRound className="size-3.5" />
+                          )}
+                          <ChevronDown className="size-3 opacity-60" />
+                        </button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">{sourceLabel}</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="start" className="w-56">
+                    <DropdownMenuItem
+                      className="flex-col items-start gap-0.5"
+                      onSelect={() => switchSource("text")}
+                    >
+                      <span className="text-sm">Text value</span>
+                      <span className="text-(length:--text-micro) text-muted-foreground">
+                        Store the value inline as plain text.
+                      </span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="flex-col items-start gap-0.5"
+                      onSelect={() => switchSource("secret")}
+                    >
+                      <span className="text-sm">Organization secret</span>
+                      <span className="text-(length:--text-micro) text-muted-foreground">
+                        Resolve a stored organization secret at run start.
+                      </span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="flex-col items-start gap-0.5"
+                      onSelect={() => switchSource("user_secret")}
+                    >
+                      <span className="text-sm">User secret</span>
+                      <span className="text-(length:--text-micro) text-muted-foreground">
+                        Resolve the responsible user&apos;s own value at run start.
+                      </span>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
 
               {row.source === "text" ? (
                 <>
@@ -315,7 +337,12 @@ export function EnvironmentVariableRow({
                       }
                     }}
                   />
-                  {sensitive ? (
+                  {sensitive && plainOnly ? (
+                    <div className="flex shrink-0 items-center gap-1 border-l border-border px-2 text-(length:--text-micro) text-(--status-task-icon-todo)">
+                      <ShieldAlert className="size-3.5" />
+                      <span className="hidden @[30rem]/env:inline">Assign on Secrets tab</span>
+                    </div>
+                  ) : sensitive ? (
                     <div className="flex shrink-0 items-stretch border-l border-border">
                       <button
                         type="button"
@@ -562,7 +589,7 @@ export function EnvironmentVariableRow({
 
       {/* Actions cell — mobile col 2 line 1 / desktop col 3 */}
       <div className="col-start-2 row-start-1 flex items-center justify-end gap-0.5 self-start @[40rem]/env:col-start-3 @[40rem]/env:self-center">
-        {row.source === "text" && !sensitive && (row.name.trim() || row.textValue) ? (
+        {!plainOnly && row.source === "text" && !sensitive && (row.name.trim() || row.textValue) ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild disabled={disabled}>
               <button

--- a/ui/src/components/environment-variables-editor/index.tsx
+++ b/ui/src/components/environment-variables-editor/index.tsx
@@ -129,6 +129,8 @@ export interface EnvironmentVariablesEditorProps {
   recentlyUsedSecrets?: readonly CompanySecret[];
   /** Read-only rendering. */
   disabled?: boolean;
+  /** Hide secret sources and keep this editor limited to inline plain values. */
+  plainOnly?: boolean;
   /** Prefixes flagged as reserved/auto-provided. Default `["PAPERCLIP_"]`. */
   reservedPrefixes?: readonly string[];
   /** Context-specific hint line. `null` hides the default copy; omit for default. */
@@ -153,6 +155,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
   onCreateSecret,
   recentlyUsedSecrets,
   disabled,
+  plainOnly = false,
   reservedPrefixes = DEFAULT_RESERVED_PREFIXES,
   footerHint,
   onDirtyChange,
@@ -420,11 +423,12 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
   );
 
   const quickBind = useMemo(() => {
+    if (plainOnly) return [];
     const boundIds = new Set(rows.filter((row) => row.source === "secret" && row.secretId).map((row) => row.secretId));
     return (recentlyUsedSecrets ?? [])
       .filter((secret) => secret.status === "active" && !boundIds.has(secret.id))
       .slice(0, 8);
-  }, [recentlyUsedSecrets, rows]);
+  }, [plainOnly, recentlyUsedSecrets, rows]);
 
   const hasRows = rows.length > 0;
   const hint = footerHint === undefined ? DEFAULT_HINT : footerHint;
@@ -464,6 +468,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
                 userSecretDefinitions={userSecretDefinitions}
                 recentlyUsedSecrets={recentlyUsedSecrets}
                 disabled={disabled}
+                plainOnly={plainOnly}
                 nameIssue={issue}
                 showNameIssue={touched}
                 dirtyFields={rowDirtyFields(row, committedRowsById.get(row.id))}
@@ -556,7 +561,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
       ) : null}
 
       {hint ? <p className="text-(length:--text-micro) text-muted-foreground/70">{hint}</p> : null}
-      {rows.some((row) => row.source === "user_secret" && row.userSecretKey) ? (
+      {!plainOnly && rows.some((row) => row.source === "user_secret" && row.userSecretKey) ? (
         <p className="inline-flex items-start gap-1 text-(length:--text-micro) text-muted-foreground/70">
           <UserRound className="mt-0.5 size-3 shrink-0" />
           <span>

--- a/ui/src/components/environment-variables-editor/model.test.ts
+++ b/ui/src/components/environment-variables-editor/model.test.ts
@@ -264,5 +264,7 @@ describe("name suggestion helpers", () => {
 
   it("envKeyFromSecretName uppercases to snake", () => {
     expect(envKeyFromSecretName("github token")).toBe("GITHUB_TOKEN");
+    expect(envKeyFromSecretName("123 token")).toBe("_123_TOKEN");
+    expect(envKeyFromSecretName("!!!")).toBe("SECRET");
   });
 });

--- a/ui/src/components/environment-variables-editor/model.ts
+++ b/ui/src/components/environment-variables-editor/model.ts
@@ -297,10 +297,13 @@ export function secretNameFromKey(key: string): string {
 
 /** Suggest an env KEY (UPPER_SNAKE) from a secret name (for quick-bind). */
 export function envKeyFromSecretName(name: string): string {
-  return name
+  const normalized = name
     .trim()
     .toUpperCase()
     .replace(/[^A-Z0-9_]+/g, "_")
     .replace(/^_+|_+$/g, "")
     .slice(0, 64);
+  if (!normalized) return "SECRET";
+  if (/^[A-Z_]/.test(normalized)) return normalized;
+  return `_${normalized.slice(0, 63)}`;
 }


### PR DESCRIPTION
## Summary

Agent secret assignment now lives only on the **Secrets** tab. The **Configuration** tab keeps plain environment variables editable, hides both company and user secret references, and preserves existing hidden references when the form saves.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The agent editor controls each agent's configuration and secret access.
> - The Secrets tab already owns agent-level secret access, but Configuration still exposed a second assignment path.
> - Removing only the visible controls was not enough because form updates could then drop hidden secret references.
> - A small wrapper now separates plain values from secret references and merges the hidden references back on every change and flush.
> - The Secrets tab editor now manages existing company-secret environment bindings as well as API access grants.
> - The shared environment editor gained an opt-in plain-only mode, so other consumers keep their current behavior.
> - Focused tests cover add, remove, preservation, and runtime resolution of assigned secrets.

## Linked Issues or Issue Description

## What happened?

The agent editor offered secret assignment in two places: **Configuration** and **Secrets**. The duplicate controls made ownership unclear and could lead users to treat a secret reference as a normal environment value.

## Expected behavior

Users create a company secret once and assign or remove that existing secret only on the agent **Secrets** tab. **Configuration** continues to edit normal environment variables. Existing secret assignments must survive Configuration saves and must still resolve when the agent runs.

## Steps to reproduce

1. Open an agent.
2. Open **Configuration** and inspect the environment-variable editor.
3. Open **Secrets** and inspect the agent secret editor.
4. On the previous implementation, both surfaces offered secret assignment.

## What Changed

- Added a plain-only mode for the shared environment-variable editor.
- Added an agent Configuration wrapper that hides and preserves company and user secret references.
- Added existing-company-secret environment bindings to the Secrets tab.
- Removed inline secret creation and value entry from the agent secret assignment flow.
- Extracted the secret-access model and added focused regression coverage.

## Verification

- `112/112` focused UI tests passed on current head `080d3106`.
- `108/108` focused adapter/server secret-resolution tests passed on the rebased head.
- An earlier broader adapter/server run passed `260/260`. A repeat under machine load hit timeouts and temporary-directory races only in untouched remote-sandbox tests.
- The plain-environment regression test failed with the fix stashed (`onSave` was not called) and passed after restoration.
- UI TypeScript checks passed.
- Token-gate checks passed.
- The UI production build passed.
- A full local server test run reached `5,193` passing tests and `38` unrelated environment-sensitive failures in untouched runtime, worktree, and skills tests. Remote Linux CI passed on the final head.

## Risks

- Secret references are intentionally hidden from Configuration. The merge layer preserves references that the form does not render.
- Existing consumers of the shared editor are unchanged because plain-only behavior is opt-in.
- The local full server suite has known macOS environment failures involving ephemeral ports, `/var` path canonicalization, missing local executables, and listener diagnostics. This change does not touch those areas.

## Related work

- Builds on #11283, which introduced the searchable Secrets tab.
- Review requested from @cryppadotta, who merged the related change. GitHub does not allow the fork author to assign reviewers directly.

## Model Used

OpenAI Codex, GPT-5 family. Exact serving version is not exposed. Tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge