### PR TITLE
fix(test): use IPv4 when IPv6 loopback is disabled

### DIFF
--- a/server/src/__tests__/setup-supertest.ts
+++ b/server/src/__tests__/setup-supertest.ts
@@ -51,8 +51,11 @@ if (!SupertestTest.prototype.__paperclipLoopbackPatched) {
       throw new Error("Expected Supertest server to listen on a TCP port");
     }
 
+    // Node may report the unspecified IPv6 listener (`::`) even when IPv6
+    // loopback is disabled. Use IPv4 in that case so Supertest can reach the
+    // in-memory server on hosts that intentionally disable IPv6.
     const host = listeningAddress.address === "::"
-      ? "[::1]"
+      ? "127.0.0.1"
       : listeningAddress.address === "0.0.0.0"
         ? "127.0.0.1"
         : listeningAddress.address;

--- a/server/src/__tests__/supertest-loopback.test.ts
+++ b/server/src/__tests__/supertest-loopback.test.ts
@@ -1,0 +1,17 @@
+import express from "express";
+import request from "supertest";
+import { expect, it } from "vitest";
+
+it("reaches an in-memory Express app through the loopback address", async () => {
+  const app = express();
+  app.get("/ping", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  const response = await request(app)
+    .get("/ping")
+    .timeout({ response: 5_000, deadline: 8_000 });
+
+  expect(response.status).toBe(200);
+  expect(response.body).toEqual({ ok: true });
+});


### PR DESCRIPTION
## Summary

- Use IPv4 loopback when Supertest starts an Express app on Node's unspecified IPv6 address (`::`).
- Prevents test requests from hanging on hosts where IPv6 loopback is disabled.
- Add a focused in-memory Express/Supertest regression test.

## Verification

- New regression test: fails before the change with a 5s response timeout; passes after.
- Ownership-route suite: 87 passed.

## Notes

- This changes test harness behaviour only; no production service, telemetry, credentials, or external network path is changed.
