### PR TITLE
fix(codex-local): complete managed HTTP MCP authentication

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -996,7 +996,7 @@ describe("stageCodexHomeForSync", () => {
     }
   });
 
-  // config.toml carries the managed MCP `Authorization: Bearer …` header and is
+  // config.toml carries the managed MCP `Authorization: Bearer …` HTTP header and is
   // secret-bearing; the staged copy must be 0600, not the world-readable default.
   it("writes the staged config.toml (managed MCP bearer header) with mode 0600", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-stage-toml-mode-"));
@@ -1008,7 +1008,7 @@ describe("stageCodexHomeForSync", () => {
       // and is persisted 0600 on disk.
       await fs.writeFile(
         path.join(home, "config.toml"),
-        "[mcp_servers.paperclip]\nheaders = { Authorization = \"Bearer secret-token\" }\n",
+        "[mcp_servers.paperclip]\nhttp_headers = { Authorization = \"Bearer secret-token\" }\n",
         { mode: 0o600 },
       );
       staged = await stageCodexHomeForSync(home, { runId: "run-toml-mode" });

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -293,7 +293,7 @@ function buildManagedMcpBlock(input: {
       "",
       `[mcp_servers.${tomlString(managedName)}]`,
       `url = ${tomlString(url)}`,
-      `headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
+      `http_headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
     );
   });
   lines.push(MANAGED_MCP_BLOCK_END);

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -232,7 +232,19 @@ describe("agent auth middleware", () => {
       .send({ jsonrpc: "2.0", id: 1, method: "initialize" });
 
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ reachedManagedGatewayProtocol: true });
+    expect(res.body).toMatchObject({ reachedManagedGatewayProtocol: true, actorType: "none" });
+  });
+
+  it("does not bypass actor authentication for lookalike managed MCP paths", async () => {
+    const { db } = createDbState({ agent: { id: randomUUID(), companyId: randomUUID() } });
+
+    const res = await request(createApp(db, "local_trusted"))
+      .post(`/api/tool-gateway/gateways/${randomUUID()}/mcp/extra`)
+      .set("Authorization", `Bearer pcgw_${randomUUID()}.runtime-secret`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("Agent token did not verify");
   });
 
   it("does not bypass actor authentication for non-gateway bearers on managed MCP routes", async () => {

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -105,6 +105,9 @@ function createApp(db: any, deploymentMode: "authenticated" | "local_trusted" = 
   app.post("/mcp/gateways/:gatewayPublicId", (req, res) => {
     res.json({ reachedGatewayProtocol: true, actorType: req.actor.type });
   });
+  app.post("/api/tool-gateway/gateways/:gatewayId/mcp", (req, res) => {
+    res.json({ reachedManagedGatewayProtocol: true, actorType: req.actor.type });
+  });
   app.get("/companies/:companyId/protected", (req, res) => {
     assertCompanyAccess(req, req.params.companyId);
     res.json({ ok: true });
@@ -217,6 +220,31 @@ describe("agent auth middleware", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ reachedGatewayProtocol: true });
+  });
+
+  it("leaves managed runtime MCP gateway bearers for the gateway protocol to validate", async () => {
+    const { db } = createDbState({ agent: { id: randomUUID(), companyId: randomUUID() } });
+    const gatewayId = randomUUID();
+
+    const res = await request(createApp(db, "local_trusted"))
+      .post(`/api/tool-gateway/gateways/${gatewayId}/mcp`)
+      .set("Authorization", `Bearer pcgw_${randomUUID()}.runtime-secret`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ reachedManagedGatewayProtocol: true });
+  });
+
+  it("does not bypass actor authentication for non-gateway bearers on managed MCP routes", async () => {
+    const { db } = createDbState({ agent: { id: randomUUID(), companyId: randomUUID() } });
+
+    const res = await request(createApp(db, "local_trusted"))
+      .post(`/api/tool-gateway/gateways/${randomUUID()}/mcp`)
+      .set("Authorization", "Bearer not-a-gateway-token")
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toContain("Agent token did not verify");
   });
 
   it("does not bypass actor authentication for lookalike MCP gateway paths", async () => {

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -311,7 +311,10 @@ describe("codex execute", () => {
       expect(configText).toContain("[mcp_servers.github]");
       expect(configText).toContain("[mcp_servers.\"paperclip-github\"]");
       expect(configText).toContain('url = "http://paperclip.local:3100/api/tool-gateway/gateways/gateway-1/mcp"');
-      expect(configText).toContain('Authorization = "Bearer pcgw_secret-managed-token"');
+      expect(configText).toContain(
+        'http_headers = { Authorization = "Bearer pcgw_secret-managed-token" }',
+      );
+      expect(configText).not.toMatch(/^headers\s*=/m);
       expect(logs).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/server/src/__tests__/smoke-lab.test.ts
+++ b/server/src/__tests__/smoke-lab.test.ts
@@ -367,6 +367,24 @@ describeEmbeddedPostgres("smoke lab service pack and results API", () => {
     expect(profiles).toHaveLength(1);
   });
 
+  it("resets installed smoke fixtures without leaving connection-backed applications", async () => {
+    const company = await createCompany(db);
+    await enableSmokeLab(db);
+    const app = createRouteApp(db, boardActor(company.id));
+
+    await request(app)
+      .post(`/api/companies/${company.id}/smoke-lab/install-fixtures`)
+      .expect(201);
+
+    await request(app)
+      .post(`/api/companies/${company.id}/smoke-lab/reset`)
+      .expect(200, { reset: true });
+
+    expect(await db.select().from(toolConnections).where(eq(toolConnections.companyId, company.id))).toHaveLength(0);
+    expect(await db.select().from(toolApplications).where(eq(toolApplications.companyId, company.id))).toHaveLength(0);
+    expect(await db.select().from(toolProfiles).where(eq(toolProfiles.companyId, company.id))).toHaveLength(0);
+  });
+
   it("creates runs and lets an agent JWT actor record step results", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -464,7 +464,7 @@ function createGatewayRouteApp(
     withActorMiddleware?: boolean;
   },
 ) {
-  const options = actorOrOptions && "withActorMiddleware" in actorOrOptions
+  const options = actorOrOptions && ("actor" in actorOrOptions || "withActorMiddleware" in actorOrOptions)
     ? actorOrOptions
     : { actor: actorOrOptions };
   if (options.actor && options.withActorMiddleware) {
@@ -473,9 +473,10 @@ function createGatewayRouteApp(
   const app = express();
   app.use(express.json());
   if (options.withActorMiddleware) app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
-  if (options.actor) {
+  const actor = options.actor;
+  if (actor) {
     app.use((req, _res, next) => {
-      req.actor = options.actor!;
+      req.actor = actor;
       next();
     });
   }

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -44,6 +44,7 @@ import {
   userSecretDefinitions,
 } from "@paperclipai/db";
 import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+import { actorMiddleware } from "../middleware/auth.js";
 import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "../routes/tool-gateway.js";
 import { toolAccessService } from "../services/tool-access.js";
 import {
@@ -459,9 +460,11 @@ function createGatewayRouteApp(
   db: Db,
   gateway = createTestToolGatewayService(db),
   actor?: Express.Request["actor"],
+  withActorMiddleware = false,
 ) {
   const app = express();
   app.use(express.json());
+  if (withActorMiddleware) app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
   if (actor) {
     app.use((req, _res, next) => {
       req.actor = actor;
@@ -637,7 +640,17 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
       expect(token.ownerNote).toBe("QA fixture token");
       expect(token.tokenPrefix).toMatch(/^pcgw_[a-f0-9]{8}$/);
 
-      const app = createGatewayRouteApp(db, gateway);
+      const app = createGatewayRouteApp(db, gateway, undefined, true);
+      await request(app)
+        .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
+        .set("authorization", `Bearer ${tamperToken(token.token)}`)
+        .send({ jsonrpc: "2.0", id: 0, method: "tools/list" })
+        .expect(401);
+      await request(app)
+        .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
+        .set("authorization", `Bearer ${tamperToken(token.token)}`)
+        .send({ jsonrpc: "2.0", method: "notifications/initialized" })
+        .expect(401);
       const listed = await request(app)
         .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
         .set("authorization", `Bearer ${token.token}`)

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -459,15 +459,23 @@ function createTestToolGatewayService(db: Db, options: ToolGatewayServiceOptions
 function createGatewayRouteApp(
   db: Db,
   gateway = createTestToolGatewayService(db),
-  actor?: Express.Request["actor"],
-  withActorMiddleware = false,
+  actorOrOptions?: Express.Request["actor"] | {
+    actor?: Express.Request["actor"];
+    withActorMiddleware?: boolean;
+  },
 ) {
+  const options = actorOrOptions && "withActorMiddleware" in actorOrOptions
+    ? actorOrOptions
+    : { actor: actorOrOptions };
+  if (options.actor && options.withActorMiddleware) {
+    throw new Error("createGatewayRouteApp accepts either an explicit actor or actorMiddleware, not both");
+  }
   const app = express();
   app.use(express.json());
-  if (withActorMiddleware) app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
-  if (actor) {
+  if (options.withActorMiddleware) app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+  if (options.actor) {
     app.use((req, _res, next) => {
-      req.actor = actor;
+      req.actor = options.actor!;
       next();
     });
   }
@@ -640,7 +648,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
       expect(token.ownerNote).toBe("QA fixture token");
       expect(token.tokenPrefix).toMatch(/^pcgw_[a-f0-9]{8}$/);
 
-      const app = createGatewayRouteApp(db, gateway, undefined, true);
+      const app = createGatewayRouteApp(db, gateway, { withActorMiddleware: true });
       await request(app)
         .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
         .set("authorization", `Bearer ${tamperToken(token.token)}`)

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -246,6 +246,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       (hasBearerCredentials && publicMcpGatewayProtocolPath.test(req.path))
       || (hasGatewayBearer && managedMcpGatewayProtocolPath.test(req.path))
     ) {
+      req.actor = { type: "none", source: "none" };
       if (runIdHeader) req.actor.runId = runIdHeader;
       next();
       return;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -212,6 +212,8 @@ interface ActorMiddlewareOptions {
 }
 
 const publicMcpGatewayProtocolPath = /^\/mcp\/gateways\/gw_[a-f0-9]{32}\/?$/i;
+const managedMcpGatewayProtocolPath =
+  /^\/api\/tool-gateway\/gateways\/[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\/mcp\/?$/i;
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
@@ -232,14 +234,18 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const authHeader = req.header("authorization");
     const hasBearerCredentials = /^bearer(?:\s|$)/i.test(authHeader ?? "");
+    const hasGatewayBearer = /^bearer\s+pcgw_/i.test(authHeader ?? "");
 
     // Public MCP gateway protocol requests carry a pcgw_* bearer that is
     // validated by the gateway service itself. Do not interpret that bearer as
     // a board key or agent JWT here: doing so rejects the MCP handshake before
-    // the protocol route can verify its run-scoped credential. Keep this bypass
-    // restricted to the unguessable public gateway path; all /api routes retain
-    // the normal actor authentication path below.
-    if (hasBearerCredentials && publicMcpGatewayProtocolPath.test(req.path)) {
+    // the protocol route can verify its run-scoped credential. The internal
+    // managed route gets the same handoff only for an actual pcgw_* bearer;
+    // every other /api request retains normal actor authentication below.
+    if (
+      (hasBearerCredentials && publicMcpGatewayProtocolPath.test(req.path))
+      || (hasGatewayBearer && managedMcpGatewayProtocolPath.test(req.path))
+    ) {
       if (runIdHeader) req.actor.runId = runIdHeader;
       next();
       return;

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -88,6 +88,11 @@ async function handleMcpGatewayProtocol(
       return;
     }
     if (body.method === "notifications/initialized") {
+      await toolGateway.initializeNamedGatewayProtocol({
+        ...locator,
+        bearerToken: token,
+        callerHeaders: headers,
+      });
       res.status(202).end();
       return;
     }

--- a/server/src/services/smoke-lab.ts
+++ b/server/src/services/smoke-lab.ts
@@ -1243,24 +1243,27 @@ export function smokeLabService(db: Db, options: {
       codes.clear();
       accessTokens.clear();
       refreshTokens.clear();
-      await db.delete(smokeRuns).where(eq(smokeRuns.companyId, companyId));
-      const fixtureApplications = await db.select({ id: toolApplications.id })
-        .from(toolApplications)
-        .where(and(
+      await db.transaction(async (tx) => {
+        await tx.delete(smokeRuns).where(eq(smokeRuns.companyId, companyId));
+        const fixtureApplications = await tx.select({ id: toolApplications.id })
+          .from(toolApplications)
+          .where(and(
+            eq(toolApplications.companyId, companyId),
+            inArray(toolApplications.applicationKey, [HTTP_APP_KEY, STDIO_APP_KEY]),
+          ))
+          .for("update");
+        if (fixtureApplications.length > 0) {
+          await tx.delete(toolConnections).where(and(
+            eq(toolConnections.companyId, companyId),
+            inArray(toolConnections.applicationId, fixtureApplications.map((application) => application.id)),
+          ));
+        }
+        await tx.delete(toolApplications).where(and(
           eq(toolApplications.companyId, companyId),
           inArray(toolApplications.applicationKey, [HTTP_APP_KEY, STDIO_APP_KEY]),
         ));
-      if (fixtureApplications.length > 0) {
-        await db.delete(toolConnections).where(and(
-          eq(toolConnections.companyId, companyId),
-          inArray(toolConnections.applicationId, fixtureApplications.map((application) => application.id)),
-        ));
-      }
-      await db.delete(toolApplications).where(and(
-        eq(toolApplications.companyId, companyId),
-        inArray(toolApplications.applicationKey, [HTTP_APP_KEY, STDIO_APP_KEY]),
-      ));
-      await db.delete(toolProfiles).where(and(eq(toolProfiles.companyId, companyId), eq(toolProfiles.profileKey, PROFILE_KEY)));
+        await tx.delete(toolProfiles).where(and(eq(toolProfiles.companyId, companyId), eq(toolProfiles.profileKey, PROFILE_KEY)));
+      });
       return { reset: true };
     },
   };

--- a/server/src/services/smoke-lab.ts
+++ b/server/src/services/smoke-lab.ts
@@ -1244,6 +1244,18 @@ export function smokeLabService(db: Db, options: {
       accessTokens.clear();
       refreshTokens.clear();
       await db.delete(smokeRuns).where(eq(smokeRuns.companyId, companyId));
+      const fixtureApplications = await db.select({ id: toolApplications.id })
+        .from(toolApplications)
+        .where(and(
+          eq(toolApplications.companyId, companyId),
+          inArray(toolApplications.applicationKey, [HTTP_APP_KEY, STDIO_APP_KEY]),
+        ));
+      if (fixtureApplications.length > 0) {
+        await db.delete(toolConnections).where(and(
+          eq(toolConnections.companyId, companyId),
+          inArray(toolConnections.applicationId, fixtureApplications.map((application) => application.id)),
+        ));
+      }
       await db.delete(toolApplications).where(and(
         eq(toolApplications.companyId, companyId),
         inArray(toolApplications.applicationKey, [HTTP_APP_KEY, STDIO_APP_KEY]),


### PR DESCRIPTION
Fixes #10346.

Paperclip's managed Codex MCP path had two independent incompatibilities:

1. generated Codex config used `headers`, while streamable HTTP MCP servers require `http_headers`;
2. Paperclip's actor-JWT middleware rejected its own `pcgw_*` gateway bearer before the gateway protocol could authenticate it.

This change repairs both halves and hardens the surrounding lifecycle:

- emit `http_headers` for managed Codex MCP servers;
- bypass actor authentication only for gateway-shaped bearers on the exact internal managed-MCP route;
- clear any pre-existing actor on that path;
- authenticate `notifications/initialized` instead of acknowledging an invalid bearer;
- make Smoke Lab reset ordering transactional for its `NO ACTION` application relationship;
- add configuration, middleware, gateway-integration, tampered-token, actor-boundary, and reset regression tests.

Verification:

- focused tests and affected package typechecks passed during implementation;
- six-lens review findings were repaired and the final changed test surface re-reviewed cleanly;
- deployed acceptance invoked a managed HTTP MCP tool exactly once through Codex, returned the expected structured payload over `mcp_http`, spawned no local process, and completed with exit code 0;
- temporary acceptance fixtures were removed and Smoke Lab was disabled afterward.

This includes the configuration correction from #12287 and the server-side authorization repair needed for an actual managed call to succeed.
